### PR TITLE
Add missing template answers (repoName, username) to exportMigrations

### DIFF
--- a/pgpm/core/src/export/export-migrations.ts
+++ b/pgpm/core/src/export/export-migrations.ts
@@ -430,7 +430,9 @@ const preparePackage = async ({
         access: 'restricted',
         license: 'CLOSED',
         fullName,
-        ...(email && { email })
+        ...(email && { email }),
+        repoName: name,
+        username: 'constructive-io'
       }
     });
   } else {

--- a/pgpm/core/src/export/export-migrations.ts
+++ b/pgpm/core/src/export/export-migrations.ts
@@ -144,6 +144,10 @@ interface ExportMigrationsToDiskOptions {
   metaExtensionName: string;
   metaExtensionDesc?: string;
   prompter?: Prompter;
+  /** Repository name for module scaffolding. Defaults to module name if not provided. */
+  repoName?: string;
+  /** GitHub username/org for module scaffolding. Required for non-interactive use. */
+  username?: string;
 }
 
 interface ExportOptions {
@@ -162,6 +166,10 @@ interface ExportOptions {
   metaExtensionName: string;
   metaExtensionDesc?: string;
   prompter?: Prompter;
+  /** Repository name for module scaffolding. Defaults to module name if not provided. */
+  repoName?: string;
+  /** GitHub username/org for module scaffolding. Required for non-interactive use. */
+  username?: string;
 }
 
 const exportMigrationsToDisk = async ({
@@ -177,7 +185,9 @@ const exportMigrationsToDisk = async ({
   extensionDesc,
   metaExtensionName,
   metaExtensionDesc,
-  prompter
+  prompter,
+  repoName,
+  username
 }: ExportMigrationsToDiskOptions): Promise<void> => {
   outdir = outdir + '/';
 
@@ -241,7 +251,9 @@ const exportMigrationsToDisk = async ({
       name,
       description: dbExtensionDesc,
       extensions: [...DB_REQUIRED_EXTENSIONS],
-      prompter
+      prompter,
+      repoName,
+      username
     });
 
     // Install missing modules if user confirmed (now that module exists)
@@ -274,7 +286,9 @@ const exportMigrationsToDisk = async ({
       name: metaExtensionName,
       description: metaDesc,
       extensions: [...SERVICE_REQUIRED_EXTENSIONS],
-      prompter
+      prompter,
+      repoName,
+      username
     });
 
     // Install missing modules if user confirmed (now that module exists)
@@ -347,7 +361,9 @@ export const exportMigrations = async ({
   extensionDesc,
   metaExtensionName,
   metaExtensionDesc,
-  prompter
+  prompter,
+  repoName,
+  username
 }: ExportOptions): Promise<void> => {
   for (let v = 0; v < dbInfo.database_ids.length; v++) {
     const databaseId = dbInfo.database_ids[v];
@@ -364,7 +380,9 @@ export const exportMigrations = async ({
       schema_names,
       author,
       outdir,
-      prompter
+      prompter,
+      repoName,
+      username
     });
   }
 };
@@ -378,6 +396,10 @@ interface PreparePackageOptions {
   description: string;
   extensions: string[];
   prompter?: Prompter;
+  /** Repository name for module scaffolding. Defaults to module name if not provided. */
+  repoName?: string;
+  /** GitHub username/org for module scaffolding. Required for non-interactive use. */
+  username?: string;
 }
 
 interface Schema {
@@ -408,7 +430,9 @@ const preparePackage = async ({
   name,
   description,
   extensions,
-  prompter
+  prompter,
+  repoName,
+  username
 }: PreparePackageOptions): Promise<string> => {
   const curDir = process.cwd();
   const pgpmDir = path.resolve(path.join(outdir, name));
@@ -431,8 +455,9 @@ const preparePackage = async ({
         license: 'CLOSED',
         fullName,
         ...(email && { email }),
-        repoName: name,
-        username: 'constructive-io'
+        // Use provided values or sensible defaults
+        repoName: repoName || name,
+        ...(username && { username })
       }
     });
   } else {


### PR DESCRIPTION
## Summary

Adds the remaining required template fields (`repoName` and `username`) to the answers object in `preparePackage` to prevent interactive prompts when `exportMigrations` is called programmatically.

This is a follow-up to PR #533 which added `fullName` and `email`. After that fix, the module boilerplate template was still prompting for `repoName`. Inspection of the boilerplate config at `pgpm-boilerplates/default/module/.boilerplate.json` revealed these additional required fields.

## Review & Testing Checklist for Human

- [ ] **Verify hardcoded `username: 'constructive-io'` is acceptable** - This value is hardcoded rather than derived from workspace config or author info. Consider if this should be configurable or derived from somewhere else.
- [ ] **Test export functionality end-to-end** - Run the introspection export test in constructive-db to verify no more interactive prompts appear
- [ ] **Verify `repoName: name` is correct** - Using the module name as the repo name may not always be appropriate

**Recommended test plan:**
1. Merge this PR and publish a new version of `@pgpmjs/core`
2. Update constructive-db to use the new version
3. Run `pnpm test` in `packages/introspection` to verify `introspect_export.test.ts` passes without interactive prompts

### Notes

This fix was discovered by cloning `pgpm-boilerplates` and inspecting the `.boilerplate.json` questions. The template requires: `fullName`, `email`, `moduleName`, `moduleDesc`, `repoName`, `username`, `access`, and `license`.

**Link to Devin run:** https://app.devin.ai/sessions/cf99eca9a417440f98c23cd9db41555b
**Requested by:** Dan Lynch (@pyramation)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures non-interactive module initialization during exports by completing required template answers.
> 
> - Update `preparePackage` to pass `answers` with `repoName: name` and `username: 'constructive-io'` to `project.initModule`
> - Prevents template from prompting for missing fields when `exportMigrations` is run programmatically
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67f708a22c4c417f9be0b254f4d09bcc39e674af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->