### PR TITLE
Fix concurrent role creation race condition

### DIFF
--- a/packages/core/src/init/client.ts
+++ b/packages/core/src/init/client.ts
@@ -70,10 +70,10 @@ DECLARE
   v_password TEXT := '${password.replace(/'/g, "''")}';
 BEGIN
   BEGIN
+    PERFORM pg_advisory_xact_lock(42, hashtext(v_username));
     EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', v_username, v_password);
   EXCEPTION
-    WHEN duplicate_object THEN
-      -- Role already exists; optionally sync attributes here with ALTER ROLE
+    WHEN duplicate_object OR unique_violation THEN
       NULL;
   END;
 END

--- a/packages/core/src/init/sql/bootstrap-roles.sql
+++ b/packages/core/src/init/sql/bootstrap-roles.sql
@@ -1,35 +1,35 @@
 BEGIN;
 DO $do$
 BEGIN
-  -- anonymous
-  BEGIN
-    PERFORM pg_advisory_xact_lock(42, hashtext('anonymous'));
-    EXECUTE format('CREATE ROLE %I', 'anonymous');
-  EXCEPTION
-    WHEN duplicate_object OR unique_violation THEN
-      -- Role already exists (duplicate_object) or concurrent creation hit unique index (unique_violation)
-      NULL;
-  END;
+  IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'anonymous') THEN
+    BEGIN
+      PERFORM pg_advisory_xact_lock(42, hashtext('anonymous'));
+      EXECUTE format('CREATE ROLE %I', 'anonymous');
+    EXCEPTION
+      WHEN duplicate_object OR unique_violation THEN
+        NULL;
+    END;
+  END IF;
   
-  -- authenticated
-  BEGIN
-    PERFORM pg_advisory_xact_lock(42, hashtext('authenticated'));
-    EXECUTE format('CREATE ROLE %I', 'authenticated');
-  EXCEPTION
-    WHEN duplicate_object OR unique_violation THEN
-      -- Role already exists (duplicate_object) or concurrent creation hit unique index (unique_violation)
-      NULL;
-  END;
+  IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'authenticated') THEN
+    BEGIN
+      PERFORM pg_advisory_xact_lock(42, hashtext('authenticated'));
+      EXECUTE format('CREATE ROLE %I', 'authenticated');
+    EXCEPTION
+      WHEN duplicate_object OR unique_violation THEN
+        NULL;
+    END;
+  END IF;
   
-  -- administrator
-  BEGIN
-    PERFORM pg_advisory_xact_lock(42, hashtext('administrator'));
-    EXECUTE format('CREATE ROLE %I', 'administrator');
-  EXCEPTION
-    WHEN duplicate_object OR unique_violation THEN
-      -- Role already exists (duplicate_object) or concurrent creation hit unique index (unique_violation)
-      NULL;
-  END;
+  IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'administrator') THEN
+    BEGIN
+      PERFORM pg_advisory_xact_lock(42, hashtext('administrator'));
+      EXECUTE format('CREATE ROLE %I', 'administrator');
+    EXCEPTION
+      WHEN duplicate_object OR unique_violation THEN
+        NULL;
+    END;
+  END IF;
 END
 $do$;
 

--- a/packages/core/src/init/sql/bootstrap-roles.sql
+++ b/packages/core/src/init/sql/bootstrap-roles.sql
@@ -3,28 +3,31 @@ DO $do$
 BEGIN
   -- anonymous
   BEGIN
+    PERFORM pg_advisory_xact_lock(42, hashtext('anonymous'));
     EXECUTE format('CREATE ROLE %I', 'anonymous');
   EXCEPTION
-    WHEN duplicate_object THEN
-      -- Role already exists; optionally sync attributes here with ALTER ROLE
+    WHEN duplicate_object OR unique_violation THEN
+      -- Role already exists (duplicate_object) or concurrent creation hit unique index (unique_violation)
       NULL;
   END;
   
   -- authenticated
   BEGIN
+    PERFORM pg_advisory_xact_lock(42, hashtext('authenticated'));
     EXECUTE format('CREATE ROLE %I', 'authenticated');
   EXCEPTION
