### PR TITLE
fix(graphile-cache): remove redundant serv.release() to prevent double-release error

### DIFF
--- a/graphile/graphile-cache/src/graphile-cache.ts
+++ b/graphile/graphile-cache/src/graphile-cache.ts
@@ -114,17 +114,13 @@ const disposeEntry = async (entry: GraphileCacheEntry, key: string): Promise<voi
 
   log.debug(`Disposing PostGraphile[${key}]`);
   try {
-    // Release grafserv first
-    if (entry.serv) {
-      await entry.serv.release();
-    }
     // Close HTTP server if it's listening
     if (entry.httpServer?.listening) {
       await new Promise<void>((resolve) => {
         entry.httpServer.close(() => resolve());
       });
     }
-    // Release PostGraphile instance
+    // Release PostGraphile instance (this also releases grafserv internally)
     if (entry.pgl) {
       await entry.pgl.release();
     }

--- a/graphile/graphile-cache/src/graphile-cache.ts
+++ b/graphile/graphile-cache/src/graphile-cache.ts
@@ -98,9 +98,8 @@ const manualEvictionKeys = new Set<string>();
  * Dispose a PostGraphile v5 cache entry
  *
  * Properly releases resources by:
- * 1. Releasing the grafserv instance
- * 2. Closing the HTTP server if listening
- * 3. Releasing the PostGraphile instance
+ * 1. Closing the HTTP server if listening
+ * 2. Releasing the PostGraphile instance (which internally releases grafserv)
  *
  * Uses disposedKeys set to prevent double-disposal when closeAllCaches()
  * explicitly disposes entries and then clear() triggers the dispose callback.


### PR DESCRIPTION
## Summary

Fixes the "Release has already been called" error that occurs when disposing PostGraphile v5 cache entries.

The issue was that `disposeEntry()` was calling `entry.serv.release()` explicitly, then calling `entry.pgl.release()`. However, PostGraphile v5's `release()` method internally calls `serv.release()` on the grafserv instance, causing grafserv to throw an error on the second release attempt.

The fix removes the explicit `serv.release()` call and lets `pgl.release()` handle the grafserv cleanup internally.

### Disposal Path Analysis

Analyzed all disposal paths for both `pg-cache` and `graphile-cache`:

- **graphile-cache disposal paths**: LRU eviction, TTL expiration, manual delete, `clearMatchingEntries()`, pgCache cleanup callback, and `closeAllCaches()`
- **Double-disposal prevention**: The existing `disposedKeys` Set correctly prevents double-disposal across all code paths
- **Testing framework usage**: Test fixtures (CoreDeployTestFixture, MigrateTestFixture, CLIDeployTestFixture) use `pg-cache` directly via `teardownPgPools()` but don't use `graphile-cache`, so this change doesn't affect them

## Review & Testing Checklist for Human

- [ ] Verify that PostGraphile v5's `release()` does indeed call grafserv's `release()` internally (see `node_modules/.pnpm/postgraphile@5.0.0-rc.4.../node_modules/postgraphile/dist/index.js` lines 95-110)
- [ ] Test cache disposal manually by triggering the scenario that caused the original error to confirm it no longer occurs
- [ ] Confirm no resource leaks occur when cache entries are evicted (HTTP server and grafserv should still be properly cleaned up)

**Recommended test plan**: Run the GraphQL server locally, make requests to populate the graphile cache, then trigger cache eviction (via TTL, LRU pressure, or manual flush) and verify no "Release has already been called" errors appear in logs.

### Notes

Requested by @pyramation  
Link to Devin run: https://app.devin.ai/sessions/429049b483244251bbfecf110da03d52