### PR TITLE
feat(graphql-codegen): make React Query optional with config flag

### DIFF
--- a/graphql/codegen/README.md
+++ b/graphql/codegen/README.md
@@ -1,4 +1,16 @@
-# @constructive-io/graphql-sdk
+# @constructive-io/graphql-codegen
+
+<p align="center" width="100%">
+  <img height="250" src="https://raw.githubusercontent.com/constructive-io/constructive/refs/heads/main/assets/outline-logo.svg" />
+</p>
+
+<p align="center" width="100%">
+  <a href="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml">
+    <img height="20" src="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml/badge.svg" />
+  </a>
+   <a href="https://github.com/constructive-io/constructive/blob/main/LICENSE"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
+   <a href="https://www.npmjs.com/package/@constructive-io/graphql-codegen"><img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/constructive?filename=graphql%2Fcodegen%2Fpackage.json"/></a>
+</p>
 
 CLI-based GraphQL SDK generator for PostGraphile endpoints. Generate type-safe React Query hooks or a Prisma-like ORM client from your GraphQL schema.
 
@@ -39,7 +51,7 @@ CLI-based GraphQL SDK generator for PostGraphile endpoints. Generate type-safe R
 ## Installation
 
 ```bash
-pnpm add @constructive-io/graphql-sdk
+pnpm add @constructive-io/graphql-codegen
 ```
 
 ## Quick Start
