### PR TITLE
core(migrate): add toUnqualifiedLocal method for local tracking guard

### DIFF
--- a/packages/core/__tests__/migrate/local-tracking-guard.test.ts
+++ b/packages/core/__tests__/migrate/local-tracking-guard.test.ts
@@ -1,75 +1,52 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from 'fs';
-import { tmpdir } from 'os';
-import { join } from 'path';
-
-jest.mock('../../src/migrate/utils/transaction', () => ({
-  withTransaction: async (_pool: any, _opts: any, fn: any) => fn({}),
-  executeQuery: jest.fn().mockResolvedValue(undefined),
-}));
-
-jest.mock('pg-cache', () => ({
-  getPgPool: () => ({
-    query: jest
-      .fn()
-      .mockImplementation((sql: string, params?: any[]) => {
-        if (typeof sql === 'string' && sql.includes('SELECT EXISTS')) {
-          return Promise.resolve({ rows: [{ exists: true }] });
-        }
-        if (typeof sql === 'string' && sql.includes('SELECT launchql_migrate.is_deployed')) {
-          return Promise.resolve({ rows: [{ is_deployed: false }] });
-        }
-        return Promise.resolve({ rows: [] });
-      }),
-  }),
-}));
-
 import { LaunchQLMigrate } from '../../src/migrate/client';
+import { MigrateTestFixture, teardownAllPools, TestDatabase } from '../../test-utils';
 
 describe('local tracking guard for deployed/skipped', () => {
+  let fixture: MigrateTestFixture;
+  let db: TestDatabase;
+  
+  beforeEach(async () => {
+    fixture = new MigrateTestFixture();
+    db = await fixture.setupTestDatabase();
+  });
+  
+  afterEach(async () => {
+    await fixture.cleanup();
+  });
+
+  afterAll(async () => {
+    await teardownAllPools();
+  });
+
   it('normalizes same-package qualified names to unqualified in deployed', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'lql-core-test-'));
-    const packageName = 'pkgA';
-    const changeName = 'change1';
+    const tempDir = fixture.createPlanFile('test-local-tracking', [
+      { name: 'change1' }
+    ]);
+    
+    fixture.createScript(tempDir, 'deploy', 'change1', 'SELECT 1;');
 
-    const plan = [`%project=${packageName}`, `${changeName}`].join('\n');
+    const client = new LaunchQLMigrate(db.config);
 
-    mkdirSync(join(dir, 'deploy'), { recursive: true });
-    writeFileSync(join(dir, 'launchql.plan'), plan);
-    writeFileSync(join(dir, 'deploy', `${changeName}.sql`), 'select 1;');
-
-    const migrator = new LaunchQLMigrate(
-      { host: 'localhost', port: 5432, user: 'postgres', database: 'postgres', password: 'postgres' } as any,
-      {}
-    );
-
-    const res = await migrator.deploy({
-      modulePath: dir,
-      useTransaction: false,
+    const result = await client.deploy({
+      modulePath: tempDir,
       logOnly: true,
-    } as any);
+    });
 
-    expect(res.deployed).toContain(changeName);
-    expect(res.deployed.every((n: string) => !n.includes(':'))).toBe(true);
+    expect(result.deployed).toContain('change1');
+    expect(result.deployed.every((n: string) => !n.includes(':'))).toBe(true);
   });
 
   it('throws error on cross-package qualified names', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'lql-core-test-'));
-    const packageName = 'pkgA';
-    const changeName = 'change1';
+    const tempDir = fixture.createPlanFile('test-local-tracking', [
+      { name: 'change1' }
+    ]);
+    
+    fixture.createScript(tempDir, 'deploy', 'change1', 'SELECT 1;');
 
-    const plan = [`%project=${packageName}`, `${changeName}`].join('\n');
-
-    mkdirSync(join(dir, 'deploy'), { recursive: true });
-    writeFileSync(join(dir, 'launchql.plan'), plan);
-    writeFileSync(join(dir, 'deploy', `${changeName}.sql`), 'select 1;');
-
-    const migrator = new LaunchQLMigrate(
-      { host: 'localhost', port: 5432, user: 'postgres', database: 'postgres', password: 'postgres' } as any,
-      {}
-    );
+    const client = new LaunchQLMigrate(db.config);
 
     expect(() => {
-      (migrator as any).toUnqualifiedLocal('pkgA', 'pkgB:change1');
+      (client as any).toUnqualifiedLocal('pkgA', 'pkgB:change1');
     }).toThrow('Cross-package change encountered in local tracking: pkgB:change1 (current package: pkgA)');
   });
 });

--- a/packages/core/__tests__/migrate/local-tracking-guard.test.ts
+++ b/packages/core/__tests__/migrate/local-tracking-guard.test.ts
@@ -38,7 +38,7 @@ describe('local tracking guard for deployed/skipped', () => {
     writeFileSync(join(dir, 'deploy', `${changeName}.sql`), 'select 1;');
 
     const migrator = new LaunchQLMigrate(
-      { host: 'localhost', port: 5432, user: 'postgres', database: 'postgres' },
+      { host: 'localhost', port: 5432, user: 'postgres', database: 'postgres', password: 'postgres' } as any,
       {}
     );
 
@@ -46,7 +46,7 @@ describe('local tracking guard for deployed/skipped', () => {
       modulePath: dir,
       useTransaction: false,
       logOnly: true,
-    });
+    } as any);
 
     expect(res.deployed).toContain(changeName);
     expect(res.deployed.every((n) => !n.includes(':'))).toBe(true);

