### PR TITLE
feat: replace recursive option with singleModule

### DIFF
--- a/__fixtures__/kitchen-sink/md.md
+++ b/__fixtures__/kitchen-sink/md.md
@@ -70,7 +70,7 @@ skitch generate table
 Deploy recursively, using all the required modules!
 
 ```sh
-skitch deploy --createdb --recursive
+skitch deploy --createdb --single-module
 ```
 
 ## testing

--- a/extensions/@launchql/base32/readme.md
+++ b/extensions/@launchql/base32/readme.md
@@ -87,5 +87,5 @@ lql generate table --schema myschema --table mytable
 You can also deploy all modules utilizing versioning as sqtich modules. Remove `--createdb` if you already created your db:
 
 ```sh
-lql deploy awesome-db --yes --recursive --createdb
+lql deploy awesome-db --yes --single-module --createdb
 ```

--- a/extensions/@launchql/faker/readme.md
+++ b/extensions/@launchql/faker/readme.md
@@ -434,5 +434,5 @@ lql generate table --schema myschema --table mytable
 You can also deploy all modules utilizing versioning as sqtich modules. Remove `--createdb` if you already created your db:
 
 ```sh
-lql deploy awesome-db --yes --recursive --createdb
+lql deploy awesome-db --yes --single-module --createdb
 ```

--- a/extensions/@launchql/inflection/readme.md
+++ b/extensions/@launchql/inflection/readme.md
@@ -94,5 +94,5 @@ lql generate table --schema myschema --table mytable
 You can also deploy all modules utilizing versioning as sqtich modules. Remove `--createdb` if you already created your db:
 
 ```sh
-lql deploy awesome-db --yes --recursive --createdb
+lql deploy awesome-db --yes --single-module --createdb
 ```

--- a/extensions/@launchql/totp/readme.md
+++ b/extensions/@launchql/totp/readme.md
@@ -156,5 +156,5 @@ lql generate table --schema myschema --table mytable
 You can also deploy all modules utilizing versioning as sqtich modules. Remove `--createdb` if you already created your db:
 
 ```sh
-lql deploy awesome-db --yes --recursive --createdb
+lql deploy awesome-db --yes --single-module --createdb
 ```

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -66,7 +66,7 @@ export default async (
     }
   ];
 
