### PR TITLE
feat(pgpm): rename --template-path to --template flag

### DIFF
--- a/pgpm/cli/README.md
+++ b/pgpm/cli/README.md
@@ -70,6 +70,8 @@ Here are some useful commands for reference:
 
 - `pgpm init` - Initialize a new module
 - `pgpm init workspace` - Initialize a new workspace
+- `pgpm init --template <path>` - Initialize using a full template path (e.g., `pnpm/module`)
+- `pgpm init -w` - Create a workspace first, then create the module inside it
 
 ### Development Setup
 
@@ -142,7 +144,7 @@ pgpm deploy --createdb
 
 ## 🧰 Templates, Caching, and Updates
 
-- `pgpm init` now scaffolds workspaces/modules from `https://github.com/constructive-io/pgpm-boilerplates.git` using `create-gen-app` with a one-week cache (stored under `~/.pgpm/cache/repos`). Override with `--repo`, `--from-branch`, and `--template-path`, or use a local template path.
+- `pgpm init` now scaffolds workspaces/modules from `https://github.com/constructive-io/pgpm-boilerplates.git` using `create-gen-app` with a one-week cache (stored under `~/.pgpm/cache/repos`). Override with `--repo`, `--from-branch`, and `--template`, or use a local template path.
 - Run `pgpm cache clean` to wipe the cached boilerplates if you need a fresh pull.
 - The CLI performs a lightweight npm version check at most once per week (skipped in CI or when `PGPM_SKIP_UPDATE_CHECK` is set). Use `pgpm update` to upgrade to the latest release.
 

--- a/pgpm/cli/__tests__/init.test.ts
+++ b/pgpm/cli/__tests__/init.test.ts
@@ -109,7 +109,7 @@ describe('cmds:init', () => {
   });
 
   describe('with custom templates', () => {
-    it('initializes workspace with --template-path', async () => {
+    it('initializes workspace with --template', async () => {
       const { mockInput, mockOutput } = environment;
       const prompter = new Inquirerer({
         input: mockInput,
@@ -122,7 +122,7 @@ describe('cmds:init', () => {
         cwd: fixture.tempDir,
         name: 'test-workspace-template',
         workspace: true,
-        templatePath: 'default/workspace'
+        template: 'pgpm/workspace'
       });
 
       await commands(argv, prompter, {
@@ -139,7 +139,7 @@ describe('cmds:init', () => {
       expect(existsSync(path.join(workspaceDir, 'pgpm.json'))).toBe(true);
     });
 
-    it('initializes module with --template-path', async () => {
+    it('initializes module with --template', async () => {
       // First create a workspace
       const workspaceDir = path.join(fixture.tempDir, 'test-workspace-for-module');
       const { mockInput, mockOutput } = environment;
@@ -170,7 +170,7 @@ describe('cmds:init', () => {
         name: 'test-module-template',
         moduleName: 'test-module-template',
         extensions: ['plpgsql'],
-        templatePath: 'default/module'
+        template: 'pgpm/module'
       }), prompter, {
         noTty: true,
         input: mockInput,

--- a/pgpm/cli/src/commands/init/workspace.ts
+++ b/pgpm/cli/src/commands/init/workspace.ts
@@ -31,8 +31,9 @@ export default async function runWorkspaceSetup(
   prompter.close();
 
   const templateRepo = (argv.repo as string) ?? DEFAULT_TEMPLATE_REPO;
-  // Don't set default templatePath - let scaffoldTemplate use metadata-driven resolution
-  const templatePath = argv.templatePath as string | undefined;
+  // Don't set default template - let scaffoldTemplate use metadata-driven resolution
+  // Support both --template (new) and --template-path (deprecated) for backward compatibility
+  const template = (argv.template || argv.templatePath) as string | undefined;
 
   // Register workspace.dirname resolver so boilerplate templates can use it via defaultFrom/setFrom
   // This provides the intended workspace directory name before the folder is created
@@ -42,7 +43,7 @@ export default async function runWorkspaceSetup(
   const dir = argv.dir as string | undefined;
 
   await scaffoldTemplate({
-    fromPath: templatePath ?? 'workspace',
+    fromPath: template ?? 'workspace',
     outputDir: targetPath,
     templateRepo,
     branch: argv.fromBranch as string | undefined,

--- a/pgpm/cli/src/index.ts
+++ b/pgpm/cli/src/index.ts
@@ -36,7 +36,9 @@ export const options: Partial<CLIOptions> = {
       v: 'version',
       h: 'help',
       'from-branch': 'fromBranch',
-      'template-path': 'templatePath'
+      // Support both --template and --template-path (deprecated) for backward compatibility
+      'template-path': 'template',
+      t: 'template'
     }
   }
 };

--- a/pgpm/cli/src/index.ts
+++ b/pgpm/cli/src/index.ts
@@ -38,7 +38,10 @@ export const options: Partial<CLIOptions> = {
       'from-branch': 'fromBranch',
       // Support both --template and --template-path (deprecated) for backward compatibility
       'template-path': 'template',
-      t: 'template'
+      t: 'template',
+      // -w for --create-workspace flag
+      w: 'createWorkspace',
+      'create-workspace': 'createWorkspace'
     }
   }
 };


### PR DESCRIPTION
## Summary

Renames the `--template-path` flag to `--template` (with `-t` alias) for a cleaner CLI experience. The new `--template` flag can parse combined paths like `pnpm/module` and automatically extract the `dir` and `fromPath` components.

**New usage:**
```bash
pgpm init --template pnpm/module    # Equivalent to: pgpm init module --dir pnpm
pgpm init -t pgpm/workspace         # Short form
```

Backward compatibility is maintained - `--template-path` still works but is deprecated.

## Updates since last revision

- **Fixed `-w` alias**: Added missing CLI alias mapping for `-w` → `createWorkspace`. Without this, `pgpm init --template pgpm/module -w` would fail with "NOT_IN_WORKSPACE" error.
- **Updated README**: Documented the new `--template` and `-w` flags in the Getting Started section and updated the Templates section to reference `--template` instead of `--template-path`.

## Review & Testing Checklist for Human

- [ ] **Test `--template` with `-w` flag together**: Run `pgpm init --template pgpm/module -w` outside a workspace - should create workspace first, then module inside it
- [ ] **Verify parsing edge cases**: Test with `--template workspace` (no slash), `--template pnpm/sub/module` (multiple slashes), and `--template /module` (leading slash)
- [ ] **Test precedence behavior**: When both `--template pnpm/module` and `--dir supabase` are provided, `--template` silently overrides `--dir` - verify this is the desired behavior
- [ ] **Verify backward compatibility**: Test that `--template-path pgpm/workspace` still works as expected

**Recommended test plan:**
```bash
# Test new flag with create-workspace
pgpm init --template pnpm/module -w   # Should create workspace + module

# Test new flag standalone
pgpm init --template pnpm/workspace
pgpm init -t pgpm/module

# Test backward compatibility  
pgpm init --template-path pgpm/workspace

# Test edge cases
pgpm init --template workspace  # No slash - should work as fromPath only
```

### Notes

This PR depends on the pgpm-boilerplates repo having the `pgpm/` folder (merged in PR #25).

Link to Devin run: https://app.devin.ai/sessions/86fc90000ad24b2cacf3b750dc077be3
Requested by: Dan Lynch (@pyramation)