### PR TITLE
Fix interactive prompt in exportMigrations by parsing author string

### DIFF
--- a/pgpm/core/src/files/plan/writer.ts
+++ b/pgpm/core/src/files/plan/writer.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { Change, PlanFile, PgpmRow, Tag, ExtendedPlanFile } from '../types';
+import { parseAuthor } from '../../utils/author';
 
 export interface PlanWriteOptions {
   outdir: string;
@@ -19,22 +20,9 @@ export function writePgpmPlan(rows: PgpmRow[], opts: PlanWriteOptions): void {
 
   const date = (): string => '2017-08-11T08:11:51Z'; // stubbed timestamp
   
-  // Parse author string - it might contain email in format "Name <email>"
-  const authorInput = (opts.author || 'constructive').trim();
-  let authorName = authorInput;
-  let authorEmail = '';
-  
-  // Check if author already contains email in <...> format
-  const emailMatch = authorInput.match(/^(.+?)\s*<([^>]+)>\s*$/);
-  if (emailMatch) {
-    // Author already has email format: "Name <email>"
-    authorName = emailMatch[1].trim();
-    authorEmail = emailMatch[2].trim();
-  } else {
-    // No email in author, use default format
-    authorName = authorInput;
-    authorEmail = `${authorName}@5b0c196eeb62`;
-  }
+  const { fullName, email } = parseAuthor(opts.author || 'constructive');
+  const authorName = fullName;
+  const authorEmail = email || `${fullName}@5b0c196eeb62`;
 
   const duplicates: Record<string, boolean> = {};
 

--- a/pgpm/core/src/utils/author.ts
+++ b/pgpm/core/src/utils/author.ts
@@ -1,0 +1,16 @@
+export interface ParsedAuthor {
+  fullName: string;
+  email?: string;
+}
+
+export function parseAuthor(author: string): ParsedAuthor {
+  const trimmed = (author || '').trim();
+  const match = trimmed.match(/^(.+?)\s*<([^>]+)>$/);
+  if (match) {
+    return {
+      fullName: match[1].trim(),
+      email: match[2].trim()
+    };
+  }
+  return { fullName: trimmed };
+}


### PR DESCRIPTION
## Summary

When `exportMigrations` is called programmatically (e.g., from tests in constructive-db), it was prompting for interactive input:

```
Enter author full name (--fullName) [Dan Lynch]
>
```

This happened because `preparePackage` calls `initModule` with an `author` string (e.g., `'Constructive <developers@constructive.io>'`), but the module template expects separate `fullName` and `email` fields in the answers.

This PR:
1. Adds a `parseAuthorString` helper that extracts `fullName` and `email` from the author string
2. Passes these fields to the `answers` object when calling `initModule`
3. Sets `noTty: true` to disable interactive prompts for programmatic use

## Review & Testing Checklist for Human

- [ ] **Verify the regex handles edge cases**: Test with author strings like `"John Doe"` (no email), `"Name <email>"`, and `"Name With Spaces <email@domain.com>"`
- [ ] **Check if `noTty: true` has unintended side effects**: Ensure this doesn't suppress prompts that should still appear in CLI usage
- [ ] **Verify CI passes**: I couldn't build locally due to workspace dependency issues

**Recommended test plan:**
1. Run the introspection export test in constructive-db after this is merged and the dependency is updated
2. Manually test `pgpm export` from CLI to ensure interactive prompts still work when needed

### Notes

This fix is needed to unblock the introspection package tests in constructive-db PR #159.

**Link to Devin run:** https://app.devin.ai/sessions/cf99eca9a417440f98c23cd9db41555b
**Requested by:** Dan Lynch (@pyramation)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures programmatic exports don't trigger interactive prompts during module scaffolding.
> 
> - Adds `parseAuthorString(author)` to extract `fullName` and optional `email` from strings like `"Name <email@domain>"`
> - Updates `preparePackage` to pass `fullName`/`email` in `initModule` `answers` and sets `noTty: true`
> - Minor cleanup: preserve existing overwrite logic; no behavior changes elsewhere
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf6e9d7b45f3036db4fad5dbbb1c5986e1e24576. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->