### PR TITLE
fix: add circular dependency detection to setModuleDependencies

### DIFF
--- a/packages/core/__tests__/core/module-metadata.test.ts
+++ b/packages/core/__tests__/core/module-metadata.test.ts
@@ -27,3 +27,39 @@ it('writes module metadata files without modifying fixture', async () => {
 
   fixture.cleanup();
 });
+
+it('throws error when module depends on itself', async () => {
+  const fixture = new TestFixture('sqitch', 'launchql', 'packages', 'secrets');
+  const dst = fixture.tempFixtureDir;
+  const project = new LaunchQLProject(dst);
+
+  expect(() =>
+    project.setModuleDependencies(['plpgsql', 'secrets', 'uuid-ossp'])
+  ).toThrow('Circular reference detected: module "secrets" cannot depend on itself');
+
+  fixture.cleanup();
+});
+
+it('throws error with specific circular dependency example from issue', async () => {
+  const fixture = new TestFixture('sqitch', 'launchql', 'packages', 'secrets');
+  const dst = fixture.tempFixtureDir;
+  const project = new LaunchQLProject(dst);
+
+  expect(() =>
+    project.setModuleDependencies(['some-native-module', 'secrets'])
+  ).toThrow('Circular reference detected: module "secrets" cannot depend on itself');
+
+  fixture.cleanup();
+});
+
+it('allows valid dependencies without circular references', async () => {
+  const fixture = new TestFixture('sqitch', 'launchql', 'packages', 'secrets');
+  const dst = fixture.tempFixtureDir;
+  const project = new LaunchQLProject(dst);
+
+  expect(() =>
+    project.setModuleDependencies(['plpgsql', 'uuid-ossp', 'other-module'])
+  ).not.toThrow();
+
+  fixture.cleanup();
+});


### PR DESCRIPTION
- Add validateModuleDependencies method to detect self-references
- Throw descriptive error messages for circular dependencies
- Add comprehensive tests for circular dependency scenarios
- Fixes issue where mod.setModuleDependencies allowed circular references