### PR TITLE
Refactor pgpm init system to eliminate hardcoded variables and add validation

### DIFF
--- a/boilerplates/workspace/.questions.json
+++ b/boilerplates/workspace/.questions.json
@@ -11,7 +11,12 @@
   },
   {
     "name": "__MODULENAME__",
-    "message": "Enter the module name",
+    "message": "Enter the workspace name",
+    "required": true
+  },
+  {
+    "name": "__MODULEDESC__",
+    "message": "Enter the workspace description",
     "required": true
   },
   {

--- a/packages/pgpm/src/commands/init/index.ts
+++ b/packages/pgpm/src/commands/init/index.ts
@@ -15,15 +15,24 @@ Options:
   --workspace             Initialize workspace instead of module
   --cwd <directory>       Working directory (default: current directory)
   --repo <repo>           Use templates from GitHub repository (e.g., owner/repo)
-  --template-path <path>   Use templates from local path
-  --from-branch <branch>   Specify branch when using --repo (default: main)
+  --template-path <path>  Use templates from local path
+  --from-branch <branch>  Specify branch when using --repo (default: main)
+  --dry-run               Show what would be created without creating files
+  --show-vars             Display all resolved variables
+  --strict                Fail on missing variables (default: true)
+  --no-strict             Allow undefined variables (not recommended)
+  --non-interactive       Use defaults and provided values without prompting
+  --verbose               Show detailed information during initialization
 
 Examples:
   pgpm init                                  Initialize new module in existing workspace
-  pgpm init --workspace                       Initialize new workspace
+  pgpm init --workspace                      Initialize new workspace
   pgpm init --repo owner/repo                Use templates from GitHub repository
   pgpm init --template-path ./custom-templates Use templates from local path
   pgpm init --repo owner/repo --from-branch develop  Use specific branch
+  pgpm init --dry-run                        Preview what would be created
+  pgpm init --show-vars                      Display all resolved variables
+  pgpm init --non-interactive --modulename=my-module  Non-interactive initialization
 `;
 
 export default async (

--- a/packages/pgpm/src/commands/init/session.ts
+++ b/packages/pgpm/src/commands/init/session.ts
@@ -1,0 +1,209 @@
+import { Logger } from '@launchql/logger';
+import {
+  extractVarNamesFromDir,
+  loadQuestions,
+  loadTemplates,
+  moduleTemplate,
+  Question,
+  renderStrict,
+  type TemplateSource,
+  validateRequiredVars,
+  workspaceTemplate
+} from '@launchql/templatizer';
+import { Inquirerer, Question as InquirerQuestion } from 'inquirerer';
+import path from 'path';
+import { generateSeedValues, mergeSeedValues } from '../../utils/seedProviders';
+
+const log = new Logger('init-session');
+
+export interface InitSessionOptions {
+  /** Type of initialization: 'module' or 'workspace' */
+  type: 'module' | 'workspace';
+  /** Command-line arguments */
+  argv: Partial<Record<string, any>>;
+  /** Inquirer instance for prompting */
+  prompter: Inquirerer;
+  /** Current working directory */
+  cwd?: string;
+  /** Additional questions to merge with discovered ones */
+  additionalQuestions?: InquirerQuestion[];
+}
+
+export interface InitSessionResult {
+  /** Resolved variables */
+  vars: Record<string, any>;
+  /** Target directory where files were written */
+  targetDir: string;
+  /** Whether this was a dry run */
+  dryRun: boolean;
+}
+
+/**
+ * Build and execute an initialization session
+ * This is the unified entry point for both module and workspace initialization
+ */
+export async function buildInitSession(
+  options: InitSessionOptions
+): Promise<InitSessionResult> {
+  const { type, argv, prompter, additionalQuestions = [] } = options;
+  const cwd = options.cwd || argv.cwd || process.cwd();
+  
+  const dryRun = argv.dryRun || false;
+  const showVars = argv.showVars || false;
+  const strict = argv.strict !== false;
+  const verbose = argv.verbose || showVars || dryRun;
+  
+  log.info(`Starting ${type} initialization session`);
+  
+  if (dryRun) {
+    log.info('DRY RUN MODE: No files will be written');
+  }
+  
+  let templateDir: string | undefined;
+  let templates: any[];
+  
+  if (argv.repo || argv.templatePath) {
+    const source: TemplateSource = argv.repo
+      ? {
+          type: 'github',
+          path: argv.repo as string,
+          branch: argv.fromBranch as string
+        }
+      : {
+          type: 'local',
+          path: argv.templatePath as string
+        };
+    
+    log.info(`Loading templates from ${source.type}: ${source.path}`);
+    
+    const compiledTemplates = loadTemplates(source, type);
+    templates = compiledTemplates.map((t: any) => t.render);
+    
+    templateDir = source.type === 'local' 
+      ? path.resolve(source.path)
+      : undefined;
+  } else {
+    log.info('Using default built-in templates');
+    templates = type === 'module' ? moduleTemplate : workspaceTemplate;
+    
+    const boilerplatesPath = path.join(__dirname, '../../../../../boilerplates');
+    templateDir = path.join(boilerplatesPath, type);
+  }
+  
+  let discoveredVars = new Set<string>();
+  let questionsFromFile: Question[] = [];
+  
+  if (templateDir) {
+    log.info(`Discovering variables from template directory: ${templateDir}`);
+    discoveredVars = extractVarNamesFromDir(templateDir);
+    log.info(`Discovered ${discoveredVars.size} variable(s): ${Array.from(discoveredVars).join(', ')}`);
+    
+    questionsFromFile = loadQuestions(templateDir);
+    if (questionsFromFile.length > 0) {
+      log.info(`Loaded ${questionsFromFile.length} question(s) from .questions.json`);
+    }
+  } else {
+    log.warn('Template directory not available, skipping variable discovery');
+  }
+  
+  const allVarNames = new Set([
+    ...discoveredVars,
+    ...questionsFromFile.map(q => q.name)
+  ]);
+  
+  const seedValues = generateSeedValues(allVarNames, cwd);
+  if (verbose) {
+    log.info('Generated seed values:');
+    Object.entries(seedValues).forEach(([key, value]) => {
+      log.info(`  ${key}: ${value}`);
+    });
+  }
+  
+  const questionMap = new Map<string, Question>();
+  questionsFromFile.forEach(q => questionMap.set(q.name, q));
+  
+  const questions: InquirerQuestion[] = [];
+  
+  for (const varName of allVarNames) {
+    if (questionMap.has(varName)) {
+      const q = questionMap.get(varName)!;
+      questions.push({
+        name: varName,
+        message: q.message || `Enter ${varName}`,
+        type: q.type || 'text',
+        required: q.required !== false,
+        default: seedValues[varName] || q.default,
+        ...(q.choices ? { options: q.choices } : {})
+      } as InquirerQuestion);
+    } else {
+      questions.push({
+        name: varName,
+        message: `Enter ${varName}`,
+        type: 'text',
+        required: true,
+        default: seedValues[varName]
+      } as InquirerQuestion);
+    }
+  }
+  
+  questions.push(...additionalQuestions);
+  
+  if (argv.nonInteractive) {
+    log.info('Non-interactive mode: using defaults and provided values');
+  }
+  
+  const answers = argv.nonInteractive
+    ? mergeSeedValues(seedValues, argv)
+    : await prompter.prompt(argv, questions);
+  
+  const finalVars = mergeSeedValues(seedValues, answers);
+  
+  if (strict) {
+    const requiredVars = new Set(
+      Array.from(allVarNames).filter(varName => {
+        const q = questionMap.get(varName);
+        return !q || q.required !== false;
+      })
+    );
+    
+    const validation = validateRequiredVars(requiredVars, finalVars);
+    if (!validation.valid) {
+      const missingList = validation.missing.map(v => `  - ${v}`).join('\n');
+      throw new Error(
+        `Missing required variables:\n${missingList}\n\n` +
+        `To fix this:\n` +
+        `1. Provide values via CLI arguments (e.g., --${validation.missing[0].toLowerCase()}=value)\n` +
+        `2. Run in interactive mode (remove --non-interactive)\n` +
+        `3. Use --no-strict to allow undefined variables (not recommended)`
+      );
+    }
+  }
+  
+  if (showVars) {
+    console.log('\n' + '='.repeat(60));
+    console.log('Resolved Variables:');
+    console.log('='.repeat(60));
+    Object.keys(finalVars).sort().forEach(key => {
+      console.log(`  ${key}: ${finalVars[key]}`);
+    });
+    console.log('='.repeat(60) + '\n');
+  }
+  
+  const targetDir = cwd;
+  
+  renderStrict(templates, targetDir, finalVars, {
+    dryRun,
+    strict,
+    verbose
+  });
+  
+  if (!dryRun) {
+    log.success(`${type} initialized successfully at: ${targetDir}`);
+  }
+  
+  return {
+    vars: finalVars,
+    targetDir,
+    dryRun
+  };
+}

--- a/packages/pgpm/src/utils/seedProviders.ts
+++ b/packages/pgpm/src/utils/seedProviders.ts
@@ -1,0 +1,143 @@
+import { getGitConfigInfo } from '@launchql/types';
+import { execSync } from 'child_process';
+import path from 'path';
+
+/**
+ * Pattern-based seed providers for common variable types
+ * These provide intelligent defaults without hardcoding specific variable names
+ */
+
+/**
+ * Get GitHub username from git remote origin URL
+ * @returns GitHub username or null if not found
+ */
+function getGitHubUsernameFromRemote(): string | null {
+  try {
+    const remoteUrl = execSync('git config --get remote.origin.url', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore']
+    }).trim();
+    
+    const match = remoteUrl.match(/github\.com[:/]([^/]+)\//);
+    return match ? match[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Sanitize a string to be used as a username (lowercase, alphanumeric + hyphens)
+ */
+function sanitizeUsername(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+/**
+ * Generate seed values for variables based on pattern matching
+ * @param varNames - Set of variable names to generate seeds for
+ * @param cwd - Current working directory
+ * @returns Object with seed values
+ */
+export function generateSeedValues(
+  varNames: Set<string>,
+  cwd: string = process.cwd()
+): Record<string, any> {
+  const seeds: Record<string, any> = {};
+  
+  let gitInfo: { username: string; email: string } | null = null;
+  let githubUsername: string | null = null;
+  
+  try {
+    gitInfo = getGitConfigInfo();
+  } catch {
+  }
+  
+  for (const varName of varNames) {
+    const upperName = varName.toUpperCase();
+    
+    if (upperName.includes('EMAIL') && gitInfo) {
+      seeds[varName] = gitInfo.email;
+      continue;
+    }
+    
+    if ((upperName.includes('USERFULLNAME') || upperName.includes('FULLNAME') || upperName.includes('AUTHOR')) && gitInfo) {
+      seeds[varName] = gitInfo.username;
+      continue;
+    }
+    
+    if (upperName.includes('USERNAME')) {
+      if (!githubUsername) {
+        githubUsername = getGitHubUsernameFromRemote();
+        if (!githubUsername && gitInfo) {
+          githubUsername = sanitizeUsername(gitInfo.username);
+        }
+      }
+      if (githubUsername) {
+        seeds[varName] = githubUsername;
+      }
+      continue;
+    }
+    
+    if (upperName.includes('MODULENAME') || upperName === 'NAME') {
+      const dirName = path.basename(cwd);
+      seeds[varName] = dirName;
+      continue;
+    }
+    
+    if (upperName.includes('REPONAME') || upperName.includes('REPO')) {
+      const dirName = path.basename(cwd);
+      seeds[varName] = dirName;
+      continue;
+    }
+    
+    if (upperName.includes('PACKAGE') && upperName.includes('IDENTIFIER')) {
+      if (!githubUsername) {
+        githubUsername = getGitHubUsernameFromRemote();
+        if (!githubUsername && gitInfo) {
+          githubUsername = sanitizeUsername(gitInfo.username);
+        }
+      }
+      
+      const dirName = path.basename(cwd);
+      if (githubUsername) {
+        seeds[varName] = `@${githubUsername}/${dirName}`;
+      } else {
+        seeds[varName] = dirName;
+      }
+      continue;
+    }
+    
+    if (upperName.includes('MODULEDESC') || upperName.includes('DESCRIPTION')) {
+      const dirName = path.basename(cwd);
+      seeds[varName] = `${dirName} module`;
+      continue;
+    }
+    
+    if (upperName.includes('ACCESS')) {
+      seeds[varName] = 'public';
+      continue;
+    }
+  }
+  
+  return seeds;
+}
+
+/**
+ * Merge seed values with provided values, preferring provided values
+ * @param seeds - Seed values generated from patterns
+ * @param provided - Values provided by user or CLI
+ * @returns Merged values
+ */
+export function mergeSeedValues(
+  seeds: Record<string, any>,
+  provided: Record<string, any>
+): Record<string, any> {
+  return {
+    ...seeds,
+    ...provided
+  };
+}

--- a/packages/templatizer/src/discovery.ts
+++ b/packages/templatizer/src/discovery.ts
@@ -1,0 +1,51 @@
+import fs from 'fs';
+import { sync as globSync } from 'glob';
+import path from 'path';
+
+/**
+ * Extract variable names from a string using the __VARNAME__ pattern
+ * @param content - String content to scan for variables
+ * @returns Set of variable names (without the __ delimiters)
+ */
+export function extractVarNamesFromString(content: string): Set<string> {
+  const varPattern = /__([A-Z0-9_]+)__/g;
+  const matches = content.matchAll(varPattern);
+  const varNames = new Set<string>();
+  
+  for (const match of matches) {
+    varNames.add(match[1]);
+  }
+  
+  return varNames;
+}
+
+/**
+ * Extract all variable names from a directory by scanning file contents and file paths
+ * @param dir - Directory path to scan
+ * @returns Set of variable names (without the __ delimiters)
+ */
+export function extractVarNamesFromDir(dir: string): Set<string> {
+  const IGNORE = ['.DS_Store', '.questions.json'];
+  
+  const files = [
+    ...globSync('**/*', { cwd: dir, nodir: true }),
+    ...globSync('**/.*', { cwd: dir, nodir: true }),
+  ].filter(f => !IGNORE.includes(path.basename(f)));
+  
+  const allVarNames = new Set<string>();
+  
+  for (const relPath of files) {
+    const pathVars = extractVarNamesFromString(relPath);
+    pathVars.forEach(v => allVarNames.add(v));
+    
+    const fullPath = path.join(dir, relPath);
+    try {
+      const content = fs.readFileSync(fullPath, 'utf8');
+      const contentVars = extractVarNamesFromString(content);
+      contentVars.forEach(v => allVarNames.add(v));
+    } catch (error) {
+    }
+  }
+  
+  return allVarNames;
+}

--- a/packages/templatizer/src/index.ts
+++ b/packages/templatizer/src/index.ts
@@ -16,3 +16,7 @@ export {
   writeRenderedTemplates,
   loadTemplates
 };
+
+export { extractVarNamesFromString, extractVarNamesFromDir } from './discovery';
+export { loadQuestions, normalizeQuestionName, type Question } from './questions';
+export { renderStrict, validateRequiredVars, type RenderOptions } from './render';

--- a/packages/templatizer/src/questions.ts
+++ b/packages/templatizer/src/questions.ts
@@ -1,0 +1,57 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Question interface matching inquirerer's Question type
+ * This is a simplified version that covers the common fields
+ */
+export interface Question {
+  name: string;
+  message?: string;
+  type?: string;
+  required?: boolean;
+  default?: any;
+  choices?: string[];
+  [key: string]: any;
+}
+
+/**
+ * Normalize a question name by stripping leading and trailing double underscores
+ * This converts __VARNAME__ to VARNAME to match the compiled template keys
+ * @param nameWithUnderscores - Variable name with underscores (e.g., "__MODULENAME__")
+ * @returns Normalized variable name (e.g., "MODULENAME")
+ */
+export function normalizeQuestionName(nameWithUnderscores: string): string {
+  return nameWithUnderscores.replace(/^__/, '').replace(/__$/, '');
+}
+
+/**
+ * Load questions from a .questions.json file in the template directory
+ * @param templateDir - Path to the template directory
+ * @returns Array of questions, or empty array if file doesn't exist
+ */
+export function loadQuestions(templateDir: string): Question[] {
+  const questionsPath = path.join(templateDir, '.questions.json');
+  
+  if (!fs.existsSync(questionsPath)) {
+    return [];
+  }
+  
+  try {
+    const content = fs.readFileSync(questionsPath, 'utf8');
+    const questions = JSON.parse(content);
+    
+    if (!Array.isArray(questions)) {
+      console.warn(`Warning: .questions.json in ${templateDir} is not an array, ignoring`);
+      return [];
+    }
+    
+    return questions.map(q => ({
+      ...q,
+      name: normalizeQuestionName(q.name)
+    }));
+  } catch (error) {
+    console.warn(`Warning: Failed to parse .questions.json in ${templateDir}:`, error);
+    return [];
+  }
+}

--- a/packages/templatizer/src/render.ts
+++ b/packages/templatizer/src/render.ts
@@ -1,0 +1,131 @@
+import { mkdirSync, writeFileSync } from 'fs';
+import path from 'path';
+
+type TemplateFunc = (vars: Record<string, any>) => { relPath: string; content: string };
+
+export interface RenderOptions {
+  /** If true, show what would be written without actually writing files */
+  dryRun?: boolean;
+  /** If true, throw error on missing variables (default: true) */
+  strict?: boolean;
+  /** If true, print detailed information about rendering */
+  verbose?: boolean;
+}
+
+/**
+ * Create a proxy around vars object that throws on missing keys
+ * This prevents "undefined" from silently appearing in rendered templates
+ */
+function createStrictVarsProxy(vars: Record<string, any>, templatePath: string): Record<string, any> {
+  return new Proxy(vars, {
+    get(target, prop: string) {
+      if (prop in target) {
+        return target[prop];
+      }
+      
+      throw new Error(
+        `Missing required variable: "${prop}"\n` +
+        `Referenced in template: ${templatePath}\n` +
+        `Available variables: ${Object.keys(target).join(', ')}\n` +
+        `\nTo fix this:\n` +
+        `1. Add "${prop}" to your .questions.json file, or\n` +
+        `2. Provide it via CLI argument: --${prop.toLowerCase()}=value, or\n` +
+        `3. Use --no-strict to allow undefined variables (not recommended)`
+      );
+    }
+  });
+}
+
+/**
+ * Render templates with strict validation and optional dry-run mode
+ * @param templates - Array of template functions to render
+ * @param outDir - Output directory for rendered files
+ * @param vars - Variables to pass to templates
+ * @param options - Rendering options
+ */
+export function renderStrict(
+  templates: TemplateFunc[],
+  outDir: string,
+  vars: Record<string, any>,
+  options: RenderOptions = {}
+): void {
+  const { dryRun = false, strict = true, verbose = false } = options;
+  
+  if (verbose || dryRun) {
+    console.log(`\n${'='.repeat(60)}`);
+    console.log(`Rendering ${templates.length} template(s) to: ${outDir}`);
+    console.log(`Mode: ${dryRun ? 'DRY RUN (no files will be written)' : 'LIVE'}`);
+    console.log(`Strict: ${strict ? 'YES (fail on missing vars)' : 'NO (allow undefined)'}`);
+    console.log(`${'='.repeat(60)}\n`);
+    
+    if (verbose) {
+      console.log('Available variables:');
+      Object.keys(vars).sort().forEach(key => {
+        const value = vars[key];
+        const displayValue = typeof value === 'string' && value.length > 50
+          ? value.substring(0, 50) + '...'
+          : value;
+        console.log(`  ${key}: ${JSON.stringify(displayValue)}`);
+      });
+      console.log('');
+    }
+  }
+  
+  const renderedFiles: Array<{ path: string; size: number }> = [];
+  
+  templates.forEach((tmpl, index) => {
+    try {
+      const varsToUse = strict ? createStrictVarsProxy(vars, `template #${index + 1}`) : vars;
+      
+      const output = tmpl(varsToUse);
+      const outPath = path.join(outDir, output.relPath);
+      
+      if (dryRun || verbose) {
+        console.log(`${dryRun ? '[DRY RUN] Would write' : 'Writing'}: ${output.relPath} (${output.content.length} bytes)`);
+      }
+      
+      if (!dryRun) {
+        mkdirSync(path.dirname(outPath), { recursive: true });
+        writeFileSync(outPath, output.content);
+      }
+      
+      renderedFiles.push({ path: output.relPath, size: output.content.length });
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(`Failed to render template #${index + 1}: ${error.message}`);
+      }
+      throw error;
+    }
+  });
+  
+  if (verbose || dryRun) {
+    console.log(`\n${'='.repeat(60)}`);
+    console.log(`${dryRun ? 'Would render' : 'Rendered'} ${renderedFiles.length} file(s)`);
+    console.log(`Total size: ${renderedFiles.reduce((sum, f) => sum + f.size, 0)} bytes`);
+    console.log(`${'='.repeat(60)}\n`);
+  }
+}
+
+/**
+ * Validate that all required variables are present before rendering
+ * @param requiredVars - Set of required variable names
+ * @param providedVars - Object of provided variables
+ * @returns Object with validation result and missing variables
+ */
+export function validateRequiredVars(
+  requiredVars: Set<string>,
+  providedVars: Record<string, any>
+): { valid: boolean; missing: string[] } {
+  const missing: string[] = [];
+  
+  for (const varName of requiredVars) {
+    if (!(varName in providedVars)) {
+      missing.push(varName);
+    }
+  }
+  
+  return {
+    valid: missing.length === 0,
+    missing
+  };
+}


