### PR TITLE
Simplify deploy script headers while maintaining backwards compatibility

### DIFF
--- a/packages/core/__tests__/core/add-functionality.test.ts
+++ b/packages/core/__tests__/core/add-functionality.test.ts
@@ -179,15 +179,15 @@ describe('Add functionality', () => {
     const revertContent = readFileSync(join(moduleDir, 'revert', 'test-headers.sql'), 'utf8');
     const verifyContent = readFileSync(join(moduleDir, 'verify', 'test-headers.sql'), 'utf8');
     
-    expect(deployContent).toContain('-- Deploy: test-headers to pg');
+    expect(deployContent).toContain('-- Deploy: test-headers');
     expect(deployContent).toContain('-- made with <3 @ launchql.com');
     expect(deployContent).toContain('-- requires: users');
     expect(deployContent).toContain('-- Add your deployment SQL here');
     
-    expect(revertContent).toContain('-- Revert: test-headers from pg');
+    expect(revertContent).toContain('-- Revert: test-headers');
     expect(revertContent).toContain('-- Add your revert SQL here');
     
-    expect(verifyContent).toContain('-- Verify: test-headers on pg');
+    expect(verifyContent).toContain('-- Verify: test-headers');
     expect(verifyContent).toContain('-- Add your verification SQL here');
   });
 

