### PR TITLE
Fix concurrent role creation with exception handling only (no advisory locks)

### DIFF
--- a/packages/core/src/init/client.ts
+++ b/packages/core/src/init/client.ts
@@ -69,41 +69,52 @@ DECLARE
   v_username TEXT := '${username.replace(/'/g, "''")}';
   v_password TEXT := '${password.replace(/'/g, "''")}';
 BEGIN
-  BEGIN
-    EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', v_username, v_password);
-  EXCEPTION
-    WHEN duplicate_object OR unique_violation THEN
-      NULL;
-  END;
+  IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = v_username) THEN
+    BEGIN
+      EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', v_username, v_password);
+    EXCEPTION
+      WHEN duplicate_object OR unique_violation THEN
+        NULL;
+    END;
+  END IF;
 END
 $do$;
 
--- Robust GRANTs under concurrency: GRANT can race on pg_auth_members unique index.
--- Catch unique_violation (23505) and continue so CI/CD concurrent jobs don't fail.
 DO $do$
 DECLARE
   v_username TEXT := '${username.replace(/'/g, "''")}';
 BEGIN
-  BEGIN
-    EXECUTE format('GRANT %I TO %I', 'anonymous', v_username);
-  EXCEPTION
-    WHEN unique_violation THEN
-      -- Membership was granted concurrently; ignore.
-      NULL;
-    WHEN undefined_object THEN
-      -- One of the roles doesn't exist yet; order operations as needed.
-      RAISE NOTICE 'Missing role when granting % to %', 'anonymous', v_username;
-  END;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_auth_members am
+    JOIN pg_roles r1 ON am.roleid = r1.oid
+    JOIN pg_roles r2 ON am.member = r2.oid
+    WHERE r1.rolname = 'anonymous' AND r2.rolname = v_username
+  ) THEN
+    BEGIN
+      EXECUTE format('GRANT %I TO %I', 'anonymous', v_username);
+    EXCEPTION
+      WHEN unique_violation THEN
+        NULL;
+      WHEN undefined_object THEN
+        RAISE NOTICE 'Missing role when granting % to %', 'anonymous', v_username;
+    END;
+  END IF;
 
-  BEGIN
-    EXECUTE format('GRANT %I TO %I', 'authenticated', v_username);
-  EXCEPTION
-    WHEN unique_violation THEN
-      -- Membership was granted concurrently; ignore.
-      NULL;
-    WHEN undefined_object THEN
-      RAISE NOTICE 'Missing role when granting % to %', 'authenticated', v_username;
-  END;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_auth_members am
+    JOIN pg_roles r1 ON am.roleid = r1.oid
+    JOIN pg_roles r2 ON am.member = r2.oid
+    WHERE r1.rolname = 'authenticated' AND r2.rolname = v_username
+  ) THEN
+    BEGIN
+      EXECUTE format('GRANT %I TO %I', 'authenticated', v_username);
+    EXCEPTION
+      WHEN unique_violation THEN
+        NULL;
+      WHEN undefined_object THEN
+        RAISE NOTICE 'Missing role when granting % to %', 'authenticated', v_username;
+    END;
+  END IF;
 END
 $do$;
 COMMIT;

--- a/packages/core/src/init/client.ts
+++ b/packages/core/src/init/client.ts
@@ -72,8 +72,7 @@ BEGIN
   BEGIN
     EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', v_username, v_password);
   EXCEPTION
-    WHEN duplicate_object THEN
-      -- Role already exists; optionally sync attributes here with ALTER ROLE
+    WHEN duplicate_object OR unique_violation THEN
       NULL;
   END;
 END

--- a/packages/core/src/init/sql/bootstrap-roles.sql
+++ b/packages/core/src/init/sql/bootstrap-roles.sql
@@ -1,29 +1,32 @@
 BEGIN;
 DO $do$
 BEGIN
-  -- anonymous
-  BEGIN
-    EXECUTE format('CREATE ROLE %I', 'anonymous');
-  EXCEPTION
-    WHEN duplicate_object OR unique_violation THEN
-      NULL;
-  END;
+  IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'anonymous') THEN
+    BEGIN
+      EXECUTE format('CREATE ROLE %I', 'anonymous');
+    EXCEPTION
+      WHEN duplicate_object OR unique_violation THEN
+        NULL;
+    END;
+  END IF;
   
