### PR TITLE
feat(pgsql-test): Add auth() method to PgTestClient with default auth options

### DIFF
--- a/packages/pgsql-test/__tests__/postgres-test.auth-methods.test.ts
+++ b/packages/pgsql-test/__tests__/postgres-test.auth-methods.test.ts
@@ -40,7 +40,7 @@ describe('auth() method', () => {
 
   it('sets role and userId', async () => {
     const authRole = getRoleName('authenticated');
-    await db.auth({ role: authRole, userId: '12345' });
+    db.auth({ role: authRole, userId: '12345' });
 
     const role = await db.query('SELECT current_setting(\'role\', true) AS role');
     expect(role.rows[0].role).toBe(authRole);
@@ -51,7 +51,7 @@ describe('auth() method', () => {
 
   it('sets role with custom userIdKey', async () => {
     const authRole = getRoleName('authenticated');
-    await db.auth({ 
+    db.auth({ 
       role: authRole, 
       userId: 'custom-123',
       userIdKey: 'app.user.id'
@@ -66,7 +66,7 @@ describe('auth() method', () => {
 
   it('handles numeric userId', async () => {
     const authRole = getRoleName('authenticated');
-    await db.auth({ role: authRole, userId: 99999 });
+    db.auth({ role: authRole, userId: 99999 });
 
     const userId = await db.query('SELECT current_setting(\'jwt.claims.user_id\', true) AS user_id');
     expect(userId.rows[0].user_id).toBe('99999');
@@ -74,7 +74,7 @@ describe('auth() method', () => {
 
   it('sets role without userId', async () => {
     const authRole = getRoleName('authenticated');
-    await db.auth({ role: authRole });
+    db.auth({ role: authRole });
 
     const role = await db.query('SELECT current_setting(\'role\', true) AS role');
     expect(role.rows[0].role).toBe(authRole);
@@ -91,7 +91,7 @@ describe('auth() with default role', () => {
   });
 
   it('uses default authenticated role when role not provided', async () => {
-    await db.auth({ userId: 'test-user-456' });
+    db.auth({ userId: 'test-user-456' });
 
     const role = await db.query('SELECT current_setting(\'role\', true) AS role');
     const expectedRole = getRoleName('authenticated');
@@ -103,7 +103,7 @@ describe('auth() with default role', () => {
 
   it('allows explicit role override', async () => {
     const anonRole = getRoleName('anonymous');
-    await db.auth({ userId: 'admin-user-789', role: anonRole });
+    db.auth({ userId: 'admin-user-789', role: anonRole });
 
     const role = await db.query('SELECT current_setting(\'role\', true) AS role');
     expect(role.rows[0].role).toBe(anonRole);
@@ -113,7 +113,7 @@ describe('auth() with default role', () => {
   });
 
   it('handles numeric userId with default role', async () => {
-    await db.auth({ userId: 42 });
+    db.auth({ userId: 42 });
 
     const userId = await db.query('SELECT current_setting(\'jwt.claims.user_id\', true) AS user_id');
     expect(userId.rows[0].user_id).toBe('42');
@@ -166,7 +166,7 @@ describe('clearContext() method', () => {
     expect(userIdBefore.rows[0].user_id).toBe('old-user');
 
     db.clearContext();
-    await db.auth({ userId: 'new-user' });
+    db.auth({ userId: 'new-user' });
 
     const userId = await db.query('SELECT current_setting(\'jwt.claims.user_id\', true) AS user_id');
     expect(userId.rows[0].user_id).toBe('new-user');
@@ -200,7 +200,7 @@ describe('publish() method', () => {
 
   it('preserves context after publish', async () => {
     const authRole = getRoleName('authenticated');
-    await db.auth({ role: authRole, userId: 'test-999' });
+    db.auth({ role: authRole, userId: 'test-999' });
 
     await db.publish();
 

--- a/packages/pgsql-test/__tests__/postgres-test.auth-methods.test.ts
+++ b/packages/pgsql-test/__tests__/postgres-test.auth-methods.test.ts
@@ -149,6 +149,10 @@ describe('clearContext() method', () => {
     const defaultRole = getRoleName('anonymous');
     const roleAfter = await db.query('SELECT current_setting(\'role\', true) AS role');
     expect(roleAfter.rows[0].role).toBe(defaultRole);
+
+    const userIdAfter = await db.query('SELECT current_setting(\'jwt.claims.user_id\', true) AS user_id');
+    expect(userIdAfter.rows[0].user_id).toBe('');
+
   });
 
   it('allows setting new context after clearing', async () => {

--- a/packages/pgsql-test/__tests__/postgres-test.auth-methods.test.ts
+++ b/packages/pgsql-test/__tests__/postgres-test.auth-methods.test.ts
@@ -81,7 +81,7 @@ describe('auth() method', () => {
   });
 });
 
-describe('authUser() method', () => {
+describe('auth() with default role', () => {
   beforeEach(async () => {
     await db.beforeEach();
   });
@@ -90,8 +90,8 @@ describe('authUser() method', () => {
     await db.afterEach();
   });
 
-  it('sets user context with default authenticated role', async () => {
-    await db.authUser('test-user-456');
+  it('uses default authenticated role when role not provided', async () => {
+    await db.auth({ userId: 'test-user-456' });
 
     const role = await db.query('SELECT current_setting(\'role\', true) AS role');
     const expectedRole = getRoleName('authenticated');
@@ -101,9 +101,9 @@ describe('authUser() method', () => {
     expect(userId.rows[0].user_id).toBe('test-user-456');
   });
 
-  it('sets user context with custom role', async () => {
+  it('allows explicit role override', async () => {
     const anonRole = getRoleName('anonymous');
-    await db.authUser('admin-user-789', anonRole);
+    await db.auth({ userId: 'admin-user-789', role: anonRole });
 
     const role = await db.query('SELECT current_setting(\'role\', true) AS role');
     expect(role.rows[0].role).toBe(anonRole);
@@ -112,8 +112,8 @@ describe('authUser() method', () => {
     expect(userId.rows[0].user_id).toBe('admin-user-789');
   });
 
-  it('handles numeric userId', async () => {
-    await db.authUser(42);
+  it('handles numeric userId with default role', async () => {
+    await db.auth({ userId: 42 });
 
     const userId = await db.query('SELECT current_setting(\'jwt.claims.user_id\', true) AS user_id');
     expect(userId.rows[0].user_id).toBe('42');
@@ -162,7 +162,7 @@ describe('clearContext() method', () => {
     expect(userIdBefore.rows[0].user_id).toBe('old-user');
 
     db.clearContext();
-    await db.authUser('new-user');
+    await db.auth({ userId: 'new-user' });
 
     const userId = await db.query('SELECT current_setting(\'jwt.claims.user_id\', true) AS user_id');
     expect(userId.rows[0].user_id).toBe('new-user');

--- a/packages/pgsql-test/__tests__/postgres-test.auth-methods.test.ts
+++ b/packages/pgsql-test/__tests__/postgres-test.auth-methods.test.ts
@@ -1,0 +1,227 @@
+process.env.LOG_SCOPE = 'pgsql-test';
+
+import { getConnections } from '../src/connect';
+import { getRoleName } from '../src/roles';
+import { PgTestClient } from '../src/test-client';
+
+let db: PgTestClient;
+let pg: PgTestClient;
+let teardown: () => Promise<void>;
+
+beforeAll(async () => {
+  ({ db, pg, teardown } = await getConnections());
+  
+  await pg.query(`
+    CREATE TABLE IF NOT EXISTS test_users (
+      id SERIAL PRIMARY KEY,
+      email TEXT NOT NULL,
+      name TEXT
+    )
+  `);
+});
+
+afterAll(async () => {
+  await pg.query(`DROP TABLE IF EXISTS test_users`);
+  await teardown();
+});
+
+describe('auth() method', () => {
+  beforeEach(async () => {
+    await db.beforeEach();
+  });
+
+  afterEach(async () => {
+    await db.afterEach();
+  });
+
+  it('sets role and userId', async () => {
+    const authRole = getRoleName('authenticated');
+    await db.auth({ role: authRole, userId: '12345' });
+
+    const role = await db.query('SELECT current_setting(\'role\', true) AS role');
+    expect(role.rows[0].role).toBe(authRole);
+
+    const userId = await db.query('SELECT current_setting(\'jwt.claims.user_id\', true) AS user_id');
+    expect(userId.rows[0].user_id).toBe('12345');
+  });
+
+  it('sets role with custom userIdKey', async () => {
+    const authRole = getRoleName('authenticated');
+    await db.auth({ 
+      role: authRole, 
+      userId: 'custom-123',
+      userIdKey: 'app.user.id'
+    });
+
+    const role = await db.query('SELECT current_setting(\'role\', true) AS role');
+    expect(role.rows[0].role).toBe(authRole);
+
+    const userId = await db.query('SELECT current_setting(\'app.user.id\', true) AS user_id');
+    expect(userId.rows[0].user_id).toBe('custom-123');
+  });
+
+  it('handles numeric userId', async () => {
+    const authRole = getRoleName('authenticated');
+    await db.auth({ role: authRole, userId: 99999 });
+
+    const userId = await db.query('SELECT current_setting(\'jwt.claims.user_id\', true) AS user_id');
+    expect(userId.rows[0].user_id).toBe('99999');
+  });
+
+  it('sets role without userId', async () => {
+    const adminRole = getRoleName('administrator');
+    await db.auth({ role: adminRole });
+
+    const role = await db.query('SELECT current_setting(\'role\', true) AS role');
+    expect(role.rows[0].role).toBe(adminRole);
+  });
+});
+
+describe('authUser() method', () => {
+  beforeEach(async () => {
+    await db.beforeEach();
+  });
+
+  afterEach(async () => {
+    await db.afterEach();
+  });
+
+  it('sets user context with default authenticated role', async () => {
+    await db.authUser('test-user-456');
+
+    const role = await db.query('SELECT current_setting(\'role\', true) AS role');
+    const expectedRole = getRoleName('authenticated');
+    expect(role.rows[0].role).toBe(expectedRole);
+
+    const userId = await db.query('SELECT current_setting(\'jwt.claims.user_id\', true) AS user_id');
+    expect(userId.rows[0].user_id).toBe('test-user-456');
+  });
+
+  it('sets user context with custom role', async () => {
+    const adminRole = getRoleName('administrator');
+    await db.authUser('admin-user-789', adminRole);
+
+    const role = await db.query('SELECT current_setting(\'role\', true) AS role');
+    expect(role.rows[0].role).toBe(adminRole);
+
+    const userId = await db.query('SELECT current_setting(\'jwt.claims.user_id\', true) AS user_id');
+    expect(userId.rows[0].user_id).toBe('admin-user-789');
+  });
+
+  it('handles numeric userId', async () => {
+    await db.authUser(42);
+
+    const userId = await db.query('SELECT current_setting(\'jwt.claims.user_id\', true) AS user_id');
+    expect(userId.rows[0].user_id).toBe('42');
+  });
+});
+
+describe('clearContext() method', () => {
+  beforeEach(async () => {
+    await db.beforeEach();
+  });
+
+  afterEach(async () => {
+    await db.afterEach();
+  });
+
+  it('clears all session variables', async () => {
+    const authRole = getRoleName('authenticated');
+    db.setContext({
+      role: authRole,
+      'jwt.claims.user_id': 'test-123',
+      'jwt.claims.ip_address': '192.168.1.1',
+      'custom.var': 'custom-value'
+    });
+
+    const roleBefore = await db.query('SELECT current_setting(\'role\', true) AS role');
+    expect(roleBefore.rows[0].role).toBe(authRole);
+
+    const userIdBefore = await db.query('SELECT current_setting(\'jwt.claims.user_id\', true) AS user_id');
+    expect(userIdBefore.rows[0].user_id).toBe('test-123');
+
+    db.clearContext();
+
+    const defaultRole = getRoleName('anonymous');
+    const roleAfter = await db.query('SELECT current_setting(\'role\', true) AS role');
+    expect(roleAfter.rows[0].role).toBe(defaultRole);
+  });
+
+  it('allows setting new context after clearing', async () => {
+    const authRole = getRoleName('authenticated');
+    db.setContext({
+      role: authRole,
+      'jwt.claims.user_id': 'old-user'
+    });
+
+    const userIdBefore = await db.query('SELECT current_setting(\'jwt.claims.user_id\', true) AS user_id');
+    expect(userIdBefore.rows[0].user_id).toBe('old-user');
+
+    db.clearContext();
+    await db.authUser('new-user');
+
+    const userId = await db.query('SELECT current_setting(\'jwt.claims.user_id\', true) AS user_id');
+    expect(userId.rows[0].user_id).toBe('new-user');
+  });
+});
+
+describe('publish() method', () => {
+  beforeEach(async () => {
+    await pg.beforeEach();
+    await db.beforeEach();
+  });
+
+  afterEach(async () => {
+    await db.afterEach();
+    await pg.afterEach();
+  });
+
+  it('makes data visible to other connections after publish', async () => {
+    const adminRole = getRoleName('administrator');
+    await pg.auth({ role: adminRole });
+
+    await pg.query(`INSERT INTO test_users (email, name) VALUES ('alice@test.com', 'Alice')`);
+
+    const beforePublish = await db.any('SELECT * FROM test_users WHERE email = $1', ['alice@test.com']);
+    expect(beforePublish.length).toBe(0);
+
+    await pg.publish();
+
+    const afterPublish = await db.any('SELECT * FROM test_users WHERE email = $1', ['alice@test.com']);
+    expect(afterPublish.length).toBe(1);
+    expect(afterPublish[0].email).toBe('alice@test.com');
+    expect(afterPublish[0].name).toBe('Alice');
+  });
+
+  it('preserves context after publish', async () => {
+    const authRole = getRoleName('authenticated');
+    await pg.auth({ role: authRole, userId: 'test-999' });
+
+    await pg.publish();
+
+    const role = await pg.query('SELECT current_setting(\'role\', true) AS role');
+    expect(role.rows[0].role).toBe(authRole);
+
+    const userId = await pg.query('SELECT current_setting(\'jwt.claims.user_id\', true) AS user_id');
+    expect(userId.rows[0].user_id).toBe('test-999');
+  });
+
+  it('allows rollback after publish', async () => {
+    const adminRole = getRoleName('administrator');
+    await pg.auth({ role: adminRole });
+
+    await pg.query(`INSERT INTO test_users (email, name) VALUES ('bob@test.com', 'Bob')`);
+    await pg.publish();
+
+    await pg.query(`INSERT INTO test_users (email, name) VALUES ('charlie@test.com', 'Charlie')`);
+
+    const beforeRollback = await pg.any('SELECT * FROM test_users WHERE email IN ($1, $2)', ['bob@test.com', 'charlie@test.com']);
+    expect(beforeRollback.length).toBe(2);
+
+    await pg.afterEach();
+    await pg.beforeEach();
+
+    const afterRollback = await pg.any('SELECT * FROM test_users WHERE email IN ($1, $2)', ['bob@test.com', 'charlie@test.com']);
+    expect(afterRollback.length).toBe(0);
+  });
+});

--- a/packages/pgsql-test/src/connect.ts
+++ b/packages/pgsql-test/src/connect.ts
@@ -105,11 +105,13 @@ export const getConnections = async (
   const dbConfig = {
     ...config,
     user: connOpts.connection.user,
-    password: connOpts.connection.password,
-    auth: connOpts.auth
+    password: connOpts.connection.password
   } as PgConfig;
   
-  const db = manager.getClient(dbConfig);
+  const db = manager.getClient(dbConfig, {
+    auth: connOpts.auth,
+    roles: connOpts.roles
+  });
   db.setContext({ role: getDefaultRole(connOpts) });
 
   return { pg, db, teardown, manager, admin };

--- a/packages/pgsql-test/src/connect.ts
+++ b/packages/pgsql-test/src/connect.ts
@@ -102,11 +102,14 @@ export const getConnections = async (
     }
   }
 
-  const db = manager.getClient({
+  const dbConfig = {
     ...config,
     user: connOpts.connection.user,
-    password: connOpts.connection.password
-  });
+    password: connOpts.connection.password,
+    auth: connOpts.auth
+  } as PgConfig;
+  
+  const db = manager.getClient(dbConfig);
   db.setContext({ role: getDefaultRole(connOpts) });
 
   return { pg, db, teardown, manager, admin };

--- a/packages/pgsql-test/src/manager.ts
+++ b/packages/pgsql-test/src/manager.ts
@@ -84,11 +84,14 @@ export class PgTestConnector {
     return this.pgPools.get(key)!;
   }
 
-  getClient(config: PgConfig): PgTestClient {
+  getClient(config: PgConfig, opts: any = {}): PgTestClient {
     if (this.shuttingDown) {
       throw new Error('PgTestConnector is shutting down; no new clients allowed');
     }
-    const client = new PgTestClient(config, { trackConnect: (p) => this.registerConnect(p) });
+    const client = new PgTestClient(config, { 
+      trackConnect: (p) => this.registerConnect(p),
+      ...opts
+    });
     this.clients.add(client);
 
     const key = this.dbKey(config);

--- a/packages/pgsql-test/src/manager.ts
+++ b/packages/pgsql-test/src/manager.ts
@@ -3,7 +3,7 @@ import { Pool } from 'pg';
 import { getPgEnvOptions, PgConfig } from 'pg-env';
 
 import { DbAdmin } from './admin';
-import { PgTestClient } from './test-client';
+import { PgTestClient, PgTestClientOpts } from './test-client';
 
 const log = new Logger('test-connector');
 
@@ -84,7 +84,7 @@ export class PgTestConnector {
     return this.pgPools.get(key)!;
   }
 
-  getClient(config: PgConfig, opts: any = {}): PgTestClient {
+  getClient(config: PgConfig, opts: Partial<PgTestClientOpts> = {}): PgTestClient {
     if (this.shuttingDown) {
       throw new Error('PgTestConnector is shutting down; no new clients allowed');
     }

--- a/packages/pgsql-test/src/test-client.ts
+++ b/packages/pgsql-test/src/test-client.ts
@@ -91,7 +91,7 @@ export class PgTestClient {
    * Set authentication context for the current session.
    * Configures role and user ID using cascading defaults from options → opts.auth → RoleMapping.
    */
-  async auth(options: AuthOptions = {}): Promise<void> {
+  auth(options: AuthOptions = {}): void {
     const role =
       options.role ?? this.opts.auth?.role ?? getRoleName('authenticated', this.opts);
     const userIdKey =

--- a/packages/pgsql-test/src/test-client.ts
+++ b/packages/pgsql-test/src/test-client.ts
@@ -3,7 +3,7 @@ import { PgConfig } from 'pg-env';
 import { AuthOptions, PgTestConnectionOptions } from '@launchql/types';
 import { getRoleName } from './roles';
 
-type PgTestClientOpts = {
+export type PgTestClientOpts = {
   deferConnect?: boolean;
   trackConnect?: (p: Promise<any>) => void;
 } & Partial<PgTestConnectionOptions>;

--- a/packages/pgsql-test/src/test-client.ts
+++ b/packages/pgsql-test/src/test-client.ts
@@ -98,6 +98,13 @@ export class PgTestClient {
     });
   }
 
+  async publish(): Promise<void> {
+    await this.commit();    // make data visible to other sessions
+    await this.begin();     // fresh tx
+    await this.savepoint(); // keep rollback harness
+    await this.ctxQuery();  // reapply all setContext()
+  }
+
   async any<T = any>(query: string, values?: any[]): Promise<T[]> {
     const result = await this.query(query, values);
     return result.rows;

--- a/packages/pgsql-test/src/test-client.ts
+++ b/packages/pgsql-test/src/test-client.ts
@@ -30,9 +30,6 @@ export class PgTestClient {
     if (!opts.deferConnect) {
       this.connectPromise = this.client.connect();
       if (opts.trackConnect) opts.trackConnect(this.connectPromise);
-      if (opts.auth) {
-        this.connectPromise = this.connectPromise.then(() => this.auth(opts.auth));
-      }
     }
   }
 

--- a/packages/pgsql-test/src/test-client.ts
+++ b/packages/pgsql-test/src/test-client.ts
@@ -85,15 +85,14 @@ export class PgTestClient {
       .join('\n');
   }
 
-  async auth(options?: AuthOptions): Promise<void> {
-    const role = options?.role ?? (this.config as any).auth?.role ?? null;
+  async auth(options: AuthOptions): Promise<void> {
     const userIdKey =
-      options?.userIdKey ?? (this.config as any).auth?.userIdKey ?? 'jwt.claims.user_id';
+      options.userIdKey ?? (this.config as any).auth?.userIdKey ?? 'jwt.claims.user_id';
     const userId =
-      options?.userId ?? (this.config as any).auth?.userId ?? null;
+      options.userId ?? (this.config as any).auth?.userId ?? null;
 
     this.setContext({
-      role,
+      role: options.role,
       [userIdKey]: userId !== null ? String(userId) : null
     });
   }

--- a/packages/pgsql-test/src/test-client.ts
+++ b/packages/pgsql-test/src/test-client.ts
@@ -85,6 +85,10 @@ export class PgTestClient {
       .join('\n');
   }
 
+  /**
+   * Set authentication context for the current session.
+   * Configures role and user ID using cascading defaults from options → config.auth → hardcoded.
+   */
   async auth(options: AuthOptions): Promise<void> {
     const userIdKey =
       options.userIdKey ?? (this.config as any).auth?.userIdKey ?? 'jwt.claims.user_id';
@@ -97,6 +101,10 @@ export class PgTestClient {
     });
   }
 
+  /**
+   * Commit current transaction to make data visible to other connections, then start fresh transaction.
+   * Maintains test isolation by creating a savepoint and reapplying session context.
+   */
   async publish(): Promise<void> {
     await this.commit();    // make data visible to other sessions
     await this.begin();     // fresh tx

--- a/packages/pgsql-test/src/test-client.ts
+++ b/packages/pgsql-test/src/test-client.ts
@@ -128,10 +128,11 @@ export class PgTestClient {
   }
 
   /**
-   * Clear all session context variables.
+   * Clear all session context variables and reset to default anonymous role.
    */
   clearContext(): void {
-    this.setContext({});
+    const defaultRole = getRoleName('anonymous', (this.config as any).roles);
+    this.setContext({ role: defaultRole });
   }
 
   async any<T = any>(query: string, values?: any[]): Promise<T[]> {

--- a/packages/types/src/launchql.ts
+++ b/packages/types/src/launchql.ts
@@ -4,6 +4,18 @@ import { PgConfig } from 'pg-env';
 import { PostGraphileOptions } from 'postgraphile';
 
 /**
+ * Authentication options for test client sessions
+ */
+export interface AuthOptions {
+    /** Role to assume (e.g., 'authenticated', 'administrator') */
+    role?: string;
+    /** User ID to set in session context */
+    userId?: string | number;
+    /** Key name for user ID in session context (defaults to 'jwt.claims.user_id') */
+    userIdKey?: string;
+}
+
+/**
  * Configuration options for PostgreSQL test database connections
  */
 export interface PgTestConnectionOptions {
@@ -21,6 +33,8 @@ export interface PgTestConnectionOptions {
     connection?: DatabaseConnectionOptions;
     /** Role mapping configuration */
     roles?: RoleMapping;
+    /** Default authentication options for db connections */
+    auth?: AuthOptions;
 }
 
 /**

--- a/packages/types/src/launchql.ts
+++ b/packages/types/src/launchql.ts
@@ -8,7 +8,7 @@ import { PostGraphileOptions } from 'postgraphile';
  */
 export interface AuthOptions {
     /** Role to assume (e.g., 'authenticated', 'administrator') */
-    role?: string;
+    role: string;
     /** User ID to set in session context */
     userId?: string | number;
     /** Key name for user ID in session context (defaults to 'jwt.claims.user_id') */

--- a/packages/types/src/launchql.ts
+++ b/packages/types/src/launchql.ts
@@ -7,8 +7,8 @@ import { PostGraphileOptions } from 'postgraphile';
  * Authentication options for test client sessions
  */
 export interface AuthOptions {
-    /** Role to assume (e.g., 'authenticated', 'administrator') */
-    role: string;
+    /** Role to assume (defaults to 'authenticated' from RoleMapping config) */
+    role?: string;
     /** User ID to set in session context */
     userId?: string | number;
     /** Key name for user ID in session context (defaults to 'jwt.claims.user_id') */


### PR DESCRIPTION
# Add authentication and context management methods to PgTestClient

## Summary
Adds comprehensive authentication and context management methods to `PgTestClient` for better test isolation and RLS testing:

- **`auth()` method**: Sets authentication context with cascading defaults (options → `opts.auth` → RoleMapping)
- **`clearContext()` method**: Resets all session variables to defaults with proper state tracking  
- **`publish()` method**: Enables dual-connection data sharing by committing transactions while preserving test isolation
- **Removed auto-authentication**: Authentication is now purely manual (breaking change)
- **Type safety improvements**: Added `AuthOptions` interface, exported `PgTestClientOpts`, removed `opts: any` casting

## Review & Testing Checklist for Human
This is a **medium-high risk** PR due to transaction management complexity and breaking changes. Please verify:

- [ ] **Test `clearContext()` thoroughly** - Dan's initial breaking test exposed this was buggy. Verify it actually clears ALL session variables, not just the role
- [ ] **Verify `publish()` transaction isolation** - Ensure that after `publish()`, `rollback()` still works correctly and test isolation is maintained  
- [ ] **Check for broken tests due to auto-auth removal** - Search codebase for any tests that may have relied on automatic authentication
- [ ] **Test `auth()` cascading defaults** - Verify options → `opts.auth` → RoleMapping defaults work in all combinations (missing role, missing userId, etc.)
- [ ] **End-to-end RLS testing** - Run some real RLS tests using the new `auth()` method to ensure it works correctly in practice

### Notes
- The `contextSettings` state tracking was added to fix `clearContext()` - it now tracks all variables set via `setContext()` so they can be properly NULLed
- Auto-authentication removal was explicitly requested by Dan to make authentication behavior more explicit
- Local PostgreSQL testing wasn't possible (connection refused), so all verification was done via CI only

**Link to Devin run:** https://app.devin.ai/sessions/9f8a848e9243492ea12a17d043d7d6e9  
**Requested by:** Dan Lynch (@pyramation)