### PR TITLE
refactor(cli): simplify arg parsing with generic transforms, remove --browser-compatible

### DIFF
--- a/graphql/codegen/src/cli/shared.ts
+++ b/graphql/codegen/src/cli/shared.ts
@@ -1,27 +1,21 @@
 /**
  * Shared CLI utilities for graphql-codegen
  * 
- * These are exported so that packages/cli can use the same questions
- * and types, ensuring consistency between the two CLIs.
+ * These are exported so that packages/cli can use the same questions,
+ * types, and transform utilities, ensuring consistency between the two CLIs.
  */
 import { camelize } from 'inflekt';
 import { inflektTree } from 'inflekt/transform-keys';
 import type { Question } from 'inquirerer';
 
 import type { GenerateResult } from '../core/generate';
+import type { GraphQLSDKConfigTarget } from '../types/config';
 
-/**
- * Sanitize function that splits comma-separated strings into arrays
- */
 export const splitCommas = (input: string | undefined): string[] | undefined => {
   if (!input) return undefined;
   return input.split(',').map((s) => s.trim()).filter(Boolean);
 };
 
-/**
- * Interface for codegen CLI answers
- * CLI accepts kebab-case arguments, converted to camelCase for internal use
- */
 export interface CodegenAnswers {
   endpoint?: string;
   schemaFile?: string;
@@ -30,15 +24,11 @@ export interface CodegenAnswers {
   apiNames?: string[];
   reactQuery?: boolean;
   orm?: boolean;
-  browserCompatible?: boolean;
   authorization?: string;
   dryRun?: boolean;
   verbose?: boolean;
 }
 
-/**
- * Questions for the codegen CLI
- */
 export const codegenQuestions: Question[] = [
   {
     name: 'endpoint',
@@ -91,14 +81,6 @@ export const codegenQuestions: Question[] = [
     useDefault: true
   },
   {
-    name: 'browser-compatible',
-    message: 'Browser-compatible mode (deprecated no-op)?',
-    type: 'confirm',
-    required: false,
-    default: true,
-    useDefault: true
-  },
-  {
     name: 'authorization',
     message: 'Authorization header value',
     type: 'text',
@@ -122,9 +104,6 @@ export const codegenQuestions: Question[] = [
   }
 ];
 
-/**
- * Print the result of a generate operation
- */
 export function printResult(result: GenerateResult): void {
   if (result.success) {
     console.log('[ok]', result.message);
@@ -138,15 +117,69 @@ export function printResult(result: GenerateResult): void {
   }
 }
 
+// ============================================================================
+// Key transform utilities
+// ============================================================================
+
 const isTopLevel = (_key: string, path: string[]) => path.length === 0;
-export const camelizeArgv = (argv: Record<string, any>) =>
+const skipNonTopLevel = (key: string, path: string[]) =>
+  !isTopLevel(key, path) || key === '_' || key.startsWith('_');
+
+export const camelizeArgv = (argv: Record<string, any>): Record<string, any> =>
   inflektTree(argv, (key) => {
-    // inflection.camelize expects underscores, so replace hyphens first
     const underscored = key.replace(/-/g, '_');
     return camelize(underscored, true);
-  }, {
-    skip: (key, path) =>
-      !isTopLevel(key, path) ||
-      key === '_' ||
-      key.startsWith('_')
+  }, { skip: skipNonTopLevel });
+
+export const hyphenateKeys = (obj: Record<string, any>): Record<string, any> =>
+  inflektTree(obj, (key) => key.replace(/[A-Z]/g, (m) => '-' + m.toLowerCase()), {
+    skip: skipNonTopLevel
   });
+
+// ============================================================================
+// Config <-> CLI shape transforms
+// ============================================================================
+
+export function filterDefined(obj: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, v]) => v !== undefined && v !== null)
+  );
+}
+
+export function flattenDbFields(config: Record<string, unknown>): Record<string, unknown> {
+  const { db, ...rest } = config;
+  if (db && typeof db === 'object') {
+    const dbObj = db as Record<string, unknown>;
+    const schemas = Array.isArray(dbObj.schemas) ? dbObj.schemas.join(',') : dbObj.schemas;
+    const apiNames = Array.isArray(dbObj.apiNames) ? dbObj.apiNames.join(',') : dbObj.apiNames;
+    return { ...rest, schemas, apiNames };
+  }
+  return rest;
+}
+
+export function buildDbConfig(options: Record<string, unknown>): Record<string, unknown> {
+  const { schemas, apiNames, ...rest } = options;
+  if (schemas || apiNames) {
+    return { ...rest, db: { schemas, apiNames } };
+  }
+  return rest;
+}
+
+export function seedArgvFromConfig(
+  argv: Record<string, unknown>,
+  fileConfig: GraphQLSDKConfigTarget
+): Record<string, unknown> {
+  const flat = flattenDbFields(fileConfig as Record<string, unknown>);
+  const hyphenated = hyphenateKeys(flat);
+  const defined = filterDefined(hyphenated);
+  return { ...defined, ...argv };
+}
+
+export function buildGenerateOptions(
+  answers: Record<string, unknown>,
+  fileConfig: GraphQLSDKConfigTarget = {}
+): GraphQLSDKConfigTarget {
+  const camelized = camelizeArgv(answers);
+  const withDb = buildDbConfig(camelized);
+  return { ...fileConfig, ...withDb } as GraphQLSDKConfigTarget;
+}