-  -- authenticated
-  BEGIN
-    EXECUTE format('CREATE ROLE %I', 'authenticated');
-  EXCEPTION
-    WHEN duplicate_object OR unique_violation THEN
-      NULL;
-  END;
+  IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'authenticated') THEN
+    BEGIN
+      EXECUTE format('CREATE ROLE %I', 'authenticated');
+    EXCEPTION
+      WHEN duplicate_object OR unique_violation THEN
+        NULL;
+    END;
+  END IF;
   
-  -- administrator
-  BEGIN
-    EXECUTE format('CREATE ROLE %I', 'administrator');
-  EXCEPTION
-    WHEN duplicate_object OR unique_violation THEN
-      NULL;
-  END;
+  IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'administrator') THEN
+    BEGIN
+      EXECUTE format('CREATE ROLE %I', 'administrator');
+    EXCEPTION
+      WHEN duplicate_object OR unique_violation THEN
+        NULL;
+    END;
+  END IF;
 END
 $do$;
 

--- a/packages/core/src/init/sql/bootstrap-roles.sql
+++ b/packages/core/src/init/sql/bootstrap-roles.sql
@@ -5,8 +5,7 @@ BEGIN
   BEGIN
     EXECUTE format('CREATE ROLE %I', 'anonymous');
   EXCEPTION
-    WHEN duplicate_object THEN
-      -- Role already exists; optionally sync attributes here with ALTER ROLE
+    WHEN duplicate_object OR unique_violation THEN
       NULL;
   END;
   
@@ -14,8 +13,7 @@ BEGIN
   BEGIN
     EXECUTE format('CREATE ROLE %I', 'authenticated');
   EXCEPTION
-    WHEN duplicate_object THEN
-      -- Role already exists; optionally sync attributes here with ALTER ROLE
+    WHEN duplicate_object OR unique_violation THEN
       NULL;
   END;
   
@@ -23,8 +21,7 @@ BEGIN
   BEGIN
     EXECUTE format('CREATE ROLE %I', 'administrator');
   EXCEPTION
-    WHEN duplicate_object THEN
-      -- Role already exists; optionally sync attributes here with ALTER ROLE
+    WHEN duplicate_object OR unique_violation THEN
       NULL;
   END;
 END

--- a/packages/core/src/init/sql/bootstrap-test-roles.sql
+++ b/packages/core/src/init/sql/bootstrap-test-roles.sql
@@ -1,70 +1,107 @@
 BEGIN;
 DO $do$
 BEGIN
-  BEGIN
-    EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', 'app_user', 'app_password');
-  EXCEPTION
-    WHEN duplicate_object OR unique_violation THEN
-      NULL;
-  END;
+  IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'app_user') THEN
+    BEGIN
+      EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', 'app_user', 'app_password');
+    EXCEPTION
+      WHEN duplicate_object OR unique_violation THEN
+        NULL;
+    END;
+  END IF;
   
-  BEGIN
-    EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', 'app_admin', 'admin_password');
-  EXCEPTION
-    WHEN duplicate_object OR unique_violation THEN
-      NULL;
-  END;
+  IF NOT EXISTS (SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = 'app_admin') THEN
+    BEGIN
+      EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', 'app_admin', 'admin_password');
+    EXCEPTION
+      WHEN duplicate_object OR unique_violation THEN
+        NULL;
+    END;
+  END IF;
 END
 $do$;
 
 DO $do$
 BEGIN
-  BEGIN
-    EXECUTE format('GRANT %I TO %I', 'anonymous', 'app_user');
-  EXCEPTION
-    WHEN unique_violation THEN
-      -- Membership was granted concurrently; ignore.
-      NULL;
-    WHEN undefined_object THEN
-      -- One of the roles doesn't exist yet; order operations as needed.
-      RAISE NOTICE 'Missing role when granting % to %', 'anonymous', 'app_user';
-  END;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_auth_members am
+    JOIN pg_roles r1 ON am.roleid = r1.oid
+    JOIN pg_roles r2 ON am.member = r2.oid
+    WHERE r1.rolname = 'anonymous' AND r2.rolname = 'app_user'
+  ) THEN
+    BEGIN
+      EXECUTE format('GRANT %I TO %I', 'anonymous', 'app_user');
+    EXCEPTION
+      WHEN unique_violation THEN
+        NULL;
+      WHEN undefined_object THEN
+        RAISE NOTICE 'Missing role when granting % to %', 'anonymous', 'app_user';
+    END;
+  END IF;
 