-    WHEN duplicate_object THEN
-      -- Role already exists; optionally sync attributes here with ALTER ROLE
+    WHEN duplicate_object OR unique_violation THEN
+      -- Role already exists (duplicate_object) or concurrent creation hit unique index (unique_violation)
       NULL;
   END;
   
   -- administrator
   BEGIN
+    PERFORM pg_advisory_xact_lock(42, hashtext('administrator'));
     EXECUTE format('CREATE ROLE %I', 'administrator');
   EXCEPTION
-    WHEN duplicate_object THEN
-      -- Role already exists; optionally sync attributes here with ALTER ROLE
+    WHEN duplicate_object OR unique_violation THEN
+      -- Role already exists (duplicate_object) or concurrent creation hit unique index (unique_violation)
       NULL;
   END;
 END

--- a/packages/core/src/init/sql/bootstrap-test-roles.sql
+++ b/packages/core/src/init/sql/bootstrap-test-roles.sql
@@ -2,18 +2,18 @@ BEGIN;
 DO $do$
 BEGIN
   BEGIN
+    PERFORM pg_advisory_xact_lock(42, hashtext('app_user'));
     EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', 'app_user', 'app_password');
   EXCEPTION
-    WHEN duplicate_object THEN
-      -- Role already exists; optionally sync attributes here with ALTER ROLE
+    WHEN duplicate_object OR unique_violation THEN
       NULL;
   END;
   
   BEGIN
+    PERFORM pg_advisory_xact_lock(42, hashtext('app_admin'));
     EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', 'app_admin', 'admin_password');
   EXCEPTION
-    WHEN duplicate_object THEN
-      -- Role already exists; optionally sync attributes here with ALTER ROLE
+    WHEN duplicate_object OR unique_violation THEN
       NULL;
   END;
 END

--- a/packages/core/src/init/sql/bootstrap-test-roles.sql
+++ b/packages/core/src/init/sql/bootstrap-test-roles.sql
@@ -1,72 +1,109 @@
 BEGIN;
 DO $do$
 BEGIN
-  BEGIN
-    PERFORM pg_advisory_xact_lock(42, hashtext('app_user'));
-    EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', 'app_user', 'app_password');
-  EXCEPTION
-    WHEN duplicate_object OR unique_violation THEN
-      NULL;
-  END;
+  IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'app_user') THEN
+    BEGIN
+      PERFORM pg_advisory_xact_lock(42, hashtext('app_user'));
+      EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', 'app_user', 'app_password');
+    EXCEPTION
+      WHEN duplicate_object OR unique_violation THEN
+        NULL;
+    END;
+  END IF;
   
-  BEGIN
-    PERFORM pg_advisory_xact_lock(42, hashtext('app_admin'));
-    EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', 'app_admin', 'admin_password');
-  EXCEPTION
-    WHEN duplicate_object OR unique_violation THEN
-      NULL;
-  END;
+  IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'app_admin') THEN
+    BEGIN
+      PERFORM pg_advisory_xact_lock(42, hashtext('app_admin'));
+      EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', 'app_admin', 'admin_password');
+    EXCEPTION
+      WHEN duplicate_object OR unique_violation THEN
+        NULL;
+    END;
+  END IF;
 END
 $do$;
 
 DO $do$
 BEGIN
-  BEGIN
-    EXECUTE format('GRANT %I TO %I', 'anonymous', 'app_user');
-  EXCEPTION
-    WHEN unique_violation THEN
-      -- Membership was granted concurrently; ignore.
-      NULL;
-    WHEN undefined_object THEN
-      -- One of the roles doesn't exist yet; order operations as needed.
-      RAISE NOTICE 'Missing role when granting % to %', 'anonymous', 'app_user';
-  END;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_auth_members am
+    JOIN pg_roles r1 ON am.roleid = r1.oid
+    JOIN pg_roles r2 ON am.member = r2.oid
+    WHERE r1.rolname = 'anonymous' AND r2.rolname = 'app_user'
+  ) THEN
+    BEGIN
+      EXECUTE format('GRANT %I TO %I', 'anonymous', 'app_user');
+    EXCEPTION
+      WHEN unique_violation THEN
+        NULL;
+      WHEN undefined_object THEN
+        RAISE NOTICE 'Missing role when granting % to %', 'anonymous', 'app_user';
+    END;
+  END IF;
 
