### PR TITLE
fix(pgpm): stop deploy on 'No modules found' error and use consistent module discovery

### DIFF
--- a/pgpm/cli/src/utils/module-utils.ts
+++ b/pgpm/cli/src/utils/module-utils.ts
@@ -9,6 +9,9 @@ import { resolvePackageAlias } from './package-alias';
 /**
  * Handle package selection for operations that need a specific package
  * Returns the selected package name, or undefined if validation fails or no packages exist
+ * 
+ * Uses getModuleMap() which discovers modules by scanning for .control files,
+ * ensuring consistency with how core deploy discovers modules.
  */
 export async function selectPackage(
   argv: Partial<ParsedArgs>,
@@ -18,8 +21,10 @@ export async function selectPackage(
   log?: Logger
 ): Promise<string | undefined> {
   const pkg = new PgpmPackage(cwd);
-  const modules = await pkg.getModules();
-  const moduleNames = modules.map(mod => mod.getModuleName());
+  // Use getModuleMap() instead of getModules() for consistency with core deploy
+  // getModuleMap() scans for .control files, while getModules() uses pgpm.json patterns
+  const modules = pkg.getModuleMap();
+  const moduleNames = Object.keys(modules);
 
   // Check if any modules exist
   if (!moduleNames.length) {


### PR DESCRIPTION
## Summary

Fixes an issue where `pgpm deploy --createdb` would log "No modules found in the specified directory" but continue executing instead of stopping. The deploy command now properly handles the error case and uses consistent module discovery with the core deploy logic.

**Key changes:**
1. **Error handling**: Deploy now stops execution when `selectPackage` returns undefined (no modules found)
2. **Module discovery**: Changed `selectPackage` to use `getModuleMap()` instead of `getModules()` - the former scans for `.control` files directly while the latter uses pgpm.json patterns, which could miss nested modules
3. **Context-aware selection**: Added logic to detect if running from inside a module (use current module) vs workspace root (prompt for selection), similar to the `tag.ts` command pattern
4. **Flag bug fixes**: Fixed `fast` and `logOnly` flags which were incorrectly defaulting to true when not specified

## Review & Testing Checklist for Human

- [ ] **Test from startkit-example-workspace root**: Run `pgpm deploy --createdb --database testdb` and verify it now prompts for package selection instead of showing error then continuing
- [ ] **Test from inside a module directory**: Verify deploy uses the current module automatically without prompting
- [ ] **Test with --package flag**: Verify `pgpm deploy --package mymodule` works correctly
- [ ] **Verify logOnly behavior**: Run deploy without `--logOnly` flag and confirm it actually executes SQL (not just logging)
- [ ] **Check nested workspace scenarios**: The module discovery change (`getModuleMap` vs `getModules`) could behave differently in complex workspace structures

### Notes

The root cause was a mismatch between how the CLI discovers modules (`getModules()` using pgpm.json patterns) vs how core deploy discovers them (`getModuleMap()` scanning for .control files). In nested workspaces like startkit-example-workspace, the CLI would find no modules while core deploy would find them via .control file scanning.

Link to Devin run: https://app.devin.ai/sessions/5d6fa89b81314b06842a9c19ddcfcd62
Requested by: Dan Lynch (@pyramation)