### PR TITLE
feat(pgpm): add workspace.dirname resolver for boilerplate templates

### DIFF
--- a/pgpm/pgpm/src/commands/init/workspace.ts
+++ b/pgpm/pgpm/src/commands/init/workspace.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_TEMPLATE_REPO, DEFAULT_TEMPLATE_TOOL_NAME, scaffoldTemplate, sluggify } from '@pgpmjs/core';
 import { Logger } from '@pgpmjs/logger';
-import { Inquirerer, Question } from 'inquirerer';
+import { Inquirerer, Question, registerDefaultResolver } from 'inquirerer';
 import path from 'path';
 
 const log = new Logger('workspace-init');
@@ -27,6 +27,11 @@ export default async function runWorkspaceSetup(
   const templateRepo = (argv.repo as string) ?? DEFAULT_TEMPLATE_REPO;
   // Don't set default templatePath - let scaffoldTemplate use metadata-driven resolution
   const templatePath = argv.templatePath as string | undefined;
+
+  // Register workspace.dirname resolver so boilerplate templates can use it via defaultFrom/setFrom
+  // This provides the intended workspace directory name before the folder is created
+  const dirName = path.basename(targetPath);
+  registerDefaultResolver('workspace.dirname', () => dirName);
 
   const scaffoldResult = await scaffoldTemplate({
     type: 'workspace',


### PR DESCRIPTION
## Summary

Registers a `workspace.dirname` resolver in the inquirerer global registry before scaffolding workspace templates. This allows boilerplate templates to use `defaultFrom: "workspace.dirname"` or `setFrom: "workspace.dirname"` to automatically derive values from the intended workspace directory name.

**Context**: When creating a workspace, asking for both a folder name and a repository name is redundant since they're typically the same. This resolver enables boilerplate templates to default `repoName` to the workspace directory name, reducing the number of questions asked.

**Note**: This PR only adds the resolver registration. The `pgpm-boilerplates` repo will need a separate update to add `"defaultFrom": "workspace.dirname"` to the `repoName` question in the workspace `.boilerplate.json`.

## Review & Testing Checklist for Human

- [ ] Verify the resolver is registered at the correct time (after `targetPath` is computed, before `scaffoldTemplate` is called)
- [ ] Consider whether the resolver should be unregistered after scaffolding completes to avoid polluting global state
- [ ] Test manually: run `pgpm init workspace`, then in a separate terminal check if the resolver is available during template prompting

### Recommended Test Plan
1. After merging, update `pgpm-boilerplates` workspace template to add `"defaultFrom": "workspace.dirname"` for `repoName`
2. Create a new workspace with `pgpm init workspace`
3. Verify that `repoName` defaults to the workspace folder name

### Notes
- Link to Devin run: https://app.devin.ai/sessions/fed966add0284ae0b88295cb40116e7b
- Requested by: Dan Lynch (@pyramation)