### PR TITLE
feat(core, cli): analyze and rename module/package (fix/renaming)

### DIFF
--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -20,6 +20,8 @@ import revert from './commands/revert';
 import server from './commands/server';
 import tag from './commands/tag';
 import verify from './commands/verify';
+import analyze from './commands/analyze';
+import renameCmd from './commands/rename';
 import { readAndParsePackageJson } from './package';
 import { extractFirst, usageText } from './utils';
 
@@ -51,6 +53,8 @@ const createCommandMap = (skipPgTeardown: boolean = false): Record<string, Funct
     kill: pgt(kill),
     install: pgt(install),
     migrate: pgt(migrate),
+    analyze: pgt(analyze),
+    rename: pgt(renameCmd),
 
     // These manage their own connection lifecycles
     server,

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -1,0 +1,19 @@
+import { Inquirerer } from 'inquirerer';
+import { ParsedArgs } from 'minimist';
+import path from 'path';
+import { LaunchQLPackage } from '@launchql/core';
+
+export default async (argv: Partial<ParsedArgs>, _prompter: Inquirerer) => {
+  const cwd = (argv.cwd as string) || process.cwd();
+  const proj = new LaunchQLPackage(path.resolve(cwd));
+  const result = proj.analyzeModule();
+  if (result.ok) {
+    console.log(`OK ${result.name}`);
+    return;
+  }
+  console.log(`NOT OK ${result.name}`);
+  for (const issue of result.issues) {
+    const loc = issue.file ? ` (${issue.file})` : '';
+    console.log(`- [${issue.code}] ${issue.message}${loc}`);
+  }
+};

--- a/packages/cli/src/commands/rename.ts
+++ b/packages/cli/src/commands/rename.ts
@@ -1,0 +1,30 @@
+import { Inquirerer } from 'inquirerer';
+import { ParsedArgs } from 'minimist';
+import path from 'path';
+import { LaunchQLPackage } from '@launchql/core';
+
+export default async (argv: Partial<ParsedArgs>, _prompter: Inquirerer) => {
+  const cwd = (argv.cwd as string) || process.cwd();
+  const to = (argv.to as string) || (argv._ && argv._[0] as string);
+  if (!to) {
+    console.error('Missing new name. Use --to <name> or provide as positional argument.');
+    process.exit(1);
+  }
+  const dryRun = !!argv['dry-run'] || !!argv.dryRun;
+  const syncPkg = !!argv['sync-pkg-name'] || !!argv.syncPkgName;
+  const proj = new LaunchQLPackage(path.resolve(cwd));
+  const res = proj.renameModule(to, { dryRun, syncPackageJsonName: syncPkg });
+  if (dryRun) {
+    console.log('Dry run');
+  }
+  if (res.changed.length > 0) {
+    console.log('Changed:');
+    for (const f of res.changed) console.log(`- ${f}`);
+  } else {
+    console.log('No changes');
+  }
+  if (res.warnings.length > 0) {
+    console.log('Warnings:');
+    for (const w of res.warnings) console.log(`- ${w}`);
+  }
+};

--- a/packages/core/__tests__/core/analyze-module.test.ts
+++ b/packages/core/__tests__/core/analyze-module.test.ts
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 import { TestFixture } from '../../test-utils';
+import { parsePlanFile } from '../../src/files/plan/parser';
+import { writePlanFile } from '../../src/files/plan/writer';
 
 let fixture: TestFixture;
 
@@ -24,6 +26,21 @@ describe('LaunchQLPackage.analyzeModule', () => {
     expect(result.issues.find(i => i.code === 'missing_sql')?.file).toContain(`sql/my-first--`);
   });
 
