### PR TITLE
Fix: Handle missing requires line in .control file during install

### DIFF
--- a/packages/core/__tests__/files/extension/reader.test.ts
+++ b/packages/core/__tests__/files/extension/reader.test.ts
@@ -132,4 +132,18 @@ superuser = false
     
     expect(() => getInstalledExtensions(controlFilePath)).toThrow();
   });
+
+  it('should handle control file without requires line (regression test for #291)', () => {
+    const content = `# test extension
+comment = 'test extension'
+default_version = '1.0.0'
+module_pathname = '$libdir/test'
+relocatable = false
+superuser = false
+`;
+    fs.writeFileSync(controlFilePath, content);
+    
+    const result = getInstalledExtensions(controlFilePath);
+    expect(result).toEqual([]);
+  });
 });

--- a/packages/core/__tests__/files/extension/reader.test.ts
+++ b/packages/core/__tests__/files/extension/reader.test.ts
@@ -127,12 +127,9 @@ superuser = false
     expect(result).toEqual(['pgcrypto', 'postgis']);
   });
 
-  it('should throw error for permission issues', () => {
-    fs.writeFileSync(controlFilePath, 'test content');
-    fs.chmodSync(controlFilePath, 0o000);
+  it('should throw error for non-ENOENT read errors', () => {
+    fs.mkdirSync(controlFilePath);
     
     expect(() => getInstalledExtensions(controlFilePath)).toThrow();
-    
-    fs.chmodSync(controlFilePath, 0o644);
   });
 });

--- a/packages/core/__tests__/files/extension/reader.test.ts
+++ b/packages/core/__tests__/files/extension/reader.test.ts
@@ -1,0 +1,138 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { getInstalledExtensions } from '../../../src/files/extension/reader';
+
+describe('getInstalledExtensions', () => {
+  let tempDir: string;
+  let controlFilePath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'launchql-test-'));
+    controlFilePath = path.join(tempDir, 'test.control');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should return empty array when control file has no requires line', () => {
+    const content = `# test extension
+comment = 'test extension'
+default_version = '1.0.0'
+module_pathname = '$libdir/test'
+relocatable = false
+superuser = false
+`;
+    fs.writeFileSync(controlFilePath, content);
+    
+    const result = getInstalledExtensions(controlFilePath);
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array when control file does not exist', () => {
+    const nonExistentPath = path.join(tempDir, 'nonexistent.control');
+    
+    const result = getInstalledExtensions(nonExistentPath);
+    expect(result).toEqual([]);
+  });
+
+  it('should parse single extension from requires line', () => {
+    const content = `# test extension
+comment = 'test extension'
+default_version = '1.0.0'
+requires = 'pgcrypto'
+module_pathname = '$libdir/test'
+relocatable = false
+superuser = false
+`;
+    fs.writeFileSync(controlFilePath, content);
+    
+    const result = getInstalledExtensions(controlFilePath);
+    expect(result).toEqual(['pgcrypto']);
+  });
+
+  it('should parse multiple extensions from requires line', () => {
+    const content = `# test extension
+comment = 'test extension'
+default_version = '1.0.0'
+requires = 'pgcrypto,postgis,plpgsql'
+module_pathname = '$libdir/test'
+relocatable = false
+superuser = false
+`;
+    fs.writeFileSync(controlFilePath, content);
+    
+    const result = getInstalledExtensions(controlFilePath);
+    expect(result).toEqual(['pgcrypto', 'postgis', 'plpgsql']);
+  });
+
+  it('should handle requires line with spaces', () => {
+    const content = `# test extension
+comment = 'test extension'
+default_version = '1.0.0'
+requires = 'pgcrypto, postgis, plpgsql'
+module_pathname = '$libdir/test'
+relocatable = false
+superuser = false
+`;
+    fs.writeFileSync(controlFilePath, content);
+    
+    const result = getInstalledExtensions(controlFilePath);
+    expect(result).toEqual(['pgcrypto', 'postgis', 'plpgsql']);
+  });
+
+  it('should handle requires line with leading/trailing whitespace', () => {
+    const content = `# test extension
+comment = 'test extension'
+default_version = '1.0.0'
+  requires = 'pgcrypto,postgis'  
+module_pathname = '$libdir/test'
+relocatable = false
+superuser = false
+`;
+    fs.writeFileSync(controlFilePath, content);
+    
+    const result = getInstalledExtensions(controlFilePath);
+    expect(result).toEqual(['pgcrypto', 'postgis']);
+  });
+
+  it('should return empty array when requires line is empty', () => {
+    const content = `# test extension
+comment = 'test extension'
+default_version = '1.0.0'
+requires = ''
+module_pathname = '$libdir/test'
+relocatable = false
+superuser = false
+`;
+    fs.writeFileSync(controlFilePath, content);
+    
+    const result = getInstalledExtensions(controlFilePath);
+    expect(result).toEqual([]);
+  });
+
+  it('should filter out empty strings from comma-separated list', () => {
+    const content = `# test extension
+comment = 'test extension'
+default_version = '1.0.0'
+requires = 'pgcrypto,,postgis'
+module_pathname = '$libdir/test'
+relocatable = false
+superuser = false
+`;
+    fs.writeFileSync(controlFilePath, content);
+    
+    const result = getInstalledExtensions(controlFilePath);
+    expect(result).toEqual(['pgcrypto', 'postgis']);
+  });
+
+  it('should throw error for permission issues', () => {
+    fs.writeFileSync(controlFilePath, 'test content');
+    fs.chmodSync(controlFilePath, 0o000);
+    
+    expect(() => getInstalledExtensions(controlFilePath)).toThrow();
+    
+    fs.chmodSync(controlFilePath, 0o644);
+  });
+});

