### PR TITLE
feat(export): generate separate meta.sql files per table type

### DIFF
--- a/pgpm/core/__tests__/export/__snapshots__/export-flow.test.ts.snap
+++ b/pgpm/core/__tests__/export/__snapshots__/export-flow.test.ts.snap
@@ -20,6 +20,9 @@ exports[`Export Flow E2E Export to second workspace should match snapshot for da
 exports[`Export Flow E2E Export to second workspace should match snapshot for service export deploy/ folder structure: pets-export-svc deploy folder 1`] = `
 [
   "migrate/",
-  "migrate/metaschema_public.sql",
+  "migrate/database.sql",
+  "migrate/field.sql",
+  "migrate/schema.sql",
+  "migrate/table.sql",
 ]
 `;

--- a/pgpm/core/__tests__/export/__snapshots__/export-flow.test.ts.snap
+++ b/pgpm/core/__tests__/export/__snapshots__/export-flow.test.ts.snap
@@ -20,6 +20,6 @@ exports[`Export Flow E2E Export to second workspace should match snapshot for da
 exports[`Export Flow E2E Export to second workspace should match snapshot for service export deploy/ folder structure: pets-export-svc deploy folder 1`] = `
 [
   "migrate/",
-  "migrate/meta.sql",
+  "migrate/metaschema_public.sql",
 ]
 `;

--- a/pgpm/core/__tests__/export/__snapshots__/export-flow.test.ts.snap
+++ b/pgpm/core/__tests__/export/__snapshots__/export-flow.test.ts.snap
@@ -20,9 +20,13 @@ exports[`Export Flow E2E Export to second workspace should match snapshot for da
 exports[`Export Flow E2E Export to second workspace should match snapshot for service export deploy/ folder structure: pets-export-svc deploy folder 1`] = `
 [
   "migrate/",
+  "migrate/api_schemas.sql",
+  "migrate/apis.sql",
   "migrate/database.sql",
+  "migrate/domains.sql",
   "migrate/field.sql",
   "migrate/schema.sql",
+  "migrate/sites.sql",
   "migrate/table.sql",
 ]
 `;

--- a/pgpm/core/__tests__/export/export-flow.test.ts
+++ b/pgpm/core/__tests__/export/export-flow.test.ts
@@ -738,17 +738,19 @@ relocatable = false
       
       const planContent = readFileSync(planPath, 'utf-8');
       expect(planContent).toContain('%project=' + META_EXTENSION_NAME);
-      expect(planContent).toContain('migrate/meta');
+      // Now generates separate files per table type instead of single meta.sql
+      expect(planContent).toContain('migrate/database');
     });
 
-    it('should have created deploy/migrate/meta.sql with collections data', () => {
-      const metaSqlPath = join(exportWorkspaceDir, 'packages', META_EXTENSION_NAME, 'deploy', 'migrate', 'meta.sql');
-      expect(existsSync(metaSqlPath)).toBe(true);
+    it('should have created deploy/migrate/*.sql files with collections data', () => {
+      // Now generates separate files per table type instead of single meta.sql
+      const databaseSqlPath = join(exportWorkspaceDir, 'packages', META_EXTENSION_NAME, 'deploy', 'migrate', 'database.sql');
+      expect(existsSync(databaseSqlPath)).toBe(true);
       
-      const metaContent = readFileSync(metaSqlPath, 'utf-8');
+      const databaseContent = readFileSync(databaseSqlPath, 'utf-8');
       // Should contain INSERT statements for meta tables
-      expect(metaContent).toContain('INSERT INTO');
-      expect(metaContent).toContain('session_replication_role');
+      expect(databaseContent).toContain('INSERT INTO');
+      expect(databaseContent).toContain('session_replication_role');
     });
 
     it('should have created control files for both modules', () => {

--- a/pgpm/core/src/export/export-meta.ts
+++ b/pgpm/core/src/export/export-meta.ts
@@ -784,72 +784,7 @@ interface ExportMetaParams {
   database_id: string;
 }
 
-export interface ExportMetaResult {
-  metaschema_public: string;
-  services_public: string;
-  metaschema_modules_public: string;
-}
-
-const METASCHEMA_PUBLIC_TABLES = [
-  'database',
-  'database_extension',
-  'schema',
-  'table',
-  'field',
-  'policy',
-  'index',
-  'trigger',
-  'trigger_function',
-  'rls_function',
-  'limit_function',
-  'procedure',
-  'foreign_key_constraint',
-  'primary_key_constraint',
-  'unique_constraint',
-  'check_constraint',
-  'full_text_search',
-  'schema_grant',
-  'table_grant'
-] as const;
-
-const SERVICES_PUBLIC_TABLES = [
-  'domains',
-  'sites',
-  'apis',
-  'apps',
-  'site_modules',
-  'site_themes',
-  'site_metadata',
-  'api_modules',
-  'api_extensions',
-  'api_schemas'
-] as const;
-
-const METASCHEMA_MODULES_PUBLIC_TABLES = [
-  'rls_module',
-  'user_auth_module',
-  'memberships_module',
-  'permissions_module',
-  'limits_module',
-  'levels_module',
-  'users_module',
-  'hierarchy_module',
-  'membership_types_module',
-  'invites_module',
-  'emails_module',
-  'tokens_module',
-  'secrets_module',
-  'profiles_module',
-  'encrypted_secrets_module',
-  'connected_accounts_module',
-  'phone_numbers_module',
-  'crypto_addresses_module',
-  'crypto_auth_module',
-  'field_module',
-  'uuid_module',
-  'default_ids_module',
-  'denormalized_table_field'
-] as const;
+export type ExportMetaResult = Record<string, string>;
 
 export const exportMeta = async ({ opts, dbname, database_id }: ExportMetaParams): Promise<ExportMetaResult> => {
   const pool = getPgPool({
@@ -944,16 +879,5 @@ export const exportMeta = async ({ opts, dbname, database_id }: ExportMetaParams
   await queryAndParse('default_ids_module', `SELECT * FROM metaschema_modules_public.default_ids_module WHERE database_id = $1`);
   await queryAndParse('denormalized_table_field', `SELECT * FROM metaschema_modules_public.denormalized_table_field WHERE database_id = $1`);
 
-  const collectSql = (tables: readonly string[]): string => {
-    return tables
-      .filter(key => sql[key])
-      .map(key => sql[key])
-      .join('\n\n');
-  };
-
-  return {
-    metaschema_public: collectSql(METASCHEMA_PUBLIC_TABLES),
-    services_public: collectSql(SERVICES_PUBLIC_TABLES),
-    metaschema_modules_public: collectSql(METASCHEMA_MODULES_PUBLIC_TABLES)
-  };
+  return sql;
 };


### PR DESCRIPTION
# feat(export): generate separate meta.sql files per table type

## Summary

Changes the metaschema export to generate individual SQL files for each table type instead of a single combined `meta.sql` file.

**Before:** Single `migrate/meta.sql` containing all INSERT statements for all table types concatenated together.

**After:** Separate files like `migrate/database.sql`, `migrate/schema.sql`, `migrate/table.sql`, `migrate/field.sql`, etc. - one for each table type that has content.

Key changes:
- `exportMeta()` now returns `Record<string, string>` mapping table names to their SQL
- `export-migrations.ts` iterates through all table types and creates individual files
- Dependencies are set up as a chain (each file depends on the previous one with content)

## Updates since last revision

- Fixed failing CI tests by updating assertions to expect `migrate/database` instead of `migrate/meta`
- Updated test snapshots to reflect new file structure (api_schemas.sql, apis.sql, database.sql, domains.sql, field.sql, schema.sql, sites.sql, table.sql)

## Review & Testing Checklist for Human

- [ ] **Verify dependency chain logic**: The current implementation creates a linear chain where each file depends on the previous. Confirm this is the desired deployment ordering (e.g., should `services_public` tables really depend on `table_grant`?)
- [ ] **Confirm requirements alignment**: User mentioned "should be a few" files - verify this implementation of ~50+ potential files matches expectations
- [ ] **Test export flow end-to-end**: Run the export against a real database with metaschema data and verify the generated files deploy correctly in order
- [ ] **Check removed TODO comment**: The original code had a commented-out TODO about security concerns with UPDATE statements for `apis`/`sites` dbname - this was removed in the refactor

### Notes

Requested by: @pyramation (Dan Lynch)
Devin session: https://app.devin.ai/sessions/c4099f9abe0f4a238b44d11bcd50d019

CI checks are now passing.