### PR DESCRIPTION
# Refactor pgpm init: dynamic variables, validation, and new CLI flags

## Summary

This PR comprehensively refactors the pgpm init system to address multiple issues with variable handling and template rendering. The main changes eliminate hardcoded variable names, add automatic variable discovery from templates, implement strict validation to prevent "undefined" values in output, and introduce new CLI flags for better control.

**Key improvements:**
- **Dynamic variable discovery**: Automatically extracts all `__VARNAME__` patterns from template files and paths
- **Strict rendering with validation**: Uses Proxy-based validation to throw clear errors on missing variables instead of silently rendering "undefined"
- **Pattern-based seed providers**: Intelligently generates default values based on variable name patterns (e.g., EMAIL → git email, USERNAME → GitHub username)
- **Unified init session**: Both module and workspace init now use the same `buildInitSession` flow
- **New CLI flags**: `--dry-run`, `--show-vars`, `--strict/--no-strict`, `--non-interactive`, `--verbose`

**Issues fixed:**
1. Silent "undefined" rendering in templates when variables are missing
2. Misaligned variables between workspace templates and init flow (workspace templates expected `__MODULEDESC__` but it was never provided)
3. Inconsistent git variable injection (modules got git info, workspaces didn't)
4. Hardcoded variable names throughout init flows
5. No validation or guardrails for template authors

## Review & Testing Checklist for Human

⚠️ **CRITICAL - This PR has NOT been tested end-to-end.** The TypeScript build passes but runtime behavior needs verification.

- [ ] **Test basic workspace creation**: Run `pgpm init --workspace` and verify all files are created correctly with no "undefined" values
- [ ] **Test basic module creation**: Run `pgpm init` inside a workspace and verify module is created correctly
- [ ] **Test new CLI flags**: Try `--dry-run`, `--show-vars`, `--non-interactive` to ensure they work as expected
- [ ] **Verify variable resolution**: Check that git config info (name, email, GitHub username) is properly injected into templates
- [ ] **Test with custom templates**: Try `--repo owner/repo` or `--template-path ./path` to ensure custom templates work
- [ ] **Check template path resolution**: The code uses `__dirname` to find built-in templates - verify this works when running from installed package
- [ ] **Verify extensions handling**: In module init, check that the extensions checkbox question still works correctly

### Test Plan

```bash
# Test 1: Workspace creation
cd /tmp
pgpm init --workspace --name test-workspace

# Verify: Check that all files exist and contain no "undefined" strings
grep -r "undefined" test-workspace/

# Test 2: Module creation  
cd test-workspace
pgpm init --name test-module

# Verify: Check module files are created correctly
ls -la packages/test-module/

# Test 3: Dry run mode
pgpm init --dry-run --name another-module

# Verify: No files should be created, but should show what would be created

# Test 4: Show vars mode
pgpm init --show-vars --name another-module

# Verify: Should display all resolved variables before prompting
```

### Notes

**Architecture changes:**
- New `packages/templatizer/src/discovery.ts`: Variable extraction from templates
- New `packages/templatizer/src/questions.ts`: Loading and normalizing .questions.json
- New `packages/templatizer/src/render.ts`: Strict rendering with Proxy validation
- New `packages/pgpm/src/commands/init/session.ts`: Unified init session builder (209 lines)
- New `packages/pgpm/src/utils/seedProviders.ts`: Pattern-based default generation

**Potential issues to watch for:**
1. Template path resolution using `__dirname` might not work correctly in all execution contexts
2. Variable name normalization (stripping `__`) must work correctly or variables won't match
3. Pattern-based seed generation might match unintended variables or miss intended ones
4. The Proxy-based strict validation is clever but could have edge cases

**Session info:**
- Requested by: Dan Lynch (pyramation@gmail.com) / @pyramation
- Devin session: https://app.devin.ai/sessions/f63e4a1a82f948f9b857863c612f0378