### PR TITLE
Add table_template_module to export flow and remove old modules

### DIFF
--- a/pgpm/core/src/export/export-meta.ts
+++ b/pgpm/core/src/export/export-meta.ts
@@ -865,6 +865,21 @@ const config: Record<string, TableConfig> = {
       fields: 'uuid[]'
     }
   },
+  table_template_module: {
+    schema: 'metaschema_modules_public',
+    table: 'table_template_module',
+    fields: {
+      id: 'uuid',
+      database_id: 'uuid',
+      schema_id: 'uuid',
+      private_schema_id: 'uuid',
+      table_id: 'uuid',
+      owner_table_id: 'uuid',
+      table_name: 'text',
+      node_type: 'text',
+      data: 'jsonb'
+    }
+  },
   user_profiles_module: {
     schema: 'metaschema_modules_public',
     table: 'user_profiles_module',
@@ -1075,6 +1090,7 @@ export const exportMeta = async ({ opts, dbname, database_id }: ExportMetaParams
   await queryAndParse('crypto_addresses_module', `SELECT * FROM metaschema_modules_public.crypto_addresses_module WHERE database_id = $1`);
   await queryAndParse('crypto_auth_module', `SELECT * FROM metaschema_modules_public.crypto_auth_module WHERE database_id = $1`);
   await queryAndParse('field_module', `SELECT * FROM metaschema_modules_public.field_module WHERE database_id = $1`);
+  await queryAndParse('table_template_module', `SELECT * FROM metaschema_modules_public.table_template_module WHERE database_id = $1`);
   await queryAndParse('uuid_module', `SELECT * FROM metaschema_modules_public.uuid_module WHERE database_id = $1`);
   await queryAndParse('default_ids_module', `SELECT * FROM metaschema_modules_public.default_ids_module WHERE database_id = $1`);
   await queryAndParse('denormalized_table_field', `SELECT * FROM metaschema_modules_public.denormalized_table_field WHERE database_id = $1`);

--- a/pgpm/core/src/export/export-meta.ts
+++ b/pgpm/core/src/export/export-meta.ts
@@ -880,46 +880,6 @@ const config: Record<string, TableConfig> = {
       data: 'jsonb'
     }
   },
-  user_profiles_module: {
-    schema: 'metaschema_modules_public',
-    table: 'user_profiles_module',
-    fields: {
-      id: 'uuid',
-      database_id: 'uuid',
-      schema_id: 'uuid',
-      private_schema_id: 'uuid',
-      table_id: 'uuid',
-      table_name: 'text',
-      users_table_id: 'uuid'
-    }
-  },
-  user_settings_module: {
-    schema: 'metaschema_modules_public',
-    table: 'user_settings_module',
-    fields: {
-      id: 'uuid',
-      database_id: 'uuid',
-      schema_id: 'uuid',
-      private_schema_id: 'uuid',
-      table_id: 'uuid',
-      table_name: 'text',
-      users_table_id: 'uuid'
-    }
-  },
-  organization_settings_module: {
-    schema: 'metaschema_modules_public',
-    table: 'organization_settings_module',
-    fields: {
-      id: 'uuid',
-      database_id: 'uuid',
-      schema_id: 'uuid',
-      private_schema_id: 'uuid',
-      table_id: 'uuid',
-      table_name: 'text',
-      entity_table_id: 'uuid',
-      membership_type: 'int'
-    }
-  },
   uuid_module: {
     schema: 'metaschema_modules_public',
     table: 'uuid_module',


### PR DESCRIPTION
## Summary

Adds `table_template_module` to the metadata export flow and removes the old module configs it replaces. This is a companion change to [constructive-db PR #340](https://github.com/constructive-io/constructive-db/pull/340) which introduced the `table_template_module` table.

Changes:
- Added config entry for `table_template_module` with field definitions (id, database_id, schema_id, private_schema_id, table_id, owner_table_id, table_name, node_type, data)
- Added `queryAndParse` call to export data from `metaschema_modules_public.table_template_module`
- Removed config entries for `user_profiles_module`, `user_settings_module`, and `organization_settings_module` (these tables no longer exist - replaced by `table_template_module`)

## Review & Testing Checklist for Human

- [ ] Verify field names and types match the actual `table_template_module` table schema in constructive-db
- [ ] Confirm that the old modules (`user_profiles_module`, `user_settings_module`, `organization_settings_module`) have been removed from constructive-db before merging this PR
- [ ] Test export flow against a database provisioned with `table_template_module` to verify it exports correctly

**Recommended test plan:**
1. Ensure PR #340 is merged in constructive-db first
2. Run the export against a constructive database that has been provisioned with table templates
3. Verify the exported SQL includes the `table_template_module` INSERT statements

### Notes

This follows the existing pattern for all other module exports in `export-meta.ts`. The export will gracefully skip if the table doesn't exist (handled by the try/catch in `queryAndParse`).

Link to Devin run: https://app.devin.ai/sessions/f4b2066a3e3e434da15de84fba001ac3
Requested by: Dan Lynch (@pyramation)