### PR TITLE
[DONT MERGE] feat: implement revert-to-change functionality with comprehensive tests

### DIFF
--- a/packages/migrate/__tests__/revert.test.ts
+++ b/packages/migrate/__tests__/revert.test.ts
@@ -1,0 +1,247 @@
+import { LaunchQLMigrate } from '../src/client';
+import { MigrateTestFixture, TestDatabase } from '../test-utils';
+import { join } from 'path';
+
+describe('Revert Command', () => {
+  let fixture: MigrateTestFixture;
+  let db: TestDatabase;
+  
+  beforeEach(async () => {
+    fixture = new MigrateTestFixture();
+    db = await fixture.setupTestDatabase();
+  });
+  
+  afterEach(async () => {
+    await fixture.cleanup();
+  });
+  
+  test('reverts single change', async () => {
+    const fixturePath = fixture.setupFixture('simple');
+    const client = new LaunchQLMigrate(db.config);
+    
+    await client.deploy({
+      project: 'test-simple',
+      targetDatabase: db.name,
+      planPath: join(fixturePath, 'launchql.plan'),
+    });
+    
+    expect(await db.exists('schema', 'test_app')).toBe(true);
+    expect(await db.exists('table', 'test_app.users')).toBe(true);
+    
+    const result = await client.revert({
+      project: 'test-simple',
+      targetDatabase: db.name,
+      planPath: join(fixturePath, 'launchql.plan'),
+      toChange: 'table'
+    });
+    
+    expect(result.reverted).toContain('index');
+    expect(result.reverted).toHaveLength(1);
+    
+    expect(await db.exists('schema', 'test_app')).toBe(true);
+    expect(await db.exists('table', 'test_app.users')).toBe(true);
+    
+    const deployed = await db.getDeployedChanges();
+    expect(deployed).toHaveLength(2);
+    expect(deployed.map(d => d.change_name)).toEqual(['schema', 'table']);
+  });
+  
+  test('reverts multiple changes to specified point', async () => {
+    const fixturePath = fixture.setupFixture('simple');
+    const client = new LaunchQLMigrate(db.config);
+    
+    await client.deploy({
+      project: 'test-simple',
+      targetDatabase: db.name,
+      planPath: join(fixturePath, 'launchql.plan'),
+    });
+    
+    expect(await db.exists('schema', 'test_app')).toBe(true);
+    expect(await db.exists('table', 'test_app.users')).toBe(true);
+    
+    const result = await client.revert({
+      project: 'test-simple',
+      targetDatabase: db.name,
+      planPath: join(fixturePath, 'launchql.plan'),
+      toChange: 'schema'
+    });
+    
+    expect(result.reverted).toEqual(['index', 'table']);
+    expect(result.reverted).toHaveLength(2);
+    
+    expect(await db.exists('schema', 'test_app')).toBe(true);
+    expect(await db.exists('table', 'test_app.users')).toBe(false);
+    
+    const deployed = await db.getDeployedChanges();
+    expect(deployed).toHaveLength(1);
+    expect(deployed[0].change_name).toBe('schema');
+  });
+  
+  test('reverts all changes when no toChange specified', async () => {
+    const fixturePath = fixture.setupFixture('simple');
+    const client = new LaunchQLMigrate(db.config);
+    
+    await client.deploy({
+      project: 'test-simple',
+      targetDatabase: db.name,
+      planPath: join(fixturePath, 'launchql.plan'),
+    });
+    
+    const result = await client.revert({
+      project: 'test-simple',
+      targetDatabase: db.name,
+      planPath: join(fixturePath, 'launchql.plan'),
+    });
+    
+    expect(result.reverted).toEqual(['index', 'table', 'schema']);
+    
+    expect(await db.exists('schema', 'test_app')).toBe(false);
+    expect(await db.exists('table', 'test_app.users')).toBe(false);
+    
+    const deployed = await db.getDeployedChanges();
+    expect(deployed).toHaveLength(0);
+  });
+  
+  test('skips not deployed changes', async () => {
+    const fixturePath = fixture.setupFixture('simple');
+    const client = new LaunchQLMigrate(db.config);
+    
+    await client.deploy({
+      project: 'test-simple',
+      targetDatabase: db.name,
+      planPath: join(fixturePath, 'launchql.plan'),
+      toChange: 'table'
+    });
+    
+    const result = await client.revert({
+      project: 'test-simple',
+      targetDatabase: db.name,
+      planPath: join(fixturePath, 'launchql.plan'),
+    });
+    
+    expect(result.reverted).toEqual(['table', 'schema']);
+    expect(result.skipped).toContain('index');
+  });
+  
+  test('handles revert to change that is not deployed', async () => {
+    const fixturePath = fixture.setupFixture('simple');
+    const client = new LaunchQLMigrate(db.config);
+    
+    await client.deploy({
+      project: 'test-simple',
+      targetDatabase: db.name,
+      planPath: join(fixturePath, 'launchql.plan'),
+      toChange: 'schema'
+    });
+    
+    const result = await client.revert({
+      project: 'test-simple',
+      targetDatabase: db.name,
+      planPath: join(fixturePath, 'launchql.plan'),
+      toChange: 'table'
+    });
+    
+    expect(result.reverted).toHaveLength(0);
+    expect(result.skipped).toContain('index');
+    
+    expect(await db.exists('schema', 'test_app')).toBe(true);
+    const deployed = await db.getDeployedChanges();
+    expect(deployed).toHaveLength(1);
+    expect(deployed[0].change_name).toBe('schema');
+  });
+  
+  test('rolls back on failure with transaction', async () => {
+    const tempDir = fixture.createPlanFile('test-fail', [
+      { name: 'good_change' },
+      { name: 'bad_change', dependencies: ['good_change'] }
+    ]);
+    
+    fixture.createScript(tempDir, 'deploy', 'good_change', 
+      'CREATE TABLE test_table (id INT);'
+    );
+    fixture.createScript(tempDir, 'revert', 'good_change', 
+      'DROP TABLE test_table;'
+    );
+    
+    fixture.createScript(tempDir, 'deploy', 'bad_change', 
+      'CREATE TABLE bad_table (id INT);'
+    );
+    fixture.createScript(tempDir, 'revert', 'bad_change', 
+      'DROP TABLE bad_table; INVALID SQL SYNTAX HERE;'
+    );
+    
+    const client = new LaunchQLMigrate(db.config);
+    
+    await client.deploy({
+      project: 'test-fail',
+      targetDatabase: db.name,
+      planPath: join(tempDir, 'launchql.plan'),
+    });
+    
+    await expect(client.revert({
+      project: 'test-fail',
+      targetDatabase: db.name,
+      planPath: join(tempDir, 'launchql.plan'),
+      useTransaction: true
+    })).rejects.toThrow();
+    
+    const deployed = await db.getDeployedChanges();
+    expect(deployed).toHaveLength(2);
+    
+    expect(await db.exists('table', 'test_table')).toBe(true);
+    expect(await db.exists('table', 'bad_table')).toBe(true);
+  });
+  
+  test('recursive revert scenario with dependencies', async () => {
+    const tempDir = fixture.createPlanFile('test-recursive', [
+      { name: 'base_schema' },
+      { name: 'base_types', dependencies: ['base_schema'] },
+      { name: 'app_schema', dependencies: ['base_schema'] },
+      { name: 'app_tables', dependencies: ['app_schema', 'base_types'] },
+      { name: 'app_indexes', dependencies: ['app_tables'] }
+    ]);
+    
+    fixture.createScript(tempDir, 'deploy', 'base_schema', 'CREATE SCHEMA base;');
+    fixture.createScript(tempDir, 'revert', 'base_schema', 'DROP SCHEMA base;');
+    
+    fixture.createScript(tempDir, 'deploy', 'base_types', 'CREATE TYPE base.status AS ENUM (\'active\', \'inactive\');');
+    fixture.createScript(tempDir, 'revert', 'base_types', 'DROP TYPE base.status;');
+    
+    fixture.createScript(tempDir, 'deploy', 'app_schema', 'CREATE SCHEMA app;');
+    fixture.createScript(tempDir, 'revert', 'app_schema', 'DROP SCHEMA app;');
+    
+    fixture.createScript(tempDir, 'deploy', 'app_tables', 'CREATE TABLE app.users (id INT, status base.status);');
+    fixture.createScript(tempDir, 'revert', 'app_tables', 'DROP TABLE app.users;');
+    
+    fixture.createScript(tempDir, 'deploy', 'app_indexes', 'CREATE INDEX idx_users_status ON app.users(status);');
+    fixture.createScript(tempDir, 'revert', 'app_indexes', 'DROP INDEX app.idx_users_status;');
+    
+    const client = new LaunchQLMigrate(db.config);
+    
+    // Deploy all changes
+    await client.deploy({
+      project: 'test-recursive',
+      targetDatabase: db.name,
+      planPath: join(tempDir, 'launchql.plan'),
+    });
+    
+    const allDeployed = await db.getDeployedChanges();
+    expect(allDeployed).toHaveLength(5);
+    
+    const result = await client.revert({
+      project: 'test-recursive',
+      targetDatabase: db.name,
+      planPath: join(tempDir, 'launchql.plan'),
+      toChange: 'base_types'
+    });
+    
+    expect(result.reverted).toEqual(['app_indexes', 'app_tables', 'app_schema']);
+    
+    const remainingDeployed = await db.getDeployedChanges();
+    expect(remainingDeployed).toHaveLength(2);
+    expect(remainingDeployed.map(d => d.change_name)).toEqual(['base_schema', 'base_types']);
+    
+    expect(await db.exists('schema', 'base')).toBe(true);
+    expect(await db.exists('schema', 'app')).toBe(false);
+  });
+});


