### PR TITLE
feat: expand error system with templated error types

### DIFF
--- a/packages/cli/__tests__/tags.test.ts
+++ b/packages/cli/__tests__/tags.test.ts
@@ -96,7 +96,7 @@ describe('CLI Tag Command', () => {
       await exec(`lql tag v1.6.0 --package my-first --changeName nonexistent_change --yes`);
       fail('Expected non-existent change to throw error');
     } catch (error) {
-      expect((error as Error).message).toContain('not found in plan file');
+      expect((error as Error).message).toContain('not found in plan');
     }
   });
 });

--- a/packages/cli/src/commands/clear.ts
+++ b/packages/cli/src/commands/clear.ts
@@ -4,6 +4,7 @@ import { getEnvOptions } from '@launchql/env';
 import { CLIOptions, Inquirerer, Question } from 'inquirerer';
 import { getPgEnvOptions } from 'pg-env';
 import { parsePlanFile } from '@launchql/core';
+import { errors } from '@launchql/types';
 import path from 'path';
 
 import { getTargetDatabase } from '../utils';
@@ -53,7 +54,7 @@ export default async (
   const result = parsePlanFile(planPath);
   
   if (result.errors.length > 0) {
-    throw new Error(`Failed to parse plan file: ${result.errors.map(e => e.message).join(', ')}`);
+    throw errors.PLAN_PARSE_ERROR({ planPath, errors: result.errors.map(e => e.message).join(', ') });
   }
   
   const plan = result.data!;

--- a/packages/cli/src/commands/tag.ts
+++ b/packages/cli/src/commands/tag.ts
@@ -1,5 +1,6 @@
 import { LaunchQLPackage } from '@launchql/core';
 import { Logger } from '@launchql/logger';
+import { errors } from '@launchql/types';
 import { CLIOptions, Inquirerer, Question } from 'inquirerer';
 import { extractFirst } from '../utils/argv';
 import { selectPackage } from '../utils/module-utils';
@@ -123,7 +124,7 @@ export default async (
       const moduleMap = pkg.getModuleMap();
       const module = moduleMap[packageName];
       if (!module) {
-        throw new Error(`Module '${packageName}' not found.`);
+        throw errors.MODULE_NOT_FOUND({ name: packageName });
       }
       
       const workspacePath = pkg.getWorkspacePath()!;

--- a/packages/core/__tests__/core/module-metadata.test.ts
+++ b/packages/core/__tests__/core/module-metadata.test.ts
@@ -35,7 +35,7 @@ it('throws error when module depends on itself', async () => {
 
   expect(() =>
     project.setModuleDependencies(['plpgsql', 'secrets', 'uuid-ossp'])
-  ).toThrow('Circular reference detected: module "secrets" cannot depend on itself');
+  ).toThrow('Circular reference detected: secrets → secrets');
 
   fixture.cleanup();
 });
@@ -47,7 +47,7 @@ it('throws error with specific circular dependency example from issue', async ()
 
   expect(() =>
     project.setModuleDependencies(['some-native-module', 'secrets'])
-  ).toThrow('Circular reference detected: module "secrets" cannot depend on itself');
+  ).toThrow('Circular reference detected: secrets → secrets');
 
   fixture.cleanup();
 });

--- a/packages/core/__tests__/core/target-api.test.ts
+++ b/packages/core/__tests__/core/target-api.test.ts
@@ -43,19 +43,19 @@ describe('LaunchQLPackage Target API', () => {
     });
 
     test('throws error for invalid tag format', () => {
-      expect(() => parseTarget('secrets:@')).toThrow('Invalid tag format: secrets:@. Expected format: package:@tagName');
+      expect(() => parseTarget('secrets:@')).toThrow('Invalid tag name: secrets:@. Expected format: package:@tagName');
     });
 
     test('throws error for invalid change format', () => {
-      expect(() => parseTarget('secrets:')).toThrow('Invalid change format: secrets:. Expected format: package:changeName');
+      expect(() => parseTarget('secrets:')).toThrow('Invalid change name: secrets:. Expected format: package:changeName');
     });
 
     test('throws error for invalid format with multiple colons', () => {
-      expect(() => parseTarget('secrets:change:extra')).toThrow('Invalid target format: secrets:change:extra. Expected formats: package, package:changeName, or package:@tagName');
+      expect(() => parseTarget('secrets:change:extra')).toThrow('Invalid change name: secrets:change:extra. Expected formats: package, package:changeName, or package:@tagName');
     });
 
     test('throws error for multi-colon tag format', () => {
-      expect(() => parseTarget('my-third:my-first:@v1.0.0')).toThrow('Invalid target format: my-third:my-first:@v1.0.0. Expected formats: package, package:changeName, or package:@tagName');
+      expect(() => parseTarget('my-third:my-first:@v1.0.0')).toThrow('Invalid change name: my-third:my-first:@v1.0.0. Expected formats: package, package:changeName, or package:@tagName');
     });
   });
 

