### PR TITLE
fix: add circular dependency detection to setModuleDependencies

### DIFF
--- a/packages/core/__tests__/core/module-metadata.test.ts
+++ b/packages/core/__tests__/core/module-metadata.test.ts
@@ -27,3 +27,39 @@ it('writes module metadata files without modifying fixture', async () => {
 
   fixture.cleanup();
 });
+
+it('throws error when module depends on itself', async () => {
+  const fixture = new TestFixture('sqitch', 'launchql', 'packages', 'secrets');
+  const dst = fixture.tempFixtureDir;
+  const project = new LaunchQLProject(dst);
+
+  expect(() =>
+    project.setModuleDependencies(['plpgsql', 'secrets', 'uuid-ossp'])
+  ).toThrow('Circular reference detected: module "secrets" cannot depend on itself');
+
+  fixture.cleanup();
+});
+
+it('throws error with specific circular dependency example from issue', async () => {
+  const fixture = new TestFixture('sqitch', 'launchql', 'packages', 'secrets');
+  const dst = fixture.tempFixtureDir;
+  const project = new LaunchQLProject(dst);
+
+  expect(() =>
+    project.setModuleDependencies(['some-native-module', 'secrets'])
+  ).toThrow('Circular reference detected: module "secrets" cannot depend on itself');
+
+  fixture.cleanup();
+});
+
+it('allows valid dependencies without circular references', async () => {
+  const fixture = new TestFixture('sqitch', 'launchql', 'packages', 'secrets');
+  const dst = fixture.tempFixtureDir;
+  const project = new LaunchQLProject(dst);
+
+  expect(() =>
+    project.setModuleDependencies(['plpgsql', 'uuid-ossp', 'other-module'])
+  ).not.toThrow();
+
+  fixture.cleanup();
+});


### PR DESCRIPTION
# fix: add circular dependency detection to setModuleDependencies

## Summary

Fixes the issue where `mod.setModuleDependencies(['some-native-module', 'pg-utilities'])` allows circular references by adding validation before writing module dependencies to extension files.

**Key Changes:**
- Added `validateModuleDependencies()` private method to `LaunchQLProject` class that detects when a module depends on itself
- Modified `setModuleDependencies()` to call validation before `writeExtensions()`
- Added comprehensive test cases covering self-reference scenarios and valid dependency cases
- Throws descriptive error messages following existing error handling patterns

**Scope:** Currently detects direct self-references (module A depending on itself). More complex circular dependency chains (A → B → A) are not yet implemented.

## Review & Testing Checklist for Human

- [ ] **Verify circular dependency detection scope**: Test whether the current implementation catches all relevant circular dependency scenarios in your use case, or if more complex multi-module circular detection is needed
- [ ] **Test with real module dependencies**: Verify the fix works with actual LaunchQL modules that have dependency relationships, not just test fixtures
- [ ] **Confirm backwards compatibility**: Ensure existing valid module setups continue to work without issues after this validation is added
- [ ] **Review error message clarity**: Check that error messages provide sufficient context for users to understand and fix circular dependency issues

**Recommended Test Plan:**
1. Create modules with self-references and verify errors are thrown
2. Test existing valid module dependency chains still work
3. Try edge cases like empty dependency arrays, duplicate dependencies, etc.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Core["packages/core/src/core/class/launchql.ts<br/>LaunchQLProject class"]:::major-edit
    Tests["packages/core/__tests__/core/module-metadata.test.ts<br/>Test cases"]:::major-edit
    Writer["packages/core/src/files/extension/writer.ts<br/>writeExtensions()"]:::context
    Deps["packages/core/src/resolution/deps.ts<br/>Existing circular detection logic"]:::context
    
    Core -->|"calls validation before"| Writer
    Core -->|"references pattern from"| Deps
    Tests -->|"tests"| Core
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#F5F5F5
```

### Notes

- The implementation follows existing error handling patterns from the codebase's dependency resolution logic
- Currently focuses on the most common circular dependency case (self-reference) as mentioned in the TODO item
- All tests pass and build completes successfully without TypeScript compilation issues
- **Session Info**: Link to Devin run: https://app.devin.ai/sessions/e599742374b84d01827b28dac25a8adf | Requested by @pyramation