### PR TITLE
Add pgpm env command with dual-mode behavior and profile selection

### DIFF
--- a/packages/pgpm/src/commands.ts
+++ b/packages/pgpm/src/commands.ts
@@ -7,6 +7,7 @@ import adminUsers from './commands/admin-users';
 import analyze from './commands/analyze';
 import clear from './commands/clear';
 import deploy from './commands/deploy';
+import env from './commands/env';
 import _export from './commands/export';
 import extension from './commands/extension';
 import init from './commands/init';
@@ -41,6 +42,7 @@ export const createPgpmCommandMap = (skipPgTeardown: boolean = false): Record<st
     'admin-users': pgt(adminUsers),
     clear: pgt(clear),
     deploy: pgt(deploy),
+    env,
     verify: pgt(verify),
     revert: pgt(revert),
     remove: pgt(remove),

--- a/packages/pgpm/src/commands/env.ts
+++ b/packages/pgpm/src/commands/env.ts
@@ -1,0 +1,145 @@
+import { spawn } from 'child_process';
+import { Inquirerer } from 'inquirerer';
+import { ParsedArgs } from 'minimist';
+import { defaultPgConfig, PgConfig } from 'pg-env';
+
+const envUsageText = `
+Environment Command:
+
+  pgpm env [OPTIONS] [COMMAND...]
+
+  Manage PostgreSQL environment variables with profile support.
+
+Profiles:
+  (default)          Use local Postgres development profile
+  --supabase         Use Supabase local development profile
+
+Modes:
+  No command         Print export statements for shell evaluation
+  With command       Execute command with environment variables applied
+
+Options:
+  --help, -h         Show this help message
+  --supabase         Use Supabase profile instead of default Postgres
+
+Examples:
+  pgpm env                                    Print default Postgres env exports
+  pgpm env --supabase                         Print Supabase env exports
+  eval "$(pgpm env)"                          Load default Postgres env into shell
+  eval "$(pgpm env --supabase)"               Load Supabase env into shell
+  pgpm env lql deploy --database db1          Run command with default Postgres env
+  pgpm env createdb mydb                      Run command with default Postgres env
+  pgpm env --supabase lql deploy --database db1  Run command with Supabase env
+  pgpm env --supabase createdb mydb           Run command with Supabase env
+`;
+
+const SUPABASE_PROFILE: PgConfig = {
+  host: 'localhost',
+  port: 54322,
+  user: 'supabase_admin',
+  password: 'postgres',
+  database: 'postgres'
+};
+
+const DEFAULT_PROFILE: PgConfig = {
+  ...defaultPgConfig
+};
+
+function configToEnvVars(config: PgConfig): Record<string, string> {
+  return {
+    PGHOST: config.host,
+    PGPORT: String(config.port),
+    PGUSER: config.user,
+    PGPASSWORD: config.password,
+    PGDATABASE: config.database
+  };
+}
+
+function printExports(config: PgConfig): void {
+  const envVars = configToEnvVars(config);
+  for (const [key, value] of Object.entries(envVars)) {
+    const escapedValue = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    console.log(`export ${key}="${escapedValue}"`);
+  }
+}
+
+function executeCommand(config: PgConfig, command: string, args: string[]): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const envVars = configToEnvVars(config);
+    const env = {
+      ...process.env,
+      ...envVars
+    };
+
+    const child = spawn(command, args, {
+      env,
+      stdio: 'inherit',
+      shell: false
+    });
+
+    child.on('error', (error) => {
+      reject(error);
+    });
+
+    child.on('close', (code) => {
+      resolve(code ?? 0);
+    });
+  });
+}
+
+export default async (
+  argv: Partial<ParsedArgs>,
+  _prompter: Inquirerer
+) => {
+  if (argv.help || argv.h) {
+    console.log(envUsageText);
+    process.exit(0);
+  }
+
+  const useSupabase = argv.supabase === true || typeof argv.supabase === 'string';
+  const profile = useSupabase ? SUPABASE_PROFILE : DEFAULT_PROFILE;
+
+  const rawArgs = process.argv.slice(2);
+  
+  let envIndex = rawArgs.findIndex(arg => arg === 'env');
+  if (envIndex === -1) {
+    envIndex = 0;
+  }
+  
+  const argsAfterEnv = rawArgs.slice(envIndex + 1);
+  
+  const supabaseIndex = argsAfterEnv.findIndex(arg => arg === '--supabase');
+  
+  let commandArgs: string[];
+  if (supabaseIndex !== -1) {
+    commandArgs = argsAfterEnv.slice(supabaseIndex + 1);
+  } else {
+    commandArgs = argsAfterEnv;
+  }
+  
+  commandArgs = commandArgs.filter(arg => arg !== '--cwd' && !arg.startsWith('--cwd='));
+  
+  const cwdIndex = commandArgs.findIndex(arg => arg === '--cwd');
+  if (cwdIndex !== -1 && cwdIndex + 1 < commandArgs.length) {
+    commandArgs.splice(cwdIndex, 2);
+  }
+
+  if (commandArgs.length === 0) {
+    printExports(profile);
+    return;
+  }
+
+  const [command, ...args] = commandArgs;
+  
+  try {
+    const exitCode = await executeCommand(profile, command, args);
+    process.exit(exitCode);
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(`Error executing command: ${error.message}`);
+    } else {
+      console.error(`Error executing command: ${String(error)}`);
+    }
+    process.exit(1);
+  }
+};

