### PR TITLE
fix(export): add missing is_public field to schema export config

### DIFF
--- a/pgpm/core/src/export/export-meta.ts
+++ b/pgpm/core/src/export/export-meta.ts
@@ -130,7 +130,8 @@ const config: Record<string, TableConfig> = {
       database_id: 'uuid',
       name: 'text',
       schema_name: 'text',
-      description: 'text'
+      description: 'text',
+      is_public: 'boolean'
     }
   },
   table: {


### PR DESCRIPTION
## Summary

Adds the missing `is_public` field to the `metaschema_public.schema` table export configuration. This field exists in the database schema but was not included in the hardcoded config, causing it to be silently dropped during schema exports via `pnpm run generate:constructive -- --regexp`.

The `buildDynamicFields` function only exports fields that are both in the hardcoded config AND exist in the database, so `is_public` was being excluded from the generated SQL.

## Review & Testing Checklist for Human

- [ ] Re-run `pnpm run generate:constructive -- --regexp` in constructive-db's introspection folder and verify the diff no longer shows `is_public` being removed
- [ ] Confirm the exported SQL now includes the `is_public` field in the schema table VALUES

### Notes

Requested by: @pyramation  
Link to Devin run: https://app.devin.ai/sessions/9a48fb5dd50744da9994e3ded145ff7e