### PR TITLE
Removed pg.database setting from env explicitly

### DIFF
--- a/graphql/server/src/run.ts
+++ b/graphql/server/src/run.ts
@@ -4,10 +4,4 @@ import { getEnvOptions } from '@constructive-io/graphql-env';
 
 import { GraphQLServer as server } from './server';
 
-server(
-  getEnvOptions({
-    pg: {
-      database: process.env.PGDATABASE,
-    },
-  })
-);
+server(getEnvOptions());


### PR DESCRIPTION
Removed pg.database setting from env explicitly:
from:
```ts
server(
  getEnvOptions({
    pg: {
      database: process.env.PGDATABASE,
    },
  })
);
```

to:
```ts
server(
  getEnvOptions()
);
```
so that there won't be error when PGDATABASE's not set
