### PR TITLE
fix(graphql-server-test): close caches on server stop to prevent test hanging

### DIFF
--- a/graphql/server-test/src/server.ts
+++ b/graphql/server-test/src/server.ts
@@ -58,7 +58,7 @@ export const createTestServer = async (
   const actualPort = (httpServer.address() as { port: number }).port;
 
   const stop = async (): Promise<void> => {
-    await server.close();
+    await server.close({ closeCaches: true });
   };
 
   return {


### PR DESCRIPTION
## Summary

Fixes the graphql-server-test hanging in CI by ensuring database connection pools are properly closed when the test server stops.

The issue was that `server.close()` was called without the `closeCaches: true` option, leaving pg pools open which prevented Jest from exiting. The `Server.close()` method in `@constructive-io/graphql-server` has an optional `closeCaches` parameter that defaults to `false`, which when set to `true` calls `pgCache.close()` to properly terminate all database connections.

## Review & Testing Checklist for Human

- [ ] Verify the graphql-server-test CI job completes successfully without hanging
- [ ] Confirm that closing caches globally doesn't cause issues with other tests in the same file (the test has two describe blocks that each call `getConnections()`)

### Notes

This fix was identified through code analysis rather than local reproduction of the hanging test. The root cause analysis traced through:
1. `teardown()` → `server.stop()` → `server.close()` 
2. `Server.close()` only closes pg pools when `closeCaches: true` is passed

Requested by @pyramation  
Link to Devin run: https://app.devin.ai/sessions/ba5a15b86c184614ad87ba3367c4f7d1