### PR TITLE
feat(cli): add lql version command for semver bumping and tagging

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.12.7",
+    "@types/semver": "^7.7.0",
     "@types/shelljs": "^0.8.16",
     "ts-node": "^10.9.2"
   },
@@ -54,6 +55,7 @@
     "minimist": "^1.2.8",
     "pg-cache": "^1.1.1",
     "pg-env": "^1.1.0",
+    "semver": "^7.7.2",
     "shelljs": "^0.9.2"
   },
   "resolutions": {

--- a/packages/cli/src/commands.ts
+++ b/packages/cli/src/commands.ts
@@ -20,6 +20,7 @@ import revert from './commands/revert';
 import server from './commands/server';
 import tag from './commands/tag';
 import verify from './commands/verify';
+import version from './commands/version';
 import analyze from './commands/analyze';
 import renameCmd from './commands/rename';
 import { readAndParsePackageJson } from './package';
@@ -50,6 +51,7 @@ const createCommandMap = (skipPgTeardown: boolean = false): Record<string, Funct
     export: pgt(_export),
     package: pgt(_package),
     tag: pgt(tag),
+    version: pgt(version),
     kill: pgt(kill),
     install: pgt(install),
     migrate: pgt(migrate),

--- a/packages/cli/src/commands/version.ts
+++ b/packages/cli/src/commands/version.ts
@@ -1,0 +1,146 @@
+import { LaunchQLPackage } from '@launchql/core';
+import { Logger } from '@launchql/logger';
+import { errors } from '@launchql/types';
+import { CLIOptions, Inquirerer, Question } from 'inquirerer';
+import { extractFirst } from '../utils/argv';
+import { selectPackage } from '../utils/module-utils';
+import * as path from 'path';
+import * as fs from 'fs';
+const semver = require('semver');
+
+const log = new Logger('version');
+
+const versionUsageText = `
+LaunchQL Version Command:
+
+  lql version [OPTIONS]
+
+  Bump package version and create corresponding tag.
+
+Options:
+  --help, -h              Show this help message
+  --package <name>        Target specific package
+  --cwd <directory>       Working directory (default: current directory)
+
+Examples:
+  lql version                                       Prompt for version bump type
+  lql version --package mypackage                   Version specific package
+`;
+
+export default async (
+  argv: Partial<Record<string, any>>,
+  prompter: Inquirerer,
+  _options: CLIOptions
+) => {
+  if (argv.help || argv.h) {
+    console.log(versionUsageText);
+    process.exit(0);
+  }
+
+  const { newArgv } = extractFirst(argv);
+  
+  const cwdResult = await prompter.prompt(newArgv, [
+    {
+      type: 'text',
+      name: 'cwd',
+      message: 'Working directory',
+      required: false,
+      default: process.cwd(),
+      useDefault: true
+    }
+  ]);
+  const cwd = (cwdResult as any).cwd || process.cwd();
+
+  const pkg = new LaunchQLPackage(cwd);
+
+  let packageName: string | undefined;
+  
+  if (argv.package) {
+    packageName = argv.package as string;
+    log.info(`Using specified package: ${packageName}`);
+  }
+  else if (pkg.isInModule()) {
+    packageName = pkg.getModuleName();
+    log.info(`Using current module: ${packageName}`);
+  }
+  else if (pkg.isInWorkspace()) {
+    packageName = await selectPackage(newArgv, prompter, cwd, 'version', log);
+    if (!packageName) {
+      throw new Error('No package selected. Cannot version without specifying a target package.');
+    }
+  } else {
+    throw new Error('This command must be run inside a LaunchQL workspace or module.');
+  }
+
+  const versionAnswer = await prompter.prompt(newArgv, [
+    {
+      type: 'autocomplete',
+      name: 'bumpType',
+      message: 'Select version bump type',
+      options: ['patch', 'minor', 'major'],
+      required: true
+    }
+  ]) as any;
+
+  const bumpType = versionAnswer.bumpType;
+
+  try {
+    if (argv.package || !pkg.isInModule()) {
+      const moduleMap = pkg.getModuleMap();
+      const module = moduleMap[packageName];
+      if (!module) {
+        throw errors.MODULE_NOT_FOUND({ name: packageName });
+      }
+      
+      const workspacePath = pkg.getWorkspacePath()!;
+      const absoluteModulePath = path.resolve(workspacePath, module.path);
+      
+      const originalCwd = process.cwd();
+      process.chdir(absoluteModulePath);
+      
+      try {
+        const modulePkg = new LaunchQLPackage(absoluteModulePath);
+        const newVersion = await updatePackageVersion(absoluteModulePath, bumpType);
+        modulePkg.addTag(`v${newVersion}`, undefined, `Version bump: ${bumpType}`);
+        log.info(`Successfully bumped ${packageName} to version ${newVersion} and added tag v${newVersion}`);
+      } finally {
+        process.chdir(originalCwd);
+      }
+    } else {
+      const newVersion = await updatePackageVersion(pkg.getModulePath()!, bumpType);
+      pkg.addTag(`v${newVersion}`, undefined, `Version bump: ${bumpType}`);
+      log.info(`Successfully bumped to version ${newVersion} and added tag v${newVersion}`);
+    }
+  } catch (error) {
+    log.error(`Failed to version package: ${error instanceof Error ? error.message : String(error)}`);
+    throw error;
+  }
+  
+  return newArgv;
+};
+
+async function updatePackageVersion(modulePath: string, bumpType: 'major' | 'minor' | 'patch'): Promise<string> {
+  const pkgJsonPath = path.join(modulePath, 'package.json');
+  
+  if (!fs.existsSync(pkgJsonPath)) {
+    throw new Error(`No package.json found at module path: ${modulePath}`);
+  }
+  
+  const pkgData = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+  const currentVersion = pkgData.version;
+  
+  if (!currentVersion) {
+    throw new Error('No version field found in package.json');
+  }
+  
+  const newVersion = semver.inc(currentVersion, bumpType);
+  
+  if (!newVersion) {
+    throw new Error(`Failed to calculate new ${bumpType} version from ${currentVersion}`);
+  }
+  
+  pkgData.version = newVersion;
+  fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgData, null, 2) + '\n');
+  
+  return newVersion;
+}


