### PR TITLE
feat(core): add file creation logging to pgpm add command

### DIFF
--- a/packages/core/src/core/class/launchql.ts
+++ b/packages/core/src/core/class/launchql.ts
@@ -837,6 +837,8 @@ export class LaunchQLPackage {
       throw errors.PATH_NOT_FOUND({ path: 'module path', type: 'module' });
     }
 
+    const createdFiles: string[] = [];
+
     const createSqlFile = (type: 'deploy' | 'revert' | 'verify', content: string) => {
       const dir = path.dirname(changeName);
       const fileName = path.basename(changeName);
@@ -846,6 +848,10 @@ export class LaunchQLPackage {
       
       fs.mkdirSync(targetDir, { recursive: true });
       fs.writeFileSync(filePath, content);
+      
+      // Track the relative path from module root
+      const relativePath = path.relative(this.modulePath!, filePath);
+      createdFiles.push(relativePath);
     };
 
     // Create deploy file
@@ -871,6 +877,13 @@ ${dependencies.length > 0 ? dependencies.map(dep => `-- requires: ${dep}`).join(
     createSqlFile('deploy', deployContent);
     createSqlFile('revert', revertContent);
     createSqlFile('verify', verifyContent);
+
+    // Log created files to stdout
+    process.stdout.write('\n✔ Files created\n\n');
+    createdFiles.forEach(file => {
+      process.stdout.write(`   create  ${file}\n`);
+    });
+    process.stdout.write('\n✨ All set!\n\n');
   }
 
   // ──────────────── Packaging and npm ────────────────


### PR DESCRIPTION
# feat(core): add file creation logging to pgpm add command

## Summary
Added stdout logging to the `pgpm add` / `lql add` command to display which SQL files were created. Previously, the command was completely silent after creating the deploy/revert/verify SQL files. Now it outputs a friendly message showing the created files with their relative paths.

**Changes:**
- Modified `createSqlFiles()` method in `packages/core/src/core/class/launchql.ts`
- Tracks created file paths in an array as files are written
- Outputs formatted list to stdout using `process.stdout.write()` as requested
- Format: `✔ Files created` header, list of files with `create` prefix, `✨ All set!` footer

**Example output:**
```
✔ Files created

   create  deploy/pets.sql
   create  revert/pets.sql
   create  verify/pets.sql

✨ All set!
```

## Review & Testing Checklist for Human
- [ ] **Test the command output**: Run `lql add <change_name>` in a test module and verify the output format looks correct
- [ ] **Test nested paths**: Try `lql add schema/tables/users` to verify nested directory paths display correctly
- [ ] **Verify no side effects**: Ensure the logging doesn't break any automated tooling or scripts that might parse command output

### Test Plan
1. Navigate to a LaunchQL module directory
2. Run `lql add test_change` (or with dependencies: `lql add test_change --requires other_change`)
3. Verify the output shows the three created files with correct relative paths
4. Test with nested paths like `lql add schema/tables/my_table`
5. Confirm files are actually created in the expected locations

### Notes
- This change was **not manually tested** - the output format should be verified before merging
- Uses plain `process.stdout.write()` as specifically requested (no logging libraries)
- The change is purely additive and shouldn't affect existing functionality
- Session: https://app.devin.ai/sessions/fe0d29465b774c7d95e1273ca633f3f5
- Requested by: Dan Lynch (@pyramation)