+  it('reports OK when combined SQL exists and names align', () => {
+    const project = fixture.getModuleProject(['simple'], 'my-first');
+    const modPath = project.getModulePath()!;
+    const pkgJson = JSON.parse(fs.readFileSync(path.join(modPath, 'package.json'), 'utf8'));
+    const version = pkgJson.version;
+    const sqlDir = path.join(modPath, 'sql');
+    const combined = path.join(sqlDir, `my-first--${version}.sql`);
+    fs.mkdirSync(sqlDir, { recursive: true });
+    fs.writeFileSync(combined, '-- combined sql');
+
+    const result = project.analyzeModule();
+    expect(result.ok).toBe(true);
+    expect(result.issues.length).toBe(0);
+  });
+
   it('detects missing control file when renamed away', () => {
     const project = fixture.getModuleProject(['simple'], 'my-first');
     const modPath = project.getModulePath()!;
@@ -39,6 +56,85 @@ describe('LaunchQLPackage.analyzeModule', () => {
       if (fs.existsSync(wrongControlPath)) {
         fs.renameSync(wrongControlPath, controlPath);
       }
+    }
+  });
+
+  it('detects Makefile EXTENSION mismatch', () => {
+    const project = fixture.getModuleProject(['simple'], 'my-first');
+    const modPath = project.getModulePath()!;
+    const makefilePath = path.join(modPath, 'Makefile');
+    const original = fs.readFileSync(makefilePath, 'utf8');
+    try {
+      const mutated = original.replace(/^EXTENSION\s*=.*$/m, 'EXTENSION = wrongname');
+      fs.writeFileSync(makefilePath, mutated);
+      const result = project.analyzeModule();
+      const codes = result.issues.map(i => i.code);
+      expect(codes).toContain('makefile_extension_mismatch');
+    } finally {
+      fs.writeFileSync(makefilePath, original);
+    }
+  });
+
+  it('detects Makefile DATA mismatch', () => {
+    const project = fixture.getModuleProject(['simple'], 'my-first');
+    const modPath = project.getModulePath()!;
+    const makefilePath = path.join(modPath, 'Makefile');
+    const original = fs.readFileSync(makefilePath, 'utf8');
+    try {
+      const mutated = original.replace(/^DATA\s*=.*$/m, 'DATA = sql/wrong--0.0.0.sql');
+      fs.writeFileSync(makefilePath, mutated);
+      const result = project.analyzeModule();
+      const codes = result.issues.map(i => i.code);
+      expect(codes).toContain('makefile_data_mismatch');
+    } finally {
+      fs.writeFileSync(makefilePath, original);
+    }
+  });
+
+  it('detects plan %uri mismatch', () => {
+    const project = fixture.getModuleProject(['simple'], 'my-first');
+    const modPath = project.getModulePath()!;
+    const planPath = path.join(modPath, 'launchql.plan');
+    const original = fs.readFileSync(planPath, 'utf8');
+    try {
+      const parsed = parsePlanFile(planPath);
+      if (!parsed.data) throw new Error('Failed to parse plan');
+      parsed.data.uri = 'different-uri';
+      writePlanFile(planPath, parsed.data);
+      const result = project.analyzeModule();
+      const codes = result.issues.map(i => i.code);
+      expect(codes).toContain('plan_uri_mismatch');
+    } finally {
+      fs.writeFileSync(planPath, original);
+    }
+  });
+
+  it('detects missing deploy/revert/verify directories', () => {
+    const project = fixture.getModuleProject(['simple'], 'my-first');
+    const modPath = project.getModulePath()!;
+
+    const deployDir = path.join(modPath, 'deploy');
+    const revertDir = path.join(modPath, 'revert');
+    const verifyDir = path.join(modPath, 'verify');
+
+    const tmpDeploy = path.join(modPath, '_deploy_bak');
+    const tmpRevert = path.join(modPath, '_revert_bak');
+    const tmpVerify = path.join(modPath, '_verify_bak');
+
+    fs.renameSync(deployDir, tmpDeploy);
+    fs.renameSync(revertDir, tmpRevert);
+    fs.renameSync(verifyDir, tmpVerify);
+
+    try {
+      const result = project.analyzeModule();
+      const codes = result.issues.map(i => i.code);
+      expect(codes).toContain('missing_deploy_dir');
+      expect(codes).toContain('missing_revert_dir');
+      expect(codes).toContain('missing_verify_dir');
+    } finally {
+      if (fs.existsSync(tmpDeploy)) fs.renameSync(tmpDeploy, deployDir);
+      if (fs.existsSync(tmpRevert)) fs.renameSync(tmpRevert, revertDir);
+      if (fs.existsSync(tmpVerify)) fs.renameSync(tmpVerify, verifyDir);
     }
   });
 });

