### PR TITLE
fix: update remaining db-meta-schema reference to metaschema-schema in fixture dependency

### DIFF
--- a/__fixtures__/stage/extensions/@pgpm/metaschema-modules/pgpm.plan
+++ b/__fixtures__/stage/extensions/@pgpm/metaschema-modules/pgpm.plan
@@ -2,7 +2,7 @@
 %project=metaschema-modules
 %uri=metaschema-modules
   
-schemas/meta_private/schema [db-meta-schema:schemas/meta_public/tables/site_themes/table] 2017-08-11T08:11:51Z skitch <skitch@5b0c196eeb62> # add schemas/meta_private/schema
+schemas/meta_private/schema [metaschema-schema:schemas/meta_public/tables/site_themes/table] 2017-08-11T08:11:51Z skitch <skitch@5b0c196eeb62> # add schemas/meta_private/schema
 schemas/meta_public/schema 2017-08-11T08:11:51Z skitch <skitch@5b0c196eeb62> # add schemas/meta_public/schema
 schemas/meta_public/tables/apis/table [schemas/meta_public/schema] 2017-08-11T08:11:51Z skitch <skitch@5b0c196eeb62> # add schemas/meta_public/tables/apis/table
 schemas/meta_public/tables/connected_accounts_module/table [schemas/meta_public/schema] 2017-08-11T08:11:51Z skitch <skitch@5b0c196eeb62> # add schemas/meta_public/tables/connected_accounts_module/table


### PR DESCRIPTION
## Summary

Fixes a missed reference from the db-meta to metaschema rename. The `metaschema-modules` fixture's pgpm.plan file still had a dependency reference to `db-meta-schema` instead of `metaschema-schema`.

This was causing the test `getModules() returns all modules from extensions/@pgpm and packages` in `stage-workspace.test.ts` to fail when checking for metaschema module names.

## Review & Testing Checklist for Human

- [ ] Verify the dependency reference `metaschema-schema:schemas/meta_public/tables/site_themes/table` is correct and matches the actual module name in `__fixtures__/stage/extensions/@pgpm/metaschema-schema/pgpm.plan`

### Test Plan
Run the stage-workspace tests to verify the fix:
```bash
cd pgpm/core && pnpm test -- __tests__/projects/stage-workspace.test.ts
```

### Notes
- This completes the db-meta → metaschema rename that was mostly done in PR #561
- Link to Devin run: https://app.devin.ai/sessions/6497dd7a81524f12a8adce47724ed35c
- Requested by: Dan Lynch (@pyramation)