--- a/graphql/codegen/src/core/generate.ts
+++ b/graphql/codegen/src/core/generate.ts
@@ -43,13 +43,6 @@ export async function generate(options: GenerateOptions = {}): Promise<GenerateR
   const config = getConfigOptions(options);
   const outputRoot = config.output;
 
-  // Keep backward compatibility for deprecated config fields.
-  if (options.browserCompatible === false) {
-    console.warn(
-      '[graphql-codegen] "browserCompatible" is deprecated and currently a no-op.'
-    );
-  }
-
   // Determine which generators to run
   // ORM is always required when React Query is enabled (hooks delegate to ORM)
   // This handles minimist setting orm=false when --orm flag is absent

--- a/graphql/codegen/src/index.ts
+++ b/graphql/codegen/src/index.ts
@@ -30,7 +30,18 @@ export { findConfigFile, loadConfigFile } from './core/config';
 
 // CLI shared utilities (for packages/cli to import)
 export type { CodegenAnswers } from './cli/shared';
-export { camelizeArgv,codegenQuestions, printResult, splitCommas } from './cli/shared';
+export {
+  buildDbConfig,
+  buildGenerateOptions,
+  camelizeArgv,
+  codegenQuestions,
+  filterDefined,
+  flattenDbFields,
+  hyphenateKeys,
+  printResult,
+  seedArgvFromConfig,
+  splitCommas
+} from './cli/shared';
 
 // Database schema utilities (re-exported from core for convenience)
 export type {

--- a/graphql/codegen/src/types/config.ts
+++ b/graphql/codegen/src/types/config.ts
@@ -262,14 +262,6 @@ export interface GraphQLSDKConfigTarget {
   reactQuery?: boolean;
 
   /**
-   * @deprecated Currently a no-op.
-   * Generated clients always use native fetch. This flag is retained for
-   * backward compatibility and will be removed in a future major version.
-   * @default true
-   */
-  browserCompatible?: boolean;
-
-  /**
    * Query key generation configuration
    * Controls how query keys are structured for cache management
    */
@@ -406,7 +398,6 @@ export const DEFAULT_CONFIG: GraphQLSDKConfigTarget = {
   },
   orm: false,
   reactQuery: false,
-  browserCompatible: true,
   queryKeys: DEFAULT_QUERY_KEY_CONFIG,
   watch: DEFAULT_WATCH_CONFIG
 };

--- a/packages/cli/__tests__/codegen.test.ts
+++ b/packages/cli/__tests__/codegen.test.ts
@@ -19,14 +19,14 @@ jest.mock('@constructive-io/graphql-codegen', () => {
     splitCommas: splitCommasMock,
     codegenQuestions: [
       { name: 'endpoint', message: 'GraphQL endpoint URL', type: 'text', required: false },
-      { name: 'schemaFile', message: 'Path to GraphQL schema file', type: 'text', required: false },
+      { name: 'schema-file', message: 'Path to GraphQL schema file', type: 'text', required: false },
       { name: 'output', message: 'Output directory', type: 'text', required: false, default: 'codegen', useDefault: true },
       { name: 'schemas', message: 'PostgreSQL schemas', type: 'text', required: false, sanitize: splitCommasMock },
-      { name: 'apiNames', message: 'API names', type: 'text', required: false, sanitize: splitCommasMock },
-      { name: 'reactQuery', message: 'Generate React Query hooks?', type: 'confirm', required: false, default: false, useDefault: true },
+      { name: 'api-names', message: 'API names', type: 'text', required: false, sanitize: splitCommasMock },
+      { name: 'react-query', message: 'Generate React Query hooks?', type: 'confirm', required: false, default: false, useDefault: true },
       { name: 'orm', message: 'Generate ORM client?', type: 'confirm', required: false, default: false, useDefault: true },
       { name: 'authorization', message: 'Authorization header value', type: 'text', required: false },
-      { name: 'dryRun', message: 'Preview without writing files?', type: 'confirm', required: false, default: false, useDefault: true },
+      { name: 'dry-run', message: 'Preview without writing files?', type: 'confirm', required: false, default: false, useDefault: true },
       { name: 'verbose', message: 'Verbose output?', type: 'confirm', required: false, default: false, useDefault: true },
     ],
     printResult: jest.fn((result: any) => {
@@ -38,6 +38,14 @@ jest.mock('@constructive-io/graphql-codegen', () => {
       }
     }),
     camelizeArgv: jest.fn((argv: Record<string, any>) => argv),
+    seedArgvFromConfig: jest.fn((argv: Record<string, unknown>, _fileConfig: any) => argv),
+    buildGenerateOptions: jest.fn((answers: Record<string, unknown>, _fileConfig: any) => {
+      const { schemas, apiNames, ...rest } = answers;
+      if (schemas || apiNames) {
+        return { ...rest, db: { schemas, apiNames } };
+      }
+      return rest;
+    }),
   };
 })
 

--- a/packages/cli/src/commands/codegen.ts
+++ b/packages/cli/src/commands/codegen.ts
@@ -5,9 +5,8 @@ import {
   loadConfigFile,
   codegenQuestions,
   printResult,
-  camelizeArgv,
-  splitCommas,
-  type CodegenAnswers,
+  buildGenerateOptions,
+  seedArgvFromConfig,
   type GraphQLSDKConfigTarget,
 } from '@constructive-io/graphql-codegen';
 
@@ -30,7 +29,6 @@ Generator Options:
   --orm                      Generate ORM client
   --output <dir>             Output directory (default: codegen)
   --authorization <token>    Authorization header value
-  --browser-compatible       Deprecated no-op (retained for compatibility)
   --dry-run                  Preview without writing files
   --verbose                  Verbose output
 
@@ -47,52 +45,13 @@ export default async (
     process.exit(0);
   }
 
-  const hasSourceCliFlags = Boolean(
-    argv.endpoint ||
-      argv['schema-file'] ||
-      argv.schemaFile ||
-      argv.schemas ||
-      argv['api-names'] ||
-      argv.apiNames
+  const hasSourceFlags = Boolean(
+    argv.endpoint || argv['schema-file'] || argv.schemas || argv['api-names']
   );
-  const explicitConfigPath = argv.config as string | undefined;
-  const autoConfigPath = !explicitConfigPath && !hasSourceCliFlags
-    ? findConfigFile()
-    : undefined;
-  const configPath = explicitConfigPath || autoConfigPath;
+  const configPath = (argv.config as string | undefined) ||
+    (!hasSourceFlags ? findConfigFile() : undefined);
 
-  const endpoint = argv.endpoint as string | undefined;
-  const schemaFile = (argv['schema-file'] || argv.schemaFile) as string | undefined;
-  const schemas = splitCommas(argv.schemas as string | undefined);
-  const apiNames = splitCommas((argv['api-names'] || argv.apiNames) as string | undefined);
-
-  const cliOverrides: Partial<GraphQLSDKConfigTarget> = {};
-  if (endpoint) {
-    cliOverrides.endpoint = endpoint;
-    cliOverrides.schemaFile = undefined;
-    cliOverrides.db = undefined;
-  }
-  if (schemaFile) {
-    cliOverrides.schemaFile = schemaFile;
-    cliOverrides.endpoint = undefined;
-    cliOverrides.db = undefined;
-  }
-  if (schemas || apiNames) {
-    cliOverrides.db = { schemas, apiNames };
-    cliOverrides.endpoint = undefined;
-    cliOverrides.schemaFile = undefined;
-  }
-  if (argv['react-query'] === true || argv.reactQuery === true) cliOverrides.reactQuery = true;
-  if (argv.orm === true) cliOverrides.orm = true;
-  if (argv.verbose === true) cliOverrides.verbose = true;
-  if (argv['dry-run'] === true || argv.dryRun === true) cliOverrides.dryRun = true;
-  if (argv.output) cliOverrides.output = argv.output as string;
-  if (argv.authorization) cliOverrides.authorization = argv.authorization as string;
-  if (argv['browser-compatible'] !== undefined) {
-    cliOverrides.browserCompatible = argv['browser-compatible'] as boolean;
-  } else if (argv.browserCompatible !== undefined) {
-    cliOverrides.browserCompatible = argv.browserCompatible as boolean;
-  }
+  let fileConfig: GraphQLSDKConfigTarget = {};
 
   if (configPath) {
     const loaded = await loadConfigFile(configPath);
@@ -100,60 +59,12 @@ export default async (
       console.error('x', loaded.error);
       process.exit(1);
     }
-    const result = await generate({
-      ...(loaded.config as GraphQLSDKConfigTarget),
-      ...cliOverrides,
-    });
-    printResult(result);
-    return;
+    fileConfig = loaded.config as GraphQLSDKConfigTarget;
   }
 
-  const hasNonInteractiveArgs = Boolean(
-    endpoint ||
-      schemaFile ||
-      schemas ||
-      apiNames ||
-      argv['react-query'] === true ||
-      argv.reactQuery === true ||
-      argv.orm === true ||
-      argv.output ||
-      argv.authorization ||
-      argv['dry-run'] === true ||
-      argv.dryRun === true ||
-      argv.verbose === true ||
-      argv['browser-compatible'] !== undefined ||
-      argv.browserCompatible !== undefined
-  );
-
-  if (hasNonInteractiveArgs) {
-    const result = await generate({ ...cliOverrides });
-    printResult(result);
-    return;
-  }
-
-  // No config file - prompt for options using shared questions
-  const answers = await prompter.prompt<CodegenAnswers>(argv as CodegenAnswers, codegenQuestions);
-  // Convert kebab-case CLI args to camelCase for internal use
-  const camelized = camelizeArgv(answers);
-
-  // Build db config if schemas or apiNames provided
-  const db = (camelized.schemas || camelized.apiNames) ? {
-    schemas: camelized.schemas,
-    apiNames: camelized.apiNames,
-  } : undefined;
-
-  const result = await generate({
-    endpoint: camelized.endpoint,
-    schemaFile: camelized.schemaFile,
-    db,
-    output: camelized.output,
-    authorization: camelized.authorization,
-    reactQuery: camelized.reactQuery,
-    orm: camelized.orm,
-    browserCompatible: camelized.browserCompatible,
-    dryRun: camelized.dryRun,
-    verbose: camelized.verbose,
-  });
-
+  const seeded = seedArgvFromConfig(argv as Record<string, unknown>, fileConfig);
+  const answers = await prompter.prompt(seeded, codegenQuestions);
+  const options = buildGenerateOptions(answers, fileConfig);
+  const result = await generate(options);
   printResult(result);
 };


### PR DESCRIPTION
# refactor(cli): simplify arg parsing with generic transforms, remove --browser-compatible

## Summary

Replaces the manual field-by-field CLI argument parsing in both CLI entry points with a generic transform pipeline: `seedArgvFromConfig → prompt → camelizeArgv → buildDbConfig → generate`. Removes the deprecated `--browser-compatible` flag entirely.

**Before:** Each CLI file had ~3 redundant layers — manual `cliOverrides` built field-by-field with if-statements, a `hasNonInteractiveArgs` guard duplicating the same flag list, and a post-prompt field-by-field mapping into `generate()` options. All duplicated across both CLIs.

**After:** Both CLIs share generic utilities from `shared.ts`:
- `hyphenateKeys` / `camelizeArgv` — bidirectional key transforms (camelCase ↔ hyphen-case)
- `flattenDbFields` / `buildDbConfig` — flatten/nest the `db.schemas`/`db.apiNames` structure
- `seedArgvFromConfig` — merge config file values into argv (config as defaults, CLI flags override)
- `buildGenerateOptions` — camelize answers, nest db fields, merge with full config

The core flow in each CLI becomes:
```ts
const seeded = seedArgvFromConfig(argv, fileConfig);
const answers = await prompter.prompt(seeded, codegenQuestions);
const options = buildGenerateOptions(answers, fileConfig);
const result = await generate(options);
```

`packages/cli/src/commands/codegen.ts` went from 160 → 71 lines. `graphql/codegen/src/cli/index.ts` went from 239 → 148 lines.


## Review & Testing Checklist for Human

- [ ] **Test config file + CLI override flow**: Run `graphql-codegen --config ./config.ts --output ./override` and verify CLI flags override config values while config-only fields (tables, hooks, queryKeys) pass through
- [ ] **Test interactive prompting**: Run `graphql-codegen` with no config file and no CLI flags — verify prompts appear and work correctly
- [ ] **Verify `hyphenateKeys` edge cases**: Check that `schemaFile` → `schema-file`, `reactQuery` → `react-query`, `apiNames` → `api-names` all transform correctly (the regex `key.replace(/[A-Z]/g, m => '-' + m.toLowerCase())` should handle these)
- [ ] **Test multi-target config**: The standalone CLI (`graphql-codegen`) still has multi-target loop logic — verify it works with a multi-target config file

### Notes

- The test mocks in `packages/cli/__tests__/codegen.test.ts` bypass the real transform logic — they mock `seedArgvFromConfig` as pass-through and `buildGenerateOptions` with simplified logic. Real integration testing is needed.
- `--browser-compatible` was a deprecated no-op; removing it is a breaking change for anyone passing the flag (they'll get an unknown flag warning from minimist)
- This PR is branched from `feat/graphql-codegen-orm-core` — the cumulative diff to main is large because it includes the ORM-as-core refactor. The CLI cleanup is the final commit (`7720cc4cd`).

---

Link to Devin run: https://app.devin.ai/sessions/a93d427c49214dce877d1fedee950c04
Requested by: @pyramation