### PR TITLE
Add concurrent role creation test demonstrating race condition (intentionally fails on main)

### DIFF
--- a/packages/pgsql-test/__tests__/postgres-test.concurrent-roles.test.ts
+++ b/packages/pgsql-test/__tests__/postgres-test.concurrent-roles.test.ts
@@ -1,0 +1,240 @@
+process.env.LOG_SCOPE = 'pgsql-test';
+
+import { Pool } from 'pg';
+import { getPgEnvOptions } from 'pg-env';
+import { DbAdmin } from '../src/admin';
+
+/**
+ * Concurrent Role Creation Test
+ * 
+ * This test demonstrates the race condition that occurs when multiple processes
+ * attempt to create the same PostgreSQL role simultaneously. On the main branch,
+ * this test should FAIL with a unique_violation error.
+ * 
+ * The test also includes performance benchmarks comparing different concurrency levels.
+ */
+
+const config = getPgEnvOptions({});
+const admin = new DbAdmin(config, false);
+
+describe('Concurrent Role Creation', () => {
+  const testDbName = `concurrent_role_test_${Date.now()}`;
+  let pool: Pool;
+
+  beforeAll(async () => {
+    admin.create(testDbName);
+    
+    const bootstrapSql = `
+      CREATE ROLE IF NOT EXISTS anonymous;
+      CREATE ROLE IF NOT EXISTS authenticated;
+      CREATE ROLE IF NOT EXISTS administrator;
+    `;
+    await admin.streamSql(bootstrapSql, testDbName);
+
+    pool = new Pool({
+      ...config,
+      database: testDbName,
+      max: 20
+    });
+  });
+
+  afterAll(async () => {
+    await pool?.end();
+    admin.drop(testDbName);
+  });
+
+  /**
+   * This test reproduces the unique_violation error that occurs under concurrency.
+   * 
+   * Expected behavior on main branch: FAIL with unique_violation
+   * Expected behavior on fix branches: PASS
+   */
+  it('should handle concurrent role creation without errors', async () => {
+    const roleName = `test_user_${Date.now()}`;
+    const password = 'test_password';
+
+    const createRoleSql = `
+      DO $$
+      BEGIN
+        BEGIN
+          EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', '${roleName}', '${password}');
+        EXCEPTION
+          WHEN duplicate_object THEN
+            NULL;
+        END;
+      END $$;
+    `;
+
+    const concurrentCreations = Array.from({ length: 4 }, async () => {
+      const client = await pool.connect();
+      try {
+        await client.query(createRoleSql);
+      } finally {
+        client.release();
+      }
+    });
+
+    await expect(Promise.all(concurrentCreations)).resolves.not.toThrow();
+  });
+
+  /**
+   * Performance benchmark: Measure latency at different concurrency levels
+   */
+  it('should benchmark concurrent role creation performance', async () => {
+    const concurrencyLevels = [2, 4, 8];
+    const iterations = 5;
+
+    console.log('\n=== Performance Benchmark Results ===\n');
+
+    for (const concurrency of concurrencyLevels) {
+      const latencies: number[] = [];
+
+      for (let i = 0; i < iterations; i++) {
+        const roleName = `bench_user_${concurrency}_${i}_${Date.now()}`;
+        const password = 'bench_password';
+
+        const createRoleSql = `
+          DO $$
+          BEGIN
+            BEGIN
+              EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', '${roleName}', '${password}');
+            EXCEPTION
+              WHEN duplicate_object OR unique_violation THEN
+                NULL;
+            END;
+          END $$;
+        `;
+
+        const startTime = Date.now();
+
+        const concurrentCreations = Array.from({ length: concurrency }, async () => {
+          const client = await pool.connect();
+          try {
+            await client.query(createRoleSql);
+          } finally {
+            client.release();
+          }
+        });
+
+        await Promise.all(concurrentCreations);
+
+        const endTime = Date.now();
+        const latency = endTime - startTime;
+        latencies.push(latency);
+
+        try {
+          await pool.query(`DROP ROLE IF EXISTS ${roleName}`);
+        } catch (err) {
+        }
+      }
+
+      const avgLatency = latencies.reduce((a, b) => a + b, 0) / latencies.length;
+      const sortedLatencies = [...latencies].sort((a, b) => a - b);
+      const medianLatency = sortedLatencies[Math.floor(sortedLatencies.length / 2)];
+
+      console.log(`Concurrency Level: ${concurrency}`);
+      console.log(`  Average Latency: ${avgLatency.toFixed(2)}ms`);
+      console.log(`  Median Latency: ${medianLatency}ms`);
+      console.log(`  Min Latency: ${Math.min(...latencies)}ms`);
+      console.log(`  Max Latency: ${Math.max(...latencies)}ms`);
+      console.log('');
+    }
+
+    console.log('=== End Performance Benchmark ===\n');
+  });
+
+  /**
+   * Test concurrent GRANT operations
+   */
+  it('should handle concurrent GRANT operations without errors', async () => {
+    const userName = `grant_test_user_${Date.now()}`;
+    const password = 'test_password';
+
+    await pool.query(`CREATE ROLE ${userName} LOGIN PASSWORD '${password}'`);
+
+    const grantSql = `
+      DO $$
+      BEGIN
+        BEGIN
+          EXECUTE format('GRANT %I TO %I', 'anonymous', '${userName}');
+        EXCEPTION
+          WHEN unique_violation THEN
+            NULL;
+        END;
+      END $$;
+    `;
+
+    const concurrentGrants = Array.from({ length: 4 }, async () => {
+      const client = await pool.connect();
+      try {
+        await client.query(grantSql);
+      } finally {
+        client.release();
+      }
+    });
+
+    await expect(Promise.all(concurrentGrants)).resolves.not.toThrow();
+
+    await pool.query(`DROP ROLE IF EXISTS ${userName}`);
+  });
+
+  /**
+   * Stress test: Create many roles concurrently with retries
+   */
+  it('should handle high concurrency role creation with retries', async () => {
+    const baseRoleName = `stress_test_${Date.now()}`;
+    const numRoles = 10;
+    const concurrencyPerRole = 3;
+
+    const createRoleWithRetries = async (roleName: string, password: string, maxRetries = 3) => {
+      for (let attempt = 0; attempt < maxRetries; attempt++) {
+        try {
+          const createRoleSql = `
+            DO $$
+            BEGIN
+              BEGIN
+                EXECUTE format('CREATE ROLE %I LOGIN PASSWORD %L', '${roleName}', '${password}');
+              EXCEPTION
+                WHEN duplicate_object OR unique_violation THEN
+                  NULL;
+              END;
+            END $$;
+          `;
+
+          const client = await pool.connect();
+          try {
+            await client.query(createRoleSql);
+            return;
+          } finally {
+            client.release();
+          }
+        } catch (err: any) {
+          if (attempt === maxRetries - 1) {
+            throw err;
+          }
+          await new Promise(resolve => setTimeout(resolve, 10));
+        }
+      }
+    };
+
+    const allCreations = [];
+    for (let i = 0; i < numRoles; i++) {
+      const roleName = `${baseRoleName}_${i}`;
+      const password = 'stress_password';
+
+      for (let j = 0; j < concurrencyPerRole; j++) {
+        allCreations.push(createRoleWithRetries(roleName, password));
+      }
+    }
+
+    await expect(Promise.all(allCreations)).resolves.not.toThrow();
+
+    for (let i = 0; i < numRoles; i++) {
+      const roleName = `${baseRoleName}_${i}`;
+      try {
+        await pool.query(`DROP ROLE IF EXISTS ${roleName}`);
+      } catch (err) {
+      }
+    }
+  });
+});