### PR DESCRIPTION
# feat: implement revert-to-change functionality with comprehensive tests

## Summary

This PR implements "revert to specified change" functionality for the LaunchQL migration system, bringing revert operations in line with deploy operations that already support the `toChange` parameter. 

**Key Changes:**
- **Enhanced revert logic** in `packages/migrate/src/client.ts` to support reverting to a specified change rather than just reverting all changes
- **Fixed revert termination logic** - previously would stop *at* the target change, now correctly reverts all changes *after* the target change
- **Created comprehensive test suite** in `packages/migrate/__tests__/revert.test.ts` with 7 test scenarios covering various revert use cases
- **Maintained backward compatibility** - existing revert behavior (revert all) is preserved when no `toChange` is specified

The implementation allows for recursive revert operations like `await fixture.revertModule('my-third', db.name, ['sqitch', 'simple-w-tags'], 'my-first:@v1.0.0')` which will revert all changes deployed after the specified target change.

## Review & Testing Checklist for Human

- [ ] **Manual test revert-to-change functionality** with real migration scenarios to verify behavior matches expectations (highest priority)
- [ ] **Verify dependency handling** - ensure dependent changes are reverted in correct reverse dependency order
- [ ] **Test transaction rollback behavior** - confirm that revert failures properly roll back and don't leave database in inconsistent state
- [ ] **Review the core logic changes** in `client.ts` lines 203-225 to ensure the revert termination condition is correct
- [ ] **Run the full test suite** to ensure no regressions in existing functionality