--- a/packages/core/__tests__/resolution/header-format-compatibility.test.ts
+++ b/packages/core/__tests__/resolution/header-format-compatibility.test.ts
@@ -1,0 +1,149 @@
+import { resolveDependencies } from '../../src/resolution/deps';
+import { TestFixture } from '../../test-utils';
+import { writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+
+describe('Header format compatibility', () => {
+  let fixture: TestFixture;
+
+  beforeEach(() => {
+    fixture = new TestFixture();
+  });
+
+  afterEach(() => {
+    fixture.cleanup();
+  });
+
+  const setupModule = (moduleDir: string, headerFormat: 'old' | 'new' | 'mixed') => {
+    mkdirSync(join(moduleDir, 'deploy'), { recursive: true });
+    
+    const planContent = `%syntax-version=1.0.0
+%project=test-module
+%uri=https://github.com/test/test-module
+
+schema 2024-01-01T00:00:00Z Test User <test@example.com> # Add schema
+tables/users [schema] 2024-01-02T00:00:00Z Test User <test@example.com> # Add users table
+`;
+    writeFileSync(join(moduleDir, 'launchql.plan'), planContent);
+    
+    if (headerFormat === 'old') {
+      const schemaContent = `-- Deploy test-module:schema to pg
+
+CREATE SCHEMA app;
+`;
+      const usersContent = `-- Deploy test-module:tables/users to pg
+-- requires: schema
+
+CREATE TABLE app.users (id serial primary key);
+`;
+      writeFileSync(join(moduleDir, 'deploy', 'schema.sql'), schemaContent);
+      mkdirSync(join(moduleDir, 'deploy', 'tables'), { recursive: true });
+      writeFileSync(join(moduleDir, 'deploy', 'tables', 'users.sql'), usersContent);
+    } else if (headerFormat === 'new') {
+      const schemaContent = `-- Deploy test-module:schema
+
+CREATE SCHEMA app;
+`;
+      const usersContent = `-- Deploy test-module:tables/users
+-- requires: schema
+
+CREATE TABLE app.users (id serial primary key);
+`;
+      writeFileSync(join(moduleDir, 'deploy', 'schema.sql'), schemaContent);
+      mkdirSync(join(moduleDir, 'deploy', 'tables'), { recursive: true });
+      writeFileSync(join(moduleDir, 'deploy', 'tables', 'users.sql'), usersContent);
+    } else {
+      const schemaContent = `-- Deploy test-module:schema to pg
+
+CREATE SCHEMA app;
+`;
+      const usersContent = `-- Deploy test-module:tables/users
+-- requires: schema
+
+CREATE TABLE app.users (id serial primary key);
+`;
+      writeFileSync(join(moduleDir, 'deploy', 'schema.sql'), schemaContent);
+      mkdirSync(join(moduleDir, 'deploy', 'tables'), { recursive: true });
+      writeFileSync(join(moduleDir, 'deploy', 'tables', 'users.sql'), usersContent);
+    }
+  };
+
+  test('parses old header format with "to pg"', () => {
+    const moduleDir = join(fixture.tempDir, 'test-old-format');
+    setupModule(moduleDir, 'old');
+    
+    const result = resolveDependencies(moduleDir, 'test-module', { source: 'sql' });
+    
+    expect(result.resolved).toContain('schema');
+    expect(result.resolved).toContain('tables/users');
+    expect(result.resolved.indexOf('schema')).toBeLessThan(result.resolved.indexOf('tables/users'));
+  });
+
+  test('parses new header format without "to pg"', () => {
+    const moduleDir = join(fixture.tempDir, 'test-new-format');
+    setupModule(moduleDir, 'new');
+    
+    const result = resolveDependencies(moduleDir, 'test-module', { source: 'sql' });
+    
+    expect(result.resolved).toContain('schema');
+    expect(result.resolved).toContain('tables/users');
+    expect(result.resolved.indexOf('schema')).toBeLessThan(result.resolved.indexOf('tables/users'));
+  });
+
+  test('parses mixed header formats (backwards compatibility)', () => {
+    const moduleDir = join(fixture.tempDir, 'test-mixed-format');
+    setupModule(moduleDir, 'mixed');
+    
+    const result = resolveDependencies(moduleDir, 'test-module', { source: 'sql' });
+    
+    expect(result.resolved).toContain('schema');
+    expect(result.resolved).toContain('tables/users');
+    expect(result.resolved.indexOf('schema')).toBeLessThan(result.resolved.indexOf('tables/users'));
+  });
+
+  test('validates simple header format without project prefix', () => {
+    const moduleDir = join(fixture.tempDir, 'test-simple-format');
+    mkdirSync(join(moduleDir, 'deploy'), { recursive: true });
+    
+    const planContent = `%syntax-version=1.0.0
+%project=test-module
+%uri=https://github.com/test/test-module
+
+init 2024-01-01T00:00:00Z Test User <test@example.com> # Initialize
+`;
+    writeFileSync(join(moduleDir, 'launchql.plan'), planContent);
+    
+    const initContent = `-- Deploy init
+
+SELECT 1;
+`;
+    writeFileSync(join(moduleDir, 'deploy', 'init.sql'), initContent);
+    
+    const result = resolveDependencies(moduleDir, 'test-module', { source: 'sql' });
+    
+    expect(result.resolved).toContain('init');
+  });
+
+  test('validates simple header format with old "to pg" suffix', () => {
+    const moduleDir = join(fixture.tempDir, 'test-simple-old-format');
+    mkdirSync(join(moduleDir, 'deploy'), { recursive: true });
+    
+    const planContent = `%syntax-version=1.0.0
+%project=test-module
+%uri=https://github.com/test/test-module
+
+init 2024-01-01T00:00:00Z Test User <test@example.com> # Initialize
+`;
+    writeFileSync(join(moduleDir, 'launchql.plan'), planContent);
+    
+    const initContent = `-- Deploy init to pg
+
+SELECT 1;
+`;
+    writeFileSync(join(moduleDir, 'deploy', 'init.sql'), initContent);
+    
+    const result = resolveDependencies(moduleDir, 'test-module', { source: 'sql' });
+    
+    expect(result.resolved).toContain('init');
+  });
+});

--- a/packages/core/src/core/class/launchql.ts
+++ b/packages/core/src/core/class/launchql.ts
@@ -819,7 +819,7 @@ export class LaunchQLPackage {
     };
 
     // Create deploy file
-    const deployContent = `-- Deploy: ${changeName} to pg
+    const deployContent = `-- Deploy: ${changeName}
 -- made with <3 @ launchql.com
 
 ${dependencies.length > 0 ? dependencies.map(dep => `-- requires: ${dep}`).join('\n') + '\n' : ''}
@@ -827,13 +827,13 @@ ${dependencies.length > 0 ? dependencies.map(dep => `-- requires: ${dep}`).join(
 `;
 
     // Create revert file  
-    const revertContent = `-- Revert: ${changeName} from pg
+    const revertContent = `-- Revert: ${changeName}
 
 -- Add your revert SQL here
 `;
 
     // Create verify file
-    const verifyContent = `-- Verify: ${changeName} on pg
+    const verifyContent = `-- Verify: ${changeName}
 
 -- Add your verification SQL here
 `;

--- a/packages/core/src/files/sql/writer.ts
+++ b/packages/core/src/files/sql/writer.ts
@@ -51,7 +51,7 @@ const writeDeploy = (row: SqitchRow, opts: SqlWriteOptions): void => {
   
   const sqlContent = opts.replacer(row.content);
   
-  const content = `-- Deploy: ${deploy} to pg
+  const content = `-- Deploy: ${deploy}
 -- made with <3 @ launchql.com
 
 ${opts.replacer(
@@ -89,7 +89,7 @@ const writeVerify = (row: SqitchRow, opts: SqlWriteOptions): void => {
   
   const sqlContent = opts.replacer(row.verify);
   
-  const content = opts.replacer(`-- Verify: ${deploy} on pg
+  const content = opts.replacer(`-- Verify: ${deploy}
 
 ${useTx ? 'BEGIN;' : ''}
 ${sqlContent}
@@ -121,7 +121,7 @@ const writeRevert = (row: SqitchRow, opts: SqlWriteOptions): void => {
   
   const sqlContent = opts.replacer(row.revert);
   
-  const content = `-- Revert: ${deploy} from pg
+  const content = `-- Revert: ${deploy}
 
 ${useTx ? 'BEGIN;' : ''}
 ${sqlContent}

--- a/packages/core/src/resolution/deps.ts
+++ b/packages/core/src/resolution/deps.ts
@@ -523,7 +523,7 @@ export const resolveDependencies = (
       let keyToTest;
 
       if (/:/.test(line)) {
-        m2 = line.match(/^-- Deploy ([^:]*):([\w\/]+) to pg/);
+        m2 = line.match(/^-- Deploy ([^:]*):([\w\/]+)(?:\s+to\s+pg)?/);
         if (m2) {
           const actualProject = m2[1];
           keyToTest = m2[2];
@@ -549,9 +549,9 @@ export const resolveDependencies = (
         }
 
       } else {
-        m2 = line.match(/^-- Deploy (.*) to pg/);
+        m2 = line.match(/^-- Deploy (.*?)(?:\s+to\s+pg)?\s*$/);
         if (m2) {
-          keyToTest = m2[1];
+          keyToTest = m2[1].trim();
           if (key !== makeKey(keyToTest)) {
             throw new Error(
               'deployment script in wrong place or is named wrong internally\n' + line


### PR DESCRIPTION
# Simplify deploy script headers while maintaining backwards compatibility

## Summary
This PR simplifies the SQL script headers generated by LaunchQL by removing the redundant "to pg", "from pg", and "on pg" suffixes while maintaining full backwards compatibility with existing scripts.

**Changes:**
- Updated regex patterns in `deps.ts` to accept both old format (`-- Deploy: change to pg`) and new format (`-- Deploy: change`)
- Modified generators in `launchql.ts` and `writer.ts` to produce simpler headers without the suffixes
- Added comprehensive test suite (`header-format-compatibility.test.ts`) with 5 tests covering old, new, and mixed formats
- Updated existing test assertions to expect the new simpler format

**Backwards Compatibility:**
Existing repositories with the old header format will continue to work without any changes. The parser now accepts both formats, allowing for a gradual migration.

## Review & Testing Checklist for Human
- [ ] **Test with real repositories**: Verify that existing repositories with old-format headers (`to pg`, `from pg`, `on pg`) still deploy correctly
- [ ] **Verify regex edge cases**: Test the regex with unusual change names (e.g., names with hyphens, underscores, deeply nested paths) to ensure proper parsing
- [ ] **Run full test suite with PostgreSQL**: I couldn't run database-dependent tests due to PostgreSQL not being available. Please run the full test suite with a running PostgreSQL instance to verify all tests pass
- [ ] **Check for other generator locations**: Verify there are no other places in the codebase that generate these headers that I might have missed

### Test Plan
1. Create a new module and add a change using `lql add` - verify it generates headers without "to pg"
2. Take an existing module with old-format headers and run `lql deploy` - verify it deploys successfully
3. Create a module with mixed formats (some old, some new) and verify deployment works correctly

### Notes
- The regex uses non-greedy matching (`.*?`) and optional groups (`(?:\s+to\s+pg)?`) to handle both formats
- All non-database tests pass (223 tests), including the new compatibility tests
- Database-dependent tests failed due to PostgreSQL connection issues (unrelated to these changes)

**Session Info:**
- Devin session: https://app.devin.ai/sessions/ad3e53ac55414b19ad13a0a2ef9c9f39
- Requested by: Dan Lynch (@pyramation)