### PR TITLE
feat: add create-gen-app package for template repository cloning and customization

### DIFF
--- a/packages/create-gen-app/README.md
+++ b/packages/create-gen-app/README.md
@@ -1,0 +1,136 @@
+# @launchql/create-gen-app
+
+A TypeScript library for cloning and customizing template repositories with variable replacement.
+
+## Features
+
+- Clone GitHub repositories or any git URL
+- Extract template variables from filenames and file contents using `__VARIABLE__` syntax
+- Load custom questions from `.questions.json` or `.questions.js` files
+- Interactive prompts using inquirerer with CLI argument support
+- Stream-based file processing for efficient variable replacement
+
+## Installation
+
+```bash
+npm install @launchql/create-gen-app
+```
+
+## Usage
+
+### Basic Usage
+
+```typescript
+import { createGen } from '@launchql/create-gen-app';
+
+await createGen({
+  templateUrl: 'https://github.com/user/template-repo',
+  outputDir: './my-new-project',
+  argv: {
+    PROJECT_NAME: 'my-project',
+    AUTHOR: 'John Doe'
+  }
+});
+```
+
+### Template Variables
+
+Variables in your template should be wrapped in double underscores:
+
+**Filename variables:**
+```
+__PROJECT_NAME__/
+  __MODULE_NAME__.ts
+```
+
+**Content variables:**
+```typescript
+// __MODULE_NAME__.ts
+export const projectName = "__PROJECT_NAME__";
+export const author = "__AUTHOR__";
+```
+
+### Custom Questions
+
+Create a `.questions.json` file in your template repository:
+
+```json
+{
+  "questions": [
+    {
+      "name": "PROJECT_NAME",
+      "type": "text",
+      "message": "What is your project name?",
+      "required": true
+    },
+    {
+      "name": "AUTHOR",
+      "type": "text",
+      "message": "Who is the author?"
+    }
+  ]
+}
+```
+
+Or use `.questions.js` for dynamic questions:
+
+```javascript
+/**
+ * @typedef {Object} Questions
+ * @property {Array} questions - Array of question objects
+ */
+
+module.exports = {
+  questions: [
+    {
+      name: 'PROJECT_NAME',
+      type: 'text',
+      message: 'What is your project name?',
+      required: true
+    }
+  ]
+};
+```
+
+## API
+
+### `createGen(options: CreateGenOptions): Promise<string>`
+
+Main function to create a project from a template.
+
+**Options:**
+- `templateUrl` (string): URL or path to the template repository
+- `outputDir` (string): Destination directory for the generated project
+- `argv` (Record<string, any>): Command-line arguments to pre-populate answers
+- `noTty` (boolean): Whether to disable TTY mode for non-interactive usage
+
+### `extractVariables(templateDir: string): Promise<ExtractedVariables>`
+
+Extract all variables from a template directory.
+
+### `promptUser(extractedVariables: ExtractedVariables, argv?: Record<string, any>, noTty?: boolean): Promise<Record<string, any>>`
+
+Prompt the user for variable values using inquirerer.
+
+### `replaceVariables(templateDir: string, outputDir: string, extractedVariables: ExtractedVariables, answers: Record<string, any>): Promise<void>`
+
+Replace variables in all files and filenames.
+
+## Variable Naming Rules
+
+Variables can contain:
+- Letters (a-z, A-Z)
+- Numbers (0-9)
+- Underscores (_)
+- Must start with a letter or underscore
+
+Examples of valid variables:
+- `__PROJECT_NAME__`
+- `__author__`
+- `__CamelCase__`
+- `__snake_case__`
+- `__VERSION_1__`
+
+## License
+
+MIT

