### PR TITLE
fix: update outdated extension names from db-meta-* to metaschema-*

### DIFF
--- a/pgpm/core/src/export/export-migrations.ts
+++ b/pgpm/core/src/export/export-migrations.ts
@@ -23,7 +23,7 @@ const DB_REQUIRED_EXTENSIONS = [
   'btree_gist',
   'postgis',
   'hstore',
-  'db-meta-schema',
+  'metaschema-schema',
   'pgpm-inflection',
   'pgpm-uuid',
   'pgpm-utils',
@@ -41,8 +41,8 @@ const DB_REQUIRED_EXTENSIONS = [
  */
 const SERVICE_REQUIRED_EXTENSIONS = [
   'plpgsql',
-  'db-meta-schema',
-  'db-meta-modules'
+  'metaschema-schema',
+  'metaschema-modules'
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary

Updates outdated PostgreSQL extension names in the pgpm export code:
- `db-meta-schema` → `metaschema-schema`
- `db-meta-modules` → `metaschema-modules`

These constants are used when generating `.control` files for exported pgpm modules. The old `db-meta-*` names no longer exist, causing deployment failures with errors like:
```
could not open extension control file "/usr/local/share/postgresql/extension/db-meta-schema.control": No such file or directory
```

## Review & Testing Checklist for Human

- [ ] **Verify extension names are correct** - Confirm that `metaschema-schema` and `metaschema-modules` are the actual names of the PostgreSQL extensions in your environment
- [ ] **Test module generation** - Run `pnpm generate:rls` in constructive-db after updating to this version and verify the generated `.control` files have the correct `requires` line
- [ ] **Test deployment** - Deploy a generated module to verify the extension dependencies resolve correctly

**Recommended test plan:**
1. Update constructive-db to use this pgpm version
2. Run `pnpm generate:rls` 
3. Check `services/constructive-services/constructive-services.control` shows `requires = 'plpgsql,metaschema-schema,metaschema-modules'`
4. Run integration tests to verify deployment works

### Notes

This fix is needed to unblock the RLS baseline generation PR in constructive-db (PR #219), which was failing integration tests due to the outdated extension names.

Link to Devin run: https://app.devin.ai/sessions/23949faa112a4110a435a82d88fb47c1
Requested by: Dan Lynch (@pyramation)