### PR TITLE
feat(pgpm): add --create-workspace / -w flag to create workspace then module

### DIFF
--- a/pgpm/cli/__tests__/init.test.ts
+++ b/pgpm/cli/__tests__/init.test.ts
@@ -122,7 +122,7 @@ describe('cmds:init', () => {
         cwd: fixture.tempDir,
         name: 'test-workspace-template',
         workspace: true,
-        templatePath: 'default/workspace'
+        templatePath: 'pgpm/workspace'
       });
 
       await commands(argv, prompter, {
@@ -170,7 +170,7 @@ describe('cmds:init', () => {
         name: 'test-module-template',
         moduleName: 'test-module-template',
         extensions: ['plpgsql'],
-        templatePath: 'default/module'
+        templatePath: 'pgpm/module'
       }), prompter, {
         noTty: true,
         input: mockInput,
@@ -485,5 +485,148 @@ describe('cmds:init', () => {
       expect(existsSync(path.join(modDir, 'pgpm.plan'))).toBe(true);
       expect(existsSync(path.join(modDir, 'package.json'))).toBe(true);
     });
+  });
+
+  describe('--create-workspace flag', () => {
+    const shouldSkipGitHubTests = process.env.CI === 'true' && !process.env.ALLOW_NETWORK_TESTS;
+
+    (shouldSkipGitHubTests ? it.skip : it)(
+      'creates workspace then module with --create-workspace flag (pgpm)',
+      async () => {
+        const { mockInput, mockOutput } = environment;
+        const prompter = new Inquirerer({
+          input: mockInput,
+          output: mockOutput,
+          noTty: true
+        });
+
+        const wsName = 'ws-create-workspace-pgpm';
+
+        // Run init with --create-workspace flag outside any workspace
+        await commands(withInitDefaults({
+          _: ['init'],
+          cwd: fixture.tempDir,
+          name: wsName,
+          moduleName: 'my-module',
+          createWorkspace: true,
+          extensions: ['plpgsql']
+        }), prompter, {
+          noTty: true,
+          input: mockInput,
+          output: mockOutput,
+          version: '1.0.0',
+          minimistOpts: {}
+        });
+
+        // Workspace should be created
+        const wsRoot = path.join(fixture.tempDir, wsName);
+        expect(existsSync(wsRoot)).toBe(true);
+        expect(existsSync(path.join(wsRoot, 'pgpm.json'))).toBe(true);
+
+        // Module should be created inside workspace
+        const modDir = path.join(wsRoot, 'packages', 'my-module');
+        expect(existsSync(modDir)).toBe(true);
+        expect(existsSync(path.join(modDir, 'pgpm.plan'))).toBe(true);
+        expect(existsSync(path.join(modDir, 'package.json'))).toBe(true);
+      },
+      120000
+    );
+
+    (shouldSkipGitHubTests ? it.skip : it)(
+      'creates workspace then module with --create-workspace flag and --dir pnpm',
+      async () => {
+        const { mockInput, mockOutput } = environment;
+        const prompter = new Inquirerer({
+          input: mockInput,
+          output: mockOutput,
+          noTty: true
+        });
+
+        const wsName = 'ws-create-workspace-pnpm';
+
+        // Run init with --create-workspace flag and --dir pnpm outside any workspace
+        await commands(withInitDefaults({
+          _: ['init'],
+          cwd: fixture.tempDir,
+          name: wsName,
+          moduleName: 'my-pnpm-module',
+          createWorkspace: true,
+          dir: 'pnpm'
+        }), prompter, {
+          noTty: true,
+          input: mockInput,
+          output: mockOutput,
+          version: '1.0.0',
+          minimistOpts: {}
+        });
+
+        // Workspace should be created
+        const wsRoot = path.join(fixture.tempDir, wsName);
+        expect(existsSync(wsRoot)).toBe(true);
+        expect(existsSync(path.join(wsRoot, 'package.json'))).toBe(true);
+        expect(existsSync(path.join(wsRoot, 'pnpm-workspace.yaml'))).toBe(true);
+
+        // Module should be created inside workspace
+        const modDir = path.join(wsRoot, 'packages', 'my-pnpm-module');
+        expect(existsSync(modDir)).toBe(true);
+        expect(existsSync(path.join(modDir, 'package.json'))).toBe(true);
+      },
+      120000
+    );
+
+    (shouldSkipGitHubTests ? it.skip : it)(
+      '--create-workspace is ignored when already inside a workspace',
+      async () => {
+        const { mockInput, mockOutput } = environment;
+        const prompter = new Inquirerer({
+          input: mockInput,
+          output: mockOutput,
+          noTty: true
+        });
+
+        // First create a workspace
+        const wsName = 'ws-already-exists';
+        await commands(withInitDefaults({
+          _: ['init', 'workspace'],
+          cwd: fixture.tempDir,
+          name: wsName,
+          workspace: true
+        }), prompter, {
+          noTty: true,
+          input: mockInput,
+          output: mockOutput,
+          version: '1.0.0',
+          minimistOpts: {}
+        });
+
+        const wsRoot = path.join(fixture.tempDir, wsName);
+
+        // Now run init with --create-workspace inside the workspace
+        // It should just create the module without creating another workspace
+        await commands(withInitDefaults({
+          _: ['init'],
+          cwd: wsRoot,
+          moduleName: 'module-in-existing-ws',
+          createWorkspace: true,
+          extensions: ['plpgsql']
+        }), prompter, {
+          noTty: true,
+          input: mockInput,
+          output: mockOutput,
+          version: '1.0.0',
+          minimistOpts: {}
+        });
+
+        // Module should be created in the existing workspace
+        const modDir = path.join(wsRoot, 'packages', 'module-in-existing-ws');
+        expect(existsSync(modDir)).toBe(true);
+        expect(existsSync(path.join(modDir, 'pgpm.plan'))).toBe(true);
+
+        // No nested workspace should be created
+        const nestedWs = path.join(wsRoot, 'packages', 'module-in-existing-ws', 'pgpm.json');
+        expect(existsSync(nestedWs)).toBe(false);
+      },
+      120000
+    );
   });
 });

