### PR TITLE
refactor: rename enableMetaApi to enableServicesApi

### DIFF
--- a/graphql/env/README.md
+++ b/graphql/env/README.md
@@ -38,7 +38,7 @@ In addition to all environment variables supported by `@pgpmjs/env`, this packag
 - `FEATURES_POSTGIS` - Enable PostGIS support
 
 ### API Configuration
-- `API_ENABLE_META` - Enable meta API
+- `API_ENABLE_SERVICES` - Enable services API (domain/subdomain routing)
 - `API_IS_PUBLIC` - Whether API is public
 - `API_EXPOSED_SCHEMAS` - Comma-separated list of exposed schemas
 - `API_META_SCHEMAS` - Comma-separated list of meta schemas
@@ -59,7 +59,7 @@ GraphQL defaults are provided by `@constructive-io/graphql-types`:
     postgis: true
   },
   api: {
-    enableMetaApi: true,
+    enableServicesApi: true,
     exposedSchemas: [],
     anonRole: 'administrator',
     roleName: 'administrator',

--- a/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
+++ b/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
@@ -5,7 +5,7 @@ exports[`getEnvOptions merges pgpm defaults, graphql defaults, config, env, and 
   "api": {
     "anonRole": "env_anon",
     "defaultDatabaseId": "override_db",
-    "enableMetaApi": false,
+    "enableServicesApi": false,
     "exposedSchemas": [
       "public",
       "app",
@@ -59,6 +59,11 @@ exports[`getEnvOptions merges pgpm defaults, graphql defaults, config, env, and 
     "logOnly": false,
     "usePlan": true,
     "useTx": true,
+  },
+  "errorOutput": {
+    "maxLength": 10000,
+    "queryHistoryLimit": 30,
+    "verbose": false,
   },
   "features": {
     "oppositeBaseNames": false,

--- a/graphql/env/__tests__/merge.test.ts
+++ b/graphql/env/__tests__/merge.test.ts
@@ -34,7 +34,7 @@ describe('getEnvOptions', () => {
         simpleInflection: false
       },
       api: {
-        enableMetaApi: false,
+        enableServicesApi: false,
         isPublic: false,
         metaSchemas: ['config_meta']
       }
@@ -46,7 +46,7 @@ describe('getEnvOptions', () => {
       GRAPHILE_SCHEMA: 'env_schema_a,env_schema_b',
       FEATURES_SIMPLE_INFLECTION: 'true',
       FEATURES_POSTGIS: 'false',
-      API_ENABLE_META: 'true',
+      API_ENABLE_SERVICES: 'true',
       API_IS_PUBLIC: 'true',
       API_EXPOSED_SCHEMAS: 'public,app',
       API_META_SCHEMAS: 'env_meta1,env_meta2',
@@ -73,7 +73,7 @@ describe('getEnvOptions', () => {
           oppositeBaseNames: false
         },
         api: {
-          enableMetaApi: false,
+          enableServicesApi: false,
           defaultDatabaseId: 'override_db'
         }
       },

--- a/graphql/env/src/env.ts
+++ b/graphql/env/src/env.ts
@@ -20,7 +20,7 @@ export const getGraphQLEnvVars = (env: NodeJS.ProcessEnv = process.env): Partial
     FEATURES_OPPOSITE_BASE_NAMES,
     FEATURES_POSTGIS,
 
-    API_ENABLE_META,
+    API_ENABLE_SERVICES,
     API_IS_PUBLIC,
     API_EXPOSED_SCHEMAS,
     API_META_SCHEMAS,
@@ -43,7 +43,7 @@ export const getGraphQLEnvVars = (env: NodeJS.ProcessEnv = process.env): Partial
       ...(FEATURES_POSTGIS && { postgis: parseEnvBoolean(FEATURES_POSTGIS) }),
     },
     api: {
-      ...(API_ENABLE_META && { enableMetaApi: parseEnvBoolean(API_ENABLE_META) }),
+      ...(API_ENABLE_SERVICES && { enableServicesApi: parseEnvBoolean(API_ENABLE_SERVICES) }),
       ...(API_IS_PUBLIC && { isPublic: parseEnvBoolean(API_IS_PUBLIC) }),
       ...(API_EXPOSED_SCHEMAS && { exposedSchemas: API_EXPOSED_SCHEMAS.split(',').map(s => s.trim()) }),
       ...(API_META_SCHEMAS && { metaSchemas: API_META_SCHEMAS.split(',').map(s => s.trim()) }),

--- a/graphql/server/src/middleware/api.ts
+++ b/graphql/server/src/middleware/api.ts
@@ -85,7 +85,7 @@ export const createApiMiddleware = (opts: any) => {
     res: Response,
     next: NextFunction
   ): Promise<void> => {
-    if (opts.api?.enableMetaApi === false) {
+    if (opts.api?.enableServicesApi === false) {
       const schemas = opts.api.exposedSchemas;
       const anonRole = opts.api.anonRole;
       const roleName = opts.api.roleName;

--- a/graphql/types/README.md
+++ b/graphql/types/README.md
@@ -28,7 +28,7 @@ const config: ConstructiveOptions = {
     appendPlugins: [],
   },
   api: {
-    enableMetaApi: true,
+    enableServicesApi: true,
     exposedSchemas: ['public'],
   },
   features: {

--- a/graphql/types/src/graphile.ts
+++ b/graphql/types/src/graphile.ts
@@ -31,8 +31,8 @@ export interface GraphileFeatureOptions {
  * Configuration options for the Constructive API
  */
 export interface ApiOptions {
-  /** Whether to enable the meta API endpoints */
-  enableMetaApi?: boolean;
+  /** Whether to enable the services API (domain/subdomain routing via services_public) */
+  enableServicesApi?: boolean;
   /** Database schemas to expose through the API */
   exposedSchemas?: string[];
   /** Anonymous role name for unauthenticated requests */
@@ -70,7 +70,7 @@ export const graphileFeatureDefaults: GraphileFeatureOptions = {
  * Default API configuration values
  */
 export const apiDefaults: ApiOptions = {
-  enableMetaApi: true,
+  enableServicesApi: true,
   exposedSchemas: [],
   anonRole: 'administrator',
   roleName: 'administrator',

--- a/packages/cli/src/commands/server.ts
+++ b/packages/cli/src/commands/server.ts
@@ -21,7 +21,7 @@ Options:
   --simpleInflection      Use simple inflection (default: true)
   --oppositeBaseNames     Use opposite base names (default: false)
   --postgis               Enable PostGIS extension (default: true)
-  --metaApi               Enable Meta API (default: true)
+  --servicesApi           Enable Services API (default: true)
   --cwd <directory>       Working directory (default: current directory)
 
 Examples:
@@ -57,8 +57,8 @@ const questions: Question[] = [
     useDefault: true
   },
   {
-    name: 'metaApi',
-    message: 'Enable Meta API?',
+    name: 'servicesApi',
+    message: 'Enable Services API?',
     type: 'confirm',
     required: false,
     default: true,
@@ -125,7 +125,7 @@ export default async (
     port,
     postgis,
     simpleInflection,
-    metaApi,
+    servicesApi,
     origin
   } = await prompter.prompt(argv, questions);
 
@@ -144,7 +144,7 @@ export default async (
   let selectedSchemas: string[] = [];
   let authRole: string | undefined;
   let roleName: string | undefined;
-  if (!metaApi) {
+  if (!servicesApi) {
     const db = await getPgPool({ database: selectedDb });
     const result = await db.query(`
       SELECT nspname 
@@ -197,8 +197,8 @@ export default async (
       postgis
     },
     api: {
-      enableMetaApi: metaApi,
-      ...(metaApi === false && { exposedSchemas: selectedSchemas, authRole, roleName })
+      enableServicesApi: servicesApi,
+      ...(servicesApi === false && { exposedSchemas: selectedSchemas, authRole, roleName })
     },
     server: {
       port,


### PR DESCRIPTION
## Summary

Renames `enableMetaApi` to `enableServicesApi` across the codebase to better reflect the purpose of this option - it controls whether the services API (domain/subdomain routing via `services_public`) is enabled.

**Changes:**
- Renamed `enableMetaApi` → `enableServicesApi` in `ApiOptions` interface (`graphql/types`)
- Renamed `API_ENABLE_META` → `API_ENABLE_SERVICES` environment variable (`graphql/env`)
- Renamed `--metaApi` → `--servicesApi` CLI flag (`packages/cli`)
- Updated middleware check in `graphql/server`
- Updated all documentation and tests

## Review & Testing Checklist for Human

- [ ] **Breaking change**: Verify any existing deployments using `API_ENABLE_META` env var or `enableMetaApi` config option are updated to use the new names
- [ ] Verify the CLI `--servicesApi` flag works correctly: `cnc server --no-servicesApi` should prompt for schema selection
- [ ] Confirm the snapshot update includes an unrelated `errorOutput` field - this was a pre-existing change that needed syncing, not part of this rename

**Test plan:**
1. Run `cnc server --help` and verify `--servicesApi` appears in the help text
2. Run `cnc server --no-servicesApi` and verify it prompts for schema selection
3. Set `API_ENABLE_SERVICES=false` env var and verify the server starts without services API

### Notes
- Link to Devin run: https://app.devin.ai/sessions/a583a9da700a4feca3985c559d33e51f
- Requested by: Dan Lynch (@pyramation)