### PR TITLE
feat(pgpm): add --clobber flag for export command

### DIFF
--- a/pgpm/cli/src/commands/export.ts
+++ b/pgpm/cli/src/commands/export.ts
@@ -18,9 +18,11 @@ Options:
   --extensionName <name>  Extension name
   --metaExtensionName <name>  Meta extension name (default: svc)
   --cwd <directory>       Working directory (default: current directory)
+  --clobber               Overwrite existing deploy/revert/verify directories if module exists
 
 Examples:
   pgpm export              Export migrations from selected database
+  pgpm export --clobber    Export and overwrite existing module directories
 `;
 
 export default async (
@@ -139,7 +141,8 @@ export default async (
     schema_names,
     outdir,
     extensionName,
-    metaExtensionName
+    metaExtensionName,
+    clobber: argv.clobber ?? false
   });
 
   console.log(`


### PR DESCRIPTION
# feat(pgpm): add --clobber flag for export command

## Summary

This PR changes the `pgpm export` command to be **non-destructive by default**. Previously, exporting to an existing module would silently delete and recreate the `deploy/`, `revert/`, and `verify/` directories. Now it throws an error unless the `--clobber` flag is explicitly provided.

**Key changes:**
- Added `clobber` option to `ExportOptions`, `ExportMigrationsToDiskOptions`, and `PreparePackageOptions` interfaces
- Updated `preparePackage` to throw a descriptive error when module exists and `clobber=false`
- Added `--clobber` CLI flag to `pgpm export` command with help text

## Review & Testing Checklist for Human

- [ ] **Breaking change awareness**: This changes default behavior - existing scripts that rely on `pgpm export` overwriting modules will now fail. Verify this is the intended behavior.
- [ ] **Test the error path**: Run `pgpm export` targeting an existing module without `--clobber` and verify the error message is clear
- [ ] **Test the clobber path**: Run `pgpm export --clobber` on an existing module and verify it overwrites correctly
- [ ] **Verify both packages are protected**: The export creates two packages (database dump and services) - both should be protected by this check

**Recommended test plan:**
1. Create a test workspace with `pgpm init workspace`
2. Run `pgpm export` to create initial modules
3. Run `pgpm export` again without `--clobber` → should error
4. Run `pgpm export --clobber` → should succeed and overwrite

### Notes

No unit tests were added for this new functionality - the existing test suite doesn't have database connectivity in CI to test the full export flow.

Link to Devin run: https://app.devin.ai/sessions/7e7813472a0643aa88ccb509b288050a
Requested by: Dan Lynch (pyramation@gmail.com) @pyramation