### PR TITLE
docs(pgsql-client): add ephemeral database documentation

### DIFF
--- a/postgres/pgsql-client/README.md
+++ b/postgres/pgsql-client/README.md
@@ -123,6 +123,59 @@ await client.close();
 - `clearContext()` - Clear context and reset to anonymous
 - `close()` - Close connection
 
+### Ephemeral Databases
+
+Create temporary databases for testing, code generation, or other ephemeral use cases:
+
+```typescript
+import { createEphemeralDb } from 'pgsql-client';
+
+// Create a temporary database with a unique UUID-based name
+const { name, config, admin, teardown } = createEphemeralDb();
+
+// Use the database
+const pool = new Pool(config);
+await pool.query('SELECT 1');
+await pool.end();
+
+// Clean up when done
+teardown();
+
+// Or keep for debugging
+teardown({ keepDb: true });
+```
+
+#### Options
+
+```typescript
+const { config, teardown } = createEphemeralDb({
+  prefix: 'test_',           // Database name prefix (default: 'ephemeral_')
+  extensions: ['uuid-ossp'], // PostgreSQL extensions to install
+  baseConfig: {              // Override connection settings
+    host: 'localhost',
+    port: 5432,
+    user: 'postgres',
+    password: 'password'
+  },
+  verbose: true              // Enable logging
+});
+```
+
+#### Return Value
+
+- `name` - The generated database name (e.g., `ephemeral_a1b2c3d4_...`)
+- `config` - Full PostgreSQL configuration for connecting
+- `admin` - DbAdmin instance for additional operations
+- `teardown(opts?)` - Function to drop the database (pass `{ keepDb: true }` to preserve)
+
+#### Use Cases
+
+Ephemeral databases are useful for:
+- **Code generation**: Generate types from a temporary schema
+- **Integration tests**: Isolated database per test suite
+- **CI pipelines**: Clean database state for each run
+- **Local development**: Experiment without affecting shared databases
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

Adds documentation for the `createEphemeralDb` function to the pgsql-client README. This function creates temporary PostgreSQL databases with unique UUID-based names, useful for testing, code generation, and CI pipelines.

The documentation covers:
- Basic usage example
- Configuration options (prefix, extensions, baseConfig, verbose)
- Return value description (name, config, admin, teardown)
- Common use cases

## Review & Testing Checklist for Human

- [ ] **Verify API accuracy** — Compare the documented API against `postgres/pgsql-client/src/ephemeral.ts` to ensure options and return values match the implementation
- [ ] **Test the example** — Run the basic usage example to confirm it works as documented

### Notes

Link to Devin run: https://app.devin.ai/sessions/5edec0c962d04ee9bd15efc58ca2a050
Requested by: @pyramation