### PR TITLE
fix(graphile-plugin-connection-filter-postgis): update version check to support ^3.0.0

### DIFF
--- a/graphile/graphile-plugin-connection-filter-postgis/src/index.ts
+++ b/graphile/graphile-plugin-connection-filter-postgis/src/index.ts
@@ -28,7 +28,7 @@ const PostGraphileConnectionFilterPostgisPlugin: Plugin = (
     };
 
     depends("graphile-build-pg", "^4.5.0");
-    depends("graphile-plugin-connection-filter", "^2.0.0");
+    depends("graphile-plugin-connection-filter", "^3.0.0");
 
     build.versions = build.extend(build.versions, { [pkg.name]: pkg.version });
 


### PR DESCRIPTION
## Summary

Updates the runtime version check in `graphile-plugin-connection-filter-postgis` to require `graphile-plugin-connection-filter@^3.0.0` instead of `^2.0.0`.

This fix is needed because `graphile-settings@3.0.0` depends on `graphile-plugin-connection-filter@^3.0.0`, and the old version check was causing runtime errors:

```
Plugin graphile-plugin-connection-filter-postgis@2.0.0 requires graphile-plugin-connection-filter@^2.0.0 (current version: 3.0.0)
```

## Review & Testing Checklist for Human

- [ ] Verify that the postgis plugin is actually compatible with `graphile-plugin-connection-filter@3.0.0` (this PR only updates the version check, not the actual compatibility)
- [ ] Test PostGIS filtering operations work correctly after this change

### Notes

This was discovered while upgrading dependencies in constructive-db PR #435.

**Link to Devin run:** https://app.devin.ai/sessions/52a59f63cea74493bcb0d97f67422e8d
**Requested by:** Dan Lynch (@pyramation)