--- a/packages/create-gen-app/__tests__/create-gen.test.ts
+++ b/packages/create-gen-app/__tests__/create-gen.test.ts
@@ -1,0 +1,352 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { extractVariables } from '../src/extract';
+import { promptUser } from '../src/prompt';
+import { ExtractedVariables } from '../src/types';
+
+jest.mock('inquirerer', () => {
+  return {
+    Inquirerer: jest.fn().mockImplementation(() => {
+      return {
+        prompt: jest.fn().mockResolvedValue({})
+      };
+    })
+  };
+});
+
+describe('create-gen-app', () => {
+  let testTempDir: string;
+  let testOutputDir: string;
+
+  beforeEach(() => {
+    testTempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-template-'));
+    testOutputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-output-'));
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(testTempDir)) {
+      fs.rmSync(testTempDir, { recursive: true, force: true });
+    }
+    if (fs.existsSync(testOutputDir)) {
+      fs.rmSync(testOutputDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('extractVariables', () => {
+    it('should extract variables from filenames', async () => {
+      fs.writeFileSync(path.join(testTempDir, '__PROJECT_NAME__.txt'), 'content');
+      fs.writeFileSync(path.join(testTempDir, '__AUTHOR__.md'), 'content');
+
+      const result = await extractVariables(testTempDir);
+
+      expect(result.fileReplacers).toHaveLength(2);
+      expect(result.fileReplacers.map(r => r.variable)).toContain('PROJECT_NAME');
+      expect(result.fileReplacers.map(r => r.variable)).toContain('AUTHOR');
+    });
+
+    it('should extract variables from file contents', async () => {
+      fs.writeFileSync(
+        path.join(testTempDir, 'test.txt'),
+        'Hello __USER_NAME__, welcome to __PROJECT_NAME__!'
+      );
+
+      const result = await extractVariables(testTempDir);
+
+      expect(result.contentReplacers.length).toBeGreaterThanOrEqual(2);
+      expect(result.contentReplacers.map(r => r.variable)).toContain('USER_NAME');
+      expect(result.contentReplacers.map(r => r.variable)).toContain('PROJECT_NAME');
+    });
+
+    it('should extract variables from nested directories', async () => {
+      const nestedDir = path.join(testTempDir, 'src', '__MODULE_NAME__');
+      fs.mkdirSync(nestedDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(nestedDir, '__FILE_NAME__.ts'),
+        'export const __CONSTANT__ = "value";'
+      );
+
+      const result = await extractVariables(testTempDir);
+
+      expect(result.fileReplacers.map(r => r.variable)).toContain('MODULE_NAME');
+      expect(result.fileReplacers.map(r => r.variable)).toContain('FILE_NAME');
+      expect(result.contentReplacers.map(r => r.variable)).toContain('CONSTANT');
+    });
+
+    it('should load questions from .questions.json', async () => {
+      const questions = {
+        questions: [
+          {
+            name: 'projectName',
+            type: 'text',
+            message: 'What is your project name?'
+          },
+          {
+            name: 'author',
+            type: 'text',
+            message: 'Who is the author?'
+          }
+        ]
+      };
+
+      fs.writeFileSync(
+        path.join(testTempDir, '.questions.json'),
+        JSON.stringify(questions, null, 2)
+      );
+
+      const result = await extractVariables(testTempDir);
+
+      expect(result.projectQuestions).not.toBeNull();
+      expect(result.projectQuestions?.questions).toHaveLength(2);
+      expect(result.projectQuestions?.questions[0].name).toBe('projectName');
+    });
+
+    it('should load questions from .questions.js', async () => {
+      const questionsContent = `
+module.exports = {
+  questions: [
+    {
+      name: 'projectName',
+      type: 'text',
+      message: 'What is your project name?'
+    }
+  ]
+};
+`;
+
+      fs.writeFileSync(path.join(testTempDir, '.questions.js'), questionsContent);
+
+      const result = await extractVariables(testTempDir);
+
+      expect(result.projectQuestions).not.toBeNull();
+      expect(result.projectQuestions?.questions).toHaveLength(1);
+      expect(result.projectQuestions?.questions[0].name).toBe('projectName');
+    });
+
+    it('should handle templates with no variables', async () => {
+      fs.writeFileSync(path.join(testTempDir, 'README.md'), 'Simple readme');
+
+      const result = await extractVariables(testTempDir);
+
+      expect(result.fileReplacers).toHaveLength(0);
+      expect(result.contentReplacers).toHaveLength(0);
+      expect(result.projectQuestions).toBeNull();
+    });
+
+    it('should skip .questions.json and .questions.js from variable extraction', async () => {
+      fs.writeFileSync(
+        path.join(testTempDir, '.questions.json'),
+        '{"questions": [{"name": "__SHOULD_NOT_EXTRACT__"}]}'
+      );
+
+      const result = await extractVariables(testTempDir);
+
+      expect(result.fileReplacers.map(r => r.variable)).not.toContain('SHOULD_NOT_EXTRACT');
+    });
+
+    it('should handle variables with different casings', async () => {
+      fs.writeFileSync(
+        path.join(testTempDir, 'test.txt'),
+        '__lowercase__ __UPPERCASE__ __CamelCase__ __snake_case__'
+      );
+
+      const result = await extractVariables(testTempDir);
+
+      expect(result.contentReplacers.map(r => r.variable)).toContain('lowercase');
+      expect(result.contentReplacers.map(r => r.variable)).toContain('UPPERCASE');
+      expect(result.contentReplacers.map(r => r.variable)).toContain('CamelCase');
+      expect(result.contentReplacers.map(r => r.variable)).toContain('snake_case');
+    });
+  });
+
+  describe('promptUser', () => {
+    it('should generate questions for file and content replacers', async () => {
+      const { Inquirerer } = require('inquirerer');
+      const mockPrompt = jest.fn().mockResolvedValue({
+        PROJECT_NAME: 'my-project',
+        AUTHOR: 'John Doe'
+      });
+
+      Inquirerer.mockImplementation(() => ({
+        prompt: mockPrompt
+      }));
+
+      const extractedVariables: ExtractedVariables = {
+        fileReplacers: [
+          { variable: 'PROJECT_NAME', pattern: /__PROJECT_NAME__/g }
+        ],
+        contentReplacers: [
+          { variable: 'AUTHOR', pattern: /__AUTHOR__/g }
+        ],
+        projectQuestions: null
+      };
+
+      await promptUser(extractedVariables, {}, false);
+
+      expect(mockPrompt).toHaveBeenCalled();
+      const questions = mockPrompt.mock.calls[0][1];
+      expect(questions).toHaveLength(2);
+      expect(questions.map((q: any) => q.name)).toContain('PROJECT_NAME');
+      expect(questions.map((q: any) => q.name)).toContain('AUTHOR');
+    });
+
+    it('should prioritize project questions over auto-generated ones', async () => {
+      const { Inquirerer } = require('inquirerer');
+      const mockPrompt = jest.fn().mockResolvedValue({
+        projectName: 'my-project'
+      });
+
+      Inquirerer.mockImplementation(() => ({
+        prompt: mockPrompt
+      }));
+
+      const extractedVariables: ExtractedVariables = {
+        fileReplacers: [
+          { variable: 'projectName', pattern: /__projectName__/g }
+        ],
+        contentReplacers: [],
+        projectQuestions: {
+          questions: [
+            {
+              name: 'projectName',
+              type: 'text' as const,
+              message: 'Custom question for project name'
+            }
+          ]
+        }
+      };
+
+      await promptUser(extractedVariables, {}, false);
+
+      expect(mockPrompt).toHaveBeenCalled();
+      const questions = mockPrompt.mock.calls[0][1];
+      expect(questions).toHaveLength(1);
+      expect(questions[0].message).toBe('Custom question for project name');
+    });
+
+    it('should use argv to pre-populate answers', async () => {
+      const { Inquirerer } = require('inquirerer');
+      const mockPrompt = jest.fn().mockResolvedValue({
+        PROJECT_NAME: 'my-project',
+        AUTHOR: 'John Doe'
+      });
+
+      Inquirerer.mockImplementation(() => ({
+        prompt: mockPrompt
+      }));
+
+      const extractedVariables: ExtractedVariables = {
+        fileReplacers: [
+          { variable: 'PROJECT_NAME', pattern: /__PROJECT_NAME__/g }
+        ],
+        contentReplacers: [],
+        projectQuestions: null
+      };
+
+      const argv = { PROJECT_NAME: 'pre-filled-project' };
+      await promptUser(extractedVariables, argv, false);
+
+      expect(mockPrompt).toHaveBeenCalledWith(
+        argv,
+        expect.any(Array)
+      );
+    });
+  });
+
+  describe('variable replacement', () => {
+    it('should replace variables in file contents', async () => {
+      fs.writeFileSync(
+        path.join(testTempDir, 'README.md'),
+        '# __PROJECT_NAME__\n\nBy __AUTHOR__'
+      );
+
+      const extractedVariables = await extractVariables(testTempDir);
+      const answers = {
+        PROJECT_NAME: 'My Awesome Project',
+        AUTHOR: 'Jane Smith'
+      };
+
+      const { replaceVariables } = require('../src/replace');
+      await replaceVariables(testTempDir, testOutputDir, extractedVariables, answers);
+
+      const content = fs.readFileSync(path.join(testOutputDir, 'README.md'), 'utf8');
+      expect(content).toBe('# My Awesome Project\n\nBy Jane Smith');
+    });
+
+    it('should replace variables in filenames', async () => {
+      fs.writeFileSync(
+        path.join(testTempDir, '__PROJECT_NAME__.config.js'),
+        'module.exports = {};'
+      );
+
+      const extractedVariables = await extractVariables(testTempDir);
+      const answers = {
+        PROJECT_NAME: 'myproject'
+      };
+
+      const { replaceVariables } = require('../src/replace');
+      await replaceVariables(testTempDir, testOutputDir, extractedVariables, answers);
+
+      expect(fs.existsSync(path.join(testOutputDir, 'myproject.config.js'))).toBe(true);
+    });
+
+    it('should replace variables in nested directory names', async () => {
+      const nestedDir = path.join(testTempDir, 'src', '__MODULE_NAME__');
+      fs.mkdirSync(nestedDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(nestedDir, 'index.ts'),
+        'export const name = "__MODULE_NAME__";'
+      );
+
+      const extractedVariables = await extractVariables(testTempDir);
+      const answers = {
+        MODULE_NAME: 'auth'
+      };
+
+      const { replaceVariables } = require('../src/replace');
+      await replaceVariables(testTempDir, testOutputDir, extractedVariables, answers);
+
+      const outputFile = path.join(testOutputDir, 'src', 'auth', 'index.ts');
+      expect(fs.existsSync(outputFile)).toBe(true);
+      const content = fs.readFileSync(outputFile, 'utf8');
+      expect(content).toBe('export const name = "auth";');
+    });
+
+    it('should skip .questions.json and .questions.js files', async () => {
+      fs.writeFileSync(
+        path.join(testTempDir, '.questions.json'),
+        '{"questions": []}'
+      );
+      fs.writeFileSync(
+        path.join(testTempDir, 'README.md'),
+        'Regular file'
+      );
+
+      const extractedVariables = await extractVariables(testTempDir);
+      const { replaceVariables } = require('../src/replace');
+      await replaceVariables(testTempDir, testOutputDir, extractedVariables, {});
+
+      expect(fs.existsSync(path.join(testOutputDir, '.questions.json'))).toBe(false);
+      expect(fs.existsSync(path.join(testOutputDir, 'README.md'))).toBe(true);
+    });
+
+    it('should handle multiple occurrences of the same variable', async () => {
+      fs.writeFileSync(
+        path.join(testTempDir, 'test.txt'),
+        '__NAME__ loves __NAME__ and __NAME__ is great!'
+      );
+
+      const extractedVariables = await extractVariables(testTempDir);
+      const answers = {
+        NAME: 'Alice'
+      };
+
+      const { replaceVariables } = require('../src/replace');
+      await replaceVariables(testTempDir, testOutputDir, extractedVariables, answers);
+
+      const content = fs.readFileSync(path.join(testOutputDir, 'test.txt'), 'utf8');
+      expect(content).toBe('Alice loves Alice and Alice is great!');
+    });
+  });
+});

--- a/packages/create-gen-app/jest.config.js
+++ b/packages/create-gen-app/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/*.d.ts'
+  ],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node']
+};

--- a/packages/create-gen-app/package.json
+++ b/packages/create-gen-app/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@launchql/create-gen-app",
+  "version": "0.0.1",
+  "author": "Dan Lynch <pyramation@gmail.com>",
+  "description": "Clone and customize template repositories",
+  "main": "index.js",
+  "module": "esm/index.js",
+  "types": "index.d.ts",
+  "homepage": "https://github.com/launchql/launchql",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "directory": "dist"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/launchql/launchql"
+  },
+  "bugs": {
+    "url": "https://github.com/launchql/launchql/issues"
+  },
+  "scripts": {
+    "copy": "copyfiles -f ../../LICENSE README.md package.json dist",
+    "clean": "rimraf dist/**",
+    "prepack": "npm run build",
+    "build": "npm run clean; tsc -p tsconfig.json; tsc -p tsconfig.esm.json; npm run copy",
+    "build:dev": "npm run clean; tsc -p tsconfig.json --declarationMap; tsc -p tsconfig.esm.json; npm run copy",
+    "lint": "eslint . --fix",
+    "test": "jest",
+    "test:watch": "jest --watch"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "@types/rimraf": "^4.0.5",
+    "strip-ansi": "^6",
+    "ts-node": "^10.9.2"
+  },
+  "dependencies": {
+    "inquirerer": "^2.0.8",
+    "rimraf": "^6.0.1"
+  }
+}

--- a/packages/create-gen-app/src/clone.ts
+++ b/packages/create-gen-app/src/clone.ts
@@ -1,0 +1,51 @@
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * Clone a repository to a temporary directory
+ * @param url - Repository URL (GitHub or any git URL)
+ * @returns Path to the cloned repository
+ */
+export async function cloneRepo(url: string): Promise<string> {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'create-gen-'));
+  
+  try {
+    const gitUrl = normalizeGitUrl(url);
+    
+    execSync(`git clone ${gitUrl} ${tempDir}`, {
+      stdio: 'inherit'
+    });
+    
+    const gitDir = path.join(tempDir, '.git');
+    if (fs.existsSync(gitDir)) {
+      fs.rmSync(gitDir, { recursive: true, force: true });
+    }
+    
+    return tempDir;
+  } catch (error) {
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to clone repository: ${errorMessage}`);
+  }
+}
+
+/**
+ * Normalize a URL to a git-cloneable format
+ * @param url - Input URL
+ * @returns Normalized git URL
+ */
+function normalizeGitUrl(url: string): string {
+  if (url.startsWith('git@') || url.startsWith('https://') || url.startsWith('http://')) {
+    return url;
+  }
+  
+  if (/^[\w-]+\/[\w-]+$/.test(url)) {
+    return `https://github.com/${url}.git`;
+  }
+  
+  return url;
+}

--- a/packages/create-gen-app/src/extract.ts
+++ b/packages/create-gen-app/src/extract.ts
@@ -1,0 +1,161 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { ContentReplacer, ExtractedVariables, FileReplacer, Questions } from './types';
+
+/**
+ * Pattern to match __VARIABLE__ in filenames and content
+ */
+const VARIABLE_PATTERN = /__([A-Za-z_][A-Za-z0-9_]*)__/g;
+
+/**
+ * Extract all variables from a template directory
+ * @param templateDir - Path to the template directory
+ * @returns Extracted variables including file replacers, content replacers, and project questions
+ */
+export async function extractVariables(templateDir: string): Promise<ExtractedVariables> {
+  const fileReplacers: FileReplacer[] = [];
+  const contentReplacers: ContentReplacer[] = [];
+  const fileReplacerVars = new Set<string>();
+  const contentReplacerVars = new Set<string>();
+  
+  const projectQuestions = await loadProjectQuestions(templateDir);
+  
+  await walkDirectory(templateDir, async (filePath) => {
+    const relativePath = path.relative(templateDir, filePath);
+    
+    if (relativePath === '.questions.json' || relativePath === '.questions.js') {
+      return;
+    }
+    
+    const matches = relativePath.matchAll(VARIABLE_PATTERN);
+    for (const match of matches) {
+      const varName = match[1];
+      if (!fileReplacerVars.has(varName)) {
+        fileReplacerVars.add(varName);
+        fileReplacers.push({
+          variable: varName,
+          pattern: new RegExp(`__${varName}__`, 'g')
+        });
+      }
+    }
+    
+    const contentVars = await extractFromFileContent(filePath);
+    for (const varName of contentVars) {
+      if (!contentReplacerVars.has(varName)) {
+        contentReplacerVars.add(varName);
+        contentReplacers.push({
+          variable: varName,
+          pattern: new RegExp(`__${varName}__`, 'g')
+        });
+      }
+    }
+  });
+  
+  return {
+    fileReplacers,
+    contentReplacers,
+    projectQuestions
+  };
+}
+
+/**
+ * Extract variables from file content using streams
+ * @param filePath - Path to the file
+ * @returns Set of variable names found in the file
+ */
+async function extractFromFileContent(filePath: string): Promise<Set<string>> {
+  const variables = new Set<string>();
+  
+  return new Promise((resolve) => {
+    const stream = fs.createReadStream(filePath, { encoding: 'utf8' });
+    let buffer = '';
+    
+    stream.on('data', (chunk: string | Buffer) => {
+      buffer += chunk.toString();
+      
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || ''; // Keep the last incomplete line in buffer
+      
+      for (const line of lines) {
+        const matches = line.matchAll(VARIABLE_PATTERN);
+        for (const match of matches) {
+          variables.add(match[1]);
+        }
+      }
+    });
+    
+    stream.on('end', () => {
+      const matches = buffer.matchAll(VARIABLE_PATTERN);
+      for (const match of matches) {
+        variables.add(match[1]);
+      }
+      resolve(variables);
+    });
+    
+    stream.on('error', () => {
+      resolve(variables);
+    });
+  });
+}
+
+/**
+ * Walk through a directory recursively
+ * @param dir - Directory to walk
+ * @param callback - Callback function for each file
+ */
+async function walkDirectory(dir: string, callback: (filePath: string) => Promise<void>): Promise<void> {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    
+    if (entry.isDirectory()) {
+      await walkDirectory(fullPath, callback);
+    } else if (entry.isFile()) {
+      await callback(fullPath);
+    }
+  }
+}
+
+/**
+ * Load project questions from .questions.json or .questions.js
+ * @param templateDir - Path to the template directory
+ * @returns Questions object or null if not found
+ */
+async function loadProjectQuestions(templateDir: string): Promise<Questions | null> {
+  const jsonPath = path.join(templateDir, '.questions.json');
+  if (fs.existsSync(jsonPath)) {
+    try {
+      const content = fs.readFileSync(jsonPath, 'utf8');
+      const questions = JSON.parse(content);
+      return validateQuestions(questions) ? questions : null;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.warn(`Failed to parse .questions.json: ${errorMessage}`);
+    }
+  }
+  
+  const jsPath = path.join(templateDir, '.questions.js');
+  if (fs.existsSync(jsPath)) {
+    try {
+      const module = require(jsPath);
+      const questions = module.default || module;
+      return validateQuestions(questions) ? questions : null;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.warn(`Failed to load .questions.js: ${errorMessage}`);
+    }
+  }
+  
+  return null;
+}
+
+/**
+ * Validate that the questions object has the correct structure
+ * @param obj - Object to validate
+ * @returns True if valid, false otherwise
+ */
+function validateQuestions(obj: any): obj is Questions {
+  return obj && typeof obj === 'object' && Array.isArray(obj.questions);
+}

