### PR TITLE
feat(core): simplify deploy script headers while maintaining backward…

### DIFF
--- a/packages/core/__tests__/core/add-functionality.test.ts
+++ b/packages/core/__tests__/core/add-functionality.test.ts
@@ -179,15 +179,15 @@ describe('Add functionality', () => {
     const revertContent = readFileSync(join(moduleDir, 'revert', 'test-headers.sql'), 'utf8');
     const verifyContent = readFileSync(join(moduleDir, 'verify', 'test-headers.sql'), 'utf8');
     
-    expect(deployContent).toContain('-- Deploy: test-headers to pg');
+    expect(deployContent).toContain('-- Deploy: test-headers');
     expect(deployContent).toContain('-- made with <3 @ launchql.com');
     expect(deployContent).toContain('-- requires: users');
     expect(deployContent).toContain('-- Add your deployment SQL here');
     
-    expect(revertContent).toContain('-- Revert: test-headers from pg');
+    expect(revertContent).toContain('-- Revert: test-headers');
     expect(revertContent).toContain('-- Add your revert SQL here');
     
-    expect(verifyContent).toContain('-- Verify: test-headers on pg');
+    expect(verifyContent).toContain('-- Verify: test-headers');
     expect(verifyContent).toContain('-- Add your verification SQL here');
   });
 