--- a/pgpm/cli/src/commands/init/index.ts
+++ b/pgpm/cli/src/commands/init/index.ts
@@ -40,6 +40,7 @@ Options:
   --from-branch <branch>  Branch/tag to use when cloning repo
   --dir <variant>         Template variant directory (e.g., supabase, drizzle)
   --boilerplate           Prompt to select from available boilerplates
+  --create-workspace, -w  Create a workspace first, then create the module inside it
 
 Examples:
   ${binaryName} init                                   Initialize new module (default)
@@ -49,6 +50,7 @@ Examples:
   ${binaryName} init --boilerplate                     Select from available boilerplates
   ${binaryName} init --repo owner/repo                 Use templates from GitHub repository
   ${binaryName} init --repo owner/repo --from-branch develop  Use specific branch
+  ${binaryName} init --dir pnpm -w                     Create pnpm workspace + module in one command
 `;
 };
 
@@ -73,6 +75,7 @@ async function handleInit(argv: Partial<Record<string, any>>, prompter: Inquirer
   const dir = argv.dir as string | undefined;
   const noTty = Boolean((argv as any).noTty || argv['no-tty'] || process.env.CI === 'true');
   const useBoilerplatePrompt = Boolean(argv.boilerplate);
+  const createWorkspace = Boolean(argv.createWorkspace || argv['create-workspace'] || argv.w);
 
   // Get fromPath from first positional arg
   const positionalFromPath = argv._?.[0] as string | undefined;
@@ -127,6 +130,7 @@ async function handleInit(argv: Partial<Record<string, any>>, prompter: Inquirer
     noTty,
     cwd,
     requiresWorkspace: inspection.config?.requiresWorkspace,
+    createWorkspace,
   }, wasExplicitModuleRequest);
 }
 
@@ -246,6 +250,10 @@ interface InitContext {
    * 'pgpm' also indicates pgpm files should be created.
    */
   requiresWorkspace?: 'pgpm' | 'pnpm' | 'lerna' | 'npm' | false;
+  /**
+   * If true, create a workspace first, then create the module inside it.
+   */
+  createWorkspace?: boolean;
 }
 
 async function handleWorkspaceInit(
@@ -307,6 +315,57 @@ async function handleWorkspaceInit(
   return { ...argv, ...answers, cwd: targetPath };
 }
 
+interface WorkspaceTemplateConfig {
+  repo: string;
+  branch?: string;
+  dir?: string;
+}
+
+function resolveWorkspaceTemplateRepo(options: {
+  templateRepo: string;
+  branch?: string;
+  dir?: string;
+  workspaceType: 'pgpm' | 'pnpm';
+  cwd: string;
+}): WorkspaceTemplateConfig {
+  const { templateRepo, branch, dir, workspaceType, cwd } = options;
+
+  // Determine the dir to use for workspace template
+  // If dir is specified, use it; otherwise use the workspaceType as the dir variant
+  const workspaceDir = dir || workspaceType;
+
+  // Try to find workspace template in the specified repo
+  try {
+    const inspection = inspectTemplate({
+      fromPath: 'workspace',
+      templateRepo,
+      branch,
+      dir: workspaceDir,
+      toolName: DEFAULT_TEMPLATE_TOOL_NAME,
+      cwd,
+    });
+
+    // If we found a valid workspace template, use the specified repo
+    if (inspection.config?.type === 'workspace') {
+      return {
+        repo: templateRepo,
+        branch,
+        dir: workspaceDir,
+      };
+    }
+  } catch {
+    // Template not found in specified repo, fall through to default
+  }
+
+  // Fall back to default template repo
+  // Use the workspaceType as the dir variant (pgpm or pnpm)
+  return {
+    repo: DEFAULT_TEMPLATE_REPO,
+    branch: undefined, // Use default branch for default repo
+    dir: workspaceType,
+  };
+}
+
 async function handleModuleInit(
   argv: Partial<Record<string, any>>,
   prompter: Inquirerer,
@@ -318,7 +377,7 @@ async function handleModuleInit(
   // Whether this is a pgpm-managed template (creates pgpm.plan, .control files)
   const isPgpmTemplate = workspaceType === 'pgpm';
 
-  const project = new PgpmPackage(ctx.cwd);
+  let project = new PgpmPackage(ctx.cwd);
 
   // Track resolved workspace path for both pgpm and non-pgpm workspace types
   let resolvedWorkspacePath: string | undefined;
@@ -337,43 +396,81 @@ async function handleModuleInit(
     if (!resolvedWorkspacePath) {
       const noTty = Boolean((argv as any).noTty || argv['no-tty'] || process.env.CI === 'true');
 
-      // If user explicitly requested module init or we're in non-interactive mode,
-      // just show the error with helpful guidance
-      if (wasExplicitModuleRequest || noTty) {
+      // Handle --create-workspace flag: create workspace first, then module
+      if (ctx.createWorkspace && (workspaceType === 'pgpm' || workspaceType === 'pnpm')) {
+        // Resolve workspace template repo with fallback to default
+        const workspaceTemplateConfig = resolveWorkspaceTemplateRepo({
+          templateRepo: ctx.templateRepo,
+          branch: ctx.branch,
+          dir: ctx.dir,
+          workspaceType,
+          cwd: ctx.cwd,
+        });
+
+        // Create workspace first
+        const workspaceResult = await handleWorkspaceInit(argv, prompter, {
+          fromPath: 'workspace',
+          templateRepo: workspaceTemplateConfig.repo,
+          branch: workspaceTemplateConfig.branch,
+          dir: workspaceTemplateConfig.dir,
+          noTty: ctx.noTty,
+          cwd: ctx.cwd,
+        });
+
+        // Update context to point to new workspace and continue with module creation
+        const newCwd = workspaceResult.cwd as string;
+        project = new PgpmPackage(newCwd);
+        
+        // Re-resolve workspace path with new cwd
+        if (workspaceType === 'pgpm') {
+          resolvedWorkspacePath = project.workspacePath;
+        } else {
+          resolvedWorkspacePath = resolveWorkspaceByType(newCwd, workspaceType);
+        }
+
+        // Update ctx for module creation
+        ctx.cwd = newCwd;
+        
+        // Continue to module creation below (don't return here)
+      } else {
+        // If user explicitly requested module init or we're in non-interactive mode,
+        // just show the error with helpful guidance
+        if (wasExplicitModuleRequest || noTty) {
+          process.stderr.write(`Not inside a ${workspaceTypeName} workspace.\n`);
+          throw errors.NOT_IN_WORKSPACE({});
+        }
+
+        // Offer to create a workspace for pgpm templates or when --dir is specified
+        // (when --dir is specified, we know which workspace variant to use)
+        if (workspaceType === 'pgpm' || ctx.dir) {
+          const recoveryQuestion: Question[] = [
+            {
+              name: 'workspace',
+              alias: 'W',
+              message: `You are not inside a ${workspaceTypeName} workspace. Would you like to create a new workspace instead?`,
+              type: 'confirm',
+              required: true,
+            },
+          ];
+
+          const { workspace } = await prompter.prompt(argv, recoveryQuestion);
+
+          if (workspace) {
+            return handleWorkspaceInit(argv, prompter, {
+              fromPath: 'workspace',
+              templateRepo: ctx.templateRepo,
+              branch: ctx.branch,
+              dir: ctx.dir,
+              noTty: ctx.noTty,
+              cwd: ctx.cwd,
+            });
+          }
+        }
+
+        // User declined or non-pgpm workspace type without --dir, show the error
         process.stderr.write(`Not inside a ${workspaceTypeName} workspace.\n`);
         throw errors.NOT_IN_WORKSPACE({});
       }
-
-      // Offer to create a workspace for pgpm templates or when --dir is specified
-      // (when --dir is specified, we know which workspace variant to use)
-      if (workspaceType === 'pgpm' || ctx.dir) {
-        const recoveryQuestion: Question[] = [
-          {
-            name: 'workspace',
-            alias: 'w',
-            message: `You are not inside a ${workspaceTypeName} workspace. Would you like to create a new workspace instead?`,
-            type: 'confirm',
-            required: true,
-          },
-        ];
-
-        const { workspace } = await prompter.prompt(argv, recoveryQuestion);
-
-        if (workspace) {
-          return handleWorkspaceInit(argv, prompter, {
-            fromPath: 'workspace',
-            templateRepo: ctx.templateRepo,
-            branch: ctx.branch,
-            dir: ctx.dir,
-            noTty: ctx.noTty,
-            cwd: ctx.cwd,
-          });
-        }
-      }
-
-      // User declined or non-pgpm workspace type without --dir, show the error
-      process.stderr.write(`Not inside a ${workspaceTypeName} workspace.\n`);
-      throw errors.NOT_IN_WORKSPACE({});
     }
   }
 


### PR DESCRIPTION
## Summary

Adds a new `--create-workspace` / `-w` flag to `pgpm init` that automates the two-step process of creating a workspace and then creating a module inside it. When used outside a workspace, the command will:

1. Create a workspace first (prompting for workspace name)
2. Automatically change into the new workspace directory
3. Create the module inside `packages/`

The feature includes fallback logic: if the specified `--repo` doesn't contain a workspace template, it falls back to the default pgpm-boilerplates repo for the workspace template while still using the specified repo for the module template.

**Example usage:**
```bash
pgpm init --dir pnpm -w  # Creates pnpm workspace + module in one command
pgpm init -w             # Creates pgpm workspace + module
```

Also changes the recovery prompt alias from `-w` to `-W` to avoid conflict with the new flag.

## Review & Testing Checklist for Human

- [ ] **Companion PR required**: This PR updates test references from `default/` to `pgpm/`. The [pgpm-boilerplates PR](https://github.com/constructive-io/pgpm-boilerplates/pull/new/devin/1769582569-rename-default-to-pgpm) that renames `default/` to `pgpm/` must be merged first, or tests will fail
- [ ] **Test the fallback logic manually**: Run `pgpm init --repo some-repo-without-workspace-templates --dir pnpm -w` and verify it falls back to pgpm-boilerplates for the workspace
- [ ] **Verify state mutation is correct**: After workspace creation, `ctx.cwd` and `project` are reassigned - verify module creation uses the correct paths
- [ ] **Breaking change**: The `-w` alias for the recovery prompt is now `-W` - verify this doesn't break existing workflows

### Notes

- Only `pgpm` and `pnpm` workspace types are supported for `--create-workspace` (per user request)
- New tests are skipped in CI unless `ALLOW_NETWORK_TESTS` is set (they require GitHub access)
- The `resolveWorkspaceTemplateRepo` function catches all errors when checking for workspace templates - this is intentional to fall back gracefully

Link to Devin run: https://app.devin.ai/sessions/86fc90000ad24b2cacf3b750dc077be3
Requested by: Dan Lynch (@pyramation)