### PR TITLE
fix(csv-to-pg): add uuid[] and interval type support for proper PostgreSQL formatting

### DIFF
--- a/packages/csv-to-pg/__tests__/__snapshots__/export.test.ts.snap
+++ b/packages/csv-to-pg/__tests__/__snapshots__/export.test.ts.snap
@@ -26,6 +26,58 @@ exports[`test case image/attachment 1`] = `
 );"
 `;
 
+exports[`test case interval type 1`] = `
+"INSERT INTO metaschema_modules_public.tokens_module (
+  id,
+  database_id,
+  tokens_default_expiration,
+  tokens_table
+) VALUES
+(
+  '42aaba39-de20-4be0-95a1-4873d7d4b6d4',
+  '8e739194-ced7-479b-b46c-e6b06146ac11',
+  '24:00:00',
+  'api_tokens'
+);
+
+INSERT INTO metaschema_modules_public.tokens_module (
+  id,
+  database_id,
+  tokens_default_expiration,
+  tokens_table
+) VALUES
+(
+  '550e8400-e29b-41d4-a716-446655440000',
+  '8e739194-ced7-479b-b46c-e6b06146ac11',
+  '7 days 12:30:00',
+  'refresh_tokens'
+);
+
+INSERT INTO metaschema_modules_public.tokens_module (
+  id,
+  database_id,
+  tokens_default_expiration,
+  tokens_table
+) VALUES
+(
+  '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+  '8e739194-ced7-479b-b46c-e6b06146ac11',
+  '1 year 6 mons',
+  'long_lived_tokens'
+);"
+`;
+
+exports[`test case interval type with string value 1`] = `
+"INSERT INTO metaschema_modules_public.tokens_module (
+  id,
+  tokens_default_expiration
+) VALUES
+(
+  '42aaba39-de20-4be0-95a1-4873d7d4b6d4',
+  '1 day 02:30:00'
+);"
+`;
+
 exports[`test case jsonb/json 1`] = `
 "INSERT INTO metaschema_public.field (
   id,
@@ -55,5 +107,37 @@ exports[`test case test case parser 1`] = `
   '450e3b3b-b68d-4abc-990c-65cb8a1dcdb4',
   'name here',
   'description'
