### PR TITLE
chore: update postgres docker image to ghcr.io/constructive-io/docker/postgres-plus:17

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -107,7 +107,7 @@ jobs:
 
     services:
       pg_db:
-        image: pyramation/pgvector:13.3-alpine
+        image: ghcr.io/constructive-io/docker/postgres-plus:17
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password

--- a/postgres/pgsql-test/__tests__/__snapshots__/postgres-test.enhanced-errors.test.ts.snap
+++ b/postgres/pgsql-test/__tests__/__snapshots__/postgres-test.enhanced-errors.test.ts.snap
@@ -4,6 +4,7 @@ exports[`Enhanced PostgreSQL Error Messages JSON/JSONB Type Mismatch Errors snap
 "invalid input syntax for type json
 Detail: Token "not_valid_json" is invalid.
 Where: JSON data, line 1: not_valid_json
+unnamed portal parameter $2 = '...'
 Query: INSERT INTO test_json_errors (name, config) VALUES ($1, $2)
 Values: ["test_name","not_valid_json"]"
 `;


### PR DESCRIPTION
## Summary

Updates the PostgreSQL Docker image used in CI tests from `pyramation/pgvector:13.3-alpine` to `ghcr.io/constructive-io/docker/postgres-plus:17`.

This is a major version upgrade from PostgreSQL 13 to PostgreSQL 17.

## Updates since last revision

- Updated `pgsql-test` error message snapshot for PG17 compatibility. PostgreSQL 17 adds additional diagnostic context to error messages (e.g., `unnamed portal parameter $2 = '...'`), so the snapshot was updated to reflect this new format.

## Review & Testing Checklist for Human

- [ ] Verify the `ghcr.io/constructive-io/docker/postgres-plus:17` image is accessible from GitHub Actions runners
- [ ] Confirm CI tests pass with the new PostgreSQL 17 image
- [ ] Note: The error message snapshot is now PG17-specific - tests will fail if run against older PostgreSQL versions

### Notes

Requested by @pyramation

Link to Devin run: https://app.devin.ai/sessions/2cbc447fd8fa4f1f818bffe295657f2f