### PR TITLE
fix(pgpm/cli): use database name instead of UUID for default extension name

### DIFF
--- a/pgpm/cli/src/commands/export.ts
+++ b/pgpm/cli/src/commands/export.ts
@@ -83,6 +83,10 @@ export default async (
     }
   ]));
 
+  const selectedDatabaseNames = database_ids
+    .filter(did => did.selected)
+    .map(did => did.name);
+
   const dbInfo = {
     dbname,
     database_ids: database_ids.map(did =>
@@ -102,7 +106,7 @@ export default async (
       type: 'text',
       name: 'extensionName',
       message: 'Extension name',
-      default: dbInfo.database_ids[0],
+      default: selectedDatabaseNames[0] || dbname,
       required: true
     },
     {


### PR DESCRIPTION
## Summary

Changes the default value for `extensionName` in the `pgpm export` command from a UUID to the human-readable database name.

Previously, the default was `dbInfo.database_ids[0]` which is a UUID like `7c944bc6-511a-44ad-a407-ce2cefd5e466`. Now it uses the selected database name from `collections_public.database`, falling back to the PostgreSQL database name (`dbname`) if unavailable.

## Review & Testing Checklist for Human

- [ ] **Run `pgpm export` end-to-end** - Verify the extension name prompt now shows a readable database name as the default instead of a UUID
- [ ] **Verify the fallback works** - If `selectedDatabaseNames[0]` is somehow undefined, confirm it falls back to `dbname` correctly

### Test Plan
1. Run `pgpm export` against a database with entries in `collections_public.database`
2. When prompted for "Extension name", verify the default value shown is the database name (not a UUID)
3. Accept the default and confirm the export completes successfully

### Notes

Link to Devin run: https://app.devin.ai/sessions/7530c5fa0b95477e9758c657dff7e299
Requested by: Dan Lynch (@pyramation)