+);"
+`;
+
+exports[`test case uuid[] arrays 1`] = `
+"INSERT INTO metaschema_public.primary_key_constraint (
+  id,
+  database_id,
+  table_id,
+  name,
+  field_ids
+) VALUES
+(
+  'cdc96a32-572c-4f69-8bce-4c7bd4024a4e',
+  '8e739194-ced7-479b-b46c-e6b06146ac11',
+  '6616358d-8da8-45e4-834f-d735a0f02acc',
+  'object_pkey',
+  '{f853daae-f563-447d-ac09-901ddd68586e,a4257181-147d-4558-a51f-4b43246527a2}'
+);
+
+INSERT INTO metaschema_public.primary_key_constraint (
+  id,
+  database_id,
+  table_id,
+  name,
+  field_ids
+) VALUES
+(
+  '03d7007c-5262-4250-9ce1-efcabc5bedea',
+  '8e739194-ced7-479b-b46c-e6b06146ac11',
+  '535d5894-679a-4a7b-aa5a-bd07cce8a505',
+  'ref_pkey',
+  '{8cc2da93-a8e0-4565-9d14-f814c3a1432d,40a34889-eb4c-4833-8daf-b99441962971}'
 );"
 `;

--- a/packages/csv-to-pg/__tests__/export.test.ts
+++ b/packages/csv-to-pg/__tests__/export.test.ts
@@ -148,4 +148,96 @@ it('arrays', async () => {
 
   expect(sql).toMatchSnapshot();
   });
+
+it('uuid[] arrays', async () => {
+  const parser = new Parser({
+    schema: 'metaschema_public',
+    singleStmts: true,
+    table: 'primary_key_constraint',
+    fields: {
+      id: 'uuid',
+      database_id: 'uuid',
+      table_id: 'uuid',
+      name: 'text',
+      field_ids: 'uuid[]'
+    }
+  });
+
+  const sql = await parser.parse([
+    {
+      id: 'cdc96a32-572c-4f69-8bce-4c7bd4024a4e',
+      database_id: '8e739194-ced7-479b-b46c-e6b06146ac11',
+      table_id: '6616358d-8da8-45e4-834f-d735a0f02acc',
+      name: 'object_pkey',
+      field_ids: ['f853daae-f563-447d-ac09-901ddd68586e', 'a4257181-147d-4558-a51f-4b43246527a2']
+    },
+    {
+      id: '03d7007c-5262-4250-9ce1-efcabc5bedea',
+      database_id: '8e739194-ced7-479b-b46c-e6b06146ac11',
+      table_id: '535d5894-679a-4a7b-aa5a-bd07cce8a505',
+      name: 'ref_pkey',
+      field_ids: ['8cc2da93-a8e0-4565-9d14-f814c3a1432d', '40a34889-eb4c-4833-8daf-b99441962971']
+    }
+  ]);
+
+  expect(sql).toMatchSnapshot();
+});
+
+it('interval type', async () => {
+  const parser = new Parser({
+    schema: 'metaschema_modules_public',
+    singleStmts: true,
+    table: 'tokens_module',
+    fields: {
+      id: 'uuid',
+      database_id: 'uuid',
+      tokens_default_expiration: 'interval',
+      tokens_table: 'text'
+    }
+  });
+
+  const sql = await parser.parse([
+    {
+      id: '42aaba39-de20-4be0-95a1-4873d7d4b6d4',
+      database_id: '8e739194-ced7-479b-b46c-e6b06146ac11',
+      tokens_default_expiration: { hours: 24 },
+      tokens_table: 'api_tokens'
+    },
+    {
+      id: '550e8400-e29b-41d4-a716-446655440000',
+      database_id: '8e739194-ced7-479b-b46c-e6b06146ac11',
+      tokens_default_expiration: { days: 7, hours: 12, minutes: 30 },
+      tokens_table: 'refresh_tokens'
+    },
+    {
+      id: '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+      database_id: '8e739194-ced7-479b-b46c-e6b06146ac11',
+      tokens_default_expiration: { years: 1, months: 6 },
+      tokens_table: 'long_lived_tokens'
+    }
+  ]);
+
+  expect(sql).toMatchSnapshot();
+});
+
+it('interval type with string value', async () => {
+  const parser = new Parser({
+    schema: 'metaschema_modules_public',
+    singleStmts: true,
+    table: 'tokens_module',
+    fields: {
+      id: 'uuid',
+      tokens_default_expiration: 'interval'
+    }
+  });
+
+  const sql = await parser.parse([
+    {
+      id: '42aaba39-de20-4be0-95a1-4873d7d4b6d4',
+      tokens_default_expiration: '1 day 02:30:00'
+    }
+  ]);
+
+  expect(sql).toMatchSnapshot();
+});
 });

--- a/packages/csv-to-pg/src/parse.ts
+++ b/packages/csv-to-pg/src/parse.ts
@@ -39,6 +39,52 @@ const parseJson = (value: unknown): string | undefined => {
 };
 
 /**
+ * PostgreSQL interval object type as returned by node-postgres
+ */
+interface PgInterval {
+  years?: number;
+  months?: number;
+  days?: number;
+  hours?: number;
+  minutes?: number;
+  seconds?: number;
+  milliseconds?: number;
+}
+
+/**
+ * Convert a PostgreSQL interval object to a PostgreSQL interval string.
+ * node-postgres returns intervals as objects like { hours: 12, minutes: 6, seconds: 41 }
+ */
+const formatInterval = (value: unknown): string | undefined => {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (value && typeof value === 'object') {
+    const interval = value as PgInterval;
+    const parts: string[] = [];
+    
+    if (interval.years) parts.push(`${interval.years} year${interval.years !== 1 ? 's' : ''}`);
+    if (interval.months) parts.push(`${interval.months} mon${interval.months !== 1 ? 's' : ''}`);
+    if (interval.days) parts.push(`${interval.days} day${interval.days !== 1 ? 's' : ''}`);
+    
+    // Build time component
+    const hours = interval.hours || 0;
+    const minutes = interval.minutes || 0;
+    const seconds = interval.seconds || 0;
+    const milliseconds = interval.milliseconds || 0;
+    
+    if (hours || minutes || seconds || milliseconds) {
+      const totalSeconds = seconds + milliseconds / 1000;
+      const timeStr = `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${totalSeconds.toFixed(milliseconds ? 6 : 0).padStart(milliseconds ? 9 : 2, '0')}`;
+      parts.push(timeStr);
+    }
+    
+    return parts.length > 0 ? parts.join(' ') : '00:00:00';
+  }
+  return undefined;
+};
+
+/**
  * Escape a single array element for PostgreSQL array literal format.
  * Handles: NULL, quotes, backslashes, commas, braces, and whitespace.
  */
@@ -315,6 +361,21 @@ const getCoercionFunc = (type: string, from: string[], opts: FieldOptions, field
         }
         // If not an array, treat as empty/null
         return makeNullOrThrow(fieldName, rawValue, type, required, 'value is not an array');
+      };
+    case 'interval':
+      return (record: Record<string, unknown>): Node => {
+        const rawValue = record[from[0]];
+        if (isNullToken(rawValue)) {
+          return makeNullOrThrow(fieldName, rawValue, type, required, 'value is empty or null');
+        }
+        const value = formatInterval(rawValue);
+        if (isEmpty(value)) {
+          return makeNullOrThrow(fieldName, rawValue, type, required, 'value is empty or invalid interval');
+        }
+        const val = nodes.aConst({
+          sval: ast.string({ sval: String(value) })
+        });
+        return wrapValue(val, opts);
       };
     case 'timestamp':
     case 'timestamptz':


### PR DESCRIPTION
## Summary

Fixes incorrect export of `uuid[]` and `interval` columns in the metaschema export functionality.

### uuid[] fix

Previously, `uuid[]` fields fell through to the default case which used `String(value)` on arrays, producing comma-separated values like:

```sql
'f853daae-f563-447d-ac09-901ddd68586e,a4257181-147d-4558-a51f-4b43246527a2'
```

Instead of proper PostgreSQL array literal format:

```sql
'{f853daae-f563-447d-ac09-901ddd68586e,a4257181-147d-4558-a51f-4b43246527a2}'
```

This affected tables with `uuid[]` columns like `field_ids` in `metaschema_public.primary_key_constraint`, `foreign_key_constraint`, `index`, `unique_constraint`, `full_text_search`, and others.

### interval fix

Similarly, `interval` fields fell through to the default case which used `String(value)` on the node-postgres interval object, producing:

```sql
'[object Object]'
```

Instead of proper PostgreSQL interval format like:

```sql
'1 day 02:30:00'
```

This affected tables with interval columns like `tokens_default_expiration` in `metaschema_modules_public.tokens_module`.

### Updates since last revision

Added snapshot tests covering:
- `uuid[]` arrays with multiple UUIDs
- `interval` objects with various combinations (hours only, days+time, years+months)
- `interval` string pass-through values

## Review & Testing Checklist for Human

- [ ] Verify the fix works end-to-end by running an actual export and checking that `uuid[]` columns are formatted correctly with curly braces
- [ ] Verify interval columns export correctly against real database output (the `formatInterval` function assumes node-postgres interval object structure)
- [ ] Test edge cases not covered by unit tests: empty arrays, arrays with invalid UUIDs, null values, intervals with milliseconds

### Notes

The `formatInterval` function makes assumptions about the node-postgres interval object structure - the unit tests use synthetic data, so it's worth verifying the output matches actual database exports.

Requested by @pyramation

[Link to Devin run](https://app.devin.ai/sessions/37ff20f38fef4988b901f7185204c448)