@@ -53,7 +65,7 @@ npx graphql-sdk init
 Creates a `graphql-sdk.config.ts` file:
 
 ```typescript
-import { defineConfig } from '@constructive-io/graphql-sdk';
+import { defineConfig } from '@constructive-io/graphql-codegen';
 
 export default defineConfig({
   endpoint: 'https://api.example.com/graphql',

--- a/graphql/codegen/src/__tests__/codegen/react-query-optional.test.ts
+++ b/graphql/codegen/src/__tests__/codegen/react-query-optional.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Tests for React Query optional flag in code generators
+ *
+ * Verifies that when reactQueryEnabled is false:
+ * - Query generators skip React Query imports and hooks
+ * - Mutation generators return null (since they require React Query)
+ * - Standalone fetch functions are still generated for queries
+ */
+import { generateListQueryHook, generateSingleQueryHook, generateAllQueryHooks } from '../../cli/codegen/queries';
+import { generateCreateMutationHook, generateUpdateMutationHook, generateDeleteMutationHook, generateAllMutationHooks } from '../../cli/codegen/mutations';
+import { generateCustomQueryHook, generateAllCustomQueryHooks } from '../../cli/codegen/custom-queries';
+import { generateCustomMutationHook, generateAllCustomMutationHooks } from '../../cli/codegen/custom-mutations';
+import type { CleanTable, CleanFieldType, CleanRelations, CleanOperation, CleanTypeRef, TypeRegistry } from '../../types/schema';
+
+// ============================================================================
+// Test Fixtures
+// ============================================================================
+
+const fieldTypes = {
+  uuid: { gqlType: 'UUID', isArray: false } as CleanFieldType,
+  string: { gqlType: 'String', isArray: false } as CleanFieldType,
+  int: { gqlType: 'Int', isArray: false } as CleanFieldType,
+  datetime: { gqlType: 'Datetime', isArray: false } as CleanFieldType,
+};
+
+const emptyRelations: CleanRelations = {
+  belongsTo: [],
+  hasOne: [],
+  hasMany: [],
+  manyToMany: [],
+};
+
+function createTable(partial: Partial<CleanTable> & { name: string }): CleanTable {
+  return {
+    name: partial.name,
+    fields: partial.fields ?? [],
+    relations: partial.relations ?? emptyRelations,
+    query: partial.query,
+    inflection: partial.inflection,
+    constraints: partial.constraints,
+  };
+}
+
+const userTable = createTable({
+  name: 'User',
+  fields: [
+    { name: 'id', type: fieldTypes.uuid },
+    { name: 'email', type: fieldTypes.string },
+    { name: 'name', type: fieldTypes.string },
+    { name: 'createdAt', type: fieldTypes.datetime },
+  ],
+  query: {
+    all: 'users',
+    one: 'user',
+    create: 'createUser',
+    update: 'updateUser',
+    delete: 'deleteUser',
+  },
+});
+
+function createTypeRef(kind: CleanTypeRef['kind'], name: string | null, ofType?: CleanTypeRef): CleanTypeRef {
+  return { kind, name, ofType };
+}
+
+const sampleQueryOperation: CleanOperation = {
+  name: 'currentUser',
+  kind: 'query',
+  args: [],
+  returnType: createTypeRef('OBJECT', 'User'),
+  description: 'Get the current authenticated user',
+};
+
+const sampleMutationOperation: CleanOperation = {
+  name: 'login',
+  kind: 'mutation',
+  args: [
+    { name: 'email', type: createTypeRef('NON_NULL', null, createTypeRef('SCALAR', 'String')) },
+    { name: 'password', type: createTypeRef('NON_NULL', null, createTypeRef('SCALAR', 'String')) },
+  ],
+  returnType: createTypeRef('OBJECT', 'LoginPayload'),
+  description: 'Authenticate user',
+};
+
+const emptyTypeRegistry: TypeRegistry = new Map();
+
+// ============================================================================
+// Tests - Query Generators with reactQueryEnabled: false
+// ============================================================================
+
+describe('Query generators with reactQueryEnabled: false', () => {
+  describe('generateListQueryHook', () => {
+    it('should not include React Query imports when disabled', () => {
+      const result = generateListQueryHook(userTable, { reactQueryEnabled: false });
+      expect(result.content).not.toContain('@tanstack/react-query');
+      expect(result.content).not.toContain('useQuery');
+      expect(result.content).not.toContain('UseQueryOptions');
+    });
+
+    it('should not include useXxxQuery hook when disabled', () => {
+      const result = generateListQueryHook(userTable, { reactQueryEnabled: false });
+      expect(result.content).not.toContain('export function useUsersQuery');
+    });
+
+    it('should not include prefetch function when disabled', () => {
+      const result = generateListQueryHook(userTable, { reactQueryEnabled: false });
+      expect(result.content).not.toContain('export async function prefetchUsersQuery');
+    });
+
+    it('should still include standalone fetch function when disabled', () => {
+      const result = generateListQueryHook(userTable, { reactQueryEnabled: false });
+      expect(result.content).toContain('export async function fetchUsersQuery');
+    });
+
+    it('should still include GraphQL document when disabled', () => {
+      const result = generateListQueryHook(userTable, { reactQueryEnabled: false });
+      expect(result.content).toContain('usersQueryDocument');
+    });
+
+    it('should still include query key factory when disabled', () => {
+      const result = generateListQueryHook(userTable, { reactQueryEnabled: false });
+      expect(result.content).toContain('usersQueryKey');
+    });
+
+    it('should update file header when disabled', () => {
+      const result = generateListQueryHook(userTable, { reactQueryEnabled: false });
+      expect(result.content).toContain('List query functions for User');
+    });
+  });
+
+  describe('generateSingleQueryHook', () => {
+    it('should not include React Query imports when disabled', () => {
+      const result = generateSingleQueryHook(userTable, { reactQueryEnabled: false });
+      expect(result.content).not.toContain('@tanstack/react-query');
+      expect(result.content).not.toContain('useQuery');
+    });
+
+    it('should not include useXxxQuery hook when disabled', () => {
+      const result = generateSingleQueryHook(userTable, { reactQueryEnabled: false });
+      expect(result.content).not.toContain('export function useUserQuery');
+    });
+
+    it('should still include standalone fetch function when disabled', () => {
+      const result = generateSingleQueryHook(userTable, { reactQueryEnabled: false });
+      expect(result.content).toContain('export async function fetchUserQuery');
+    });
+  });
+
+  describe('generateAllQueryHooks', () => {
+    it('should generate files without React Query when disabled', () => {
+      const results = generateAllQueryHooks([userTable], { reactQueryEnabled: false });
+      expect(results.length).toBe(2); // list + single
+      for (const result of results) {
+        expect(result.content).not.toContain('@tanstack/react-query');
+        expect(result.content).not.toContain('useQuery');
+      }
+    });
+  });
+});
+
+// ============================================================================
+// Tests - Query Generators with reactQueryEnabled: true (default)
+// ============================================================================
+
+describe('Query generators with reactQueryEnabled: true (default)', () => {
+  describe('generateListQueryHook', () => {
+    it('should include React Query imports by default', () => {
+      const result = generateListQueryHook(userTable);
+      expect(result.content).toContain('@tanstack/react-query');
+      expect(result.content).toContain('useQuery');
+    });
+
+    it('should include useXxxQuery hook by default', () => {
+      const result = generateListQueryHook(userTable);
+      expect(result.content).toContain('export function useUsersQuery');
+    });
+
+    it('should include prefetch function by default', () => {
+      const result = generateListQueryHook(userTable);
+      expect(result.content).toContain('export async function prefetchUsersQuery');
+    });
+
+    it('should include standalone fetch function by default', () => {
+      const result = generateListQueryHook(userTable);
+      expect(result.content).toContain('export async function fetchUsersQuery');
+    });
+  });
+});
+
+// ============================================================================
+// Tests - Mutation Generators with reactQueryEnabled: false
+// ============================================================================
+
+describe('Mutation generators with reactQueryEnabled: false', () => {
+  describe('generateCreateMutationHook', () => {
+    it('should return null when disabled', () => {
+      const result = generateCreateMutationHook(userTable, { reactQueryEnabled: false });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('generateUpdateMutationHook', () => {
+    it('should return null when disabled', () => {
+      const result = generateUpdateMutationHook(userTable, { reactQueryEnabled: false });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('generateDeleteMutationHook', () => {
+    it('should return null when disabled', () => {
+      const result = generateDeleteMutationHook(userTable, { reactQueryEnabled: false });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('generateAllMutationHooks', () => {
+    it('should return empty array when disabled', () => {
+      const results = generateAllMutationHooks([userTable], { reactQueryEnabled: false });
+      expect(results).toEqual([]);
+    });
+  });
+});
+
+// ============================================================================
+// Tests - Mutation Generators with reactQueryEnabled: true (default)
+// ============================================================================
+
+describe('Mutation generators with reactQueryEnabled: true (default)', () => {
+  describe('generateCreateMutationHook', () => {
+    it('should return mutation file by default', () => {
+      const result = generateCreateMutationHook(userTable);
+      expect(result).not.toBeNull();
+      expect(result!.content).toContain('useMutation');
+    });
+  });
+
+  describe('generateAllMutationHooks', () => {
+    it('should return mutation files by default', () => {
+      const results = generateAllMutationHooks([userTable]);
+      expect(results.length).toBeGreaterThan(0);
+    });
+  });
+});
+
+// ============================================================================
+// Tests - Custom Query Generators with reactQueryEnabled: false
+// ============================================================================
+
+describe('Custom query generators with reactQueryEnabled: false', () => {
+  describe('generateCustomQueryHook', () => {
+    it('should not include React Query imports when disabled', () => {
+      const result = generateCustomQueryHook({
+        operation: sampleQueryOperation,
+        typeRegistry: emptyTypeRegistry,
+        reactQueryEnabled: false,
+      });
+      expect(result.content).not.toContain('@tanstack/react-query');
+      expect(result.content).not.toContain('useQuery');
+    });
+
+    it('should not include useXxxQuery hook when disabled', () => {
+      const result = generateCustomQueryHook({
+        operation: sampleQueryOperation,
+        typeRegistry: emptyTypeRegistry,
+        reactQueryEnabled: false,
+      });
+      expect(result.content).not.toContain('export function useCurrentUserQuery');
+    });
+
+    it('should still include standalone fetch function when disabled', () => {
+      const result = generateCustomQueryHook({
+        operation: sampleQueryOperation,
+        typeRegistry: emptyTypeRegistry,
+        reactQueryEnabled: false,
+      });
+      expect(result.content).toContain('export async function fetchCurrentUserQuery');
+    });
+  });
+
+  describe('generateAllCustomQueryHooks', () => {
+    it('should generate files without React Query when disabled', () => {
+      const results = generateAllCustomQueryHooks({
+        operations: [sampleQueryOperation],
+        typeRegistry: emptyTypeRegistry,
+        reactQueryEnabled: false,
+      });
+      expect(results.length).toBe(1);
+      expect(results[0].content).not.toContain('@tanstack/react-query');
+    });
+  });
+});
+
+// ============================================================================
+// Tests - Custom Mutation Generators with reactQueryEnabled: false
+// ============================================================================
+
+describe('Custom mutation generators with reactQueryEnabled: false', () => {
+  describe('generateCustomMutationHook', () => {
+    it('should return null when disabled', () => {
+      const result = generateCustomMutationHook({
+        operation: sampleMutationOperation,
+        typeRegistry: emptyTypeRegistry,
+        reactQueryEnabled: false,
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('generateAllCustomMutationHooks', () => {
+    it('should return empty array when disabled', () => {
+      const results = generateAllCustomMutationHooks({
+        operations: [sampleMutationOperation],
+        typeRegistry: emptyTypeRegistry,
+        reactQueryEnabled: false,
+      });
+      expect(results).toEqual([]);
+    });
+  });
+});
+
+// ============================================================================
+// Tests - Custom Mutation Generators with reactQueryEnabled: true (default)
+// ============================================================================
+
+describe('Custom mutation generators with reactQueryEnabled: true (default)', () => {
+  describe('generateCustomMutationHook', () => {
+    it('should return mutation file by default', () => {
+      const result = generateCustomMutationHook({
+        operation: sampleMutationOperation,
+        typeRegistry: emptyTypeRegistry,
+      });
+      expect(result).not.toBeNull();
+      expect(result!.content).toContain('useMutation');
+    });
+  });
+});

--- a/graphql/codegen/src/cli/codegen/custom-mutations.ts
+++ b/graphql/codegen/src/cli/codegen/custom-mutations.ts
@@ -51,15 +51,23 @@ export interface GenerateCustomMutationHookOptions {
   typeRegistry: TypeRegistry;
   maxDepth?: number;
   skipQueryField?: boolean;
+  /** Whether to generate React Query hooks (default: true for backwards compatibility) */
+  reactQueryEnabled?: boolean;
 }
 
 /**
  * Generate a custom mutation hook file
+ * When reactQueryEnabled is false, returns null since mutations require React Query
  */
 export function generateCustomMutationHook(
   options: GenerateCustomMutationHookOptions
-): GeneratedCustomMutationFile {
-  const { operation } = options;
+): GeneratedCustomMutationFile | null {
+  const { operation, reactQueryEnabled = true } = options;
+
+  // Mutations require React Query - skip generation when disabled
+  if (!reactQueryEnabled) {
+    return null;
+  }
 
   try {
     return generateCustomMutationHookInternal(options);
@@ -229,15 +237,18 @@ export interface GenerateAllCustomMutationHooksOptions {
   typeRegistry: TypeRegistry;
   maxDepth?: number;
   skipQueryField?: boolean;
+  /** Whether to generate React Query hooks (default: true for backwards compatibility) */
+  reactQueryEnabled?: boolean;
 }
 
 /**
  * Generate all custom mutation hook files
+ * When reactQueryEnabled is false, returns empty array since mutations require React Query
  */
 export function generateAllCustomMutationHooks(
   options: GenerateAllCustomMutationHooksOptions
 ): GeneratedCustomMutationFile[] {
-  const { operations, typeRegistry, maxDepth = 2, skipQueryField = true } = options;
+  const { operations, typeRegistry, maxDepth = 2, skipQueryField = true, reactQueryEnabled = true } = options;
 
   return operations
     .filter((op) => op.kind === 'mutation')
@@ -247,6 +258,8 @@ export function generateAllCustomMutationHooks(
         typeRegistry,
         maxDepth,
         skipQueryField,
+        reactQueryEnabled,
       })
-    );
+    )
+    .filter((result): result is GeneratedCustomMutationFile => result !== null);
 }

--- a/graphql/codegen/src/cli/codegen/index.ts
+++ b/graphql/codegen/src/cli/codegen/index.ts
@@ -100,6 +100,7 @@ export function generate(options: GenerateOptions): GenerateResult {
   // Extract codegen options
   const maxDepth = config.codegen.maxFieldDepth;
   const skipQueryField = config.codegen.skipQueryField;
+  const reactQueryEnabled = config.reactQuery.enabled;
 
   // 1. Generate client.ts
   files.push({
@@ -114,7 +115,7 @@ export function generate(options: GenerateOptions): GenerateResult {
   });
 
   // 3. Generate table-based query hooks (queries/*.ts)
-  const queryHooks = generateAllQueryHooks(tables);
+  const queryHooks = generateAllQueryHooks(tables, { reactQueryEnabled });
   for (const hook of queryHooks) {
     files.push({
       path: `queries/${hook.fileName}`,
@@ -130,6 +131,7 @@ export function generate(options: GenerateOptions): GenerateResult {
       typeRegistry: customOperations.typeRegistry,
       maxDepth,
       skipQueryField,
+      reactQueryEnabled,
     });
 
     for (const hook of customQueryHooks) {
@@ -149,7 +151,7 @@ export function generate(options: GenerateOptions): GenerateResult {
   });
 
   // 6. Generate table-based mutation hooks (mutations/*.ts)
-  const mutationHooks = generateAllMutationHooks(tables);
+  const mutationHooks = generateAllMutationHooks(tables, { reactQueryEnabled });
   for (const hook of mutationHooks) {
     files.push({
       path: `mutations/${hook.fileName}`,
@@ -165,6 +167,7 @@ export function generate(options: GenerateOptions): GenerateResult {
       typeRegistry: customOperations.typeRegistry,
       maxDepth,
       skipQueryField,
+      reactQueryEnabled,
     });
 
     for (const hook of customMutationHooks) {

--- a/graphql/codegen/src/cli/codegen/mutations.ts
+++ b/graphql/codegen/src/cli/codegen/mutations.ts
@@ -46,14 +46,29 @@ export interface GeneratedMutationFile {
   content: string;
 }
 
+export interface MutationGeneratorOptions {
+  /** Whether to generate React Query hooks (default: true for backwards compatibility) */
+  reactQueryEnabled?: boolean;
+}
+
 // ============================================================================
 // Create mutation hook generator
 // ============================================================================
 
 /**
  * Generate create mutation hook file content using AST
+ * When reactQueryEnabled is false, returns null since mutations require React Query
  */
-export function generateCreateMutationHook(table: CleanTable): GeneratedMutationFile {
+export function generateCreateMutationHook(
+  table: CleanTable,
+  options: MutationGeneratorOptions = {}
+): GeneratedMutationFile | null {
+  const { reactQueryEnabled = true } = options;
+
+  // Mutations require React Query - skip generation when disabled
+  if (!reactQueryEnabled) {
+    return null;
+  }
   const project = createProject();
   const { typeName, singularName } = getTableNames(table);
   const hookName = getCreateMutationHookName(table);
@@ -208,8 +223,19 @@ mutate({
 
 /**
  * Generate update mutation hook file content using AST
+ * When reactQueryEnabled is false, returns null since mutations require React Query
  */
-export function generateUpdateMutationHook(table: CleanTable): GeneratedMutationFile | null {
+export function generateUpdateMutationHook(
+  table: CleanTable,
+  options: MutationGeneratorOptions = {}
+): GeneratedMutationFile | null {
+  const { reactQueryEnabled = true } = options;
+
+  // Mutations require React Query - skip generation when disabled
+  if (!reactQueryEnabled) {
+    return null;
+  }
+
   // Check if update mutation exists
   if (table.query?.update === null) {
     return null;
@@ -369,8 +395,19 @@ mutate({
 
 /**
  * Generate delete mutation hook file content using AST
+ * When reactQueryEnabled is false, returns null since mutations require React Query
  */
-export function generateDeleteMutationHook(table: CleanTable): GeneratedMutationFile | null {
+export function generateDeleteMutationHook(
+  table: CleanTable,
+  options: MutationGeneratorOptions = {}
+): GeneratedMutationFile | null {
+  const { reactQueryEnabled = true } = options;
+
+  // Mutations require React Query - skip generation when disabled
+  if (!reactQueryEnabled) {
+    return null;
+  }
+
   // Check if delete mutation exists
   if (table.query?.delete === null) {
     return null;
@@ -504,19 +541,26 @@ mutate({
 
 /**
  * Generate all mutation hook files for all tables
+ * When reactQueryEnabled is false, returns empty array since mutations require React Query
  */
-export function generateAllMutationHooks(tables: CleanTable[]): GeneratedMutationFile[] {
+export function generateAllMutationHooks(
+  tables: CleanTable[],
+  options: MutationGeneratorOptions = {}
+): GeneratedMutationFile[] {
   const files: GeneratedMutationFile[] = [];
 
   for (const table of tables) {
-    files.push(generateCreateMutationHook(table));
+    const createHook = generateCreateMutationHook(table, options);
+    if (createHook) {
+      files.push(createHook);
+    }
 
-    const updateHook = generateUpdateMutationHook(table);
+    const updateHook = generateUpdateMutationHook(table, options);
     if (updateHook) {
       files.push(updateHook);
     }
 
-    const deleteHook = generateDeleteMutationHook(table);
+    const deleteHook = generateDeleteMutationHook(table, options);
     if (deleteHook) {
       files.push(deleteHook);
     }

--- a/graphql/codegen/src/types/config.ts
+++ b/graphql/codegen/src/types/config.ts
@@ -108,6 +108,19 @@ export interface GraphQLSDKConfig {
   };
 
   /**
+   * React Query integration options
+   * Controls whether React Query hooks are generated
+   */
+  reactQuery?: {
+    /**
+     * Whether to generate React Query hooks (useQuery, useMutation)
+     * When false, only standalone fetch functions are generated (no React dependency)
+     * @default false
+     */
+    enabled?: boolean;
+  };
+
+  /**
    * Watch mode configuration (dev-only feature)
    * When enabled via CLI --watch flag, the CLI will poll the endpoint for schema changes
    */
@@ -160,7 +173,7 @@ export interface ResolvedWatchConfig {
 /**
  * Resolved configuration with defaults applied
  */
-export interface ResolvedConfig extends Required<Omit<GraphQLSDKConfig, 'headers' | 'tables' | 'queries' | 'mutations' | 'hooks' | 'postgraphile' | 'codegen' | 'orm' | 'watch'>> {
+export interface ResolvedConfig extends Required<Omit<GraphQLSDKConfig, 'headers' | 'tables' | 'queries' | 'mutations' | 'hooks' | 'postgraphile' | 'codegen' | 'orm' | 'reactQuery' | 'watch'>> {
   headers: Record<string, string>;
   tables: {
     include: string[];
@@ -190,6 +203,9 @@ export interface ResolvedConfig extends Required<Omit<GraphQLSDKConfig, 'headers
     output: string;
     useSharedTypes: boolean;
   } | null;
+  reactQuery: {
+    enabled: boolean;
+  };
   watch: ResolvedWatchConfig;
 }
 
@@ -235,6 +251,9 @@ export const DEFAULT_CONFIG: Omit<ResolvedConfig, 'endpoint'> = {
     skipQueryField: true,
   },
   orm: null, // ORM generation disabled by default
+  reactQuery: {
+    enabled: false, // React Query hooks disabled by default
+  },
   watch: DEFAULT_WATCH_CONFIG,
 };
 
@@ -292,6 +311,9 @@ export function resolveConfig(config: GraphQLSDKConfig): ResolvedConfig {
           useSharedTypes: config.orm.useSharedTypes ?? DEFAULT_ORM_CONFIG.useSharedTypes,
         }
       : null,
+    reactQuery: {
+      enabled: config.reactQuery?.enabled ?? DEFAULT_CONFIG.reactQuery.enabled,
+    },
     watch: {
       pollInterval: config.watch?.pollInterval ?? DEFAULT_WATCH_CONFIG.pollInterval,
       debounce: config.watch?.debounce ?? DEFAULT_WATCH_CONFIG.debounce,


### PR DESCRIPTION
## Summary

Adds a `reactQuery.enabled` configuration option to control whether React Query hooks are generated. When disabled (the default), only standalone fetch functions are generated, removing the React/React Query dependency from generated code.

**Key changes:**
- New `reactQuery.enabled` config option (defaults to `false`)
- Query generators conditionally skip `useQuery` hooks and React Query imports when disabled
- Mutation generators return `null` when disabled (mutations require React Query)
- Standalone `fetchXxxQuery` functions are always generated regardless of setting
- README updated to fix incorrect package name (`@constructive-io/graphql-sdk` → `@constructive-io/graphql-codegen`) and added header/badges to match other packages

## Review & Testing Checklist for Human

- [ ] **BREAKING CHANGE**: Verify that `reactQuery.enabled: false` as the default is intentional. Existing users upgrading will no longer get React Query hooks unless they explicitly set `reactQuery: { enabled: true }` in their config.
- [ ] Verify mutation behavior is acceptable: when React Query is disabled, NO mutation files are generated at all (not just hooks removed)
- [ ] Test full codegen pipeline end-to-end with both `reactQuery.enabled: true` and `reactQuery.enabled: false` to ensure generated code compiles and works correctly
- [ ] Confirm the README package name fix from `@constructive-io/graphql-sdk` to `@constructive-io/graphql-codegen` is correct

**Recommended test plan:**
1. Run codegen against a real PostGraphile endpoint with `reactQuery: { enabled: false }`
2. Verify generated query files have `fetchXxxQuery` but no `useXxxQuery` or React Query imports
3. Verify no mutation files are generated
4. Run codegen with `reactQuery: { enabled: true }` and verify hooks are generated
5. Ensure generated TypeScript compiles without errors in both cases

### Notes

Link to Devin run: https://app.devin.ai/sessions/87a0177b0e6a4c6cbd85f27e62e732df
Requested by: Dan Lynch (@pyramation)