### PR TITLE
[not for merge] see for revert 2

### DIFF
--- a/__fixtures__/sqitch/simple-w-tags/packages/my-second/revert/create_another_table.sql
+++ b/__fixtures__/sqitch/simple-w-tags/packages/my-second/revert/create_another_table.sql
@@ -2,6 +2,7 @@
 
 BEGIN;
 
-DROP TABLE otherschema.anothertable;
+DROP TABLE otherschema.consent_agreements;
+DROP TABLE otherschema.user_interactions;
 
 COMMIT;

--- a/__fixtures__/sqitch/simple-w-tags/packages/my-second/revert/create_table.sql
+++ b/__fixtures__/sqitch/simple-w-tags/packages/my-second/revert/create_table.sql
@@ -2,6 +2,6 @@
 
 BEGIN;
 
-DROP TABLE otherschema.mytable;
+DROP TABLE otherschema.users;
 
 COMMIT;

--- a/packages/core/__tests__/projects/forked-deployment-scenarios.test.ts
+++ b/packages/core/__tests__/projects/forked-deployment-scenarios.test.ts
@@ -33,10 +33,10 @@ describe('Forked Deployment with deployModules - my-third', () => {
     expect(tables.rows).toHaveLength(1);
     expect(tables.rows.map((r: any) => r.table_name)).toEqual(['customers']);
     
-    await fixture.revertModule('my-third', db.name, ['sqitch', 'simple-w-tags'], 'create_schema');
+    await fixture.revertModule('my-third', db.name, ['sqitch', 'simple-w-tags'], 'my-first:@v1.0.0');
 
-    expect(await db.exists('schema', 'metaschema')).toBe(true);
-    expect(await db.exists('table', 'metaschema.customers')).toBe(true);
+    expect(await db.exists('schema', 'metaschema')).toBe(false);
+    expect(await db.exists('table', 'metaschema.customers')).toBe(false);
 
   });
 });

--- a/packages/core/test-utils/CoreDeployTestFixture.ts
+++ b/packages/core/test-utils/CoreDeployTestFixture.ts
@@ -35,7 +35,8 @@ export class CoreDeployTestFixture extends TestFixture {
         cwd: basePath,
         recursive: true,
         projectName,
-        fast: true,
+        fast: false,
+        useSqitch: false,
         usePlan: true
       };
 


### PR DESCRIPTION
- Enhanced revert logic in client.ts to support reverting to a specified change
- Added cross-project reference handling for toChange parameters
- Fixed revert SQL files to match actual table names created in deploy
- Updated CoreDeployTestFixture to use proper migration settings
- Uncommented and fixed revertModule call in forked-deployment-scenarios test
- All tests now pass demonstrating working revert-to-change functionality