--- a/packages/core/__tests__/files/extension/writer.test.ts
+++ b/packages/core/__tests__/files/extension/writer.test.ts
@@ -19,7 +19,7 @@ describe('extension writer', () => {
     );
 
     fs.writeFileSync(
-      path.join(packageDir, 'launchql.plan'),
+      path.join(packageDir, 'pgpm.plan'),
       '%project=test-module\n\nschema 2024-01-01T00:00:00Z Test User <test@example.com> # Add schema\n'
     );
   });

--- a/packages/core/__tests__/files/extension/writer.test.ts
+++ b/packages/core/__tests__/files/extension/writer.test.ts
@@ -1,0 +1,196 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { writeExtensions, generateControlFileContent } from '../../../src/files/extension/writer';
+import { getInstalledExtensions } from '../../../src/files/extension/reader';
+
+describe('extension writer', () => {
+  let tempDir: string;
+  let packageDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'launchql-test-'));
+    packageDir = path.join(tempDir, 'test-module');
+    fs.mkdirSync(packageDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(packageDir, 'package.json'),
+      JSON.stringify({ name: 'test-module', version: '1.0.0' }, null, 2)
+    );
+
+    fs.writeFileSync(
+      path.join(packageDir, 'launchql.plan'),
+      '%project=test-module\n\nschema 2024-01-01T00:00:00Z Test User <test@example.com> # Add schema\n'
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('generateControlFileContent', () => {
+    it('generates control file with single extension', () => {
+      const content = generateControlFileContent({
+        name: 'test-module',
+        version: '1.0.0',
+        requires: ['pgcrypto']
+      });
+
+      expect(content).toContain("comment = 'test-module extension'");
+      expect(content).toContain("default_version = '1.0.0'");
+      expect(content).toContain("module_pathname = '$libdir/test-module'");
+      expect(content).toContain("requires = 'pgcrypto'");
+      expect(content).toContain('relocatable = false');
+      expect(content).toContain('superuser = false');
+    });
+
+    it('generates control file with multiple extensions', () => {
+      const content = generateControlFileContent({
+        name: 'test-module',
+        version: '1.0.0',
+        requires: ['pgcrypto', 'postgis', 'plpgsql']
+      });
+
+      expect(content).toContain("requires = 'pgcrypto,postgis,plpgsql'");
+    });
+
+    it('generates control file without requires when empty array', () => {
+      const content = generateControlFileContent({
+        name: 'test-module',
+        version: '1.0.0',
+        requires: []
+      });
+
+      expect(content).not.toContain('requires =');
+      expect(content).toContain("comment = 'test-module extension'");
+      expect(content).toContain("default_version = '1.0.0'");
+    });
+
+    it('generates control file with custom comment', () => {
+      const content = generateControlFileContent({
+        name: 'test-module',
+        version: '1.0.0',
+        comment: 'Custom test module',
+        requires: []
+      });
+
+      expect(content).toContain("comment = 'Custom test module'");
+    });
+
+    it('generates control file with custom module_pathname', () => {
+      const content = generateControlFileContent({
+        name: 'test-module',
+        version: '1.0.0',
+        module_pathname: '$libdir/custom-path',
+        requires: []
+      });
+
+      expect(content).toContain("module_pathname = '$libdir/custom-path'");
+    });
+
+    it('generates control file with schema', () => {
+      const content = generateControlFileContent({
+        name: 'test-module',
+        version: '1.0.0',
+        schema: 'public',
+        requires: []
+      });
+
+      expect(content).toContain('schema = public');
+    });
+  });
+
+  describe('writeExtensions', () => {
+    it('writes control file and Makefile with single extension', () => {
+      writeExtensions(packageDir, ['pgcrypto']);
+
+      const controlFile = path.join(packageDir, 'test-module.control');
+      const makefile = path.join(packageDir, 'Makefile');
+
+      expect(fs.existsSync(controlFile)).toBe(true);
+      expect(fs.existsSync(makefile)).toBe(true);
+
+      const controlContent = fs.readFileSync(controlFile, 'utf-8');
+      expect(controlContent).toContain("requires = 'pgcrypto'");
+      expect(controlContent).toContain("default_version = '1.0.0'");
+
+      const makefileContent = fs.readFileSync(makefile, 'utf-8');
+      expect(makefileContent).toContain('EXTENSION = test-module');
+      expect(makefileContent).toContain('DATA = sql/test-module--1.0.0.sql');
+    });
+
+    it('writes control file with multiple extensions', () => {
+      writeExtensions(packageDir, ['pgcrypto', 'postgis', 'plpgsql']);
+
+      const controlFile = path.join(packageDir, 'test-module.control');
+      const controlContent = fs.readFileSync(controlFile, 'utf-8');
+
+      expect(controlContent).toContain("requires = 'pgcrypto,postgis,plpgsql'");
+
+      const extensions = getInstalledExtensions(controlFile);
+      expect(extensions).toEqual(['pgcrypto', 'postgis', 'plpgsql']);
+    });
+
+    it('writes control file without requires when empty array', () => {
+      writeExtensions(packageDir, []);
+
+      const controlFile = path.join(packageDir, 'test-module.control');
+      const controlContent = fs.readFileSync(controlFile, 'utf-8');
+
+      expect(controlContent).not.toContain('requires =');
+
+      const extensions = getInstalledExtensions(controlFile);
+      expect(extensions).toEqual([]);
+    });
+
+    it('updates existing control file with new extensions', () => {
+      writeExtensions(packageDir, ['pgcrypto']);
+
+      let controlFile = path.join(packageDir, 'test-module.control');
+      let extensions = getInstalledExtensions(controlFile);
+      expect(extensions).toEqual(['pgcrypto']);
+
+      writeExtensions(packageDir, ['pgcrypto', 'postgis']);
+
+      extensions = getInstalledExtensions(controlFile);
+      expect(extensions).toEqual(['pgcrypto', 'postgis']);
+    });
+
+    it('handles idempotent writes with same extensions', () => {
+      writeExtensions(packageDir, ['pgcrypto', 'postgis']);
+
+      const controlFile = path.join(packageDir, 'test-module.control');
+      const firstContent = fs.readFileSync(controlFile, 'utf-8');
+
+      writeExtensions(packageDir, ['pgcrypto', 'postgis']);
+
+      const secondContent = fs.readFileSync(controlFile, 'utf-8');
+      expect(secondContent).toBe(firstContent);
+    });
+
+    it('overwrites control file when extensions change', () => {
+      writeExtensions(packageDir, ['pgcrypto']);
+
+      const controlFile = path.join(packageDir, 'test-module.control');
+      let extensions = getInstalledExtensions(controlFile);
+      expect(extensions).toEqual(['pgcrypto']);
+
+      writeExtensions(packageDir, ['postgis', 'plpgsql']);
+
+      extensions = getInstalledExtensions(controlFile);
+      expect(extensions).toEqual(['postgis', 'plpgsql']);
+    });
+
+    it('writes extensions in the order provided', () => {
+      writeExtensions(packageDir, ['plpgsql', 'pgcrypto', 'postgis']);
+
+      const controlFile = path.join(packageDir, 'test-module.control');
+      const controlContent = fs.readFileSync(controlFile, 'utf-8');
+
+      expect(controlContent).toContain("requires = 'plpgsql,pgcrypto,postgis'");
+
+      const extensions = getInstalledExtensions(controlFile);
+      expect(extensions).toEqual(['plpgsql', 'pgcrypto', 'postgis']);
+    });
+  });
+});


