### PR TITLE
feat: upgrade graphile-query to PostGraphile v5 / GraphQL 16

### DIFF
--- a/graphile/graphile-query/CHANGELOG.md
+++ b/graphile/graphile-query/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [2.5.1](https://github.com/constructive-io/constructive/compare/graphile-query@2.5.0...graphile-query@2.5.1) (2026-01-19)
+
+**Note:** Version bump only for package graphile-query
+
+# [2.5.0](https://github.com/constructive-io/constructive/compare/graphile-query@2.4.7...graphile-query@2.5.0) (2026-01-18)
+
+**Note:** Version bump only for package graphile-query
+
+## [2.4.7](https://github.com/constructive-io/constructive/compare/graphile-query@2.4.6...graphile-query@2.4.7) (2026-01-02)
+
+**Note:** Version bump only for package graphile-query
+
+## [2.4.6](https://github.com/constructive-io/constructive/compare/graphile-query@2.4.5...graphile-query@2.4.6) (2025-12-21)
+
+**Note:** Version bump only for package graphile-query
+
+## [2.4.5](https://github.com/constructive-io/constructive/compare/graphile-query@2.4.4...graphile-query@2.4.5) (2025-12-19)
+
+**Note:** Version bump only for package graphile-query
+
+## [2.4.4](https://github.com/constructive-io/constructive/compare/graphile-query@2.4.3...graphile-query@2.4.4) (2025-12-17)
+
+**Note:** Version bump only for package graphile-query

--- a/graphile/graphile-query/README.md
+++ b/graphile/graphile-query/README.md
@@ -1,0 +1,133 @@
+# graphile-query
+
+<p align="center" width="100%">
+  <img height="250" src="https://raw.githubusercontent.com/constructive-io/constructive/refs/heads/main/assets/outline-logo.svg" />
+</p>
+
+<p align="center" width="100%">
+  <a href="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml">
+    <img height="20" src="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml/badge.svg" />
+  </a>
+  <a href="https://github.com/constructive-io/constructive/blob/main/LICENSE">
+    <img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/>
+  </a>
+  <a href="https://www.npmjs.com/package/graphile-query">
+    <img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/constructive?filename=graphile%2Fgraphile-query%2Fpackage.json"/>
+  </a>
+</p>
+
+**`graphile-query`** provides utilities to execute GraphQL queries against a PostGraphile-generated schema using PostgreSQL connection pooling and contextual role-based settings.
+
+It includes two main classes:
+
+* `GraphileQuery`: A flexible query runner that supports `pgSettings`, role-based access control, and custom request context.
+* `GraphileQuerySimple`: A minimal wrapper for GraphQL execution without advanced role or settings logic.
+
+## 🚀 Installation
+
+```bash
+npm install graphile-query
+```
+
+## ✨ Features
+
+* Built-in support for PostGraphile context and role-based `pgSettings`
+* Works with pre-built PostGraphile schemas
+* Supports raw string queries or parsed `DocumentNode`s
+* Integrates with PostgreSQL via `pg.Pool`
+
+## 📦 Usage
+
+Use as a particular role, skipping any auth logic:
+
+```ts
+const results = await client.query({
+  role: 'postgres',
+  query,
+  variables
+});
+```
+
+Or pass a request object to be evaluated based on logic:
+
+```ts
+const results = await client.query({
+  req: { something: { special: 'e90829ef-1da4-448d-3e44-b3d275702b86' } },
+  query: MyGraphQLQuery,
+  variables
+});
+```
+
+
+### 1. Create a GraphQL Schema
+
+```ts
+import { Pool } from 'pg';
+import { getSchema } from 'graphile-query';
+
+const pool = new Pool();
+const schema = await getSchema(pool, {
+  schema: ['app_public'],
+  pgSettings: req => ({ 'myapp.user_id': req.user?.id }),
+});
+```
+
+### 2. Execute Queries with `GraphileQuery`
+
+```ts
+import { GraphileQuery } from 'graphile-query';
+
+const client = new GraphileQuery({ schema, pool, settings });
+
+const result = await client.query({
+  query: `
+    query GetUsers {
+      allUsers {
+        nodes {
+          id
+          username
+        }
+      }
+    }
+  `,
+  role: 'authenticated', // optional
+  req: { user: { id: 123 } }, // optional
+});
+```
+
+### 3. Use `GraphileQuerySimple` for Lightweight Execution
+
+```ts
+import { GraphileQuerySimple } from 'graphile-query';
+
+const client = new GraphileQuerySimple({ schema, pool });
+
+const result = await client.query(`
+  query {
+    currentUser {
+      id
+      email
+    }
+  }
+`);
+```
+
+## 📘 API
+
+### `getSchema(pool, settings)`
+
+* Builds a PostGraphile schema using the given database pool and settings.
+
+### `GraphileQuery`
+
+* `constructor({ schema, pool, settings })`
+* `query({ query, variables?, role?, req? })`
+
+Supports full context, roles, and settings for advanced scenarios.
+
+### `GraphileQuerySimple`
+
+* `constructor({ schema, pool })`
+* `query(query, variables?)`
+
+Lightweight version with no role or settings support.

--- a/graphile/graphile-query/__tests__/graphile-query.test.ts
+++ b/graphile/graphile-query/__tests__/graphile-query.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tests for graphile-query PostGraphile v5 integration
+ */
+import { Pool } from 'pg';
+import { getConnections, GetConnectionResult } from 'pgsql-test';
+import {
+  getSchema,
+  GraphileQuery,
+  GraphileQuerySimple,
+  createGraphileQuery,
+  createGraphileQuerySimple,
+} from '../src';
+
+const TEST_SCHEMA = `
+CREATE SCHEMA IF NOT EXISTS test_public;
+
+CREATE TABLE test_public.users (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  email TEXT UNIQUE NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE test_public.posts (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER REFERENCES test_public.users(id),
+  title TEXT NOT NULL,
+  body TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+INSERT INTO test_public.users (name, email) VALUES
+  ('Alice', 'alice@example.com'),
+  ('Bob', 'bob@example.com');
+
+INSERT INTO test_public.posts (user_id, title, body) VALUES
+  (1, 'Hello World', 'This is my first post'),
+  (1, 'GraphQL is great', 'I love using GraphQL'),
+  (2, 'Testing with Jest', 'Jest makes testing easy');
+`;
+
+describe('graphile-query', () => {
+  let pool: Pool;
+  let conn: GetConnectionResult;
+
+  beforeAll(async () => {
+    conn = await getConnections({
+      db: { extensions: [] },
+    });
+    pool = conn.manager.getPool(conn.pg.config);
+
+    const client = await pool.connect();
+    try {
+      await client.query(TEST_SCHEMA);
+    } finally {
+      client.release();
+    }
+  });
+
+  afterAll(async () => {
+    await conn.teardown();
+  });
+
+  describe('getSchema', () => {
+    it('should create a GraphQL schema from database schemas', async () => {
+      const result = await getSchema(pool, {
+        schema: 'test_public',
+      });
+
+      expect(result.schema).toBeDefined();
+      expect(result.resolvedPreset).toBeDefined();
+      expect(result.pgService).toBeDefined();
+
+      const typeMap = result.schema.getTypeMap();
+      expect(typeMap['User']).toBeDefined();
+      expect(typeMap['Post']).toBeDefined();
+    });
+
+    it('should accept multiple schemas', async () => {
+      const result = await getSchema(pool, {
+        schema: ['test_public'],
+      });
+
+      expect(result.schema).toBeDefined();
+    });
+  });
+
+  describe('GraphileQuery', () => {
+    it('should execute queries and return data', async () => {
+      const { schema, resolvedPreset, pgService } = await getSchema(pool, {
+        schema: 'test_public',
+      });
+
+      const gq = new GraphileQuery({
+        schema,
+        pool,
+        settings: { schema: 'test_public' },
+        resolvedPreset,
+        pgService,
+      });
+
+      const result = await gq.query({
+        query: '{ allUsers { nodes { name email } } }',
+      });
+
+      expect(result.errors).toBeUndefined();
+      expect(result.data).toBeDefined();
+      const data = result.data as { allUsers: { nodes: { name: string; email: string }[] } };
+      expect(data.allUsers.nodes).toHaveLength(2);
+      expect(data.allUsers.nodes[0].name).toBe('Alice');
+    });
+
+    it('should support variables', async () => {
+      const { schema, resolvedPreset, pgService } = await getSchema(pool, {
+        schema: 'test_public',
+      });
+
+      const gq = new GraphileQuery({
+        schema,
+        pool,
+        settings: { schema: 'test_public' },
+        resolvedPreset,
+        pgService,
+      });
+
+      const result = await gq.query({
+        query: `
+          query GetUsers($first: Int!) {
+            allUsers(first: $first) {
+              nodes { name }
+            }
+          }
+        `,
+        variables: { first: 1 },
+      });
+
+      expect(result.errors).toBeUndefined();
+      const data = result.data as { allUsers: { nodes: { name: string }[] } };
+      expect(data.allUsers.nodes).toHaveLength(1);
+    });
+  });
+
+  describe('GraphileQuerySimple', () => {
+    it('should execute simple queries', async () => {
+      const { schema, resolvedPreset, pgService } = await getSchema(pool, {
+        schema: 'test_public',
+      });
+
+      const gq = new GraphileQuerySimple({
+        schema,
+        pool,
+        resolvedPreset,
+        pgService,
+      });
+
+      const result = await gq.query('{ allPosts { nodes { title } } }');
+
+      expect(result.errors).toBeUndefined();
+      expect(result.data).toBeDefined();
+      const data = result.data as { allPosts: { nodes: { title: string }[] } };
+      expect(data.allPosts.nodes).toHaveLength(3);
+    });
+
+    it('should support variables', async () => {
+      const { schema, resolvedPreset, pgService } = await getSchema(pool, {
+        schema: 'test_public',
+      });
+
+      const gq = new GraphileQuerySimple({
+        schema,
+        pool,
+        resolvedPreset,
+        pgService,
+      });
+
+      const result = await gq.query(
+        `query GetPosts($first: Int!) {
+          allPosts(first: $first) { nodes { title } }
+        }`,
+        { first: 2 }
+      );
+
+      expect(result.errors).toBeUndefined();
+      const data = result.data as { allPosts: { nodes: { title: string }[] } };
+      expect(data.allPosts.nodes).toHaveLength(2);
+    });
+  });
+
+  describe('createGraphileQuery', () => {
+    it('should create a GraphileQuery instance with schema', async () => {
+      const gq = await createGraphileQuery(pool, {
+        schema: 'test_public',
+      });
+
+      const result = await gq.query({
+        query: '{ allUsers { nodes { name } } }',
+      });
+
+      expect(result.errors).toBeUndefined();
+      expect(result.data).toBeDefined();
+    });
+  });
+
+  describe('createGraphileQuerySimple', () => {
+    it('should create a GraphileQuerySimple instance with schema', async () => {
+      const gq = await createGraphileQuerySimple(pool, {
+        schema: 'test_public',
+      });
+
+      const result = await gq.query('{ allPosts { nodes { title } } }');
+
+      expect(result.errors).toBeUndefined();
+      expect(result.data).toBeDefined();
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw for missing required parameters', () => {
+      expect(() => {
+        new GraphileQuery({
+          schema: null as unknown as never,
+          pool,
+          settings: { schema: 'test_public' },
+          resolvedPreset: {} as never,
+          pgService: {} as never,
+        });
+      }).toThrow('requires a schema');
+
+      expect(() => {
+        new GraphileQuerySimple({
+          schema: null as unknown as never,
+          pool,
+          resolvedPreset: {} as never,
+          pgService: {} as never,
+        });
+      }).toThrow('requires a schema');
+    });
+  });
+});

--- a/graphile/graphile-query/jest.config.js
+++ b/graphile/graphile-query/jest.config.js
@@ -1,0 +1,18 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        babelConfig: false,
+        tsconfig: 'tsconfig.json'
+      }
+    ]
+  },
+  transformIgnorePatterns: [`/node_modules/*`],
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  modulePathIgnorePatterns: ['dist/*']
+};

