### PR TITLE
fix(boilerplates): update outdated dependencies in workspace and module templates

### DIFF
--- a/boilerplates/module/package.json
+++ b/boilerplates/module/package.json
@@ -23,6 +23,11 @@
   },
   "keywords": [],
   "devDependencies": {
-    "pgsql-test": "^2.12.0"
+    "pgsql-test": "^2.12.2"
+  },
+  "pnpm": {
+    "overrides": {
+      "graphql": "14.7.0"
+    }
   }
 }

--- a/boilerplates/workspace/package.json
+++ b/boilerplates/workspace/package.json
@@ -18,20 +18,25 @@
     "lint": "pnpm -r run lint"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.11",
-    "@types/node": "^20.12.7",
-    "@typescript-eslint/eslint-plugin": "^7.10.0",
-    "@typescript-eslint/parser": "^7.10.0",
-    "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-simple-import-sort": "^12.1.0",
-    "eslint-plugin-unused-imports": "^4.0.0",
-    "eslint": "^8.56.0",
-    "jest": "^29.6.2",
-    "lerna": "^8.2.3",
-    "pgsql-test": "^2.12.0",
-    "prettier": "^3.0.2",
-    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.14",
+    "@types/node": "^22.10.2",
+    "@typescript-eslint/eslint-plugin": "^8.15.0",
+    "@typescript-eslint/parser": "^8.15.0",
+    "eslint": "^9.13.0",
+    "eslint-config-prettier": "^10.1.1",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
+    "eslint-plugin-unused-imports": "^4.3.0",
+    "jest": "^29.7.0",
+    "lerna": "^8.2.4",
+    "pgsql-test": "^2.12.2",
+    "prettier": "^3.3.3",
+    "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
-    "typescript": "^5.1.6"
+    "typescript": "^5.6.3"
+  },
+  "pnpm": {
+    "overrides": {
+      "graphql": "14.7.0"
+    }
   }
 }

--- a/packages/cli/__tests__/__snapshots__/init.install.test.ts.snap
+++ b/packages/cli/__tests__/__snapshots__/init.install.test.ts.snap
@@ -11,12 +11,17 @@ exports[`cmds:install - with initialized workspace and module installs a module 
   },
   "description": "undefined",
   "devDependencies": {
-    "pgsql-test": "^2.12.0",
+    "pgsql-test": "^2.12.2",
   },
   "homepage": "https://github.com/undefined/undefined",
   "keywords": [],
   "license": "SEE LICENSE IN LICENSE",
   "name": "undefined",
+  "pnpm": {
+    "overrides": {
+      "graphql": "14.7.0",
+    },
+  },
   "publishConfig": {
     "access": "undefined",
     "directory": "dist",
@@ -87,12 +92,17 @@ exports[`cmds:install - with initialized workspace and module installs two modul
   },
   "description": "undefined",
   "devDependencies": {
-    "pgsql-test": "^2.12.0",
+    "pgsql-test": "^2.12.2",
   },
   "homepage": "https://github.com/undefined/undefined",
   "keywords": [],
   "license": "SEE LICENSE IN LICENSE",
   "name": "undefined",
+  "pnpm": {
+    "overrides": {
+      "graphql": "14.7.0",
+    },
+  },
   "publishConfig": {
     "access": "undefined",
     "directory": "dist",

--- a/packages/templatizer/src/generated/module.ts
+++ b/packages/templatizer/src/generated/module.ts
@@ -43,7 +43,12 @@ export default [
   },
   "keywords": [],
   "devDependencies": {
-    "pgsql-test": "^2.12.0"
+    "pgsql-test": "^2.12.2"
+  },
+  "pnpm": {
+    "overrides": {
+      "graphql": "14.7.0"
+    }
   }
 }`;
   return { relPath, content };

--- a/packages/templatizer/src/generated/workspace.ts
+++ b/packages/templatizer/src/generated/workspace.ts
@@ -53,21 +53,26 @@ export default [
     "lint": "pnpm -r run lint"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.11",
-    "@types/node": "^20.12.7",
-    "@typescript-eslint/eslint-plugin": "^7.10.0",
-    "@typescript-eslint/parser": "^7.10.0",
-    "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-simple-import-sort": "^12.1.0",
-    "eslint-plugin-unused-imports": "^4.0.0",
-    "eslint": "^8.56.0",
-    "jest": "^29.6.2",
-    "lerna": "^8.2.3",
-    "pgsql-test": "^2.12.0",
-    "prettier": "^3.0.2",
-    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.14",
+    "@types/node": "^22.10.2",
+    "@typescript-eslint/eslint-plugin": "^8.15.0",
+    "@typescript-eslint/parser": "^8.15.0",
+    "eslint": "^9.13.0",
+    "eslint-config-prettier": "^10.1.1",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
+    "eslint-plugin-unused-imports": "^4.3.0",
+    "jest": "^29.7.0",
+    "lerna": "^8.2.4",
+    "pgsql-test": "^2.12.2",
+    "prettier": "^3.3.3",
+    "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
-    "typescript": "^5.1.6"
+    "typescript": "^5.6.3"
+  },
+  "pnpm": {
+    "overrides": {
+      "graphql": "14.7.0"
+    }
   }
 }`;
   return { relPath, content };


### PR DESCRIPTION
Resolves [#183](https://github.com/hyperweb-io/projects-issues/issues/183) - Update boilerplate dependencies to resolve deprecation warnings and peer dependency conflicts when initializing new workspaces.

Changes:
- Upgrade ESLint from 8.57.1 to 9.39.1 (resolves deprecation warning)
- Upgrade @typescript-eslint/* from 7.10.0 to 8.46.4
- Upgrade eslint-config-prettier from 9.1.0 to 10.1.8
- Upgrade @types/node from 20.12.7 to 22.19.1
- Upgrade pgsql-test from 2.12.0 to 2.12.2
- Add pnpm.overrides to pin graphql@14.7.0 (resolves peer dependency conflict with @pyramation/postgis requiring graphql < 15)
- Regenerate templatizer templates to reflect updated boilerplate configs

The generated workspace now installs without ESLint deprecation warnings and graphql peer dependency conflicts. Remaining warnings are from transitive dependencies (glob, inflight, subscriptions-transport-ws) which are outside our control.