-  BEGIN
-    EXECUTE format('GRANT %I TO %I', 'authenticated', 'app_user');
-  EXCEPTION
-    WHEN unique_violation THEN
-      NULL;
-    WHEN undefined_object THEN
-      RAISE NOTICE 'Missing role when granting % to %', 'authenticated', 'app_user';
-  END;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_auth_members am
+    JOIN pg_roles r1 ON am.roleid = r1.oid
+    JOIN pg_roles r2 ON am.member = r2.oid
+    WHERE r1.rolname = 'authenticated' AND r2.rolname = 'app_user'
+  ) THEN
+    BEGIN
+      EXECUTE format('GRANT %I TO %I', 'authenticated', 'app_user');
+    EXCEPTION
+      WHEN unique_violation THEN
+        NULL;
+      WHEN undefined_object THEN
+        RAISE NOTICE 'Missing role when granting % to %', 'authenticated', 'app_user';
+    END;
+  END IF;
 
-  BEGIN
-    EXECUTE format('GRANT %I TO %I', 'anonymous', 'administrator');
-  EXCEPTION
-    WHEN unique_violation THEN
-      NULL;
-    WHEN undefined_object THEN
-      RAISE NOTICE 'Missing role when granting % to %', 'anonymous', 'administrator';
-  END;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_auth_members am
+    JOIN pg_roles r1 ON am.roleid = r1.oid
+    JOIN pg_roles r2 ON am.member = r2.oid
+    WHERE r1.rolname = 'anonymous' AND r2.rolname = 'administrator'
+  ) THEN
+    BEGIN
+      EXECUTE format('GRANT %I TO %I', 'anonymous', 'administrator');
+    EXCEPTION
+      WHEN unique_violation THEN
+        NULL;
+      WHEN undefined_object THEN
+        RAISE NOTICE 'Missing role when granting % to %', 'anonymous', 'administrator';
+    END;
+  END IF;
 
-  BEGIN
-    EXECUTE format('GRANT %I TO %I', 'authenticated', 'administrator');
-  EXCEPTION
-    WHEN unique_violation THEN
-      NULL;
-    WHEN undefined_object THEN
-      RAISE NOTICE 'Missing role when granting % to %', 'authenticated', 'administrator';
-  END;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_auth_members am
+    JOIN pg_roles r1 ON am.roleid = r1.oid
+    JOIN pg_roles r2 ON am.member = r2.oid
+    WHERE r1.rolname = 'authenticated' AND r2.rolname = 'administrator'
+  ) THEN
+    BEGIN
+      EXECUTE format('GRANT %I TO %I', 'authenticated', 'administrator');
+    EXCEPTION
+      WHEN unique_violation THEN
+        NULL;
+      WHEN undefined_object THEN
+        RAISE NOTICE 'Missing role when granting % to %', 'authenticated', 'administrator';
+    END;
+  END IF;
 
-  BEGIN
-    EXECUTE format('GRANT %I TO %I', 'administrator', 'app_admin');
-  EXCEPTION
-    WHEN unique_violation THEN
-      NULL;
-    WHEN undefined_object THEN
-      RAISE NOTICE 'Missing role when granting % to %', 'administrator', 'app_admin';
-  END;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_auth_members am
+    JOIN pg_roles r1 ON am.roleid = r1.oid
+    JOIN pg_roles r2 ON am.member = r2.oid
+    WHERE r1.rolname = 'administrator' AND r2.rolname = 'app_admin'
+  ) THEN
+    BEGIN
+      EXECUTE format('GRANT %I TO %I', 'administrator', 'app_admin');
+    EXCEPTION
+      WHEN unique_violation THEN
+        NULL;
+      WHEN undefined_object THEN
+        RAISE NOTICE 'Missing role when granting % to %', 'administrator', 'app_admin';
+    END;
+  END IF;
 END
 $do$;
 COMMIT;

