### PR TITLE
fix: remove extension table export (not scoped to database_id)

### DIFF
--- a/pgpm/core/src/export/export-meta.ts
+++ b/pgpm/core/src/export/export-meta.ts
@@ -237,16 +237,6 @@ const config: Record<string, TableConfig> = {
       privilege: 'text'
     }
   },
-  extension: {
-    schema: 'metaschema_public',
-    table: 'extension',
-    fields: {
-      id: 'uuid',
-      database_id: 'uuid',
-      name: 'text'
-    }
-  },
-
   // =============================================================================
   // services_public tables
   // =============================================================================
@@ -845,7 +835,6 @@ export const exportMeta = async ({ opts, dbname, database_id }: ExportMetaParams
   await queryAndParse('full_text_search', `SELECT * FROM metaschema_public.full_text_search WHERE database_id = $1`);
   await queryAndParse('schema_grant', `SELECT * FROM metaschema_public.schema_grant WHERE database_id = $1`);
   await queryAndParse('table_grant', `SELECT * FROM metaschema_public.table_grant WHERE database_id = $1`);
-  await queryAndParse('extension', `SELECT * FROM metaschema_public.extension WHERE database_id = $1`);
 
   // =============================================================================
   // services_public tables


### PR DESCRIPTION
## Summary

Removes the `metaschema_public.extension` table from the export-meta module. This table is a global lookup table with only `name`, `public_schemas`, and `private_schemas` columns - it does NOT have a `database_id` column.

The query `SELECT * FROM metaschema_public.extension WHERE database_id = $1` was causing the error: "column database_id does not exist" when running `generate:constructive`.

The `database_extension` table (which links databases to extensions and has `database_id`) is still being exported.

## Review & Testing Checklist for Human

- [ ] Verify that the `extension` table data is not needed in module exports (the `database_extension` join table should be sufficient)
- [ ] Run `pnpm run generate:constructive` from `packages/introspection` in constructive-db to confirm the error is resolved

### Notes

This is a follow-up fix to the v4.12.1 release which incorrectly added `WHERE database_id = $1` to the extension query (v4.12.0 had no WHERE clause but still passed parameters, causing a different error).

Requested by: @pyramation

Link to Devin run: https://app.devin.ai/sessions/cc59cbb72b7a4a73bbdcdc8859a2edf7