### PR TITLE
docs: add linting documentation and enforce no trailing commas

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,6 +42,10 @@
       "error",
       "always"
     ],
+    "comma-dangle": [
+      "error",
+      "never"
+    ],
     "simple-import-sort/imports": 1,
     "simple-import-sort/exports": 1,
     "unused-imports/no-unused-imports": 1,

--- a/README.md
+++ b/README.md
@@ -124,6 +124,23 @@ Low-level tools for parsing, transforming, and generating PostgreSQL SQL.
 
 ## Common Workflows
 
+### Development
+
+```bash
+# Run linting across all packages
+pnpm lint
+
+# Run linting for a specific package
+cd packages/cli
+pnpm lint
+
+# Build all packages
+pnpm build
+
+# Clean build artifacts
+pnpm clean
+```
+
 ### Starting a New Project
 
 ```bash

--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -7,9 +7,9 @@ module.exports = {
       'ts-jest',
       {
         babelConfig: false,
-        tsconfig: 'tsconfig.json',
-      },
-    ],
+        tsconfig: 'tsconfig.json'
+      }
+    ]
   },
   transformIgnorePatterns: [`/node_modules/*`],
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',

--- a/packages/etag-hash/jest.config.js
+++ b/packages/etag-hash/jest.config.js
@@ -7,9 +7,9 @@ module.exports = {
       'ts-jest',
       {
         babelConfig: false,
-        tsconfig: 'tsconfig.json',
-      },
-    ],
+        tsconfig: 'tsconfig.json'
+      }
+    ]
   },
   transformIgnorePatterns: [`/node_modules/*`],
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',

--- a/packages/gql-ast/jest.config.js
+++ b/packages/gql-ast/jest.config.js
@@ -7,9 +7,9 @@ module.exports = {
       'ts-jest',
       {
         babelConfig: false,
-        tsconfig: 'tsconfig.json',
-      },
-    ],
+        tsconfig: 'tsconfig.json'
+      }
+    ]
   },
   transformIgnorePatterns: [`/node_modules/*`],
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',

--- a/packages/gql-ast/src/index.ts
+++ b/packages/gql-ast/src/index.ts
@@ -20,12 +20,12 @@ import {
   StringValueNode,
   TypeNode,
   VariableDefinitionNode,
-  VariableNode,
+  VariableNode
 } from 'graphql';
 
 export const document = ({ definitions }: { definitions: DefinitionNode[] }): DocumentNode => ({
   kind: 'Document',
-  definitions,
+  definitions
 });
 
 export const operationDefinition = ({
@@ -33,7 +33,7 @@ export const operationDefinition = ({
   name,
   variableDefinitions = [],
   directives = [],
-  selectionSet,
+  selectionSet
 }: {
   operation: OperationTypeNode;
   name: string;
@@ -45,17 +45,17 @@ export const operationDefinition = ({
   operation,
   name: {
     kind: 'Name',
-    value: name,
+    value: name
   },
   variableDefinitions,
   directives,
-  selectionSet,
+  selectionSet
 });
 
 export const variableDefinition = ({
   variable,
   type,
-  directives,
+  directives
 }: {
   variable: VariableNode;
   type: TypeNode;
@@ -64,74 +64,74 @@ export const variableDefinition = ({
   kind: 'VariableDefinition',
   variable,
   type,
-  directives: directives || [],
+  directives: directives || []
 });
 
 export const selectionSet = ({ selections }: { selections: readonly FieldNode[] }): SelectionSetNode => ({
   kind: 'SelectionSet',
-  selections,
+  selections
 });
 
 export const listType = ({ type }: { type: TypeNode }): ListTypeNode => ({
   kind: 'ListType',
-  type,
+  type
 });
 
 export const nonNullType = ({ type }: { type: NamedTypeNode | ListTypeNode }): TypeNode => ({
   kind: 'NonNullType',
-  type,
+  type
 });
 
 export const namedType = ({ type }: { type: string }): NamedTypeNode => ({
   kind: 'NamedType',
   name: {
     kind: 'Name',
-    value: type,
-  },
+    value: type
+  }
 });
 
 export const variable = ({ name }: { name: string }): VariableNode => ({
   kind: 'Variable',
   name: {
     kind: 'Name',
-    value: name,
-  },
+    value: name
+  }
 });
 
 export const objectValue = ({ fields }: { fields: ObjectFieldNode[] }): ObjectValueNode => ({
   kind: 'ObjectValue',
-  fields,
+  fields
 });
 
 export const stringValue = ({ value }: { value: string }): StringValueNode => ({
   kind: 'StringValue',
-  value,
+  value
 });
 
 export const intValue = ({ value }: { value: string }): IntValueNode => ({
   kind: 'IntValue',
-  value,
+  value
 });
 
 export const booleanValue = ({ value }: { value: boolean }): BooleanValueNode => ({
   kind: 'BooleanValue',
-  value,
+  value
 });
 
 export const listValue = ({ values }: { values: any[] }): ListValueNode => ({
   kind: 'ListValue',
-  values,
+  values
 });
 
 export const nullValue = (): NullValueNode => ({
-  kind: 'NullValue',
+  kind: 'NullValue'
 });
 
 export const fragmentDefinition = ({
   name,
   typeCondition,
   directives = [],
-  selectionSet,
+  selectionSet
 }: {
   name: string;
   typeCondition: NamedTypeNode;
@@ -141,27 +141,27 @@ export const fragmentDefinition = ({
   kind: 'FragmentDefinition',
   name: {
     kind: 'Name',
-    value: name,
+    value: name
   },
   typeCondition,
   directives,
-  selectionSet,
+  selectionSet
 });
 
 export const objectField = ({ name, value }: { name: string; value: any }): ObjectFieldNode => ({
   kind: 'ObjectField',
   name: {
     kind: 'Name',
-    value: name,
+    value: name
   },
-  value,
+  value
 });
 
 export const field = ({
   name,
   args = [],
   directives = [],
-  selectionSet,
+  selectionSet
 }: {
   name: string;
   args?: ArgumentNode[];
@@ -171,18 +171,18 @@ export const field = ({
   kind: 'Field',
   name: {
     kind: 'Name',
-    value: name,
+    value: name
   },
   arguments: args,
   directives,
-  selectionSet,
+  selectionSet
 });
 
 export const argument = ({ name, value }: { name: string; value: any }): ArgumentNode => ({
   kind: 'Argument',
   name: {
     kind: 'Name',
-    value: name,
+    value: name
   },
-  value,
+  value
 });

--- a/packages/graphile-query/jest.config.js
+++ b/packages/graphile-query/jest.config.js
@@ -7,9 +7,9 @@ module.exports = {
       'ts-jest',
       {
         babelConfig: false,
-        tsconfig: 'tsconfig.json',
-      },
-    ],
+        tsconfig: 'tsconfig.json'
+      }
+    ]
   },
   transformIgnorePatterns: [`/node_modules/*`],
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',

--- a/packages/logger/jest.config.js
+++ b/packages/logger/jest.config.js
@@ -7,9 +7,9 @@ module.exports = {
       'ts-jest',
       {
         babelConfig: false,
-        tsconfig: 'tsconfig.json',
-      },
-    ],
+        tsconfig: 'tsconfig.json'
+      }
+    ]
   },
   transformIgnorePatterns: [`/node_modules/*`],
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',

--- a/packages/orm/jest.config.js
+++ b/packages/orm/jest.config.js
@@ -7,9 +7,9 @@ module.exports = {
       'ts-jest',
       {
         babelConfig: false,
-        tsconfig: 'tsconfig.json',
-      },
-    ],
+        tsconfig: 'tsconfig.json'
+      }
+    ]
   },
   transformIgnorePatterns: [`/node_modules/*`],
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',

--- a/packages/pg-query-context/jest.config.js
+++ b/packages/pg-query-context/jest.config.js
@@ -7,9 +7,9 @@ module.exports = {
       'ts-jest',
       {
         babelConfig: false,
-        tsconfig: 'tsconfig.json',
-      },
-    ],
+        tsconfig: 'tsconfig.json'
+      }
+    ]
   },
   transformIgnorePatterns: [`/node_modules/*`],
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',


### PR DESCRIPTION
# docs: add linting documentation and enforce no trailing commas

## Summary
This PR adds development workflow documentation to the README and configures ESLint to disallow trailing commas across the workspace. The linter was run to auto-fix existing trailing commas in 9 files (7 Jest config files and 1 TypeScript source file).

**Changes:**
- Added new "Development" section to README with commands for linting, building, and cleaning
- Added `comma-dangle: ["error", "never"]` rule to `.eslintrc.json`
- Auto-fixed trailing commas in 9 files across the workspace

## Review & Testing Checklist for Human
- [ ] Verify that disabling trailing commas aligns with team coding standards and preferences
- [ ] Run `pnpm lint` locally to confirm no new lint errors were introduced
- [ ] Check if there are other files in the codebase with trailing commas that weren't caught by the auto-fix (the linter only processes files it's configured to check)

### Notes
- There's a pre-existing lint error in `packages/logger` (control character in regex) that's unrelated to this PR. The lint command will still fail until that's fixed, but it's not caused by these changes.
- The auto-fix only modified files that were already being linted. Any files not covered by the current ESLint configuration may still have trailing commas.
- CI checks passed successfully.

**Link to Devin run:** https://app.devin.ai/sessions/8b784f3449664c77b920d79756fa150d  
**Requested by:** Dan Lynch (@pyramation)