### PR TITLE
(WIP) fix(codegen): missing generic types for react query mode hooks

### DIFF
--- a/graphql/codegen/examples/orm-sdk.ts
+++ b/graphql/codegen/examples/orm-sdk.ts
@@ -5,7 +5,7 @@
 import {
   createClient,
   GraphQLRequestError,
-} from '../examples/output/generated-orm';
+} from './output/generated-orm';
 
 const ENDPOINT = 'http://api.localhost:3000/graphql';
 let db = createClient({ endpoint: ENDPOINT });
@@ -17,23 +17,23 @@ async function main() {
   console.log('ORM SDK Demo\n');
 
   // ─────────────────────────────────────────────────────────────────────────────
-  // 1. Login & Auth
+  // 1. SignIn & Auth
   // ─────────────────────────────────────────────────────────────────────────────
-  section('1. Login Mutation');
-  const loginResult = await db.mutation
-    .login(
+  section('1. SignIn Mutation');
+  const signInResult = await db.mutation
+    .signIn(
       { input: { email: 'admin@gmail.com', password: 'password1111!@#$' } },
       { select: { apiToken: { select: { accessToken: true } } } }
     )
     .execute();
 
-  const token = loginResult.data?.login?.apiToken?.accessToken;
+  const token = signInResult.data?.signIn?.apiToken?.accessToken;
   if (token) {
     db = createClient({
       endpoint: ENDPOINT,
       headers: { Authorization: `Bearer ${token}` },
     });
-    console.log('✓ Logged in, token:', token.slice(0, 30) + '...');
+    console.log('✓ Signed in, token:', token.slice(0, 30) + '...');
   }
 
   // ─────────────────────────────────────────────────────────────────────────────
@@ -169,11 +169,11 @@ async function main() {
   // ─────────────────────────────────────────────────────────────────────────────
   section('6. Custom Queries');
   const currentUser = await db.query
-    .getCurrentUser({
+    .currentUser({
       select: { id: true, username: true, displayName: true },
     })
     .execute();
-  console.log('Current user:', currentUser.data?.getCurrentUser?.username);
+  console.log('Current user:', currentUser.data?.currentUser?.username);
 
   // ─────────────────────────────────────────────────────────────────────────────
   // 7. Error Handling: execute(), unwrap(), unwrapOr()
@@ -223,7 +223,7 @@ async function main() {
     select: {
       id: true,
       username: true,
-      userProfile: { select: { displayName: true } },
+      roleTypeByType: { select: { name: true } },
     },
     first: 5,
     where: { username: { isNull: false } },

--- a/graphql/codegen/examples/react-hooks-test.tsx
+++ b/graphql/codegen/examples/react-hooks-test.tsx
@@ -1,0 +1,398 @@
+/**
+ * React Query Hooks Test File
+ * Tests that the generated hooks work correctly with React + TypeScript
+ *
+ * This file is for type-checking purposes. Run: npx tsc --noEmit examples/react-hooks-test.tsx
+ */
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// Import generated hooks
+import {
+  useUsersQuery,
+  usersQueryKey,
+  fetchUsersQuery,
+  prefetchUsersQuery,
+} from './output/generated-sdk/queries/useUsersQuery';
+import {
+  useUserQuery,
+  userQueryKey,
+} from './output/generated-sdk/queries/useUserQuery';
+import {
+  useDatabasesQuery,
+  databasesQueryKey,
+} from './output/generated-sdk/queries/useDatabasesQuery';
+import {
+  useTablesQuery,
+  tablesQueryKey,
+} from './output/generated-sdk/queries/useTablesQuery';
+import {
+  useCurrentUserQuery,
+  currentUserQueryKey,
+} from './output/generated-sdk/queries/useCurrentUserQuery';
+
+// Import mutation hooks
+import { useCreateUserMutation } from './output/generated-sdk/mutations/useCreateUserMutation';
+import { useUpdateUserMutation } from './output/generated-sdk/mutations/useUpdateUserMutation';
+import { useDeleteUserMutation } from './output/generated-sdk/mutations/useDeleteUserMutation';
+import { useSignInMutation } from './output/generated-sdk/mutations/useSignInMutation';
+import { useSignOutMutation } from './output/generated-sdk/mutations/useSignOutMutation';
+import { useSignUpMutation } from './output/generated-sdk/mutations/useSignUpMutation';
+
+// Import types
+import type { UserFilter, DatabaseFilter, TableFilter } from './output/generated-sdk/schema-types';
+import type { User, Database, Table } from './output/generated-sdk/types';
+
+// Import client configuration
+import { configure } from './output/generated-sdk/client';
+
+// Import query/mutation keys for cache invalidation
+import { queryKeys, userKeys, customQueryKeys } from './output/generated-sdk/query-keys';
+import { mutationKeys, customMutationKeys } from './output/generated-sdk/mutation-keys';
+import { invalidate } from './output/generated-sdk/invalidation';
+
+const queryClient = new QueryClient();
+
+/**
+ * Test: List query hook with pagination and filtering
+ */
+function UsersListComponent() {
+  const filter: UserFilter = {
+    username: { isNull: false },
+    and: [{ type: { equalTo: 0 } }, { type: { greaterThan: 5 } }],
+  };
+
+  const { data, isLoading, error, refetch } = useUsersQuery({
+    first: 10,
+    orderBy: ['USERNAME_ASC'],
+    filter,
+  });
+
+  // Type assertions to verify return types
+  const users: User[] | undefined = data?.users?.nodes;
+  const totalCount: number | undefined = data?.users?.totalCount;
+  const hasNextPage: boolean | undefined = data?.users?.pageInfo.hasNextPage;
+  const hasPreviousPage: boolean | undefined = data?.users?.pageInfo.hasPreviousPage;
+  const startCursor: string | null | undefined = data?.users?.pageInfo.startCursor;
+  const endCursor: string | null | undefined = data?.users?.pageInfo.endCursor;
+
+  if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message}</div>;
+
+  return (
+    <div>
+      <h2>Users ({totalCount})</h2>
+      <ul>
+        {users?.map((user) => (
+          <li key={user.id}>
+            {user.username} - {user.displayName}
+          </li>
+        ))}
+      </ul>
+      <button onClick={() => refetch()}>Refresh</button>
+      <p>
+        Page: {hasNextPage ? 'Has more' : 'Last page'} |{' '}
+        {hasPreviousPage ? 'Has previous' : 'First page'}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Test: Single item query hook
+ */
+function UserDetailComponent({ userId }: { userId: string }) {
+  const { data, isLoading, error } = useUserQuery({ id: userId });
+
+  // Type assertion
+  const user: User | null | undefined = data?.user;
+
+  if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message}</div>;
+  if (!user) return <div>User not found</div>;
+
+  return (
+    <div>
+      <h2>{user.username}</h2>
+      <p>Display name: {user.displayName}</p>
+      <p>Type: {user.type}</p>
+      <p>Created: {user.createdAt}</p>
+    </div>
+  );
+}
+
+/**
+ * Test: Custom query hook (currentUser)
+ */
+function CurrentUserComponent() {
+  const { data, isLoading, error } = useCurrentUserQuery();
+
+  const currentUser = data?.currentUser;
+
+  if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message}</div>;
+  if (!currentUser) return <div>Not logged in</div>;
+
+  return (
+    <div>
+      <h2>Welcome, {currentUser.username}</h2>
+      <p>ID: {currentUser.id}</p>
+    </div>
+  );
+}
+
+/**
+ * Test: Create mutation hook
+ */
+function CreateUserForm() {
+  const createMutation = useCreateUserMutation({
+    onSuccess: (data) => {
+      console.log('Created user:', data.createUser?.user?.id);
+    },
+    onError: (error) => {
+      console.error('Failed to create user:', error.message);
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    createMutation.mutate({
+      input: {
+        user: {
+          username: 'newuser',
+          displayName: 'New User',
+        },
+      },
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <button type="submit" disabled={createMutation.isPending}>
+        {createMutation.isPending ? 'Creating...' : 'Create User'}
+      </button>
+      {createMutation.isError && <p>Error: {createMutation.error.message}</p>}
+      {createMutation.isSuccess && <p>User created!</p>}
+    </form>
+  );
+}
+
+/**
+ * Test: Update mutation hook
+ */
+function UpdateUserForm({ userId }: { userId: string }) {
+  const updateMutation = useUpdateUserMutation({
+    onSuccess: (data) => {
+      console.log('Updated user:', data.updateUser?.user?.username);
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    updateMutation.mutate({
+      input: {
+        id: userId,
+        patch: {
+          displayName: 'Updated Display Name',
+        },
+      },
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <button type="submit" disabled={updateMutation.isPending}>
+        {updateMutation.isPending ? 'Updating...' : 'Update User'}
+      </button>
+    </form>
+  );
+}
+
+/**
+ * Test: Delete mutation hook
+ */
+function DeleteUserButton({ userId }: { userId: string }) {
+  const deleteMutation = useDeleteUserMutation({
+    onSuccess: () => {
+      console.log('User deleted');
+    },
+  });
+
+  return (
+    <button
+      onClick={() => deleteMutation.mutate({ input: { id: userId } })}
+      disabled={deleteMutation.isPending}
+    >
+      {deleteMutation.isPending ? 'Deleting...' : 'Delete User'}
+    </button>
+  );
+}
+
+/**
+ * Test: Auth mutations (signIn, signOut, signUp)
+ */
+function AuthComponent() {
+  const signInMutation = useSignInMutation({
+    onSuccess: (data) => {
+      const token = data.signIn?.apiToken?.accessToken;
+      if (token) {
+        console.log('Signed in with token:', token);
+      }
+    },
+  });
+
+  const signOutMutation = useSignOutMutation({
+    onSuccess: () => {
+      console.log('Signed out');
+    },
+  });
+
+  const signUpMutation = useSignUpMutation({
+    onSuccess: (data) => {
+      console.log('Signed up:', data.signUp?.apiToken?.accessToken);
+    },
+  });
+
+  const handleSignIn = () => {
+    signInMutation.mutate({
+      input: {
+        email: 'test@example.com',
+        password: 'password123',
+      },
+    });
+  };
+
+  const handleSignOut = () => {
+    signOutMutation.mutate({ input: {} });
+  };
+
+  const handleSignUp = () => {
+    signUpMutation.mutate({
+      input: {
+        email: 'newuser@example.com',
+        password: 'password123',
+      },
+    });
+  };
+
+  return (
+    <div>
+      <button onClick={handleSignIn} disabled={signInMutation.isPending}>
+        Sign In
+      </button>
+      <button onClick={handleSignOut} disabled={signOutMutation.isPending}>
+        Sign Out
+      </button>
+      <button onClick={handleSignUp} disabled={signUpMutation.isPending}>
+        Sign Up
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Test: Query keys and cache invalidation
+ */
+function CacheInvalidationTest() {
+  // Test query key factories
+  const usersKey = userKeys.list({ first: 10 });
+  const userKey = userKeys.detail('123');
+  const currentUserKey = customQueryKeys.currentUser();
+
+  // Test centralized query keys
+  const allUserKeys = queryKeys.user;
+  const allDatabaseKeys = queryKeys.database;
+
+  // Test invalidation helper
+  const handleInvalidate = async () => {
+    await invalidate.user.all(queryClient);
+  };
+
+  return (
+    <div>
+      <p>Users key: {JSON.stringify(usersKey)}</p>
+      <p>User key: {JSON.stringify(userKey)}</p>
+      <button onClick={handleInvalidate}>Invalidate Users Cache</button>
+    </div>
+  );
+}
+
+/**
+ * Test: Prefetch and fetch functions
+ */
+async function testPrefetchAndFetch() {
+  // Configure the client
+  configure({
+    endpoint: 'http://api.localhost:3000/graphql',
+    headers: { Authorization: 'Bearer token' },
+  });
+
+  // Test fetch function (for SSR/server components)
+  const users = await fetchUsersQuery({ first: 10 });
+  console.log('Fetched users:', users.users?.nodes?.length);
+
+  // Test prefetch function (for cache warming)
+  await prefetchUsersQuery(queryClient, { first: 10 });
+  console.log('Prefetched users query');
+}
+
+/**
+ * Test: Relation queries with filters
+ */
+function RelationQueriesComponent() {
+  const { data: dbData } = useDatabasesQuery({ first: 1 });
+  const databaseId = dbData?.databases?.nodes?.[0]?.id;
+
+  // Filter tables by database ID (foreign key filter)
+  const tableFilter: TableFilter | undefined = databaseId
+    ? { databaseId: { equalTo: databaseId } }
+    : undefined;
+
+  const { data: tablesData } = useTablesQuery(
+    {
+      first: 10,
+      filter: tableFilter,
+      orderBy: ['NAME_ASC'],
+    },
+    {
+      enabled: !!databaseId,
+    }
+  );
+
+  const tables: Table[] | undefined = tablesData?.tables?.nodes;
+
+  return (
+    <div>
+      <h2>Tables in Database</h2>
+      <ul>
+        {tables?.map((table) => (
+          <li key={table.id}>{table.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/**
+ * Main App component to wrap everything
+ */
+export function App() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <div>
+        <h1>React Query Hooks Test</h1>
+        <CurrentUserComponent />
+        <UsersListComponent />
+        <UserDetailComponent userId="123" />
+        <CreateUserForm />
+        <UpdateUserForm userId="123" />
+        <DeleteUserButton userId="123" />
+        <AuthComponent />
+        <CacheInvalidationTest />
+        <RelationQueriesComponent />
+      </div>
+    </QueryClientProvider>
+  );
+}
+
+export default App;

--- a/graphql/codegen/examples/react-query-sdk.ts
+++ b/graphql/codegen/examples/react-query-sdk.ts
@@ -8,45 +8,45 @@ import {
   execute,
   executeWithErrors,
   GraphQLClientError,
-} from '../examples/output/generated-sdk/client';
+} from './output/generated-sdk/client';
 import {
   usersQueryDocument,
   type UsersQueryResult,
   type UsersQueryVariables,
-} from '../examples/output/generated-sdk/queries/useUsersQuery';
+} from './output/generated-sdk/queries/useUsersQuery';
 import {
   userQueryDocument,
   type UserQueryResult,
   type UserQueryVariables,
-} from '../examples/output/generated-sdk/queries/useUserQuery';
+} from './output/generated-sdk/queries/useUserQuery';
 import {
   databasesQueryDocument,
   type DatabasesQueryResult,
   type DatabasesQueryVariables,
-} from '../examples/output/generated-sdk/queries/useDatabasesQuery';
+} from './output/generated-sdk/queries/useDatabasesQuery';
 import {
   tablesQueryDocument,
   type TablesQueryResult,
   type TablesQueryVariables,
-} from '../examples/output/generated-sdk/queries/useTablesQuery';
+} from './output/generated-sdk/queries/useTablesQuery';
 import {
-  getCurrentUserQueryDocument,
-  type GetCurrentUserQueryResult,
-} from '../examples/output/generated-sdk/queries/useGetCurrentUserQuery';
+  currentUserQueryDocument,
+  type CurrentUserQueryResult,
+} from './output/generated-sdk/queries/useCurrentUserQuery';
 import {
   userByUsernameQueryDocument,
   type UserByUsernameQueryResult,
   type UserByUsernameQueryVariables,
-} from '../examples/output/generated-sdk/queries/useUserByUsernameQuery';
+} from './output/generated-sdk/queries/useUserByUsernameQuery';
 import {
-  loginMutationDocument,
-  type LoginMutationResult,
-  type LoginMutationVariables,
-} from '../examples/output/generated-sdk/mutations/useLoginMutation';
+  signInMutationDocument,
+  type SignInMutationResult,
+  type SignInMutationVariables,
+} from './output/generated-sdk/mutations/useSignInMutation';
 import type {
   UserFilter,
   TableFilter,
-} from '../examples/output/generated-sdk/schema-types';
+} from './output/generated-sdk/schema-types';
 
 const ENDPOINT = 'http://api.localhost:3000/graphql';
 const section = (title: string) =>
@@ -66,25 +66,25 @@ async function main() {
   console.log('✓ Client configured');
 
   // ─────────────────────────────────────────────────────────────────────────────
-  // 2. Login Mutation
+  // 2. SignIn Mutation
   // ─────────────────────────────────────────────────────────────────────────────
-  section('2. Login Mutation');
+  section('2. SignIn Mutation');
   try {
-    const loginResult = await execute<
-      LoginMutationResult,
-      LoginMutationVariables
-    >(loginMutationDocument, {
+    const signInResult = await execute<
+      SignInMutationResult,
+      SignInMutationVariables
+    >(signInMutationDocument, {
       input: { email: 'admin@gmail.com', password: 'password1111!@#$' },
     });
-    const token = loginResult.login?.apiToken?.accessToken;
+    const token = signInResult.signIn?.apiToken?.accessToken;
     if (token) {
       // Use setHeader() to update auth without re-configuring
       setHeader('Authorization', `Bearer ${token}`);
-      console.log('✓ Logged in, token:', token.slice(0, 30) + '...');
+      console.log('✓ Signed in, token:', token.slice(0, 30) + '...');
     }
   } catch (e) {
     if (e instanceof GraphQLClientError)
-      console.log('Login failed:', e.errors[0]?.message);
+      console.log('SignIn failed:', e.errors[0]?.message);
     else throw e;
   }
 
@@ -162,11 +162,10 @@ async function main() {
   // 6. Custom Queries
   // ─────────────────────────────────────────────────────────────────────────────
   section('6. Custom Queries');
-  const { data: currentUser } =
-    await executeWithErrors<GetCurrentUserQueryResult>(
-      getCurrentUserQueryDocument
-    );
-  console.log('Current user:', currentUser?.getCurrentUser?.username);
+  const { data: currentUser } = await executeWithErrors<CurrentUserQueryResult>(
+    currentUserQueryDocument
+  );
+  console.log('Current user:', currentUser?.currentUser?.username);
 
   // ─────────────────────────────────────────────────────────────────────────────
   // 7. Relation Queries (Foreign Key Filter)
@@ -212,8 +211,8 @@ async function main() {
 
   // execute - throws on error
   try {
-    await execute<LoginMutationResult, LoginMutationVariables>(
-      loginMutationDocument,
+    await execute<SignInMutationResult, SignInMutationVariables>(
+      signInMutationDocument,
       { input: { email: 'invalid@x.com', password: 'wrong' } }
     );
   } catch (e) {

--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/input-types-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/input-types-generator.test.ts.snap
@@ -166,6 +166,66 @@ export interface InternetAddressFilter {
 export interface FullTextFilter {
   matches?: string;
 }
+export interface StringListFilter {
+  isNull?: boolean;
+  equalTo?: string[];
+  notEqualTo?: string[];
+  distinctFrom?: string[];
+  notDistinctFrom?: string[];
+  lessThan?: string[];
+  lessThanOrEqualTo?: string[];
+  greaterThan?: string[];
+  greaterThanOrEqualTo?: string[];
+  contains?: string[];
+  containedBy?: string[];
+  overlaps?: string[];
+  anyEqualTo?: string;
+  anyNotEqualTo?: string;
+  anyLessThan?: string;
+  anyLessThanOrEqualTo?: string;
+  anyGreaterThan?: string;
+  anyGreaterThanOrEqualTo?: string;
+}
+export interface IntListFilter {
+  isNull?: boolean;
+  equalTo?: number[];
+  notEqualTo?: number[];
+  distinctFrom?: number[];
+  notDistinctFrom?: number[];
+  lessThan?: number[];
+  lessThanOrEqualTo?: number[];
+  greaterThan?: number[];
+  greaterThanOrEqualTo?: number[];
+  contains?: number[];
+  containedBy?: number[];
+  overlaps?: number[];
+  anyEqualTo?: number;
+  anyNotEqualTo?: number;
+  anyLessThan?: number;
+  anyLessThanOrEqualTo?: number;
+  anyGreaterThan?: number;
+  anyGreaterThanOrEqualTo?: number;
+}
+export interface UUIDListFilter {
+  isNull?: boolean;
+  equalTo?: string[];
+  notEqualTo?: string[];
+  distinctFrom?: string[];
+  notDistinctFrom?: string[];
+  lessThan?: string[];
+  lessThanOrEqualTo?: string[];
+  greaterThan?: string[];
+  greaterThanOrEqualTo?: string[];
+  contains?: string[];
+  containedBy?: string[];
+  overlaps?: string[];
+  anyEqualTo?: string;
+  anyNotEqualTo?: string;
+  anyLessThan?: string;
+  anyLessThanOrEqualTo?: string;
+  anyGreaterThan?: string;
+  anyGreaterThanOrEqualTo?: string;
+}
 // ============ Entity Types ============
 export interface User {
   id: string;
@@ -578,6 +638,66 @@ export interface InternetAddressFilter {
 export interface FullTextFilter {
   matches?: string;
 }
+export interface StringListFilter {
+  isNull?: boolean;
+  equalTo?: string[];
+  notEqualTo?: string[];
+  distinctFrom?: string[];
+  notDistinctFrom?: string[];
+  lessThan?: string[];
+  lessThanOrEqualTo?: string[];
+  greaterThan?: string[];
+  greaterThanOrEqualTo?: string[];
+  contains?: string[];
+  containedBy?: string[];
+  overlaps?: string[];
+  anyEqualTo?: string;
+  anyNotEqualTo?: string;
+  anyLessThan?: string;
+  anyLessThanOrEqualTo?: string;
+  anyGreaterThan?: string;
+  anyGreaterThanOrEqualTo?: string;
+}
+export interface IntListFilter {
+  isNull?: boolean;
+  equalTo?: number[];
+  notEqualTo?: number[];
+  distinctFrom?: number[];
+  notDistinctFrom?: number[];
+  lessThan?: number[];
+  lessThanOrEqualTo?: number[];
+  greaterThan?: number[];
+  greaterThanOrEqualTo?: number[];
+  contains?: number[];
+  containedBy?: number[];
+  overlaps?: number[];
+  anyEqualTo?: number;
+  anyNotEqualTo?: number;
+  anyLessThan?: number;
+  anyLessThanOrEqualTo?: number;
+  anyGreaterThan?: number;
+  anyGreaterThanOrEqualTo?: number;
+}
+export interface UUIDListFilter {
+  isNull?: boolean;
+  equalTo?: string[];
+  notEqualTo?: string[];
+  distinctFrom?: string[];
+  notDistinctFrom?: string[];
+  lessThan?: string[];
+  lessThanOrEqualTo?: string[];
+  greaterThan?: string[];
+  greaterThanOrEqualTo?: string[];
+  contains?: string[];
+  containedBy?: string[];
+  overlaps?: string[];
+  anyEqualTo?: string;
+  anyNotEqualTo?: string;
+  anyLessThan?: string;
+  anyLessThanOrEqualTo?: string;
+  anyGreaterThan?: string;
+  anyGreaterThanOrEqualTo?: string;
+}
 // ============ Entity Types ============
 export interface User {
   id: string;
@@ -833,6 +953,66 @@ export interface InternetAddressFilter {
 }
 export interface FullTextFilter {
   matches?: string;
+}
+export interface StringListFilter {
+  isNull?: boolean;
+  equalTo?: string[];
+  notEqualTo?: string[];
+  distinctFrom?: string[];
+  notDistinctFrom?: string[];
+  lessThan?: string[];
+  lessThanOrEqualTo?: string[];
+  greaterThan?: string[];
+  greaterThanOrEqualTo?: string[];
+  contains?: string[];
+  containedBy?: string[];
+  overlaps?: string[];
+  anyEqualTo?: string;
+  anyNotEqualTo?: string;
+  anyLessThan?: string;
+  anyLessThanOrEqualTo?: string;
+  anyGreaterThan?: string;
+  anyGreaterThanOrEqualTo?: string;
+}
+export interface IntListFilter {
+  isNull?: boolean;
+  equalTo?: number[];
+  notEqualTo?: number[];
+  distinctFrom?: number[];
+  notDistinctFrom?: number[];
+  lessThan?: number[];
+  lessThanOrEqualTo?: number[];
+  greaterThan?: number[];
+  greaterThanOrEqualTo?: number[];
+  contains?: number[];
+  containedBy?: number[];
+  overlaps?: number[];
+  anyEqualTo?: number;
+  anyNotEqualTo?: number;
+  anyLessThan?: number;
+  anyLessThanOrEqualTo?: number;
+  anyGreaterThan?: number;
+  anyGreaterThanOrEqualTo?: number;
+}
+export interface UUIDListFilter {
+  isNull?: boolean;
+  equalTo?: string[];
+  notEqualTo?: string[];
+  distinctFrom?: string[];
+  notDistinctFrom?: string[];
+  lessThan?: string[];
+  lessThanOrEqualTo?: string[];
+  greaterThan?: string[];
+  greaterThanOrEqualTo?: string[];
+  contains?: string[];
+  containedBy?: string[];
+  overlaps?: string[];
+  anyEqualTo?: string;
+  anyNotEqualTo?: string;
+  anyLessThan?: string;
+  anyLessThanOrEqualTo?: string;
+  anyGreaterThan?: string;
+  anyGreaterThanOrEqualTo?: string;
 }
 // ============ Entity Types ============
 export interface User {
@@ -1101,6 +1281,66 @@ export interface InternetAddressFilter {
 }
 export interface FullTextFilter {
   matches?: string;
+}
+export interface StringListFilter {
+  isNull?: boolean;
+  equalTo?: string[];
+  notEqualTo?: string[];
+  distinctFrom?: string[];
+  notDistinctFrom?: string[];
+  lessThan?: string[];
+  lessThanOrEqualTo?: string[];
+  greaterThan?: string[];
+  greaterThanOrEqualTo?: string[];
+  contains?: string[];
+  containedBy?: string[];
+  overlaps?: string[];
+  anyEqualTo?: string;
+  anyNotEqualTo?: string;
+  anyLessThan?: string;
+  anyLessThanOrEqualTo?: string;
+  anyGreaterThan?: string;
+  anyGreaterThanOrEqualTo?: string;
+}
+export interface IntListFilter {
+  isNull?: boolean;
+  equalTo?: number[];
+  notEqualTo?: number[];
+  distinctFrom?: number[];
+  notDistinctFrom?: number[];
+  lessThan?: number[];
+  lessThanOrEqualTo?: number[];
+  greaterThan?: number[];
+  greaterThanOrEqualTo?: number[];
+  contains?: number[];
+  containedBy?: number[];
+  overlaps?: number[];
+  anyEqualTo?: number;
+  anyNotEqualTo?: number;
+  anyLessThan?: number;
+  anyLessThanOrEqualTo?: number;
+  anyGreaterThan?: number;
+  anyGreaterThanOrEqualTo?: number;
+}
+export interface UUIDListFilter {
+  isNull?: boolean;
+  equalTo?: string[];
+  notEqualTo?: string[];
+  distinctFrom?: string[];
+  notDistinctFrom?: string[];
+  lessThan?: string[];
+  lessThanOrEqualTo?: string[];
+  greaterThan?: string[];
+  greaterThanOrEqualTo?: string[];
+  contains?: string[];
+  containedBy?: string[];
+  overlaps?: string[];
+  anyEqualTo?: string;
+  anyNotEqualTo?: string;
+  anyLessThan?: string;
+  anyLessThanOrEqualTo?: string;
+  anyGreaterThan?: string;
+  anyGreaterThanOrEqualTo?: string;
 }
 // ============ Entity Types ============
 export interface User {
@@ -1374,6 +1614,66 @@ export interface InternetAddressFilter {
 }
 export interface FullTextFilter {
   matches?: string;
+}
+export interface StringListFilter {
+  isNull?: boolean;
+  equalTo?: string[];
+  notEqualTo?: string[];
+  distinctFrom?: string[];
+  notDistinctFrom?: string[];
+  lessThan?: string[];
+  lessThanOrEqualTo?: string[];
+  greaterThan?: string[];
+  greaterThanOrEqualTo?: string[];
+  contains?: string[];
+  containedBy?: string[];
+  overlaps?: string[];
+  anyEqualTo?: string;
+  anyNotEqualTo?: string;
+  anyLessThan?: string;
+  anyLessThanOrEqualTo?: string;
+  anyGreaterThan?: string;
+  anyGreaterThanOrEqualTo?: string;
+}
+export interface IntListFilter {
+  isNull?: boolean;
+  equalTo?: number[];
+  notEqualTo?: number[];
+  distinctFrom?: number[];
+  notDistinctFrom?: number[];
+  lessThan?: number[];
+  lessThanOrEqualTo?: number[];
+  greaterThan?: number[];
+  greaterThanOrEqualTo?: number[];
+  contains?: number[];
+  containedBy?: number[];
+  overlaps?: number[];
+  anyEqualTo?: number;
+  anyNotEqualTo?: number;
+  anyLessThan?: number;
+  anyLessThanOrEqualTo?: number;
+  anyGreaterThan?: number;
+  anyGreaterThanOrEqualTo?: number;
+}
+export interface UUIDListFilter {
+  isNull?: boolean;
+  equalTo?: string[];
+  notEqualTo?: string[];
+  distinctFrom?: string[];
+  notDistinctFrom?: string[];
+  lessThan?: string[];
+  lessThanOrEqualTo?: string[];
+  greaterThan?: string[];
+  greaterThanOrEqualTo?: string[];
+  contains?: string[];
+  containedBy?: string[];
+  overlaps?: string[];
+  anyEqualTo?: string;
+  anyNotEqualTo?: string;
+  anyLessThan?: string;
+  anyLessThanOrEqualTo?: string;
+  anyGreaterThan?: string;
+  anyGreaterThanOrEqualTo?: string;
 }
 // ============ Entity Types ============
 export interface User {
@@ -1700,6 +2000,66 @@ export interface InternetAddressFilter {
 export interface FullTextFilter {
   matches?: string;
 }
+export interface StringListFilter {
+  isNull?: boolean;
+  equalTo?: string[];
+  notEqualTo?: string[];
+  distinctFrom?: string[];
+  notDistinctFrom?: string[];
+  lessThan?: string[];
+  lessThanOrEqualTo?: string[];
+  greaterThan?: string[];
+  greaterThanOrEqualTo?: string[];
+  contains?: string[];
+  containedBy?: string[];
+  overlaps?: string[];
+  anyEqualTo?: string;
+  anyNotEqualTo?: string;
+  anyLessThan?: string;
+  anyLessThanOrEqualTo?: string;
+  anyGreaterThan?: string;
+  anyGreaterThanOrEqualTo?: string;
+}
+export interface IntListFilter {
+  isNull?: boolean;
+  equalTo?: number[];
+  notEqualTo?: number[];
+  distinctFrom?: number[];
+  notDistinctFrom?: number[];
+  lessThan?: number[];
+  lessThanOrEqualTo?: number[];
+  greaterThan?: number[];
+  greaterThanOrEqualTo?: number[];
+  contains?: number[];
+  containedBy?: number[];
+  overlaps?: number[];
+  anyEqualTo?: number;
+  anyNotEqualTo?: number;
+  anyLessThan?: number;
+  anyLessThanOrEqualTo?: number;
+  anyGreaterThan?: number;
+  anyGreaterThanOrEqualTo?: number;
+}
+export interface UUIDListFilter {
+  isNull?: boolean;
+  equalTo?: string[];
+  notEqualTo?: string[];
+  distinctFrom?: string[];
+  notDistinctFrom?: string[];
+  lessThan?: string[];
+  lessThanOrEqualTo?: string[];
+  greaterThan?: string[];
+  greaterThanOrEqualTo?: string[];
+  contains?: string[];
+  containedBy?: string[];
+  overlaps?: string[];
+  anyEqualTo?: string;
+  anyNotEqualTo?: string;
+  anyLessThan?: string;
+  anyLessThanOrEqualTo?: string;
+  anyGreaterThan?: string;
+  anyGreaterThanOrEqualTo?: string;
+}
 // ============ Entity Types ============
 export interface Post {
   id: string;
@@ -2017,5 +2377,65 @@ export interface InternetAddressFilter {
 }
 export interface FullTextFilter {
   matches?: string;
+}
+export interface StringListFilter {
+  isNull?: boolean;
+  equalTo?: string[];
+  notEqualTo?: string[];
+  distinctFrom?: string[];
+  notDistinctFrom?: string[];
+  lessThan?: string[];
+  lessThanOrEqualTo?: string[];
+  greaterThan?: string[];
+  greaterThanOrEqualTo?: string[];
+  contains?: string[];
+  containedBy?: string[];
+  overlaps?: string[];
+  anyEqualTo?: string;
+  anyNotEqualTo?: string;
+  anyLessThan?: string;
+  anyLessThanOrEqualTo?: string;
+  anyGreaterThan?: string;
+  anyGreaterThanOrEqualTo?: string;
+}
+export interface IntListFilter {
+  isNull?: boolean;
+  equalTo?: number[];
+  notEqualTo?: number[];
+  distinctFrom?: number[];
+  notDistinctFrom?: number[];
+  lessThan?: number[];
+  lessThanOrEqualTo?: number[];
+  greaterThan?: number[];
+  greaterThanOrEqualTo?: number[];
+  contains?: number[];
+  containedBy?: number[];
+  overlaps?: number[];
+  anyEqualTo?: number;
+  anyNotEqualTo?: number;
+  anyLessThan?: number;
+  anyLessThanOrEqualTo?: number;
+  anyGreaterThan?: number;
+  anyGreaterThanOrEqualTo?: number;
+}
+export interface UUIDListFilter {
+  isNull?: boolean;
+  equalTo?: string[];
+  notEqualTo?: string[];
+  distinctFrom?: string[];
+  notDistinctFrom?: string[];
+  lessThan?: string[];
+  lessThanOrEqualTo?: string[];
+  greaterThan?: string[];
+  greaterThanOrEqualTo?: string[];
+  contains?: string[];
+  containedBy?: string[];
+  overlaps?: string[];
+  anyEqualTo?: string;
+  anyNotEqualTo?: string;
+  anyLessThan?: string;
+  anyLessThanOrEqualTo?: string;
+  anyGreaterThan?: string;
+  anyGreaterThanOrEqualTo?: string;
 }"
 `;

--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/react-query-hooks.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/react-query-hooks.test.ts.snap
@@ -215,7 +215,7 @@ export interface LoginMutationResult {
 export function useLoginMutation(options?: Omit<UseMutationOptions<LoginMutationResult, Error, LoginMutationVariables>, 'mutationFn'>) {
   return useMutation({
     mutationKey: customMutationKeys.login(),
-    mutationFn: (variables: LoginMutationVariables) => execute(loginMutationDocument, variables),
+    mutationFn: (variables: LoginMutationVariables) => execute<LoginMutationResult, LoginMutationVariables>(loginMutationDocument, variables),
     ...options
   });
 }"
@@ -250,7 +250,7 @@ export interface RegisterMutationResult {
 export function useRegisterMutation(options?: Omit<UseMutationOptions<RegisterMutationResult, Error, RegisterMutationVariables>, 'mutationFn'>) {
   return useMutation({
     mutationKey: customMutationKeys.register(),
-    mutationFn: (variables: RegisterMutationVariables) => execute(registerMutationDocument, variables),
+    mutationFn: (variables: RegisterMutationVariables) => execute<RegisterMutationResult, RegisterMutationVariables>(registerMutationDocument, variables),
     ...options
   });
 }"
@@ -282,7 +282,7 @@ export interface LogoutMutationResult {
 export function useLogoutMutation(options?: Omit<UseMutationOptions<LogoutMutationResult, Error, void>, 'mutationFn'>) {
   return useMutation({
     mutationKey: customMutationKeys.logout(),
-    mutationFn: () => execute(logoutMutationDocument),
+    mutationFn: () => execute<LogoutMutationResult>(logoutMutationDocument),
     ...options
   });
 }"
@@ -316,7 +316,7 @@ export interface LoginMutationResult {
 }
 export function useLoginMutation(options?: Omit<UseMutationOptions<LoginMutationResult, Error, LoginMutationVariables>, 'mutationFn'>) {
   return useMutation({
-    mutationFn: (variables: LoginMutationVariables) => execute(loginMutationDocument, variables),
+    mutationFn: (variables: LoginMutationVariables) => execute<LoginMutationResult, LoginMutationVariables>(loginMutationDocument, variables),
     ...options
   });
 }"
@@ -365,7 +365,7 @@ export const searchUsersQueryKey = customQueryKeys.searchUsers;
 export function useSearchUsersQuery(variables: SearchUsersQueryVariables, options?: Omit<UseQueryOptions<SearchUsersQueryResult, Error>, 'queryKey' | 'queryFn'>) {
   return useQuery({
     queryKey: searchUsersQueryKey(variables),
-    queryFn: () => execute(searchUsersQueryDocument, variables),
+    queryFn: () => execute<SearchUsersQueryResult, SearchUsersQueryVariables>(searchUsersQueryDocument, variables),
     enabled: !!variables && options?.enabled !== false,
     ...options
   });
@@ -379,7 +379,7 @@ export function useSearchUsersQuery(variables: SearchUsersQueryVariables, option
  * \`\`\`
  */
 export async function fetchSearchUsersQuery(variables: SearchUsersQueryVariables, options?: ExecuteOptions): Promise<SearchUsersQueryResult> {
-  return execute(searchUsersQueryDocument, variables, options);
+  return execute<SearchUsersQueryResult, SearchUsersQueryVariables>(searchUsersQueryDocument, variables, options);
 }
 /**
  * Prefetch searchUsers for SSR or cache warming
@@ -392,7 +392,7 @@ export async function fetchSearchUsersQuery(variables: SearchUsersQueryVariables
 export async function prefetchSearchUsersQuery(queryClient: QueryClient, variables: SearchUsersQueryVariables, options?: ExecuteOptions): Promise<void> {
   await queryClient.prefetchQuery({
     queryKey: searchUsersQueryKey(variables),
-    queryFn: () => execute(searchUsersQueryDocument, variables, options)
+    queryFn: () => execute<SearchUsersQueryResult, SearchUsersQueryVariables>(searchUsersQueryDocument, variables, options)
   });
 }"
 `;
@@ -436,7 +436,7 @@ export const currentUserQueryKey = customQueryKeys.currentUser;
 export function useCurrentUserQuery(options?: Omit<UseQueryOptions<CurrentUserQueryResult, Error>, 'queryKey' | 'queryFn'>) {
   return useQuery({
     queryKey: currentUserQueryKey(),
-    queryFn: () => execute(currentUserQueryDocument),
+    queryFn: () => execute<CurrentUserQueryResult>(currentUserQueryDocument),
     ...options
   });
 }
@@ -449,7 +449,7 @@ export function useCurrentUserQuery(options?: Omit<UseQueryOptions<CurrentUserQu
  * \`\`\`
  */
 export async function fetchCurrentUserQuery(options?: ExecuteOptions): Promise<CurrentUserQueryResult> {
-  return execute(currentUserQueryDocument, undefined, options);
+  return execute<CurrentUserQueryResult>(currentUserQueryDocument, undefined, options);
 }
 /**
  * Prefetch currentUser for SSR or cache warming
@@ -462,7 +462,7 @@ export async function fetchCurrentUserQuery(options?: ExecuteOptions): Promise<C
 export async function prefetchCurrentUserQuery(queryClient: QueryClient, options?: ExecuteOptions): Promise<void> {
   await queryClient.prefetchQuery({
     queryKey: currentUserQueryKey(),
-    queryFn: () => execute(currentUserQueryDocument, undefined, options)
+    queryFn: () => execute<CurrentUserQueryResult>(currentUserQueryDocument, undefined, options)
   });
 }"
 `;
@@ -505,7 +505,7 @@ export const currentUserQueryKey = () => ["currentUser"] as const;
 export function useCurrentUserQuery(options?: Omit<UseQueryOptions<CurrentUserQueryResult, Error>, 'queryKey' | 'queryFn'>) {
   return useQuery({
     queryKey: currentUserQueryKey(),
-    queryFn: () => execute(currentUserQueryDocument),
+    queryFn: () => execute<CurrentUserQueryResult>(currentUserQueryDocument),
     ...options
   });
 }
@@ -518,7 +518,7 @@ export function useCurrentUserQuery(options?: Omit<UseQueryOptions<CurrentUserQu
  * \`\`\`
  */
 export async function fetchCurrentUserQuery(options?: ExecuteOptions): Promise<CurrentUserQueryResult> {
-  return execute(currentUserQueryDocument, undefined, options);
+  return execute<CurrentUserQueryResult>(currentUserQueryDocument, undefined, options);
 }
 /**
  * Prefetch currentUser for SSR or cache warming
@@ -531,7 +531,7 @@ export async function fetchCurrentUserQuery(options?: ExecuteOptions): Promise<C
 export async function prefetchCurrentUserQuery(queryClient: QueryClient, options?: ExecuteOptions): Promise<void> {
   await queryClient.prefetchQuery({
     queryKey: currentUserQueryKey(),
-    queryFn: () => execute(currentUserQueryDocument, undefined, options)
+    queryFn: () => execute<CurrentUserQueryResult>(currentUserQueryDocument, undefined, options)
   });
 }"
 `;
@@ -597,7 +597,7 @@ export function useCreateUserMutation(options?: Omit<UseMutationOptions<CreateUs
   const queryClient = useQueryClient();
   return useMutation({
     mutationKey: userMutationKeys.create(),
-    mutationFn: (variables: CreateUserMutationVariables) => execute(createUserMutationDocument, variables),
+    mutationFn: (variables: CreateUserMutationVariables) => execute<CreateUserMutationResult, CreateUserMutationVariables>(createUserMutationDocument, variables),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: userKeys.lists()
@@ -674,7 +674,7 @@ export function useCreatePostMutation(options?: Omit<UseMutationOptions<CreatePo
   const queryClient = useQueryClient();
   return useMutation({
     mutationKey: postMutationKeys.create(),
-    mutationFn: (variables: CreatePostMutationVariables) => execute(createPostMutationDocument, variables),
+    mutationFn: (variables: CreatePostMutationVariables) => execute<CreatePostMutationResult, CreatePostMutationVariables>(createPostMutationDocument, variables),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: postKeys.lists()
@@ -743,7 +743,7 @@ export interface CreateUserMutationResult {
 export function useCreateUserMutation(options?: Omit<UseMutationOptions<CreateUserMutationResult, Error, CreateUserMutationVariables>, 'mutationFn'>) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (variables: CreateUserMutationVariables) => execute(createUserMutationDocument, variables),
+    mutationFn: (variables: CreateUserMutationVariables) => execute<CreateUserMutationResult, CreateUserMutationVariables>(createUserMutationDocument, variables),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ["user", "list"]
@@ -803,7 +803,7 @@ export function useDeleteUserMutation(options?: Omit<UseMutationOptions<DeleteUs
   const queryClient = useQueryClient();
   return useMutation({
     mutationKey: userMutationKeys.all,
-    mutationFn: (variables: DeleteUserMutationVariables) => execute(deleteUserMutationDocument, variables),
+    mutationFn: (variables: DeleteUserMutationVariables) => execute<DeleteUserMutationResult, DeleteUserMutationVariables>(deleteUserMutationDocument, variables),
     onSuccess: (_, variables) => {
       queryClient.removeQueries({
         queryKey: userKeys.detail(variables.input.id)
@@ -867,7 +867,7 @@ export function useDeletePostMutation(options?: Omit<UseMutationOptions<DeletePo
   const queryClient = useQueryClient();
   return useMutation({
     mutationKey: postMutationKeys.all,
-    mutationFn: (variables: DeletePostMutationVariables) => execute(deletePostMutationDocument, variables),
+    mutationFn: (variables: DeletePostMutationVariables) => execute<DeletePostMutationResult, DeletePostMutationVariables>(deletePostMutationDocument, variables),
     onSuccess: (_, variables) => {
       queryClient.removeQueries({
         queryKey: postKeys.detail(variables.input.id)
@@ -927,7 +927,7 @@ export interface DeleteUserMutationResult {
 export function useDeleteUserMutation(options?: Omit<UseMutationOptions<DeleteUserMutationResult, Error, DeleteUserMutationVariables>, 'mutationFn'>) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (variables: DeleteUserMutationVariables) => execute(deleteUserMutationDocument, variables),
+    mutationFn: (variables: DeleteUserMutationVariables) => execute<DeleteUserMutationResult, DeleteUserMutationVariables>(deleteUserMutationDocument, variables),
     onSuccess: (_, variables) => {
       queryClient.removeQueries({
         queryKey: ["user", "detail", variables.input.id]
@@ -1005,7 +1005,7 @@ export function useUpdateUserMutation(options?: Omit<UseMutationOptions<UpdateUs
   const queryClient = useQueryClient();
   return useMutation({
     mutationKey: userMutationKeys.all,
-    mutationFn: (variables: UpdateUserMutationVariables) => execute(updateUserMutationDocument, variables),
+    mutationFn: (variables: UpdateUserMutationVariables) => execute<UpdateUserMutationResult, UpdateUserMutationVariables>(updateUserMutationDocument, variables),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
         queryKey: userKeys.detail(variables.input.id)
@@ -1088,7 +1088,7 @@ export function useUpdatePostMutation(options?: Omit<UseMutationOptions<UpdatePo
   const queryClient = useQueryClient();
   return useMutation({
     mutationKey: postMutationKeys.all,
-    mutationFn: (variables: UpdatePostMutationVariables) => execute(updatePostMutationDocument, variables),
+    mutationFn: (variables: UpdatePostMutationVariables) => execute<UpdatePostMutationResult, UpdatePostMutationVariables>(updatePostMutationDocument, variables),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
         queryKey: postKeys.detail(variables.input.id)
@@ -1163,7 +1163,7 @@ export interface UpdateUserMutationResult {
 export function useUpdateUserMutation(options?: Omit<UseMutationOptions<UpdateUserMutationResult, Error, UpdateUserMutationVariables>, 'mutationFn'>) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (variables: UpdateUserMutationVariables) => execute(updateUserMutationDocument, variables),
+    mutationFn: (variables: UpdateUserMutationVariables) => execute<UpdateUserMutationResult, UpdateUserMutationVariables>(updateUserMutationDocument, variables),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
         queryKey: ["user", "detail", variables.input.id]
@@ -1255,7 +1255,7 @@ export const usersQueryKey = userKeys.list;
 export function useUsersQuery(variables?: UsersQueryVariables, options?: Omit<UseQueryOptions<UsersQueryResult, Error>, 'queryKey' | 'queryFn'>) {
   return useQuery({
     queryKey: userKeys.list(variables),
-    queryFn: () => execute(usersQueryDocument, variables),
+    queryFn: () => execute<UsersQueryResult, UsersQueryVariables>(usersQueryDocument, variables),
     ...options
   });
 }
@@ -1275,7 +1275,7 @@ export function useUsersQuery(variables?: UsersQueryVariables, options?: Omit<Us
  * \`\`\`
  */
 export async function fetchUsersQuery(variables?: UsersQueryVariables, options?: ExecuteOptions): Promise<UsersQueryResult> {
-  return execute(usersQueryDocument, variables, options);
+  return execute<UsersQueryResult, UsersQueryVariables>(usersQueryDocument, variables, options);
 }
 /**
  * Prefetch User list for SSR or cache warming
@@ -1288,7 +1288,7 @@ export async function fetchUsersQuery(variables?: UsersQueryVariables, options?:
 export async function prefetchUsersQuery(queryClient: QueryClient, variables?: UsersQueryVariables, options?: ExecuteOptions): Promise<void> {
   await queryClient.prefetchQuery({
     queryKey: userKeys.list(variables),
-    queryFn: () => execute(usersQueryDocument, variables, options)
+    queryFn: () => execute<UsersQueryResult, UsersQueryVariables>(usersQueryDocument, variables, options)
   });
 }"
 `;
@@ -1388,7 +1388,7 @@ export function usePostsQuery(variables?: PostsQueryVariables, options?: Omit<Us
   } = options ?? {};
   return useQuery({
     queryKey: postKeys.list(variables, scope),
-    queryFn: () => execute(postsQueryDocument, variables),
+    queryFn: () => execute<PostsQueryResult, PostsQueryVariables>(postsQueryDocument, variables),
     ...queryOptions
   });
 }
@@ -1408,7 +1408,7 @@ export function usePostsQuery(variables?: PostsQueryVariables, options?: Omit<Us
  * \`\`\`
  */
 export async function fetchPostsQuery(variables?: PostsQueryVariables, options?: ExecuteOptions): Promise<PostsQueryResult> {
-  return execute(postsQueryDocument, variables, options);
+  return execute<PostsQueryResult, PostsQueryVariables>(postsQueryDocument, variables, options);
 }
 /**
  * Prefetch Post list for SSR or cache warming
@@ -1421,7 +1421,7 @@ export async function fetchPostsQuery(variables?: PostsQueryVariables, options?:
 export async function prefetchPostsQuery(queryClient: QueryClient, variables?: PostsQueryVariables, scope?: PostScope, options?: ExecuteOptions): Promise<void> {
   await queryClient.prefetchQuery({
     queryKey: postKeys.list(variables, scope),
-    queryFn: () => execute(postsQueryDocument, variables, options)
+    queryFn: () => execute<PostsQueryResult, PostsQueryVariables>(postsQueryDocument, variables, options)
   });
 }"
 `;
@@ -1502,7 +1502,7 @@ export const usersQueryKey = (variables?: UsersQueryVariables) => ["user", "list
 export function useUsersQuery(variables?: UsersQueryVariables, options?: Omit<UseQueryOptions<UsersQueryResult, Error>, 'queryKey' | 'queryFn'>) {
   return useQuery({
     queryKey: usersQueryKey(variables),
-    queryFn: () => execute(usersQueryDocument, variables),
+    queryFn: () => execute<UsersQueryResult, UsersQueryVariables>(usersQueryDocument, variables),
     ...options
   });
 }
@@ -1522,7 +1522,7 @@ export function useUsersQuery(variables?: UsersQueryVariables, options?: Omit<Us
  * \`\`\`
  */
 export async function fetchUsersQuery(variables?: UsersQueryVariables, options?: ExecuteOptions): Promise<UsersQueryResult> {
-  return execute(usersQueryDocument, variables, options);
+  return execute<UsersQueryResult, UsersQueryVariables>(usersQueryDocument, variables, options);
 }
 /**
  * Prefetch User list for SSR or cache warming
@@ -1535,7 +1535,7 @@ export async function fetchUsersQuery(variables?: UsersQueryVariables, options?:
 export async function prefetchUsersQuery(queryClient: QueryClient, variables?: UsersQueryVariables, options?: ExecuteOptions): Promise<void> {
   await queryClient.prefetchQuery({
     queryKey: usersQueryKey(variables),
-    queryFn: () => execute(usersQueryDocument, variables, options)
+    queryFn: () => execute<UsersQueryResult, UsersQueryVariables>(usersQueryDocument, variables, options)
   });
 }"
 `;
@@ -1583,7 +1583,7 @@ export const userQueryKey = userKeys.detail;
 export function useUserQuery(variables: UserQueryVariables, options?: Omit<UseQueryOptions<UserQueryResult, Error>, 'queryKey' | 'queryFn'>) {
   return useQuery({
     queryKey: userKeys.detail(variables.id),
-    queryFn: () => execute(userQueryDocument, variables),
+    queryFn: () => execute<UserQueryResult, UserQueryVariables>(userQueryDocument, variables),
     ...options
   });
 }
@@ -1596,7 +1596,7 @@ export function useUserQuery(variables: UserQueryVariables, options?: Omit<UseQu
  * \`\`\`
  */
 export async function fetchUserQuery(variables: UserQueryVariables, options?: ExecuteOptions): Promise<UserQueryResult> {
-  return execute(userQueryDocument, variables, options);
+  return execute<UserQueryResult, UserQueryVariables>(userQueryDocument, variables, options);
 }
 /**
  * Prefetch a single User for SSR or cache warming
@@ -1609,7 +1609,7 @@ export async function fetchUserQuery(variables: UserQueryVariables, options?: Ex
 export async function prefetchUserQuery(queryClient: QueryClient, variables: UserQueryVariables, options?: ExecuteOptions): Promise<void> {
   await queryClient.prefetchQuery({
     queryKey: userKeys.detail(variables.id),
-    queryFn: () => execute(userQueryDocument, variables, options)
+    queryFn: () => execute<UserQueryResult, UserQueryVariables>(userQueryDocument, variables, options)
   });
 }"
 `;
@@ -1672,7 +1672,7 @@ export function usePostQuery(variables: PostQueryVariables, options?: Omit<UseQu
   } = options ?? {};
   return useQuery({
     queryKey: postKeys.detail(variables.id, scope),
-    queryFn: () => execute(postQueryDocument, variables),
+    queryFn: () => execute<PostQueryResult, PostQueryVariables>(postQueryDocument, variables),
     ...queryOptions
   });
 }
@@ -1685,7 +1685,7 @@ export function usePostQuery(variables: PostQueryVariables, options?: Omit<UseQu
  * \`\`\`
  */
 export async function fetchPostQuery(variables: PostQueryVariables, options?: ExecuteOptions): Promise<PostQueryResult> {
-  return execute(postQueryDocument, variables, options);
+  return execute<PostQueryResult, PostQueryVariables>(postQueryDocument, variables, options);
 }
 /**
  * Prefetch a single Post for SSR or cache warming
@@ -1698,7 +1698,7 @@ export async function fetchPostQuery(variables: PostQueryVariables, options?: Ex
 export async function prefetchPostQuery(queryClient: QueryClient, variables: PostQueryVariables, scope?: PostScope, options?: ExecuteOptions): Promise<void> {
   await queryClient.prefetchQuery({
     queryKey: postKeys.detail(variables.id, scope),
-    queryFn: () => execute(postQueryDocument, variables, options)
+    queryFn: () => execute<PostQueryResult, PostQueryVariables>(postQueryDocument, variables, options)
   });
 }"
 `;
@@ -1744,7 +1744,7 @@ export const userQueryKey = (id: string) => ["user", "detail", id] as const;
 export function useUserQuery(variables: UserQueryVariables, options?: Omit<UseQueryOptions<UserQueryResult, Error>, 'queryKey' | 'queryFn'>) {
   return useQuery({
     queryKey: userQueryKey(variables.id),
-    queryFn: () => execute(userQueryDocument, variables),
+    queryFn: () => execute<UserQueryResult, UserQueryVariables>(userQueryDocument, variables),
     ...options
   });
 }
@@ -1757,7 +1757,7 @@ export function useUserQuery(variables: UserQueryVariables, options?: Omit<UseQu
  * \`\`\`
  */
 export async function fetchUserQuery(variables: UserQueryVariables, options?: ExecuteOptions): Promise<UserQueryResult> {
-  return execute(userQueryDocument, variables, options);
+  return execute<UserQueryResult, UserQueryVariables>(userQueryDocument, variables, options);
 }
 /**
  * Prefetch a single User for SSR or cache warming
@@ -1770,7 +1770,7 @@ export async function fetchUserQuery(variables: UserQueryVariables, options?: Ex
 export async function prefetchUserQuery(queryClient: QueryClient, variables: UserQueryVariables, options?: ExecuteOptions): Promise<void> {
   await queryClient.prefetchQuery({
     queryKey: userQueryKey(variables.id),
-    queryFn: () => execute(userQueryDocument, variables, options)
+    queryFn: () => execute<UserQueryResult, UserQueryVariables>(userQueryDocument, variables, options)
   });
 }"
 `;

--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/react-query-hooks.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/react-query-hooks.test.ts.snap
@@ -1192,8 +1192,17 @@ import type { User, UUIDFilter, StringFilter, DatetimeFilter } from "../types";
 import { userKeys } from "../query-keys";
 export type { User } from "../types";
 export const usersQueryDocument = \`
-query UsersQuery($first: Int, $offset: Int, $filter: UserFilter, $orderBy: [UsersOrderBy!]) {
-  users(first: $first, offset: $offset, filter: $filter, orderBy: $orderBy) {
+query UsersQuery($first: Int, $last: Int, $offset: Int, $before: Cursor, $after: Cursor, $filter: UserFilter, $condition: UserCondition, $orderBy: [UsersOrderBy!]) {
+  users(
+    first: $first
+    last: $last
+    offset: $offset
+    before: $before
+    after: $after
+    filter: $filter
+    condition: $condition
+    orderBy: $orderBy
+  ) {
     totalCount
     nodes {
       id
@@ -1219,11 +1228,21 @@ interface UserFilter {
   or?: UserFilter[];
   not?: UserFilter;
 }
+interface UserCondition {
+  id?: string;
+  email?: string;
+  name?: string;
+  createdAt?: string;
+}
 type UsersOrderBy = "ID_ASC" | "ID_DESC" | "EMAIL_ASC" | "EMAIL_DESC" | "NAME_ASC" | "NAME_DESC" | "CREATED_AT_ASC" | "CREATED_AT_DESC" | "NATURAL" | "PRIMARY_KEY_ASC" | "PRIMARY_KEY_DESC";
 export interface UsersQueryVariables {
   first?: number;
+  last?: number;
   offset?: number;
+  before?: string;
+  after?: string;
   filter?: UserFilter;
+  condition?: UserCondition;
   orderBy?: UsersOrderBy[];
 }
 export interface UsersQueryResult {
@@ -1309,8 +1328,17 @@ import { postKeys } from "../query-keys";
 import type { PostScope } from "../query-keys";
 export type { Post } from "../types";
 export const postsQueryDocument = \`
-query PostsQuery($first: Int, $offset: Int, $filter: PostFilter, $orderBy: [PostsOrderBy!]) {
-  posts(first: $first, offset: $offset, filter: $filter, orderBy: $orderBy) {
+query PostsQuery($first: Int, $last: Int, $offset: Int, $before: Cursor, $after: Cursor, $filter: PostFilter, $condition: PostCondition, $orderBy: [PostsOrderBy!]) {
+  posts(
+    first: $first
+    last: $last
+    offset: $offset
+    before: $before
+    after: $after
+    filter: $filter
+    condition: $condition
+    orderBy: $orderBy
+  ) {
     totalCount
     nodes {
       id
@@ -1340,11 +1368,23 @@ interface PostFilter {
   or?: PostFilter[];
   not?: PostFilter;
 }
+interface PostCondition {
+  id?: string;
+  title?: string;
+  content?: string;
+  authorId?: string;
+  published?: boolean;
+  createdAt?: string;
+}
 type PostsOrderBy = "ID_ASC" | "ID_DESC" | "TITLE_ASC" | "TITLE_DESC" | "CONTENT_ASC" | "CONTENT_DESC" | "AUTHOR_ID_ASC" | "AUTHOR_ID_DESC" | "PUBLISHED_ASC" | "PUBLISHED_DESC" | "CREATED_AT_ASC" | "CREATED_AT_DESC" | "NATURAL" | "PRIMARY_KEY_ASC" | "PRIMARY_KEY_DESC";
 export interface PostsQueryVariables {
   first?: number;
+  last?: number;
   offset?: number;
+  before?: string;
+  after?: string;
   filter?: PostFilter;
+  condition?: PostCondition;
   orderBy?: PostsOrderBy[];
 }
 export interface PostsQueryResult {
@@ -1440,8 +1480,17 @@ import type { ExecuteOptions } from "../client";
 import type { User, UUIDFilter, StringFilter, DatetimeFilter } from "../types";
 export type { User } from "../types";
 export const usersQueryDocument = \`
-query UsersQuery($first: Int, $offset: Int, $filter: UserFilter, $orderBy: [UsersOrderBy!]) {
-  users(first: $first, offset: $offset, filter: $filter, orderBy: $orderBy) {
+query UsersQuery($first: Int, $last: Int, $offset: Int, $before: Cursor, $after: Cursor, $filter: UserFilter, $condition: UserCondition, $orderBy: [UsersOrderBy!]) {
+  users(
+    first: $first
+    last: $last
+    offset: $offset
+    before: $before
+    after: $after
+    filter: $filter
+    condition: $condition
+    orderBy: $orderBy
+  ) {
     totalCount
     nodes {
       id
@@ -1467,11 +1516,21 @@ interface UserFilter {
   or?: UserFilter[];
   not?: UserFilter;
 }
+interface UserCondition {
+  id?: string;
+  email?: string;
+  name?: string;
+  createdAt?: string;
+}
 type UsersOrderBy = "ID_ASC" | "ID_DESC" | "EMAIL_ASC" | "EMAIL_DESC" | "NAME_ASC" | "NAME_DESC" | "CREATED_AT_ASC" | "CREATED_AT_DESC" | "NATURAL" | "PRIMARY_KEY_ASC" | "PRIMARY_KEY_DESC";
 export interface UsersQueryVariables {
   first?: number;
+  last?: number;
   offset?: number;
+  before?: string;
+  after?: string;
   filter?: UserFilter;
+  condition?: UserCondition;
   orderBy?: UsersOrderBy[];
 }
 export interface UsersQueryResult {

--- a/graphql/codegen/src/cli/codegen/babel-ast.ts
+++ b/graphql/codegen/src/cli/codegen/babel-ast.ts
@@ -109,9 +109,28 @@ export function typedParam(
 export function keyofTypeof(name: string): t.TSTypeOperator {
   const typeofOp = t.tsTypeOperator(t.tsTypeReference(t.identifier(name)));
   typeofOp.operator = 'typeof';
-  
+
   const keyofOp = t.tsTypeOperator(typeofOp);
   keyofOp.operator = 'keyof';
-  
+
   return keyofOp;
+}
+
+/**
+ * Create a call expression with TypeScript type parameters
+ *
+ * This is used to generate typed function calls like:
+ * execute<ResultType, VariablesType>(document, variables)
+ */
+export function createTypedCallExpression(
+  callee: t.Expression,
+  args: (t.Expression | t.SpreadElement)[],
+  typeParams: t.TSType[]
+): t.CallExpression {
+  const call = t.callExpression(callee, args);
+  if (typeParams.length > 0) {
+    // @ts-ignore - Babel types support typeParameters on CallExpression for TS
+    call.typeParameters = t.tsTypeParameterInstantiation(typeParams);
+  }
+  return call;
 }

--- a/graphql/codegen/src/cli/codegen/custom-mutations.ts
+++ b/graphql/codegen/src/cli/codegen/custom-mutations.ts
@@ -16,7 +16,7 @@ import type {
   TypeRegistry,
 } from '../../types/schema';
 import * as t from '@babel/types';
-import { generateCode, addJSDocComment, typedParam } from './babel-ast';
+import { generateCode, addJSDocComment, typedParam, createTypedCallExpression } from './babel-ast';
 import { buildCustomMutationString } from './schema-gql-ast';
 import {
   typeRefToTsType,
@@ -236,10 +236,14 @@ function generateCustomMutationHookInternal(
         t.identifier('mutationFn'),
         t.arrowFunctionExpression(
           [typedParam('variables', t.tsTypeReference(t.identifier(variablesTypeName)))],
-          t.callExpression(t.identifier('execute'), [
-            t.identifier(documentConstName),
-            t.identifier('variables'),
-          ])
+          createTypedCallExpression(
+            t.identifier('execute'),
+            [t.identifier(documentConstName), t.identifier('variables')],
+            [
+              t.tsTypeReference(t.identifier(resultTypeName)),
+              t.tsTypeReference(t.identifier(variablesTypeName)),
+            ]
+          )
         )
       )
     );
@@ -249,7 +253,11 @@ function generateCustomMutationHookInternal(
         t.identifier('mutationFn'),
         t.arrowFunctionExpression(
           [],
-          t.callExpression(t.identifier('execute'), [t.identifier(documentConstName)])
+          createTypedCallExpression(
+            t.identifier('execute'),
+            [t.identifier(documentConstName)],
+            [t.tsTypeReference(t.identifier(resultTypeName))]
+          )
         )
       )
     );

--- a/graphql/codegen/src/cli/codegen/custom-queries.ts
+++ b/graphql/codegen/src/cli/codegen/custom-queries.ts
@@ -16,7 +16,7 @@ import type {
   TypeRegistry,
 } from '../../types/schema';
 import * as t from '@babel/types';
-import { generateCode, addJSDocComment, typedParam } from './babel-ast';
+import { generateCode, addJSDocComment, typedParam, createTypedCallExpression } from './babel-ast';
 import { buildCustomQueryString } from './schema-gql-ast';
 import {
   typeRefToTsType,
@@ -267,10 +267,14 @@ export function generateCustomQueryHook(
           t.identifier('queryFn'),
           t.arrowFunctionExpression(
             [],
-            t.callExpression(t.identifier('execute'), [
-              t.identifier(documentConstName),
-              t.identifier('variables'),
-            ])
+            createTypedCallExpression(
+              t.identifier('execute'),
+              [t.identifier(documentConstName), t.identifier('variables')],
+              [
+                t.tsTypeReference(t.identifier(resultTypeName)),
+                t.tsTypeReference(t.identifier(variablesTypeName)),
+              ]
+            )
           )
         )
       );
@@ -307,7 +311,11 @@ export function generateCustomQueryHook(
           t.identifier('queryFn'),
           t.arrowFunctionExpression(
             [],
-            t.callExpression(t.identifier('execute'), [t.identifier(documentConstName)])
+            createTypedCallExpression(
+              t.identifier('execute'),
+              [t.identifier(documentConstName)],
+              [t.tsTypeReference(t.identifier(resultTypeName))]
+            )
           )
         )
       );
@@ -365,21 +373,24 @@ export function generateCustomQueryHook(
   if (hasArgs) {
     fetchBodyStatements.push(
       t.returnStatement(
-        t.callExpression(t.identifier('execute'), [
-          t.identifier(documentConstName),
-          t.identifier('variables'),
-          t.identifier('options'),
-        ])
+        createTypedCallExpression(
+          t.identifier('execute'),
+          [t.identifier(documentConstName), t.identifier('variables'), t.identifier('options')],
+          [
+            t.tsTypeReference(t.identifier(resultTypeName)),
+            t.tsTypeReference(t.identifier(variablesTypeName)),
+          ]
+        )
       )
     );
   } else {
     fetchBodyStatements.push(
       t.returnStatement(
-        t.callExpression(t.identifier('execute'), [
-          t.identifier(documentConstName),
-          t.identifier('undefined'),
-          t.identifier('options'),
-        ])
+        createTypedCallExpression(
+          t.identifier('execute'),
+          [t.identifier(documentConstName), t.identifier('undefined'), t.identifier('options')],
+          [t.tsTypeReference(t.identifier(resultTypeName))]
+        )
       )
     );
   }
@@ -436,11 +447,14 @@ export function generateCustomQueryHook(
           t.identifier('queryFn'),
           t.arrowFunctionExpression(
             [],
-            t.callExpression(t.identifier('execute'), [
-              t.identifier(documentConstName),
-              t.identifier('variables'),
-              t.identifier('options'),
-            ])
+            createTypedCallExpression(
+              t.identifier('execute'),
+              [t.identifier(documentConstName), t.identifier('variables'), t.identifier('options')],
+              [
+                t.tsTypeReference(t.identifier(resultTypeName)),
+                t.tsTypeReference(t.identifier(variablesTypeName)),
+              ]
+            )
           )
         )
       );
@@ -456,11 +470,11 @@ export function generateCustomQueryHook(
           t.identifier('queryFn'),
           t.arrowFunctionExpression(
             [],
-            t.callExpression(t.identifier('execute'), [
-              t.identifier(documentConstName),
-              t.identifier('undefined'),
-              t.identifier('options'),
-            ])
+            createTypedCallExpression(
+              t.identifier('execute'),
+              [t.identifier(documentConstName), t.identifier('undefined'), t.identifier('options')],
+              [t.tsTypeReference(t.identifier(resultTypeName))]
+            )
           )
         )
       );

--- a/graphql/codegen/src/cli/codegen/gql-ast.ts
+++ b/graphql/codegen/src/cli/codegen/gql-ast.ts
@@ -21,6 +21,7 @@ import {
   getUpdateMutationName,
   getDeleteMutationName,
   getFilterTypeName,
+  getConditionTypeName,
   getOrderByTypeName,
   getScalarFields,
   getPrimaryKeyInfo,
@@ -72,13 +73,18 @@ export function buildListQueryAST(config: ListQueryConfig): DocumentNode {
   const { table } = config;
   const queryName = getAllRowsQueryName(table);
   const filterType = getFilterTypeName(table);
+  const conditionType = getConditionTypeName(table);
   const orderByType = getOrderByTypeName(table);
   const scalarFields = getScalarFields(table);
 
-  // Variable definitions
+  // Variable definitions - all pagination arguments from PostGraphile
   const variableDefinitions: VariableDefinitionNode[] = [
     t.variableDefinition({
       variable: t.variable({ name: 'first' }),
+      type: t.namedType({ type: 'Int' }),
+    }),
+    t.variableDefinition({
+      variable: t.variable({ name: 'last' }),
       type: t.namedType({ type: 'Int' }),
     }),
     t.variableDefinition({
@@ -86,8 +92,20 @@ export function buildListQueryAST(config: ListQueryConfig): DocumentNode {
       type: t.namedType({ type: 'Int' }),
     }),
     t.variableDefinition({
+      variable: t.variable({ name: 'before' }),
+      type: t.namedType({ type: 'Cursor' }),
+    }),
+    t.variableDefinition({
+      variable: t.variable({ name: 'after' }),
+      type: t.namedType({ type: 'Cursor' }),
+    }),
+    t.variableDefinition({
       variable: t.variable({ name: 'filter' }),
       type: t.namedType({ type: filterType }),
+    }),
+    t.variableDefinition({
+      variable: t.variable({ name: 'condition' }),
+      type: t.namedType({ type: conditionType }),
     }),
     t.variableDefinition({
       variable: t.variable({ name: 'orderBy' }),
@@ -100,8 +118,12 @@ export function buildListQueryAST(config: ListQueryConfig): DocumentNode {
   // Query arguments
   const args: ArgumentNode[] = [
     t.argument({ name: 'first', value: t.variable({ name: 'first' }) }),
+    t.argument({ name: 'last', value: t.variable({ name: 'last' }) }),
     t.argument({ name: 'offset', value: t.variable({ name: 'offset' }) }),
+    t.argument({ name: 'before', value: t.variable({ name: 'before' }) }),
+    t.argument({ name: 'after', value: t.variable({ name: 'after' }) }),
     t.argument({ name: 'filter', value: t.variable({ name: 'filter' }) }),
+    t.argument({ name: 'condition', value: t.variable({ name: 'condition' }) }),
     t.argument({ name: 'orderBy', value: t.variable({ name: 'orderBy' }) }),
   ];
 

--- a/graphql/codegen/src/cli/codegen/index.ts
+++ b/graphql/codegen/src/cli/codegen/index.ts
@@ -255,6 +255,7 @@ export function generate(options: GenerateOptions): GenerateResult {
     enumsFromSchemaTypes: generatedEnumNames,
     useCentralizedKeys,
     hasRelationships,
+    tableTypeNames,
   });
   for (const hook of mutationHooks) {
     files.push({

--- a/graphql/codegen/src/cli/codegen/queries.ts
+++ b/graphql/codegen/src/cli/codegen/queries.ts
@@ -23,10 +23,13 @@ import {
   getAllRowsQueryName,
   getSingleRowQueryName,
   getFilterTypeName,
+  getConditionTypeName,
   getOrderByTypeName,
   getScalarFields,
   getScalarFilterType,
   getPrimaryKeyInfo,
+  hasValidPrimaryKey,
+  fieldTypeToTs,
   toScreamingSnake,
   ucFirst,
   lcFirst,
@@ -106,6 +109,7 @@ export function generateListQueryHook(
   const hookName = getListQueryHookName(table);
   const queryName = getAllRowsQueryName(table);
   const filterTypeName = getFilterTypeName(table);
+  const conditionTypeName = getConditionTypeName(table);
   const orderByTypeName = getOrderByTypeName(table);
   const scalarFields = getScalarFields(table);
   const keysName = `${lcFirst(typeName)}Keys`;
@@ -232,6 +236,80 @@ export function generateListQueryHook(
     createFilterInterfaceDeclaration(filterTypeName, fieldFilters, false)
   );
 
+  // Generate Condition interface (simple equality filter with scalar types)
+  // Track non-primitive types (enums) that need to be imported
+  const enumTypesUsed = new Set<string>();
+  const conditionProperties: t.TSPropertySignature[] = scalarFields.map(
+    (field) => {
+      const tsType = fieldTypeToTs(field.type);
+      const isPrimitive =
+        tsType === 'string' ||
+        tsType === 'number' ||
+        tsType === 'boolean' ||
+        tsType === 'unknown' ||
+        tsType.endsWith('[]');
+      let typeAnnotation: t.TSType;
+      if (field.type.isArray) {
+        const baseType = tsType.replace('[]', '');
+        const isBasePrimitive =
+          baseType === 'string' ||
+          baseType === 'number' ||
+          baseType === 'boolean' ||
+          baseType === 'unknown';
+        if (!isBasePrimitive) {
+          enumTypesUsed.add(baseType);
+        }
+        typeAnnotation = t.tsArrayType(
+          baseType === 'string'
+            ? t.tsStringKeyword()
+            : baseType === 'number'
+              ? t.tsNumberKeyword()
+              : baseType === 'boolean'
+                ? t.tsBooleanKeyword()
+                : t.tsTypeReference(t.identifier(baseType))
+        );
+      } else {
+        if (!isPrimitive) {
+          enumTypesUsed.add(tsType);
+        }
+        typeAnnotation =
+          tsType === 'string'
+            ? t.tsStringKeyword()
+            : tsType === 'number'
+              ? t.tsNumberKeyword()
+              : tsType === 'boolean'
+                ? t.tsBooleanKeyword()
+                : t.tsTypeReference(t.identifier(tsType));
+      }
+      const prop = t.tsPropertySignature(
+        t.identifier(field.name),
+        t.tsTypeAnnotation(typeAnnotation)
+      );
+      prop.optional = true;
+      return prop;
+    }
+  );
+
+  // Add import for enum types if any are used
+  if (enumTypesUsed.size > 0) {
+    const schemaTypesImport = t.importDeclaration(
+      Array.from(enumTypesUsed).map((et) =>
+        t.importSpecifier(t.identifier(et), t.identifier(et))
+      ),
+      t.stringLiteral('../schema-types')
+    );
+    schemaTypesImport.importKind = 'type';
+    statements.push(schemaTypesImport);
+  }
+
+  const conditionInterface = t.tsInterfaceDeclaration(
+    t.identifier(conditionTypeName),
+    null,
+    null,
+    t.tsInterfaceBody(conditionProperties)
+  );
+  statements.push(conditionInterface);
+
   const orderByValues = [
     ...scalarFields.flatMap((f) => [
       `${toScreamingSnake(f.name)}_ASC`,
@@ -259,6 +337,14 @@ export function generateListQueryHook(
     })(),
     (() => {
       const p = t.tsPropertySignature(
+        t.identifier('last'),
+        t.tsTypeAnnotation(t.tsNumberKeyword())
+      );
+      p.optional = true;
+      return p;
+    })(),
+    (() => {
+      const p = t.tsPropertySignature(
         t.identifier('offset'),
         t.tsTypeAnnotation(t.tsNumberKeyword())
       );
@@ -267,8 +353,32 @@ export function generateListQueryHook(
     })(),
     (() => {
       const p = t.tsPropertySignature(
+        t.identifier('before'),
+        t.tsTypeAnnotation(t.tsStringKeyword())
+      );
+      p.optional = true;
+      return p;
+    })(),
+    (() => {
+      const p = t.tsPropertySignature(
+        t.identifier('after'),
+        t.tsTypeAnnotation(t.tsStringKeyword())
+      );
+      p.optional = true;
+      return p;
+    })(),
+    (() => {
+      const p = t.tsPropertySignature(
         t.identifier('filter'),
         t.tsTypeAnnotation(t.tsTypeReference(t.identifier(filterTypeName)))
+      );
+      p.optional = true;
+      return p;
+    })(),
+    (() => {
+      const p = t.tsPropertySignature(
+        t.identifier('condition'),
+        t.tsTypeAnnotation(t.tsTypeReference(t.identifier(conditionTypeName)))
       );
       p.optional = true;
       return p;
@@ -735,7 +845,12 @@ export function generateListQueryHook(
 export function generateSingleQueryHook(
   table: CleanTable,
   options: QueryGeneratorOptions = {}
-): GeneratedQueryFile {
+): GeneratedQueryFile | null {
+  // Skip tables with composite keys - they are handled as custom queries
+  if (!hasValidPrimaryKey(table)) {
+    return null;
+  }
+
   const {
     reactQueryEnabled = true,
     useCentralizedKeys = true,
@@ -1279,7 +1394,10 @@ export function generateAllQueryHooks(
   const files: GeneratedQueryFile[] = [];
   for (const table of tables) {
     files.push(generateListQueryHook(table, options));
-    files.push(generateSingleQueryHook(table, options));
+    const singleHook = generateSingleQueryHook(table, options);
+    if (singleHook) {
+      files.push(singleHook);
+    }
   }
   return files;
 }

--- a/graphql/codegen/src/cli/codegen/queries.ts
+++ b/graphql/codegen/src/cli/codegen/queries.ts
@@ -8,7 +8,7 @@
  */
 import type { CleanTable } from '../../types/schema';
 import * as t from '@babel/types';
-import { generateCode, addJSDocComment, typedParam } from './babel-ast';
+import { generateCode, addJSDocComment, typedParam, createTypedCallExpression } from './babel-ast';
 import {
   buildListQueryAST,
   buildSingleQueryAST,
@@ -426,10 +426,14 @@ export function generateListQueryHook(
                 t.identifier('queryFn'),
                 t.arrowFunctionExpression(
                   [],
-                  t.callExpression(t.identifier('execute'), [
-                    t.identifier(`${queryName}QueryDocument`),
-                    t.identifier('variables'),
-                  ])
+                  createTypedCallExpression(
+                    t.identifier('execute'),
+                    [t.identifier(`${queryName}QueryDocument`), t.identifier('variables')],
+                    [
+                      t.tsTypeReference(t.identifier(`${ucFirst(pluralName)}QueryResult`)),
+                      t.tsTypeReference(t.identifier(`${ucFirst(pluralName)}QueryVariables`)),
+                    ]
+                  )
                 )
               ),
               t.spreadElement(t.identifier('queryOptions')),
@@ -456,10 +460,14 @@ export function generateListQueryHook(
                 t.identifier('queryFn'),
                 t.arrowFunctionExpression(
                   [],
-                  t.callExpression(t.identifier('execute'), [
-                    t.identifier(`${queryName}QueryDocument`),
-                    t.identifier('variables'),
-                  ])
+                  createTypedCallExpression(
+                    t.identifier('execute'),
+                    [t.identifier(`${queryName}QueryDocument`), t.identifier('variables')],
+                    [
+                      t.tsTypeReference(t.identifier(`${ucFirst(pluralName)}QueryResult`)),
+                      t.tsTypeReference(t.identifier(`${ucFirst(pluralName)}QueryVariables`)),
+                    ]
+                  )
                 )
               ),
               t.spreadElement(t.identifier('options')),
@@ -482,10 +490,14 @@ export function generateListQueryHook(
                 t.identifier('queryFn'),
                 t.arrowFunctionExpression(
                   [],
-                  t.callExpression(t.identifier('execute'), [
-                    t.identifier(`${queryName}QueryDocument`),
-                    t.identifier('variables'),
-                  ])
+                  createTypedCallExpression(
+                    t.identifier('execute'),
+                    [t.identifier(`${queryName}QueryDocument`), t.identifier('variables')],
+                    [
+                      t.tsTypeReference(t.identifier(`${ucFirst(pluralName)}QueryResult`)),
+                      t.tsTypeReference(t.identifier(`${ucFirst(pluralName)}QueryVariables`)),
+                    ]
+                  )
                 )
               ),
               t.spreadElement(t.identifier('options')),
@@ -549,11 +561,14 @@ export function generateListQueryHook(
 
   const fetchFuncBody = t.blockStatement([
     t.returnStatement(
-      t.callExpression(t.identifier('execute'), [
-        t.identifier(`${queryName}QueryDocument`),
-        t.identifier('variables'),
-        t.identifier('options'),
-      ])
+      createTypedCallExpression(
+        t.identifier('execute'),
+        [t.identifier(`${queryName}QueryDocument`), t.identifier('variables'), t.identifier('options')],
+        [
+          t.tsTypeReference(t.identifier(`${ucFirst(pluralName)}QueryResult`)),
+          t.tsTypeReference(t.identifier(`${ucFirst(pluralName)}QueryVariables`)),
+        ]
+      )
     ),
   ]);
   const fetchFunc = t.functionDeclaration(
@@ -664,11 +679,14 @@ export function generateListQueryHook(
                   t.identifier('queryFn'),
                   t.arrowFunctionExpression(
                     [],
-                    t.callExpression(t.identifier('execute'), [
-                      t.identifier(`${queryName}QueryDocument`),
-                      t.identifier('variables'),
-                      t.identifier('options'),
-                    ])
+                    createTypedCallExpression(
+                      t.identifier('execute'),
+                      [t.identifier(`${queryName}QueryDocument`), t.identifier('variables'), t.identifier('options')],
+                      [
+                        t.tsTypeReference(t.identifier(`${ucFirst(pluralName)}QueryResult`)),
+                        t.tsTypeReference(t.identifier(`${ucFirst(pluralName)}QueryVariables`)),
+                      ]
+                    )
                   )
                 ),
               ]),
@@ -951,10 +969,14 @@ export function generateSingleQueryHook(
                 t.identifier('queryFn'),
                 t.arrowFunctionExpression(
                   [],
-                  t.callExpression(t.identifier('execute'), [
-                    t.identifier(`${queryName}QueryDocument`),
-                    t.identifier('variables'),
-                  ])
+                  createTypedCallExpression(
+                    t.identifier('execute'),
+                    [t.identifier(`${queryName}QueryDocument`), t.identifier('variables')],
+                    [
+                      t.tsTypeReference(t.identifier(`${ucFirst(singularName)}QueryResult`)),
+                      t.tsTypeReference(t.identifier(`${ucFirst(singularName)}QueryVariables`)),
+                    ]
+                  )
                 )
               ),
               t.spreadElement(t.identifier('queryOptions')),
@@ -986,10 +1008,14 @@ export function generateSingleQueryHook(
                 t.identifier('queryFn'),
                 t.arrowFunctionExpression(
                   [],
-                  t.callExpression(t.identifier('execute'), [
-                    t.identifier(`${queryName}QueryDocument`),
-                    t.identifier('variables'),
-                  ])
+                  createTypedCallExpression(
+                    t.identifier('execute'),
+                    [t.identifier(`${queryName}QueryDocument`), t.identifier('variables')],
+                    [
+                      t.tsTypeReference(t.identifier(`${ucFirst(singularName)}QueryResult`)),
+                      t.tsTypeReference(t.identifier(`${ucFirst(singularName)}QueryVariables`)),
+                    ]
+                  )
                 )
               ),
               t.spreadElement(t.identifier('options')),
@@ -1015,10 +1041,14 @@ export function generateSingleQueryHook(
                 t.identifier('queryFn'),
                 t.arrowFunctionExpression(
                   [],
-                  t.callExpression(t.identifier('execute'), [
-                    t.identifier(`${queryName}QueryDocument`),
-                    t.identifier('variables'),
-                  ])
+                  createTypedCallExpression(
+                    t.identifier('execute'),
+                    [t.identifier(`${queryName}QueryDocument`), t.identifier('variables')],
+                    [
+                      t.tsTypeReference(t.identifier(`${ucFirst(singularName)}QueryResult`)),
+                      t.tsTypeReference(t.identifier(`${ucFirst(singularName)}QueryVariables`)),
+                    ]
+                  )
                 )
               ),
               t.spreadElement(t.identifier('options')),
@@ -1077,11 +1107,14 @@ export function generateSingleQueryHook(
 
   const fetchFuncBody = t.blockStatement([
     t.returnStatement(
-      t.callExpression(t.identifier('execute'), [
-        t.identifier(`${queryName}QueryDocument`),
-        t.identifier('variables'),
-        t.identifier('options'),
-      ])
+      createTypedCallExpression(
+        t.identifier('execute'),
+        [t.identifier(`${queryName}QueryDocument`), t.identifier('variables'), t.identifier('options')],
+        [
+          t.tsTypeReference(t.identifier(`${ucFirst(singularName)}QueryResult`)),
+          t.tsTypeReference(t.identifier(`${ucFirst(singularName)}QueryVariables`)),
+        ]
+      )
     ),
   ]);
   const fetchFunc = t.functionDeclaration(
@@ -1186,11 +1219,14 @@ export function generateSingleQueryHook(
                   t.identifier('queryFn'),
                   t.arrowFunctionExpression(
                     [],
-                    t.callExpression(t.identifier('execute'), [
-                      t.identifier(`${queryName}QueryDocument`),
-                      t.identifier('variables'),
-                      t.identifier('options'),
-                    ])
+                    createTypedCallExpression(
+                      t.identifier('execute'),
+                      [t.identifier(`${queryName}QueryDocument`), t.identifier('variables'), t.identifier('options')],
+                      [
+                        t.tsTypeReference(t.identifier(`${ucFirst(singularName)}QueryResult`)),
+                        t.tsTypeReference(t.identifier(`${ucFirst(singularName)}QueryVariables`)),
+                      ]
+                    )
                   )
                 ),
               ]),

--- a/graphql/codegen/src/cli/codegen/utils.ts
+++ b/graphql/codegen/src/cli/codegen/utils.ts
@@ -381,6 +381,25 @@ export function getPrimaryKeyFields(table: CleanTable): string[] {
   return getPrimaryKeyInfo(table).map((pk) => pk.name);
 }
 
+/**
+ * Check if table has a valid single-field primary key
+ * Used to determine if a single query hook can be generated
+ * Tables with composite keys return false (handled as custom queries)
+ */
+export function hasValidPrimaryKey(table: CleanTable): boolean {
+  // Check for explicit primary key constraint with single field
+  const pk = table.constraints?.primaryKey?.[0];
+  if (pk && pk.fields.length === 1) {
+    return true;
+  }
+  // Check for 'id' field as fallback
+  const idField = table.fields.find((f) => f.name.toLowerCase() === 'id');
+  if (idField) {
+    return true;
+  }
+  return false;
+}
+
 // ============================================================================
 // Query key generation
 // ============================================================================


### PR DESCRIPTION
1. Missing generic type parameters on execute() calls - The execute<TData, TVariables>() function was called without type parameters, causing TypeScript to infer unknown for return types.
  2. Missing table type imports in mutations - When a table field references another table type (e.g., schema?: Schema), the referenced type wasn't imported, causing "Cannot find name" errors.

  Solution

  - Added createTypedCallExpression() helper to generate properly typed execute<Result, Variables>() calls
  - Updated mutation generators to track and import all table types used in scalar fields
  - Added list filter types (StringListFilter, IntListFilter, UUIDListFilter) to ORM generator