### PR TITLE
feat: update export flow for new metaschema tables and columns

### DIFF
--- a/pgpm/core/src/export/export-meta.ts
+++ b/pgpm/core/src/export/export-meta.ts
@@ -553,12 +553,10 @@ const config: Record<string, TableConfig> = {
       actor_perm_check: 'text',
       entity_ids_by_mask: 'text',
       entity_ids_by_perm: 'text',
-      entity_ids_function: 'text',
-      default_is_approved: 'boolean',
-      default_is_verified: 'boolean'
+      entity_ids_function: 'text'
     }
   },
-  permissions_module: {
+  permissions_module:{
     schema: 'metaschema_modules_public',
     table: 'permissions_module',
     fields: {

--- a/pgpm/core/src/export/export-meta.ts
+++ b/pgpm/core/src/export/export-meta.ts
@@ -553,7 +553,9 @@ const config: Record<string, TableConfig> = {
       actor_perm_check: 'text',
       entity_ids_by_mask: 'text',
       entity_ids_by_perm: 'text',
-      entity_ids_function: 'text'
+      entity_ids_function: 'text',
+      default_is_approved: 'boolean',
+      default_is_verified: 'boolean'
     }
   },
   permissions_module: {
@@ -846,9 +848,63 @@ const config: Record<string, TableConfig> = {
       private_schema_id: 'uuid',
       table_id: 'uuid',
       field_id: 'uuid',
+      node_type: 'text',
       data: 'jsonb',
       triggers: 'text[]',
       functions: 'text[]'
+    }
+  },
+  table_module: {
+    schema: 'metaschema_modules_public',
+    table: 'table_module',
+    fields: {
+      id: 'uuid',
+      database_id: 'uuid',
+      private_schema_id: 'uuid',
+      table_id: 'uuid',
+      node_type: 'text',
+      data: 'jsonb',
+      fields: 'uuid[]'
+    }
+  },
+  user_profiles_module: {
+    schema: 'metaschema_modules_public',
+    table: 'user_profiles_module',
+    fields: {
+      id: 'uuid',
+      database_id: 'uuid',
+      schema_id: 'uuid',
+      private_schema_id: 'uuid',
+      table_id: 'uuid',
+      table_name: 'text',
+      users_table_id: 'uuid'
+    }
+  },
+  user_settings_module: {
+    schema: 'metaschema_modules_public',
+    table: 'user_settings_module',
+    fields: {
+      id: 'uuid',
+      database_id: 'uuid',
+      schema_id: 'uuid',
+      private_schema_id: 'uuid',
+      table_id: 'uuid',
+      table_name: 'text',
+      users_table_id: 'uuid'
+    }
+  },
+  organization_settings_module: {
+    schema: 'metaschema_modules_public',
+    table: 'organization_settings_module',
+    fields: {
+      id: 'uuid',
+      database_id: 'uuid',
+      schema_id: 'uuid',
+      private_schema_id: 'uuid',
+      table_id: 'uuid',
+      table_name: 'text',
+      entity_table_id: 'uuid',
+      membership_type: 'int'
     }
   },
   uuid_module: {

--- a/pgpm/core/src/export/export-migrations.ts
+++ b/pgpm/core/src/export/export-migrations.ts
@@ -409,6 +409,10 @@ SET session_replication_role TO DEFAULT;`;
       'crypto_addresses_module',
       'crypto_auth_module',
       'field_module',
+      'table_module',
+      'user_profiles_module',
+      'user_settings_module',
+      'organization_settings_module',
       'uuid_module',
       'default_ids_module',
       'denormalized_table_field'


### PR DESCRIPTION
## Summary

Updates the export flow configuration to support new metaschema tables and columns that were added to the upstream pgpm-modules repository. This PR adds export configs for 4 new module tables and updates existing configs with new fields.

**New table configs added:**
- `table_module` - table-level module configuration with node_type pattern
- `user_profiles_module` - user profiles configuration
- `user_settings_module` - user settings configuration  
- `organization_settings_module` - organization settings configuration

**Updated existing configs:**
- `field_module` - added `node_type` field

**Companion PRs:**
- pgpm-modules: https://github.com/constructive-io/pgpm-modules/pull/35
- constructive-db: https://github.com/constructive-io/constructive-db/pull/337

## Updates since last revision

- Removed `default_is_approved` and `default_is_verified` fields from `memberships_module` config in favor of a secure-by-default approach (coordinated with companion PRs)

## Review & Testing Checklist for Human

- [ ] Verify field definitions in export-meta.ts match the actual database schema in constructive-db (especially field types like `membership_type: 'int'`)
- [ ] Verify the tableOrder placement in export-migrations.ts is correct - new modules should be exported after their dependencies
- [ ] Ensure all 3 companion PRs are merged together to avoid schema/export mismatches
- [ ] Test the export flow end-to-end with a database that has the new tables populated

**Recommended test plan:** After merging all companion PRs and deploying the schema changes, run the export flow against a test database and verify the new tables are exported correctly with all fields.

### Notes

Link to Devin run: https://app.devin.ai/sessions/7ae0a5a06e9f4cbea02826b895676582

Requested by: Dan Lynch (@pyramation)