### PR TITLE
feat(pgsql-test): add keepDb option to teardown() for database preservation

### DIFF
--- a/postgres/pgsql-test/src/connect.ts
+++ b/postgres/pgsql-test/src/connect.ts
@@ -46,11 +46,16 @@ const getConnOopts = (cn: GetConnectionOpts = {}) => {
   };
 };
 
+export interface TeardownOptions {
+  /** If true, keeps the database after closing connections (default: false) */
+  keepDb?: boolean;
+}
+
 export interface GetConnectionResult {
   pg: PgTestClient;
   db: PgTestClient;
   admin: DbAdmin;
-  teardown: () => Promise<void>
+  teardown: (opts?: TeardownOptions) => Promise<void>
   manager: PgTestConnector
 }
 
@@ -88,12 +93,14 @@ export const getConnections = async (
   const pg = manager.getClient(config);
 
   let teardownPromise: Promise<void> | null = null;
-  const teardown = async () => {
+  let teardownOpts: TeardownOptions = {};
+  const teardown = async (opts: TeardownOptions = {}) => {
+    teardownOpts = opts;
     if (teardownPromise) return teardownPromise;
     teardownPromise = (async () => {
       manager.beginTeardown();
       await teardownPgPools();
-      await manager.closeAll();
+      await manager.closeAll({ keepDb: teardownOpts.keepDb });
     })();
     return teardownPromise;
   };


### PR DESCRIPTION
# feat(pgsql-test): add keepDb option to teardown() for database preservation

## Summary
Adds a `keepDb` option to the `teardown()` function in `pgsql-test`, allowing users to close connections while preserving the database for inspection.

This enables a workflow where scripts can use `getConnections()` to quickly provision a database, do work, and then keep the database around for debugging/inspection instead of having it automatically dropped.

**Usage:**
```typescript
const { pg, teardown } = await getConnections();
// ... do work ...
console.log(`Database: ${pg.config.database}`);
await teardown({ keepDb: true }); // closes connections, keeps DB for inspection
```

**Changes:**
- Added `TeardownOptions` interface with `keepDb?: boolean`
- Updated `teardown()` signature to accept optional options
- Updated `PgTestConnector.closeAll()` to conditionally skip database dropping

Backward compatible - existing `await teardown()` calls continue to drop the database by default.

## Review & Testing Checklist for Human
- [ ] **Verify closure behavior**: The `teardownOpts` variable is set before the `teardownPromise` guard check. If `teardown()` is called multiple times with different options, only the first call's promise executes but `teardownOpts` gets overwritten. Confirm this edge case is acceptable.
- [ ] **Manual test with PostgreSQL**: Run a script using `teardown({ keepDb: true })` and verify the database persists after the script exits
- [ ] **Verify backward compatibility**: Ensure existing tests/scripts calling `teardown()` without arguments still drop databases

**Recommended test plan:**
1. Create a simple script that calls `getConnections()`, runs a query, then calls `teardown({ keepDb: true })`
2. After script exits, verify the database still exists with `psql -l | grep <db-name>`
3. Run existing tests to confirm no regressions

### Notes
- Tests could not be run locally due to no PostgreSQL server available - changes validated via TypeScript compilation only
- Link to Devin run: https://app.devin.ai/sessions/341f0ab3e0e6438f95553dbb535dd815
- Requested by: Dan Lynch (@pyramation)