### PR TITLE
fix(graphql-codegen): re-export models and custom operations from index.ts

### DIFF
--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/client-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/client-generator.test.ts.snap
@@ -14,6 +14,7 @@ export type { OrmClientConfig, QueryResult, GraphQLError } from "./client";
 export { GraphQLRequestError } from "./client";
 export { QueryBuilder } from "./query-builder";
 export * from "./select-types";
+export * from "./models";
 /**
  * Create an ORM client instance
  *
@@ -61,6 +62,9 @@ export type { OrmClientConfig, QueryResult, GraphQLError } from "./client";
 export { GraphQLRequestError } from "./client";
 export { QueryBuilder } from "./query-builder";
 export * from "./select-types";
+export * from "./models";
+export { createQueryOperations } from "./query";
+export { createMutationOperations } from "./mutation";
 /**
  * Create an ORM client instance
  *

--- a/graphql/codegen/src/cli/codegen/orm/client-generator.ts
+++ b/graphql/codegen/src/cli/codegen/orm/client-generator.ts
@@ -424,6 +424,40 @@ export function generateCreateClientFile(
   // export * from './select-types';
   statements.push(t.exportAllDeclaration(t.stringLiteral('./select-types')));
 
+  // Re-export all models for backwards compatibility
+  // export * from './models';
+  statements.push(t.exportAllDeclaration(t.stringLiteral('./models')));
+
+  // Re-export custom operations for backwards compatibility
+  if (hasCustomQueries) {
+    statements.push(
+      t.exportNamedDeclaration(
+        null,
+        [
+          t.exportSpecifier(
+            t.identifier('createQueryOperations'),
+            t.identifier('createQueryOperations')
+          ),
+        ],
+        t.stringLiteral('./query')
+      )
+    );
+  }
+  if (hasCustomMutations) {
+    statements.push(
+      t.exportNamedDeclaration(
+        null,
+        [
+          t.exportSpecifier(
+            t.identifier('createMutationOperations'),
+            t.identifier('createMutationOperations')
+          ),
+        ],
+        t.stringLiteral('./mutation')
+      )
+    );
+  }
+
   // Build the return object properties
   const returnProperties: t.ObjectProperty[] = [];
 


### PR DESCRIPTION
## Summary

Fixes backwards compatibility for code that imports model classes directly from the SDK:

```typescript
import { DatabaseModel, TableModel, createMutationOperations } from '@constructive-db/constructive-sdk';
```

The generated `index.ts` was importing models but not re-exporting them, causing TypeScript errors like:
```
Module '"@constructive-db/constructive-sdk"' has no exported member 'DatabaseModel'.
```

This adds the following re-exports to the generated index.ts:
- `export * from './models'` - all model classes
- `export { createQueryOperations } from './query'` - when queries exist
- `export { createMutationOperations } from './mutation'` - when mutations exist

## Updates since last revision

- Updated test snapshots in `client-generator.test.ts.snap` to reflect the new export statements

## Review & Testing Checklist for Human

- [ ] Regenerate the SDK in constructive-db (`pnpm run generate:sdk`) and verify the tests pass (`pnpm test` in application/app)
- [ ] Verify no naming conflicts between model exports and existing exports from `./select-types` or `./client`
- [ ] Check that the generated `index.ts` includes the new export statements

### Notes

Link to Devin run: https://app.devin.ai/sessions/475ee077a17e4f02b2b71f5aeba11854
Requested by: Dan Lynch (@pyramation)