### PR TITLE
fix function job, add more logs in middleware

### DIFF
--- a/functions/send-email-link/src/index.ts
+++ b/functions/send-email-link/src/index.ts
@@ -71,11 +71,20 @@ const getRequiredEnv = (name: string): string => {
   return value;
 };
 
-const createGraphQLClient = (url: string): GraphQLClient => {
+const createGraphQLClient = (
+  url: string,
+  hostHeaderEnvVar?: string
+): GraphQLClient => {
   const headers: Record<string, string> = {};
 
   if (process.env.GRAPHQL_AUTH_TOKEN) {
     headers.Authorization = `Bearer ${process.env.GRAPHQL_AUTH_TOKEN}`;
+  }
+
+  const envName = hostHeaderEnvVar || 'GRAPHQL_HOST_HEADER';
+  const hostHeader = process.env[envName];
+  if (hostHeader) {
+    headers.host = hostHeader;
   }
 
   return new GraphQLClient(url, { headers });
@@ -275,8 +284,8 @@ app.post('*', async (req: any, res: any, next: any) => {
     const graphqlUrl = getRequiredEnv('GRAPHQL_URL');
     const metaGraphqlUrl = process.env.META_GRAPHQL_URL || graphqlUrl;
 
-    const client = createGraphQLClient(graphqlUrl);
-    const meta = createGraphQLClient(metaGraphqlUrl);
+    const client = createGraphQLClient(graphqlUrl, 'GRAPHQL_HOST_HEADER');
+    const meta = createGraphQLClient(metaGraphqlUrl, 'META_GRAPHQL_HOST_HEADER');
 
     const result = await sendEmailLink(params, {
       client,

--- a/jobs/knative-job-fn/src/index.ts
+++ b/jobs/knative-job-fn/src/index.ts
@@ -17,6 +17,35 @@ const app: any = express();
 
 app.use(bodyParser.json());
 
+// Basic request logging for all incoming job invocations.
+app.use((req: any, res: any, next: any) => {
+  try {
+    // Log only the headers we care about plus a shallow body snapshot
+    const headers = {
+      'x-worker-id': req.get('X-Worker-Id'),
+      'x-job-id': req.get('X-Job-Id'),
+      'x-database-id': req.get('X-Database-Id'),
+      'x-callback-url': req.get('X-Callback-Url')
+    };
+
+    const body =
+      req.body && typeof req.body === 'object'
+        ? { keys: Object.keys(req.body), preview: req.body }
+        : req.body;
+
+    // eslint-disable-next-line no-console
+    console.log('[knative-job-fn] Incoming job request', {
+      method: req.method,
+      path: req.originalUrl || req.url,
+      headers,
+      body
+    });
+  } catch {
+    // best-effort logging; never block the request
+  }
+  next();
+});
+
 // Echo job headers back on responses for debugging/traceability.
 app.use((req: any, res: any, next: any) => {
   res.set({
@@ -151,6 +180,13 @@ app.use((req: any, res: any, next: any) => {
       // If an error handler already sent a callback, skip.
       if (res.locals.jobCallbackSent) return;
       res.locals.jobCallbackSent = true;
+      // eslint-disable-next-line no-console
+      console.log('[knative-job-fn] Function completed', {
+        workerId: ctx.workerId,
+        jobId: ctx.jobId,
+        databaseId: ctx.databaseId,
+        statusCode: res.statusCode
+      });
       void sendJobCallback(ctx, 'success');
     });
   }
@@ -183,6 +219,41 @@ export default {
       } catch (err) {
         // eslint-disable-next-line no-console
         console.error('[knative-job-fn] Failed to send error callback', err);
+      }
+
+      // Log the full error context for debugging.
+      try {
+        const headers = {
+          'x-worker-id': req.get('X-Worker-Id'),
+          'x-job-id': req.get('X-Job-Id'),
+          'x-database-id': req.get('X-Database-Id'),
+          'x-callback-url': req.get('X-Callback-Url')
+        };
+
+        // Some error types (e.g. GraphQL ClientError) expose response info.
+        const errorDetails: any = {
+          message: error?.message,
+          name: error?.name,
+          stack: error?.stack
+        };
+
+        if (error?.response) {
+          errorDetails.response = {
+            status: error.response.status,
+            statusText: error.response.statusText,
+            errors: error.response.errors,
+            data: error.response.data
+          };
+        }
+
+        // eslint-disable-next-line no-console
+        console.error('[knative-job-fn] Function error', {
+          headers,
+          path: req.originalUrl || req.url,
+          error: errorDetails
+        });
+      } catch {
+        // never throw from the error logger
       }
 
       res.status(200).json({ message: error.message });

--- a/jobs/knative-job-fn/src/index.ts
+++ b/jobs/knative-job-fn/src/index.ts
@@ -28,10 +28,16 @@ app.use((req: any, res: any, next: any) => {
       'x-callback-url': req.get('X-Callback-Url')
     };
 
-    const body =
-      req.body && typeof req.body === 'object'
-        ? { keys: Object.keys(req.body), preview: req.body }
-        : req.body;
+    let body: any;
+    if (req.body && typeof req.body === 'object') {
+      // Only log top-level keys to avoid exposing sensitive body contents.
+      body = { keys: Object.keys(req.body) };
+    } else if (typeof req.body === 'string') {
+      // For string bodies, log only the length.
+      body = { length: req.body.length };
+    } else {
+      body = undefined;
+    }
 
     // eslint-disable-next-line no-console
     console.log('[knative-job-fn] Incoming job request', {


### PR DESCRIPTION
This pull request introduces enhanced logging and configuration flexibility for both the `send-email-link` and `knative-job-fn` services. The main improvements are better observability of job requests and error handling in `knative-job-fn`, and added support for custom host headers in GraphQL client creation in `send-email-link`. These changes aid in debugging, traceability, and deployment flexibility.

**Enhanced logging and observability in `knative-job-fn`:**
- Added middleware to log incoming job requests, including relevant headers and a snapshot of the request body, improving traceability and debugging of job invocations.
- Added logging when a job function completes, capturing worker, job, and database IDs along with the status code.
- Improved error logging by capturing and outputting detailed error context, including headers, error message, stack trace, and GraphQL response details if available.

**GraphQL client configuration improvements in `send-email-link`:**
- Modified `createGraphQLClient` to accept an optional environment variable name for the host header, allowing different host headers for different GraphQL endpoints.
- Updated GraphQL client instantiation to use the appropriate host header environment variables for both the main and meta GraphQL clients.