--- a/packages/core/__tests__/core/analyze-module.test.ts
+++ b/packages/core/__tests__/core/analyze-module.test.ts
@@ -1,0 +1,44 @@
+import fs from 'fs';
+import path from 'path';
+import { TestFixture } from '../../test-utils';
+
+let fixture: TestFixture;
+
+beforeAll(() => {
+  fixture = new TestFixture('sqitch');
+});
+
+afterAll(() => {
+  fixture.cleanup();
+});
+
+describe('LaunchQLPackage.analyzeModule', () => {
+  it('reports issues for a basic fixture (e.g. missing combined SQL)', () => {
+    const project = fixture.getModuleProject(['simple'], 'my-first');
+    const result = project.analyzeModule();
+
+    expect(result.name).toBe('my-first');
+    expect(result.ok).toBe(false);
+    const codes = result.issues.map(i => i.code);
+    expect(codes).toContain('missing_sql');
+    expect(result.issues.find(i => i.code === 'missing_sql')?.file).toContain(`sql/my-first--`);
+  });
+
+  it('detects plan project name mismatch', () => {
+    const project = fixture.getModuleProject(['simple'], 'my-first');
+    const modPath = project.getModulePath()!;
+    const planPath = path.join(modPath, 'launchql.plan');
+
+    const original = fs.readFileSync(planPath, 'utf8');
+    try {
+      const mutated = original.replace(/^%project\s*=\s*my-first/m, '%project = different-name');
+      fs.writeFileSync(planPath, mutated);
+
+      const result = project.analyzeModule();
+      const codes = result.issues.map(i => i.code);
+      expect(codes).toContain('plan_project_mismatch');
+    } finally {
+      fs.writeFileSync(planPath, original);
+    }
+  });
+});

--- a/packages/core/__tests__/core/rename-module.test.ts
+++ b/packages/core/__tests__/core/rename-module.test.ts
@@ -1,0 +1,45 @@
+import fs from 'fs';
+import path from 'path';
+import { TestFixture } from '../../test-utils';
+
+let fixture: TestFixture;
+
+beforeAll(() => {
+  fixture = new TestFixture('sqitch');
+});
+
+afterAll(() => {
+  fixture.cleanup();
+});
+
+describe('LaunchQLPackage.renameModule', () => {
+  it('performs dry-run rename and reports changed files/warnings', () => {
+    const project = fixture.getModuleProject(['simple'], 'my-first');
+    const res = project.renameModule('renamed_mod', { dryRun: true });
+
+    expect(Array.isArray(res.changed)).toBe(true);
+    expect(res.changed.find(f => f.endsWith('launchql.plan'))).toBeTruthy();
+    expect(res.changed.find(f => f.endsWith('Makefile'))).toBeTruthy();
+    expect(res.changed.find(f => f.endsWith('renamed_mod.control'))).toBeTruthy();
+
+    expect(Array.isArray(res.warnings)).toBe(true);
+    expect(res.warnings.find(w => /combined sql/i.test(w))).toBeTruthy();
+  });
+
+  it('renames plan/control/makefile and Analyze reports no name mismatches', () => {
+    const project = fixture.getModuleProject(['simple'], 'my-first');
+    const modPath = project.getModulePath()!;
+
+    const res = project.renameModule('renamed_mod', { dryRun: false, syncPackageJsonName: false });
+    expect(res.changed.length).toBeGreaterThan(0);
+
+    const newControl = path.join(modPath, 'renamed_mod.control');
+    expect(fs.existsSync(newControl)).toBe(true);
+
+    const analysis = project.analyzeModule();
+    const mismatchCodes = analysis.issues.filter(i =>
+      i.code === 'plan_project_mismatch' || i.code === 'plan_uri_mismatch' || i.code === 'control_filename_mismatch'
+    );
+    expect(mismatchCodes.length).toBe(0);
+  });
+});

