### PR TITLE
fix: update default Docker image to ghcr.io/constructive-io/docker/postgres-plus:17

### DIFF
--- a/pgpm/cli/src/commands/docker.ts
+++ b/pgpm/cli/src/commands/docker.ts
@@ -16,7 +16,7 @@ Subcommands:
 Options:
   --help, -h         Show this help message
   --name <name>      Container name (default: postgres)
-  --image <image>    Docker image (default: pyramation/pgvector:13.3-alpine)
+  --image <image>    Docker image (default: ghcr.io/constructive-io/docker/postgres-plus:17)
   --port <port>      Host port mapping (default: 5432)
   --user <user>      PostgreSQL user (default: postgres)
   --password <pass>  PostgreSQL password (default: password)
@@ -213,7 +213,7 @@ export default async (
   }
 
   const name = (args.name as string) || 'postgres';
-  const image = (args.image as string) || 'pyramation/pgvector:13.3-alpine';
+  const image = (args.image as string) || 'ghcr.io/constructive-io/docker/postgres-plus:17';
   const port = typeof args.port === 'number' ? args.port : 5432;
   const user = (args.user as string) || 'postgres';
   const password = (args.password as string) || 'password';


### PR DESCRIPTION
## Summary

Updates the default Docker image in the `pgpm docker` CLI command to match the image used in CI workflows. The default image changes from `pyramation/pgvector:13.3-alpine` to `ghcr.io/constructive-io/docker/postgres-plus:17`.

Changes made in `pgpm/cli/src/commands/docker.ts`:
- Updated the help text to show the new default image
- Updated the actual default value used when no `--image` flag is provided

## Review & Testing Checklist for Human

- [ ] Verify the `ghcr.io/constructive-io/docker/postgres-plus:17` image is publicly accessible and pulls correctly
- [ ] Test `pgpm docker start` locally to confirm the container starts and PostgreSQL is accessible
- [ ] Consider if the PostgreSQL version upgrade (13 → 17) could impact existing users who rely on the default image

### Notes

This aligns the CLI default with the image used in `.github/workflows/run-tests.yaml`.

Link to Devin run: https://app.devin.ai/sessions/e7054b498dfa4bf2af31efec4bf8a26f
Requested by: Dan Lynch (@pyramation)