### PR TITLE
feat(pgpm): add outputDir option to initModule for explicit module directory control

### DIFF
--- a/pgpm/core/src/core/class/pgpm.ts
+++ b/pgpm/core/src/core/class/pgpm.ts
@@ -118,6 +118,12 @@ export interface InitModuleOptions {
   noTty?: boolean;
   toolName?: string;
   answers?: Record<string, any>;
+  /** 
+   * Parent directory where the module should be created. 
+   * When provided, bypasses createModuleDirectory() and creates the module at outputDir/name.
+   * Must be an absolute path or relative to workspace root.
+   */
+  outputDir?: string;
 }
 
 export class PgpmPackage {
@@ -429,7 +435,19 @@ export class PgpmPackage {
 
   async initModule(options: InitModuleOptions): Promise<void> {
     this.ensureWorkspace();
-    const targetPath = this.createModuleDirectory(options.name);
+    
+    // If outputDir is provided, use it directly instead of createModuleDirectory
+    let targetPath: string;
+    if (options.outputDir) {
+      // Resolve outputDir relative to workspace if not absolute
+      const resolvedOutputDir = path.isAbsolute(options.outputDir) 
+        ? options.outputDir 
+        : path.resolve(this.workspacePath!, options.outputDir);
+      targetPath = path.join(resolvedOutputDir, options.name);
+      fs.mkdirSync(targetPath, { recursive: true });
+    } else {
+      targetPath = this.createModuleDirectory(options.name);
+    }
     
     const answers = {
       ...options.answers,

--- a/pgpm/core/src/export/export-migrations.ts
+++ b/pgpm/core/src/export/export-migrations.ts
@@ -458,6 +458,8 @@ const preparePackage = async ({
       description,
       author,
       extensions,
+      // Use outputDir to create module directly in the specified location
+      outputDir: outdir,
       answers: {
         moduleName: name,
         moduleDesc: description,


### PR DESCRIPTION
# feat(pgpm): add outputDir option to initModule for explicit module directory control

## Summary

Adds an `outputDir` option to `InitModuleOptions` that allows callers to explicitly specify where a module should be created, bypassing the default `createModuleDirectory()` behavior which defaults to `packages/` when called from workspace root.

This fixes an issue where `exportMigrations` was creating modules in `packages/` even when a different `outdir` was specified (e.g., `application/` or `services/`). The `preparePackage` function now passes the `outdir` parameter through to `initModule` via the new `outputDir` option.

**Key changes:**
- Added `outputDir?: string` to `InitModuleOptions` interface
- Modified `initModule()` to use `outputDir` when provided (resolves relative paths against workspace root)
- Updated `preparePackage()` to pass `outputDir: outdir` to `initModule()`

## Review & Testing Checklist for Human

- [ ] **Path resolution edge cases**: Verify that both absolute paths and relative paths (e.g., `application`, `./services`) resolve correctly against the workspace root
- [ ] **Test export to custom directories**: Run an export with `outdir: 'application'` and `serviceOutdir: 'services'` and verify modules are created in the correct locations (not in `packages/`)
- [ ] **Verify existing behavior**: Test that `initModule` without `outputDir` still creates modules in `packages/` as expected

**Recommended test plan:**
1. In a pgpm workspace, call `exportMigrations` with `outdir: 'application'` and `serviceOutdir: 'services'`
2. Verify the DB module is created at `application/<name>/` (not `packages/<name>/`)
3. Verify the service module is created at `services/<name>/` (not `packages/<name>/`)

### Notes

- No validation is performed on `outputDir` to check if it's within allowed workspace directories - this is intentional to give explicit control to programmatic callers
- The `workspacePath!` non-null assertion is safe because `ensureWorkspace()` is called first

Link to Devin run: https://app.devin.ai/sessions/cf99eca9a417440f98c23cd9db41555b
Requested by: Dan Lynch (@pyramation)