### PR TITLE
feat: make usePlan default to true in CLI deploy command

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,103 @@
+# usePlan Default Analysis and Implementation Plan
+
+## Problem Statement
+
+There is a mismatch between the core package and CLI package regarding the default value of `usePlan`:
+
+- **Core Package**: Defaults `usePlan = true` in `packageModule()` function
+- **CLI Package**: Passes `argv.usePlan` (undefined by default) to core methods
+- **Result**: Inconsistent behavior between development and production environments
+
+## Current State Analysis
+
+### Core Package Defaults
+
+1. **`packageModule()` function** (`packages/core/src/packaging/package.ts:47`)
+   - Defaults `usePlan = true`
+   - Uses `resolveWithPlan` when `usePlan = true`, `resolve` when `usePlan = false`
+
+2. **`LaunchQLMigrate.deploy()`** (`packages/core/src/migrate/client.ts:138`)
+   - Uses `options.usePlan ? 'plan' : 'sql'` for dependency resolution source
+   - Plan-based resolution reads `launchql.plan` files directly
+   - SQL-based resolution parses deploy/*.sql file headers
+
+### CLI Package Current State
+
+1. **Deploy Command** (`packages/cli/src/commands/deploy.ts:133`)
+   - Passes `usePlan: argv.usePlan` (undefined by default)
+   - Has `--usePlan` flag but no default value
+   - Help text shows `--usePlan` as optional flag
+
+2. **Revert Command** (`packages/cli/src/commands/revert.ts`)
+   - Does NOT support `usePlan` at all
+   - Only passes `useTx` to deployment options
+
+3. **Verify Command** (`packages/cli/src/commands/verify.ts`)
+   - Does NOT support `usePlan` at all
+   - No deployment options passed
+
+### Key Differences Between Resolution Methods
+
+#### Plan-based Resolution (`usePlan: true`)
+- Reads dependency order directly from `launchql.plan` files
+- Uses `resolveWithPlan()` function
+- More reliable and explicit dependency management
+- Follows the exact order specified in plan files
+
+#### SQL-based Resolution (`usePlan: false`)
+- Parses deploy/*.sql file headers to build dependency graph
+- Uses `resolve()` function with topological sorting
+- Legacy approach that scans filesystem
+- May have different ordering than plan files
+
+## Implementation Changes
+
+### 1. CLI Deploy Command Updates
+
+**File**: `packages/cli/src/commands/deploy.ts`
+
+- Change `usePlan: argv.usePlan` to `usePlan: argv.usePlan !== false`
+- Update help text to reflect new default
+- Add `--no-usePlan` flag documentation
+
+### 2. CLI Argument Parsing Updates
+
+**File**: `packages/cli/src/utils/argv.ts`
+
+- Update boolean flag handling to support `--no-usePlan` pattern
+- Ensure proper validation of usePlan argument
+
+### 3. Revert and Verify Command Analysis
+
+**Revert Command**: Currently does not use dependency resolution, so `usePlan` may not be applicable.
+
+**Verify Command**: Currently does not use dependency resolution, so `usePlan` may not be applicable.
+
+**Decision**: Keep revert and verify commands as-is since they don't appear to use the dependency resolution system that `usePlan` affects.
+
+## Expected Impact
+
+### Positive Changes
+- Consistent behavior between development and production
+- Plan-based resolution is more reliable and explicit
+- Aligns CLI defaults with core package expectations
+
+### Potential Breaking Changes
+- Users relying on SQL-based resolution by default will need to use `--no-usePlan`
+- Existing scripts may need updating if they depend on SQL-based resolution behavior
+
+### Migration Path
+- Add `--no-usePlan` flag for users who need the old behavior
+- Update documentation to explain the change
+- Consider deprecation warnings in future versions
+
+## Testing Strategy
+
+1. **Existing Tests**: Ensure all current CLI tests pass with new defaults
+2. **New Flag Testing**: Verify `--no-usePlan` works correctly
+3. **Integration Testing**: Test both plan-based and SQL-based resolution paths
+4. **Regression Testing**: Ensure no breaking changes to existing functionality
+
+## Conclusion
+
+Making `usePlan` default to `true` in the CLI aligns the behavior with the core package expectations and provides more consistent, reliable dependency resolution. The `--no-usePlan` flag provides backward compatibility for users who need the legacy SQL-based resolution behavior.

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -28,7 +28,8 @@ Options:
   --tx               Use transactions (default: true)
   --fast             Use fast deployment strategy
   --logOnly          Log-only mode, skip script execution
-  --usePlan          Use deployment plan
+  --usePlan          Use deployment plan (default: true)
+  --no-usePlan       Disable deployment plan, use SQL-based resolution
   --cache            Enable caching
   --cwd <directory>  Working directory (default: current directory)
 
@@ -130,7 +131,7 @@ export default async (
     deployment: {
       useTx: tx,
       fast,
-      usePlan: argv.usePlan,
+      usePlan: argv.usePlan !== false,
       cache: argv.cache,
       logOnly
     }

--- a/packages/cli/src/utils/argv.ts
+++ b/packages/cli/src/utils/argv.ts
@@ -55,6 +55,10 @@ export function validateCommonArgs(argv: Partial<ParsedArgs>): ValidatedArgv {
     }
   }
 
+  if (argv['no-usePlan'] !== undefined) {
+    validated.usePlan = false;
+  }
+
   const stringFlags = ['package', 'to', 'database'];
   
   for (const flag of stringFlags) {


### PR DESCRIPTION
# feat: make usePlan default to true in CLI deploy command

## Summary

This PR addresses a mismatch between the core package and CLI package regarding the default value of `usePlan`. Previously, the core package defaulted to plan-based dependency resolution (`usePlan = true`) while the CLI passed `undefined`, causing inconsistent behavior between development and production environments.

**Key Changes:**
- Deploy command now defaults `usePlan` to `true` instead of passing `undefined`
- Added `--no-usePlan` flag support to disable plan-based resolution when needed
- Updated help text to reflect the new default behavior
- Added comprehensive analysis in `PLAN.md` documenting the current state and rationale

**Behavior Change:**
- **Before**: CLI used SQL-based dependency resolution by default (parsing deploy/*.sql headers)
- **After**: CLI uses plan-based dependency resolution by default (reading launchql.plan files)
- **Fallback**: Users can use `--no-usePlan` to get the old SQL-based behavior

## Review & Testing Checklist for Human

- [ ] **Test backward compatibility**: Run existing deploy commands without `--usePlan` flag to ensure they work with the new default
- [ ] **Test new flag functionality**: Verify `--no-usePlan` flag works correctly and produces SQL-based resolution behavior
- [ ] **Run full test suite**: Execute `yarn test` in CLI package after setting up PostgreSQL to catch any regressions
- [ ] **Check production impact**: Consider if any existing scripts or workflows depend on SQL-based resolution as default
- [ ] **Evaluate revert/verify commands**: Determine if these commands should also support usePlan for consistency

**Recommended Test Plan:**
1. Set up local PostgreSQL (`docker-compose up -d`)
2. Run CLI tests: `cd packages/cli && yarn test`
3. Test deploy with new default: `lql deploy --database test --package example --yes`
4. Test opt-out behavior: `lql deploy --no-usePlan --database test --package example --yes`
5. Compare deployment results between plan-based and SQL-based resolution

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    CLI["packages/cli/src/commands/deploy.ts<br/>Deploy Command"]:::major-edit
    ARGV["packages/cli/src/utils/argv.ts<br/>Argument Parsing"]:::major-edit
    CORE["packages/core/src/core/class/launchql.ts<br/>LaunchQL Core"]:::context
    MIGRATE["packages/core/src/migrate/client.ts<br/>Migration Client"]:::context
    TYPES["packages/core/src/migrate/types.ts<br/>Type Definitions"]:::context
    PLAN["PLAN.md<br/>Analysis Document"]:::minor-edit

    CLI -->|"usePlan: argv.usePlan !== false"| CORE
    ARGV -->|"Handle --no-usePlan flag"| CLI
    CORE -->|"Pass usePlan option"| MIGRATE
    MIGRATE -->|"Uses plan vs sql resolution"| TYPES
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes

- **Breaking Change Risk**: This is potentially a breaking change for users who rely on SQL-based resolution as the default behavior
- **Limited Testing**: Unable to run full test suite due to database setup issues, so manual testing is crucial
- **Scope Limitation**: Only modified deploy command; revert and verify commands were not touched as they don't appear to use dependency resolution
- **Core Package Alignment**: This change aligns CLI behavior with the core package's expectation that plan-based resolution is the default

**Session Details:**
- Link to Devin run: https://app.devin.ai/sessions/900a444c8b514b089a9bf71fce569b5b
- Requested by: Dan Lynch (@pyramation)