### PR TITLE
fix(pgpm): improve export flow with better defaults and scaffold answers

### DIFF
--- a/pgpm/cli/src/commands/export.ts
+++ b/pgpm/cli/src/commands/export.ts
@@ -113,7 +113,7 @@ export default async (
       type: 'text',
       name: 'metaExtensionName',
       message: 'Meta extension name',
-      default: 'svc',
+      default: `${selectedDatabaseNames[0] || dbname}-svc`,
       required: true
     }
   ]);
@@ -135,6 +135,21 @@ export default async (
   ]);
 
   const outdir = resolve(project.workspacePath, 'packages/');
+
+  // Parse author string to extract fullName and email for scaffolding
+  // Expected format: "Name <email@example.com>" or just "Name"
+  const authorMatch = author.match(/^(.+?)\s*<(.+?)>$/);
+  const fullName = authorMatch ? authorMatch[1].trim() : author;
+  const authorEmail = authorMatch ? authorMatch[2].trim() : email;
+
+  // Build scaffold answers to pass to initModule to avoid redundant prompts
+  const scaffoldAnswers = {
+    fullName,
+    email: authorEmail,
+    author,
+    access: 'public',
+    license: 'MIT'
+  };
   
   await exportMigrations({
     project,
@@ -144,7 +159,8 @@ export default async (
     schema_names,
     outdir,
     extensionName,
-    metaExtensionName
+    metaExtensionName,
+    scaffoldAnswers
   });
 
   console.log(`

--- a/pgpm/cli/src/commands/export.ts
+++ b/pgpm/cli/src/commands/export.ts
@@ -135,21 +135,6 @@ export default async (
   ]);
 
   const outdir = resolve(project.workspacePath, 'packages/');
-
-  // Parse author string to extract fullName and email for scaffolding
-  // Expected format: "Name <email@example.com>" or just "Name"
-  const authorMatch = author.match(/^(.+?)\s*<(.+?)>$/);
-  const fullName = authorMatch ? authorMatch[1].trim() : author;
-  const authorEmail = authorMatch ? authorMatch[2].trim() : email;
-
-  // Build scaffold answers to pass to initModule to avoid redundant prompts
-  const scaffoldAnswers = {
-    fullName,
-    email: authorEmail,
-    author,
-    access: 'public',
-    license: 'MIT'
-  };
   
   await exportMigrations({
     project,
@@ -159,8 +144,7 @@ export default async (
     schema_names,
     outdir,
     extensionName,
-    metaExtensionName,
-    scaffoldAnswers
+    metaExtensionName
   });
 
   console.log(`

--- a/pgpm/core/src/export/export-migrations.ts
+++ b/pgpm/core/src/export/export-migrations.ts
@@ -19,7 +19,6 @@ interface ExportMigrationsToDiskOptions {
   schema_names: string[];
   extensionName?: string;
   metaExtensionName: string;
-  scaffoldAnswers?: Record<string, any>;
 }
 
 interface ExportOptions {
@@ -34,7 +33,6 @@ interface ExportOptions {
   schema_names: string[];
   extensionName?: string;
   metaExtensionName: string;
-  scaffoldAnswers?: Record<string, any>;
 }
 
 const exportMigrationsToDisk = async ({
@@ -46,8 +44,7 @@ const exportMigrationsToDisk = async ({
   outdir,
   schema_names,
   extensionName,
-  metaExtensionName,
-  scaffoldAnswers
+  metaExtensionName
 }: ExportMigrationsToDiskOptions): Promise<void> => {
   outdir = outdir + '/';
 
@@ -120,8 +117,7 @@ const exportMigrationsToDisk = async ({
         'pgpm-base32',
         'pgpm-totp',
         'pgpm-types'
-      ],
-      scaffoldAnswers
+      ]
     });
 
     writeSqitchPlan(results.rows, opts);
@@ -140,8 +136,7 @@ const exportMigrationsToDisk = async ({
       author,
       outdir,
       extensions: ['plpgsql', 'db-meta-schema', 'db-meta-modules'],
-      name: metaExtensionName,
-      scaffoldAnswers
+      name: metaExtensionName
     });
 
     const metaReplacer = makeReplacer({
@@ -202,8 +197,7 @@ export const exportMigrations = async ({
   outdir,
   schema_names,
   extensionName,
-  metaExtensionName,
-  scaffoldAnswers
+  metaExtensionName
 }: ExportOptions): Promise<void> => {
   for (let v = 0; v < dbInfo.database_ids.length; v++) {
     const databaseId = dbInfo.database_ids[v];
@@ -216,8 +210,7 @@ export const exportMigrations = async ({
       databaseId,
       schema_names,
       author,
-      outdir,
-      scaffoldAnswers
+      outdir
     });
   }
 };
@@ -229,7 +222,6 @@ interface PreparePackageOptions {
   outdir: string;
   name: string;
   extensions: string[];
-  scaffoldAnswers?: Record<string, any>;
 }
 
 interface Schema {
@@ -255,8 +247,7 @@ const preparePackage = async ({
   author,
   outdir,
   name,
-  extensions,
-  scaffoldAnswers
+  extensions
 }: PreparePackageOptions): Promise<void> => {
   const curDir = process.cwd();
   const sqitchDir = path.resolve(path.join(outdir, name));
@@ -265,11 +256,10 @@ const preparePackage = async ({
 
   const plan = glob(path.join(sqitchDir, 'pgpm.plan'));
   if (!plan.length) {
-    // Build module-specific answers for scaffolding
-    const moduleAnswers = {
-      ...scaffoldAnswers,
+    // Only pass module-specific values; let boilerplate resolvers handle
+    // author info, license, access, etc. via setFrom/defaultFrom
+    const templateAnswers = {
       moduleName: name,
-      moduleDesc: name,
       packageIdentifier: name
     };
 
@@ -278,8 +268,7 @@ const preparePackage = async ({
       description: name,
       author,
       extensions,
-      answers: moduleAnswers,
-      noTty: true
+      answers: templateAnswers
     });
   } else {
     rmSync(path.resolve(sqitchDir, 'deploy'), { recursive: true, force: true });


### PR DESCRIPTION
# fix(pgpm): improve export flow with better defaults and scaffold answers

## Summary

This PR improves the `pgpm export` command flow by:

1. **Better default for meta extension name**: Changed from generic `'svc'` to `${extensionName}-svc` (e.g., `mydb-svc` instead of just `svc`)

2. **Proper use of resolver pattern**: Instead of hardcoding scaffold values, the export flow now only passes module-specific values (`moduleName`, `packageIdentifier`) to the scaffolding system. Author info, license, access, etc. are resolved via the boilerplate's `setFrom`/`defaultFrom` resolvers from workspace config and git config.

## Updates since last revision

Removed hardcoded scaffold values (`fullName`, `email`, `access: 'public'`, `license: 'MIT'`) per reviewer feedback. The implementation now follows the same pattern as `handleModuleInit` in `init/index.ts`, letting the boilerplate resolvers handle author/license/access values dynamically.

## Review & Testing Checklist for Human

- [ ] **Test export flow end-to-end**: Run `pgpm export` and verify the meta extension name defaults to `{extensionName}-svc`
- [ ] **Verify resolver behavior**: Confirm that author, license, and access values are properly resolved from workspace config or git config (not hardcoded)
- [ ] **Check generated package.json**: Verify the generated modules have correct metadata populated by resolvers

**Recommended test plan:**
1. Run `pgpm export` on a database with existing collections
2. Verify the meta extension name defaults to `{extensionName}-svc`
3. Check the generated `package.json` files have correct author, license, and access values from workspace/git config

### Notes

- Link to Devin run: https://app.devin.ai/sessions/7530c5fa0b95477e9758c657dff7e299
- Requested by: Dan Lynch (@pyramation)