### PR TITLE
feat(pgpm): support non-pgpm templates in init command

### DIFF
--- a/pgpm/cli/src/commands/init/index.ts
+++ b/pgpm/cli/src/commands/init/index.ts
@@ -16,7 +16,7 @@ import { CLIOptions, Inquirerer, OptionValue, Question, registerDefaultResolver 
 
 const DEFAULT_MOTD = `
                  |              _   _
-    ===         |.===.        '\\-//\`
+     ===         |.===.        '\\-//\`
     (o o)        {}o o{}        (o o)
 ooO--(_)--Ooo-ooO--(_)--Ooo-ooO--(_)--Ooo-
 `;

--- a/pgpm/core/src/core/boilerplate-scanner.ts
+++ b/pgpm/core/src/core/boilerplate-scanner.ts
@@ -74,11 +74,20 @@ export function scanBoilerplates(baseDir: string): ScannedBoilerplate[] {
     const config = readBoilerplateConfig(boilerplatePath);
 
     if (config) {
+      // Validate and normalize the type field
+      const validTypes = ['workspace', 'module', 'generic'] as const;
+      const configType = config.type as string;
+      const type: 'workspace' | 'module' | 'generic' = validTypes.includes(configType as any) 
+        ? (configType as 'workspace' | 'module' | 'generic')
+        : 'module';
+
       boilerplates.push({
         name: entry.name,
         path: boilerplatePath,
-        type: config.type ?? 'module',
-        questions: config.questions
+        type,
+        pgpm: config.pgpm,
+        requiresWorkspace: config.requiresWorkspace,
+        questions: config.questions as ScannedBoilerplate['questions']
       });
     }
   }

--- a/pgpm/core/src/core/boilerplate-scanner.ts
+++ b/pgpm/core/src/core/boilerplate-scanner.ts
@@ -81,12 +81,24 @@ export function scanBoilerplates(baseDir: string): ScannedBoilerplate[] {
         ? (configType as 'workspace' | 'module' | 'generic')
         : 'module';
 
+      // Validate and normalize requiresWorkspace field
+      const validWorkspaceTypes = ['pgpm', 'pnpm', 'lerna', 'npm'] as const;
+      let requiresWorkspace: ScannedBoilerplate['requiresWorkspace'];
+      if (config.requiresWorkspace === false) {
+        requiresWorkspace = false;
+      } else if (typeof config.requiresWorkspace === 'string' && 
+                 validWorkspaceTypes.includes(config.requiresWorkspace as any)) {
+        requiresWorkspace = config.requiresWorkspace as 'pgpm' | 'pnpm' | 'lerna' | 'npm';
+      } else {
+        // Default: 'pgpm' for module type (backward compatibility), undefined for others
+        requiresWorkspace = type === 'module' ? 'pgpm' : undefined;
+      }
+
       boilerplates.push({
         name: entry.name,
         path: boilerplatePath,
         type,
-        pgpm: config.pgpm,
-        requiresWorkspace: config.requiresWorkspace,
+        requiresWorkspace,
         questions: config.questions as ScannedBoilerplate['questions']
       });
     }

--- a/pgpm/core/src/core/boilerplate-types.ts
+++ b/pgpm/core/src/core/boilerplate-types.ts
@@ -3,6 +3,10 @@
  * These types support the `.boilerplate.json` and `.boilerplates.json` configuration files.
  */
 
+// Re-export BoilerplateConfig from template-scaffold to avoid duplication
+// The extended type in template-scaffold adds pgpm-specific fields to the genomic base type
+export type { BoilerplateConfig } from './template-scaffold';
+
 /**
  * A question to prompt the user during template scaffolding.
  */
@@ -26,17 +30,6 @@ export interface BoilerplateQuestion {
 }
 
 /**
- * Configuration for a single boilerplate template.
- * Stored in `.boilerplate.json` within each template directory.
- */
-export interface BoilerplateConfig {
-  /** The type of boilerplate: workspace or module */
-  type: 'workspace' | 'module';
-  /** Questions to prompt the user during scaffolding */
-  questions?: BoilerplateQuestion[];
-}
-
-/**
  * Root configuration for a boilerplates repository.
  * Stored in `.boilerplates.json` at the repository root.
  */
@@ -54,7 +47,11 @@ export interface ScannedBoilerplate {
   /** The full path to the boilerplate directory */
   path: string;
   /** The type of boilerplate */
-  type: 'workspace' | 'module';
+  type: 'workspace' | 'module' | 'generic';
+  /** Whether this is a pgpm-managed template */
+  pgpm?: boolean;
+  /** Whether this template requires being inside a workspace */
+  requiresWorkspace?: boolean;
   /** Questions from the boilerplate config */
   questions?: BoilerplateQuestion[];
 }

--- a/pgpm/core/src/core/boilerplate-types.ts
+++ b/pgpm/core/src/core/boilerplate-types.ts
@@ -3,9 +3,9 @@
  * These types support the `.boilerplate.json` and `.boilerplates.json` configuration files.
  */
 
-// Re-export BoilerplateConfig from template-scaffold to avoid duplication
-// The extended type in template-scaffold adds pgpm-specific fields to the genomic base type
-export type { BoilerplateConfig } from './template-scaffold';
+// Re-export BoilerplateConfig and WorkspaceType from template-scaffold to avoid duplication
+// The extended type in template-scaffold adds workspace requirement field to the genomic base type
+export type { BoilerplateConfig, WorkspaceType } from './template-scaffold';
 
 /**
  * A question to prompt the user during template scaffolding.
@@ -48,10 +48,11 @@ export interface ScannedBoilerplate {
   path: string;
   /** The type of boilerplate */
   type: 'workspace' | 'module' | 'generic';
-  /** Whether this is a pgpm-managed template */
-  pgpm?: boolean;
-  /** Whether this template requires being inside a workspace */
-  requiresWorkspace?: boolean;
+  /** 
+   * What type of workspace this template requires.
+   * 'pgpm' also indicates pgpm files should be created.
+   */
+  requiresWorkspace?: 'pgpm' | 'pnpm' | 'lerna' | 'npm' | false;
   /** Questions from the boilerplate config */
   questions?: BoilerplateQuestion[];
 }