### PR DESCRIPTION
# Add concurrent role creation test (reproduces unique_violation bug)

## Summary

This PR adds a comprehensive test suite that **intentionally demonstrates the race condition** in concurrent PostgreSQL role creation on the main branch. The test should FAIL on main and PASS on the fix branches (PR #325 and PR #326).

**Key Changes:**
- New test file: `packages/pgsql-test/__tests__/postgres-test.concurrent-roles.test.ts`
- Four test cases covering different concurrency scenarios
- Performance benchmarks measuring latency at concurrency levels 2, 4, and 8

**The Bug Being Demonstrated:**
When multiple processes attempt to create the same PostgreSQL role simultaneously, the current code only catches `duplicate_object` exceptions. However, under concurrency, the actual error is `unique_violation` (error code 23505) when both sessions race to insert into `pg_authid` and hit the `pg_authid_rolname_index` unique constraint.

**Test Cases:**
1. **Concurrent role creation** - Reproduces the bug (should FAIL on main)
2. **Performance benchmarks** - Measures latency with both exceptions caught (informational)
3. **Concurrent GRANT operations** - Tests role membership grants under concurrency
4. **High concurrency stress test** - Tests 10 roles × 3 concurrent attempts each with retries

## Review & Testing Checklist for Human

**CRITICAL - This PR is expected to FAIL on main branch:**
- [ ] Verify the first test case (`should handle concurrent role creation without errors`) actually FAILS on main with a `unique_violation` error
- [ ] Run the performance benchmark test and note the latency results for comparison with fix PRs
- [ ] Cherry-pick or merge this test onto PR #325 branch and verify it PASSES
- [ ] Cherry-pick or merge this test onto PR #326 branch and verify it PASSES
- [ ] Review the test for potential flakiness - concurrent tests can be timing-dependent

**Test Plan:**
```bash
# On main branch (should fail):
cd packages/pgsql-test
pnpm test postgres-test.concurrent-roles.test.ts

# Expected: First test fails with unique_violation error
# Expected: Performance benchmark completes and prints latency stats

# On PR #325 or #326 branches (should pass):
git checkout devin/1763429451-fix-concurrent-role-creation  # or PR #326 branch
cd packages/pgsql-test
pnpm test postgres-test.concurrent-roles.test.ts

# Expected: All tests pass
```

### Notes

**Related PRs:**
- PR #325: Fix with advisory locks + pre-checks + both exceptions
- PR #326: Fix with pre-checks + both exceptions (no locks)

**Why this test is valuable:**
- Provides reproducible demonstration of the concurrency bug
- Establishes performance baseline for comparing lock vs no-lock approaches
- Can be used for regression testing to ensure the fix works

**Potential Issues:**
- Test may be flaky due to timing - concurrent operations might not always race
- If test infrastructure doesn't support high concurrency, the bug might not reproduce consistently
- Database cleanup could fail if tests are interrupted

---

**Session Info:**
- Devin Session: https://app.devin.ai/sessions/2c33cab4511f4a7897e29001895487df
- Requested by: Dan Lynch (pyramation@gmail.com) / @pyramation