### PR TITLE
fix: scope extension export query by database_id

### DIFF
--- a/pgpm/core/src/export/export-meta.ts
+++ b/pgpm/core/src/export/export-meta.ts
@@ -844,7 +844,7 @@ export const exportMeta = async ({ opts, dbname, database_id }: ExportMetaParams
   await queryAndParse('full_text_search', `SELECT * FROM metaschema_public.full_text_search WHERE database_id = $1`);
   await queryAndParse('schema_grant', `SELECT * FROM metaschema_public.schema_grant WHERE database_id = $1`);
   await queryAndParse('table_grant', `SELECT * FROM metaschema_public.table_grant WHERE database_id = $1`);
-  await queryAndParse('extension', `SELECT * FROM metaschema_public.extension`);
+  await queryAndParse('extension', `SELECT DISTINCT e.* FROM metaschema_public.extension e JOIN metaschema_public.database_extension de ON de.name = e.name WHERE de.database_id = $1`);
 
   // =============================================================================
   // services_public tables

--- a/pgpm/core/src/export/export-meta.ts
+++ b/pgpm/core/src/export/export-meta.ts
@@ -242,6 +242,7 @@ const config: Record<string, TableConfig> = {
     table: 'extension',
     fields: {
       id: 'uuid',
+      database_id: 'uuid',
       name: 'text'
     }
   },
@@ -844,7 +845,7 @@ export const exportMeta = async ({ opts, dbname, database_id }: ExportMetaParams
   await queryAndParse('full_text_search', `SELECT * FROM metaschema_public.full_text_search WHERE database_id = $1`);
   await queryAndParse('schema_grant', `SELECT * FROM metaschema_public.schema_grant WHERE database_id = $1`);
   await queryAndParse('table_grant', `SELECT * FROM metaschema_public.table_grant WHERE database_id = $1`);
-  await queryAndParse('extension', `SELECT DISTINCT e.* FROM metaschema_public.extension e JOIN metaschema_public.database_extension de ON de.name = e.name WHERE de.database_id = $1`);
+  await queryAndParse('extension', `SELECT * FROM metaschema_public.extension WHERE database_id = $1`);
 
   // =============================================================================
   // services_public tables


### PR DESCRIPTION
## Summary

The `extension` export query was not scoped by `database_id`, causing it to export all extensions globally instead of only those associated with the specific database being exported.

This fix adds the `WHERE database_id = $1` clause to the extension query, consistent with all other export queries in the file. Also added `database_id` to the extension config fields so the parser handles it correctly.

**Before:**
```sql
SELECT * FROM metaschema_public.extension
```

**After:**
```sql
SELECT * FROM metaschema_public.extension WHERE database_id = $1
```

## Review & Testing Checklist for Human

- [ ] **Verify `metaschema_public.extension` table has a `database_id` column** - the table schema needs this column for the query to work
- [ ] Test export functionality with a database to confirm extensions are properly scoped
- [ ] Verify the exported data includes the `database_id` field as expected

### Notes

Requested by Dan Lynch (@pyramation)

[Link to Devin run](https://app.devin.ai/sessions/95143461a8a64d0db0c481aa9d1bd1e7)