### PR TITLE
refactor: rename api_schemata table to api_schemas

### DIFF
--- a/__fixtures__/output/schemas/services_public.ts
+++ b/__fixtures__/output/schemas/services_public.ts
@@ -38,18 +38,18 @@ export class api_modules implements api_modules {
     this.data = data.data;
   }
 }
-export interface api_schemata {
+export interface api_schemas {
   id: UUID;
   database_id: UUID;
   schema_id: UUID;
   api_id: UUID;
 }
-export class api_schemata implements api_schemata {
+export class api_schemas implements api_schemas {
   id: UUID;
   database_id: UUID;
   schema_id: UUID;
   api_id: UUID;
-  constructor(data: api_schemata) {
+  constructor(data: api_schemas) {
     this.id = data.id;
     this.database_id = data.database_id;
     this.schema_id = data.schema_id;

--- a/pgpm/core/__tests__/export/export-flow.test.ts
+++ b/pgpm/core/__tests__/export/export-flow.test.ts
@@ -303,7 +303,7 @@ insert_meta_schema [insert_sql_actions] 2017-08-11T08:11:53Z constructive <const
         dbname text
       );
 
-      CREATE TABLE IF NOT EXISTS services_public.api_schemata (
+      CREATE TABLE IF NOT EXISTS services_public.api_schemas (
         id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
         database_id uuid,
         schema_id uuid,
@@ -530,7 +530,7 @@ INSERT INTO services_public.sites (id, database_id, title, description, dbname) 
 INSERT INTO services_public.domains (id, database_id, domain, subdomain) VALUES
   ('dddd0001-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'localhost', 'pets');
 
-INSERT INTO services_public.api_schemata (id, database_id, schema_id, api_id) VALUES
+INSERT INTO services_public.api_schemas (id, database_id, schema_id, api_id) VALUES
   ('1111aaaa-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'aaaa0001-0000-0000-0000-000000000001', 'eeee0001-0000-0000-0000-000000000001');
 `;
   }

--- a/pgpm/core/__tests__/export/export-meta.test.ts
+++ b/pgpm/core/__tests__/export/export-meta.test.ts
@@ -70,7 +70,7 @@ describe('Export Meta Config Validation', () => {
         'site_themes',
         'api_modules',
         'api_extensions',
-        'api_schemata'
+        'api_schemas'
       ];
 
       for (const table of requiredTables) {
@@ -128,7 +128,7 @@ describe('Export Meta Config Drift Detection', () => {
       'apis',
       'api_extensions',
       'api_modules',
-      'api_schemata',
+      'api_schemas',
       'apps',
       'domains',
       'site_modules',

--- a/pgpm/core/src/export/export-meta.ts
+++ b/pgpm/core/src/export/export-meta.ts
@@ -353,9 +353,9 @@ const config: Record<string, TableConfig> = {
       schema_name: 'text'
     }
   },
-  api_schemata: {
+  api_schemas: {
     schema: 'services_public',
-    table: 'api_schemata',
+    table: 'api_schemas',
     fields: {
       id: 'uuid',
       database_id: 'uuid',
@@ -853,7 +853,7 @@ export const exportMeta = async ({ opts, dbname, database_id }: ExportMetaParams
   await queryAndParse('site_metadata', `SELECT * FROM services_public.site_metadata WHERE database_id = $1`);
   await queryAndParse('api_modules', `SELECT * FROM services_public.api_modules WHERE database_id = $1`);
   await queryAndParse('api_extensions', `SELECT * FROM services_public.api_extensions WHERE database_id = $1`);
-  await queryAndParse('api_schemata', `SELECT * FROM services_public.api_schemata WHERE database_id = $1`);
+  await queryAndParse('api_schemas', `SELECT * FROM services_public.api_schemas WHERE database_id = $1`);
 
   // =============================================================================
   // metaschema_modules_public tables


### PR DESCRIPTION
# refactor: rename api_schemata table to api_schemas

## Summary
Renames the `services_public.api_schemata` table reference to `api_schemas` throughout the `@pgpmjs/core` package. This change aligns with the corresponding rename in constructive-db (PR #266).

Changes include:
- Updated `export-meta.ts` config object and query to use `api_schemas`
- Updated test files with new table name in CREATE TABLE and INSERT statements
- Updated TypeScript fixture interface/class from `api_schemata` to `api_schemas`

## Review & Testing Checklist for Human
- [ ] Verify this PR is merged in coordination with constructive-db PR #266 - the database schema and this export code must stay in sync
- [ ] Run `pnpm test` in `pgpm/core` to ensure export tests pass with the new table name
- [ ] After both PRs merge, verify `generate:constructive` works correctly in constructive-db

### Notes
This is a companion PR to constructive-io/constructive-db#266. The `@pgpmjs/core` package's `exportMeta` function queries `services_public.api_schemas`, so this change must be coordinated with the database schema rename.

Link to Devin run: https://app.devin.ai/sessions/36fffff78c2b4fe29adf1221045c484c
Requested by: Dan Lynch (@pyramation)