--- a/packages/core/src/files/types/index.ts
+++ b/packages/core/src/files/types/index.ts
@@ -1,3 +1,5 @@
+export * from './package';
+
 // Plan file types
 export interface Change {
   name: string;

--- a/packages/core/src/files/types/package.ts
+++ b/packages/core/src/files/types/package.ts
@@ -1,0 +1,23 @@
+export interface PackageAnalysisIssue {
+  code: string;
+  message: string;
+  file?: string;
+  fixable?: boolean;
+}
+
+export interface PackageAnalysisResult {
+  ok: boolean;
+  name: string;
+  path: string;
+  issues: PackageAnalysisIssue[];
+}
+
+export interface RenameOptions {
+  dryRun?: boolean;
+  syncPackageJsonName?: boolean;
+}
+
+export interface RenameResult {
+  changed: string[];
+  warnings: string[];
+}


### PR DESCRIPTION
# feat(core, cli): analyze and rename module/package (fix/renaming)

## Summary

This PR implements two new capabilities for LaunchQL modules/packages:

1. **Package Analysis** (`lql analyze`) - Analyzes a module to determine if it's "OK" by checking for required files (Makefile, control file, launchql.plan, package.json, sql directories) and validating naming consistency across these files.

2. **Package Renaming** (`lql rename`) - Renames a module/package by updating the control file, Makefile, launchql.plan, and SQL files while maintaining consistency. Supports dry-run mode and optional package.json name synchronization.

### Core Implementation
- Added `analyzeModule()` and `renameModule()` methods to the `LaunchQLPackage` class
- Created new TypeScript interfaces for analysis results and rename options
- Leverages existing file readers/writers for plan files, control files, and Makefiles

### CLI Integration  
- New `lql analyze` command that reports module status and any issues found
- New `lql rename <newname>` command with `--dry-run` and `--sync-pkg-name` options
- Both commands follow existing CLI patterns and error handling

## Review & Testing Checklist for Human

- [ ] **Test rename functionality end-to-end** - Create a test module, run `lql rename newname`, and verify all files (control, Makefile, plan, SQL) are correctly updated with the new name
- [ ] **Verify analysis accuracy** - Test `lql analyze` on both valid and invalid modules to ensure it correctly identifies issues and reports "OK" status appropriately  
- [ ] **Test edge cases** - Try renaming with invalid names, missing files, malformed plan files, and scoped package.json names to ensure proper error handling
- [ ] **Validate dry-run mode** - Confirm `lql rename --dry-run` shows expected changes without actually modifying files
- [ ] **Check file system safety** - Ensure rename operations don't leave orphaned files or corrupt existing modules

**Recommended Test Plan**: Create a simple test module in a safe directory, run both commands with various inputs, and manually inspect the resulting file changes to verify correctness.


---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    CLI["packages/cli/src/commands.ts"]:::minor-edit --> AnalyzeCmd["packages/cli/src/commands/analyze.ts"]:::major-edit
    CLI --> RenameCmd["packages/cli/src/commands/rename.ts"]:::major-edit
    
    AnalyzeCmd --> LaunchQLClass["packages/core/src/core/class/launchql.ts"]:::major-edit
    RenameCmd --> LaunchQLClass
    
    LaunchQLClass --> Types["packages/core/src/files/types/package.ts"]:::major-edit
    LaunchQLClass --> PlanParser["packages/core/src/files/plan/parser.ts"]:::context
    LaunchQLClass --> PlanWriter["packages/core/src/files/plan/writer.ts"]:::context
    LaunchQLClass --> ExtWriter["packages/core/src/files/extension/writer.ts"]:::context
    
    Types --> TypesIndex["packages/core/src/files/types/index.ts"]:::minor-edit
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **File Operations**: The rename functionality performs actual file system operations (move, delete, write). While dry-run mode is implemented, thorough testing is essential to prevent data loss.
- **Validation Rules**: The analysis uses conservative validation rules - modules must have all required files and consistent naming. The package.json name can differ unless explicitly synced.
- **Testing Limitation**: Full integration tests couldn't be run due to database setup requirements, but the core functionality is file-system based and builds successfully.

**Link to Devin run**: https://app.devin.ai/sessions/e947b0bdc14b4a3f9a002dd7ba543948  
**Requested by**: Dan Lynch (@pyramation)