### PR TITLE
refactor(graphql-server-test): move api options inside server key

### DIFF
--- a/graphql/server-test/README.md
+++ b/graphql/server-test/README.md
@@ -166,27 +166,58 @@ it('matches snapshot', async () => {
 | `server.port` | `number` | random | Port to run the server on |
 | `server.host` | `string` | `localhost` | Host to bind the server to |
 | `enableServicesApi` | `boolean` | `false` | Enable domain/subdomain routing via services_public |
+| `api` | `Partial<ApiOptions>` | - | Full API configuration options (see below) |
+
+### API Options
+
+The `api` option provides full control over the GraphQL server configuration. It accepts a partial `ApiOptions` object from `@constructive-io/graphql-types`:
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `enableServicesApi` | `boolean` | `false` | Enable domain/subdomain routing via services_public |
+| `exposedSchemas` | `string[]` | from `schemas` | Database schemas to expose (overridden by `schemas`) |
+| `anonRole` | `string` | from `authRole` | Anonymous role name (overridden by `authRole`) |
+| `roleName` | `string` | from `authRole` | Default role name (overridden by `authRole`) |
+| `defaultDatabaseId` | `string` | `'test-database'` | Default database identifier |
+| `isPublic` | `boolean` | - | Whether the API is publicly accessible |
+| `metaSchemas` | `string[]` | - | Schemas containing metadata tables |
+
+The convenience properties (`schemas`, `authRole`, `enableServicesApi`) take precedence over values in the `api` object when both are specified.
+
+```typescript
+// Using convenience properties (recommended for most cases)
+const { query } = await getConnections({
+  schemas: ['app_public'],
+  authRole: 'anonymous'
+});
+
+// Using full api options for advanced configuration
+const { query } = await getConnections({
+  schemas: ['app_public'],
+  api: {
+    isPublic: false,
+    defaultDatabaseId: 'my-test-db',
+    metaSchemas: ['services_public', 'metaschema_public']
+  }
+});
+
+// Combining convenience properties with api options
+const { query } = await getConnections({
+  schemas: ['app_public'],
+  authRole: 'authenticated',
+  enableServicesApi: true,
+  api: {
+    isPublic: true,
+    metaSchemas: ['services_public']
+  }
+});
+```
 
 ### Services API
 
 By default, `enableServicesApi` is set to `false`, which bypasses domain/subdomain routing and directly exposes the schemas you specify. This is the recommended setting for most testing scenarios.
 
 When `enableServicesApi` is `true`, the server uses the `services_public` schema to resolve which API and schemas to expose based on the incoming request's domain/subdomain. This is useful when you need to test the full domain routing behavior.
-
-```typescript
-// Default: bypasses domain routing, directly exposes specified schemas
-const { query } = await getConnections({
-  schemas: ['app_public'],
-  authRole: 'anonymous'
-});
-
-// With Services API enabled: uses domain/subdomain routing
-const { query } = await getConnections({
-  schemas: ['app_public'],
-  authRole: 'anonymous',
-  enableServicesApi: true
-});
-```
 
 ## Comparison with Other Test Packages
 

--- a/graphql/server-test/README.md
+++ b/graphql/server-test/README.md
@@ -163,61 +163,67 @@ it('matches snapshot', async () => {
 | `authRole` | `string` | - | Default role for anonymous requests |
 | `useRoot` | `boolean` | `false` | Use root/superuser for queries (bypasses RLS) |
 | `graphile` | `GraphileOptions` | - | Graphile/PostGraphile configuration |
+| `server` | `ServerOptions` | - | Server configuration (port, host, and API options) |
+
+### ServerOptions
+
+All server configuration lives under the `server` key:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
 | `server.port` | `number` | random | Port to run the server on |
 | `server.host` | `string` | `localhost` | Host to bind the server to |
-| `enableServicesApi` | `boolean` | `false` | Enable domain/subdomain routing via services_public |
-| `api` | `Partial<ApiOptions>` | - | Full API configuration options (see below) |
+| `server.api` | `Partial<ApiOptions>` | - | API configuration options (see below) |
 
 ### API Options
 
-The `api` option provides full control over the GraphQL server configuration. It accepts a partial `ApiOptions` object from `@constructive-io/graphql-types`:
+The `server.api` option provides full control over the GraphQL server configuration. It accepts a partial `ApiOptions` object from `@constructive-io/graphql-types`:
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `enableServicesApi` | `boolean` | `false` | Enable domain/subdomain routing via services_public |
+| `enableServicesApi` | `boolean` | package default | Enable domain/subdomain routing via services_public |
 | `exposedSchemas` | `string[]` | from `schemas` | Database schemas to expose (overridden by `schemas`) |
 | `anonRole` | `string` | from `authRole` | Anonymous role name (overridden by `authRole`) |
 | `roleName` | `string` | from `authRole` | Default role name (overridden by `authRole`) |
-| `defaultDatabaseId` | `string` | `'test-database'` | Default database identifier |
-| `isPublic` | `boolean` | - | Whether the API is publicly accessible |
-| `metaSchemas` | `string[]` | - | Schemas containing metadata tables |
+| `defaultDatabaseId` | `string` | package default | Default database identifier |
+| `isPublic` | `boolean` | package default | Whether the API is publicly accessible |
+| `metaSchemas` | `string[]` | package default | Schemas containing metadata tables |
 
-The convenience properties (`schemas`, `authRole`, `enableServicesApi`) take precedence over values in the `api` object when both are specified.
+The convenience properties (`schemas`, `authRole`) take precedence over corresponding values in `server.api`.
 
 ```typescript
-// Using convenience properties (recommended for most cases)
+// Basic usage with convenience properties
 const { query } = await getConnections({
   schemas: ['app_public'],
   authRole: 'anonymous'
 });
 
-// Using full api options for advanced configuration
+// Disabling Services API for testing (bypasses domain routing)
 const { query } = await getConnections({
   schemas: ['app_public'],
-  api: {
-    isPublic: false,
-    defaultDatabaseId: 'my-test-db',
-    metaSchemas: ['services_public', 'metaschema_public']
+  server: {
+    api: {
+      enableServicesApi: false
+    }
   }
 });
 
-// Combining convenience properties with api options
+// Full server configuration
 const { query } = await getConnections({
   schemas: ['app_public'],
   authRole: 'authenticated',
-  enableServicesApi: true,
-  api: {
-    isPublic: true,
-    metaSchemas: ['services_public']
+  server: {
+    port: 5555,
+    host: 'localhost',
+    api: {
+      enableServicesApi: false,
+      isPublic: false,
+      defaultDatabaseId: 'my-test-db',
+      metaSchemas: ['services_public', 'metaschema_public']
+    }
   }
 });
 ```
-
-### Services API
-
-By default, `enableServicesApi` is set to `false`, which bypasses domain/subdomain routing and directly exposes the schemas you specify. This is the recommended setting for most testing scenarios.
-
-When `enableServicesApi` is `true`, the server uses the `services_public` schema to resolve which API and schemas to expose based on the incoming request's domain/subdomain. This is useful when you need to test the full domain routing behavior.
 
 ## Comparison with Other Test Packages
 

--- a/graphql/server-test/__tests__/server-test.test.ts
+++ b/graphql/server-test/__tests__/server-test.test.ts
@@ -20,7 +20,12 @@ describe('graphql-server-test', () => {
       ({ db, pg, server, query, request, teardown } = await getConnections(
         {
           schemas: ['app_public'],
-          authRole: 'anonymous'
+          authRole: 'anonymous',
+          server: {
+            api: {
+              enableServicesApi: false
+            }
+          }
         },
         [seed.sqlfile([sql('test.sql')])]
       ));
@@ -104,7 +109,12 @@ describe('graphql-server-test', () => {
       ({ db, pg, query, teardown } = await getConnections(
         {
           schemas: ['app_public'],
-          authRole: 'authenticated'
+          authRole: 'authenticated',
+          server: {
+            api: {
+              enableServicesApi: false
+            }
+          }
         },
         [seed.sqlfile([sql('test.sql')])]
       ));

--- a/graphql/server-test/src/get-connections.ts
+++ b/graphql/server-test/src/get-connections.ts
@@ -45,17 +45,14 @@ export const getConnections = async (
   const { pg, db, teardown: dbTeardown } = conn;
 
   // Build options for the HTTP server
-  // Merge user-provided api options with convenience properties
-  // Convenience properties (schemas, authRole, enableServicesApi) take precedence
+  // Merge user-provided server.api options with convenience properties (schemas, authRole)
   const serverOpts = getEnvOptions({
     pg: pg.config,
     api: {
-      // Start with user-provided api options
-      ...input.api,
-      // Apply defaults and convenience properties (these take precedence)
-      enableServicesApi: input.enableServicesApi ?? input.api?.enableServicesApi ?? false,
+      // Start with user-provided api options from server.api
+      ...input.server?.api,
+      // Apply convenience properties (these take precedence)
       exposedSchemas: input.schemas,
-      defaultDatabaseId: input.api?.defaultDatabaseId ?? 'test-database',
       ...(input.authRole && { anonRole: input.authRole, roleName: input.authRole })
     },
     graphile: input.graphile

--- a/graphql/server-test/src/get-connections.ts
+++ b/graphql/server-test/src/get-connections.ts
@@ -45,13 +45,17 @@ export const getConnections = async (
   const { pg, db, teardown: dbTeardown } = conn;
 
   // Build options for the HTTP server
-  // enableServicesApi defaults to false for testing (bypasses domain routing)
+  // Merge user-provided api options with convenience properties
+  // Convenience properties (schemas, authRole, enableServicesApi) take precedence
   const serverOpts = getEnvOptions({
     pg: pg.config,
     api: {
-      enableServicesApi: input.enableServicesApi ?? false,
+      // Start with user-provided api options
+      ...input.api,
+      // Apply defaults and convenience properties (these take precedence)
+      enableServicesApi: input.enableServicesApi ?? input.api?.enableServicesApi ?? false,
       exposedSchemas: input.schemas,
-      defaultDatabaseId: 'test-database',
+      defaultDatabaseId: input.api?.defaultDatabaseId ?? 'test-database',
       ...(input.authRole && { anonRole: input.authRole, roleName: input.authRole })
     },
     graphile: input.graphile

--- a/graphql/server-test/src/types.ts
+++ b/graphql/server-test/src/types.ts
@@ -12,6 +12,26 @@ export interface ServerOptions {
   port?: number;
   /** Host to bind the server to (defaults to localhost) */
   host?: string;
+  /**
+   * API configuration options for the GraphQL server.
+   * These options control how the server handles requests and which features are enabled.
+   * 
+   * @example
+   * ```typescript
+   * const { query } = await getConnections({
+   *   schemas: ['app_public'],
+   *   server: {
+   *     port: 5555,
+   *     api: {
+   *       enableServicesApi: false,
+   *       isPublic: false,
+   *       defaultDatabaseId: 'my-database'
+   *     }
+   *   }
+   * });
+   * ```
+   */
+  api?: Partial<ApiOptions>;
 }
 
 /**
@@ -44,35 +64,8 @@ export interface GetConnectionsInput {
   authRole?: string;
   /** Graphile/PostGraphile configuration options */
   graphile?: GraphileOptions;
-  /** Server configuration options */
+  /** Server configuration options (port, host, and API configuration) */
   server?: ServerOptions;
-  /**
-   * Enable the Services API (domain/subdomain routing via services_public).
-   * When false (default), bypasses domain routing and directly exposes the specified schemas.
-   * When true, uses services_public to resolve which API/schemas to expose based on domain/subdomain.
-   * @default false
-   */
-  enableServicesApi?: boolean;
-  /**
-   * Full API configuration options for the GraphQL server.
-   * This allows fine-grained control over all API settings.
-   * 
-   * Note: The convenience properties `schemas`, `authRole`, and `enableServicesApi` 
-   * take precedence over values in this object when both are specified.
-   * 
-   * @example
-   * ```typescript
-   * const { query } = await getConnections({
-   *   schemas: ['app_public'],
-   *   api: {
-   *     isPublic: false,
-   *     defaultDatabaseId: 'my-database',
-   *     metaSchemas: ['services_public', 'metaschema_public']
-   *   }
-   * });
-   * ```
-   */
-  api?: Partial<ApiOptions>;
 }
 
 /**

--- a/graphql/server-test/src/types.ts
+++ b/graphql/server-test/src/types.ts
@@ -1,7 +1,7 @@
 import type { Server } from 'http';
 import type { DocumentNode, GraphQLError } from 'graphql';
 import type { PgTestClient } from 'pgsql-test/test-client';
-import type { GraphileOptions } from '@constructive-io/graphql-types';
+import type { GraphileOptions, ApiOptions } from '@constructive-io/graphql-types';
 import type supertest from 'supertest';
 
 /**
@@ -53,6 +53,26 @@ export interface GetConnectionsInput {
    * @default false
    */
   enableServicesApi?: boolean;
+  /**
+   * Full API configuration options for the GraphQL server.
+   * This allows fine-grained control over all API settings.
+   * 
+   * Note: The convenience properties `schemas`, `authRole`, and `enableServicesApi` 
+   * take precedence over values in this object when both are specified.
+   * 
+   * @example
+   * ```typescript
+   * const { query } = await getConnections({
+   *   schemas: ['app_public'],
+   *   api: {
+   *     isPublic: false,
+   *     defaultDatabaseId: 'my-database',
+   *     metaSchemas: ['services_public', 'metaschema_public']
+   *   }
+   * });
+   * ```
+   */
+  api?: Partial<ApiOptions>;
 }
 
 /**


### PR DESCRIPTION
## Summary

Restructures the `getConnections()` API so that all server configuration lives under the `server` key. This provides a cleaner, more intuitive interface where `server.api` contains all API configuration options.

**Key changes:**
- Moved `api` options inside `server` (now `server.api` instead of top-level `api`)
- Removed top-level `enableServicesApi` property (now accessed via `server.api.enableServicesApi`)
- Removed hardcoded defaults (`enableServicesApi: false`, `defaultDatabaseId: 'test-database'`) - now uses package defaults from `getEnvOptions`
- Updated internal tests to explicitly set `enableServicesApi: false` via `server.api`
- Updated README documentation with cleaner structure and examples

**New interface structure:**
```typescript
const { query } = await getConnections({
  schemas: ['app_public'],
  authRole: 'anonymous',
  server: {
    port: 5555,
    host: 'localhost',
    api: {
      enableServicesApi: false,
      isPublic: false,
      defaultDatabaseId: 'my-database'
    }
  }
});
```

## Review & Testing Checklist for Human

- [ ] **Breaking change verification**: The top-level `enableServicesApi` property was removed. Confirm this is the intended design (users must now use `server.api.enableServicesApi`)
- [ ] **Default behavior change**: The function no longer hardcodes `enableServicesApi: false` - it uses package defaults. Verify this is correct behavior (user mentioned internal tests should set it to false, but defaults should follow the package)
- [ ] **Test with `server.api` options**: Verify that providing `server.api.enableServicesApi`, `server.api.isPublic`, etc. actually affects server behavior
- [ ] **Convenience property precedence**: Confirm that `schemas` and `authRole` still override corresponding values in `server.api`

**Suggested test plan:** 
1. Run existing tests to confirm they pass with the new structure
2. Create a test that uses `server.api` with various options and verify the server respects them
3. Verify that omitting `server.api.enableServicesApi` uses the package default (not hardcoded false)

### Notes

Link to Devin run: https://app.devin.ai/sessions/c9333132d97741deaa5876c78aaade39
Requested by: Dan Lynch (@pyramation)