--- a/packages/create-gen-app/src/index.ts
+++ b/packages/create-gen-app/src/index.ts
@@ -1,0 +1,50 @@
+import * as fs from 'fs';
+
+import { cloneRepo } from './clone';
+import { extractVariables } from './extract';
+import { promptUser } from './prompt';
+import { replaceVariables } from './replace';
+import { CreateGenOptions } from './types';
+
+export * from './clone';
+export * from './extract';
+export * from './prompt';
+export * from './replace';
+export * from './types';
+
+/**
+ * Create a new project from a template repository
+ * @param options - Options for creating the project
+ * @returns Path to the generated project
+ */
+export async function createGen(options: CreateGenOptions): Promise<string> {
+  const { templateUrl, outputDir, argv = {}, noTty = false } = options;
+  
+  console.log(`Cloning template from ${templateUrl}...`);
+  const tempDir = await cloneRepo(templateUrl);
+  
+  try {
+    console.log('Extracting template variables...');
+    const extractedVariables = await extractVariables(tempDir);
+    
+    console.log(`Found ${extractedVariables.fileReplacers.length} file replacers`);
+    console.log(`Found ${extractedVariables.contentReplacers.length} content replacers`);
+    if (extractedVariables.projectQuestions) {
+      console.log(`Found ${extractedVariables.projectQuestions.questions.length} project questions`);
+    }
+    
+    console.log('Prompting for variable values...');
+    const answers = await promptUser(extractedVariables, argv, noTty);
+    
+    console.log(`Generating project in ${outputDir}...`);
+    await replaceVariables(tempDir, outputDir, extractedVariables, answers);
+    
+    console.log('Project created successfully!');
+    
+    return outputDir;
+  } finally {
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
+}

--- a/packages/create-gen-app/src/prompt.ts
+++ b/packages/create-gen-app/src/prompt.ts
@@ -1,0 +1,73 @@
+import { Inquirerer, Question } from 'inquirerer';
+
+import { ExtractedVariables } from './types';
+
+/**
+ * Generate questions from extracted variables
+ * @param extractedVariables - Variables extracted from the template
+ * @returns Array of questions to prompt the user
+ */
+export function generateQuestions(extractedVariables: ExtractedVariables): Question[] {
+  const questions: Question[] = [];
+  const askedVariables = new Set<string>();
+  
+  if (extractedVariables.projectQuestions) {
+    for (const question of extractedVariables.projectQuestions.questions) {
+      questions.push(question);
+      askedVariables.add(question.name);
+    }
+  }
+  
+  for (const replacer of extractedVariables.fileReplacers) {
+    if (!askedVariables.has(replacer.variable)) {
+      questions.push({
+        name: replacer.variable,
+        type: 'text',
+        message: `Enter value for ${replacer.variable}:`,
+        required: true
+      });
+      askedVariables.add(replacer.variable);
+    }
+  }
+  
+  for (const replacer of extractedVariables.contentReplacers) {
+    if (!askedVariables.has(replacer.variable)) {
+      questions.push({
+        name: replacer.variable,
+        type: 'text',
+        message: `Enter value for ${replacer.variable}:`,
+        required: true
+      });
+      askedVariables.add(replacer.variable);
+    }
+  }
+  
+  return questions;
+}
+
+/**
+ * Prompt the user for variable values
+ * @param extractedVariables - Variables extracted from the template
+ * @param argv - Command-line arguments to pre-populate answers
+ * @param noTty - Whether to disable TTY mode
+ * @returns Answers from the user
+ */
+export async function promptUser(
+  extractedVariables: ExtractedVariables,
+  argv: Record<string, any> = {},
+  noTty: boolean = false
+): Promise<Record<string, any>> {
+  const questions = generateQuestions(extractedVariables);
+  
+  if (questions.length === 0) {
+    return argv;
+  }
+  
+  const prompter = new Inquirerer({
+    noTty
+  });
+  
+  const answers = await prompter.prompt(argv, questions);
+  
+  return answers;
+}

--- a/packages/create-gen-app/src/replace.ts
+++ b/packages/create-gen-app/src/replace.ts
@@ -1,0 +1,123 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { Transform } from 'stream';
+import { pipeline } from 'stream/promises';
+
+import { ExtractedVariables } from './types';
+
+/**
+ * Replace variables in all files in the template directory
+ * @param templateDir - Path to the template directory
+ * @param outputDir - Path to the output directory
+ * @param extractedVariables - Variables extracted from the template
+ * @param answers - User answers for variable values
+ */
+export async function replaceVariables(
+  templateDir: string,
+  outputDir: string,
+  extractedVariables: ExtractedVariables,
+  answers: Record<string, any>
+): Promise<void> {
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+  
+  await walkAndReplace(templateDir, outputDir, extractedVariables, answers);
+}
+
+/**
+ * Walk through directory and replace variables in files and filenames
+ * @param sourceDir - Source directory
+ * @param destDir - Destination directory
+ * @param extractedVariables - Variables extracted from the template
+ * @param answers - User answers for variable values
+ * @param sourceRelativePath - Current relative path in source (for recursion)
+ * @param destRelativePath - Current relative path in destination (for recursion)
+ */
+async function walkAndReplace(
+  sourceDir: string,
+  destDir: string,
+  extractedVariables: ExtractedVariables,
+  answers: Record<string, any>,
+  sourceRelativePath: string = '',
+  destRelativePath: string = ''
+): Promise<void> {
+  const currentSource = path.join(sourceDir, sourceRelativePath);
+  const entries = fs.readdirSync(currentSource, { withFileTypes: true });
+  
+  for (const entry of entries) {
+    const sourceEntryPath = path.join(currentSource, entry.name);
+    
+    if (entry.name === '.questions.json' || entry.name === '.questions.js') {
+      continue;
+    }
+    
+    let newName = entry.name;
+    for (const replacer of extractedVariables.fileReplacers) {
+      if (answers[replacer.variable] !== undefined) {
+        newName = newName.replace(replacer.pattern, String(answers[replacer.variable]));
+      }
+    }
+    
+    const destEntryPath = path.join(destDir, destRelativePath, newName);
+    
+    if (entry.isDirectory()) {
+      if (!fs.existsSync(destEntryPath)) {
+        fs.mkdirSync(destEntryPath, { recursive: true });
+      }
+      await walkAndReplace(
+        sourceDir,
+        destDir,
+        extractedVariables,
+        answers,
+        path.join(sourceRelativePath, entry.name),
+        path.join(destRelativePath, newName)
+      );
+    } else if (entry.isFile()) {
+      await replaceInFile(sourceEntryPath, destEntryPath, extractedVariables, answers);
+    }
+  }
+}
+
+/**
+ * Replace variables in a file using streams
+ * @param sourcePath - Source file path
+ * @param destPath - Destination file path
+ * @param extractedVariables - Variables extracted from the template
+ * @param answers - User answers for variable values
+ */
+async function replaceInFile(
+  sourcePath: string,
+  destPath: string,
+  extractedVariables: ExtractedVariables,
+  answers: Record<string, any>
+): Promise<void> {
+  const destDir = path.dirname(destPath);
+  if (!fs.existsSync(destDir)) {
+    fs.mkdirSync(destDir, { recursive: true });
+  }
+  
+  const replaceTransform = new Transform({
+    transform(chunk: Buffer, encoding, callback) {
+      let content = chunk.toString();
+      
+      for (const replacer of extractedVariables.contentReplacers) {
+        if (answers[replacer.variable] !== undefined) {
+          content = content.replace(replacer.pattern, String(answers[replacer.variable]));
+        }
+      }
+      
+      callback(null, Buffer.from(content));
+    }
+  });
+  
+  try {
+    await pipeline(
+      fs.createReadStream(sourcePath),
+      replaceTransform,
+      fs.createWriteStream(destPath)
+    );
+  } catch (error) {
+    fs.copyFileSync(sourcePath, destPath);
+  }
+}

--- a/packages/create-gen-app/src/types.ts
+++ b/packages/create-gen-app/src/types.ts
@@ -1,0 +1,69 @@
+import { Question } from 'inquirerer';
+
+/**
+ * Questions configuration that can be loaded from .questions.json or .questions.js
+ * @typedef {Object} Questions
+ * @property {Question[]} questions - Array of inquirerer questions
+ */
+export interface Questions {
+  questions: Question[];
+}
+
+/**
+ * Variable extracted from filename patterns like __VARIABLE__
+ */
+export interface FileReplacer {
+  variable: string;
+  pattern: RegExp;
+}
+
+/**
+ * Variable extracted from file content patterns like __VARIABLE__
+ */
+export interface ContentReplacer {
+  variable: string;
+  pattern: RegExp;
+}
+
+/**
+ * Options for creating a new project from a template
+ */
+export interface CreateGenOptions {
+  /**
+   * URL or path to the template repository
+   */
+  templateUrl: string;
+  
+  /**
+   * Destination directory for the generated project
+   */
+  outputDir: string;
+  
+  /**
+   * Command-line arguments to pre-populate answers
+   */
+  argv?: Record<string, any>;
+  
+  /**
+   * Whether to use TTY for interactive prompts
+   */
+  noTty?: boolean;
+}
+
+/**
+ * Result of extracting variables from a template
+ */
+export interface ExtractedVariables {
+  fileReplacers: FileReplacer[];
+  contentReplacers: ContentReplacer[];
+  projectQuestions: Questions | null;
+}
+
+/**
+ * Context for processing a template
+ */
+export interface TemplateContext {
+  tempDir: string;
+  extractedVariables: ExtractedVariables;
+  answers: Record<string, any>;
+}

--- a/packages/create-gen-app/tsconfig.esm.json
+++ b/packages/create-gen-app/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/esm",
+    "module": "es2022"
+  }
+}