### PR DESCRIPTION
# Fix: Handle missing requires line in .control file during install

## Summary
Fixes #291 where `lql install` (or `pgpm install`) would fail when trying to install a package into a module whose `.control` file doesn't have a `requires` line yet.

**Root Cause:** The `getInstalledExtensions()` function threw an error when it couldn't find a `requires` line in the .control file. This caused `installModules()` to crash before it could write the updated .control file with the new dependencies.

**Changes:**
- Modified `getInstalledExtensions()` in `packages/core/src/files/extension/reader.ts` to return an empty array instead of throwing when:
  - The .control file has no `requires` line
  - The .control file doesn't exist (ENOENT)
  - The `requires` line is empty or contains only whitespace
- Improved parsing with a more robust regex pattern that handles whitespace variations
- Added comprehensive unit tests (9 test cases) covering various edge cases

## Review & Testing Checklist for Human
This is a **yellow risk** change (behavior modification in error handling).

- [ ] **CRITICAL: Test end-to-end** - Create a test module with a .control file that has no `requires` line, then run `lql install <some-package>` and verify the .control file is updated correctly
- [ ] **Verify no breaking changes** - Check if any other code in the codebase depends on `getInstalledExtensions()` throwing errors (I only found one caller: `getRequiredModules()`, but please double-check)
- [ ] **Regex pattern validation** - The new regex assumes single quotes: `/^\s*requires\s*=\s*'([^']*)'/m`. Verify that all .control files in the ecosystem use single quotes (not double quotes or no quotes)
- [ ] **Review error handling** - Confirm that returning `[]` for ENOENT is appropriate, and that permission errors still throw (as intended)

### Test Plan
1. Create a new module: `lql init my-test-module`
2. Verify the .control file exists but has no `requires` line (or remove it)
3. Run: `lql install @pgpm/base32` (or any other package)
4. Verify the .control file now has: `requires = 'base32'` (or appropriate extension name)
5. Run install again with another package and verify it appends correctly

### Notes
- All 9 unit tests pass
- Build completes successfully
- This changes the function from throwing errors to returning empty arrays, which is technically a breaking change in the API contract, but appears to be the intended behavior based on how it's used in `installModules()`
- The fix aligns with how `parseControlFile()` already handles missing requires (returns empty array)

---
**Link to Devin run:** https://app.devin.ai/sessions/ab03044e89dd4fdfbc0107c684e05afb  
**Requested by:** Dan Lynch (pyramation@gmail.com) / @pyramation