--- a/graphile/graphile-query/package.json
+++ b/graphile/graphile-query/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "graphile-query",
+  "version": "3.0.0",
+  "author": "Constructive <developers@constructive.io>",
+  "description": "Execute GraphQL queries against PostGraphile v5 schemas",
+  "main": "index.js",
+  "module": "esm/index.js",
+  "types": "index.d.ts",
+  "homepage": "https://github.com/constructive-io/constructive",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "directory": "dist"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/constructive-io/constructive"
+  },
+  "bugs": {
+    "url": "https://github.com/constructive-io/constructive/issues"
+  },
+  "scripts": {
+    "clean": "makage clean",
+    "prepack": "npm run build",
+    "build": "makage build",
+    "build:dev": "makage build --dev",
+    "lint": "eslint . --fix",
+    "test": "jest",
+    "test:watch": "jest --watch"
+  },
+  "dependencies": {
+    "grafast": "^1.0.0-rc.4",
+    "graphile-build": "^5.0.0-rc.3",
+    "graphile-build-pg": "^5.0.0-rc.3",
+    "graphile-config": "1.0.0-rc.3",
+    "graphql": "^16.9.0",
+    "pg": "^8.17.1",
+    "postgraphile": "^5.0.0-rc.4"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.16.0",
+    "makage": "^0.1.10",
+    "pgsql-test": "workspace:^"
+  },
+  "keywords": [
+    "graphql",
+    "query",
+    "builder",
+    "graphile",
+    "postgraphile",
+    "v5",
+    "constructive",
+    "pgpm"
+  ]
+}