--- a/packages/core/__tests__/projects/deploy-failure-scenarios.test.ts
+++ b/packages/core/__tests__/projects/deploy-failure-scenarios.test.ts
@@ -315,7 +315,7 @@ describe('Deploy Failure Scenarios', () => {
     
     await expect(client.verify({
       modulePath: tempDir
-    })).rejects.toThrow('Verification failed for 1 change(s): create_simple_table');
+    })).rejects.toThrow('Verification failed: 1 change(s): create_simple_table');
     
     const finalState = await db.getMigrationState();
     

--- a/packages/core/__tests__/resolution/sql-script-resolution.test.ts
+++ b/packages/core/__tests__/resolution/sql-script-resolution.test.ts
@@ -39,7 +39,7 @@ describe('resolve tests', () => {
       await resolve(baseFixture.getFixturePath('error-case'));
     } catch (e: unknown) {
       if (e instanceof Error) {
-        expect(e.message).toBe('Internal module not found: schemas/myschema/somethingdoesntexist');
+        expect(e.message).toBe('Module "schemas/myschema/somethingdoesntexist" not found in modules list.');
         failed = true;
       } else {
         throw new Error('Caught an unexpected non-error exception');
@@ -57,7 +57,7 @@ describe('resolve tests', () => {
     } catch (e: unknown) {
       if (e instanceof Error) {
         expect(e.message).toBe(
-          'Circular reference detected schemas/myschema/tables/sometable/table, schemas/myschema/schema'
+          'Circular reference detected: schemas/myschema/tables/sometable/table → schemas/myschema/schema'
         );
         failed = true;
       } else {

--- a/packages/core/src/core/class/launchql.ts
+++ b/packages/core/src/core/class/launchql.ts
@@ -261,7 +261,7 @@ export class LaunchQLPackage {
     
     const modules = this.getModuleMap();
     if (!modules[name]) {
-      throw new Error(`Module "${name}" does not exist.`);
+      throw errors.MODULE_NOT_FOUND({ name });
     }
     
     const modulePath = path.resolve(this.workspacePath!, modules[name].path);
@@ -302,7 +302,7 @@ export class LaunchQLPackage {
     const currentModuleName = this.getModuleName();
     
     if (modules.includes(currentModuleName)) {
-      throw new Error(`Circular reference detected: module "${currentModuleName}" cannot depend on itself`);
+      throw errors.CIRCULAR_DEPENDENCY({ module: currentModuleName, dependency: currentModuleName });
     }
     
     // Check for circular dependencies by examining each module's dependencies
@@ -311,7 +311,7 @@ export class LaunchQLPackage {
     
     const checkCircular = (moduleName: string, path: string[] = []): void => {
       if (visiting.has(moduleName)) {
-        throw new Error(`Circular reference detected: ${path.join(' -> ')} -> ${moduleName}`);
+        throw errors.CIRCULAR_DEPENDENCY({ module: path.join(' -> '), dependency: moduleName });
       }
       if (visited.has(moduleName)) {
         return;
@@ -583,12 +583,12 @@ export class LaunchQLPackage {
     this.ensureModule();
     
     if (!this.modulePath) {
-      throw new Error('Module path not found');
+      throw errors.PATH_NOT_FOUND({ path: 'module path', type: 'module' });
     }
     
     // Validate tag name
     if (!isValidTagName(tagName)) {
-      throw new Error(`Invalid tag name: ${tagName}. Tag names must follow Sqitch naming rules and cannot contain '/'.`);
+      throw errors.INVALID_NAME({ name: tagName, type: 'tag', rules: "Tag names must follow Sqitch naming rules and cannot contain '/'" });
     }
     
     const planPath = path.join(this.modulePath, 'launchql.plan');
@@ -596,7 +596,7 @@ export class LaunchQLPackage {
     // Parse existing plan file
     const planResult = parsePlanFile(planPath);
     if (!planResult.data) {
-      throw new Error(`Could not parse plan file: ${planPath}`);
+      throw errors.PLAN_PARSE_ERROR({ planPath, errors: planResult.errors.map(e => e.message).join(', ') });
     }
     
     const plan = planResult.data;
@@ -611,7 +611,7 @@ export class LaunchQLPackage {
       // Validate that the specified change exists
       const changeExists = plan.changes.some(c => c.name === targetChange);
       if (!changeExists) {
-        throw new Error(`Change '${targetChange}' not found in plan file.`);
+        throw errors.CHANGE_NOT_FOUND({ change: targetChange });
       }
     }
     
@@ -931,7 +931,7 @@ export class LaunchQLPackage {
                 });
               
                 if (result.failed) {
-                  throw new Error(`Deployment failed at change: ${result.failed}`);
+                  throw errors.OPERATION_FAILED({ operation: 'Deployment', target: result.failed });
                 }
               } catch (deployError) {
                 log.error(`❌ Deployment failed for module ${extension}`);
@@ -950,12 +950,12 @@ export class LaunchQLPackage {
       log.success(`✅ Deployment complete for ${targetDescription}.`);
     } else {
       if (name === null) {
-        throw new Error('Cannot perform non-recursive operation on workspace. Use recursive=true or specify a target module.');
+        throw errors.WORKSPACE_OPERATION_ERROR({ operation: 'deployment' });
       }
       const moduleProject = this.getModuleProject(name);
       const modulePath = moduleProject.getModulePath();
       if (!modulePath) {
-        throw new Error(`Could not resolve module path for ${name}`);
+        throw errors.PATH_NOT_FOUND({ path: name, type: 'module' });
       }
 
       const client = new LaunchQLMigrate(opts.pg as PgConfig);
@@ -968,7 +968,7 @@ export class LaunchQLPackage {
       });
 
       if (result.failed) {
-        throw new Error(`Deployment failed at change: ${result.failed}`);
+        throw errors.OPERATION_FAILED({ operation: 'Deployment', target: result.failed });
       }
 
       log.success(`✅ Single module deployment complete for ${name}.`);
@@ -1042,7 +1042,7 @@ export class LaunchQLPackage {
               });
             
               if (result.failed) {
-                throw new Error(`Revert failed at change: ${result.failed}`);
+                throw errors.OPERATION_FAILED({ operation: 'Revert', target: result.failed });
               }
             } catch (revertError) {
               log.error(`❌ Revert failed for module ${extension}`);
@@ -1059,12 +1059,12 @@ export class LaunchQLPackage {
       log.success(`✅ Revert complete for ${targetDescription}.`);
     } else {
       if (name === null) {
-        throw new Error('Cannot perform non-recursive operation on workspace. Use recursive=true or specify a target module.');
+        throw errors.WORKSPACE_OPERATION_ERROR({ operation: 'revert' });
       }
       const moduleProject = this.getModuleProject(name);
       const modulePath = moduleProject.getModulePath();
       if (!modulePath) {
-        throw new Error(`Could not resolve module path for ${name}`);
+        throw errors.PATH_NOT_FOUND({ path: name, type: 'module' });
       }
 
       const client = new LaunchQLMigrate(opts.pg as PgConfig);
@@ -1075,7 +1075,7 @@ export class LaunchQLPackage {
       });
 
       if (result.failed) {
-        throw new Error(`Revert failed at change: ${result.failed}`);
+        throw errors.OPERATION_FAILED({ operation: 'Revert', target: result.failed });
       }
 
       log.success(`✅ Single module revert complete for ${name}.`);
@@ -1130,7 +1130,7 @@ export class LaunchQLPackage {
               });
             
               if (result.failed.length > 0) {
-                throw new Error(`Verification failed for ${result.failed.length} changes: ${result.failed.join(', ')}`);
+                throw errors.OPERATION_FAILED({ operation: 'Verification', reason: `${result.failed.length} changes: ${result.failed.join(', ')}` });
               }
             } catch (verifyError) {
               log.error(`❌ Verification failed for module ${extension}`);
@@ -1147,12 +1147,12 @@ export class LaunchQLPackage {
       log.success(`✅ Verification complete for ${targetDescription}.`);
     } else {
       if (name === null) {
-        throw new Error('Cannot perform non-recursive operation on workspace. Use recursive=true or specify a target module.');
+        throw errors.WORKSPACE_OPERATION_ERROR({ operation: 'verification' });
       }
       const moduleProject = this.getModuleProject(name);
       const modulePath = moduleProject.getModulePath();
       if (!modulePath) {
-        throw new Error(`Could not resolve module path for ${name}`);
+        throw errors.PATH_NOT_FOUND({ path: name, type: 'module' });
       }
 
       const client = new LaunchQLMigrate(opts.pg as PgConfig);
@@ -1162,7 +1162,7 @@ export class LaunchQLPackage {
       });
 
       if (result.failed.length > 0) {
-        throw new Error(`Verification failed for ${result.failed.length} changes: ${result.failed.join(', ')}`);
+        throw errors.OPERATION_FAILED({ operation: 'Verification', reason: `${result.failed.length} changes: ${result.failed.join(', ')}` });
       }
 
       log.success(`✅ Single module verification complete for ${name}.`);
@@ -1173,14 +1173,14 @@ export class LaunchQLPackage {
     const log = new Logger('remove');
     const modulePath = this.getModulePath();
     if (!modulePath) {
-      throw new Error('Could not resolve module path');
+      throw errors.PATH_NOT_FOUND({ path: 'module path', type: 'module' });
     }
     
     const planPath = path.join(modulePath, 'launchql.plan');
     const result = parsePlanFile(planPath);
     
     if (result.errors.length > 0) {
-      throw new Error(`Failed to parse plan file: ${result.errors.map(e => e.message).join(', ')}`);
+      throw errors.PLAN_PARSE_ERROR({ planPath, errors: result.errors.map(e => e.message).join(', ') });
     }
     
     const plan = result.data!;
@@ -1189,12 +1189,12 @@ export class LaunchQLPackage {
       const tagName = toChange.substring(1); // Remove the '@' prefix
       const tagToRemove = plan.tags.find(tag => tag.name === tagName);
       if (!tagToRemove) {
-        throw new Error(`Tag '${toChange}' not found in plan`);
+        throw errors.TAG_NOT_FOUND({ tag: toChange });
       }
       
       const tagChangeIndex = plan.changes.findIndex(c => c.name === tagToRemove.change);
       if (tagChangeIndex === -1) {
-        throw new Error(`Associated change '${tagToRemove.change}' not found for tag '${toChange}'`);
+        throw errors.CHANGE_NOT_FOUND({ change: tagToRemove.change, plan: `for tag '${toChange}'` });
       }
       
       const changesToRemove = plan.changes.slice(tagChangeIndex);
@@ -1222,7 +1222,7 @@ export class LaunchQLPackage {
 
     const targetIndex = plan.changes.findIndex(c => c.name === toChange);
     if (targetIndex === -1) {
-      throw new Error(`Change '${toChange}' not found in plan`);
+      throw errors.CHANGE_NOT_FOUND({ change: toChange });
     }
 
     const changesToRemove = plan.changes.slice(targetIndex);

--- a/packages/core/src/files/plan/parser.ts
+++ b/packages/core/src/files/plan/parser.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'fs';
 
 import { Change, ExtendedPlanFile, ParseError, ParseResult,PlanFile, Tag } from '../types';
 import { isValidChangeName, isValidDependency, isValidTagName, parseReference } from './validators';
+import { errors } from '@launchql/types';
 
 /**
  * Parse a Sqitch plan file with full validation
@@ -324,7 +325,7 @@ export function parsePlanFileSimple(planPath: string): PlanFile {
   // If there are errors, throw with details
   if (result.errors && result.errors.length > 0) {
     const errorMessages = result.errors.map(e => `Line ${e.line}: ${e.message}`).join('\n');
-    throw new Error(`Failed to parse plan file ${planPath}:\n${errorMessages}`);
+    throw errors.PLAN_PARSE_ERROR({ planPath, errors: errorMessages });
   }
   
   // Return empty plan if no data and no errors

--- a/packages/core/src/migrate/client.ts
+++ b/packages/core/src/migrate/client.ts
@@ -4,6 +4,7 @@ import { dirname,join } from 'path';
 import { Pool } from 'pg';
 import { getPgPool } from 'pg-cache';
 import { PgConfig } from 'pg-env';
+import { errors } from '@launchql/types';
 
 import { LaunchQLPackage } from '../core/class/launchql';
 import { Change, parsePlanFile, parsePlanFileSimple, readScript } from '../files';
@@ -413,7 +414,7 @@ export class LaunchQLMigrate {
     }
     
     if (failed.length > 0) {
-      throw new Error(`Verification failed for ${failed.length} change(s): ${failed.join(', ')}`);
+      throw errors.OPERATION_FAILED({ operation: 'Verification', reason: `${failed.length} change(s): ${failed.join(', ')}` });
     }
     
     return { verified, failed };

--- a/packages/core/src/modules/modules.ts
+++ b/packages/core/src/modules/modules.ts
@@ -2,6 +2,7 @@ import { sync as glob } from 'glob';
 import { basename } from 'path';
 
 import { getLatestChange, Module,parseControlFile } from '../files';
+import { errors } from '@launchql/types';
 
 export type ModuleMap = Record<string, Module>;
 
@@ -30,7 +31,7 @@ export const latestChange = (
 ): string => {
   const module = modules[sqlmodule];
   if (!module) {
-    throw new Error(`latestChange() ${sqlmodule} NOT FOUND!`);
+    throw errors.MODULE_NOT_FOUND({ name: sqlmodule });
   }
 
   const planPath = `${basePath}/${module.path}/launchql.plan`;
@@ -47,7 +48,7 @@ export const latestChangeAndVersion = (
 ): { change: string; version: string } => {
   const module = modules[sqlmodule];
   if (!module) {
-    throw new Error(`latestChangeAndVersion() ${sqlmodule} NOT FOUND!`);
+    throw errors.MODULE_NOT_FOUND({ name: sqlmodule });
   }
 
   const planPath = `${basePath}/${module.path}/launchql.plan`;
@@ -66,7 +67,7 @@ export const getExtensionsAndModules = (
 ): { native: string[]; sqitch: string[] } => {
   const module = modules[sqlmodule];
   if (!module) {
-    throw new Error(`getExtensionsAndModules() ${sqlmodule} NOT FOUND!`);
+    throw errors.MODULE_NOT_FOUND({ name: sqlmodule });
   }
 
   const native = module.requires.filter(

--- a/packages/core/src/projects/deploy.ts
+++ b/packages/core/src/projects/deploy.ts
@@ -42,7 +42,7 @@ export const deployProject = async (
 
   if (!modules[name]) {
     log.error(`❌ Module "${name}" not found in modules list.`);
-    throw new Error(`Module "${name}" does not exist.`);
+    throw errors.MODULE_NOT_FOUND({ name });
   }
 
   const modulePath = path.resolve(pkg.workspacePath!, modules[name].path);
@@ -135,7 +135,7 @@ export const deployProject = async (
             });
             
             if (result.failed) {
-              throw new Error(`Deployment failed at change: ${result.failed}`);
+              throw errors.OPERATION_FAILED({ operation: 'Deployment', target: result.failed });
             }
           } catch (deployError) {
             log.error(`❌ Deployment failed for module ${extension}`);

--- a/packages/core/src/projects/revert.ts
+++ b/packages/core/src/projects/revert.ts
@@ -34,7 +34,7 @@ export const revertProject = async (
 
   if (!modules[name]) {
     log.error(`❌ Module "${name}" not found in modules list.`);
-    throw new Error(`Module "${name}" does not exist.`);
+    throw errors.MODULE_NOT_FOUND({ name });
   }
 
   const modulePath = path.resolve(pkg.workspacePath!, modules[name].path);
@@ -85,7 +85,7 @@ export const revertProject = async (
           });
           
           if (result.failed) {
-            throw new Error(`Revert failed at change: ${result.failed}`);
+            throw errors.OPERATION_FAILED({ operation: 'Revert', target: result.failed });
           }
         } catch (revertError) {
           log.error(`❌ Revert failed for module ${extension}`);

--- a/packages/core/src/projects/verify.ts
+++ b/packages/core/src/projects/verify.ts
@@ -28,7 +28,7 @@ export const verifyProject = async (
 
   if (!modules[name]) {
     log.error(`❌ Module "${name}" not found in modules list.`);
-    throw new Error(`Module "${name}" does not exist.`);
+    throw errors.MODULE_NOT_FOUND({ name });
   }
 
   const modulePath = path.resolve(pkg.workspacePath!, modules[name].path);
@@ -65,7 +65,7 @@ export const verifyProject = async (
           });
           
           if (result.failed.length > 0) {
-            throw new Error(`Verification failed for ${result.failed.length} changes: ${result.failed.join(', ')}`);
+            throw errors.OPERATION_FAILED({ operation: 'Verification', reason: `${result.failed.length} changes: ${result.failed.join(', ')}` });
           }
         } catch (verifyError) {
           log.error(`❌ Verification failed for module ${extension}`);

--- a/packages/core/src/utils/target-utils.ts
+++ b/packages/core/src/utils/target-utils.ts
@@ -1,3 +1,5 @@
+import { errors } from '@launchql/types';
+
 export interface ParsedTarget {
   packageName: string;
   toChange?: string;
@@ -14,31 +16,31 @@ export function parseTarget(target: string): ParsedTarget {
     const afterAt = target.substring(atIndex + 2);
     
     if (!afterAt) {
-      throw new Error(`Invalid tag format: ${target}. Expected format: package:@tagName`);
+      throw errors.INVALID_NAME({ name: target, type: 'tag', rules: 'Expected format: package:@tagName' });
     }
     
     // Check if this is a simple package:@tag format
     if (!beforeAt.includes(':')) {
       if (!beforeAt) {
-        throw new Error(`Invalid tag format: ${target}. Expected format: package:@tagName`);
+        throw errors.INVALID_NAME({ name: target, type: 'tag', rules: 'Expected format: package:@tagName' });
       }
       return { packageName: beforeAt, toChange: `@${afterAt}` };
     }
     
-    throw new Error(`Invalid target format: ${target}. Expected formats: package, package:changeName, or package:@tagName`);
+    throw errors.INVALID_NAME({ name: target, type: 'change', rules: 'Expected formats: package, package:changeName, or package:@tagName' });
   }
   
   if (target.includes(':') && !target.includes('@')) {
     const parts = target.split(':');
     
     if (parts.length > 2) {
-      throw new Error(`Invalid target format: ${target}. Expected formats: package, package:changeName, or package:@tagName`);
+      throw errors.INVALID_NAME({ name: target, type: 'change', rules: 'Expected formats: package, package:changeName, or package:@tagName' });
     }
     
     const [packageName, changeName] = parts;
     
     if (!packageName || !changeName) {
-      throw new Error(`Invalid change format: ${target}. Expected format: package:changeName`);
+      throw errors.INVALID_NAME({ name: target, type: 'change', rules: 'Expected format: package:changeName' });
     }
     
     return { packageName, toChange: changeName };
@@ -48,5 +50,5 @@ export function parseTarget(target: string): ParsedTarget {
     return { packageName: target, toChange: undefined };
   }
 
-  throw new Error(`Invalid target format: ${target}. Expected formats: package, package:changeName, or package:@tagName`);
+  throw errors.INVALID_NAME({ name: target, type: 'change', rules: 'Expected formats: package, package:changeName, or package:@tagName' });
 }

--- a/packages/core/src/workspace/utils.ts
+++ b/packages/core/src/workspace/utils.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'fs';
 import { dirname, resolve } from 'path';
+import { errors } from '@launchql/types';
 
 /**
  * Recursively walks up directories to find a specific file (sync version).
@@ -23,7 +24,7 @@ export const walkUp = (startDir: string, filename: string): string => {
     currentDir = parentDir;
   }
 
-  throw new Error(`File "${filename}" not found in any parent directories.`);
+  throw errors.FILE_NOT_FOUND({ filePath: filename, type: 'configuration' });
 };
 
 export const sluggify = (text: string): string => {

--- a/packages/types/src/error-factory.ts
+++ b/packages/types/src/error-factory.ts
@@ -25,7 +25,7 @@ export const errors = {
 
   MODULE_NOT_FOUND: makeError(
     'MODULE_NOT_FOUND',
-    ({ name }) => `Module "${name}" not found.`,
+    ({ name }: { name: string }) => `Module "${name}" not found in modules list.`,
     404
   ),
 
@@ -81,6 +81,69 @@ export const errors = {
     'UNKNOWN_COMMAND',
     ({ cmd }) => `Unknown command: ${cmd}`,
     400
+  ),
+
+  CHANGE_NOT_FOUND: makeError(
+    'CHANGE_NOT_FOUND',
+    ({ change, plan }: { change: string, plan?: string }) => 
+      `Change '${change}' not found in plan${plan ? ` file: ${plan}` : ''}`,
+    404
+  ),
+
+  TAG_NOT_FOUND: makeError(
+    'TAG_NOT_FOUND',
+    ({ tag, project }: { tag: string, project?: string }) => 
+      `Tag '${tag}' not found${project ? ` in project ${project}` : ' in plan'}`,
+    404
+  ),
+
+  PATH_NOT_FOUND: makeError(
+    'PATH_NOT_FOUND',
+    ({ path, type }: { path: string, type: 'module' | 'workspace' | 'file' }) => 
+      `${type} path not found: ${path}`,
+    404
+  ),
+
+  OPERATION_FAILED: makeError(
+    'OPERATION_FAILED',
+    ({ operation, target, reason }: { operation: string, target?: string, reason?: string }) => 
+      `${operation} failed${target ? ` for ${target}` : ''}${reason ? `: ${reason}` : ''}`,
+    500
+  ),
+
+  PLAN_PARSE_ERROR: makeError(
+    'PLAN_PARSE_ERROR',
+    ({ planPath, errors }: { planPath: string, errors: string }) => 
+      `Failed to parse plan file ${planPath}: ${errors}`,
+    400
+  ),
+
+  CIRCULAR_DEPENDENCY: makeError(
+    'CIRCULAR_DEPENDENCY',
+    ({ module, dependency }: { module: string, dependency: string }) => 
+      `Circular reference detected: ${module} → ${dependency}`,
+    400
+  ),
+
+  INVALID_NAME: makeError(
+    'INVALID_NAME',
+    ({ name, type, rules }: { name: string, type: 'tag' | 'change' | 'module', rules?: string }) => 
+      `Invalid ${type} name: ${name}${rules ? `. ${rules}` : ''}`,
+    400
+  ),
+
+  WORKSPACE_OPERATION_ERROR: makeError(
+    'WORKSPACE_OPERATION_ERROR',
+    ({ operation }: { operation: string }) => 
+      `Cannot perform non-recursive ${operation} on workspace. Use recursive=true or specify a target module.`,
+    400
+  ),
+
+  FILE_NOT_FOUND: makeError(
+    'FILE_NOT_FOUND',
+    ({ filePath, type }: { filePath: string, type?: string }) => 
+      `${type ? `${type} file` : 'File'} not found: ${filePath}`,
+    404
   ),
 };
 


### PR DESCRIPTION
# feat: expand error system with templated error types

## Summary

This PR addresses the inconsistent error handling across the LaunchQL codebase by expanding the existing templated error system. Previously, the codebase mixed structured templated errors (like `errors.DEPLOYMENT_FAILED()`) with plain `Error` objects, undermining the benefits of the structured approach.

**Key Changes:**
- **Added 10 new templated error types** to `error-factory.ts` covering common patterns:
  - Resource errors: `MODULE_NOT_FOUND`, `CHANGE_NOT_FOUND`, `TAG_NOT_FOUND`, `PATH_NOT_FOUND`, `FILE_NOT_FOUND`
  - Operation errors: `OPERATION_FAILED`, `PLAN_PARSE_ERROR`, `CIRCULAR_DEPENDENCY` 
  - Validation errors: `INVALID_NAME`, `WORKSPACE_OPERATION_ERROR`

- **Converted 50+ plain Error usages** to structured templated errors across core deployment operations, dependency resolution, and CLI commands

- **Improved error context** by providing rich debugging information (module names, operation types, file paths, etc.)

- **Updated test expectations** to match new standardized error message formats

The new error messages provide better debugging context. For example:
- Before: `throw new Error('Internal module not found: ' + name)`
- After: `throw errors.MODULE_NOT_FOUND({ name })`
- Result: `"Module \"my-module\" not found in modules list."` with structured error code and HTTP status

## Review & Testing Checklist for Human

- [ ] **Run full test suite** - I only ran focused tests due to DB connection issues. Verify no regressions in integration tests
- [ ] **Test deployment scenarios end-to-end** - Deploy/revert operations with intentional failures to verify error messages are helpful and don't break workflows  
- [ ] **Verify error message compatibility** - Check if any external tooling or user scripts depend on specific error message formats that may have changed
- [ ] **Review error parameter completeness** - Ensure all new templated errors receive the correct context parameters and don't cause runtime errors
- [ ] **Search for remaining plain Error patterns** - Run `grep -r "throw new Error" packages/` to identify any conversion patterns I may have missed

**Recommended Test Plan:**
1. Deploy a module with a missing dependency → should show clear MODULE_NOT_FOUND error
2. Attempt circular dependency → should show CIRCULAR_DEPENDENCY with clear module chain
3. Reference non-existent change/tag → should show CHANGE_NOT_FOUND/TAG_NOT_FOUND with context
4. Run deployment operations that intentionally fail → verify OPERATION_FAILED provides useful debugging info

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    ErrorFactory["packages/types/src/<br/>error-factory.ts"]:::major-edit
    LaunchQLClass["packages/core/src/core/class/<br/>launchql.ts"]:::major-edit
    MigrateClient["packages/core/src/migrate/<br/>client.ts"]:::major-edit
    DepResolution["packages/core/src/resolution/<br/>deps.ts"]:::major-edit
    Deploy["packages/core/src/projects/<br/>deploy.ts"]:::minor-edit
    Revert["packages/core/src/projects/<br/>revert.ts"]:::minor-edit
    Verify["packages/core/src/projects/<br/>verify.ts"]:::minor-edit
    CLITag["packages/cli/src/commands/<br/>tag.ts"]:::minor-edit
    Tests["packages/core/__tests__/<br/>*.test.ts"]:::minor-edit
    
    ErrorFactory -->|"exports errors object"| LaunchQLClass
    ErrorFactory -->|"provides templated errors"| MigrateClient
    ErrorFactory -->|"standardizes error formats"| DepResolution
    LaunchQLClass -->|"uses for operations"| Deploy
    LaunchQLClass -->|"uses for operations"| Revert  
    LaunchQLClass -->|"uses for operations"| Verify
    ErrorFactory -->|"imports errors"| CLITag
    Tests -->|"expects new formats"| LaunchQLClass
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes

- **Session Info**: Requested by Dan Lynch (@pyramation) - https://app.devin.ai/sessions/ca1c7390a3a14315b8b06be464b41314
- **Import Path Fix**: Had to correct imports from `@launchql/errors` to `@launchql/types` since the error system is part of the types package
- **Error Message Evolution**: The new messages are more descriptive but different from the old format. This is intentional for better UX but needs verification that no external dependencies break
- **Test Database Issues**: Local test runs had PostgreSQL connection issues, so comprehensive testing is especially important for this PR
- **Backward Compatibility**: Error codes and HTTP status codes remain consistent, only message formats changed for better clarity