### PR TITLE
feat(codegen): add pluggable GraphQL adapter pattern

### DIFF
--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/client-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/client-generator.test.ts.snap
@@ -129,6 +129,14 @@ export interface GraphQLAdapter {
    * Execute a GraphQL operation and return the result.
    */
   execute<T>(document: string, variables?: Record<string, unknown>): Promise<QueryResult<T>>;
+  /**
+   * Set headers for requests (optional - only implement if adapter supports headers).
+   */
+  setHeaders?(headers: Record<string, string>): void;
+  /**
+   * Get the endpoint URL (optional - only implement if adapter has an endpoint).
+   */
+  getEndpoint?(): string;
 }
 
 /**
@@ -229,14 +237,12 @@ export class GraphQLRequestError extends Error {
 
 export class OrmClient {
   private adapter: GraphQLAdapter;
-  private fetchAdapter: FetchAdapter | null = null;
 
   constructor(config: OrmClientConfig) {
     if (config.adapter) {
       this.adapter = config.adapter;
     } else if (config.endpoint) {
-      this.fetchAdapter = new FetchAdapter(config.endpoint, config.headers);
-      this.adapter = this.fetchAdapter;
+      this.adapter = new FetchAdapter(config.endpoint, config.headers);
     } else {
       throw new Error('OrmClientConfig requires either an endpoint or a custom adapter');
     }
@@ -250,24 +256,21 @@ export class OrmClient {
   }
 
   /**
-   * Set headers for HTTP requests.
-   * Only works when using the default FetchAdapter.
+   * Set headers for requests.
+   * Only works if the adapter supports headers.
    */
   setHeaders(headers: Record<string, string>): void {
-    if (this.fetchAdapter) {
-      this.fetchAdapter.setHeaders(headers);
+    if (this.adapter.setHeaders) {
+      this.adapter.setHeaders(headers);
     }
   }
 
   /**
    * Get the endpoint URL.
-   * Only works when using the default FetchAdapter.
+   * Returns empty string if the adapter doesn't have an endpoint.
    */
   getEndpoint(): string {
-    if (this.fetchAdapter) {
-      return this.fetchAdapter.getEndpoint();
-    }
-    return '';
+    return this.adapter.getEndpoint?.() ?? '';
   }
 }
 "

--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/client-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/client-generator.test.ts.snap
@@ -10,7 +10,7 @@ import { OrmClient } from "./client";
 import type { OrmClientConfig } from "./client";
 import { UserModel } from "./models/user";
 import { PostModel } from "./models/post";
-export type { OrmClientConfig, QueryResult, GraphQLError } from "./client";
+export type { OrmClientConfig, QueryResult, GraphQLError, GraphQLAdapter } from "./client";
 export { GraphQLRequestError } from "./client";
 export { QueryBuilder } from "./query-builder";
 export * from "./select-types";
@@ -58,7 +58,7 @@ import type { OrmClientConfig } from "./client";
 import { UserModel } from "./models/user";
 import { createQueryOperations } from "./query";
 import { createMutationOperations } from "./mutation";
-export type { OrmClientConfig, QueryResult, GraphQLError } from "./client";
+export type { OrmClientConfig, QueryResult, GraphQLError, GraphQLAdapter } from "./client";
 export { GraphQLRequestError } from "./client";
 export { QueryBuilder } from "./query-builder";
 export * from "./select-types";
