### PR TITLE
chore(pgpm): update genomic to 5.1.0

### DIFF
--- a/pgpm/cli/package.json
+++ b/pgpm/cli/package.json
@@ -53,7 +53,7 @@
     "@pgpmjs/types": "workspace:^",
     "appstash": "^0.2.6",
     "find-and-require-package-json": "^0.8.2",
-    "genomic": "^5.0.3",
+    "genomic": "^5.1.0",
     "inquirerer": "^4.1.2",
     "js-yaml": "^4.1.0",
     "minimist": "^1.2.8",

--- a/pgpm/core/package.json
+++ b/pgpm/core/package.json
@@ -53,7 +53,7 @@
     "@pgpmjs/server-utils": "workspace:^",
     "@pgpmjs/types": "workspace:^",
     "csv-to-pg": "workspace:^",
-    "genomic": "^5.0.3",
+    "genomic": "^5.1.0",
     "glob": "^13.0.0",
     "komoji": "^0.7.11",
     "parse-package-name": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1436,8 +1436,8 @@ importers:
         specifier: ^0.8.2
         version: 0.8.3
       genomic:
-        specifier: ^5.0.3
-        version: 5.0.3
+        specifier: ^5.1.0
+        version: 5.1.0
       inquirerer:
         specifier: ^4.1.2
         version: 4.1.2
@@ -1516,8 +1516,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/csv-to-pg/dist
       genomic:
-        specifier: ^5.0.3
-        version: 5.0.3
+        specifier: ^5.1.0
+        version: 5.1.0
       glob:
         specifier: ^13.0.0
         version: 13.0.0
@@ -5289,8 +5289,8 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
-  genomic@5.0.3:
-    resolution: {integrity: sha512-VR+Y82NA1SLFzX5XR/r0vzcKZQHPMWszVwOuqhhTQ9TWnz2cP1R18IAIP0J61Akxl0QhErw0ENaVQKX8WlBWOQ==}
+  genomic@5.1.0:
+    resolution: {integrity: sha512-MRg8bh6iz628qKdQ1TwfO4o1P5khDA+qnqQzYSArvYz5JwcgHUm+/7b6e/8beMr93SD9ZgASHJ1mTIsOttCNkw==}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -12503,7 +12503,7 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-  genomic@5.0.3:
+  genomic@5.1.0:
     dependencies:
       appstash: 0.2.7
       inquirerer: 4.1.2


### PR DESCRIPTION
## Summary

Updates the `genomic` dependency from `^5.0.3` to `^5.1.0` in both `pgpm/core` and `pgpm/cli` packages.

genomic@5.1.0 includes recursive boilerplate scanning functionality that enables proper filtering of directories by `.boilerplate.json` presence. This is future-proofing for cases where users use `--dir .` to bypass `.boilerplates.json` - directories without `.boilerplate.json` (like `scripts/`) will no longer appear as boilerplate options.

**Existing behavior is unchanged** - the new recursive scan only runs as a fallback after existing resolution methods fail.

## Review & Testing Checklist for Human

- [ ] Verify `pgpm init workspace` still works correctly with pgpm-boilerplates
- [ ] Verify `pgpm init` (module) still works correctly
- [ ] Optionally test `pgpm init --dir .` to confirm only valid boilerplates appear (not `scripts/`)

### Test Plan
```bash
# In a test directory
pgpm init workspace
cd packages/
pgpm init
# Both should work as before
```

### Notes
- Link to Devin run: https://app.devin.ai/sessions/2015de005a8b4cb59e20b976c5d6696a
- Requested by: Dan Lynch (@pyramation)
- Related PR: https://github.com/constructive-io/dev-utils/pull/48 (genomic changes, merged)