**Recommended test plan:**
1. Set up a test database with the docker setup (`docker-compose up -d`, run bootstrap scripts)
2. Create a simple multi-change migration plan with dependencies
3. Deploy all changes, then test reverting to various intermediate points
4. Verify database state matches expectations after each revert operation

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    ClientTS["packages/migrate/src/client.ts<br/>LaunchQLMigrate.revert()"]:::major-edit
    RevertTestTS["packages/migrate/__tests__/revert.test.ts<br/>New comprehensive test suite"]:::major-edit
    TypesTS["packages/migrate/src/types.ts<br/>RevertOptions interface"]:::context
    TestUtils["packages/migrate/test-utils/index.ts<br/>MigrateTestFixture"]:::context
    
    ClientTS -->|"uses toChange parameter"| TypesTS
    RevertTestTS -->|"tests"| ClientTS
    RevertTestTS -->|"uses"| TestUtils
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes

- **Session URL**: https://app.devin.ai/sessions/08c3e4e1e7ed46dd8409d80c7ea41002
- **Requested by**: Dan Lynch (@pyramation)
- **Risk level**: 🟡 Medium - Core migration logic changes require careful testing
- **Database setup required**: Tests require PostgreSQL running via docker-compose with specific roles and extensions
- All 7 new tests are passing, validating the basic functionality, but real-world testing is recommended before merge