### PR TITLE
feat(pgpm): add defaultExtensions support to boilerplate config

### DIFF
--- a/pgpm/cli/src/commands/init/index.ts
+++ b/pgpm/cli/src/commands/init/index.ts
@@ -123,6 +123,7 @@ async function handleInit(argv: Partial<Record<string, any>>, prompter: Inquirer
     dir,
     noTty,
     cwd,
+    defaultExtensions: inspection.config?.defaultExtensions,
   });
 }
 
@@ -225,6 +226,7 @@ async function handleBoilerplateInit(
     dir: ctx.dir,
     noTty: ctx.noTty,
     cwd: ctx.cwd,
+    defaultExtensions: inspection.config?.defaultExtensions,
   });
 }
 
@@ -235,6 +237,7 @@ interface InitContext {
   dir?: string;
   noTty: boolean;
   cwd: string;
+  defaultExtensions?: string[];
 }
 
 async function handleWorkspaceInit(
@@ -329,6 +332,7 @@ async function handleModuleInit(
       type: 'checkbox',
       allowCustomOptions: true,
       required: true,
+      default: ctx.defaultExtensions,
     },
   ];
 

--- a/pgpm/core/src/core/boilerplate-scanner.ts
+++ b/pgpm/core/src/core/boilerplate-scanner.ts
@@ -2,10 +2,10 @@ import fs from 'fs';
 import path from 'path';
 
 import {
-  BoilerplateConfig,
   BoilerplatesRootConfig,
   ScannedBoilerplate
 } from './boilerplate-types';
+import { BoilerplateConfig } from './template-scaffold';
 
 /**
  * Read the root `.boilerplates.json` configuration from a template repository.

--- a/pgpm/core/src/core/boilerplate-types.ts
+++ b/pgpm/core/src/core/boilerplate-types.ts
@@ -26,17 +26,6 @@ export interface BoilerplateQuestion {
 }
 
 /**
- * Configuration for a single boilerplate template.
- * Stored in `.boilerplate.json` within each template directory.
- */
-export interface BoilerplateConfig {
-  /** The type of boilerplate: workspace or module */
-  type: 'workspace' | 'module';
-  /** Questions to prompt the user during scaffolding */
-  questions?: BoilerplateQuestion[];
-}
-
-/**
  * Root configuration for a boilerplates repository.
  * Stored in `.boilerplates.json` at the repository root.
  */
@@ -54,7 +43,7 @@ export interface ScannedBoilerplate {
   /** The full path to the boilerplate directory */
   path: string;
   /** The type of boilerplate */
-  type: 'workspace' | 'module';
+  type: string;
   /** Questions from the boilerplate config */
-  questions?: BoilerplateQuestion[];
+  questions?: unknown[];
 }

--- a/pgpm/core/src/core/template-scaffold.ts
+++ b/pgpm/core/src/core/template-scaffold.ts
@@ -1,7 +1,17 @@
 import os from 'os';
 import path from 'path';
-import { TemplateScaffolder, BoilerplateConfig } from 'create-gen-app';
+import { TemplateScaffolder, BoilerplateConfig as BaseBoilerplateConfig } from 'create-gen-app';
 import type { Inquirerer, Question } from 'inquirerer';
+
+/**
+ * Extended boilerplate configuration that includes pgpm-specific fields.
+ * This extends the base BoilerplateConfig from create-gen-app with additional
+ * properties that can be specified in .boilerplate.json files.
+ */
+export interface BoilerplateConfig extends BaseBoilerplateConfig {
+  /** Default extensions to pre-select when creating a module (only for type: module) */
+  defaultExtensions?: string[];
+}
 
 export interface InspectTemplateOptions {
   /**


### PR DESCRIPTION
# feat(pgpm): add defaultExtensions support to boilerplate config

## Summary

This PR adds support for specifying default extensions in boilerplate configuration files. When creating a new module with `pgpm init`, extensions listed in `defaultExtensions` in the `.boilerplate.json` file will be pre-selected in the checkbox prompt.

The implementation extends the `BoilerplateConfig` type from `create-gen-app` to add a `defaultExtensions?: string[]` field, then passes this through the init flow to set the `default` property on the extensions checkbox question.

**Note:** This PR only adds the infrastructure. To actually make plpgsql a default extension, a corresponding change is needed in the [pgpm-boilerplates](https://github.com/constructive-io/pgpm-boilerplates) repo to add `"defaultExtensions": ["plpgsql"]` to the module's `.boilerplate.json`.

## Review & Testing Checklist for Human

- [ ] **Verify type loosening is acceptable**: `ScannedBoilerplate.type` changed from `'workspace' | 'module'` to `string`, and `questions` changed from `BoilerplateQuestion[]` to `unknown[]`. Check if any code relies on the stricter types.
- [ ] **Test `pgpm init` with defaultExtensions**: Create a test boilerplate with `"defaultExtensions": ["plpgsql"]` and verify the extension is pre-selected when running `pgpm init`
- [ ] **Test `pgpm init` without defaultExtensions**: Verify the init flow still works correctly when no `defaultExtensions` is specified (should behave as before)

### Test Plan
1. Build the project: `pnpm build`
2. Create a test workspace: `pgpm init workspace`
3. Temporarily modify the cached boilerplate's `.boilerplate.json` to add `"defaultExtensions": ["plpgsql"]`
4. Run `pgpm init` inside the workspace and verify plpgsql is pre-selected in the extensions checkbox

### Notes

- Link to Devin run: https://app.devin.ai/sessions/6f5174717757493088d0e15f81526dfd
- Requested by: Dan Lynch (@pyramation)