### PR TITLE
fix(pgpm/core): update export-meta.ts config to match actual metaschema table definitions

### DIFF
--- a/pgpm/core/src/export/export-meta.ts
+++ b/pgpm/core/src/export/export-meta.ts
@@ -210,8 +210,8 @@ const config: Record<string, TableConfig> = {
     fields: {
       id: 'uuid',
       database_id: 'uuid',
-      schema_id: 'uuid',
-      name: 'text'
+      name: 'text',
+      code: 'text'
     }
   },
   rls_function: {
@@ -220,8 +220,13 @@ const config: Record<string, TableConfig> = {
     fields: {
       id: 'uuid',
       database_id: 'uuid',
-      schema_id: 'uuid',
-      name: 'text'
+      table_id: 'uuid',
+      name: 'text',
+      label: 'text',
+      description: 'text',
+      data: 'jsonb',
+      inline: 'boolean',
+      security: 'int'
     }
   },
   limit_function: {
@@ -230,8 +235,12 @@ const config: Record<string, TableConfig> = {
     fields: {
       id: 'uuid',
       database_id: 'uuid',
-      schema_id: 'uuid',
-      name: 'text'
+      table_id: 'uuid',
+      name: 'text',
+      label: 'text',
+      description: 'text',
+      data: 'jsonb',
+      security: 'int'
     }
   },
   procedure: {
@@ -240,8 +249,12 @@ const config: Record<string, TableConfig> = {
     fields: {
       id: 'uuid',
       database_id: 'uuid',
-      schema_id: 'uuid',
-      name: 'text'
+      name: 'text',
+      argnames: 'text[]',
+      argtypes: 'text[]',
+      argdefaults: 'text[]',
+      lang_name: 'text',
+      definition: 'text'
     }
   },
   foreign_key_constraint: {
@@ -252,11 +265,14 @@ const config: Record<string, TableConfig> = {
       database_id: 'uuid',
       table_id: 'uuid',
       name: 'text',
+      description: 'text',
+      smart_tags: 'jsonb',
+      type: 'text',
       field_ids: 'uuid[]',
       ref_table_id: 'uuid',
       ref_field_ids: 'uuid[]',
-      on_delete: 'text',
-      on_update: 'text'
+      delete_action: 'text',
+      update_action: 'text'
     }
   },
   primary_key_constraint: {
@@ -267,6 +283,7 @@ const config: Record<string, TableConfig> = {
       database_id: 'uuid',
       table_id: 'uuid',
       name: 'text',
+      type: 'text',
       field_ids: 'uuid[]'
     }
   },
@@ -278,6 +295,9 @@ const config: Record<string, TableConfig> = {
       database_id: 'uuid',
       table_id: 'uuid',
       name: 'text',
+      description: 'text',
+      smart_tags: 'jsonb',
+      type: 'text',
       field_ids: 'uuid[]'
     }
   },
@@ -289,7 +309,9 @@ const config: Record<string, TableConfig> = {
       database_id: 'uuid',
       table_id: 'uuid',
       name: 'text',
-      expression: 'text'
+      type: 'text',
+      field_ids: 'uuid[]',
+      expr: 'jsonb'
     }
   },
   full_text_search: {
@@ -299,9 +321,10 @@ const config: Record<string, TableConfig> = {
       id: 'uuid',
       database_id: 'uuid',
       table_id: 'uuid',
-      name: 'text',
+      field_id: 'uuid',
       field_ids: 'uuid[]',
-      weights: 'text[]'
+      weights: 'text[]',
+      langs: 'text[]'
     }
   },
   schema_grant: {
@@ -311,8 +334,7 @@ const config: Record<string, TableConfig> = {
       id: 'uuid',
       database_id: 'uuid',
       schema_id: 'uuid',
-      role_name: 'text',
-      privilege: 'text'
+      grantee_name: 'text'
     }
   },
   table_grant: {
@@ -322,8 +344,9 @@ const config: Record<string, TableConfig> = {
       id: 'uuid',
       database_id: 'uuid',
       table_id: 'uuid',
+      privilege: 'text',
       role_name: 'text',
-      privilege: 'text'
+      field_ids: 'uuid[]'
     }
   },
   // =============================================================================


### PR DESCRIPTION
## Summary

Updates the export-meta.ts config to match the actual metaschema table definitions in constructive-db. The export config was out of date, causing NOT NULL violations during deployment because the export was missing columns that have NOT NULL constraints in the target schema.

**Tables updated:**
- `check_constraint`: added `type`, `field_ids`, `expr`; removed `expression`
- `full_text_search`: added `field_id`, `langs`; removed `name`
- `foreign_key_constraint`: added `description`, `smart_tags`, `type`, `delete_action`, `update_action`; removed `on_delete`, `on_update`
- `primary_key_constraint`: added `type`
- `unique_constraint`: added `description`, `smart_tags`, `type`
- `trigger_function`: added `code`; removed `schema_id`
- `rls_function`: added `table_id`, `label`, `description`, `data`, `inline`, `security`; removed `schema_id`
- `limit_function`: added `table_id`, `label`, `description`, `data`, `security`; removed `schema_id`
- `procedure`: added `argnames`, `argtypes`, `argdefaults`, `lang_name`, `definition`; removed `schema_id`
- `schema_grant`: added `grantee_name`; removed `role_name`, `privilege`
- `table_grant`: added `field_ids`

## Review & Testing Checklist for Human

- [ ] **Verify column names match actual database schema** - I derived these from the SQL files in `constructive-db/pgpm-modules/metaschema-schema/deploy/schemas/metaschema_public/tables/*/table.sql`. Double-check that column names like `delete_action` vs `on_delete`, `expr` vs `expression`, `grantee_name` vs `role_name` are correct.
- [ ] **Test deployment end-to-end** - Run `pgpm deploy` for constructive-services against a target database to verify the NOT NULL violations are resolved
- [ ] **Verify dynamic column filtering still works** - The `buildDynamicFields` function filters config columns against actual source database columns. Ensure this still works correctly with the updated config.

### Notes

This fix addresses deployment errors like:
- `column "field_ids" of relation "check_constraint" does not exist` (error 23502 - NOT NULL violation)
- `column "field_id" of relation "full_text_search" does not exist` (error 23502 - NOT NULL violation)

The root cause was that the export config didn't include columns that have NOT NULL constraints in the target schema, so PostgreSQL was inserting NULL for missing columns.

Link to Devin run: https://app.devin.ai/sessions/37ff20f38fef4988b901f7185204c448
Requested by: @pyramation