### PR TITLE
fix(pgpm): fix AST round-trip diff comparison bug and add --outputDiff flag

### DIFF
--- a/pgpm/cli/src/commands/package.ts
+++ b/pgpm/cli/src/commands/package.ts
@@ -13,11 +13,13 @@ Options:
   --plan                          Include deployment plan (default: true)
   --pretty                        Pretty-print output (default: true)
   --functionDelimiter <delimiter> Function delimiter (default: $EOFCODE$)
+  --outputDiff                    Export AST diff files when round-trip mismatch detected (default: false)
   --cwd <directory>               Working directory (default: current directory)
 
 Examples:
   pgpm package                     Package with defaults
   pgpm package --no-plan           Package without plan
+  pgpm package --outputDiff        Package and export AST diff files if mismatch detected
 `;
 
 export default async (
@@ -51,10 +53,17 @@ export default async (
       default: '$EOFCODE$',
       useDefault: true,
       required: false
+    },
+    {
+      type: 'confirm',
+      name: 'outputDiff',
+      default: false,
+      useDefault: true,
+      required: false
     }
   ];
 
-  let { cwd, plan, pretty, functionDelimiter } = await prompter.prompt(argv, questions);
+  let { cwd, plan, pretty, functionDelimiter, outputDiff } = await prompter.prompt(argv, questions);
 
   const project = new PgpmPackage(cwd);
 
@@ -69,7 +78,8 @@ export default async (
     usePlan: plan,
     packageDir: project.modulePath,
     pretty,
-    functionDelimiter
+    functionDelimiter,
+    outputDiff
   });
 
   return argv;


### PR DESCRIPTION
## Summary

Fixes a bug in the `pgpm package` command where the AST round-trip diff check was always reporting a mismatch due to comparing incompatible types. Also adds a new `--outputDiff` flag to export the AST diff files for debugging.

**Bug fix:** The original code compared `tree1` (an array of `RawStmt[]`) to `tree2` (a full `ParseResult` object), which would always show a diff even when the ASTs were identical. The fix now correctly compares `tree1` to `reparsed.stmts` with the same `filterStatements` applied to both.

**New feature:** Added `--outputDiff` flag that writes `orig.*.tree.json` and `parsed.*.tree.json` files when a diff is detected, making it easier to debug AST mismatches.

## Review & Testing Checklist for Human

- [ ] **Verify the comparison fix is correct**: Confirm that `tree2 = filterStatements(reparsed.stmts as any, extension)` properly mirrors the filtering applied to `tree1` at line 62
- [ ] **Test the --outputDiff flag**: Run `pgpm package --outputDiff` on a module and verify the JSON files are written correctly when a diff exists
- [ ] **Test without --outputDiff**: Verify the warning message suggests using `--outputDiff` when a diff is detected

**Recommended test plan:**
1. Find or create a module that triggers an AST diff (or temporarily break the deparser)
2. Run `pgpm package` and verify you see the new warning message suggesting `--outputDiff`
3. Run `pgpm package --outputDiff` and verify the JSON files are written to the `sql/` folder
4. Compare the two JSON files to understand the diff

### Notes

- The TypeScript build has pre-existing errors due to missing `@pgpmjs/*` module declarations - these are unrelated to this change
- No tests were added as the user did not request them

Link to Devin run: https://app.devin.ai/sessions/369b1b00cb84494d93307674f0b9fb0e
Requested by: Dan Lynch (@pyramation)