### PR TITLE
refactor: replace tokens_module with sessions_module in export

### DIFF
--- a/pgpm/core/src/export/export-meta.ts
+++ b/pgpm/core/src/export/export-meta.ts
@@ -467,7 +467,6 @@ const config: Record<string, TableConfig> = {
       api_id: 'uuid',
       schema_id: 'uuid',
       private_schema_id: 'uuid',
-      tokens_table_id: 'uuid',
       users_table_id: 'uuid',
       authenticate: 'text',
       authenticate_strict: 'text',
@@ -486,7 +485,6 @@ const config: Record<string, TableConfig> = {
       users_table_id: 'uuid',
       secrets_table_id: 'uuid',
       encrypted_table_id: 'uuid',
-      tokens_table_id: 'uuid',
       sign_in_function: 'text',
       sign_up_function: 'text',
       sign_out_function: 'text',
@@ -701,17 +699,21 @@ const config: Record<string, TableConfig> = {
       table_name: 'text'
     }
   },
-  tokens_module: {
+  sessions_module: {
     schema: 'metaschema_modules_public',
-    table: 'tokens_module',
+    table: 'sessions_module',
     fields: {
       id: 'uuid',
       database_id: 'uuid',
       schema_id: 'uuid',
-      table_id: 'uuid',
-      owned_table_id: 'uuid',
-      tokens_default_expiration: 'interval',
-      tokens_table: 'text'
+      sessions_table_id: 'uuid',
+      session_credentials_table_id: 'uuid',
+      auth_settings_table_id: 'uuid',
+      users_table_id: 'uuid',
+      sessions_default_expiration: 'interval',
+      sessions_table: 'text',
+      session_credentials_table: 'text',
+      auth_settings_table: 'text'
     }
   },
   secrets_module: {
@@ -809,7 +811,8 @@ const config: Record<string, TableConfig> = {
       database_id: 'uuid',
       schema_id: 'uuid',
       users_table_id: 'uuid',
-      tokens_table_id: 'uuid',
+      sessions_table_id: 'uuid',
+      session_credentials_table_id: 'uuid',
       secrets_table_id: 'uuid',
       addresses_table_id: 'uuid',
       user_field: 'text',
@@ -1024,7 +1027,7 @@ export const exportMeta = async ({ opts, dbname, database_id }: ExportMetaParams
   await queryAndParse('membership_types_module', `SELECT * FROM metaschema_modules_public.membership_types_module WHERE database_id = $1`);
   await queryAndParse('invites_module', `SELECT * FROM metaschema_modules_public.invites_module WHERE database_id = $1`);
   await queryAndParse('emails_module', `SELECT * FROM metaschema_modules_public.emails_module WHERE database_id = $1`);
-  await queryAndParse('tokens_module', `SELECT * FROM metaschema_modules_public.tokens_module WHERE database_id = $1`);
+  await queryAndParse('sessions_module', `SELECT * FROM metaschema_modules_public.sessions_module WHERE database_id = $1`);
   await queryAndParse('secrets_module', `SELECT * FROM metaschema_modules_public.secrets_module WHERE database_id = $1`);
   await queryAndParse('profiles_module', `SELECT * FROM metaschema_modules_public.profiles_module WHERE database_id = $1`);
   await queryAndParse('encrypted_secrets_module', `SELECT * FROM metaschema_modules_public.encrypted_secrets_module WHERE database_id = $1`);

--- a/pgpm/core/src/export/export-meta.ts
+++ b/pgpm/core/src/export/export-meta.ts
@@ -467,6 +467,8 @@ const config: Record<string, TableConfig> = {
       api_id: 'uuid',
       schema_id: 'uuid',
       private_schema_id: 'uuid',
+      session_credentials_table_id: 'uuid',
+      sessions_table_id: 'uuid',
       users_table_id: 'uuid',
       authenticate: 'text',
       authenticate_strict: 'text',
@@ -485,6 +487,10 @@ const config: Record<string, TableConfig> = {
       users_table_id: 'uuid',
       secrets_table_id: 'uuid',
       encrypted_table_id: 'uuid',
+      sessions_table_id: 'uuid',
+      session_credentials_table_id: 'uuid',
+      audits_table_id: 'uuid',
+      audits_table_name: 'text',
       sign_in_function: 'text',
       sign_up_function: 'text',
       sign_out_function: 'text',
@@ -497,7 +503,9 @@ const config: Record<string, TableConfig> = {
       reset_password_function: 'text',
       forgot_password_function: 'text',
       send_verification_email_function: 'text',
-      verify_email_function: 'text'
+      verify_email_function: 'text',
+      verify_password_function: 'text',
+      check_password_function: 'text'
     }
   },
   memberships_module: {

--- a/pgpm/core/src/export/export-migrations.ts
+++ b/pgpm/core/src/export/export-migrations.ts
@@ -398,7 +398,7 @@ SET session_replication_role TO DEFAULT;`;
       'membership_types_module',
       'invites_module',
       'emails_module',
-      'tokens_module',
+      'sessions_module',
       'secrets_module',
       'profiles_module',
       'encrypted_secrets_module',


### PR DESCRIPTION
# refactor: replace tokens_module with sessions_module in export

## Summary
Updates the export functionality to use the new `sessions_module` instead of the deprecated `tokens_module`. This is part of the session-centric auth migration where all authentication tokens now live in `session_credentials` table instead of `api_tokens`.

Changes:
- Replace `tokens_module` with `sessions_module` in `tableOrder` array (export-migrations.ts)
- Replace `tokens_module` config with `sessions_module` config with new field structure (export-meta.ts)
- Replace `tokens_table_id` with `sessions_table_id` and `session_credentials_table_id` in `rls_module` config
- Replace `tokens_table_id` with `sessions_table_id` and `session_credentials_table_id` in `user_auth_module` config (also added missing `audits_table_id`, `audits_table_name`, `verify_password_function`, `check_password_function`)
- Replace `tokens_table_id` with `sessions_table_id` and `session_credentials_table_id` in `crypto_auth_module` config

## Review & Testing Checklist for Human
- [ ] **Verify dependent PRs are merged first**: This requires [constructive-db PR #458](https://github.com/constructive-io/constructive-db/pull/458) and [pgpm-modules PR #39](https://github.com/constructive-io/pgpm-modules/pull/39) to be merged, otherwise exports will fail
- [ ] **Verify field configs match actual table schemas**: Compare the fields in `rls_module`, `user_auth_module`, `crypto_auth_module`, and `sessions_module` configs against the actual table definitions in constructive-db to ensure they match exactly
- [ ] **Test an actual export**: Run `generate:constructive` or similar export command after dependent PRs are merged to verify the export works end-to-end

### Notes
- The test file `packages/csv-to-pg/__tests__/export.test.ts` still uses `tokens_module` as an example table name for parser tests - this is just a test fixture and doesn't affect functionality
- The `__fixtures__/output/schemas/services_public.ts` file will need to be regenerated after the dependent PRs are merged

Link to Devin run: https://app.devin.ai/sessions/d30b2724020f43f6b94865bbd5cf71c6
Requested by: Dan Lynch (@pyramation)