### PR TITLE
ci: add 11 missing packages with tests to CI workflow

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -106,8 +106,8 @@ jobs:
             env: {}
           - package: graphql/playwright-test
             env: {}
-          - package: jobs/knative-job-worker
-            env: {}
+          # - package: jobs/knative-job-worker
+          #   env: {}
           - package: packages/csv-to-pg
             env: {}
           - package: packages/smtppostmaster

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -96,6 +96,8 @@ jobs:
             env: {}
           - package: graphile/graphile-sql-expression-validator
             env: {}
+          - package: graphql/server-test
+            env: {}
 
     env:
       PGHOST: localhost

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -98,6 +98,28 @@ jobs:
             env: {}
           - package: graphql/server-test
             env: {}
+          - package: graphql/env
+            env: {}
+          - package: graphql/server
+            env: {}
+          - package: graphql/test
+            env: {}
+          - package: graphql/playwright-test
+            env: {}
+          - package: jobs/knative-job-worker
+            env: {}
+          - package: packages/csv-to-pg
+            env: {}
+          - package: packages/smtppostmaster
+            env: {}
+          - package: postgres/drizzle-orm-test
+            env: {}
+          - package: uploads/etag-hash
+            env: {}
+          - package: uploads/etag-stream
+            env: {}
+          - package: uploads/stream-to-etag
+            env: {}
 
     env:
       PGHOST: localhost

--- a/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
+++ b/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
@@ -120,5 +120,12 @@ exports[`getEnvOptions merges pgpm defaults, graphql defaults, config, env, and 
     "strictAuth": false,
     "trustProxy": false,
   },
+  "smtp": {
+    "debug": false,
+    "logger": false,
+    "pool": false,
+    "port": 587,
+    "secure": false,
+  },
 }
 `;


### PR DESCRIPTION
## Summary

Adds 11 packages with tests that were missing from the CI test matrix. These packages all have `__tests__` directories with test files but were not previously included in the workflow.

**Packages added:**
- `graphql/server-test` (newly created package)
- `graphql/env`
- `graphql/server`
- `graphql/test`
- `graphql/playwright-test`
- `packages/csv-to-pg`
- `packages/smtppostmaster`
- `postgres/drizzle-orm-test`
- `uploads/etag-hash`
- `uploads/etag-stream`
- `uploads/stream-to-etag`

**Temporarily commented out:**
- `jobs/knative-job-worker` (per user request)

## Updates since last revision

- Updated `graphql/env` test snapshot to include new `smtp` configuration fields
- Commented out `jobs/knative-job-worker` from CI workflow (temporarily disabled)

## Review & Testing Checklist for Human

- [ ] Verify all 11 new CI jobs run and pass
- [ ] Review the `graphql/env` snapshot update - new `smtp` config was added with default values (port: 587, secure: false, etc.)
- [ ] Check if any packages need special environment variables beyond the existing PostgreSQL/MinIO config

**Suggested test plan:** 
Wait for CI to complete and verify all 11 new jobs pass. If any fail, check if they need additional environment configuration.

### Notes

Link to Devin run: https://app.devin.ai/sessions/c9333132d97741deaa5876c78aaade39
Requested by: Dan Lynch (@pyramation)