### PR TITLE
feat(pgpm): add interactive prompts for export flow

### DIFF
--- a/pgpm/cli/src/commands/export.ts
+++ b/pgpm/cli/src/commands/export.ts
@@ -128,8 +128,6 @@ export default async (
   ]);
 
   const outdir = resolve(project.workspacePath, 'packages/');
-
-  prompter.close();
   
   await exportMigrations({
     project,
@@ -139,8 +137,11 @@ export default async (
     schema_names,
     outdir,
     extensionName,
-    metaExtensionName
+    metaExtensionName,
+    prompter
   });
+
+  prompter.close();
 
   console.log(`
 

--- a/pgpm/core/src/modules/modules.ts
+++ b/pgpm/core/src/modules/modules.ts
@@ -4,6 +4,60 @@ import { errors } from '@pgpmjs/types';
 export type ModuleMap = Record<string, Module>;
 
 /**
+ * Mapping from control file names (used in extensions list) to npm package names.
+ * Only includes modules that can be installed via pgpm install from @pgpm/* packages.
+ * Native PostgreSQL extensions (plpgsql, uuid-ossp, etc.) are not included.
+ */
+export const PGPM_MODULE_MAP: Record<string, string> = {
+  'pgpm-base32': '@pgpm/base32',
+  'pgpm-database-jobs': '@pgpm/database-jobs',
+  'db-meta-modules': '@pgpm/db-meta-modules',
+  'db-meta-schema': '@pgpm/db-meta-schema',
+  'pgpm-inflection': '@pgpm/inflection',
+  'pgpm-jwt-claims': '@pgpm/jwt-claims',
+  'pgpm-stamps': '@pgpm/stamps',
+  'pgpm-totp': '@pgpm/totp',
+  'pgpm-types': '@pgpm/types',
+  'pgpm-utils': '@pgpm/utils',
+  'pgpm-uuid': '@pgpm/uuid'
+};
+
+/**
+ * Result of checking for missing installable modules.
+ */
+export interface MissingModule {
+  controlName: string;
+  npmName: string;
+}
+
+/**
+ * Determines which pgpm modules from an extensions list are missing from the installed modules.
+ * Only checks modules that are in PGPM_MODULE_MAP (installable via pgpm install).
+ * 
+ * @param extensions - List of extension/control file names to check
+ * @param installedModules - List of installed npm package names (e.g., '@pgpm/base32')
+ * @returns Array of missing modules with their control names and npm package names
+ */
+export const getMissingInstallableModules = (
+  extensions: string[],
+  installedModules: string[]
+): MissingModule[] => {
+  const missingModules: MissingModule[] = [];
+  
+  for (const ext of extensions) {
+    const npmName = PGPM_MODULE_MAP[ext];
+    if (npmName && !installedModules.includes(npmName)) {
+      missingModules.push({
+        controlName: ext,
+        npmName
+      });
+    }
+  }
+  
+  return missingModules;
+};
+
+/**
  * Get the latest change from the pgpm.plan file for a specific module.
  */
 export const latestChange = (


### PR DESCRIPTION
## Summary

Adds interactive prompts to the `pgpm export` command for two scenarios:

1. **Module overwrite confirmation**: When exporting to a module that already exists, prompts the user with "Module exists. Overwrite? [y/N]" before deleting deploy/revert/verify directories
2. **Missing module auto-install**: Detects which pgpm modules from the required extensions list are missing from the workspace and offers to install them automatically

The `prompter` parameter is now threaded through `exportMigrations` → `exportMigrationsToDisk` → `preparePackage` and `promptAndInstallMissingModules`. When no prompter is provided (non-interactive mode), the existing behavior is preserved.

### Code Organization

- `PGPM_MODULE_MAP` and `getMissingInstallableModules()` extracted to `pgpm/core/src/modules/modules.ts` for reusability
- `DB_REQUIRED_EXTENSIONS` and `SERVICE_REQUIRED_EXTENSIONS` constants hoisted to top of `export-migrations.ts`
- Uses `getInstalledModules()` for accurate detection of installed npm packages

## Updates since last revision

- Moved `PGPM_MODULE_MAP` and detection logic to `modules/modules.ts` (more generic location near module installation code)
- Added `MissingModule` interface for type safety
- Hoisted extension constants (`DB_REQUIRED_EXTENSIONS`, `SERVICE_REQUIRED_EXTENSIONS`) per code review feedback
- Renamed `checkAndInstallMissingModules` → `promptAndInstallMissingModules` for clarity
- Switched from `getModuleMap()` to `getInstalledModules()` for more accurate installed module detection

## Review & Testing Checklist for Human

- [ ] **Verify PGPM_MODULE_MAP accuracy**: The mapping was built by inspecting the pgpm-modules repo. Confirm all 11 entries are correct and no modules are missing
- [ ] **Test `project.getInstalledModules()` return value**: The code compares against `installed` array which should contain npm package names (e.g., `@pgpm/base32`) - verify this matches actual behavior
- [ ] **Test `project.installModules()` with npm package names**: The code passes `@pgpm/base32` style names - verify this is the expected format
- [ ] **Manual E2E test**: Run `pgpm export` on a database with existing modules and verify:
  - Overwrite prompt appears when module exists
  - Missing module detection works correctly
  - Module installation succeeds when confirmed

### Notes

- No unit tests were added for the new functionality
- When user declines overwrite, an error is thrown (`Export cancelled: Module "X" already exists.`) - consider if this is the desired UX

**Requested by**: Dan Lynch (@pyramation)  
**Devin session**: https://app.devin.ai/sessions/7e7813472a0643aa88ccb509b288050a