### PR TITLE
feat(cli): make recursive default to true, add --no-recursive option

### DIFF
--- a/packages/cli/__tests__/cli-deploy-fixture.test.ts
+++ b/packages/cli/__tests__/cli-deploy-fixture.test.ts
@@ -66,8 +66,8 @@ describe('CLIDeployTestFixture', () => {
   it('should emulate terminal commands with database operations', async () => {
     const terminalCommands = `
       cd packages/
-      lql deploy --recursive --database ${testDb.name} --yes --package my-first
-      lql revert --recursive --database ${testDb.name} --yes --package my-first
+      lql deploy --database ${testDb.name} --yes --package my-first
+      lql revert --database ${testDb.name} --yes --package my-first
     `;
     
     const results = await fixture.runTerminalCommands(terminalCommands, {
@@ -97,7 +97,7 @@ describe('CLIDeployTestFixture', () => {
   it('should work with fixture directories like sqitch-w-tags', async () => {
     const commands = `
       cd packages/
-      lql deploy --recursive --database test_db --createdb --yes --package my-first
+      lql deploy --database test_db --createdb --yes --package my-first
     `;
     
     const results = await fixture.runTerminalCommands(commands, {

--- a/packages/cli/__tests__/cli-deploy-stage-unique-names.test.ts
+++ b/packages/cli/__tests__/cli-deploy-stage-unique-names.test.ts
@@ -23,7 +23,7 @@ describe('CLIDeployTestFixture Migrate', () => {
 
   it('should emulate terminal commands with database operations', async () => {
     const terminalCommands = `
-      lql deploy --recursive --database ${testDb.name} --yes --no-usePlan --package unique-names
+      lql deploy --database ${testDb.name} --yes --no-usePlan --package unique-names
     `;
     
     const results = await fixture.runTerminalCommands(terminalCommands, {
@@ -35,7 +35,7 @@ describe('CLIDeployTestFixture Migrate', () => {
 
   it('should emulate terminal commands with database operations usePlan', async () => {
     const terminalCommands = `
-      lql deploy --recursive --database ${testDb.name} --yes --usePlan --package unique-names
+      lql deploy --database ${testDb.name} --yes --usePlan --package unique-names
     `;
     
     const results = await fixture.runTerminalCommands(terminalCommands, {

--- a/packages/cli/__tests__/deploy.test.ts
+++ b/packages/cli/__tests__/deploy.test.ts
@@ -99,4 +99,21 @@ describe('CLI Deploy Command', () => {
     expect(await testDb.exists('table', 'myfirstapp.users')).toBe(false);
     expect(await testDb.exists('table', 'myfirstapp.products')).toBe(false);
   });
+
+  it('should deploy with --no-recursive flag', async () => {
+    const commands = `lql deploy --database ${testDb.name} --package my-first --no-recursive --yes`;
+    
+    await fixture.runTerminalCommands(commands, {
+      database: testDb.name
+    }, true);
+    
+    expect(await testDb.exists('schema', 'myfirstapp')).toBe(true);
+    expect(await testDb.exists('table', 'myfirstapp.users')).toBe(true);
+    expect(await testDb.exists('table', 'myfirstapp.products')).toBe(true);
+    
+    const deployedChanges = await testDb.getDeployedChanges();
+    expect(deployedChanges.some((change: any) => change.package === 'my-first')).toBe(true);
+    expect(deployedChanges.find((change: any) => change.package === 'my-second')).toBeFalsy();
+    expect(deployedChanges.find((change: any) => change.package === 'my-third')).toBeFalsy();
+  });
 });

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -101,18 +101,12 @@ export default async (
       useDefault: true,
       default: false,
       required: false
-    },
-    {
-      name: 'recursive',
-      type: 'confirm',
-      message: 'Deploy recursively through dependencies?',
-      useDefault: true,
-      default: true,
-      required: false
     }
   ];
 
-  let { yes, recursive, createdb, cwd, tx, fast, logOnly } = await prompter.prompt(argv, questions);
+  let { yes, createdb, cwd, tx, fast, logOnly } = await prompter.prompt(argv, questions);
+  
+  const recursive = argv.recursive !== false;
 
   if (!yes) {
     log.info('Operation cancelled.');

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -22,7 +22,7 @@ LaunchQL Deploy Command:
 Options:
   --help, -h         Show this help message
   --createdb         Create database if it doesn't exist
-  --recursive        Deploy recursively through dependencies
+  --no-recursive     Disable recursive deployment through dependencies
   --package <name>   Target specific package
   --to <target>      Deploy to specific change or tag
   --tx               Use transactions (default: true)
@@ -100,6 +100,14 @@ export default async (
       message: 'Log-only mode (skip script execution)?',
       useDefault: true,
       default: false,
+      required: false
+    },
+    {
+      name: 'recursive',
+      type: 'confirm',
+      message: 'Deploy recursively through dependencies?',
+      useDefault: true,
+      default: true,
       required: false
     }
   ];

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -79,6 +79,14 @@ export default async (
       required: true
     },
     {
+      name: 'recursive',
+      type: 'confirm',
+      message: 'Deploy recursively through dependencies?',
+      useDefault: true,
+      default: true,
+      required: false
+    },
+    {
       name: 'tx',
       type: 'confirm',
       message: 'Use Transaction?',
@@ -104,9 +112,7 @@ export default async (
     }
   ];
 
-  let { yes, createdb, cwd, tx, fast, logOnly } = await prompter.prompt(argv, questions);
-  
-  const recursive = argv.recursive !== false;
+  let { yes, createdb, cwd, recursive, tx, fast, logOnly } = await prompter.prompt(argv, questions);
 
   if (!yes) {
     log.info('Operation cancelled.');

--- a/packages/cli/src/commands/revert.ts
+++ b/packages/cli/src/commands/revert.ts
@@ -72,6 +72,8 @@ export default async (
     }
   ];
 
+  const explicitRecursive = argv.recursive === true;
+
   let { yes, cwd, recursive, tx } = await prompter.prompt(argv, questions);
 
   if (!yes) {
@@ -82,7 +84,7 @@ export default async (
   log.debug(`Using current directory: ${cwd}`);
 
   let packageName: string | undefined;
-  if (argv.recursive === true && argv.to !== true) {
+  if (explicitRecursive && argv.to !== true) {
     packageName = await selectDeployedPackage(database, argv, prompter, log, 'revert');
     if (!packageName) {
       await cliExitWithError('No package found to revert');

--- a/packages/cli/src/commands/revert.ts
+++ b/packages/cli/src/commands/revert.ts
@@ -82,12 +82,6 @@ export default async (
   log.debug(`Using current directory: ${cwd}`);
 
   let packageName: string | undefined;
-  if (recursive && argv.to !== true && argv.package) {
-    packageName = await selectDeployedPackage(database, argv, prompter, log, 'revert');
-    if (!packageName) {
-      await cliExitWithError('No package found to revert');
-    }
-  }
 
   const pkg = new LaunchQLPackage(cwd);
   

--- a/packages/cli/src/commands/revert.ts
+++ b/packages/cli/src/commands/revert.ts
@@ -61,18 +61,12 @@ export default async (
       useDefault: true,
       default: true,
       required: false
-    },
-    {
-      name: 'recursive',
-      type: 'confirm',
-      message: 'Revert recursively through dependencies?',
-      useDefault: true,
-      default: true,
-      required: false
     }
   ];
 
-  let { yes, recursive, cwd, tx } = await prompter.prompt(argv, questions);
+  let { yes, cwd, tx } = await prompter.prompt(argv, questions);
+  
+  const recursive = argv.recursive !== false;
 
   if (!yes) {
     log.info('Operation cancelled.');
@@ -82,7 +76,7 @@ export default async (
   log.debug(`Using current directory: ${cwd}`);
 
   let packageName: string | undefined;
-  if (recursive && argv.to !== true) {
+  if (recursive && argv.to !== true && argv.package) {
     packageName = await selectDeployedPackage(database, argv, prompter, log, 'revert');
     if (!packageName) {
       await cliExitWithError('No package found to revert');

--- a/packages/cli/src/commands/revert.ts
+++ b/packages/cli/src/commands/revert.ts
@@ -72,6 +72,8 @@ export default async (
     }
   ];
 
+  const explicitRecursive = argv.recursive === true;
+
   let { yes, cwd, recursive, tx } = await prompter.prompt(argv, questions);
 
   if (!yes) {
@@ -82,6 +84,12 @@ export default async (
   log.debug(`Using current directory: ${cwd}`);
 
   let packageName: string | undefined;
+  if (explicitRecursive && argv.to !== true) {
+    packageName = await selectDeployedPackage(database, argv, prompter, log, 'revert');
+    if (!packageName) {
+      await cliExitWithError('No package found to revert');
+    }
+  }
 
   const pkg = new LaunchQLPackage(cwd);
   

--- a/packages/cli/src/commands/revert.ts
+++ b/packages/cli/src/commands/revert.ts
@@ -72,8 +72,6 @@ export default async (
     }
   ];
 
-  const explicitRecursive = argv.recursive === true;
-
   let { yes, cwd, recursive, tx } = await prompter.prompt(argv, questions);
 
   if (!yes) {
@@ -84,7 +82,7 @@ export default async (
   log.debug(`Using current directory: ${cwd}`);
 
   let packageName: string | undefined;
-  if (explicitRecursive && argv.to !== true) {
+  if (argv.recursive === true && argv.to !== true) {
     packageName = await selectDeployedPackage(database, argv, prompter, log, 'revert');
     if (!packageName) {
       await cliExitWithError('No package found to revert');

--- a/packages/cli/src/commands/revert.ts
+++ b/packages/cli/src/commands/revert.ts
@@ -55,6 +55,14 @@ export default async (
       required: true
     },
     {
+      name: 'recursive',
+      type: 'confirm',
+      message: 'Revert recursively through dependencies?',
+      useDefault: true,
+      default: true,
+      required: false
+    },
+    {
       name: 'tx',
       type: 'confirm',
       message: 'Use Transaction?',
@@ -64,9 +72,7 @@ export default async (
     }
   ];
 
-  let { yes, cwd, tx } = await prompter.prompt(argv, questions);
-  
-  const recursive = argv.recursive !== false;
+  let { yes, cwd, recursive, tx } = await prompter.prompt(argv, questions);
 
   if (!yes) {
     log.info('Operation cancelled.');
@@ -76,7 +82,7 @@ export default async (
   log.debug(`Using current directory: ${cwd}`);
 
   let packageName: string | undefined;
-  if (argv.package) {
+  if (recursive && argv.to !== true) {
     packageName = await selectDeployedPackage(database, argv, prompter, log, 'revert');
     if (!packageName) {
       await cliExitWithError('No package found to revert');

--- a/packages/cli/src/commands/revert.ts
+++ b/packages/cli/src/commands/revert.ts
@@ -19,7 +19,7 @@ LaunchQL Revert Command:
 
 Options:
   --help, -h         Show this help message
-  --recursive        Revert recursively through dependencies
+  --no-recursive     Disable recursive revert through dependencies
   --package <name>   Revert specific package
   --to <target>      Revert to specific change or tag
   --to               Interactive selection of deployed changes
@@ -58,6 +58,14 @@ export default async (
       name: 'tx',
       type: 'confirm',
       message: 'Use Transaction?',
+      useDefault: true,
+      default: true,
+      required: false
+    },
+    {
+      name: 'recursive',
+      type: 'confirm',
+      message: 'Revert recursively through dependencies?',
       useDefault: true,
       default: true,
       required: false

--- a/packages/cli/src/commands/revert.ts
+++ b/packages/cli/src/commands/revert.ts
@@ -76,7 +76,7 @@ export default async (
   log.debug(`Using current directory: ${cwd}`);
 
   let packageName: string | undefined;
-  if (recursive && argv.to !== true && argv.package) {
+  if (argv.package) {
     packageName = await selectDeployedPackage(database, argv, prompter, log, 'revert');
     if (!packageName) {
       await cliExitWithError('No package found to revert');

--- a/packages/cli/src/commands/revert.ts
+++ b/packages/cli/src/commands/revert.ts
@@ -82,7 +82,7 @@ export default async (
   log.debug(`Using current directory: ${cwd}`);
 
   let packageName: string | undefined;
-  if (recursive && argv.to !== true) {
+  if (recursive && argv.to !== true && argv.package) {
     packageName = await selectDeployedPackage(database, argv, prompter, log, 'revert');
     if (!packageName) {
       await cliExitWithError('No package found to revert');

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -45,18 +45,11 @@ export default async (
     message: 'Select database'
   });
 
-  const questions: Question[] = [
-    {
-      name: 'recursive',
-      type: 'confirm',
-      message: 'Verify recursively through dependencies?',
-      useDefault: true,
-      default: true,
-      required: false
-    }
-  ];
+  const questions: Question[] = [];
 
-  let { recursive, cwd } = await prompter.prompt(argv, questions);
+  let { cwd } = await prompter.prompt(argv, questions);
+  
+  const recursive = argv.recursive !== false;
 
   log.debug(`Using current directory: ${cwd}`);
 

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -19,7 +19,7 @@ LaunchQL Verify Command:
 
 Options:
   --help, -h         Show this help message
-  --recursive        Verify recursively through dependencies
+  --no-recursive     Disable recursive verify through dependencies
   --package <name>   Verify specific package
   --to <target>      Verify up to specific change or tag
   --to               Interactive selection of deployed changes
@@ -45,7 +45,16 @@ export default async (
     message: 'Select database'
   });
 
-  const questions: Question[] = [];
+  const questions: Question[] = [
+    {
+      name: 'recursive',
+      type: 'confirm',
+      message: 'Verify recursively through dependencies?',
+      useDefault: true,
+      default: true,
+      required: false
+    }
+  ];
 
   let { recursive, cwd } = await prompter.prompt(argv, questions);
 

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -45,11 +45,18 @@ export default async (
     message: 'Select database'
   });
 
-  const questions: Question[] = [];
+  const questions: Question[] = [
+    {
+      name: 'recursive',
+      type: 'confirm',
+      message: 'Verify recursively through dependencies?',
+      useDefault: true,
+      default: true,
+      required: false
+    }
+  ];
 
-  let { cwd } = await prompter.prompt(argv, questions);
-  
-  const recursive = argv.recursive !== false;
+  let { cwd, recursive } = await prompter.prompt(argv, questions);
 
   log.debug(`Using current directory: ${cwd}`);
 

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -61,7 +61,7 @@ export default async (
   log.debug(`Using current directory: ${cwd}`);
 
   let packageName: string | undefined;
-  if (recursive && argv.to !== true) {
+  if (recursive && argv.to !== true && argv.package) {
     packageName = await selectDeployedPackage(database, argv, prompter, log, 'verify');
     if (!packageName) {
       await cliExitWithError('No package found to verify');

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -56,14 +56,12 @@ export default async (
     }
   ];
 
-  const explicitRecursive = argv.recursive === true;
-
   let { cwd, recursive } = await prompter.prompt(argv, questions);
 
   log.debug(`Using current directory: ${cwd}`);
 
   let packageName: string | undefined;
-  if (explicitRecursive && argv.to !== true) {
+  if (argv.recursive === true && argv.to !== true) {
     packageName = await selectDeployedPackage(database, argv, prompter, log, 'verify');
     if (!packageName) {
       await cliExitWithError('No package found to verify');

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -56,11 +56,19 @@ export default async (
     }
   ];
 
+  const explicitRecursive = argv.recursive === true;
+
   let { cwd, recursive } = await prompter.prompt(argv, questions);
 
   log.debug(`Using current directory: ${cwd}`);
 
   let packageName: string | undefined;
+  if (explicitRecursive && argv.to !== true) {
+    packageName = await selectDeployedPackage(database, argv, prompter, log, 'verify');
+    if (!packageName) {
+      await cliExitWithError('No package found to verify');
+    }
+  }
 
   const project = new LaunchQLPackage(cwd);
   

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -61,12 +61,6 @@ export default async (
   log.debug(`Using current directory: ${cwd}`);
 
   let packageName: string | undefined;
-  if (recursive && argv.to !== true && argv.package) {
-    packageName = await selectDeployedPackage(database, argv, prompter, log, 'verify');
-    if (!packageName) {
-      await cliExitWithError('No package found to verify');
-    }
-  }
 
   const project = new LaunchQLPackage(cwd);
   

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -56,12 +56,14 @@ export default async (
     }
   ];
 
+  const explicitRecursive = argv.recursive === true;
+
   let { cwd, recursive } = await prompter.prompt(argv, questions);
 
   log.debug(`Using current directory: ${cwd}`);
 
   let packageName: string | undefined;
-  if (argv.recursive === true && argv.to !== true) {
+  if (explicitRecursive && argv.to !== true) {
     packageName = await selectDeployedPackage(database, argv, prompter, log, 'verify');
     if (!packageName) {
       await cliExitWithError('No package found to verify');

--- a/packages/cli/test-utils/CLIDeployTestFixture.ts
+++ b/packages/cli/test-utils/CLIDeployTestFixture.ts
@@ -217,7 +217,13 @@ export class CLIDeployTestFixture extends TestFixture {
       
       if (token.startsWith('--')) {
         const key = token.substring(2);
-        if (i + 1 < tokens.length && !tokens[i + 1].startsWith('--')) {
+        
+        // Handle --no-* flags by setting the base property to false
+        if (key.startsWith('no-')) {
+          const baseKey = key.substring(3);
+          argv[baseKey] = false;
+          i += 1;
+        } else if (i + 1 < tokens.length && !tokens[i + 1].startsWith('--')) {
           argv[key] = tokens[i + 1];
           i += 2;
         } else {

--- a/packages/cli/test-utils/CLIDeployTestFixture.ts
+++ b/packages/cli/test-utils/CLIDeployTestFixture.ts
@@ -236,6 +236,10 @@ export class CLIDeployTestFixture extends TestFixture {
       }
     }
     
+    if (argv.recursive === undefined) {
+      argv.recursive = true;
+    }
+    
     return argv;
   }
 

--- a/packages/cli/test-utils/CLIDeployTestFixture.ts
+++ b/packages/cli/test-utils/CLIDeployTestFixture.ts
@@ -230,6 +230,10 @@ export class CLIDeployTestFixture extends TestFixture {
       }
     }
     
+    if (argv.recursive === undefined) {
+      argv.recursive = true;
+    }
+    
     return argv;
   }
 

--- a/packages/cli/test-utils/CLIDeployTestFixture.ts
+++ b/packages/cli/test-utils/CLIDeployTestFixture.ts
@@ -236,10 +236,6 @@ export class CLIDeployTestFixture extends TestFixture {
       }
     }
     
-    if (argv.recursive === undefined) {
-      argv.recursive = true;
-    }
-    
     return argv;
   }
 


### PR DESCRIPTION
# feat(cli): make recursive default to true, add --no-recursive option

## Summary
This PR implements a breaking change to make `recursive` default to `true` for CLI commands (`deploy`, `revert`, `verify`) and introduces `--no-recursive` as the explicit way to disable recursion.

**Key Changes:**
- Added `recursive` Question with `useDefault: true`, `default: true`, `required: false` to deploy, revert, and verify commands
- Updated usage text to show `--no-recursive` instead of `--recursive` 
- Removed explicit `--recursive` flags from tests since it's now default behavior
- Added test case for `--no-recursive` functionality

**Breaking Change:** All CLI operations will now be recursive by default unless explicitly disabled with `--no-recursive`.

## Review & Testing Checklist for Human

- [ ] **Verify `--no-recursive` flag works correctly** - Test that `lql deploy --no-recursive` actually disables recursive behavior (most critical to verify)
- [ ] **Test default recursive behavior** - Confirm that `lql deploy` (without flags) now deploys recursively through dependencies
- [ ] **Check existing workflows aren't broken** - Verify that current deployment/revert/verify operations still work as expected with the new defaults
- [ ] **Review breaking change impact** - Consider if existing users/scripts that relied on non-recursive default need migration guidance

### Test Plan
```bash
# Test default recursive behavior
lql deploy --database test_db --package my-package --yes

# Test explicit non-recursive behavior  
lql deploy --database test_db --package my-package --no-recursive --yes

# Test help text shows correct options
lql deploy --help
```

### Notes
- **Environment Issue**: Local tests failed due to PostgreSQL connection issues, so end-to-end functionality wasn't fully verified during development
- **CLI Parser Assumption**: Based implementation on observed pattern from other `--no-*` flags (like `--no-drop` in kill command), but this mapping wasn't directly tested
- **Session**: https://app.devin.ai/sessions/b7841fa538604ec7a4b25815a0d403d0 (requested by Dan Lynch - pyramation@gmail.com)