### PR TITLE
feat(core): Make Makefile optional for packaging and publish; document usage

### DIFF
--- a/MAKEFILE_USAGE.md
+++ b/MAKEFILE_USAGE.md
@@ -1,0 +1,23 @@
+# Makefile Usage in LaunchQL Modules
+
+This document explains where Makefiles are used in LaunchQL modules, when they are optional, and why.
+
+- The module-level Makefile typically contains targets that reference the generated SQL artifact (e.g., extname--X.Y.Z.sql) and can be helpful for local workflows.
+- As of this change, the Makefile is optional in packaging and publishing flows. If present, it will be read, updated, and copied as before. If absent, those flows will proceed without it.
+
+What remains required:
+- The launchql.plan file is required and must exist. Errors are thrown if it is missing or invalid.
+- The .control file for the extension is required and must exist. Errors are thrown if it is missing.
+
+Areas affected by this behavior:
+- Packaging (lql package):
+  - When building the SQL artifact, if the Makefile exists it will be updated to point to the new SQL filename. If the Makefile does not exist, the process continues without error.
+- Publishing to a dist folder:
+  - Required files (package.json, launchql.plan, and the module’s .control file) must exist and will be copied.
+  - The Makefile, if present, will be copied; if it does not exist, publishing continues without error.
+- Direct Makefile reads:
+  - Calls that read the Makefile will return an empty string if it does not exist, instead of throwing, so that non-essential flows do not fail purely due to a missing Makefile.
+
+Rationale:
+- Extension generation and packaging can function without a Makefile. Making it optional avoids unnecessary failures in workflows where the Makefile is not needed.
+- The launchql.plan and .control files define core schema and extension metadata, and must remain mandatory for correct operation.

--- a/packages/core/src/core/class/launchql.ts
+++ b/packages/core/src/core/class/launchql.ts
@@ -406,6 +406,7 @@ export class LaunchQLPackage {
   getModuleMakefile(): string {
     this.ensureModule();
     const info = this.getModuleInfo();
+    if (!fs.existsSync(info.Makefile)) return '';
     return fs.readFileSync(info.Makefile, 'utf8');
   }
 
@@ -676,13 +677,12 @@ export class LaunchQLPackage {
     fs.mkdirSync(fullDist, { recursive: true });
 
     const folders = ['deploy', 'revert', 'sql', 'verify'];
-    const files = ['Makefile', 'package.json', 'launchql.plan', controlFile];
+    const filesRequired = ['package.json', 'launchql.plan', controlFile];
+    const filesOptional = ['Makefile'];
 
-
-    // Add README file regardless of casing
     const readmeFile = fs.readdirSync(modPath).find(f => /^readme\.md$/i.test(f));
     if (readmeFile) {
-      files.push(readmeFile); // Include it in the list of files to copy
+      filesOptional.push(readmeFile);
     }
 
     for (const folder of folders) {
@@ -692,12 +692,19 @@ export class LaunchQLPackage {
       }
     }
 
-    for (const file of files) {
+    for (const file of filesRequired) {
       const src = path.join(modPath, file);
       if (!fs.existsSync(src)) {
         throw new Error(`Missing required file: ${file}`);
       }
       fs.cpSync(src, path.join(fullDist, file));
+    }
+
+    for (const file of filesOptional) {
+      const src = path.join(modPath, file);
+      if (fs.existsSync(src)) {
+        fs.cpSync(src, path.join(fullDist, file));
+      }
     }
   }
 


### PR DESCRIPTION
# feat(core): Make Makefile optional for packaging and publish; document usage

## Summary

This PR makes the `Makefile` optional for extension generation in LaunchQL modules, while keeping `.control` and `launchql.plan` files mandatory. The change primarily affects the `lql package` command flow and the `publishToDist()` method.

**Key Changes:**
- Updated `writePackage()` in `packages/core/src/packaging/package.ts` to conditionally read/update Makefile only if it exists
- Modified `publishToDist()` in `packages/core/src/core/class/launchql.ts` to copy Makefile only if present, while still requiring `.control` and `launchql.plan` files
- Changed `getModuleMakefile()` to return empty string instead of throwing when Makefile is missing
- Added comprehensive documentation in `MAKEFILE_USAGE.md` explaining the new behavior

## Review & Testing Checklist for Human

- [ ] **Test `lql package` command with missing Makefile** - Verify it completes successfully without errors when no Makefile is present in a module
- [ ] **Test `lql package` command with existing Makefile** - Ensure existing behavior is preserved when Makefile exists (should update SQL filename reference)
- [ ] **Test `publishToDist()` with missing Makefile** - Verify dist folder is created correctly without Makefile, but still includes required files
- [ ] **Run existing test suites** - Especially `packages/core` and `packages/cli` tests to ensure no regressions
- [ ] **Verify `.control` and `.plan` files are still enforced** - Try removing these files and confirm appropriate errors are thrown

**Recommended Test Plan:**
1. Create a test module without a Makefile and run `lql package`
2. Remove Makefile from an existing module and test packaging/publishing
3. Verify that removing `.control` or `launchql.plan` files still causes failures

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    CLI["packages/cli/src/commands/package.ts"]:::context
    WritePackage["packages/core/src/packaging/package.ts<br/>writePackage()"]:::major-edit
    LaunchQL["packages/core/src/core/class/launchql.ts"]:::major-edit
    PublishToDist["publishToDist()"]:::major-edit
    GetMakefile["getModuleMakefile()"]:::minor-edit
    Doc["MAKEFILE_USAGE.md"]:::major-edit
    
    CLI -->|calls| WritePackage
    WritePackage -->|conditionally reads| Makefile[Makefile<br/>now optional]:::context
    WritePackage -->|always reads| Control[.control file<br/>still required]:::context
    LaunchQL -->|contains| PublishToDist
    LaunchQL -->|contains| GetMakefile
    PublishToDist -->|conditionally copies| Makefile
    PublishToDist -->|always requires| Control
    PublishToDist -->|always requires| Plan[launchql.plan<br/>still required]:::context
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Session Details**: Requested by Dan Lynch (@pyramation) - [Link to Devin run](https://app.devin.ai/sessions/9418035d06084aa4ac1d7d7ae5f5a5f9)
- **Risk Assessment**: Medium 🟡 - The changes are well-localized but affect core packaging logic. The build passes but comprehensive testing is needed.
- **Backward Compatibility**: Should be maintained - existing modules with Makefiles will continue to work as before
- **Error Handling**: `.control` and `launchql.plan` files maintain existing error behavior when missing