### PR TITLE
fix: update export-meta.ts to use 'policy_type' instead of 'template'

### DIFF
--- a/pgpm/core/src/export/export-meta.ts
+++ b/pgpm/core/src/export/export-meta.ts
@@ -172,7 +172,7 @@ const config: Record<string, TableConfig> = {
       privilege: 'text',
       permissive: 'boolean',
       disabled: 'boolean',
-      template: 'text',
+      policy_type: 'text',
       data: 'jsonb'
     }
   },


### PR DESCRIPTION
## Summary

Updates the export-meta.ts config to use `policy_type` instead of `template` for the policy table field mapping. This aligns with the schema change in constructive-db PR #328 where the `template` column was renamed to `policy_type` in the `metaschema_public.policy` table.

## Review & Testing Checklist for Human

- [ ] **Verify constructive-db PR #328 is merged first** - This change depends on the policy table having a `policy_type` column instead of `template`. If merged before constructive-db, exports will fail.
- [ ] Confirm no other references to `template` for policies exist in this codebase that need updating

### Notes

This is part of a larger refactoring effort to rename policy types to use PascalCase with Authz prefix (e.g., `AuthzMembership`, `AuthzDirectOwner`) and rename the column from `template` to `policy_type`.

**Related PRs:**
- constructive-db #328: Main schema and code changes
- dashboard #105: Frontend policy type naming updates

**Link to Devin run:** https://app.devin.ai/sessions/14351ad5a39d46c9aa33be151e6977e4
**Requested by:** Dan Lynch (@pyramation)