--- a/graphile/graphile-query/src/index.ts
+++ b/graphile/graphile-query/src/index.ts
@@ -1,0 +1,281 @@
+import type { ExecutionResult, GraphQLSchema, DocumentNode } from 'graphql';
+import { parse } from 'graphql';
+import type { GraphileConfig } from 'graphile-config';
+import { makeSchema } from 'graphile-build';
+import { defaultPreset as graphileBuildDefaultPreset } from 'graphile-build';
+import { defaultPreset as graphileBuildPgDefaultPreset, withPgClientFromPgService } from 'graphile-build-pg';
+import { makePgService } from 'postgraphile/adaptors/pg';
+import { execute } from 'grafast';
+import type { Pool } from 'pg';
+
+/**
+ * Minimal preset that provides core functionality without Node/Relay.
+ * This matches the pattern from graphile-settings.
+ */
+const MinimalPreset: GraphileConfig.Preset = {
+  extends: [graphileBuildDefaultPreset, graphileBuildPgDefaultPreset],
+  disablePlugins: ['NodePlugin'],
+};
+
+/**
+ * Settings for creating a GraphQL schema with PostGraphile v5.
+ */
+export interface GraphileSettings {
+  /** Database schema(s) to expose */
+  schema: string | string[];
+  /** Optional preset to extend the minimal preset */
+  preset?: GraphileConfig.Preset;
+  /** Function to generate pgSettings from a request object */
+  pgSettings?: (req: unknown) => Record<string, string> | Promise<Record<string, string>>;
+}
+
+/**
+ * Result from getSchema containing the schema and resolved preset.
+ */
+export interface SchemaResult {
+  schema: GraphQLSchema;
+  resolvedPreset: GraphileConfig.ResolvedPreset;
+  pgService: ReturnType<typeof makePgService>;
+}
+
+/**
+ * Create a GraphQL schema using PostGraphile v5's preset-based API.
+ *
+ * @param pool - PostgreSQL connection pool
+ * @param settings - Schema configuration including database schemas and optional preset
+ * @returns Promise resolving to schema, resolved preset, and pgService
+ */
+export const getSchema = async (
+  pool: Pool,
+  settings: GraphileSettings
+): Promise<SchemaResult> => {
+  const schemas = Array.isArray(settings.schema) ? settings.schema : [settings.schema];
+
+  // Create the pgService for database access
+  const pgService = makePgService({
+    pool,
+    schemas,
+  });
+
+  // Build the complete preset
+  const completePreset: GraphileConfig.Preset = {
+    extends: [
+      MinimalPreset,
+      ...(settings.preset?.extends ?? []),
+    ],
+    ...(settings.preset?.disablePlugins && { disablePlugins: settings.preset.disablePlugins }),
+    ...(settings.preset?.plugins && { plugins: settings.preset.plugins }),
+    ...(settings.preset?.schema && { schema: settings.preset.schema }),
+    ...(settings.preset?.grafast && { grafast: settings.preset.grafast }),
+    pgServices: [pgService],
+  };
+
+  // Use makeSchema from graphile-build to create the schema
+  const result = await makeSchema(completePreset);
+
+  return {
+    schema: result.schema,
+    resolvedPreset: result.resolvedPreset,
+    pgService,
+  };
+};
+
+/**
+ * Parameters for creating a GraphileQuery instance.
+ */
+export interface GraphileQueryParams {
+  schema: GraphQLSchema;
+  pool: Pool;
+  settings: GraphileSettings;
+  resolvedPreset: GraphileConfig.ResolvedPreset;
+  pgService: ReturnType<typeof makePgService>;
+}
+
+/**
+ * Options for executing a GraphQL query.
+ */
+export interface QueryOptions {
+  /** Optional request object for pgSettings generation */
+  req?: unknown;
+  /** GraphQL query string or DocumentNode */
+  query: string | DocumentNode;
+  /** Query variables */
+  variables?: Record<string, unknown>;
+  /** PostgreSQL role to use for the query */
+  role?: string;
+}
+
+/**
+ * GraphileQuery provides a way to execute GraphQL queries against a PostGraphile v5 schema.
+ *
+ * This is the full-featured version that supports pgSettings generation from requests.
+ */
+export class GraphileQuery {
+  private pool: Pool;
+  private schema: GraphQLSchema;
+  private settings: GraphileSettings;
+  private resolvedPreset: GraphileConfig.ResolvedPreset;
+  private pgService: ReturnType<typeof makePgService>;
+
+  constructor({ schema, pool, settings, resolvedPreset, pgService }: GraphileQueryParams) {
+    if (!schema) throw new Error('requires a schema');
+    if (!pool) throw new Error('requires a pool');
+    if (!settings) throw new Error('requires graphile settings');
+    if (!resolvedPreset) throw new Error('requires resolvedPreset');
+    if (!pgService) throw new Error('requires pgService');
+
+    this.pool = pool;
+    this.schema = schema;
+    this.settings = settings;
+    this.resolvedPreset = resolvedPreset;
+    this.pgService = pgService;
+  }
+
+  /**
+   * Execute a GraphQL query.
+   *
+   * @param options - Query options including query string, variables, and optional role
+   * @returns Promise resolving to the GraphQL execution result
+   */
+  async query({ req = {}, query, variables, role }: QueryOptions): Promise<ExecutionResult> {
+    // Parse the query if it's a string
+    const document = typeof query === 'string' ? parse(query) : query;
+
+    // Generate pgSettings
+    const { pgSettings: pgSettingsGenerator } = this.settings;
+    let pgSettings: Record<string, string> = {};
+
+    if (role != null) {
+      pgSettings = { role };
+    } else if (typeof pgSettingsGenerator === 'function') {
+      pgSettings = await pgSettingsGenerator(req);
+    }
+
+    // Build context with withPgClient using withPgClientFromPgService
+    const withPgClientKey = this.pgService.withPgClientKey ?? 'withPgClient';
+    const contextValue: Record<string, unknown> = {
+      pgSettings,
+      [withPgClientKey]: withPgClientFromPgService.bind(null, this.pgService),
+    };
+
+    // Execute using grafast
+    const result = await execute({
+      schema: this.schema,
+      document,
+      variableValues: variables ?? undefined,
+      contextValue,
+      resolvedPreset: this.resolvedPreset,
+    });
+
+    // Handle streaming results
+    if (Symbol.asyncIterator in result) {
+      throw new Error('Streaming results (subscriptions) are not supported');
+    }
+
+    return result as ExecutionResult;
+  }
+}
+
+/**
+ * Parameters for creating a GraphileQuerySimple instance.
+ */
+export interface GraphileQuerySimpleParams {
+  schema: GraphQLSchema;
+  pool: Pool;
+  resolvedPreset: GraphileConfig.ResolvedPreset;
+  pgService: ReturnType<typeof makePgService>;
+}
+
+/**
+ * GraphileQuerySimple provides a simplified way to execute GraphQL queries.
+ *
+ * This version doesn't support pgSettings generation from requests - it's meant
+ * for simple use cases where you just need to run queries.
+ */
+export class GraphileQuerySimple {
+  private pool: Pool;
+  private schema: GraphQLSchema;
+  private resolvedPreset: GraphileConfig.ResolvedPreset;
+  private pgService: ReturnType<typeof makePgService>;
+
+  constructor({ schema, pool, resolvedPreset, pgService }: GraphileQuerySimpleParams) {
+    if (!schema) throw new Error('requires a schema');
+    if (!pool) throw new Error('requires a pool');
+    if (!resolvedPreset) throw new Error('requires resolvedPreset');
+    if (!pgService) throw new Error('requires pgService');
+
+    this.pool = pool;
+    this.schema = schema;
+    this.resolvedPreset = resolvedPreset;
+    this.pgService = pgService;
+  }
+
+  /**
+   * Execute a GraphQL query.
+   *
+   * @param query - GraphQL query string or DocumentNode
+   * @param variables - Optional query variables
+   * @returns Promise resolving to the GraphQL execution result
+   */
+  async query(
+    query: string | DocumentNode,
+    variables?: Record<string, unknown>
+  ): Promise<ExecutionResult> {
+    // Parse the query if it's a string
+    const document = typeof query === 'string' ? parse(query) : query;
+
+    // Build context with withPgClient using withPgClientFromPgService
+    const withPgClientKey = this.pgService.withPgClientKey ?? 'withPgClient';
+    const contextValue: Record<string, unknown> = {
+      [withPgClientKey]: withPgClientFromPgService.bind(null, this.pgService),
+    };
+
+    // Execute using grafast
+    const result = await execute({
+      schema: this.schema,
+      document,
+      variableValues: variables ?? undefined,
+      contextValue,
+      resolvedPreset: this.resolvedPreset,
+    });
+
+    // Handle streaming results
+    if (Symbol.asyncIterator in result) {
+      throw new Error('Streaming results (subscriptions) are not supported');
+    }
+
+    return result as ExecutionResult;
+  }
+}
+
+/**
+ * Helper function to create a GraphileQuery instance with schema creation.
+ *
+ * This is a convenience function that combines getSchema and GraphileQuery creation.
+ *
+ * @param pool - PostgreSQL connection pool
+ * @param settings - Schema configuration
+ * @returns Promise resolving to a GraphileQuery instance
+ */
+export const createGraphileQuery = async (
+  pool: Pool,
+  settings: GraphileSettings
+): Promise<GraphileQuery> => {
+  const { schema, resolvedPreset, pgService } = await getSchema(pool, settings);
+  return new GraphileQuery({ schema, pool, settings, resolvedPreset, pgService });
+};
+
+/**
+ * Helper function to create a GraphileQuerySimple instance with schema creation.
+ *
+ * @param pool - PostgreSQL connection pool
+ * @param settings - Schema configuration
+ * @returns Promise resolving to a GraphileQuerySimple instance
+ */
+export const createGraphileQuerySimple = async (
+  pool: Pool,
+  settings: GraphileSettings
+): Promise<GraphileQuerySimple> => {
+  const { schema, resolvedPreset, pgService } = await getSchema(pool, settings);
+  return new GraphileQuerySimple({ schema, pool, resolvedPreset, pgService });
+};