@@ -105,30 +105,11 @@ exports[`client-generator generateOrmClientFile generates OrmClient class with e
  * DO NOT EDIT - changes will be overwritten
  */
 
-export interface OrmClientConfig {
-  endpoint: string;
-  headers?: Record<string, string>;
-}
-
 export interface GraphQLError {
   message: string;
   locations?: { line: number; column: number }[];
   path?: (string | number)[];
   extensions?: Record<string, unknown>;
-}
-
-/**
- * Error thrown when GraphQL request fails
- */
-export class GraphQLRequestError extends Error {
-  constructor(
-    public readonly errors: GraphQLError[],
-    public readonly data: unknown = null
-  ) {
-    const messages = errors.map(e => e.message).join('; ');
-    super(\`GraphQL Error: \${messages}\`);
-    this.name = 'GraphQLRequestError';
-  }
 }
 
 /**
@@ -140,21 +121,28 @@ export type QueryResult<T> =
   | { ok: false; data: null; errors: GraphQLError[] };
 
 /**
- * Legacy QueryResult type for backwards compatibility
- * @deprecated Use QueryResult discriminated union instead
+ * Pluggable adapter interface for GraphQL execution.
+ * Implement this interface to provide custom execution logic (e.g., for testing).
  */
-export interface LegacyQueryResult<T> {
-  data: T | null;
-  errors?: GraphQLError[];
+export interface GraphQLAdapter {
+  /**
+   * Execute a GraphQL operation and return the result.
+   */
+  execute<T>(document: string, variables?: Record<string, unknown>): Promise<QueryResult<T>>;
 }
 
-export class OrmClient {
-  private endpoint: string;
+/**
+ * Default adapter that uses fetch for HTTP requests.
+ * This is used when no custom adapter is provided.
+ */
+export class FetchAdapter implements GraphQLAdapter {
   private headers: Record<string, string>;
 
-  constructor(config: OrmClientConfig) {
-    this.endpoint = config.endpoint;
-    this.headers = config.headers ?? {};
+  constructor(
+    private endpoint: string,
+    headers?: Record<string, string>
+  ) {
+    this.headers = headers ?? {};
   }
 
   async execute<T>(
@@ -187,7 +175,6 @@ export class OrmClient {
       errors?: GraphQLError[];
     };
 
-    // Return discriminated union based on presence of errors
     if (json.errors && json.errors.length > 0) {
       return {
         ok: false,
@@ -209,6 +196,87 @@ export class OrmClient {
 
   getEndpoint(): string {
     return this.endpoint;
+  }
+}
+
+/**
+ * Configuration for creating an ORM client.
+ * Either provide endpoint (and optional headers) for HTTP requests,
+ * or provide a custom adapter for alternative execution strategies.
+ */
+export interface OrmClientConfig {
+  /** GraphQL endpoint URL (required if adapter not provided) */
+  endpoint?: string;
+  /** Default headers for HTTP requests (only used with endpoint) */
+  headers?: Record<string, string>;
+  /** Custom adapter for GraphQL execution (overrides endpoint/headers) */
+  adapter?: GraphQLAdapter;
+}
+
+/**
+ * Error thrown when GraphQL request fails
+ */
+export class GraphQLRequestError extends Error {
+  constructor(
+    public readonly errors: GraphQLError[],
+    public readonly data: unknown = null
+  ) {
+    const messages = errors.map(e => e.message).join('; ');
+    super(\`GraphQL Error: \${messages}\`);
+    this.name = 'GraphQLRequestError';
+  }
+}
+
+/**
+ * Legacy QueryResult type for backwards compatibility
+ * @deprecated Use QueryResult discriminated union instead
+ */
+export interface LegacyQueryResult<T> {
+  data: T | null;
+  errors?: GraphQLError[];
+}
+
+export class OrmClient {
+  private adapter: GraphQLAdapter;
+  private fetchAdapter: FetchAdapter | null = null;
+
+  constructor(config: OrmClientConfig) {
+    if (config.adapter) {
+      this.adapter = config.adapter;
+    } else if (config.endpoint) {
+      this.fetchAdapter = new FetchAdapter(config.endpoint, config.headers);
+      this.adapter = this.fetchAdapter;
+    } else {
+      throw new Error('OrmClientConfig requires either an endpoint or a custom adapter');
+    }
+  }
+
+  async execute<T>(
+    document: string,
+    variables?: Record<string, unknown>
+  ): Promise<QueryResult<T>> {
+    return this.adapter.execute<T>(document, variables);
+  }
+
+  /**
+   * Set headers for HTTP requests.
+   * Only works when using the default FetchAdapter.
+   */
+  setHeaders(headers: Record<string, string>): void {
+    if (this.fetchAdapter) {
+      this.fetchAdapter.setHeaders(headers);
+    }
+  }
+
+  /**
+   * Get the endpoint URL.
+   * Only works when using the default FetchAdapter.
+   */
+  getEndpoint(): string {
+    if (this.fetchAdapter) {
+      return this.fetchAdapter.getEndpoint();
+    }
+    return '';
   }
 }
 "

--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/client-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/client-generator.test.ts.snap
@@ -227,15 +227,6 @@ export class GraphQLRequestError extends Error {
   }
 }
 
-/**
- * Legacy QueryResult type for backwards compatibility
- * @deprecated Use QueryResult discriminated union instead
- */
-export interface LegacyQueryResult<T> {
-  data: T | null;
-  errors?: GraphQLError[];
-}
-
 export class OrmClient {
   private adapter: GraphQLAdapter;
   private fetchAdapter: FetchAdapter | null = null;

--- a/graphql/codegen/src/cli/codegen/orm/client-generator.ts
+++ b/graphql/codegen/src/cli/codegen/orm/client-generator.ts
@@ -51,6 +51,14 @@ export interface GraphQLAdapter {
    * Execute a GraphQL operation and return the result.
    */
   execute<T>(document: string, variables?: Record<string, unknown>): Promise<QueryResult<T>>;
+  /**
+   * Set headers for requests (optional - only implement if adapter supports headers).
+   */
+  setHeaders?(headers: Record<string, string>): void;
+  /**
+   * Get the endpoint URL (optional - only implement if adapter has an endpoint).
+   */
+  getEndpoint?(): string;
 }
 
 /**
@@ -151,14 +159,12 @@ export class GraphQLRequestError extends Error {
 
 export class OrmClient {
   private adapter: GraphQLAdapter;
-  private fetchAdapter: FetchAdapter | null = null;
 
   constructor(config: OrmClientConfig) {
     if (config.adapter) {
       this.adapter = config.adapter;
     } else if (config.endpoint) {
-      this.fetchAdapter = new FetchAdapter(config.endpoint, config.headers);
-      this.adapter = this.fetchAdapter;
+      this.adapter = new FetchAdapter(config.endpoint, config.headers);
     } else {
       throw new Error('OrmClientConfig requires either an endpoint or a custom adapter');
     }
@@ -172,24 +178,21 @@ export class OrmClient {
   }
 
   /**
-   * Set headers for HTTP requests.
-   * Only works when using the default FetchAdapter.
+   * Set headers for requests.
+   * Only works if the adapter supports headers.
    */
   setHeaders(headers: Record<string, string>): void {
-    if (this.fetchAdapter) {
-      this.fetchAdapter.setHeaders(headers);
+    if (this.adapter.setHeaders) {
+      this.adapter.setHeaders(headers);
     }
   }
 
   /**
    * Get the endpoint URL.
-   * Only works when using the default FetchAdapter.
+   * Returns empty string if the adapter doesn't have an endpoint.
    */
   getEndpoint(): string {
-    if (this.fetchAdapter) {
-      return this.fetchAdapter.getEndpoint();
-    }
-    return '';
+    return this.adapter.getEndpoint?.() ?? '';
   }
 }
 `;

--- a/graphql/codegen/src/cli/codegen/orm/client-generator.ts
+++ b/graphql/codegen/src/cli/codegen/orm/client-generator.ts
@@ -27,30 +27,11 @@ export function generateOrmClientFile(): GeneratedClientFile {
  * DO NOT EDIT - changes will be overwritten
  */
 
-export interface OrmClientConfig {
-  endpoint: string;
-  headers?: Record<string, string>;
-}
-
 export interface GraphQLError {
   message: string;
   locations?: { line: number; column: number }[];
   path?: (string | number)[];
   extensions?: Record<string, unknown>;
-}
-
-/**
- * Error thrown when GraphQL request fails
- */
-export class GraphQLRequestError extends Error {
-  constructor(
-    public readonly errors: GraphQLError[],
-    public readonly data: unknown = null
-  ) {
-    const messages = errors.map(e => e.message).join('; ');
-    super(\`GraphQL Error: \${messages}\`);
-    this.name = 'GraphQLRequestError';
-  }
 }
 
 /**
@@ -62,21 +43,28 @@ export type QueryResult<T> =
   | { ok: false; data: null; errors: GraphQLError[] };
 
 /**
- * Legacy QueryResult type for backwards compatibility
- * @deprecated Use QueryResult discriminated union instead
+ * Pluggable adapter interface for GraphQL execution.
+ * Implement this interface to provide custom execution logic (e.g., for testing).
  */
-export interface LegacyQueryResult<T> {
-  data: T | null;
-  errors?: GraphQLError[];
+export interface GraphQLAdapter {
+  /**
+   * Execute a GraphQL operation and return the result.
+   */
+  execute<T>(document: string, variables?: Record<string, unknown>): Promise<QueryResult<T>>;
 }
 
-export class OrmClient {
-  private endpoint: string;
+/**
+ * Default adapter that uses fetch for HTTP requests.
+ * This is used when no custom adapter is provided.
+ */
+export class FetchAdapter implements GraphQLAdapter {
   private headers: Record<string, string>;
 
-  constructor(config: OrmClientConfig) {
-    this.endpoint = config.endpoint;
-    this.headers = config.headers ?? {};
+  constructor(
+    private endpoint: string,
+    headers?: Record<string, string>
+  ) {
+    this.headers = headers ?? {};
   }
 
   async execute<T>(
@@ -109,7 +97,6 @@ export class OrmClient {
       errors?: GraphQLError[];
     };
 
-    // Return discriminated union based on presence of errors
     if (json.errors && json.errors.length > 0) {
       return {
         ok: false,
@@ -131,6 +118,87 @@ export class OrmClient {
 
   getEndpoint(): string {
     return this.endpoint;
+  }
+}
+
+/**
+ * Configuration for creating an ORM client.
+ * Either provide endpoint (and optional headers) for HTTP requests,
+ * or provide a custom adapter for alternative execution strategies.
+ */
+export interface OrmClientConfig {
+  /** GraphQL endpoint URL (required if adapter not provided) */
+  endpoint?: string;
+  /** Default headers for HTTP requests (only used with endpoint) */
+  headers?: Record<string, string>;
+  /** Custom adapter for GraphQL execution (overrides endpoint/headers) */
+  adapter?: GraphQLAdapter;
+}
+
+/**
+ * Error thrown when GraphQL request fails
+ */
+export class GraphQLRequestError extends Error {
+  constructor(
+    public readonly errors: GraphQLError[],
+    public readonly data: unknown = null
+  ) {
+    const messages = errors.map(e => e.message).join('; ');
+    super(\`GraphQL Error: \${messages}\`);
+    this.name = 'GraphQLRequestError';
+  }
+}
+
+/**
+ * Legacy QueryResult type for backwards compatibility
+ * @deprecated Use QueryResult discriminated union instead
+ */
+export interface LegacyQueryResult<T> {
+  data: T | null;
+  errors?: GraphQLError[];
+}
+
+export class OrmClient {
+  private adapter: GraphQLAdapter;
+  private fetchAdapter: FetchAdapter | null = null;
+
+  constructor(config: OrmClientConfig) {
+    if (config.adapter) {
+      this.adapter = config.adapter;
+    } else if (config.endpoint) {
+      this.fetchAdapter = new FetchAdapter(config.endpoint, config.headers);
+      this.adapter = this.fetchAdapter;
+    } else {
+      throw new Error('OrmClientConfig requires either an endpoint or a custom adapter');
+    }
+  }
+
+  async execute<T>(
+    document: string,
+    variables?: Record<string, unknown>
+  ): Promise<QueryResult<T>> {
+    return this.adapter.execute<T>(document, variables);
+  }
+
+  /**
+   * Set headers for HTTP requests.
+   * Only works when using the default FetchAdapter.
+   */
+  setHeaders(headers: Record<string, string>): void {
+    if (this.fetchAdapter) {
+      this.fetchAdapter.setHeaders(headers);
+    }
+  }
+
+  /**
+   * Get the endpoint URL.
+   * Only works when using the default FetchAdapter.
+   */
+  getEndpoint(): string {
+    if (this.fetchAdapter) {
+      return this.fetchAdapter.getEndpoint();
+    }
+    return '';
   }
 }
 `;
@@ -371,7 +439,7 @@ export function generateCreateClientFile(
   }
 
   // Re-export types and classes
-  // export type { OrmClientConfig, QueryResult, GraphQLError } from './client';
+  // export type { OrmClientConfig, QueryResult, GraphQLError, GraphQLAdapter } from './client';
   const typeExportDecl = t.exportNamedDeclaration(
     null,
     [
@@ -386,6 +454,10 @@ export function generateCreateClientFile(
       t.exportSpecifier(
         t.identifier('GraphQLError'),
         t.identifier('GraphQLError')
+      ),
+      t.exportSpecifier(
+        t.identifier('GraphQLAdapter'),
+        t.identifier('GraphQLAdapter')
       ),
     ],
     t.stringLiteral('./client')

--- a/graphql/codegen/src/cli/codegen/orm/client-generator.ts
+++ b/graphql/codegen/src/cli/codegen/orm/client-generator.ts
@@ -149,15 +149,6 @@ export class GraphQLRequestError extends Error {
   }
 }
 
-/**
- * Legacy QueryResult type for backwards compatibility
- * @deprecated Use QueryResult discriminated union instead
- */
-export interface LegacyQueryResult<T> {
-  data: T | null;
-  errors?: GraphQLError[];
-}
-
 export class OrmClient {
   private adapter: GraphQLAdapter;
   private fetchAdapter: FetchAdapter | null = null;

--- a/graphql/codegen/src/cli/codegen/orm/client.ts
+++ b/graphql/codegen/src/cli/codegen/orm/client.ts
@@ -8,11 +8,6 @@
  * @internal This file is NOT part of the generated output
  */
 
-export interface OrmClientConfig {
-  endpoint: string;
-  headers?: Record<string, string>;
-}
-
 export interface GraphQLError {
   message: string;
   locations?: { line: number; column: number }[];
@@ -20,28 +15,32 @@ export interface GraphQLError {
   extensions?: Record<string, unknown>;
 }
 
-export class GraphQLRequestError extends Error {
-  constructor(
-    public readonly errors: GraphQLError[],
-    public readonly data: unknown = null
-  ) {
-    const messages = errors.map((e) => e.message).join('; ');
-    super(`GraphQL Error: ${messages}`);
-    this.name = 'GraphQLRequestError';
-  }
-}
-
 export type QueryResult<T> =
   | { ok: true; data: T; errors: undefined }
   | { ok: false; data: null; errors: GraphQLError[] };
 
-export class OrmClient {
-  private endpoint: string;
+/**
+ * Pluggable adapter interface for GraphQL execution.
+ * Implement this interface to provide custom execution logic (e.g., for testing).
+ */
+export interface GraphQLAdapter {
+  execute<T>(
+    document: string,
+    variables?: Record<string, unknown>
+  ): Promise<QueryResult<T>>;
+}
+
+/**
+ * Default adapter that uses fetch for HTTP requests.
+ */
+export class FetchAdapter implements GraphQLAdapter {
   private headers: Record<string, string>;
 
-  constructor(config: OrmClientConfig) {
-    this.endpoint = config.endpoint;
-    this.headers = config.headers ?? {};
+  constructor(
+    private endpoint: string,
+    headers?: Record<string, string>
+  ) {
+    this.headers = headers ?? {};
   }
 
   async execute<T>(
@@ -95,5 +94,66 @@ export class OrmClient {
 
   getEndpoint(): string {
     return this.endpoint;
+  }
+}
+
+/**
+ * Configuration for creating an ORM client.
+ */
+export interface OrmClientConfig {
+  /** GraphQL endpoint URL (required if adapter not provided) */
+  endpoint?: string;
+  /** Default headers for HTTP requests (only used with endpoint) */
+  headers?: Record<string, string>;
+  /** Custom adapter for GraphQL execution (overrides endpoint/headers) */
+  adapter?: GraphQLAdapter;
+}
+
+export class GraphQLRequestError extends Error {
+  constructor(
+    public readonly errors: GraphQLError[],
+    public readonly data: unknown = null
+  ) {
+    const messages = errors.map((e) => e.message).join('; ');
+    super(`GraphQL Error: ${messages}`);
+    this.name = 'GraphQLRequestError';
+  }
+}
+
+export class OrmClient {
+  private adapter: GraphQLAdapter;
+  private fetchAdapter: FetchAdapter | null = null;
+
+  constructor(config: OrmClientConfig) {
+    if (config.adapter) {
+      this.adapter = config.adapter;
+    } else if (config.endpoint) {
+      this.fetchAdapter = new FetchAdapter(config.endpoint, config.headers);
+      this.adapter = this.fetchAdapter;
+    } else {
+      throw new Error(
+        'OrmClientConfig requires either an endpoint or a custom adapter'
+      );
+    }
+  }
+
+  async execute<T>(
+    document: string,
+    variables?: Record<string, unknown>
+  ): Promise<QueryResult<T>> {
+    return this.adapter.execute<T>(document, variables);
+  }
+
+  setHeaders(headers: Record<string, string>): void {
+    if (this.fetchAdapter) {
+      this.fetchAdapter.setHeaders(headers);
+    }
+  }
+
+  getEndpoint(): string {
+    if (this.fetchAdapter) {
+      return this.fetchAdapter.getEndpoint();
+    }
+    return '';
   }
 }

--- a/graphql/codegen/src/cli/codegen/orm/client.ts
+++ b/graphql/codegen/src/cli/codegen/orm/client.ts
@@ -28,6 +28,8 @@ export interface GraphQLAdapter {
     document: string,
     variables?: Record<string, unknown>
   ): Promise<QueryResult<T>>;
+  setHeaders?(headers: Record<string, string>): void;
+  getEndpoint?(): string;
 }
 
 /**
@@ -122,14 +124,12 @@ export class GraphQLRequestError extends Error {
 
 export class OrmClient {
   private adapter: GraphQLAdapter;
-  private fetchAdapter: FetchAdapter | null = null;
 
   constructor(config: OrmClientConfig) {
     if (config.adapter) {
       this.adapter = config.adapter;
     } else if (config.endpoint) {
-      this.fetchAdapter = new FetchAdapter(config.endpoint, config.headers);
-      this.adapter = this.fetchAdapter;
+      this.adapter = new FetchAdapter(config.endpoint, config.headers);
     } else {
       throw new Error(
         'OrmClientConfig requires either an endpoint or a custom adapter'
@@ -145,15 +145,12 @@ export class OrmClient {
   }
 
   setHeaders(headers: Record<string, string>): void {
-    if (this.fetchAdapter) {
-      this.fetchAdapter.setHeaders(headers);
+    if (this.adapter.setHeaders) {
+      this.adapter.setHeaders(headers);
     }
   }
 
   getEndpoint(): string {
-    if (this.fetchAdapter) {
-      return this.fetchAdapter.getEndpoint();
-    }
-    return '';
+    return this.adapter.getEndpoint?.() ?? '';
   }
 }


### PR DESCRIPTION
## Summary

Adds a pluggable adapter pattern to the generated ORM client, allowing custom GraphQL execution strategies without modifying the codegen. This enables test frameworks (like `@constructive-io/graphql-test`) to provide their own execution logic without needing HTTP servers.

**Key changes:**
- New `GraphQLAdapter` interface with `execute<T>()` method and optional `setHeaders?()` / `getEndpoint?()` methods
- New `FetchAdapter` class (default) that extracts the existing HTTP fetch logic and implements all methods
- `OrmClientConfig.endpoint` is now optional when an `adapter` is provided
- `OrmClient` delegates all operations to the adapter (no internal `fetchAdapter` reference)
- `GraphQLAdapter` type is exported from generated `index.ts`

**Backward compatible:** Existing code using `{ endpoint, headers }` continues to work unchanged.

## Updates since last revision

- Removed deprecated `LegacyQueryResult<T>` type (was unused - only the discriminated union `QueryResult<T>` is supported)
- Refactored adapter interface: `setHeaders?()` and `getEndpoint?()` are now optional methods on `GraphQLAdapter` rather than having `OrmClient` hold a separate `fetchAdapter` reference (cleaner abstraction)

## Review & Testing Checklist for Human

- [ ] **Verify backward compatibility**: Ensure existing SDK consumers using `createClient({ endpoint: '...' })` still compile and work correctly
- [ ] **Review setHeaders/getEndpoint behavior**: These methods now delegate to the adapter if it implements them. Custom adapters can optionally implement `setHeaders?()` and `getEndpoint?()`. `getEndpoint()` returns `''` if adapter doesn't implement it.
- [ ] **Regenerate constructive-db SDK**: Run `pnpm generate:cli` in `sdk/constructive-sdk/` with a running server to verify the generated code includes the new adapter pattern
- [ ] **Run constructive-db tests**: After regenerating SDK, run tests in `application/app/` to verify the `GraphQLTestAdapter` integration works

**Recommended test plan:**
1. Build codegen: `cd graphql/codegen && pnpm build`
2. In a project using the SDK, verify `createClient({ endpoint: '...' })` still works
3. Test custom adapter: `createClient({ adapter: myCustomAdapter })`
4. Verify `setHeaders()` works with endpoint config, delegates to adapter if it implements `setHeaders?()`

### Notes

This is part 1 of a 2-PR change. Part 2 (in constructive-db) will update the test utilities to use this adapter pattern, eliminating `as any` casts and manual model enumeration.

Link to Devin run: https://app.devin.ai/sessions/ed1b873656874e36b2557ee45e8ffeda
Requested by: @pyramation