--- a/packages/create-gen-app/tsconfig.json
+++ b/packages/create-gen-app/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src/"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules", "**/*.spec.*", "**/*.test.*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,6 +246,29 @@ importers:
         version: 4.0.5
     publishDirectory: dist
 
+  packages/create-gen-app:
+    dependencies:
+      inquirerer:
+        specifier: ^2.0.8
+        version: 2.0.8
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
+    devDependencies:
+      '@types/node':
+        specifier: ^20.12.7
+        version: 20.19.24
+      '@types/rimraf':
+        specifier: ^4.0.5
+        version: 4.0.5
+      strip-ansi:
+        specifier: ^6
+        version: 6.0.1
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@20.19.24)(typescript@5.9.3)
+    publishDirectory: dist
+
   packages/env:
     dependencies:
       '@launchql/types':


### PR DESCRIPTION
# feat: add create-gen-app package for template repository cloning and customization

## Summary

This PR introduces a new `@launchql/create-gen-app` package that enables cloning and customizing template repositories with variable replacement. The library:

- Clones GitHub repositories (or any git URL) to a temporary directory
- Extracts template variables from filenames and file contents using `__VARIABLE__` syntax
- Loads custom questions from `.questions.json` or `.questions.js` files in the template
- Prompts users interactively using inquirerer (with CLI argument support for non-interactive use)
- Performs stream-based file processing to replace variables in both filenames and content
- Handles nested directory structures where directory names contain variables