--- a/graphile/graphile-query/tsconfig.esm.json
+++ b/graphile/graphile-query/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/esm",
+    "module": "node16",
+    "rootDir": "src/",
+    "declaration": false
+  }
+}

--- a/graphile/graphile-query/tsconfig.json
+++ b/graphile/graphile-query/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src/",
+    "moduleResolution": "node16",
+    "module": "node16"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules", "**/*.spec.*", "**/*.test.*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,41 @@ importers:
         version: 5.0.0-rc.4(4002ad6b62e0b8cb7e8d072c2f79179b)
     publishDirectory: dist
 
+  graphile/graphile-query:
+    dependencies:
+      grafast:
+        specifier: ^1.0.0-rc.4
+        version: 1.0.0-rc.4(graphql@16.12.0)
+      graphile-build:
+        specifier: ^5.0.0-rc.3
+        version: 5.0.0-rc.3(grafast@1.0.0-rc.4(graphql@16.12.0))(graphile-config@1.0.0-rc.3)(graphql@16.12.0)
+      graphile-build-pg:
+        specifier: ^5.0.0-rc.3
+        version: 5.0.0-rc.3(@dataplan/pg@1.0.0-rc.3(@dataplan/json@1.0.0-rc.3(grafast@1.0.0-rc.4(graphql@16.12.0)))(grafast@1.0.0-rc.4(graphql@16.12.0))(graphile-config@1.0.0-rc.3)(graphql@16.12.0)(pg-sql2@5.0.0-rc.3)(pg@8.17.1))(grafast@1.0.0-rc.4(graphql@16.12.0))(graphile-build@5.0.0-rc.3(grafast@1.0.0-rc.4(graphql@16.12.0))(graphile-config@1.0.0-rc.3)(graphql@16.12.0))(graphile-config@1.0.0-rc.3)(graphql@16.12.0)(pg-sql2@5.0.0-rc.3)(pg@8.17.1)(tamedevil@0.1.0-rc.3)
+      graphile-config:
+        specifier: 1.0.0-rc.3
+        version: 1.0.0-rc.3
+      graphql:
+        specifier: ^16.9.0
+        version: 16.12.0
+      pg:
+        specifier: ^8.17.1
+        version: 8.17.1
+      postgraphile:
+        specifier: ^5.0.0-rc.4
+        version: 5.0.0-rc.4(4002ad6b62e0b8cb7e8d072c2f79179b)
+    devDependencies:
+      '@types/pg':
+        specifier: ^8.16.0
+        version: 8.16.0
+      makage:
+        specifier: ^0.1.10
+        version: 0.1.10
+      pgsql-test:
+        specifier: workspace:^
+        version: link:../../postgres/pgsql-test/dist
+    publishDirectory: dist
+
   graphile/graphile-settings:
     dependencies:
       '@constructive-io/graphql-env':


