### PR TITLE
docs(graphql-server-test): expose and document enableServicesApi option

### DIFF
--- a/graphql/server-test/README.md
+++ b/graphql/server-test/README.md
@@ -157,14 +157,36 @@ it('matches snapshot', async () => {
 
 ### GetConnectionsInput
 
-| Option | Type | Description |
-|--------|------|-------------|
-| `schemas` | `string[]` | PostgreSQL schemas to expose in GraphQL |
-| `authRole` | `string` | Default role for anonymous requests |
-| `useRoot` | `boolean` | Use root/superuser for queries (bypasses RLS) |
-| `graphile` | `GraphileOptions` | Graphile/PostGraphile configuration |
-| `server.port` | `number` | Port to run the server on (default: random) |
-| `server.host` | `string` | Host to bind the server to (default: localhost) |
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `schemas` | `string[]` | required | PostgreSQL schemas to expose in GraphQL |
+| `authRole` | `string` | - | Default role for anonymous requests |
+| `useRoot` | `boolean` | `false` | Use root/superuser for queries (bypasses RLS) |
+| `graphile` | `GraphileOptions` | - | Graphile/PostGraphile configuration |
+| `server.port` | `number` | random | Port to run the server on |
+| `server.host` | `string` | `localhost` | Host to bind the server to |
+| `enableServicesApi` | `boolean` | `false` | Enable domain/subdomain routing via services_public |
+
+### Services API
+
+By default, `enableServicesApi` is set to `false`, which bypasses domain/subdomain routing and directly exposes the schemas you specify. This is the recommended setting for most testing scenarios.
+
+When `enableServicesApi` is `true`, the server uses the `services_public` schema to resolve which API and schemas to expose based on the incoming request's domain/subdomain. This is useful when you need to test the full domain routing behavior.
+
+```typescript
+// Default: bypasses domain routing, directly exposes specified schemas
+const { query } = await getConnections({
+  schemas: ['app_public'],
+  authRole: 'anonymous'
+});
+
+// With Services API enabled: uses domain/subdomain routing
+const { query } = await getConnections({
+  schemas: ['app_public'],
+  authRole: 'anonymous',
+  enableServicesApi: true
+});
+```
 
 ## Comparison with Other Test Packages
 

--- a/graphql/server-test/src/get-connections.ts
+++ b/graphql/server-test/src/get-connections.ts
@@ -44,11 +44,12 @@ export const getConnections = async (
   const conn: GetConnectionResult = await getPgConnections(input, seedAdapters);
   const { pg, db, teardown: dbTeardown } = conn;
 
-  // Build options for the HTTP server with enableServicesApi: false
+  // Build options for the HTTP server
+  // enableServicesApi defaults to false for testing (bypasses domain routing)
   const serverOpts = getEnvOptions({
     pg: pg.config,
     api: {
-      enableServicesApi: false,
+      enableServicesApi: input.enableServicesApi ?? false,
       exposedSchemas: input.schemas,
       defaultDatabaseId: 'test-database',
       ...(input.authRole && { anonRole: input.authRole, roleName: input.authRole })

--- a/graphql/server-test/src/types.ts
+++ b/graphql/server-test/src/types.ts
@@ -46,6 +46,13 @@ export interface GetConnectionsInput {
   graphile?: GraphileOptions;
   /** Server configuration options */
   server?: ServerOptions;
+  /**
+   * Enable the Services API (domain/subdomain routing via services_public).
+   * When false (default), bypasses domain routing and directly exposes the specified schemas.
+   * When true, uses services_public to resolve which API/schemas to expose based on domain/subdomain.
+   * @default false
+   */
+  enableServicesApi?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

Exposes `enableServicesApi` as a configurable option in `getConnections()` and documents how to use it. Previously this was hardcoded to `false`; now users can optionally set it to `true` when they need to test domain/subdomain routing behavior.

Changes:
- Added `enableServicesApi?: boolean` to `GetConnectionsInput` interface
- Updated `get-connections.ts` to use the configurable option (defaults to `false`)
- Added documentation explaining the Services API toggle with usage examples

## Review & Testing Checklist for Human

- [ ] Verify the documentation accurately describes what `enableServicesApi` does (bypasses vs uses `services_public` for domain routing)
- [ ] Run existing tests to confirm default behavior is preserved
- [ ] Test with `enableServicesApi: true` in a real scenario to verify domain routing works as expected

### Notes

Link to Devin run: https://app.devin.ai/sessions/c9333132d97741deaa5876c78aaade39
Requested by: Dan Lynch (@pyramation)