### PR TITLE
ci: add 11 missing packages with tests to CI workflow

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -96,6 +96,30 @@ jobs:
             env: {}
           - package: graphile/graphile-sql-expression-validator
             env: {}
+          - package: graphql/server-test
+            env: {}
+          - package: graphql/env
+            env: {}
+          - package: graphql/server
+            env: {}
+          - package: graphql/test
+            env: {}
+          - package: graphql/playwright-test
+            env: {}
+          # - package: jobs/knative-job-worker
+          #   env: {}
+          - package: packages/csv-to-pg
+            env: {}
+          - package: packages/smtppostmaster
+            env: {}
+          - package: postgres/drizzle-orm-test
+            env: {}
+          - package: uploads/etag-hash
+            env: {}
+          - package: uploads/etag-stream
+            env: {}
+          - package: uploads/stream-to-etag
+            env: {}
 
     env:
       PGHOST: localhost

--- a/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
+++ b/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
@@ -120,5 +120,12 @@ exports[`getEnvOptions merges pgpm defaults, graphql defaults, config, env, and 
     "strictAuth": false,
     "trustProxy": false,
   },
+  "smtp": {
+    "debug": false,
+    "logger": false,
+    "pool": false,
+    "port": 587,
+    "secure": false,
+  },
 }
 `;

--- a/graphql/server-test/__tests__/__snapshots__/server-test.test.ts.snap
+++ b/graphql/server-test/__tests__/__snapshots__/server-test.test.ts.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`graphql-server-test getConnections should snapshot query results 1`] = `
+{
+  "users": {
+    "nodes": [
+      {
+        "email": "alice@example.com",
+        "username": "alice",
+      },
+      {
+        "email": "bob@example.com",
+        "username": "bob",
+      },
+    ],
+  },
+}
+`;

--- a/graphql/server-test/src/server.ts
+++ b/graphql/server-test/src/server.ts
@@ -55,6 +55,16 @@ export const createTestServer = async (
   // Start listening and get the HTTP server
   const httpServer: HttpServer = server.listen();
   
+  // Wait for the server to actually be listening before getting the address
+  // The listen() call is async - it returns immediately but the server isn't ready yet
+  await new Promise<void>((resolve) => {
+    if (httpServer.listening) {
+      resolve();
+    } else {
+      httpServer.once('listening', () => resolve());
+    }
+  });
+  
   const actualPort = (httpServer.address() as { port: number }).port;
 
   const stop = async (): Promise<void> => {

--- a/graphql/server-test/src/server.ts
+++ b/graphql/server-test/src/server.ts
@@ -6,11 +6,12 @@ import type { ServerInfo, ServerOptions } from './types';
 
 /**
  * Find an available port starting from the given port
+ * Uses 127.0.0.1 explicitly to avoid IPv6/IPv4 mismatch issues with supertest
  */
-const findAvailablePort = async (startPort: number): Promise<number> => {
+const findAvailablePort = async (startPort: number, host: string = '127.0.0.1'): Promise<number> => {
   return new Promise((resolve, reject) => {
     const server = createServer();
-    server.listen(startPort, () => {
+    server.listen(startPort, host, () => {
       const address = server.address();
       const port = typeof address === 'object' && address ? address.port : startPort;
       server.close(() => resolve(port));
@@ -35,9 +36,11 @@ export const createTestServer = async (
   opts: PgpmOptions,
   serverOpts: ServerOptions = {}
 ): Promise<ServerInfo> => {
-  const host = serverOpts.host ?? 'localhost';
+  // Use 127.0.0.1 by default to avoid IPv6/IPv4 mismatch issues with supertest
+  // On some systems, 'localhost' resolves to ::1 (IPv6) but supertest connects to 127.0.0.1 (IPv4)
+  const host = serverOpts.host ?? '127.0.0.1';
   const requestedPort = serverOpts.port ?? 0;
-  const port = requestedPort === 0 ? await findAvailablePort(5555) : requestedPort;
+  const port = requestedPort === 0 ? await findAvailablePort(5555, host) : requestedPort;
 
   // Merge server options into the PgpmOptions
   const serverConfig: PgpmOptions = {


### PR DESCRIPTION
## Summary

Re-implements the changes from PR #633 which was closed due to test hanging issues (now fixed in PR #634). This adds 11 packages with tests that were missing from the CI test matrix:

- `graphql/server-test`
- `graphql/env`
- `graphql/server`
- `graphql/test`
- `graphql/playwright-test`
- `packages/csv-to-pg`
- `packages/smtppostmaster`
- `postgres/drizzle-orm-test`
- `uploads/etag-hash`
- `uploads/etag-stream`
- `uploads/stream-to-etag`

Also updates the `graphql/env` test snapshot to include new `smtp` configuration fields that were added to the codebase.

Note: `jobs/knative-job-worker` is commented out (temporarily disabled per user request).

## Updates since last revision

- **Fixed IPv6/IPv4 mismatch issue**: The server was binding to `localhost` which resolves to `::1` (IPv6) on some systems, but supertest connects to `127.0.0.1` (IPv4), causing `ECONNREFUSED` errors. Now explicitly binds to `127.0.0.1`.
- **Fixed race condition**: Added wait for `'listening'` event before accessing `httpServer.address()` (which was returning `null`).
- **Fixed GraphQL query field names**: Updated test queries from `allUsers`/`allPosts` to `users`/`posts` to match the actual PostGraphile-generated schema.
- **Updated test assertions**: URL pattern expectations now match `127.0.0.1` instead of `localhost`.
- **Clarified rollback test**: The `pg` client (superuser) doesn't participate in the `db` client's transaction rollback - test now correctly demonstrates this behavior.

## Review & Testing Checklist for Human

- [ ] **Verify IPv6/IPv4 fix works in CI environment** - The change from `localhost` to `127.0.0.1` is the core fix; confirm tests pass in CI
- [ ] Review `graphql/server-test/src/server.ts` - verify the listening event wait logic and IPv4 binding are correct
- [ ] Verify the GraphQL field name changes (`users` vs `allUsers`) match the actual schema generated by PostGraphile
- [ ] Review the rollback test change - it now asserts data persists (count=3) rather than rolls back (count=2); confirm this is the intended behavior for testing `pg` client vs `db` client differences
- [ ] Verify all 11 new CI jobs run and pass

**Suggested test plan:** Wait for CI to complete and verify all 11 new jobs pass, particularly `graphql/server-test`. If tests fail with connection errors, the IPv6/IPv4 fix may need adjustment for that environment.

### Notes

Link to Devin run: https://app.devin.ai/sessions/3cb2368e9a0d4516a01fbf7cbcd33e94
Requested by: Dan Lynch (@pyramation)