--- a/pgpm/core/src/core/class/pgpm.ts
+++ b/pgpm/core/src/core/class/pgpm.ts
@@ -124,6 +124,11 @@ export interface InitModuleOptions {
    * Must be an absolute path or relative to workspace root.
    */
   outputDir?: string;
+  /**
+   * Whether this is a pgpm-managed module that should create pgpm.plan and .control files.
+   * Defaults to true for backward compatibility.
+   */
+  pgpm?: boolean;
 }
 
 export class PgpmPackage {
@@ -436,6 +441,9 @@ export class PgpmPackage {
   async initModule(options: InitModuleOptions): Promise<void> {
     this.ensureWorkspace();
     
+    // Determine if this is a pgpm-managed module (defaults to true for backward compatibility)
+    const isPgpmModule = options.pgpm ?? true;
+    
     // If outputDir is provided, use it directly instead of createModuleDirectory
     let targetPath: string;
     if (options.outputDir) {
@@ -471,8 +479,11 @@ export class PgpmPackage {
       cwd: this.cwd
     });
 
-    this.initModuleSqitch(options.name, targetPath);
-    writeExtensions(targetPath, options.extensions);
+    // Only create pgpm files (pgpm.plan, .control, deploy/revert/verify dirs) for pgpm-managed modules
+    if (isPgpmModule) {
+      this.initModuleSqitch(options.name, targetPath);
+      writeExtensions(targetPath, options.extensions);
+    }
   }
 
   // ──────────────── Dependency Analysis ────────────────

--- a/pgpm/core/src/core/template-scaffold.ts
+++ b/pgpm/core/src/core/template-scaffold.ts
@@ -1,7 +1,24 @@
 import os from 'os';
 import path from 'path';
-import { TemplateScaffolder, BoilerplateConfig } from 'genomic';
+import { TemplateScaffolder, BoilerplateConfig as GenomicBoilerplateConfig } from 'genomic';
 import type { Inquirerer, Question } from 'inquirerer';
+
+/**
+ * Extended BoilerplateConfig that adds pgpm-specific fields.
+ * These fields control whether pgpm-specific files are created and workspace requirements.
+ */
+export interface BoilerplateConfig extends GenomicBoilerplateConfig {
+  /** 
+   * Whether this is a pgpm-managed template that creates pgpm.plan and .control files.
+   * Defaults to true for 'workspace' and 'module' types, false for 'generic'.
+   */
+  pgpm?: boolean;
+  /**
+   * Whether this template requires being inside a pgpm workspace.
+   * Defaults to true for 'module' type, false for 'workspace' and 'generic'.
+   */
+  requiresWorkspace?: boolean;
+}
 
 export interface InspectTemplateOptions {
   /**

--- a/pgpm/core/src/core/template-scaffold.ts
+++ b/pgpm/core/src/core/template-scaffold.ts
@@ -4,20 +4,31 @@ import { TemplateScaffolder, BoilerplateConfig as GenomicBoilerplateConfig } fro
 import type { Inquirerer, Question } from 'inquirerer';
 
 /**
- * Extended BoilerplateConfig that adds pgpm-specific fields.
- * These fields control whether pgpm-specific files are created and workspace requirements.
+ * Supported workspace types for template requirements.
+ * - 'pgpm': Requires pgpm workspace (pgpm.json/pgpm.config.js) and creates pgpm.plan/.control files
+ * - 'pnpm': Requires pnpm workspace (pnpm-workspace.yaml)
+ * - 'lerna': Requires lerna workspace (lerna.json)
+ * - 'npm': Requires npm workspace (package.json with workspaces field)
+ * - false: No workspace required, can be scaffolded anywhere
+ */
+export type WorkspaceType = 'pgpm' | 'pnpm' | 'lerna' | 'npm' | false;
+
+/**
+ * Extended BoilerplateConfig that adds workspace requirement field.
+ * This field controls both workspace detection and whether pgpm-specific files are created.
  */
 export interface BoilerplateConfig extends GenomicBoilerplateConfig {
-  /** 
-   * Whether this is a pgpm-managed template that creates pgpm.plan and .control files.
-   * Defaults to true for 'workspace' and 'module' types, false for 'generic'.
-   */
-  pgpm?: boolean;
   /**
-   * Whether this template requires being inside a pgpm workspace.
-   * Defaults to true for 'module' type, false for 'workspace' and 'generic'.
+   * Specifies what type of workspace this template requires.
+   * - 'pgpm': Requires pgpm workspace AND creates pgpm.plan/.control files
+   * - 'pnpm': Requires pnpm workspace (pnpm-workspace.yaml), no pgpm files
+   * - 'lerna': Requires lerna workspace (lerna.json), no pgpm files
+   * - 'npm': Requires npm workspace (package.json with workspaces), no pgpm files
+   * - false: No workspace required, no pgpm files
+   * 
+   * Defaults to 'pgpm' for 'module' type (backward compatibility), false for others.
    */
-  requiresWorkspace?: boolean;
+  requiresWorkspace?: WorkspaceType;
 }
 
 export interface InspectTemplateOptions {

--- a/pgpm/env/src/index.ts
+++ b/pgpm/env/src/index.ts
@@ -1,5 +1,15 @@
 export { getEnvOptions, getConnEnvOptions, getDeploymentEnvOptions } from './merge';
-export { loadConfigSync, loadConfigSyncFromDir, loadConfigFileSync, resolvePgpmPath } from './config';
+export { 
+  loadConfigSync, 
+  loadConfigSyncFromDir, 
+  loadConfigFileSync, 
+  resolvePgpmPath,
+  resolvePnpmWorkspace,
+  resolveLernaWorkspace,
+  resolveNpmWorkspace,
+  resolveWorkspaceByType
+} from './config';
+export type { WorkspaceType } from './config';
 export { getEnvVars, getNodeEnv, parseEnvBoolean } from './env';
 export { walkUp, mergeArraysUnique } from './utils';
 


### PR DESCRIPTION
## Summary

Extends the `pgpm init` command to support non-pgpm templates by adding a new `requiresWorkspace` field to `.boilerplate.json` that specifies what type of workspace a template requires:

```typescript
requiresWorkspace?: 'pgpm' | 'pnpm' | 'lerna' | 'npm' | false
```

**Behavior:**
- `'pgpm'` (default for module type): Requires pgpm workspace AND creates `pgpm.plan`, `.control`, and `deploy/revert/verify` directories
- `'pnpm'` / `'lerna'` / `'npm'`: Requires respective workspace type, no pgpm files created
- `false`: No workspace required, can scaffold anywhere, no pgpm files

This replaces the earlier two-field approach (`pgpm` + `requiresWorkspace` booleans) with a single, cleaner field.

**Key changes:**
- Added `WorkspaceType` union type and extended `BoilerplateConfig` in `template-scaffold.ts`
- Updated `boilerplate-scanner.ts` to validate and normalize the `requiresWorkspace` field with proper defaults
- Updated `handleModuleInit` to derive `isPgpmTemplate` from `requiresWorkspace === 'pgpm'`
- Updated `PgpmPackage.initModule` to conditionally skip pgpm file creation based on `pgpm` flag
- Added new code path for direct scaffolding when not in a workspace
- **Added workspace detection functions to `@pgpmjs/env`** for pnpm, lerna, and npm workspaces (alongside existing `resolvePgpmPath`)

## Updates since last revision

- **Refactored workspace detection to `@pgpmjs/env`**: Moved workspace detection functions from CLI to the env package for better reusability and consistency with existing `resolvePgpmPath` function
- Added `resolvePnpmWorkspace` (looks for `pnpm-workspace.yaml`)
- Added `resolveLernaWorkspace` (looks for `lerna.json`)
- Added `resolveNpmWorkspace` (looks for `package.json` with workspaces field)
- Added `resolveWorkspaceByType` dispatcher function
- Exported `WorkspaceType` type from `@pgpmjs/env`
- CLI now imports and uses `resolveWorkspaceByType` from `@pgpmjs/env` instead of local implementations

## Review & Testing Checklist for Human

- [ ] **Verify workspace detection imports work**: The CLI now imports `resolveWorkspaceByType` from `@pgpmjs/env` - verify this works at runtime
- [ ] **Test pnpm workspace detection**: Create a template with `"requiresWorkspace": "pnpm"` and verify it correctly detects `pnpm-workspace.yaml` in parent directories
- [ ] **Test lerna workspace detection**: Verify `lerna.json` detection works correctly
- [ ] **Test npm workspace detection**: Verify detection of `package.json` with `workspaces` field works
- [ ] **Verify backward compatibility**: Run `pgpm init` with existing templates (without the new field) to confirm they still create pgpm.plan and .control files as expected

**Recommended test plan:**
1. In an existing pgpm workspace, run `pgpm init` with a standard module template - should work as before
2. In a pnpm workspace (with `pnpm-workspace.yaml`), try a template with `"requiresWorkspace": "pnpm"` - should succeed
3. Outside any workspace, try `pgpm init` with a template that has `"requiresWorkspace": false` - should scaffold without errors
4. Outside a pnpm workspace, try a template with `"requiresWorkspace": "pnpm"` - should show "Not inside a PNPM workspace" error (no offer to create workspace)

### Notes

This PR is part of a two-repo change. The companion PR for `pgpm-boilerplates` (#21) updates existing templates to use the new `requiresWorkspace` format.

Link to Devin run: https://app.devin.ai/sessions/d1d032371bf64d3ba45c1d134004d34c
Requested by: Dan Lynch (@pyramation)