### PR TITLE
Add comprehensive tests for CLI plan command

### DIFF
--- a/packages/cli/__tests__/plan.test.ts
+++ b/packages/cli/__tests__/plan.test.ts
@@ -1,0 +1,185 @@
+import { CLIDeployTestFixture } from '../test-utils';
+import fs from 'fs';
+import path from 'path';
+
+jest.setTimeout(30000);
+
+describe('CLI Plan Command', () => {
+  let fixture: CLIDeployTestFixture;
+
+  afterAll(async () => {
+    if (fixture) {
+      await fixture.cleanup();
+    }
+    const { teardownPgPools } = require('pg-cache');
+    await teardownPgPools();
+  });
+
+  describe('Simple module plan generation', () => {
+    beforeAll(async () => {
+      fixture = new CLIDeployTestFixture('sqitch', 'simple');
+    });
+
+    it('should generate plan for simple module via CLI', async () => {
+      const commands = `
+        cd packages/my-first
+        lql plan
+      `;
+      
+      const results = await fixture.runTerminalCommands(commands, {}, true);
+      
+      expect(results).toHaveLength(2);
+      expect(results[0].type).toBe('cd');
+      expect(results[1].type).toBe('cli');
+      expect(results[1].result.argv._).toEqual(['plan']);
+      
+      const planPath = fixture.fixturePath('packages', 'my-first', 'launchql.plan');
+      expect(fs.existsSync(planPath)).toBe(true);
+      
+      const planContent = fs.readFileSync(planPath, 'utf8');
+      expect(planContent).toContain('%syntax-version=1.0.0');
+      expect(planContent).toContain('%project=my-first');
+      expect(planContent).toContain('%uri=my-first');
+      expect(planContent).toContain('schema_myfirstapp');
+      expect(planContent).toContain('table_users');
+      expect(planContent).toContain('table_products');
+    });
+
+    it('should generate plan with packages option via CLI', async () => {
+      const commands = `
+        cd packages/my-first
+        lql plan --packages
+      `;
+      
+      const results = await fixture.runTerminalCommands(commands, {}, true);
+      
+      expect(results).toHaveLength(2);
+      expect(results[0].type).toBe('cd');
+      expect(results[1].type).toBe('cli');
+      expect(results[1].result.argv.packages).toBe(true);
+      
+      const planPath = fixture.fixturePath('packages', 'my-first', 'launchql.plan');
+      const planContent = fs.readFileSync(planPath, 'utf8');
+      expect(planContent).toContain('%project=my-first');
+    });
+
+    it('should show help when --help flag is used', async () => {
+      const commands = `
+        cd packages/my-first
+        lql plan --help
+      `;
+      
+      const results = await fixture.runTerminalCommands(commands, {}, true);
+      
+      expect(results).toHaveLength(2);
+      expect(results[0].type).toBe('cd');
+      expect(results[1].type).toBe('cli');
+      expect(results[1].result.argv.help).toBe(true);
+    });
+  });
+
+  describe('Complex module plan generation', () => {
+    beforeAll(async () => {
+      fixture = new CLIDeployTestFixture('sqitch', 'launchql');
+    });
+
+    it('should generate plan for module with dependencies', async () => {
+      const commands = `
+        cd packages/secrets
+        lql plan --packages
+      `;
+      
+      const results = await fixture.runTerminalCommands(commands, {}, true);
+      
+      expect(results).toHaveLength(2);
+      expect(results[0].type).toBe('cd');
+      expect(results[1].type).toBe('cli');
+      
+      const planPath = fixture.fixturePath('packages', 'secrets', 'launchql.plan');
+      expect(fs.existsSync(planPath)).toBe(true);
+      
+      const planContent = fs.readFileSync(planPath, 'utf8');
+      expect(planContent).toContain('%project=secrets');
+      expect(planContent).toContain('procedures/secretfunction');
+      expect(planContent).toMatch(/\[.*totp:.*\]/);
+    });
+
+    it('should generate plan without dependencies when packages=false', async () => {
+      const commands = `
+        cd packages/secrets
+        lql plan
+      `;
+      
+      await fixture.runTerminalCommands(commands, {}, true);
+      
+      const planPath = fixture.fixturePath('packages', 'secrets', 'launchql.plan');
+      const planContent = fs.readFileSync(planPath, 'utf8');
+      expect(planContent).toContain('%project=secrets');
+      expect(planContent).toContain('procedures/secretfunction');
+      expect(planContent).not.toMatch(/\[.*totp:.*\]/);
+    });
+
+    it('should generate plan for utils module with dependencies', async () => {
+      const commands = `
+        cd packages/utils
+        lql plan --packages
+      `;
+      
+      await fixture.runTerminalCommands(commands, {}, true);
+      
+      const planPath = fixture.fixturePath('packages', 'utils', 'launchql.plan');
+      const planContent = fs.readFileSync(planPath, 'utf8');
+      expect(planContent).toContain('%project=utils');
+      expect(planContent).toContain('procedures/myfunction');
+      expect(planContent).toMatch(/\[.*totp:.*\]/);
+    });
+  });
+
+  describe('Tagged module plan generation', () => {
+    beforeAll(async () => {
+      fixture = new CLIDeployTestFixture('sqitch', 'simple-w-tags');
+    });
+
+    it('should generate plan preserving existing tags', async () => {
+      const commands = `
+        cd packages/my-first
+        lql plan --packages
+      `;
+      
+      await fixture.runTerminalCommands(commands, {}, true);
+      
+      const planPath = fixture.fixturePath('packages', 'my-first', 'launchql.plan');
+      const planContent = fs.readFileSync(planPath, 'utf8');
+      expect(planContent).toContain('%project=my-first');
+      expect(planContent).toContain('@v1.0.0');
+      expect(planContent).toContain('First stable release');
+    });
+  });
+
+  describe('Error cases', () => {
+    beforeAll(async () => {
+      fixture = new CLIDeployTestFixture('sqitch', 'simple');
+    });
+
+    it('should fail when not in a module directory', async () => {
+      const commands = `lql plan`;
+      
+      await expect(
+        fixture.runTerminalCommands(commands, {}, true)
+      ).rejects.toThrow(/must be run inside a LaunchQL module/);
+    });
+
+    it('should handle custom working directory', async () => {
+      const commands = `lql plan --cwd packages/my-first`;
+      
+      const results = await fixture.runTerminalCommands(commands, {}, true);
+      
+      expect(results).toHaveLength(1);
+      expect(results[0].type).toBe('cli');
+      expect(results[0].result.argv.cwd).toBe('packages/my-first');
+      
+      const planPath = fixture.fixturePath('packages', 'my-first', 'launchql.plan');
+      expect(fs.existsSync(planPath)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
# Add comprehensive tests for CLI plan command

## Summary

This PR adds dedicated tests for the `lql plan` CLI command workflow, which was previously untested at the CLI level. While the underlying `generateModulePlan()` and `writeModulePlan()` methods are well-tested in the core package, there were no tests verifying that the CLI command itself works correctly with various module structures and command-line arguments.

**Key Changes:**
- **New test file**: `packages/cli/__tests__/plan.test.ts` with comprehensive CLI plan command coverage
- **Test scenarios**: Simple modules, modules with dependencies, tagged modules, error cases, and CLI argument parsing
- **Test framework**: Uses existing `CLIDeployTestFixture` pattern following `deploy.test.ts` structure

## Review & Testing Checklist for Human

- [ ] **Verify test command execution approach**: I changed from chained commands (`cd packages/my-first && lql plan`) to separate commands due to `CLIDeployTestFixture` parsing limitations. Confirm this is the correct approach rather than fixing the command parser.
- [ ] **Validate test expectations match actual behavior**: Check that plan content assertions (dependencies, project names, file structure) align with what the `lql plan` command actually generates for the test fixtures.
- [ ] **Test isolation and cleanup**: Ensure tests don't interfere with each other when modifying plan files in shared fixtures, especially when run in parallel.
- [ ] **Manual verification**: Run `lql plan` manually in one of the test fixture directories to confirm the generated plan matches test expectations.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    TestFile["packages/cli/__tests__/<br/>plan.test.ts"]:::major-edit
    CLICmd["packages/cli/src/commands/<br/>plan.ts"]:::context
    TestFixture["packages/cli/test-utils/<br/>CLIDeployTestFixture.ts"]:::context
    CorePlan["packages/core/src/core/class/<br/>launchql.ts<br/>(writeModulePlan)"]:::context
    
    SimpleFixture["__fixtures__/sqitch/simple/<br/>packages/my-first/"]:::context
    ComplexFixture["__fixtures__/sqitch/launchql/<br/>packages/secrets/"]:::context
    TaggedFixture["__fixtures__/sqitch/simple-w-tags/<br/>packages/my-first/"]:::context
    
    TestFile --> TestFixture
    TestFixture --> CLICmd
    CLICmd --> CorePlan
    TestFile --> SimpleFixture
    TestFile --> ComplexFixture  
    TestFile --> TaggedFixture
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90,stroke:#000,stroke-width:2px
    classDef minor-edit fill:#87CEEB,stroke:#000,stroke-width:2px
    classDef context fill:#FFFFFF,stroke:#000,stroke-width:1px
```

### Notes

**Test Framework Decision**: I used the existing `CLIDeployTestFixture` pattern from `deploy.test.ts` rather than creating a simpler test setup, which provides database functionality but may be overkill for plan generation tests that primarily work with files.

**Command Parsing Issue**: The `runTerminalCommands` method in `CLIDeployTestFixture` splits on `\n|;` but doesn't handle `&&` properly, so I used separate command lines instead of shell command chaining. This may indicate a broader limitation in the test utility.

**Risk Assessment**: Medium risk due to reliance on test fixtures and assumptions about CLI behavior. The core plan generation logic is already well-tested, but the CLI wrapper and command parsing could have edge cases.

---

**Link to Devin run**: https://app.devin.ai/sessions/f0c7502ad87f433cb9304beceac00aaa    
**Requested by**: Dan Lynch (@pyramation)