### PR TITLE
feat(extensions): add vector (pgvector) to available extensions list

### DIFF
--- a/pgpm/core/src/extensions/extensions.ts
+++ b/pgpm/core/src/extensions/extensions.ts
@@ -30,6 +30,9 @@ export const getAvailableExtensions = async (
     // Geospatial (vertical showcase)
     'postgis',
   
+    // AI & embeddings
+    'vector',
+  
     // Procedural logic (baseline)
     'plpgsql',
   ];


### PR DESCRIPTION
## Summary
Adds the `vector` extension (pgvector) to the list of core extensions available when initializing a new module via `pgpm init`. This enables AI/embeddings use cases out of the box.

## Review & Testing Checklist for Human
- [ ] Verify `vector` is the correct PostgreSQL extension name for pgvector (not `pgvector`)
- [ ] Run `pgpm init` in a workspace and confirm "vector" appears in the extensions checkbox list

### Notes
- Link to Devin run: https://app.devin.ai/sessions/e424b0eaba2f4789815bb0cc22ca6233
- Requested by: Dan Lynch (@pyramation)