### PR DESCRIPTION
# feat: upgrade graphile-query to PostGraphile v5 / GraphQL 16

## Summary

Restores and upgrades the `graphile-query` package from PostGraphile v4 to v5. The package source files were missing on `develop-v5` (only dist/ remained), so they were restored from `main` and completely rewritten to use v5 APIs.

Key changes:
- Replaced `createPostGraphileSchema` with `makeSchema` from graphile-build
- Replaced `withPostGraphileContext` with `execute` from grafast
- Uses `withPgClientFromPgService` from graphile-build-pg for proper database connection handling
- Updated all dependencies to v5 versions (graphql 16, postgraphile 5.0.0-rc.4, grafast 1.0.0-rc.4)
- Version bumped to 3.0.0 (major version for breaking API changes)
- Added comprehensive test suite with 9 passing tests

**Breaking API changes**: `getSchema()` now returns `{ schema, resolvedPreset, pgService }` and both `GraphileQuery` and `GraphileQuerySimple` constructors now require `resolvedPreset` and `pgService` parameters.

## Review & Testing Checklist for Human

- [ ] **Verify API compatibility**: The constructor signatures changed significantly. Check if any other packages in the monorepo consume `graphile-query` and need updates
- [ ] **Test pgSettings generation**: The `pgSettings` callback in `GraphileSettings` is implemented but not tested - verify it works with actual request objects
- [ ] **Test role-based queries**: The `role` option in `QueryOptions` sets pgSettings but doesn't call `set_config` on the connection - verify this works correctly with RLS policies
- [ ] **Review withPgClientFromPgService usage**: This is the v5 pattern from `graphile-build-pg` - confirm it properly handles connection pooling and cleanup

**Recommended test plan**: 
1. Run `pnpm test` in `graphile/graphile-query` to verify tests pass
2. Try importing and using `graphile-query` from another package that uses ConstructivePreset to verify integration

### Notes

- The `pool` property is stored in `GraphileQuerySimple` but not directly used (connections are handled by `withPgClientFromPgService`) - this maintains API compatibility but could be cleaned up
- Tests use PostGraphile's default field naming (`allUsers`, `allPosts`) rather than custom inflection

Link to Devin run: https://app.devin.ai/sessions/ba45b64c92bb4307bf9e920123213d9e
Requested by: Dan Lynch (@pyramation)