### PR TITLE
Add serviceOutdir parameter to exportMigrations for separate service module output

### DIFF
--- a/pgpm/core/src/export/export-migrations.ts
+++ b/pgpm/core/src/export/export-migrations.ts
@@ -349,6 +349,7 @@ SET session_replication_role TO DEFAULT;
 
     opts.replacer = metaReplacer.replacer;
     opts.name = metaExtensionName;
+    opts.outdir = svcOutdir;
 
     writePgpmPlan(metaPackage, opts);
     writePgpmFiles(metaPackage, opts);

--- a/pgpm/core/src/export/export-migrations.ts
+++ b/pgpm/core/src/export/export-migrations.ts
@@ -148,6 +148,8 @@ interface ExportMigrationsToDiskOptions {
   repoName?: string;
   /** GitHub username/org for module scaffolding. Required for non-interactive use. */
   username?: string;
+  /** Output directory for service/meta module. Defaults to outdir if not provided. */
+  serviceOutdir?: string;
 }
 
 interface ExportOptions {
@@ -170,6 +172,8 @@ interface ExportOptions {
   repoName?: string;
   /** GitHub username/org for module scaffolding. Required for non-interactive use. */
   username?: string;
+  /** Output directory for service/meta module. Defaults to outdir if not provided. */
+  serviceOutdir?: string;
 }
 
 const exportMigrationsToDisk = async ({
@@ -187,9 +191,12 @@ const exportMigrationsToDisk = async ({
   metaExtensionDesc,
   prompter,
   repoName,
-  username
+  username,
+  serviceOutdir
 }: ExportMigrationsToDiskOptions): Promise<void> => {
   outdir = outdir + '/';
+  // Use serviceOutdir for service module, defaulting to outdir if not provided
+  const svcOutdir = (serviceOutdir || outdir.slice(0, -1)) + '/';
 
   const pgPool = getPgPool({
     ...options.pg,
@@ -278,11 +285,11 @@ const exportMigrationsToDisk = async ({
     // Detect missing modules at workspace level and prompt user
     const svcMissingResult = await detectMissingModules(project, [...SERVICE_REQUIRED_EXTENSIONS], prompter);
 
-    // Create/prepare the module directory
+    // Create/prepare the module directory (use serviceOutdir if provided)
     const svcModuleDir = await preparePackage({
       project,
       author,
-      outdir,
+      outdir: svcOutdir,
       name: metaExtensionName,
       description: metaDesc,
       extensions: [...SERVICE_REQUIRED_EXTENSIONS],
@@ -363,7 +370,8 @@ export const exportMigrations = async ({
   metaExtensionDesc,
   prompter,
   repoName,
-  username
+  username,
+  serviceOutdir
 }: ExportOptions): Promise<void> => {
   for (let v = 0; v < dbInfo.database_ids.length; v++) {
     const databaseId = dbInfo.database_ids[v];
@@ -382,7 +390,8 @@ export const exportMigrations = async ({
       outdir,
       prompter,
       repoName,
-      username
+      username,
+      serviceOutdir
     });
   }
 };


### PR DESCRIPTION
## Summary

Adds an optional `serviceOutdir` parameter to `exportMigrations` that allows the service/meta module to be exported to a different directory than the main DB module. When not provided, it defaults to the same `outdir` (backwards compatible).

This enables use cases like:
- DB module → `application/constructive`
- Service module → `services/constructive-services`

## Review & Testing Checklist for Human

- [ ] Verify the `svcOutdir` calculation logic is correct: `(serviceOutdir || outdir.slice(0, -1)) + '/'` - this handles the case where `outdir` already has a trailing slash appended
- [ ] Test that existing callers without `serviceOutdir` still work (backwards compatibility)
- [ ] Test with both `outdir` and `serviceOutdir` provided to verify modules go to different directories

**Suggested test plan**: Run an export with both parameters set to different directories and verify the DB module lands in `outdir` while the service module lands in `serviceOutdir`.

### Notes

- Link to Devin run: https://app.devin.ai/sessions/cf99eca9a417440f98c23cd9db41555b
- Requested by: Dan Lynch (pyramation@gmail.com) / @pyramation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables exporting the service/meta module to a separate directory while keeping the DB module in the original `outdir`.
> 
> - Adds optional `serviceOutdir` to `ExportOptions` and `ExportMigrationsToDiskOptions`
> - Computes `svcOutdir` as `(serviceOutdir || outdir.slice(0, -1)) + '/'`
> - Uses `svcOutdir` when preparing the service/meta module directory; DB module still uses `outdir`
> - Propagates the new parameter through `exportMigrations` and `exportMigrationsToDisk` (backwards compatible)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3127f46f55a576b4b70ca64a3a7a682271cb872. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->