--- a/packages/pgsql-test/src/admin.ts
+++ b/packages/pgsql-test/src/admin.ts
@@ -155,14 +155,15 @@ $$;
         v_user TEXT := '${user.replace(/'/g, "''")}';
         v_password TEXT := '${password.replace(/'/g, "''")}';
       BEGIN
-        -- Create role if it doesn't exist
-        BEGIN
-          PERFORM pg_advisory_xact_lock(42, hashtext(v_user));
-          EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', v_user, v_password);
-        EXCEPTION
-          WHEN duplicate_object OR unique_violation THEN
-            NULL;
-        END;
+        IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = v_user) THEN
+          BEGIN
+            PERFORM pg_advisory_xact_lock(42, hashtext(v_user));
+            EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', v_user, v_password);
+          EXCEPTION
+            WHEN duplicate_object OR unique_violation THEN
+              NULL;
+          END;
+        END IF;
 
         -- CI/CD concurrency note: GRANT role membership can race on pg_auth_members unique index
         -- We pre-check membership and still catch unique_violation to handle TOCTOU safely.

--- a/packages/pgsql-test/src/admin.ts
+++ b/packages/pgsql-test/src/admin.ts
@@ -157,10 +157,10 @@ $$;
       BEGIN
         -- Create role if it doesn't exist
         BEGIN
+          PERFORM pg_advisory_xact_lock(42, hashtext(v_user));
           EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', v_user, v_password);
         EXCEPTION
-          WHEN duplicate_object THEN
-            -- Role already exists; optionally sync attributes here with ALTER ROLE
+          WHEN duplicate_object OR unique_violation THEN
             NULL;
         END;
 


### PR DESCRIPTION
# Fix concurrent role creation race condition with advisory locks

## Summary

Fixes the intermittent CI error: `ERROR: duplicate key value violates unique constraint "pg_authid_rolname_index"` that occurs when multiple processes try to create the same PostgreSQL role concurrently.

**Root Cause**: Under concurrent execution, `CREATE ROLE` can hit the `pg_authid_rolname_index` unique constraint before PostgreSQL's duplicate object detection runs, resulting in `unique_violation` (error code 23505) instead of `duplicate_object` (error code 42710).

**Solution**: 
- Added `pg_advisory_xact_lock(42, hashtext(rolname))` to serialize role creation per role name
- Updated exception handlers to catch both `duplicate_object` OR `unique_violation`
- Applied consistently across all 4 role creation code paths:
  - `bootstrap-roles.sql` (anonymous, authenticated, administrator)
  - `bootstrap-test-roles.sql` (app_user, app_admin)
  - `LaunchQLInit.bootstrapDbRoles()` (custom users)
  - `DbAdmin.createUserRole()` (pgsql-test users)

The advisory lock prevents the race entirely, while catching both exceptions provides defense in depth.

## Review & Testing Checklist for Human

- [ ] **Test under actual concurrent load**: Run multiple parallel processes that try to create the same role simultaneously to verify the fix eliminates the race condition (CI tests run sequentially and may not catch this)
- [ ] **Verify no other role creation code paths were missed**: Search the codebase for any other `CREATE ROLE` statements that might need the same fix
- [ ] **Check advisory lock namespace**: Confirm that namespace `42` doesn't collide with other advisory locks used elsewhere in the system
- [ ] **Test existing functionality**: Verify that role creation still works correctly in normal (non-concurrent) scenarios and that the advisory locks don't introduce unexpected blocking

### Recommended Test Plan
1. Run the existing CI tests to ensure no regressions
2. Manually test concurrent role creation by running `lql admin-users add --test --yes` in multiple parallel shells
3. Check that the error no longer occurs in CI logs over multiple runs

### Notes
- Advisory locks are transaction-scoped (`pg_advisory_xact_lock`) and will be automatically released at transaction end
- The `hashtext()` function provides good distribution of lock keys based on role names
- This fix is compatible with PostgreSQL 13.3+ (the version used in CI)
- Performance impact should be minimal since role creation is infrequent

---

**Link to Devin run**: https://app.devin.ai/sessions/2c33cab4511f4a7897e29001895487df  
**Requested by**: Dan Lynch (@pyramation)