### PR TITLE
fix(pg-cache): add error handler to prevent unhandled pool errors

### DIFF
--- a/postgres/pg-cache/src/pg.ts
+++ b/postgres/pg-cache/src/pg.ts
@@ -24,16 +24,56 @@ export const getPgPool = (pgConfig: Partial<PgConfig>): pg.Pool => {
   }
   const connectionString = getDbString(user, password, host, port, database);
   const pgPool = new pg.Pool({ connectionString });
-  
-  // Add error handler to prevent unhandled 'error' events from crashing Node.js
-  // This commonly happens when connections are terminated during database cleanup
+
+  /**
+   * IMPORTANT: Pool-level error handler for idle connection errors.
+   *
+   * WHY THIS EXISTS:
+   * pg-pool maintains a pool of database connections. When a connection is idle
+   * (not actively running a query) and the server terminates it (e.g., during
+   * database cleanup via pg_terminate_backend), pg-pool emits an 'error' event
+   * on the pool's EventEmitter. In Node.js, an EventEmitter 'error' event with
+   * no listeners is FATAL and crashes the entire process with an unhelpful
+   * stack trace showing internal pg-pool/pg-protocol objects.
+   *
+   * WHY THIS IS SAFE (does NOT swallow real errors):
+   * This handler ONLY catches errors emitted on IDLE pooled connections via
+   * the EventEmitter pattern. It does NOT intercept errors from active queries.
+   *
+   * Error paths in pg-pool:
+   * 1. QUERY ERRORS (pool.query(), client.query()):
+   *    - Returned via Promise rejection
+   *    - Bubble up through async/await as normal exceptions
+   *    - NOT affected by this handler - they still throw as expected
+   *    - Examples: syntax errors, constraint violations, connection refused
+   *
+   * 2. IDLE CONNECTION ERRORS (this handler):
+   *    - Emitted via EventEmitter when server kills an idle connection
+   *    - Without a handler: crashes Node.js process
+   *    - With this handler: logged and process continues
+   *    - Examples: pg_terminate_backend during cleanup, server restart
+   *
+   * WHEN THIS FIRES:
+   * - pgpm test-packages creates temp databases, deploys, then drops them
+   * - Dropping requires pg_terminate_backend() to kill active connections
+   * - Idle connections in the pool receive PostgreSQL error 57P01
+   * - This handler catches that expected cleanup error
+   *
+   * PostgreSQL error codes handled:
+   * - 57P01: admin_shutdown (terminating connection due to administrator command)
+   *   This is EXPECTED during database teardown and logged at debug level.
+   *
+   * All other error codes are logged at error level for visibility but do not
+   * crash the process, allowing the test harness to continue and report results.
+   */
   pgPool.on('error', (err: Error & { code?: string }) => {
-    // 57P01 = admin_shutdown (terminating connection due to administrator command)
-    // This is expected during database cleanup/teardown
     if (err.code === '57P01') {
+      // Expected during database cleanup - log at debug level
       log.debug(`Pool ${database} connection terminated (expected during cleanup): ${err.message}`);
     } else {
-      log.error(`Pool ${database} error: ${err.message}`);
+      // Unexpected pool error - log at error level for visibility
+      // Note: This does NOT swallow query errors - those still throw via Promise rejection
+      log.error(`Pool ${database} unexpected idle connection error [${err.code || 'unknown'}]: ${err.message}`);
     }
   });
   

--- a/postgres/pg-cache/src/pg.ts
+++ b/postgres/pg-cache/src/pg.ts
@@ -1,7 +1,10 @@
 import pg from 'pg';
 import { getPgEnvOptions, PgConfig } from 'pg-env';
+import { Logger } from '@pgpmjs/logger';
 
 import { pgCache } from './lru';
+
+const log = new Logger('pg-cache');
 
 const getDbString = (
   user: string,
@@ -21,6 +24,19 @@ export const getPgPool = (pgConfig: Partial<PgConfig>): pg.Pool => {
   }
   const connectionString = getDbString(user, password, host, port, database);
   const pgPool = new pg.Pool({ connectionString });
+  
+  // Add error handler to prevent unhandled 'error' events from crashing Node.js
+  // This commonly happens when connections are terminated during database cleanup
+  pgPool.on('error', (err: Error & { code?: string }) => {
+    // 57P01 = admin_shutdown (terminating connection due to administrator command)
+    // This is expected during database cleanup/teardown
+    if (err.code === '57P01') {
+      log.debug(`Pool ${database} connection terminated (expected during cleanup): ${err.message}`);
+    } else {
+      log.error(`Pool ${database} error: ${err.message}`);
+    }
+  });
+  
   pgCache.set(database, pgPool);
   return pgPool;
 };


### PR DESCRIPTION
## Summary

Adds an error handler to pg pools to prevent unhandled 'error' events from crashing Node.js when database connections are terminated during cleanup.

When `pgpm test-packages` runs `dropDatabase` to clean up test databases, it terminates all connections via `pg_terminate_backend()`. This causes idle pool connections to receive a 57P01 (admin_shutdown) error. Without an error handler, Node.js crashes and dumps the entire pg Client object to the console - producing hundreds of lines of useless output instead of a meaningful error message.

The fix:
- Attaches an error handler to each pool when created
- Logs expected cleanup errors (57P01) at debug level
- Logs unexpected errors at error level
- Prevents the unhandled error from crashing the process

**Why this is safe (does NOT swallow real errors):**
The handler only catches errors emitted on IDLE pooled connections via the EventEmitter pattern. Query errors (`pool.query()`, `client.query()`) are returned via Promise rejection and bubble up through async/await as normal exceptions - they are NOT affected by this handler.

## Updates since last revision

Added extensive inline documentation explaining:
- Why the error handler exists (idle connection errors crash Node.js)
- Why it's safe (does NOT swallow query errors - those use Promise rejection)
- The two different error paths in pg-pool (query errors vs idle connection errors)
- When this handler fires (during pg_terminate_backend cleanup)
- PostgreSQL error codes handled (57P01 admin_shutdown)

## Review & Testing Checklist for Human

- [ ] Review the inline documentation in `pg.ts` to verify the explanation of pg-pool's two error paths (Promise rejection for queries vs EventEmitter for idle connections) is accurate
- [ ] After merge, publish a new pgpm version and update constructive-db CI to use it
- [ ] Run `pgpm test-packages` in constructive-db to confirm the fix produces clean output

**Test plan:** After publishing the new pgpm version, re-run CI on [constructive-db PR #108](https://github.com/constructive-io/constructive-db/pull/108) and verify all modules pass without the pg Client object dump.

### Notes

This is a companion fix for [constructive-db PR #108](https://github.com/constructive-io/constructive-db/pull/108) which replaces the custom `test-all-packages.js` script with `pgpm test-packages`.

Local testing confirmed: ran `pgpm test-packages` against constructive-db using the locally built pgpm with this fix - all 37 modules passed successfully.

Link to Devin run: https://app.devin.ai/sessions/ef6ccaafd0f44b358f6b529e50306865
Requested by: Dan Lynch (pyramation@gmail.com) / @pyramation