### PR TITLE
feat(csv-to-pg): add conflictDoNothing option for ON CONFLICT DO NOTHING

### DIFF
--- a/packages/csv-to-pg/__tests__/csv2pg.test.ts
+++ b/packages/csv-to-pg/__tests__/csv2pg.test.ts
@@ -15,6 +15,78 @@ const testCase = resolve(__dirname + '/../__fixtures__/test-case.csv');
 it('noop', () => {
   expect(true).toBe(true);
 });
+
+describe('conflictDoNothing', () => {
+  it('InsertOne with conflictDoNothing generates ON CONFLICT DO NOTHING AST', () => {
+    const config = {
+      schema: 'my-schema',
+      table: 'my-table',
+      fields: {
+        name: 'text'
+      }
+    };
+    const types = parseTypes(config);
+    const stmt = InsertOne({
+      schema: config.schema,
+      table: config.table,
+      types,
+      record: { name: 'test' },
+      conflictDoNothing: true
+    });
+
+    // Verify the AST contains the ON CONFLICT DO NOTHING clause
+    expect(stmt.RawStmt.stmt.InsertStmt.onConflictClause).toEqual({
+      action: 'ONCONFLICT_NOTHING'
+    });
+  });
+
+  it('InsertMany with conflictDoNothing generates ON CONFLICT DO NOTHING AST', () => {
+    const config = {
+      schema: 'my-schema',
+      table: 'my-table',
+      fields: {
+        name: 'text'
+      }
+    };
+    const types = parseTypes(config);
+    const stmt = InsertMany({
+      schema: config.schema,
+      table: config.table,
+      types,
+      records: [
+        { name: 'test1' },
+        { name: 'test2' }
+      ],
+      conflictDoNothing: true
+    });
+
+    // Verify the AST contains the ON CONFLICT DO NOTHING clause
+    expect(stmt.RawStmt.stmt.InsertStmt.onConflictClause).toEqual({
+      action: 'ONCONFLICT_NOTHING'
+    });
+  });
+
+  it('InsertOne without conflictDoNothing has no conflict clause', () => {
+    const config = {
+      schema: 'my-schema',
+      table: 'my-table',
+      fields: {
+        name: 'text'
+      }
+    };
+    const types = parseTypes(config);
+    const stmt = InsertOne({
+      schema: config.schema,
+      table: config.table,
+      types,
+      record: { name: 'test' }
+    });
+
+    // Verify no conflict clause when conflictDoNothing is not set
+    expect(stmt.RawStmt.stmt.InsertStmt.onConflictClause).toBeUndefined();
+  });
+});
+
 xdescribe('Insert Many', () => {
   it('Insert Many', async () => {
     const config = {

--- a/packages/csv-to-pg/src/parser.ts
+++ b/packages/csv-to-pg/src/parser.ts
@@ -8,6 +8,7 @@ interface ParserConfig {
   table: string;
   singleStmts?: boolean;
   conflict?: string[];
+  conflictDoNothing?: boolean;
   headers?: string[];
   delimeter?: string;
   json?: boolean;
@@ -30,7 +31,7 @@ export class Parser {
 
   async parse(data?: Record<string, unknown>[]): Promise<string | void> {
     const config = this.config;
-    const { schema, table, singleStmts, conflict, headers, delimeter } = config;
+    const { schema, table, singleStmts, conflict, conflictDoNothing, headers, delimeter } = config;
 
     const opts: CsvOptions = {};
     if (headers) opts.headers = headers;
@@ -67,7 +68,8 @@ export class Parser {
           table,
           types,
           record,
-          conflict
+          conflict,
+          conflictDoNothing
         })
       );
       return deparse(stmts);
@@ -77,7 +79,8 @@ export class Parser {
         table,
         types,
         records,
-        conflict
+        conflict,
+        conflictDoNothing
       });
       return deparse([stmt]);
     }

--- a/pgpm/core/src/export/export-meta.ts
+++ b/pgpm/core/src/export/export-meta.ts
@@ -7,6 +7,7 @@ type FieldType = 'uuid' | 'uuid[]' | 'text' | 'text[]' | 'boolean' | 'image' | '
 interface TableConfig {
   schema: string;
   table: string;
+  conflictDoNothing?: boolean;
   fields: Record<string, FieldType>;
 }
 
@@ -57,6 +58,10 @@ const config: Record<string, TableConfig> = {
   field: {
     schema: 'metaschema_public',
     table: 'field',
+    // Use ON CONFLICT DO NOTHING to handle the unique constraint (databases_field_uniq_names_idx)
+    // which normalizes UUID field names by stripping suffixes like _id, _uuid, etc.
+    // This causes collisions when tables have both 'foo' (text) and 'foo_id' (uuid) columns.
+    conflictDoNothing: true,
     fields: {
       id: 'uuid',
       database_id: 'uuid',


### PR DESCRIPTION
# feat(csv-to-pg): add conflictDoNothing option for ON CONFLICT DO NOTHING

## Summary

Adds a new `conflictDoNothing` option to the csv-to-pg package that generates `ON CONFLICT DO NOTHING` without specifying conflict columns. This is needed when the unique constraint uses a functional index with complex expressions that cannot be specified as simple column names.

The immediate use case is the `metaschema_public.field` table, which has a unique constraint (`databases_field_uniq_names_idx`) that normalizes UUID field names by stripping suffixes like `_id`, `_uuid`, etc. This causes collisions when tables have both `foo` (text) and `foo_id` (uuid) columns - they normalize to the same hash value and violate the unique constraint during deployment.

**Changes:**
- `packages/csv-to-pg/src/utils.ts`: Add `conflictDoNothing` parameter to `makeConflictClause`, `InsertOne`, and `InsertMany`
- `packages/csv-to-pg/src/parser.ts`: Add `conflictDoNothing` to Parser config
- `pgpm/core/src/export/export-meta.ts`: Enable `conflictDoNothing: true` for the `field` table config
- Added unit tests for the new option

## Review & Testing Checklist for Human

- [ ] **Verify silent skip behavior is acceptable**: Using `ON CONFLICT DO NOTHING` means duplicate field records will be silently skipped. Confirm this is the desired behavior and no important data will be lost.
- [ ] **Test actual deployment flow**: Run `generate:constructive` in constructive-db and deploy to a test database to verify the fix resolves the unique constraint violation error.
- [ ] **Review if other tables need similar treatment**: Check if any other metaschema tables have similar functional index constraints that could cause collisions.

**Recommended test plan:**
```bash
# In constructive-db repo after updating to use new csv-to-pg
pnpm run generate:constructive
pgpm docker start
eval "$(pgpm env)"
createdb db1
pgpm deploy --yes --package constructive --database db1
pgpm deploy --yes --package constructive-services --database db1
# Should complete without unique constraint errors
```

### Notes

This PR is part of fixing the deployment issue reported in constructive-db where `generate:constructive` was exporting duplicate field entries that violated the `databases_field_uniq_names_idx` constraint.

Link to Devin run: https://app.devin.ai/sessions/7ea5e5e99b73424db6856e5d07482b64
Requested by: Dan Lynch (@pyramation)