### PR TITLE
fix(pgsql-test): handle PostgreSQL NOTICE messages without failing tests

### DIFF
--- a/postgres/pgsql-test/src/stream.ts
+++ b/postgres/pgsql-test/src/stream.ts
@@ -25,14 +25,52 @@ function stringToStream(text: string): Readable {
   return stream;
 }
 
+/**
+ * Executes SQL statements by streaming them to psql.
+ * 
+ * IMPORTANT: PostgreSQL stderr handling
+ * -------------------------------------
+ * PostgreSQL sends different message types to stderr, not just errors:
+ *   - ERROR: Actual SQL errors (should fail)
+ *   - WARNING: Potential issues (informational)
+ *   - NOTICE: Informational messages (should NOT fail)
+ *   - INFO: Informational messages (should NOT fail)
+ *   - DEBUG: Debug messages (should NOT fail)
+ * 
+ * Example scenario that previously caused false failures:
+ * When running SQL like:
+ *   GRANT administrator TO app_user;
+ * 
+ * If app_user is already a member of administrator, PostgreSQL outputs:
+ *   NOTICE: role "app_user" is already a member of role "administrator"
+ * 
+ * This is NOT an error - the GRANT succeeded (it's idempotent). But because
+ * this message goes to stderr, the old implementation would reject the promise
+ * and fail the test, even though nothing was wrong.
+ * 
+ * Solution:
+ * 1. Buffer stderr instead of rejecting immediately on any output
+ * 2. Use ON_ERROR_STOP=1 so psql exits with non-zero code on actual SQL errors
+ * 3. Only reject if the exit code is non-zero, using buffered stderr as the error message
+ * 
+ * This way, NOTICE/WARNING messages are collected but don't cause failures,
+ * while actual SQL errors still properly fail with meaningful error messages.
+ */
 export async function streamSql(config: PgConfig, sql: string): Promise<void> {
   const args = [
     ...setArgs(config),
-    '-v', 'ON_ERROR_STOP=1'  // Exit with non-zero code on SQL errors
+    // ON_ERROR_STOP=1 makes psql exit with a non-zero code when it encounters
+    // an actual SQL error. Without this, psql might continue executing subsequent
+    // statements and exit with code 0 even if some statements failed.
+    '-v', 'ON_ERROR_STOP=1'
   ];
 
   return new Promise<void>((resolve, reject) => {
     const sqlStream = stringToStream(sql);
+    
+    // Buffer stderr instead of rejecting immediately. This allows us to collect
+    // all output (including harmless NOTICE messages) and only use it for error
+    // reporting if the process actually fails.
     let stderrBuffer = '';
 
     const proc = spawn('psql', args, {
@@ -41,18 +79,25 @@ export async function streamSql(config: PgConfig, sql: string): Promise<void> {
 
     sqlStream.pipe(proc.stdin);
 
+    // Collect stderr output. We don't reject here because stderr may contain
+    // harmless NOTICE/WARNING messages that shouldn't cause test failures.
     proc.stderr.on('data', (data: Buffer) => {
       stderrBuffer += data.toString();
     });
 
+    // Determine success/failure based on exit code, not stderr content.
+    // Exit code 0 = success (even if there were NOTICE messages on stderr)
+    // Exit code non-zero = actual error occurred
     proc.on('close', (code) => {
       if (code !== 0) {
+        // Include the buffered stderr in the error message for debugging
         reject(new Error(stderrBuffer || `psql exited with code ${code}`));
       } else {
         resolve();
       }
     });
 
+    // Handle spawn errors (e.g., psql not found)
     proc.on('error', (error) => {
       reject(error);
     });


### PR DESCRIPTION
## Summary

Fixes an issue where PostgreSQL `NOTICE` messages (e.g., `NOTICE: role "app_user" is already a member of role "administrator"`) caused test failures in `pgsql-test`.

The root cause was that `streamSql()` rejected the promise on **any** stderr output, but PostgreSQL sends informational NOTICE/INFO messages to stderr even though they're not errors.

**Changes:**
- Buffer stderr instead of rejecting immediately on any output
- Add `ON_ERROR_STOP=1` flag to psql to ensure non-zero exit on actual SQL errors
- Check exit code on process close - only reject if non-zero
- Added comprehensive JSDoc and inline comments explaining the fix

## Updates since last revision

Added detailed documentation per reviewer request:
- JSDoc block explaining PostgreSQL's stderr message types (ERROR, WARNING, NOTICE, INFO, DEBUG)
- Concrete example scenario: `GRANT administrator TO app_user` producing a NOTICE when role already exists
- Inline comments explaining each part of the solution

## Review & Testing Checklist for Human

- [ ] Verify `ON_ERROR_STOP=1` behaves correctly - this is critical for ensuring real SQL errors still cause failures
- [ ] Test with a SQL file that produces NOTICE messages to confirm they no longer fail
- [ ] Test with a SQL file containing an actual error to confirm it still fails properly
- [ ] Verify the fix resolves the original issue in the other repo that was experiencing failures

**Recommended test plan:**
1. Run the pgsql-test suite to ensure existing tests pass
2. Create a test SQL file with a `GRANT` statement that produces a NOTICE (e.g., granting a role that's already granted)
3. Create a test SQL file with an intentional syntax error and verify it still fails with a meaningful error message

### Notes

The previous code also had a subtle bug where it called `resolve()` on close without checking the exit code, meaning real errors could potentially be missed depending on timing. This fix addresses both issues.

**Link to Devin run:** https://app.devin.ai/sessions/b1be8d4318fb4638817009c2c35a0b46
**Requested by:** Dan Lynch (@pyramation)