-  BEGIN
-    EXECUTE format('GRANT %I TO %I', 'authenticated', 'app_user');
-  EXCEPTION
-    WHEN unique_violation THEN
-      NULL;
-    WHEN undefined_object THEN
-      RAISE NOTICE 'Missing role when granting % to %', 'authenticated', 'app_user';
-  END;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_auth_members am
+    JOIN pg_roles r1 ON am.roleid = r1.oid
+    JOIN pg_roles r2 ON am.member = r2.oid
+    WHERE r1.rolname = 'authenticated' AND r2.rolname = 'app_user'
+  ) THEN
+    BEGIN
+      EXECUTE format('GRANT %I TO %I', 'authenticated', 'app_user');
+    EXCEPTION
+      WHEN unique_violation THEN
+        NULL;
+      WHEN undefined_object THEN
+        RAISE NOTICE 'Missing role when granting % to %', 'authenticated', 'app_user';
+    END;
+  END IF;
 
-  BEGIN
-    EXECUTE format('GRANT %I TO %I', 'anonymous', 'administrator');
-  EXCEPTION
-    WHEN unique_violation THEN
-      NULL;
-    WHEN undefined_object THEN
-      RAISE NOTICE 'Missing role when granting % to %', 'anonymous', 'administrator';
-  END;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_auth_members am
+    JOIN pg_roles r1 ON am.roleid = r1.oid
+    JOIN pg_roles r2 ON am.member = r2.oid
+    WHERE r1.rolname = 'anonymous' AND r2.rolname = 'administrator'
+  ) THEN
+    BEGIN
+      EXECUTE format('GRANT %I TO %I', 'anonymous', 'administrator');
+    EXCEPTION
+      WHEN unique_violation THEN
+        NULL;
+      WHEN undefined_object THEN
+        RAISE NOTICE 'Missing role when granting % to %', 'anonymous', 'administrator';
+    END;
+  END IF;
 
-  BEGIN
-    EXECUTE format('GRANT %I TO %I', 'authenticated', 'administrator');
-  EXCEPTION
-    WHEN unique_violation THEN
-      NULL;
-    WHEN undefined_object THEN
-      RAISE NOTICE 'Missing role when granting % to %', 'authenticated', 'administrator';
-  END;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_auth_members am
+    JOIN pg_roles r1 ON am.roleid = r1.oid
+    JOIN pg_roles r2 ON am.member = r2.oid
+    WHERE r1.rolname = 'authenticated' AND r2.rolname = 'administrator'
+  ) THEN
+    BEGIN
+      EXECUTE format('GRANT %I TO %I', 'authenticated', 'administrator');
+    EXCEPTION
+      WHEN unique_violation THEN
+        NULL;
+      WHEN undefined_object THEN
+        RAISE NOTICE 'Missing role when granting % to %', 'authenticated', 'administrator';
+    END;
+  END IF;
 
-  BEGIN
-    EXECUTE format('GRANT %I TO %I', 'administrator', 'app_admin');
-  EXCEPTION
-    WHEN unique_violation THEN
-      NULL;
-    WHEN undefined_object THEN
-      RAISE NOTICE 'Missing role when granting % to %', 'administrator', 'app_admin';
-  END;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_auth_members am
+    JOIN pg_roles r1 ON am.roleid = r1.oid
+    JOIN pg_roles r2 ON am.member = r2.oid
+    WHERE r1.rolname = 'administrator' AND r2.rolname = 'app_admin'
+  ) THEN
+    BEGIN
+      EXECUTE format('GRANT %I TO %I', 'administrator', 'app_admin');
+    EXCEPTION
+      WHEN unique_violation THEN
+        NULL;
+      WHEN undefined_object THEN
+        RAISE NOTICE 'Missing role when granting % to %', 'administrator', 'app_admin';
+    END;
+  END IF;
 END
 $do$;
 COMMIT;

