### PR TITLE
feat(pgpm): improve export command UX with smart defaults

### DIFF
--- a/pgpm/cli/src/commands/export.ts
+++ b/pgpm/cli/src/commands/export.ts
@@ -1,7 +1,7 @@
 import { exportMigrations,PgpmPackage } from '@pgpmjs/core';
 import { getEnvOptions } from '@pgpmjs/env';
 import { getGitConfigInfo } from '@pgpmjs/types';
-import { CLIOptions, Inquirerer, OptionValue } from 'inquirerer';
+import { CLIOptions, Inquirerer } from 'inquirerer';
 import { resolve } from 'path';
 import { getPgPool } from 'pg-cache';
 
@@ -52,18 +52,15 @@ export default async (
       AND datname !~ '^pg_';
   `);
 
-  let databases: OptionValue[];
-  ({ databases } = await prompter.prompt(argv, [
+  const { databases: dbname } = await prompter.prompt(argv, [
     {
-      type: 'checkbox',
+      type: 'list',
       name: 'databases',
       message: 'Select a database',
       options: databasesResult.rows.map(row => row.datname),
       required: true
     }
-  ]));
-
-  const dbname = databases.filter(d=>d.selected).map(d=>d.value)[0];
+  ]);
   const selectedDb = await getPgPool({
     database: dbname
   });
@@ -72,26 +69,22 @@ export default async (
     SELECT id, name FROM collections_public.database;
   `);
 
-  let database_ids: OptionValue[];
-  ({ database_ids } = await prompter.prompt({} as any, [
+  const { database_ids: selectedDatabaseName } = await prompter.prompt({} as any, [
     {
-      type: 'checkbox',
+      type: 'list',
       name: 'database_ids',
-      message: 'Select database_id(s)',
+      message: 'Select database_id',
       options: dbsResult.rows.map(db => db.name),
       required: true
     }
-  ]));
+  ]);
 
-  const selectedDatabaseNames = database_ids
-    .filter(did => did.selected)
-    .map(did => did.name);
+  const selectedDatabase = dbsResult.rows.find(db => db.name === selectedDatabaseName);
 
   const dbInfo = {
     dbname,
-    database_ids: database_ids.map(did =>
-      dbsResult.rows.find(db => db.name === did.name)!.id
-    )
+    databaseName: selectedDatabaseName,
+    database_ids: [selectedDatabase!.id]
   };
 
   const { author, extensionName, metaExtensionName } = await prompter.prompt(argv, [
@@ -106,14 +99,14 @@ export default async (
       type: 'text',
       name: 'extensionName',
       message: 'Extension name',
-      default: selectedDatabaseNames[0] || dbname,
+      default: selectedDatabaseName || dbname,
       required: true
     },
     {
       type: 'text',
       name: 'metaExtensionName',
       message: 'Meta extension name',
-      default: 'svc',
+      default: `${selectedDatabaseName || dbname}-service`,
       required: true
     }
   ]);

