### PR TITLE
Revert: Undo Blacksmith migration from PR #559

### DIFF
--- a/.github/workflows/docker-launchql.yaml
+++ b/.github/workflows/docker-launchql.yaml
@@ -29,7 +29,7 @@ jobs:
             runner: ubuntu-latest      # x86_64
           - platform: linux/arm64
             arch: arm64
-            runner: blacksmith-4vcpu-ubuntu-2404-arm   # native arm
+            runner: ubuntu-24.04-arm   # native arm
     runs-on: ${{ matrix.runner }}
 
     permissions:
@@ -44,8 +44,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GHCR
         if: github.event_name != 'pull_request'
@@ -72,7 +72,7 @@ jobs:
       # do a quick amd64-only build without pushing.
       - name: Build (no push, PR only)
         if: github.event_name == 'pull_request' && matrix.platform == 'linux/amd64'
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
@@ -80,6 +80,8 @@ jobs:
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       # For non-PR events, build one architecture per runner
       # and push images by digest. These digests are later
@@ -87,13 +89,15 @@ jobs:
       - name: Build & push by digest
         if: github.event_name != 'pull_request'
         id: build
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REPO }}/${{ env.IMAGE_NAME }},push-by-digest=true,push=true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Export digest
         if: github.event_name != 'pull_request'
@@ -114,7 +118,7 @@ jobs:
   # multi-arch manifest for each tag.
   publish-constructive-manifest:
     if: github.event_name != 'pull_request'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: build-push-constructive
 
     permissions:
@@ -126,8 +130,8 @@ jobs:
       IMAGE_NAME: constructive
 
     steps:
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -41,7 +41,7 @@ concurrency:
 jobs:
   build-push:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read
@@ -67,8 +67,8 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GHCR
         if: github.event_name != 'pull_request'

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -18,7 +18,6 @@ concurrency:
 jobs:
   constructive-tests:
     runs-on: ubuntu-latest
-    container: pyramation/node-sqitch:20.12.0
 
     strategy:
       fail-fast: false
@@ -36,7 +35,7 @@ jobs:
             env: {}
           - package: packages/client
             env:
-              TEST_DATABASE_URL: postgres://postgres:password@pg_db:5432/postgres
+              TEST_DATABASE_URL: postgres://postgres:password@localhost:5432/postgres
           - package: postgres/pgsql-client
             env: {}
           - package: postgres/pgsql-test
@@ -97,11 +96,11 @@ jobs:
             env: {}
 
     env:
-      PGHOST: pg_db
+      PGHOST: localhost
       PGPORT: 5432
       PGUSER: postgres
       PGPASSWORD: password
-      MINIO_ENDPOINT: http://minio_cdn:9000
+      MINIO_ENDPOINT: http://localhost:9000
       AWS_ACCESS_KEY: minioadmin
       AWS_SECRET_KEY: minioadmin
       AWS_REGION: us-east-1
@@ -142,6 +141,11 @@ jobs:
 
       - name: checkout
         uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   constructive-tests:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     container: pyramation/node-sqitch:20.12.0
 
     strategy:


### PR DESCRIPTION
## Summary

This PR reverts the Blacksmith runner migration introduced in PR #559. The changes restore the original GitHub Actions configuration:

- Reverts `runs-on` from Blacksmith runners (`blacksmith-4vcpu-ubuntu-2404`, `blacksmith-4vcpu-ubuntu-2404-arm`) back to GitHub-hosted runners (`ubuntu-latest`, `ubuntu-24.04-arm`)
- Reverts Docker setup from `useblacksmith/setup-docker-builder@v1` back to `docker/setup-buildx-action@v3`
- Reverts build actions from `useblacksmith/build-push-action@v2` back to `docker/build-push-action@v5`/`v6`
- Restores GHA cache configuration (`cache-from: type=gha`, `cache-to: type=gha,mode=max`)

**Additional changes (per user request):**
- Removes `container: pyramation/node-sqitch:20.12.0` from the test workflow
- Updates service hostnames from Docker network names to `localhost` (`PGHOST`, `MINIO_ENDPOINT`, `TEST_DATABASE_URL`)
- Adds explicit `actions/setup-node@v4` step with Node.js 20

Files changed: `docker-launchql.yaml`, `docker.yaml`, `run-tests.yaml`

## Review & Testing Checklist for Human

- [ ] **Verify CI tests pass** - Removing the `node-sqitch` container is a significant change; tests now run directly on the runner and may be missing dependencies (e.g., `sqitch` CLI if any tests require it)
- [ ] Confirm all service connections work with `localhost` instead of Docker network hostnames
- [ ] Verify Docker builds complete successfully (may need to trigger a manual workflow run or wait for a merge to main)

### Notes

Requested by: Dan Lynch (@pyramation)
Link to Devin run: https://app.devin.ai/sessions/54faae16c78b4b8e9d5f3a96b2ce062b