### PR TITLE
fix(pgpm): use workspace-level module detection for export flow

### DIFF
--- a/pgpm/core/src/core/class/pgpm.ts
+++ b/pgpm/core/src/core/class/pgpm.ts
@@ -45,6 +45,12 @@ import { parseTarget } from '../../utils/target-utils';
 
 const logger = new Logger('pgpm');
 
+/**
+ * Directory name for workspace extensions.
+ * Extensions are installed globally in the workspace's extensions/ directory.
+ */
+const EXTENSIONS_DIR = 'extensions';
+
 function getUTCTimestamp(d: Date = new Date()): string {
   return (
     d.getUTCFullYear() +
@@ -954,7 +960,7 @@ ${dependencies.length > 0 ? dependencies.map(dep => `-- requires: ${dep}`).join(
     this.ensureModule();
   
     const originalDir = process.cwd();
-    const skitchExtDir = path.join(this.workspacePath!, 'extensions');
+    const skitchExtDir = path.join(this.workspacePath!, EXTENSIONS_DIR);
     const pkgJsonPath = path.join(this.modulePath!, 'package.json');
   
     if (!fs.existsSync(pkgJsonPath)) {
@@ -1089,7 +1095,7 @@ ${dependencies.length > 0 ? dependencies.map(dep => `-- requires: ${dep}`).join(
 
     const pkgData = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
     const dependencies = pkgData.dependencies || {};
-    const skitchExtDir = path.join(this.workspacePath!, 'extensions');
+    const skitchExtDir = path.join(this.workspacePath!, EXTENSIONS_DIR);
 
     const installed: string[] = [];
     const installedVersions: Record<string, string> = {};
@@ -1117,7 +1123,7 @@ ${dependencies.length > 0 ? dependencies.map(dep => `-- requires: ${dep}`).join(
   getWorkspaceInstalledModules(): string[] {
     this.ensureWorkspace();
 
-    const extensionsDir = path.join(this.workspacePath!, 'extensions');
+    const extensionsDir = path.join(this.workspacePath!, EXTENSIONS_DIR);
     
     if (!fs.existsSync(extensionsDir)) {
       return [];


### PR DESCRIPTION
# fix(pgpm): use workspace-level module detection for export flow

## Summary

Fixes "Not inside a module" error when running `pgpm export` from workspace root.

The previous implementation called `getInstalledModules()` which requires being inside a module directory. This PR:

1. Adds `getWorkspaceInstalledModules()` method to `PgpmPackage` that scans `workspace/extensions/` directly without requiring module context
2. Splits the module detection/installation flow:
   - `detectMissingModules()` - workspace-level detection + user prompt (before module creation)
   - `installMissingModules()` - module-level installation (after module creation)
3. Updates `preparePackage()` to return the module directory path for use in installation
4. Extracts `EXTENSIONS_DIR` constant to centralize the extensions directory name

## Updates since last revision

- Added `EXTENSIONS_DIR` constant at module level to avoid hardcoding `'extensions'` string in multiple places
- Updated `installModules()`, `getInstalledModules()`, and `getWorkspaceInstalledModules()` to use the constant

## Review & Testing Checklist for Human

- [ ] **Test the fix**: Run `pgpm export` from workspace root and verify it no longer throws "Not inside a module" error
- [ ] **Verify scoped package detection**: Check that `getWorkspaceInstalledModules()` correctly detects packages like `@pgpm/base32` in `extensions/@pgpm/base32/`
- [ ] **Verify installation still works**: If you have missing modules, confirm the install prompt works and modules are installed into the correct module's `package.json`
- [ ] **Check for other callers**: Verify no other code depends on `preparePackage()` returning `void`

**Recommended test plan:**
1. Navigate to a pgpm workspace root (not inside a module)
2. Run `pgpm export` with a database that has migrations
3. Confirm the export completes without "Not inside a module" error
4. If prompted to install missing modules, confirm they install correctly

### Notes

- This fix was not E2E tested due to lack of database seed data
- The flow change (detect before module creation, install after) is intentional to satisfy both workspace-level detection and module-level installation requirements

Link to Devin run: https://app.devin.ai/sessions/7e7813472a0643aa88ccb509b288050a
Requested by: Dan Lynch (@pyramation)