### PR TITLE
fix(pgpm): add missing commands to help output

### DIFF
--- a/pgpm/cli/src/utils/display.ts
+++ b/pgpm/cli/src/utils/display.ts
@@ -15,6 +15,7 @@ export const usageText = `
     export             Export database migrations from existing databases
     update             Update pgpm to the latest version
     cache              Manage cached templates (clean)
+    upgrade-modules    Upgrade installed pgpm modules to latest versions
   
   Database Administration:
     kill               Terminate database connections and optionally drop databases
@@ -32,6 +33,11 @@ export const usageText = `
       status           Show migration status
       list             List all changes
       deps             Show change dependencies
+  
+  Development Tools:
+    docker             Manage PostgreSQL Docker containers (start/stop)
+    env                Manage PostgreSQL environment variables
+    test-packages      Run integration tests on workspace packages
   
   Global Options:
     -h, --help         Display this help information


### PR DESCRIPTION
## Summary

The `pgpm help` command was missing 4 commands that are registered in the command map but not documented in the usage text:

- **docker** - Manage PostgreSQL Docker containers (start/stop)
- **env** - Manage PostgreSQL environment variables  
- **test-packages** - Run integration tests on workspace packages
- **upgrade-modules** - Upgrade installed pgpm modules to latest versions

Added `upgrade-modules` to the "Project Management" section and created a new "Development Tools" section for `docker`, `env`, and `test-packages`.

## Review & Testing Checklist for Human

- [ ] Run `pgpm help` and verify the new commands appear correctly formatted
- [ ] Verify the command descriptions are accurate (compare with `pgpm docker --help`, `pgpm env --help`, etc.)

### Notes

Link to Devin run: https://app.devin.ai/sessions/c99661181f4e436b931a09183539751f
Requested by: Dan Lynch (@pyramation)