The implementation includes 16 comprehensive tests covering variable extraction, prompting logic, and replacement functionality.

## Review & Testing Checklist for Human

- [ ] **Test end-to-end with a real repository**: The tests use mocked file systems and don't actually clone remote repositories. Please test with an actual GitHub repo to verify the git cloning works correctly (e.g., `createGen({ templateUrl: 'user/repo', outputDir: './test-output' })`)
- [ ] **Verify nested directory replacement**: I fixed a bug during development where nested directories with variables in their names weren't being replaced correctly. The fix tracks source and destination paths separately during recursion. Please test with a template that has nested directories like `src/__MODULE_NAME__/__FILE_NAME__.ts`
- [ ] **Review security implications**: The code uses `execSync` for git cloning and `require()` for loading `.questions.js` files. Consider whether URL sanitization is needed for the git clone command, and whether loading arbitrary JS files from templates poses security risks
- [ ] **Test with edge cases**: Try templates with very large files, binary files, files with special characters in names, and deeply nested structures to ensure the stream-based processing handles them correctly

### Notes

- All 16 tests pass locally
- Lint checks pass (only a TypeScript version warning which is not an error)
- The library follows the inquirerer testing patterns as requested
- Stream-based processing is used for efficiency, with a fallback to `copyFileSync` for binary files

**Link to Devin run**: https://app.devin.ai/sessions/4302a82a68874d0f89f24e6940b4f1d3  
**Requested by**: Dan Lynch (pyramation@gmail.com) / @pyramation