### PR TITLE
refactor(pgpm): rename Sqitch types and functions to PGPM naming

### DIFF
--- a/pgpm/core/__tests__/files/plan/writer.test.ts
+++ b/pgpm/core/__tests__/files/plan/writer.test.ts
@@ -1,10 +1,10 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { writeSqitchPlan } from '../../../src/files/plan/writer';
-import { SqitchRow } from '../../../src/files/types';
+import { writePgpmPlan } from '../../../src/files/plan/writer';
+import { PgpmRow } from '../../../src/files/types';
 
-describe('writeSqitchPlan', () => {
+describe('writePgpmPlan', () => {
   let tempDir: string;
   let outputDir: string;
 
@@ -18,7 +18,7 @@ describe('writeSqitchPlan', () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
-  const createTestRows = (): SqitchRow[] => [
+  const createTestRows = (): PgpmRow[] => [
     {
       deploy: 'schemas/test/schema',
       revert: 'schemas/test/schema',
@@ -46,7 +46,7 @@ describe('writeSqitchPlan', () => {
       replacer: (str: string) => str.replace('constructive-extension-name', 'test-module')
     };
 
-    writeSqitchPlan(rows, opts);
+    writePgpmPlan(rows, opts);
 
     const planPath = path.join(outputDir, 'test-module', 'pgpm.plan');
     expect(fs.existsSync(planPath)).toBe(true);
@@ -67,7 +67,7 @@ describe('writeSqitchPlan', () => {
       replacer: (str: string) => str.replace('constructive-extension-name', 'test-module')
     };
 
-    writeSqitchPlan(rows, opts);
+    writePgpmPlan(rows, opts);
 
     const planPath = path.join(outputDir, 'test-module', 'pgpm.plan');
     const content = fs.readFileSync(planPath, 'utf-8');
@@ -90,7 +90,7 @@ describe('writeSqitchPlan', () => {
       replacer: (str: string) => str.replace('constructive-extension-name', 'test-module')
     };
 
-    writeSqitchPlan(rows, opts);
+    writePgpmPlan(rows, opts);
 
     const planPath = path.join(outputDir, 'test-module', 'pgpm.plan');
     const content = fs.readFileSync(planPath, 'utf-8');
@@ -108,7 +108,7 @@ describe('writeSqitchPlan', () => {
       replacer: (str: string) => str.replace('constructive-extension-name', 'test-module')
     };
 
-    writeSqitchPlan(rows, opts);
+    writePgpmPlan(rows, opts);
 
     const planPath = path.join(outputDir, 'test-module', 'pgpm.plan');
     const content = fs.readFileSync(planPath, 'utf-8');
@@ -117,7 +117,7 @@ describe('writeSqitchPlan', () => {
   });
 
   it('should handle rows with dependencies correctly', () => {
-    const rows: SqitchRow[] = [
+    const rows: PgpmRow[] = [
       {
         deploy: 'schemas/test/schema',
         content: 'CREATE SCHEMA test;',
@@ -139,7 +139,7 @@ describe('writeSqitchPlan', () => {
       replacer: (str: string) => str.replace('constructive-extension-name', 'test-module')
     };
 
-    writeSqitchPlan(rows, opts);
+    writePgpmPlan(rows, opts);
 
     const planPath = path.join(outputDir, 'test-module', 'pgpm.plan');
     const content = fs.readFileSync(planPath, 'utf-8');
@@ -152,7 +152,7 @@ describe('writeSqitchPlan', () => {
   });
 
   it('should skip duplicate deploy paths', () => {
-    const rows: SqitchRow[] = [
+    const rows: PgpmRow[] = [
       {
         deploy: 'schemas/test/schema',
         content: 'CREATE SCHEMA test;',
@@ -176,7 +176,7 @@ describe('writeSqitchPlan', () => {
 
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
 
-    writeSqitchPlan(rows, opts);
+    writePgpmPlan(rows, opts);
 
     const planPath = path.join(outputDir, 'test-module', 'pgpm.plan');
     const content = fs.readFileSync(planPath, 'utf-8');
@@ -203,7 +203,7 @@ describe('writeSqitchPlan', () => {
       }
     };
 
-    writeSqitchPlan(rows, opts);
+    writePgpmPlan(rows, opts);
 
     const planPath = path.join(outputDir, 'test-module', 'pgpm.plan');
     const content = fs.readFileSync(planPath, 'utf-8');

--- a/pgpm/core/src/export/export-migrations.ts
+++ b/pgpm/core/src/export/export-migrations.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import { getPgPool } from 'pg-cache';
 
 import { PgpmPackage } from '../core/class/pgpm';
-import { SqitchRow, SqlWriteOptions,writeSqitchFiles, writeSqitchPlan } from '../files';
+import { PgpmRow, SqlWriteOptions, writePgpmFiles, writePgpmPlan } from '../files';
 import { exportMeta } from './export-meta';
 
 interface ExportMigrationsToDiskOptions {
@@ -133,8 +133,8 @@ const exportMigrationsToDisk = async ({
       ]
     });
 
-    writeSqitchPlan(results.rows, opts);
-    writeSqitchFiles(results.rows, opts);
+    writePgpmPlan(results.rows, opts);
+    writePgpmFiles(results.rows, opts);
 
     let meta = await exportMeta({
       opts: options,
@@ -163,7 +163,7 @@ const exportMigrationsToDisk = async ({
       name: metaExtensionName
     });
 
-    const metaPackage: SqitchRow[] = [
+    const metaPackage: PgpmRow[] = [
       {
         deps: [],
         deploy: 'migrate/meta',
@@ -199,8 +199,8 @@ SET session_replication_role TO DEFAULT;
     opts.replacer = metaReplacer.replacer;
     opts.name = metaExtensionName;
 
-    writeSqitchPlan(metaPackage, opts);
-    writeSqitchFiles(metaPackage, opts);
+    writePgpmPlan(metaPackage, opts);
+    writePgpmFiles(metaPackage, opts);
   }
 
   pgPool.end();

--- a/pgpm/core/src/files/plan/writer.ts
+++ b/pgpm/core/src/files/plan/writer.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { Change, PlanFile, SqitchRow, Tag, ExtendedPlanFile } from '../types';
+import { Change, PlanFile, PgpmRow, Tag, ExtendedPlanFile } from '../types';
 
 export interface PlanWriteOptions {
   outdir: string;
@@ -11,9 +11,9 @@ export interface PlanWriteOptions {
 }
 
 /**
- * Write a Sqitch plan file based on the provided rows
+ * Write a PGPM plan file based on the provided rows
  */
-export function writeSqitchPlan(rows: SqitchRow[], opts: PlanWriteOptions): void {
+export function writePgpmPlan(rows: PgpmRow[], opts: PlanWriteOptions): void {
   const dir = path.resolve(path.join(opts.outdir, opts.name));
   fs.mkdirSync(dir, { recursive: true });
 
@@ -165,3 +165,8 @@ export function generateTagLineContent(tag: Tag): string {
   
   return line;
 }
+
+/**
+ * @deprecated Use writePgpmPlan instead. This alias is kept for backwards compatibility.
+ */
+export const writeSqitchPlan = writePgpmPlan;

--- a/pgpm/core/src/files/sql/writer.ts
+++ b/pgpm/core/src/files/sql/writer.ts
@@ -2,7 +2,7 @@ import { getEnvOptions } from '@pgpmjs/env';
 import fs from 'fs';
 import path from 'path';
 
-import { SqitchRow } from '../types';
+import { PgpmRow } from '../types';
 
 export interface SqlWriteOptions {
   outdir: string;
@@ -13,9 +13,9 @@ export interface SqlWriteOptions {
 }
 
 /**
- * Write SQL files for Sqitch migrations (deploy, revert, verify)
+ * Write SQL files for PGPM migrations (deploy, revert, verify)
  */
-export const writeSqitchFiles = (rows: SqitchRow[], opts: SqlWriteOptions): void => {
+export const writePgpmFiles = (rows: PgpmRow[], opts: SqlWriteOptions): void => {
   rows.forEach((row) => writeVerify(row, opts));
   rows.forEach((row) => writeRevert(row, opts));
   rows.forEach((row) => writeDeploy(row, opts));
@@ -30,9 +30,9 @@ const ordered = (arr?: string[]): string[] => {
 };
 
 /**
- * Write a deploy SQL file for a Sqitch change
+ * Write a deploy SQL file for a PGPM change
  */
-const writeDeploy = (row: SqitchRow, opts: SqlWriteOptions): void => {
+const writeDeploy = (row: PgpmRow, opts: SqlWriteOptions): void => {
   const globalOpts = getEnvOptions({
     migrations: {
       codegen: {
@@ -68,9 +68,9 @@ ${useTx ? 'COMMIT;' : ''}
 };
 
 /**
- * Write a verify SQL file for a Sqitch change
+ * Write a verify SQL file for a PGPM change
  */
-const writeVerify = (row: SqitchRow, opts: SqlWriteOptions): void => {
+const writeVerify = (row: PgpmRow, opts: SqlWriteOptions): void => {
   const globalOpts = getEnvOptions({
     migrations: {
       codegen: {
@@ -100,9 +100,9 @@ ${useTx ? 'COMMIT;' : ''}
 };
 
 /**
- * Write a revert SQL file for a Sqitch change
+ * Write a revert SQL file for a PGPM change
  */
-const writeRevert = (row: SqitchRow, opts: SqlWriteOptions): void => {
+const writeRevert = (row: PgpmRow, opts: SqlWriteOptions): void => {
   const globalOpts = getEnvOptions({
     migrations: {
       codegen: {
@@ -130,3 +130,8 @@ ${useTx ? 'COMMIT;' : ''}
 `;
   fs.writeFileSync(actualFile, content);
 };
+
+/**
+ * @deprecated Use writePgpmFiles instead. This alias is kept for backwards compatibility.
+ */
+export const writeSqitchFiles = writePgpmFiles;

--- a/pgpm/core/src/files/types/index.ts
+++ b/pgpm/core/src/files/types/index.ts
@@ -50,7 +50,7 @@ export interface ResolvedReference {
 }
 
 // SQL file types
-export interface SqitchRow {
+export interface PgpmRow {
   deploy: string;
   revert?: string;
   verify?: string;
@@ -58,3 +58,8 @@ export interface SqitchRow {
   deps?: string[];
   name?: string;
 }
+
+/**
+ * @deprecated Use PgpmRow instead. This alias is kept for backwards compatibility.
+ */
+export type SqitchRow = PgpmRow;


### PR DESCRIPTION
## Summary

This PR renames legacy "Sqitch" naming conventions to "PGPM" throughout the pgpm/core package:

- `SqitchRow` → `PgpmRow`
- `writeSqitchPlan` → `writePgpmPlan`  
- `writeSqitchFiles` → `writePgpmFiles`

All old names are preserved as deprecated type aliases for backwards compatibility. Internal call sites in `export-migrations.ts` and tests have been updated to use the new names.

## Review & Testing Checklist for Human

- [ ] **Verify barrel exports**: Check that `pgpm/core/src/files/index.ts` properly re-exports both the new names (`PgpmRow`, `writePgpmPlan`, `writePgpmFiles`) and the deprecated aliases (`SqitchRow`, `writeSqitchPlan`, `writeSqitchFiles`). The diff doesn't show changes to this file.

- [ ] **Search for other consumers**: Run `grep -r "SqitchRow\|writeSqitchPlan\|writeSqitchFiles" --include="*.ts"` across the monorepo to verify no other files import these that weren't updated.

- [ ] **Test deprecated aliases**: The tests were updated to use new names. Consider adding a small test that imports the deprecated aliases to ensure backwards compatibility works.

### Notes

This is PR 2 of a planned series for the export-migrations.ts refactor. PR 1 ([#504](https://github.com/constructive-io/constructive/pull/504)) adds the `license: 'CLOSED'` field and comments out security-related SQL.

Link to Devin run: https://app.devin.ai/sessions/7e7813472a0643aa88ccb509b288050a
Requested by: Dan Lynch (@pyramation)