### PR TITLE
Rename launchql_migrate schema to pgpm_migrate

### DIFF
--- a/packages/cli/__tests__/cli-deploy-fixture.test.ts
+++ b/packages/cli/__tests__/cli-deploy-fixture.test.ts
@@ -28,7 +28,7 @@ describe('CLIDeployTestFixture', () => {
     const result = await testDb.query('SELECT 1 as test');
     expect(result.rows[0].test).toBe(1);
     
-    const schemaExists = await testDb.exists('schema', 'launchql_migrate');
+    const schemaExists = await testDb.exists('schema', 'pgpm_migrate');
     expect(schemaExists).toBe(true);
   });
 

--- a/packages/cli/test-utils/CLIDeployTestFixture.ts
+++ b/packages/cli/test-utils/CLIDeployTestFixture.ts
@@ -97,7 +97,7 @@ export class CLIDeployTestFixture extends TestFixture {
       async getDeployedChanges() {
         const result = await pool.query(
           `SELECT package, change_name, deployed_at 
-           FROM launchql_migrate.changes 
+           FROM pgpm_migrate.changes 
            ORDER BY deployed_at`
         );
         return result.rows;
@@ -106,13 +106,13 @@ export class CLIDeployTestFixture extends TestFixture {
       async getMigrationState() {
         const changes = await pool.query(`
           SELECT package, change_name, script_hash, deployed_at
-          FROM launchql_migrate.changes 
+          FROM pgpm_migrate.changes 
           ORDER BY deployed_at
         `);
         
         const events = await pool.query(`
           SELECT package, change_name, event_type, occurred_at, error_message, error_code
-          FROM launchql_migrate.events 
+          FROM pgpm_migrate.events 
           ORDER BY occurred_at
         `);
         
@@ -133,8 +133,8 @@ export class CLIDeployTestFixture extends TestFixture {
       async getDependencies(packageName: string, changeName: string) {
         const result = await pool.query(
           `SELECT d.requires 
-           FROM launchql_migrate.dependencies d
-           JOIN launchql_migrate.changes c ON c.change_id = d.change_id
+           FROM pgpm_migrate.dependencies d
+           JOIN pgpm_migrate.changes c ON c.change_id = d.change_id
            WHERE c.package = $1 AND c.change_name = $2`,
           [packageName, changeName]
         );

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -209,7 +209,7 @@ async verify(options: VerifyOptions): Promise<VerifyResult>
 - `getDependencies(packageName: string, changeName: string)` - Get change dependencies
 
 **Migration Schema:**
-- `initialize(): Promise<void>` - Create launchql_migrate schema
+- `initialize(): Promise<void>` - Create pgpm_migrate schema
 - `hasSqitchTables(): Promise<boolean>` - Check for existing Sqitch tables
 - `importFromSqitch(): Promise<void>` - Import from existing Sqitch deployment
 

--- a/packages/core/__tests__/migrate/tag-fallback.test.ts
+++ b/packages/core/__tests__/migrate/tag-fallback.test.ts
@@ -23,7 +23,7 @@ jest.mock('pg-cache', () => ({
         if (typeof sql === 'string' && sql.includes('SELECT EXISTS')) {
           return Promise.resolve({ rows: [{ exists: true }] });
         }
-        if (typeof sql === 'string' && sql.includes('SELECT launchql_migrate.is_deployed')) {
+        if (typeof sql === 'string' && sql.includes('SELECT pgpm_migrate.is_deployed')) {
           return Promise.resolve({ rows: [{ is_deployed: false }] });
         }
         return Promise.resolve({ rows: [] });

--- a/packages/core/__tests__/migration/cross-project-dependencies.test.ts
+++ b/packages/core/__tests__/migration/cross-project-dependencies.test.ts
@@ -102,7 +102,7 @@ describe('Cross-Project Dependencies', () => {
     
     // Query dependents using the SQL function
     const result = await db.query(
-      `SELECT * FROM launchql_migrate.get_dependents($1, $2)`,
+      `SELECT * FROM pgpm_migrate.get_dependents($1, $2)`,
       ['project-a', 'base_schema']
     );
     

--- a/packages/core/__tests__/projects/DEPLOYMENT_FAILURE_ANALYSIS.md
+++ b/packages/core/__tests__/projects/DEPLOYMENT_FAILURE_ANALYSIS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document analyzes the behavior of LaunchQL's migration system when SQL changes fail during deployment, specifically examining the state of the `launchql_migrate` schema and tables.
+This document analyzes the behavior of LaunchQL's migration system when SQL changes fail during deployment, specifically examining the state of the `pgpm_migrate` schema and tables.
 
 ## Key Findings
 
@@ -13,8 +13,8 @@ When a deployment fails in transaction mode:
 - **Complete Rollback**: All changes are automatically rolled back
 - **Database State**: Clean (as if deployment never happened)
 - **Migration Tracking**: 
-  - `launchql_migrate.changes`: 0 rows
-  - `launchql_migrate.events`: 0 rows
+  - `pgpm_migrate.changes`: 0 rows
+  - `pgpm_migrate.events`: 0 rows
 - **Behavior**: Entire deployment is wrapped in a single transaction
 
 **Snapshot Evidence:**
@@ -34,8 +34,8 @@ When a deployment fails in non-transaction mode:
 - **Partial Deployment**: Successful changes remain deployed
 - **Database State**: Mixed (successful changes persist)
 - **Migration Tracking**:
-  - `launchql_migrate.changes`: Contains successful deployments
-  - `launchql_migrate.events`: Contains `deploy` events for successful changes
+  - `pgpm_migrate.changes`: Contains successful deployments
+  - `pgpm_migrate.events`: Contains `deploy` events for successful changes
 - **Behavior**: Each change deployed individually
 
 **Snapshot Evidence:**
@@ -78,15 +78,15 @@ When a deployment fails in non-transaction mode:
 
 ### Failure Event Logging
 
-**Critical Discovery**: Failure events are NOT logged to the `launchql_migrate.events` table. Only successful deployments create entries with `event_type: 'deploy'`.
+**Critical Discovery**: Failure events are NOT logged to the `pgpm_migrate.events` table. Only successful deployments create entries with `event_type: 'deploy'`.
 
 - Failed deployments are logged to application logs but not persisted in the migration tracking tables
-- The `launchql_migrate.events` table only contains successful deployment records
+- The `pgpm_migrate.events` table only contains successful deployment records
 - This means you cannot query the migration tables to see deployment failure history
 
 ### Schema Structure
 
-The `launchql_migrate.events` table supports failure tracking with:
+The `pgpm_migrate.events` table supports failure tracking with:
 ```sql
 event_type TEXT NOT NULL CHECK (event_type IN ('deploy', 'revert', 'fail'))
 ```
@@ -104,7 +104,7 @@ However, in practice, only `'deploy'` events are currently being logged.
 ### For Development/Testing
 
 - Non-transaction mode can be useful for incremental rollout scenarios where partial success is acceptable
-- Always verify the state of `launchql_migrate.changes` after deployment failures
+- Always verify the state of `pgpm_migrate.changes` after deployment failures
 
 ## Test Coverage
 

--- a/packages/core/__tests__/projects/deploy-failure-scenarios.test.ts
+++ b/packages/core/__tests__/projects/deploy-failure-scenarios.test.ts
@@ -195,8 +195,8 @@ describe('Deploy Failure Scenarios', () => {
     /*
      * KEY INSIGHT: Transaction mode provides complete rollback
      * 
-     * - launchql_migrate.changes: 0 rows (complete rollback)
-     * - launchql_migrate.events: 1 failure event (logged outside transaction)
+     * - pgpm_migrate.changes: 0 rows (complete rollback)
+     * - pgpm_migrate.events: 1 failure event (logged outside transaction)
      * - Database objects: none (clean state)
      * 
      * RECOMMENDATION: Use transaction mode (default) for atomic deployments
@@ -266,8 +266,8 @@ describe('Deploy Failure Scenarios', () => {
     /*
      * KEY INSIGHT: Non-transaction mode provides partial deployment
      * 
-     * - launchql_migrate.changes: 2 rows (partial success)
-     * - launchql_migrate.events: 2 success + 1 failure event
+     * - pgpm_migrate.changes: 2 rows (partial success)
+     * - pgpm_migrate.events: 2 success + 1 failure event
      * - Database objects: schema + table exist (mixed state)
      * 
      * IMPORTANT: Deployment stops immediately at first failure, just like transaction mode.

--- a/packages/core/__tests__/projects/deploy-log-only.test.ts
+++ b/packages/core/__tests__/projects/deploy-log-only.test.ts
@@ -53,7 +53,7 @@ describe('Log-Only Deployment', () => {
     // This shows the changes were logged as deployed in the tracking tables
     const deploymentRecords = await db.query(`
       SELECT change_name, package 
-        FROM launchql_migrate.changes 
+        FROM pgpm_migrate.changes 
     `);
 
     // All 8 changes from the test fixture should be recorded as deployed

--- a/packages/core/src/migrate/sql/schema.sql
+++ b/packages/core/src/migrate/sql/schema.sql
@@ -1,17 +1,17 @@
 -- Create schema
-CREATE SCHEMA launchql_migrate;
+CREATE SCHEMA pgpm_migrate;
 
 -- 1. Packages (minimal - just name and timestamp)
-CREATE TABLE launchql_migrate.packages (
+CREATE TABLE pgpm_migrate.packages (
     package         TEXT        PRIMARY KEY,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp()
 );
 
 -- 2. Deployed changes (what's currently deployed)
-CREATE TABLE launchql_migrate.changes (
+CREATE TABLE pgpm_migrate.changes (
     change_id       TEXT        PRIMARY KEY,
     change_name     TEXT        NOT NULL,
-    package         TEXT        NOT NULL REFERENCES launchql_migrate.packages(package),
+    package         TEXT        NOT NULL REFERENCES pgpm_migrate.packages(package),
     script_hash     TEXT        NOT NULL,
     deployed_at     TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
     UNIQUE(package, change_name),
@@ -19,14 +19,14 @@ CREATE TABLE launchql_migrate.changes (
 );
 
 -- 3. Dependencies (what depends on what)
-CREATE TABLE launchql_migrate.dependencies (
-    change_id       TEXT        NOT NULL REFERENCES launchql_migrate.changes(change_id) ON DELETE CASCADE,
+CREATE TABLE pgpm_migrate.dependencies (
+    change_id       TEXT        NOT NULL REFERENCES pgpm_migrate.changes(change_id) ON DELETE CASCADE,
     requires        TEXT        NOT NULL,
     PRIMARY KEY (change_id, requires)
 );
 
 -- 4. Event log (minimal history for rollback)
-CREATE TABLE launchql_migrate.events (
+CREATE TABLE pgpm_migrate.events (
     event_id        SERIAL      PRIMARY KEY,
     event_type      TEXT        NOT NULL CHECK (event_type IN ('deploy', 'revert', 'verify')),
     change_name     TEXT        NOT NULL,

--- a/packages/core/src/migrate/utils/event-logger.ts
+++ b/packages/core/src/migrate/utils/event-logger.ts
@@ -24,7 +24,7 @@ export class EventLogger {
   async logEvent(entry: EventLogEntry): Promise<void> {
     try {
       await this.pool.query(`
-        INSERT INTO launchql_migrate.events 
+        INSERT INTO pgpm_migrate.events 
         (event_type, change_name, package, error_message, error_code)
         VALUES ($1::TEXT, $2::TEXT, $3::TEXT, $4::TEXT, $5::TEXT)
       `, [

--- a/packages/core/test-utils/MigrateTestFixture.ts
+++ b/packages/core/test-utils/MigrateTestFixture.ts
@@ -96,7 +96,7 @@ export class MigrateTestFixture {
       async getDeployedChanges() {
         const result = await pool.query(
           `SELECT package, change_name, deployed_at 
-           FROM launchql_migrate.changes 
+           FROM pgpm_migrate.changes 
            ORDER BY deployed_at`
         );
         return result.rows;
@@ -105,13 +105,13 @@ export class MigrateTestFixture {
       async getMigrationState() {
         const changes = await pool.query(`
           SELECT package, change_name, script_hash, deployed_at
-          FROM launchql_migrate.changes 
+          FROM pgpm_migrate.changes 
           ORDER BY deployed_at
         `);
         
         const events = await pool.query(`
           SELECT package, change_name, event_type, occurred_at, error_message, error_code
-          FROM launchql_migrate.events 
+          FROM pgpm_migrate.events 
           ORDER BY occurred_at
         `);
         
@@ -132,8 +132,8 @@ export class MigrateTestFixture {
       async getDependencies(packageName: string, changeName: string) {
         const result = await pool.query(
           `SELECT d.requires 
-           FROM launchql_migrate.dependencies d
-           JOIN launchql_migrate.changes c ON c.change_id = d.change_id
+           FROM pgpm_migrate.dependencies d
+           JOIN pgpm_migrate.changes c ON c.change_id = d.change_id
            WHERE c.package = $1 AND c.change_name = $2`,
           [packageName, changeName]
         );


### PR DESCRIPTION
# Rename launchql_migrate schema to pgpm_migrate

## Summary
This PR renames the migration tracking schema from `launchql_migrate` to `pgpm_migrate` throughout the codebase. The change affects SQL schema definitions, stored procedures, TypeScript client code, test utilities, and documentation.

**Files changed (13 total):**
- SQL schema and procedures: `packages/core/src/migrate/sql/schema.sql`, `procedures.sql`
- TypeScript client: `packages/core/src/migrate/client.ts`, `event-logger.ts`
- Test utilities: `packages/core/test-utils/MigrateTestFixture.ts`, `packages/cli/test-utils/CLIDeployTestFixture.ts`
- Test files: 4 test files updated with new schema name
- Documentation: `AGENTS.md`, `DEPLOYMENT_FAILURE_ANALYSIS.md`

**What changed:**
- Schema name: `launchql_migrate` → `pgpm_migrate`
- All table references: `launchql_migrate.{packages,changes,dependencies,events}` → `pgpm_migrate.{packages,changes,dependencies,events}`
- All stored procedure/function names: `launchql_migrate.{deploy,revert,verify,status,is_deployed,etc}` → `pgpm_migrate.{deploy,revert,verify,status,is_deployed,etc}`

## Review & Testing Checklist for Human

⚠️ **CRITICAL - Breaking Change**: This is a breaking change for existing deployments. Any database with the old `launchql_migrate` schema will need migration.

- [ ] **Verify SQL completeness**: Review `packages/core/src/migrate/sql/schema.sql` and `procedures.sql` to ensure all references to `launchql_migrate` have been renamed to `pgpm_migrate`
- [ ] **Test end-to-end migration flow**: Run the full test suite (`pnpm test` in packages/core and packages/cli) to verify the migration system works correctly with the new schema name
- [ ] **Check for missed references**: Search the entire codebase (including other repos if applicable) for any remaining references to `launchql_migrate` that might have been missed
- [ ] **Test with fresh database**: Create a new test database and verify that `LaunchQLMigrate.initialize()` creates the `pgpm_migrate` schema correctly
- [ ] **Consider migration path**: Determine if we need to provide a migration script for users with existing `launchql_migrate` schemas, or if this is acceptable as a breaking change requiring database recreation

### Recommended Test Plan
1. Run `pnpm test` in `packages/core` to verify all migration tests pass
2. Run `pnpm test` in `packages/cli` to verify CLI integration tests pass
3. Manually test: Create a fresh database, run `lql deploy` on a test module, verify the `pgpm_migrate` schema is created and populated correctly
4. Check that `lql status`, `lql revert`, and `lql verify` commands work with the new schema

### Notes
- Build passed successfully (`pnpm build` completed without errors related to this change)
- The only build error shown was a pre-existing TypeScript error in `supabase-test` package unrelated to this change
- All test files and test utilities have been updated to use the new schema name
- Documentation has been updated to reflect the new schema name

**Session Info:**
- Devin session: https://app.devin.ai/sessions/ad8d18fe15f743698ed4696670901c3e
- Requested by: Dan Lynch (pyramation@gmail.com) / @pyramation