--- a/packages/core/__tests__/migrate/local-tracking-guard.test.ts
+++ b/packages/core/__tests__/migrate/local-tracking-guard.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 
 jest.mock('../../src/migrate/utils/transaction', () => ({
-  withTransaction: async (_pool, _opts, fn) => fn({}),
+  withTransaction: async (_pool: any, _opts: any, fn: any) => fn({}),
   executeQuery: jest.fn().mockResolvedValue(undefined),
 }));
 
@@ -11,7 +11,7 @@ jest.mock('pg-cache', () => ({
   getPgPool: () => ({
     query: jest
       .fn()
-      .mockImplementation((sql, params) => {
+      .mockImplementation((sql: string, params?: any[]) => {
         if (typeof sql === 'string' && sql.includes('SELECT EXISTS')) {
           return Promise.resolve({ rows: [{ exists: true }] });
         }

--- a/packages/core/__tests__/migrate/local-tracking-guard.test.ts
+++ b/packages/core/__tests__/migrate/local-tracking-guard.test.ts
@@ -1,0 +1,55 @@
+import { mkdirSync,mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+jest.mock('../../src/migrate/utils/transaction', () => ({
+  withTransaction: async (_pool, _opts, fn) => fn({}),
+  executeQuery: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('pg-cache', () => ({
+  getPgPool: () => ({
+    query: jest
+      .fn()
+      .mockImplementation((sql, params) => {
+        if (typeof sql === 'string' && sql.includes('SELECT EXISTS')) {
+          return Promise.resolve({ rows: [{ exists: true }] });
+        }
+        if (typeof sql === 'string' && sql.includes('SELECT launchql_migrate.is_deployed')) {
+          return Promise.resolve({ rows: [{ is_deployed: false }] });
+        }
+        return Promise.resolve({ rows: [] });
+      }),
+  }),
+}));
+
+import { LaunchQLMigrate } from '../../src/migrate/client';
+
+describe('local tracking guard for deployed/skipped', () => {
+  it('normalizes same-package qualified names to unqualified in deployed', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'lql-core-test-'));
+    const packageName = 'pkgA';
+    const changeName = 'change1';
+
+    const plan = [`%project=${packageName}`, `${changeName}`].join('\n');
+
+    mkdirSync(join(dir, 'deploy'), { recursive: true });
+    writeFileSync(join(dir, 'launchql.plan'), plan);
+    writeFileSync(join(dir, 'deploy', `${changeName}.sql`), 'select 1;');
+
+    const migrator = new LaunchQLMigrate(
+      { host: 'localhost', port: 5432, user: 'postgres', database: 'postgres' },
+      {}
+    );
+
+    const res = await migrator.deploy({
+      modulePath: dir,
+      useTransaction: false,
+      logOnly: true,
+    });
+
+    expect(res.deployed).toContain(changeName);
+    expect(res.deployed.every((n) => !n.includes(':'))).toBe(true);
+  });
+
+});


### PR DESCRIPTION
# core(migrate): add toUnqualifiedLocal method for local tracking guard

## Summary
Adds a private `toUnqualifiedLocal` method to the `LaunchQLMigrate` class that enforces local package scope for deployed/skipped change tracking. This centralizes logic that was previously duplicated in multiple locations and adds proper error handling for cross-package changes.

**Key changes:**
- Added `toUnqualifiedLocal` private method that validates package scope and extracts local change names
- Updated 3 locations in deploy and revert methods to use this centralized logic instead of inline splitting
- Method throws an error when cross-package changes are encountered in local tracking arrays
- Added test to verify functionality (though test couldn't be run due to Jest config issues)

## Review & Testing Checklist for Human
This is a **medium-risk** change affecting critical deployment logic. Please verify:

- [ ] **Test the functionality manually** - Run a deployment with mixed qualified/unqualified change names to ensure the method works correctly and deployed/skipped arrays only contain unqualified names
- [ ] **Validate error handling** - Confirm that throwing errors on cross-package changes is the intended behavior and won't break legitimate existing workflows  
- [ ] **Run the new test** - Fix Jest configuration issues and ensure `packages/core/__tests__/migrate/local-tracking-guard.test.ts` passes and covers the right scenarios
- [ ] **Code logic review** - Verify the string splitting logic in `toUnqualifiedLocal` handles all edge cases correctly (empty strings, multiple colons, etc.)

### Notes
- The test file was created but couldn't be executed during development due to Jest/TypeScript configuration issues
- Minor import reordering occurred during development
- This change was ported from stale PR `devin/1756430832-local-tracking-guard` to create a fresh implementation

**Link to Devin run:** https://app.devin.ai/sessions/93a117783417440999ebee209a464e9d  
**Requested by:** Dan Lynch (@pyramation)