--- a/packages/core/__tests__/resolution/header-format-compatibility.test.ts
+++ b/packages/core/__tests__/resolution/header-format-compatibility.test.ts
@@ -1,0 +1,149 @@
+import { resolveDependencies } from '../../src/resolution/deps';
+import { TestFixture } from '../../test-utils';
+import { writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+
+describe('Header format compatibility', () => {
+  let fixture: TestFixture;
+
+  beforeEach(() => {
+    fixture = new TestFixture();
+  });
+
+  afterEach(() => {
+    fixture.cleanup();
+  });
+
+  const setupModule = (moduleDir: string, headerFormat: 'old' | 'new' | 'mixed') => {
+    mkdirSync(join(moduleDir, 'deploy'), { recursive: true });
+    
+    const planContent = `%syntax-version=1.0.0
+%project=test-module
+%uri=https://github.com/test/test-module
+
+schema 2024-01-01T00:00:00Z Test User <test@example.com> # Add schema
+tables/users [schema] 2024-01-02T00:00:00Z Test User <test@example.com> # Add users table
+`;
+    writeFileSync(join(moduleDir, 'launchql.plan'), planContent);
+    
+    if (headerFormat === 'old') {
+      const schemaContent = `-- Deploy test-module:schema to pg
+
+CREATE SCHEMA app;
+`;
+      const usersContent = `-- Deploy test-module:tables/users to pg
+-- requires: schema
+
+CREATE TABLE app.users (id serial primary key);
+`;
+      writeFileSync(join(moduleDir, 'deploy', 'schema.sql'), schemaContent);
+      mkdirSync(join(moduleDir, 'deploy', 'tables'), { recursive: true });
+      writeFileSync(join(moduleDir, 'deploy', 'tables', 'users.sql'), usersContent);
+    } else if (headerFormat === 'new') {
+      const schemaContent = `-- Deploy test-module:schema
+
+CREATE SCHEMA app;
+`;
+      const usersContent = `-- Deploy test-module:tables/users
+-- requires: schema
+
+CREATE TABLE app.users (id serial primary key);
+`;
+      writeFileSync(join(moduleDir, 'deploy', 'schema.sql'), schemaContent);
+      mkdirSync(join(moduleDir, 'deploy', 'tables'), { recursive: true });
+      writeFileSync(join(moduleDir, 'deploy', 'tables', 'users.sql'), usersContent);
+    } else {
+      const schemaContent = `-- Deploy test-module:schema to pg
+
+CREATE SCHEMA app;
+`;
+      const usersContent = `-- Deploy test-module:tables/users
+-- requires: schema
+
+CREATE TABLE app.users (id serial primary key);
+`;
+      writeFileSync(join(moduleDir, 'deploy', 'schema.sql'), schemaContent);
+      mkdirSync(join(moduleDir, 'deploy', 'tables'), { recursive: true });
+      writeFileSync(join(moduleDir, 'deploy', 'tables', 'users.sql'), usersContent);
+    }
+  };
+
+  test('parses old header format with "to pg"', () => {
+    const moduleDir = join(fixture.tempDir, 'test-old-format');
+    setupModule(moduleDir, 'old');
+    
+    const result = resolveDependencies(moduleDir, 'test-module', { source: 'sql' });
+    
+    expect(result.resolved).toContain('schema');
+    expect(result.resolved).toContain('tables/users');
+    expect(result.resolved.indexOf('schema')).toBeLessThan(result.resolved.indexOf('tables/users'));
+  });
+
+  test('parses new header format without "to pg"', () => {
+    const moduleDir = join(fixture.tempDir, 'test-new-format');
+    setupModule(moduleDir, 'new');
+    
+    const result = resolveDependencies(moduleDir, 'test-module', { source: 'sql' });
+    
+    expect(result.resolved).toContain('schema');
+    expect(result.resolved).toContain('tables/users');
+    expect(result.resolved.indexOf('schema')).toBeLessThan(result.resolved.indexOf('tables/users'));
+  });
+
+  test('parses mixed header formats (backwards compatibility)', () => {
+    const moduleDir = join(fixture.tempDir, 'test-mixed-format');
+    setupModule(moduleDir, 'mixed');
+    
+    const result = resolveDependencies(moduleDir, 'test-module', { source: 'sql' });
+    
+    expect(result.resolved).toContain('schema');
+    expect(result.resolved).toContain('tables/users');
+    expect(result.resolved.indexOf('schema')).toBeLessThan(result.resolved.indexOf('tables/users'));
+  });
+
+  test('validates simple header format without project prefix', () => {
+    const moduleDir = join(fixture.tempDir, 'test-simple-format');
+    mkdirSync(join(moduleDir, 'deploy'), { recursive: true });
+    
+    const planContent = `%syntax-version=1.0.0
+%project=test-module
+%uri=https://github.com/test/test-module
+
+init 2024-01-01T00:00:00Z Test User <test@example.com> # Initialize
+`;
+    writeFileSync(join(moduleDir, 'launchql.plan'), planContent);
+    
+    const initContent = `-- Deploy init
+
+SELECT 1;
+`;
+    writeFileSync(join(moduleDir, 'deploy', 'init.sql'), initContent);
+    
+    const result = resolveDependencies(moduleDir, 'test-module', { source: 'sql' });
+    
+    expect(result.resolved).toContain('init');
+  });
+
+  test('validates simple header format with old "to pg" suffix', () => {
+    const moduleDir = join(fixture.tempDir, 'test-simple-old-format');
+    mkdirSync(join(moduleDir, 'deploy'), { recursive: true });
+    
+    const planContent = `%syntax-version=1.0.0
+%project=test-module
+%uri=https://github.com/test/test-module
+
+init 2024-01-01T00:00:00Z Test User <test@example.com> # Initialize
+`;
+    writeFileSync(join(moduleDir, 'launchql.plan'), planContent);
+    
+    const initContent = `-- Deploy init to pg
+
+SELECT 1;
+`;
+    writeFileSync(join(moduleDir, 'deploy', 'init.sql'), initContent);
+    
+    const result = resolveDependencies(moduleDir, 'test-module', { source: 'sql' });
+    
+    expect(result.resolved).toContain('init');
+  });
+});

--- a/packages/core/src/core/class/launchql.ts
+++ b/packages/core/src/core/class/launchql.ts
@@ -819,7 +819,7 @@ export class LaunchQLPackage {
     };
 
     // Create deploy file
-    const deployContent = `-- Deploy: ${changeName} to pg
+    const deployContent = `-- Deploy: ${changeName}
 -- made with <3 @ launchql.com
 
 ${dependencies.length > 0 ? dependencies.map(dep => `-- requires: ${dep}`).join('\n') + '\n' : ''}
@@ -827,13 +827,13 @@ ${dependencies.length > 0 ? dependencies.map(dep => `-- requires: ${dep}`).join(
 `;
 
     // Create revert file  
-    const revertContent = `-- Revert: ${changeName} from pg
+    const revertContent = `-- Revert: ${changeName}
 
 -- Add your revert SQL here
 `;
 
     // Create verify file
-    const verifyContent = `-- Verify: ${changeName} on pg
+    const verifyContent = `-- Verify: ${changeName}
 
 -- Add your verification SQL here
 `;

--- a/packages/core/src/files/sql/writer.ts
+++ b/packages/core/src/files/sql/writer.ts
@@ -51,7 +51,7 @@ const writeDeploy = (row: SqitchRow, opts: SqlWriteOptions): void => {
   
   const sqlContent = opts.replacer(row.content);
   
-  const content = `-- Deploy: ${deploy} to pg
+  const content = `-- Deploy: ${deploy}
 -- made with <3 @ launchql.com
 
 ${opts.replacer(
@@ -89,7 +89,7 @@ const writeVerify = (row: SqitchRow, opts: SqlWriteOptions): void => {
   
   const sqlContent = opts.replacer(row.verify);
   
-  const content = opts.replacer(`-- Verify: ${deploy} on pg
+  const content = opts.replacer(`-- Verify: ${deploy}
 
 ${useTx ? 'BEGIN;' : ''}
 ${sqlContent}
@@ -121,7 +121,7 @@ const writeRevert = (row: SqitchRow, opts: SqlWriteOptions): void => {
   
   const sqlContent = opts.replacer(row.revert);
   
-  const content = `-- Revert: ${deploy} from pg
+  const content = `-- Revert: ${deploy}
 
 ${useTx ? 'BEGIN;' : ''}
 ${sqlContent}

--- a/packages/core/src/resolution/deps.ts
+++ b/packages/core/src/resolution/deps.ts
@@ -523,7 +523,7 @@ export const resolveDependencies = (
       let keyToTest;
 
       if (/:/.test(line)) {
-        m2 = line.match(/^-- Deploy ([^:]*):([\w\/]+) to pg/);
+        m2 = line.match(/^-- Deploy ([^:]*):([\w\/]+)(?:\s+to\s+pg)?/);
         if (m2) {
           const actualProject = m2[1];
           keyToTest = m2[2];
@@ -549,9 +549,9 @@ export const resolveDependencies = (
         }
 
       } else {
-        m2 = line.match(/^-- Deploy (.*) to pg/);
+        m2 = line.match(/^-- Deploy (.*?)(?:\s+to\s+pg)?\s*$/);
         if (m2) {
-          keyToTest = m2[1];
+          keyToTest = m2[1].trim();
           if (key !== makeKey(keyToTest)) {
             throw new Error(
               'deployment script in wrong place or is named wrong internally\n' + line


### PR DESCRIPTION
…s compatibility

- Update regex in deps.ts to accept both old ('to pg') and new (without 'to pg') header formats
- Update generators to produce simpler headers without 'to pg', 'from pg', 'on pg' suffixes
- Add comprehensive tests to verify both header formats work correctly
- Update existing test assertions to expect new simpler format

This change maintains full backwards compatibility - existing scripts with 'to pg' will continue to work, while new scripts will use the cleaner, simpler format.