### PR TITLE
feat(pgpm): add -w alias for --workspace flag on upgrade command

### DIFF
--- a/pgpm/cli/src/commands/upgrade.ts
+++ b/pgpm/cli/src/commands/upgrade.ts
@@ -19,7 +19,7 @@ Options:
   --cwd <directory>       Working directory (default: current directory)
   -i, --interactive       Show outdated modules and select which ones to upgrade
   --dry-run               Show what would be upgraded without making changes
-  --workspace             Upgrade modules across all packages in the workspace
+  -w, --workspace         Upgrade modules across all packages in the workspace
 
 Examples:
   pgpm upgrade                          Upgrade all installed modules
@@ -161,7 +161,7 @@ export default async (
   const { cwd = process.cwd() } = argv;
   const dryRun = Boolean(argv['dry-run']);
   const interactive = Boolean(argv.i || argv.interactive);
-  const workspaceMode = Boolean(argv.workspace);
+  const workspaceMode = Boolean(argv.w || argv.workspace);
   
   // Get specific modules from positional arguments (argv._)
   const specificModules = argv._ && argv._.length > 0 


### PR DESCRIPTION
## Summary

Adds `-w` as a short alias for `--workspace` on the `pgpm upgrade` command, matching the pattern used by `-i`/`--interactive`.

```bash
# These are now equivalent:
pgpm upgrade --workspace
pgpm upgrade -w
```

## Review & Testing Checklist for Human

- [ ] Verify `pgpm upgrade -w` works the same as `pgpm upgrade --workspace` in a real workspace

**Test plan:**
```bash
cd /path/to/pgpm/workspace
pgpm upgrade -w  # Should upgrade all modules across workspace
```

### Notes
- Requested by: Dan Lynch (@pyramation)
- Session: https://app.devin.ai/sessions/95ea22c05e164e99ac7770c57aed8b2d