### PR TITLE
Fix pgsql-test teardown drop failures

### DIFF
--- a/postgres/pgsql-test/__tests__/teardown.test.ts
+++ b/postgres/pgsql-test/__tests__/teardown.test.ts
@@ -1,0 +1,61 @@
+process.env.LOG_SCOPE = 'pgsql-test';
+
+import { getConnEnvOptions } from '@pgpmjs/env';
+import { getPgEnvOptions } from 'pg-env';
+import { Client } from 'pg';
+
+import { getConnections } from '../src/connect';
+
+jest.setTimeout(30000);
+
+const getRootConfig = () => {
+  const conn = getConnEnvOptions();
+  return getPgEnvOptions({ database: conn.rootDb });
+};
+
+const dbExists = async (dbName: string): Promise<boolean> => {
+  const client = new Client(getRootConfig());
+  await client.connect();
+  try {
+    const res = await client.query(
+      'select 1 from pg_database where datname = $1',
+      [dbName]
+    );
+    return res.rowCount > 0;
+  } finally {
+    await client.end();
+  }
+};
+
+describe('teardown', () => {
+  it('drops the test database on teardown', async () => {
+    const { db, teardown } = await getConnections({}, []);
+    const dbName = db.config.database;
+
+    expect(await dbExists(dbName)).toBe(true);
+
+    await teardown();
+
+    const existsAfter = await dbExists(dbName);
+    expect(existsAfter).toBe(false);
+  });
+
+  it('drops the database even with an external client connected', async () => {
+    const { db, teardown } = await getConnections({}, []);
+    const dbName = db.config.database;
+
+    const extraClient = new Client({ ...db.config });
+    extraClient.on('error', () => {});
+    await extraClient.connect();
+    await extraClient.query('select 1');
+
+    expect(await dbExists(dbName)).toBe(true);
+
+    await teardown();
+
+    const existsAfter = await dbExists(dbName);
+    expect(existsAfter).toBe(false);
+
+    await extraClient.end().catch(() => {});
+  });
+});

--- a/postgres/pgsql-test/src/connect.ts
+++ b/postgres/pgsql-test/src/connect.ts
@@ -100,8 +100,8 @@ export const getConnections = async (
     if (teardownPromise) return teardownPromise;
     teardownPromise = (async () => {
       manager.beginTeardown();
-      await teardownPgPools();
       await manager.closeAll({ keepDb: teardownOpts.keepDb });
+      await teardownPgPools();
     })();
     return teardownPromise;
   };


### PR DESCRIPTION
  - Terminate active sessions + fallback drop in pgsql-client so dbs don’t leak.
  - Drop dbs before closing pg-cache to avoid cache-closed errors.
  - Add teardown tests (normal + external client).