### PR TITLE
fix(graphql-codegen): copy query-builder.ts to dist during build

### DIFF
--- a/graphql/codegen/package.json
+++ b/graphql/codegen/package.json
@@ -35,8 +35,9 @@
   "scripts": {
     "clean": "makage clean",
     "prepack": "npm run build",
-    "build": "makage build",
-    "build:dev": "makage build --dev",
+    "copy:ts": "makage copy src/cli/codegen/orm/query-builder.ts dist/cli/codegen/orm --flat",
+    "build": "makage build && npm run copy:ts",
+    "build:dev": "makage build --dev && npm run copy:ts",
     "dev": "ts-node ./src/index.ts",
     "lint": "eslint . --fix",
     "fmt": "prettier --write .",


### PR DESCRIPTION
## Summary

Fixes an error when running SDK generation from an installed npm package:

```
Error: Could not find query-builder.ts source file. Searched in: .../node_modules/@constructive-io/graphql-codegen/cli/codegen/orm/query-builder.ts
```

The `generateQueryBuilderFile()` function in `client-generator.ts` reads `query-builder.ts` at runtime to use as a build artifact. However, when the package is published to npm, only the `dist/` folder is included (via `publishConfig.directory: "dist"`), and TypeScript source files are not copied there by default.

This adds a `copy:ts` script that copies the TypeScript file to `dist/cli/codegen/orm/` after the build completes.

## Review & Testing Checklist for Human

- [ ] Verify the destination path `dist/cli/codegen/orm/query-builder.ts` matches the path expected by `client-generator.ts` line 153
- [ ] Publish a canary version and test SDK generation from `constructive-db` to confirm the fix works end-to-end
- [ ] Check if any other TypeScript files are read at runtime and might need similar treatment

### Notes

Link to Devin run: https://app.devin.ai/sessions/475ee077a17e4f02b2b71f5aeba11854
Requested by: Dan Lynch (@pyramation)