--- a/packages/core/src/init/sql/bootstrap-test-roles.sql
+++ b/packages/core/src/init/sql/bootstrap-test-roles.sql
@@ -4,16 +4,14 @@ BEGIN
   BEGIN
     EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', 'app_user', 'app_password');
   EXCEPTION
-    WHEN duplicate_object THEN
-      -- Role already exists; optionally sync attributes here with ALTER ROLE
+    WHEN duplicate_object OR unique_violation THEN
       NULL;
   END;
   
   BEGIN
     EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', 'app_admin', 'admin_password');
   EXCEPTION
-    WHEN duplicate_object THEN
-      -- Role already exists; optionally sync attributes here with ALTER ROLE
+    WHEN duplicate_object OR unique_violation THEN
       NULL;
   END;
 END

--- a/packages/pgsql-test/src/admin.ts
+++ b/packages/pgsql-test/src/admin.ts
@@ -159,8 +159,7 @@ $$;
         BEGIN
           EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', v_user, v_password);
         EXCEPTION
-          WHEN duplicate_object THEN
-            -- Role already exists; optionally sync attributes here with ALTER ROLE
+          WHEN duplicate_object OR unique_violation THEN
             NULL;
         END;
 


### PR DESCRIPTION
# Fix concurrent role creation with exception handling only (no advisory locks)

## Summary

This PR addresses the intermittent CI error `ERROR: duplicate key value violates unique constraint "pg_authid_rolname_index"` by catching both `duplicate_object` AND `unique_violation` exceptions in all role creation code paths.

**Key difference from PR #325**: This PR does NOT use advisory locks - it relies solely on exception handling to deal with concurrent role creation attempts.

**Root Cause**: Under concurrent execution, `CREATE ROLE` can hit the `pg_authid_rolname_index` unique constraint before PostgreSQL's duplicate object detection runs, resulting in `unique_violation` (error code 23505) instead of `duplicate_object` (error code 42710).

**This Solution**: Updated exception handlers to catch both error codes across all 4 role creation code paths:
- `bootstrap-roles.sql` (anonymous, authenticated, administrator)
- `bootstrap-test-roles.sql` (app_user, app_admin)
- `LaunchQLInit.bootstrapDbRoles()` (custom users)
- `DbAdmin.createUserRole()` (pgsql-test users)

## Review & Testing Checklist for Human

- [ ] **Compare with PR #325**: Review the advisory lock approach in PR #325 and decide which solution is preferable (locks provide stronger guarantees but add overhead; exception-only is simpler but may have more retry attempts under high concurrency)
- [ ] **Test under actual concurrent load**: Run multiple parallel processes that try to create the same role simultaneously (e.g., `lql admin-users add --test --yes` in 5+ parallel shells) to verify this approach handles the race condition
- [ ] **Verify exception scope**: Confirm that catching `unique_violation` here doesn't accidentally mask other unrelated unique constraint violations
- [ ] **Wait for PR #3**: The third PR will include a test suite that reproduces the concurrent error on main branch, which can be used to validate both this PR and PR #325

### Recommended Test Plan
1. Run existing CI tests to ensure no regressions
2. Manually test concurrent role creation with multiple parallel processes
3. Compare error rates and performance between this PR and PR #325 under load
4. Use the test suite from PR #3 (when available) to validate the fix

### Notes
- This is PR #2 of 3 PRs created for comparison purposes
- PR #325 uses advisory locks + exception handling (more robust)
- This PR uses exception handling only (simpler, potentially less reliable under extreme concurrency)
- PR #3 will provide a test suite to reproduce the error and benchmark both approaches
- The exception handling approach may result in more failed CREATE ROLE attempts under high concurrency (which get caught and ignored), whereas advisory locks prevent the attempts entirely
- Compatible with PostgreSQL 13.3+ (the version used in CI)

---

**Link to Devin run**: https://app.devin.ai/sessions/2c33cab4511f4a7897e29001895487df  
**Requested by**: Dan Lynch (@pyramation)