--- a/pgpm/core/src/export/export-migrations.ts
+++ b/pgpm/core/src/export/export-migrations.ts
@@ -289,7 +289,7 @@ const preparePackage = async ({
         moduleName: name,
         moduleDesc: description,
         packageIdentifier: name,
-        access: 'public'
+        access: 'restricted'
       }
     });
   } else {

--- a/pgpm/core/src/export/export-migrations.ts
+++ b/pgpm/core/src/export/export-migrations.ts
@@ -14,11 +14,14 @@ interface ExportMigrationsToDiskOptions {
   options: PgpmOptions;
   database: string;
   databaseId: string;
+  databaseName: string;
   author: string;
   outdir: string;
   schema_names: string[];
   extensionName?: string;
+  extensionDesc?: string;
   metaExtensionName: string;
+  metaExtensionDesc?: string;
 }
 
 interface ExportOptions {
@@ -26,13 +29,16 @@ interface ExportOptions {
   options: PgpmOptions;
   dbInfo: {
     dbname: string;
+    databaseName: string;
     database_ids: string[];
   };
   author: string;
   outdir: string;
   schema_names: string[];
   extensionName?: string;
+  extensionDesc?: string;
   metaExtensionName: string;
+  metaExtensionDesc?: string;
 }
 
 const exportMigrationsToDisk = async ({
@@ -40,11 +46,14 @@ const exportMigrationsToDisk = async ({
   options,
   database,
   databaseId,
+  databaseName,
   author,
   outdir,
   schema_names,
   extensionName,
-  metaExtensionName
+  extensionDesc,
+  metaExtensionName,
+  metaExtensionDesc
 }: ExportMigrationsToDiskOptions): Promise<void> => {
   outdir = outdir + '/';
 
@@ -93,12 +102,16 @@ const exportMigrationsToDisk = async ({
     author
   };
 
+  // Build description for the database extension package
+  const dbExtensionDesc = extensionDesc || `${name} database schema for ${databaseName}`;
+
   if (results?.rows?.length > 0) {
     await preparePackage({
       project,
       author,
       outdir,
       name,
+      description: dbExtensionDesc,
       extensions: [
         'plpgsql',
         'uuid-ossp',
@@ -131,12 +144,16 @@ const exportMigrationsToDisk = async ({
 
     meta = replacer(meta);
 
+    // Build description for the meta/service extension package
+    const metaDesc = metaExtensionDesc || `${metaExtensionName} service utilities for managing domains, APIs, and services`;
+
     await preparePackage({
       project,
       author,
       outdir,
-      extensions: ['plpgsql', 'db-meta-schema', 'db-meta-modules'],
-      name: metaExtensionName
+      name: metaExtensionName,
+      description: metaDesc,
+      extensions: ['plpgsql', 'db-meta-schema', 'db-meta-modules']
     });
 
     const metaReplacer = makeReplacer({
@@ -197,7 +214,9 @@ export const exportMigrations = async ({
   outdir,
   schema_names,
   extensionName,
-  metaExtensionName
+  extensionDesc,
+  metaExtensionName,
+  metaExtensionDesc
 }: ExportOptions): Promise<void> => {
   for (let v = 0; v < dbInfo.database_ids.length; v++) {
     const databaseId = dbInfo.database_ids[v];
@@ -205,8 +224,11 @@ export const exportMigrations = async ({
       project,
       options,
       extensionName,
+      extensionDesc,
       metaExtensionName,
+      metaExtensionDesc,
       database: dbInfo.dbname,
+      databaseName: dbInfo.databaseName,
       databaseId,
       schema_names,
       author,
@@ -221,6 +243,7 @@ interface PreparePackageOptions {
   author: string;
   outdir: string;
   name: string;
+  description: string;
   extensions: string[];
 }
 
@@ -247,6 +270,7 @@ const preparePackage = async ({
   author,
   outdir,
   name,
+  description,
   extensions
 }: PreparePackageOptions): Promise<void> => {
   const curDir = process.cwd();
@@ -258,9 +282,15 @@ const preparePackage = async ({
   if (!plan.length) {
     await project.initModule({
       name,
-      description: name,
+      description,
       author,
       extensions,
+      answers: {
+        moduleName: name,
+        moduleDesc: description,
+        packageIdentifier: name,
+        access: 'public'
+      }
     });
   } else {
     rmSync(path.resolve(sqitchDir, 'deploy'), { recursive: true, force: true });

--- a/pgpm/core/src/export/export-migrations.ts
+++ b/pgpm/core/src/export/export-migrations.ts
@@ -288,7 +288,6 @@ const preparePackage = async ({
       answers: {
         moduleName: name,
         moduleDesc: description,
-        packageIdentifier: name,
         access: 'restricted'
       }
     });


### PR DESCRIPTION
# feat(pgpm): improve export command UX with smart defaults

## Summary

This PR improves the UX of the `pgpm export` command by:

1. **Changing multi-select to single-select** - Both `databases` and `database_ids` prompts now use `list` type instead of `checkbox`, since only one selection was actually being used
2. **Fixing a selection bug** - The original code mapped ALL options in `database_ids` instead of just the selected one
3. **Adding smart defaults** - `metaExtensionName` now defaults to `{databaseName}-service` instead of just `svc`
4. **Skipping boilerplate prompts** - Passes `answers` object to `initModule` with `moduleName`, `moduleDesc`, and `access` to skip redundant prompts during export
5. **Auto-generating descriptions** - DB package gets `{name} database schema for {databaseName}`, meta package gets `{metaExtensionName} service utilities for managing domains, APIs, and services`

## Updates since last revision

- Changed default `access` from `'public'` to `'restricted'` per feedback
- Removed `packageIdentifier` from answers (no longer required per feedback)

## Review & Testing Checklist for Human

- [ ] **Verify the non-null assertion on line 82** (`selectedDatabase!.id`) - if `dbsResult.rows.find()` returns undefined, this will throw. Consider whether error handling is needed.
- [ ] **Confirm `access: 'restricted'` is the desired default** - This was changed from `'public'` per feedback; verify this is correct for exported packages.
- [ ] **Test the export command end-to-end** - Run `pgpm export` in a workspace with a database to verify:
  - Single-select prompts work correctly
  - Defaults are populated as expected
  - No boilerplate prompts appear for moduleName/moduleDesc/access
  - Generated packages have correct descriptions and `access: restricted`
- [ ] **Verify `answers` field names match boilerplate template** - The fields `moduleName`, `moduleDesc`, `access` should match what the module boilerplate template expects

### Notes

- The description formats are hardcoded - let me know if you'd like different wording
- Link to Devin run: https://app.devin.ai/sessions/67f8153e117d4d23bbc9e156dc76fc37
- Requested by: Dan Lynch (@pyramation)