### PR TITLE
fix: use existing tag resolution infrastructure for recursive revert …

### DIFF
--- a/__fixtures__/sqitch/simple-w-tags/packages/my-second/revert/create_another_table.sql
+++ b/__fixtures__/sqitch/simple-w-tags/packages/my-second/revert/create_another_table.sql
@@ -2,6 +2,7 @@
 
 BEGIN;
 
-DROP TABLE otherschema.anothertable;
+DROP TABLE otherschema.consent_agreements;
+DROP TABLE otherschema.user_interactions;
 
 COMMIT;

--- a/__fixtures__/sqitch/simple-w-tags/packages/my-second/revert/create_table.sql
+++ b/__fixtures__/sqitch/simple-w-tags/packages/my-second/revert/create_table.sql
@@ -2,6 +2,6 @@
 
 BEGIN;
 
-DROP TABLE otherschema.mytable;
+DROP TABLE otherschema.users;
 
 COMMIT;

--- a/packages/core/__tests__/deploy/revert-deployment-recursive.test.ts
+++ b/packages/core/__tests__/deploy/revert-deployment-recursive.test.ts
@@ -33,7 +33,7 @@ describe('Forked Deployment with deployModules - my-third', () => {
     expect(tables.rows).toHaveLength(1);
     expect(tables.rows.map((r: any) => r.table_name)).toEqual(['customers']);
     
-    await fixture.revertModule('my-third', db.name, ['sqitch', 'simple-w-tags'], 'my-first:@v1.0.0');
+    await fixture.revertToChangeOrTag('my-first:@v1.0.0', db.name, ['sqitch', 'simple-w-tags']);
 
     expect(await db.exists('schema', 'metaschema')).toBe(false);
     expect(await db.exists('table', 'metaschema.customers')).toBe(false);

--- a/packages/core/src/migrate/migration.ts
+++ b/packages/core/src/migrate/migration.ts
@@ -112,7 +112,8 @@ export async function revertModules(options: MigrationOptions): Promise<void> {
       { 
         useSqitch: options.useSqitch, 
         useTransaction: options.useTransaction,
-        planFile: options.planFile
+        planFile: options.planFile,
+        toChange: options.toChange
       }
     );
   } else {


### PR DESCRIPTION
…operations

- Replace manual tag parsing in revert-project.ts with resolveReference function
- Thread toChange parameter through revertModules -> revertProject pipeline
- Implement proper global rollback semantics for project-specific constraints
- Fix SQL revert files to match actual deployed table names
- Update test to use new revertToChangeOrTag API with global rollback semantics

The recursive revert now properly handles cross-project tag references like 'my-first:@v1.0.0' by using the established tag resolution infrastructure instead of manual string parsing, ensuring consistency with the rest of the codebase's dependency resolution patterns.