-  let { yes, recursive, createdb, cwd, tx, fast } = await prompter.prompt(argv, questions);
+  let { yes, singleModule, createdb, cwd, tx, fast } = await prompter.prompt(argv, questions);
 
   if (!yes) {
     log.info('Operation cancelled.');
@@ -83,7 +83,7 @@ export default async (
   }
 
   let projectName: string | undefined;
-  if (recursive) {
+  if (singleModule) {
     projectName = await selectModule(argv, prompter, 'Choose a project to deploy', cwd);
     log.info(`Selected project: ${projectName}`);
   }
@@ -106,7 +106,7 @@ export default async (
     opts,
     projectName,
     argv.toChange,
-    recursive
+    singleModule
   );
 
   log.success('Deployment complete.');

--- a/packages/cli/src/commands/revert.ts
+++ b/packages/cli/src/commands/revert.ts
@@ -35,7 +35,7 @@ export default async (
     }
   ];
 
-  let { yes, recursive, cwd, tx } = await prompter.prompt(argv, questions);
+  let { yes, singleModule, cwd, tx } = await prompter.prompt(argv, questions);
 
   if (!yes) {
     log.info('Operation cancelled.');
@@ -45,7 +45,7 @@ export default async (
   log.debug(`Using current directory: ${cwd}`);
 
   let projectName: string | undefined;
-  if (recursive) {
+  if (singleModule) {
     projectName = await selectModule(argv, prompter, 'Choose a project to revert', cwd);
     log.info(`Selected project: ${projectName}`);
   }
@@ -63,7 +63,7 @@ export default async (
     opts,
     projectName,
     argv.toChange,
-    recursive
+    singleModule
   );
 
   log.success('Revert complete.');

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -19,12 +19,12 @@ export default async (
 
   const questions: Question[] = [];
 
-  let { recursive, cwd } = await prompter.prompt(argv, questions);
+  let { singleModule, cwd } = await prompter.prompt(argv, questions);
 
   log.debug(`Using current directory: ${cwd}`);
 
   let projectName: string | undefined;
-  if (recursive) {
+  if (singleModule) {
     projectName = await selectModule(argv, prompter, 'Choose a project to verify', cwd);
     log.info(`Selected project: ${projectName}`);
   }
@@ -39,7 +39,7 @@ export default async (
     opts,
     projectName,
     argv.toChange,
-    recursive
+    singleModule
   );
 
   log.success('Verify complete.');

--- a/packages/core/src/core/class/launchql.ts
+++ b/packages/core/src/core/class/launchql.ts
@@ -662,7 +662,7 @@ export class LaunchQLProject {
     opts: LaunchQLOptions,
     name?: string,
     toChange?: string,
-    recursive: boolean = true
+    singleModule: boolean = false
   ): Promise<void> {
     const log = new Logger('deploy');
 
@@ -670,7 +670,7 @@ export class LaunchQLProject {
       const context = this.getContext();
       if (context === ProjectContext.Module || context === ProjectContext.ModuleInsideWorkspace) {
         name = this.getModuleName();
-        recursive = false;
+        singleModule = true;
       } else if (context === ProjectContext.Workspace) {
         throw new Error('Module name is required when running from workspace root');
       } else {
@@ -678,7 +678,7 @@ export class LaunchQLProject {
       }
     }
 
-    if (recursive) {
+    if (!singleModule) {
       // Cache for fast deployment
       const deployFastCache: Record<string, Awaited<ReturnType<typeof packageModule>>> = {};
 
@@ -821,7 +821,7 @@ export class LaunchQLProject {
     opts: LaunchQLOptions,
     name?: string,
     toChange?: string,
-    recursive: boolean = true
+    singleModule: boolean = false
   ): Promise<void> {
     const log = new Logger('revert');
 
@@ -829,7 +829,7 @@ export class LaunchQLProject {
       const context = this.getContext();
       if (context === ProjectContext.Module || context === ProjectContext.ModuleInsideWorkspace) {
         name = this.getModuleName();
-        recursive = false;
+        singleModule = true;
       } else if (context === ProjectContext.Workspace) {
         throw new Error('Module name is required when running from workspace root');
       } else {
@@ -837,7 +837,7 @@ export class LaunchQLProject {
       }
     }
 
-    if (recursive) {
+    if (!singleModule) {
       log.info(`🔍 Gathering modules from ${this.workspacePath}...`);
       const modules = this.getModuleMap();
 
@@ -928,7 +928,7 @@ export class LaunchQLProject {
     opts: LaunchQLOptions,
     name?: string,
     toChange?: string,
-    recursive: boolean = true
+    singleModule: boolean = false
   ): Promise<void> {
     const log = new Logger('verify');
 
@@ -936,7 +936,7 @@ export class LaunchQLProject {
       const context = this.getContext();
       if (context === ProjectContext.Module || context === ProjectContext.ModuleInsideWorkspace) {
         name = this.getModuleName();
-        recursive = false;
+        singleModule = true;
       } else if (context === ProjectContext.Workspace) {
         throw new Error('Module name is required when running from workspace root');
       } else {
@@ -944,7 +944,7 @@ export class LaunchQLProject {
       }
     }
 
-    if (recursive) {
+    if (!singleModule) {
       log.info(`🔍 Gathering modules from ${this.workspacePath}...`);
       const modules = this.getModuleMap();
 

--- a/packages/core/test-utils/CoreDeployTestFixture.ts
+++ b/packages/core/test-utils/CoreDeployTestFixture.ts
@@ -42,7 +42,7 @@ export class CoreDeployTestFixture extends TestFixture {
         }
       });
 
-      await project.deploy(opts, projectName, undefined, true);
+      await project.deploy(opts, projectName, undefined, false);
     } finally {
       process.chdir(originalCwd);
     }
@@ -62,7 +62,7 @@ export class CoreDeployTestFixture extends TestFixture {
         pg: getPgEnvOptions({ database })
       });
 
-      await project.revert(opts, projectName, toChange, true);
+      await project.revert(opts, projectName, toChange, false);
     } finally {
       process.chdir(originalCwd);
     }

--- a/packages/types/src/launchql.ts
+++ b/packages/types/src/launchql.ts
@@ -116,6 +116,8 @@ export interface LaunchQLOptions {
         cache?: boolean;
         /** Deploy up to a specific change (inclusive) - can be a change name or tag reference (e.g., '@v1.0.0') */
         toChange?: string;
+        /** Deploy only a single module instead of workspace-wide deployment */
+        singleModule?: boolean;
     };
     /** Migration and code generation options */
     migrations?: {
@@ -185,7 +187,8 @@ export const launchqlDefaults: LaunchQLOptions = {
         useTx: true,
         fast: false,
         usePlan: true,
-        cache: false
+        cache: false,
+        singleModule: false
     },
     migrations: {
         codegen: {


### PR DESCRIPTION
# feat: replace recursive option with singleModule

## Summary

This PR replaces the `recursive` parameter with `singleModule` throughout the LaunchQL codebase, inverting the boolean logic to provide more intuitive semantics. The change affects method signatures in the `LaunchQLProject` class, CLI flags, and documentation.

**Key Changes:**
- Added `singleModule?: boolean` to `LaunchQLOptions` interface with default `false`
- Updated `LaunchQLProject` method signatures: `deploy()`, `revert()`, and `verify()` now use `singleModule: boolean = false` instead of `recursive: boolean = true`
- Inverted conditional logic: `if (recursive)` → `if (!singleModule)` for workspace-wide operations
- Updated CLI commands to use `singleModule` parameter instead of `recursive`
- Changed CLI flag from `--recursive` to `--single-module`
- Updated documentation and README files

**Logic Mapping:**
- Old: `recursive=true` (workspace-wide) → New: `singleModule=false` (workspace-wide)
- Old: `recursive=false` (single module) → New: `singleModule=true` (single module)
- Default behavior remains workspace-wide deployment

## Review & Testing Checklist for Human

- [ ] **Verify logic inversion is correct**: Check that `singleModule=false` produces the same behavior as the old `recursive=true` (workspace-wide operations)
- [ ] **Test CLI commands**: Run `lql deploy --single-module` and `lql deploy` (without flag) to ensure both single-module and workspace-wide deployments work correctly
- [ ] **Confirm default behavior**: Verify that running commands without any flags still performs workspace-wide operations (same as before)
- [ ] **Test edge cases**: Verify behavior when running from different contexts (module directory vs workspace root)
- [ ] **Check method signatures**: Ensure all places that call `deploy()`, `revert()`, `verify()` methods are compatible with new signatures

**Recommended Test Plan:**
1. Set up a test workspace with multiple modules
2. Test `lql deploy database --single-module` (should deploy one module)
3. Test `lql deploy database` (should deploy all modules - same as old `--recursive`)
4. Test from both workspace root and module directories
5. Repeat for `revert` and `verify` commands

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Types["packages/types/src/<br/>launchql.ts"]:::major-edit
    Core["packages/core/src/core/class/<br/>launchql.ts"]:::major-edit
    DeployCLI["packages/cli/src/commands/<br/>deploy.ts"]:::major-edit
    RevertCLI["packages/cli/src/commands/<br/>revert.ts"]:::major-edit
    VerifyCLI["packages/cli/src/commands/<br/>verify.ts"]:::major-edit
    Docs["Documentation<br/>README files"]:::minor-edit
    
    Types -->|"defines singleModule type"| Core
    Core -->|"implements logic"| DeployCLI
    Core -->|"implements logic"| RevertCLI
    Core -->|"implements logic"| VerifyCLI
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- This is a **breaking change** with no backward compatibility as requested
- The logic inversion (`recursive` → `singleModule`) is the highest risk area - careful testing is essential
- Build passes successfully, but end-to-end CLI testing is required
- Default behavior should remain unchanged (workspace-wide deployment)

**Link to Devin run**: https://app.devin.ai/sessions/edb50d0bbf2a43dabf4d73133d39702d  
**Requested by**: Dan Lynch (@pyramation)