--- a/packages/pgpm/src/index.ts
+++ b/packages/pgpm/src/index.ts
@@ -12,6 +12,7 @@ export { default as adminUsers } from './commands/admin-users';
 export { default as analyze } from './commands/analyze';
 export { default as clear } from './commands/clear';
 export { default as deploy } from './commands/deploy';
+export { default as env } from './commands/env';
 export { default as _export } from './commands/export';
 export { default as extension } from './commands/extension';
 export { default as install } from './commands/install';
@@ -24,7 +25,6 @@ export { default as renameCmd } from './commands/rename';
 export { default as revert } from './commands/revert';
 export { default as tag } from './commands/tag';
 export { default as verify } from './commands/verify';
-
 export * from './utils';
 
 export const options: Partial<CLIOptions> = {


### PR DESCRIPTION
# Add pgpm env command with dual-mode behavior and profile selection

## Summary
Implements a new `pgpm env` command that manages PostgreSQL environment variables with support for multiple profiles. The command has two modes:

1. **Print mode** (no command): Outputs `export` statements for shell evaluation (e.g., `eval "$(pgpm env)"`)
2. **Execute mode** (with command): Runs the specified command with environment variables applied (e.g., `pgpm env lql deploy --database db1`)

Two profiles are supported:
- **Default Postgres**: localhost:5432, user: postgres, password: password
- **Supabase** (via `--supabase` flag): localhost:54322, user: supabase_admin, password: postgres

The implementation uses `process.argv` directly to parse command arguments, working around minimist's flag parsing behavior to correctly handle commands that have their own flags.

## Review & Testing Checklist for Human

- [ ] **Test print mode**: Run `pgpm env` and `pgpm env --supabase` to verify correct environment variable output
- [ ] **Test execute mode**: Run `pgpm env sh -c 'echo $PGPORT'` and `pgpm env --supabase sh -c 'echo $PGPORT'` to verify commands execute with correct environment
- [ ] **Verify Supabase defaults**: Confirm that port 54322 and user supabase_admin are the correct defaults for Supabase local development
- [ ] **Test with complex commands**: Try `pgpm env lql deploy --database mydb --recursive` to ensure command flags are passed through correctly
- [ ] **Edge case testing**: Test with commands that contain quotes, special characters, or use `--supabase`/`--cwd` as their own flags

### Test Plan
```bash
# Test print mode
pgpm env
pgpm env --supabase

# Test execute mode
pgpm env printenv PGPORT  # Should output 5432
pgpm env --supabase printenv PGPORT  # Should output 54322

# Test with actual commands
pgpm env createdb testdb
pgpm env --supabase lql deploy --database mydb
```

### Notes
- The `env` command is NOT wrapped with the PG teardown wrapper (`pgt()`) unlike other commands, since it doesn't connect to the database directly
- Argument parsing uses `process.argv` directly to handle commands with their own flags correctly
- Shell escaping in print mode handles backslashes and double quotes, but may need additional escaping for other special characters

**Session**: https://app.devin.ai/sessions/bcc7847df272413d8603f4f9d5b4bd3b  
**Requested by**: Dan Lynch (pyramation@gmail.com) / @pyramation