### PR TITLE
feat(api): add RLS module support to API resolution for PostGraphile v5

### DIFF
--- a/graphql/server/src/middleware/api.ts
+++ b/graphql/server/src/middleware/api.ts
@@ -240,13 +240,8 @@ const queryByDomain = async (
   subdomain: string | null,
   isPublic: boolean
 ): Promise<ApiRow | null> => {
-  try {
-    const result = await pool.query<ApiRow>(DOMAIN_LOOKUP_SQL, [domain, subdomain, isPublic]);
-    return result.rows[0] ?? null;
-  } catch (err: unknown) {
-    if ((err as Error).message?.includes('does not exist')) return null;
-    throw err;
-  }
+  const result = await pool.query<ApiRow>(DOMAIN_LOOKUP_SQL, [domain, subdomain, isPublic]);
+  return result.rows[0] ?? null;
 };
 
 const queryByApiName = async (
@@ -255,33 +250,18 @@ const queryByApiName = async (
   name: string,
   isPublic: boolean
 ): Promise<ApiRow | null> => {
-  try {
-    const result = await pool.query<ApiRow>(API_NAME_LOOKUP_SQL, [databaseId, name, isPublic]);
-    return result.rows[0] ?? null;
-  } catch (err: unknown) {
-    if ((err as Error).message?.includes('does not exist')) return null;
-    throw err;
-  }
+  const result = await pool.query<ApiRow>(API_NAME_LOOKUP_SQL, [databaseId, name, isPublic]);
+  return result.rows[0] ?? null;
 };
 
 const queryApiList = async (pool: Pool, isPublic: boolean): Promise<ApiListRow[]> => {
-  try {
-    const result = await pool.query<ApiListRow>(API_LIST_SQL, [isPublic]);
-    return result.rows;
-  } catch (err: unknown) {
-    if ((err as Error).message?.includes('does not exist')) return [];
-    throw err;
-  }
+  const result = await pool.query<ApiListRow>(API_LIST_SQL, [isPublic]);
+  return result.rows;
 };
 
 const queryRlsModule = async (pool: Pool, apiId: string): Promise<RlsModuleRow | null> => {
-  try {
-    const result = await pool.query<RlsModuleRow>(RLS_MODULE_SQL, [apiId]);
-    return result.rows[0] ?? null;
-  } catch (err: unknown) {
-    if ((err as Error).message?.includes('does not exist')) return null;
-    throw err;
-  }
+  const result = await pool.query<RlsModuleRow>(RLS_MODULE_SQL, [apiId]);
+  return result.rows[0] ?? null;
 };
 
 // =============================================================================

--- a/graphql/server/src/middleware/api.ts
+++ b/graphql/server/src/middleware/api.ts
@@ -84,7 +84,7 @@ const RLS_MODULE_SQL = `
     rm.authenticate,
     rm.authenticate_strict,
     ps.schema_name as private_schema_name
-  FROM services_public.rls_module rm
+  FROM metaschema_modules_public.rls_module rm
   LEFT JOIN metaschema_public.schema ps ON rm.private_schema_id = ps.id
   WHERE rm.api_id = $1
   LIMIT 1

--- a/graphql/server/src/middleware/api.ts
+++ b/graphql/server/src/middleware/api.ts
@@ -8,7 +8,7 @@ import { getPgPool } from 'pg-cache';
 
 import errorPage50x from '../errors/50x';
 import errorPage404Message from '../errors/404-message';
-import { ApiConfigResult, ApiError, ApiOptions, ApiStructure } from '../types';
+import { ApiConfigResult, ApiError, ApiOptions, ApiStructure, RlsModule } from '../types';
 import './types';
 
 const log = new Logger('api');
@@ -20,6 +20,7 @@ const isDev = () => getNodeEnv() === 'development';
 
 const DOMAIN_LOOKUP_SQL = `
   SELECT 
+    a.id as api_id,
     a.database_id,
     a.dbname,
     a.role_name,
@@ -39,6 +40,7 @@ const DOMAIN_LOOKUP_SQL = `
 
 const API_NAME_LOOKUP_SQL = `
   SELECT 
+    a.id as api_id,
     a.database_id,
     a.dbname,
     a.role_name,
@@ -77,17 +79,35 @@ const API_LIST_SQL = `
   LIMIT 100
 `;
 
+const RLS_MODULE_SQL = `
+  SELECT 
+    rm.authenticate,
+    rm.authenticate_strict,
+    ps.schema_name as private_schema_name
+  FROM services_public.rls_module rm
+  LEFT JOIN metaschema_public.schema ps ON rm.private_schema_id = ps.id
+  WHERE rm.api_id = $1
+  LIMIT 1
+`;
+
 // =============================================================================
 // Types
 // =============================================================================
 
 interface ApiRow {
+  api_id: string;
   database_id: string;
   dbname: string;
   role_name: string;
   anon_role: string;
   is_public: boolean;
   schemas: string[];
+}
+
+interface RlsModuleRow {
+  authenticate: string | null;
+  authenticate_strict: string | null;
+  private_schema_name: string | null;
 }
 
 interface ApiListRow {
@@ -164,12 +184,24 @@ export const getSvcKey = (opts: ApiOptions, req: Request): string => {
   return baseKey;
 };
 
-const toApiStructure = (row: ApiRow, opts: ApiOptions): ApiStructure => ({
+const toRlsModule = (row: RlsModuleRow | null): RlsModule | undefined => {
+  if (!row || !row.private_schema_name) return undefined;
+  return {
+    authenticate: row.authenticate ?? undefined,
+    authenticateStrict: row.authenticate_strict ?? undefined,
+    privateSchema: {
+      schemaName: row.private_schema_name,
+    },
+  };
+};
+
+const toApiStructure = (row: ApiRow, opts: ApiOptions, rlsModuleRow?: RlsModuleRow | null): ApiStructure => ({
   dbname: row.dbname || opts.pg?.database || '',
   anonRole: row.anon_role || 'anon',
   roleName: row.role_name || 'authenticated',
   schema: row.schemas || [],
   apiModules: [],
+  rlsModule: toRlsModule(rlsModuleRow ?? null),
   domains: [],
   databaseId: row.database_id,
   isPublic: row.is_public,
@@ -242,6 +274,16 @@ const queryApiList = async (pool: Pool, isPublic: boolean): Promise<ApiListRow[]
   }
 };
 
+const queryRlsModule = async (pool: Pool, apiId: string): Promise<RlsModuleRow | null> => {
+  try {
+    const result = await pool.query<RlsModuleRow>(RLS_MODULE_SQL, [apiId]);
+    return result.rows[0] ?? null;
+  } catch (err: unknown) {
+    if ((err as Error).message?.includes('does not exist')) return null;
+    throw err;
+  }
+};
+
 // =============================================================================
 // Resolution Logic
 // =============================================================================
@@ -300,8 +342,9 @@ const resolveApiNameHeader = async (ctx: ResolveContext): Promise<ApiStructure |
     return null;
   }
 
-  log.debug(`[api-name-lookup] resolved schemas: [${row.schemas?.join(', ')}]`);
-  return toApiStructure(row, opts);
+  const rlsModule = await queryRlsModule(pool, row.api_id);
+  log.debug(`[api-name-lookup] resolved schemas: [${row.schemas?.join(', ')}], rlsModule: ${rlsModule ? 'found' : 'none'}`);
+  return toApiStructure(row, opts, rlsModule);
 };
 
 const resolveMetaSchemaHeader = (
@@ -324,8 +367,9 @@ const resolveDomainLookup = async (ctx: ResolveContext): Promise<ApiStructure | 
     return null;
   }
 
-  log.debug(`[domain-lookup] resolved schemas: [${row.schemas?.join(', ')}]`);
-  return toApiStructure(row, opts);
+  const rlsModule = await queryRlsModule(pool, row.api_id);
+  log.debug(`[domain-lookup] resolved schemas: [${row.schemas?.join(', ')}], rlsModule: ${rlsModule ? 'found' : 'none'}`);
+  return toApiStructure(row, opts, rlsModule);
 };
 
 const buildDevFallbackError = async (

--- a/graphql/server/src/middleware/auth.ts
+++ b/graphql/server/src/middleware/auth.ts
@@ -18,6 +18,7 @@ export const createAuthenticateMiddleware = (
     next: NextFunction
   ): Promise<void> => {
     const api = req.api;
+    log.info(`[auth] middleware called, api=${api ? 'present' : 'missing'}`);
     if (!api) {
       res.status(500).send('Missing API info');
       return;
@@ -29,21 +30,38 @@ export const createAuthenticateMiddleware = (
     });
     const rlsModule = api.rlsModule;
 
+    log.info(
+      `[auth] rlsModule=${rlsModule ? 'present' : 'missing'}, ` +
+        `authenticate=${rlsModule?.authenticate ?? 'none'}, ` +
+        `authenticateStrict=${rlsModule?.authenticateStrict ?? 'none'}, ` +
+        `privateSchema=${rlsModule?.privateSchema?.schemaName ?? 'none'}`
+    );
+
     if (!rlsModule) {
-      if (isDev()) log.debug('No RLS module configured, skipping auth');
+      log.info('[auth] No RLS module configured, skipping auth');
       return next();
     }
 
-    const authFn = opts.server.strictAuth
+    const authFn = opts.server?.strictAuth
       ? rlsModule.authenticateStrict
       : rlsModule.authenticate;
+
+    log.info(
+      `[auth] strictAuth=${opts.server?.strictAuth ?? false}, authFn=${authFn ?? 'none'}`
+    );
 
     if (authFn && rlsModule.privateSchema.schemaName) {
       const { authorization = '' } = req.headers;
       const [authType, authToken] = authorization.split(' ');
       let token: any = {};
 
+      log.info(
+        `[auth] authorization header present=${!!authorization}, ` +
+          `authType=${authType ?? 'none'}, hasToken=${!!authToken}`
+      );
+
       if (authType?.toLowerCase() === 'bearer' && authToken) {
+        log.info('[auth] Processing bearer token authentication');
         const context: Record<string, any> = {
           'jwt.claims.ip_address': req.clientIp,
         };
@@ -55,15 +73,21 @@ export const createAuthenticateMiddleware = (
           context['jwt.claims.user_agent'] = req.get('User-Agent');
         }
 
+        const authQuery = `SELECT * FROM "${rlsModule.privateSchema.schemaName}"."${authFn}"($1)`;
+        log.info(`[auth] Executing auth query: ${authQuery}`);
+
         try {
           const result = await pgQueryContext({
             client: pool,
             context,
-            query: `SELECT * FROM "${rlsModule.privateSchema.schemaName}"."${authFn}"($1)`,
+            query: authQuery,
             variables: [authToken],
           });
 
+          log.info(`[auth] Query result: rowCount=${result?.rowCount}`);
+
           if (result?.rowCount === 0) {
+            log.info('[auth] No rows returned, returning UNAUTHENTICATED');
             res.status(200).json({
               errors: [{ extensions: { code: 'UNAUTHENTICATED' } }],
             });
@@ -71,9 +95,9 @@ export const createAuthenticateMiddleware = (
           }
 
           token = result.rows[0];
-          if (isDev()) log.debug(`Auth success: role=${token.role}`);
+          log.info(`[auth] Auth success: role=${token.role}, user_id=${token.user_id}`);
         } catch (e: any) {
-          log.error('Auth error:', e.message);
+          log.error('[auth] Auth error:', e.message);
           res.status(200).json({
             errors: [
               {
@@ -86,9 +110,16 @@ export const createAuthenticateMiddleware = (
           });
           return;
         }
+      } else {
+        log.info('[auth] No bearer token provided, using anonymous auth');
       }
 
       req.token = token;
+    } else {
+      log.info(
+        `[auth] Skipping auth: authFn=${authFn ?? 'none'}, ` +
+          `privateSchema=${rlsModule.privateSchema?.schemaName ?? 'none'}`
+      );
     }
 
     next();

--- a/graphql/server/src/middleware/graphile.ts
+++ b/graphql/server/src/middleware/graphile.ts
@@ -108,7 +108,7 @@ const createGraphileInstance = async (
     },
     grafast: {
       explain: process.env.NODE_ENV === 'development',
-      context: (requestContext: Grafast.RequestContext) => {
+      context: (requestContext: Partial<Grafast.RequestContext>) => {
         // In grafserv/express/v4, the request is available at requestContext.expressv4.req
         const req = (requestContext as { expressv4?: { req?: Request } })?.expressv4?.req;
         const context: Record<string, string> = {};

--- a/graphql/server/src/middleware/graphile.ts
+++ b/graphql/server/src/middleware/graphile.ts
@@ -108,8 +108,9 @@ const createGraphileInstance = async (
     },
     grafast: {
       explain: process.env.NODE_ENV === 'development',
-      context: (ctx: unknown) => {
-        const req = (ctx as { node?: { req?: Request } } | undefined)?.node?.req;
+      context: (requestContext: Grafast.RequestContext) => {
+        // In grafserv/express/v4, the request is available at requestContext.expressv4.req
+        const req = (requestContext as { expressv4?: { req?: Request } })?.expressv4?.req;
         const context: Record<string, string> = {};
 
         if (req) {


### PR DESCRIPTION
## Summary

The develop-v5 branch rewrote API resolution to use direct SQL queries instead of the GraphQL ORM approach. However, the RLS module data (needed for authentication) was missing from the new implementation, and the grafast context was accessing the Express request incorrectly. This PR fixes both issues to restore bearer token authentication.

**Changes in api.ts:**
- Added `RLS_MODULE_SQL` query to fetch RLS module data from `metaschema_modules_public.rls_module` with private schema name
- Added `api_id` to `DOMAIN_LOOKUP_SQL` and `API_NAME_LOOKUP_SQL` queries
- Added `queryRlsModule` function and `toRlsModule` helper for type conversion
- Updated `resolveApiNameHeader` and `resolveDomainLookup` to fetch and include RLS module in the `ApiStructure`
- **Removed silent error swallowing** - query functions now let errors propagate instead of catching "does not exist" errors and returning null

**Changes in graphile.ts:**
- Fixed `grafast.context` callback to use correct request path: `requestContext.expressv4.req` instead of `ctx.node.req`
- This was causing bearer token authentication to silently fail (always using `anonRole` instead of `roleName`)

**Changes in auth.ts:**
- Added comprehensive INFO-level logging throughout the authentication middleware
- Logs RLS module presence, auth function selection, authorization header parsing, query execution, and results
- This helps diagnose why authentication may not be working as expected

## Updates since last revision

- Fixed the RLS module SQL query to use the correct schema: `metaschema_modules_public.rls_module` instead of `services_public.rls_module`
- **Removed all silent error swallowing** from query functions - errors now propagate properly instead of being hidden. If a table doesn't exist, you'll get an actual error instead of silent null returns.

## Review & Testing Checklist for Human

- [ ] **Test bearer token authentication end-to-end**: Log in, get a token, make an authenticated GraphQL request, and verify the correct role is applied (not `anonRole`). This is the most critical test.
- [ ] **Verify the requestContext path is correct**: The path `requestContext.expressv4.req` is a type assertion - confirm this is correct for grafserv/express/v4 by checking grafserv source code
- [ ] **Verify SQL query correctness**: Confirm that `metaschema_modules_public.rls_module` and `metaschema_public.schema` tables exist with the expected columns (`api_id`, `authenticate`, `authenticate_strict`, `private_schema_id`)
- [ ] **Test error propagation**: With the error swallowing removed, verify the server handles missing tables appropriately (should throw, not silently fail)
- [ ] **Consider log verbosity**: The new auth logs are at INFO level - decide if this is appropriate for production or should be DEBUG

**Recommended test plan:**
1. Start the server locally and observe the new `[auth]` logs
2. Verify logs now show `rlsModule=present` (not `missing`)
3. Make an unauthenticated GraphQL request - check logs show "No bearer token provided"
4. Authenticate and get a bearer token
5. Make an authenticated request with `Authorization: Bearer <token>` header
6. Check logs show the auth query being executed and the result
7. Verify the request uses `roleName` (not `anonRole`)

### Notes

- The `Grafast.RequestContext` type is used but cast to access `expressv4` property - this type assertion should be verified against grafserv source
- Query functions no longer swallow "does not exist" errors - they will throw if tables are missing
- Build has pre-existing issues in develop-v5 branch (missing workspace dependencies), so full build verification was not possible locally

Link to Devin run: https://app.devin.ai/sessions/c0c4671ef1dd48199e62c4bd403dd3c5
Requested by: Dan Lynch (@pyramation)