### PR TITLE
chore: remove apiExtensions and database_extension references

### DIFF
--- a/graphql/server/__tests__/api.middleware.test.ts
+++ b/graphql/server/__tests__/api.middleware.test.ts
@@ -29,7 +29,6 @@ describe('api middleware helpers', () => {
       databaseId: 'db-1',
       isPublic: false,
       domains: connection([]),
-      apiExtensions: connection([{ schemaName: 'ext_schema' }]),
       schemasByApiSchemaApiIdAndSchemaId: connection([
         { schemaName: 'app_public' },
       ]),
@@ -38,7 +37,7 @@ describe('api middleware helpers', () => {
     };
     const result = normalizeApiRecord(api);
 
-    expect(result.schema).toEqual(['ext_schema', 'app_public']);
+    expect(result.schema).toEqual(['app_public']);
   });
 
   it('builds domains from api domains', () => {
@@ -54,7 +53,6 @@ describe('api middleware helpers', () => {
         { domain: 'example.org', subdomain: '' },
         { domain: 'example.net', subdomain: '' },
       ]),
-      apiExtensions: connection([]),
       schemasByApiSchemaApiIdAndSchemaId: connection([]),
       apiModules: connection([]),
       rlsModule: null,
@@ -100,7 +98,6 @@ describe('api middleware helpers', () => {
       databaseId: 'db-1',
       isPublic: false,
       domains: connection([]),
-      apiExtensions: connection([]),
       schemasByApiSchemaApiIdAndSchemaId: connection([
         { schemaName: 'app_public' },
       ]),

--- a/graphql/server/src/middleware/gql.ts
+++ b/graphql/server/src/middleware/gql.ts
@@ -32,10 +32,6 @@ export const apiSelect = {
     },
     first: connectionFirst,
   },
-  apiExtensions: {
-    select: { schemaName: true },
-    first: connectionFirst,
-  },
   schemasByApiSchemaApiIdAndSchemaId: {
     select: { schemaName: true },
     first: connectionFirst,
@@ -146,10 +142,7 @@ export const createGraphileOrm = (graphile: GraphileQuery) => {
 };
 
 export const normalizeApiRecord = (api: ApiRecord): ApiStructure => {
-  const schemaNames = (api.apiExtensions?.nodes ?? []).flatMap((node) =>
-    node.schemaName ? [node.schemaName] : []
-  );
-  const additionalSchemas = (
+  const schemaNames = (
     api.schemasByApiSchemaApiIdAndSchemaId?.nodes ?? []
   ).flatMap((node) => (node.schemaName ? [node.schemaName] : []));
 
@@ -169,7 +162,7 @@ export const normalizeApiRecord = (api: ApiRecord): ApiStructure => {
     dbname: api.dbname,
     anonRole: api.anonRole,
     roleName: api.roleName,
-    schema: [...schemaNames, ...additionalSchemas],
+    schema: schemaNames,
     apiModules:
       api.apiModules?.nodes?.map((node) => ({
         name: node.name,

--- a/pgpm/core/__tests__/export/export-meta.test.ts
+++ b/pgpm/core/__tests__/export/export-meta.test.ts
@@ -18,24 +18,6 @@ describe('Export Meta Config Validation', () => {
   });
 
   describe('table name validation', () => {
-    it('should use singular table name "database_extension" (not plural "database_extensions")', () => {
-      // The actual table in metaschema_public is database_extension (singular)
-      // This test ensures the config uses the correct table name
-      
-      // Check that the config defines the table correctly
-      expect(exportMetaSource).toContain("table: 'database_extension'");
-      
-      // Ensure we're not using the incorrect plural form in the table definition
-      // Note: We check specifically in the config section, not the query section
-      const configSection = exportMetaSource.split('const config:')[1]?.split('interface ExportMetaParams')[0] || '';
-      expect(configSection).not.toContain("table: 'database_extensions'");
-    });
-
-    it('should query the correct table name in metaschema_public.database_extension', () => {
-      // The query should use the correct singular table name
-      expect(exportMetaSource).toContain('FROM metaschema_public.database_extension');
-    });
-
     it('should include field table in queries', () => {
       // The field table should be queried (it was missing before)
       expect(exportMetaSource).toContain("queryAndParse('field'");
@@ -47,7 +29,6 @@ describe('Export Meta Config Validation', () => {
     it('should include all required metaschema_public tables in config', () => {
       const requiredTables = [
         'database',
-        'database_extension',
         'schema',
         'table',
         'field'
@@ -69,7 +50,6 @@ describe('Export Meta Config Validation', () => {
         'site_modules',
         'site_themes',
         'api_modules',
-        'api_extensions',
         'api_schemas'
       ];
 
@@ -111,22 +91,19 @@ describe('Export Meta Config Drift Detection', () => {
     // If these change, the export-meta.ts config needs to be updated
     const expectedMetaschemaPublicTables = [
       'database',
-      'database_extension', // NOT 'database_extensions' (plural)
       'schema',
       'table',
       'field'
     ];
 
     // Document the expected tables
-    expect(expectedMetaschemaPublicTables).toContain('database_extension');
-    expect(expectedMetaschemaPublicTables).not.toContain('database_extensions');
+    expect(expectedMetaschemaPublicTables.length).toBe(4);
   });
 
   it('should document the expected table names in services_public', () => {
     // This test documents the expected table names that export-meta.ts should use
     const expectedServicesPublicTables = [
       'apis',
-      'api_extensions',
       'api_modules',
       'api_schemas',
       'apps',
@@ -137,7 +114,7 @@ describe('Export Meta Config Drift Detection', () => {
     ];
 
     // Document the expected tables
-    expect(expectedServicesPublicTables.length).toBe(9);
+    expect(expectedServicesPublicTables.length).toBe(8);
   });
 
   it('should document the expected table names in metaschema_modules_public', () => {
@@ -151,24 +128,4 @@ describe('Export Meta Config Drift Detection', () => {
     expect(expectedMetaschemaModulesPublicTables.length).toBe(2);
   });
 
-  it('should document the bug: config uses database_extensions but table is database_extension', () => {
-    // BUG DOCUMENTATION:
-    // In export-meta.ts, line 26, the config defines:
-    //   table: 'database_extensions' (plural)
-    // But the actual table in metaschema-schema is:
-    //   metaschema_public.database_extension (singular)
-    // 
-    // This causes the Parser to generate INSERT statements with the wrong table name,
-    // which will fail when the exported SQL is replayed.
-    //
-    // FIX: Change line 26 in export-meta.ts from:
-    //   table: 'database_extensions'
-    // to:
-    //   table: 'database_extension'
-    
-    const buggyConfigTableName = 'database_extensions';
-    const correctTableName = 'database_extension';
-    
-    expect(buggyConfigTableName).not.toBe(correctTableName);
-  });
 });

--- a/pgpm/core/src/export/export-meta.ts
+++ b/pgpm/core/src/export/export-meta.ts
@@ -114,14 +114,6 @@ const config: Record<string, TableConfig> = {
       hash: 'uuid'
     }
   },
-  database_extension: {
-    schema: 'metaschema_public',
-    table: 'database_extension',
-    fields: {
-      name: 'text',
-      database_id: 'uuid'
-    }
-  },
   schema: {
     schema: 'metaschema_public',
     table: 'schema',
@@ -450,16 +442,6 @@ const config: Record<string, TableConfig> = {
       api_id: 'uuid',
       name: 'text',
       data: 'jsonb'
-    }
-  },
-  api_extensions: {
-    schema: 'services_public',
-    table: 'api_extensions',
-    fields: {
-      id: 'uuid',
-      database_id: 'uuid',
-      api_id: 'uuid',
-      schema_name: 'text'
     }
   },
   api_schemas: {

--- a/pgpm/core/src/export/export-migrations.ts
+++ b/pgpm/core/src/export/export-migrations.ts
@@ -361,7 +361,6 @@ SET session_replication_role TO DEFAULT;`;
     // Tables that depend on 'database' being inserted first
     const tableOrder = [
       'database',
-      'database_extension',
       'schema',
       'table',
       'field',
@@ -387,7 +386,6 @@ SET session_replication_role TO DEFAULT;`;
       'site_themes',
       'site_metadata',
       'api_modules',
-      'api_extensions',
       'api_schemas',
       'rls_module',
       'user_auth_module',


### PR DESCRIPTION
## Summary

Removes all references to the `apiExtensions`, `database_extension`, and `api_extensions` tables from the constructive repo. This is a follow-up to [constructive-db PR #434](https://github.com/constructive-io/constructive-db/pull/434) which removed these unused extension tables from the database schema.

**Key changes:**
- Removed `apiExtensions` from the GraphQL API select and `normalizeApiRecord` function - schema names now come solely from `schemasByApiSchemaApiIdAndSchemaId`
- Removed `database_extension` and `api_extensions` configs from the pgpm export utilities
- Updated tests to reflect the removal of these tables

## Review & Testing Checklist for Human

- [ ] **CRITICAL: Ensure [constructive-db PR #434](https://github.com/constructive-io/constructive-db/pull/434) is merged before this PR** - otherwise the GraphQL server will try to query fields that don't exist
- [ ] Verify no production APIs rely on `apiExtensions` for schema name resolution (the `schemasByApiSchemaApiIdAndSchemaId` relation should be the canonical source)
- [ ] Run the full test suite locally to catch any additional dependencies on these tables
- [ ] After merging, verify the GraphQL server starts correctly and API lookups work as expected

### Updates since last revision

- Rebased on main to incorporate latest fixes

### Notes

This PR is part of a cleanup effort to remove extension-tracking tables that were designed but never implemented. The tables existed in the schema but no application logic ever populated or read from them.

Requested by: Dan Lynch (@pyramation)
Link to Devin run: https://app.devin.ai/sessions/89938c05148d4fd1953769e7af899382