### PR DESCRIPTION
# feat(cli): add lql version command for semver bumping and tagging

## Summary

This PR adds a new `lql version` CLI command that allows users to bump package versions using semantic versioning and automatically creates corresponding tags. The command:

- Prompts users to select a semver bump type (major, minor, patch)
- Updates the package.json version field in the target module
- Creates a corresponding git tag using `LaunchQLPackage.addTag()` to keep versions and tags in sync
- Supports both workspace and individual module contexts
- Follows established CLI patterns from the existing `tag` command

**Files Changed:**
- `packages/cli/src/commands.ts` - Added version command import and registration
- `packages/cli/src/commands/version.ts` - New command implementation
- `packages/cli/package.json` - Added semver dependency

## Review & Testing Checklist for Human

⚠️ **HIGH PRIORITY** - This implementation was not fully tested due to build system issues:

- [ ] **End-to-end testing**: Test the command in a working LaunchQL workspace/module environment to ensure it actually runs without errors
- [ ] **Package.json integrity**: Verify that package.json files are updated correctly and maintain proper formatting/structure after version bumps
- [ ] **Tag creation verification**: Confirm that `LaunchQLPackage.addTag()` properly creates tags and they appear in the plan file as expected
- [ ] **Semver calculations**: Test all three bump types (major, minor, patch) with various starting versions to ensure semver library integration works correctly
- [ ] **Context handling**: Test the command in both workspace and individual module contexts to verify proper package selection logic

**Recommended Test Plan:**
1. Navigate to a test LaunchQL module with an existing version in package.json
2. Run `lql version` and select each bump type (patch, minor, major)
3. Verify package.json version updates and tags are created correctly
4. Test in workspace context with multiple packages
5. Test error cases (missing package.json, invalid versions, etc.)

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Commands["packages/cli/src/commands.ts"]:::minor-edit
    VersionCmd["packages/cli/src/commands/version.ts"]:::major-edit
    TagCmd["packages/cli/src/commands/tag.ts"]:::context
    LaunchQLPkg["@launchql/core<br/>LaunchQLPackage"]:::context
    PackageJson["package.json<br/>(target module)"]:::context
    PlanFile["launchql.plan<br/>(target module)"]:::context
    
    Commands -->|imports and registers| VersionCmd
    VersionCmd -->|follows patterns from| TagCmd
    VersionCmd -->|uses addTag method| LaunchQLPkg
    VersionCmd -->|reads/writes version| PackageJson
    LaunchQLPkg -->|creates tags in| PlanFile
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

⚠️ **Important**: The build system had widespread TypeScript module resolution errors during development, preventing full end-to-end testing. The implementation uses `require('semver')` instead of ES6 imports due to type definition issues. While the code follows established patterns from the tag command, thorough manual testing is essential before merging.

The command implementation closely mirrors the existing `tag` command structure for consistency, including package selection logic, error handling, and support for both workspace and module contexts.

**Session Info:**
- Link to Devin run: https://app.devin.ai/sessions/72715815f2f743199277e0058c0b189f
- Requested by: @pyramation