### PR TITLE
fix(graphile-settings): uppercase enum values to match v4 CONSTANT_CASE convention

### DIFF
--- a/graphile/graphile-settings/src/plugins/custom-inflector.ts
+++ b/graphile/graphile-settings/src/plugins/custom-inflector.ts
@@ -444,6 +444,25 @@ export const InflektPlugin: GraphileConfig.Plugin = {
         }
         return previous!(details);
       },
+
+      /**
+       * Uppercase enum values to match GraphQL CONSTANT_CASE convention.
+       *
+       * WHY THIS EXISTS:
+       * In PostGraphile v4, custom PostgreSQL enum values (e.g., 'app', 'core', 'module')
+       * were automatically uppercased to CONSTANT_CASE ('APP', 'CORE', 'MODULE').
+       * In PostGraphile v5, the default `enumValue` inflector preserves the original
+       * PostgreSQL casing via `coerceToGraphQLName(value)`, resulting in lowercase
+       * enum values in the GraphQL schema.
+       *
+       * OUR FIX:
+       * We call the previous inflector to retain all special character handling
+       * (asterisks, symbols, etc.), then uppercase the result to restore v4 behavior.
+       */
+      enumValue(previous, _options, value, codec) {
+        const result = previous!(value, codec);
+        return result.toUpperCase();
+      },
     },
   },
 };


### PR DESCRIPTION
# fix(graphile-settings): uppercase enum values to match v4 CONSTANT_CASE

## Summary

Adds an `enumValue` inflector override to the existing `InflektPlugin` in `graphile-settings` to restore PostGraphile v4's behavior of uppercasing PostgreSQL enum values in the GraphQL schema.

In PostGraphile v5, the default `enumValue` inflector in `PgCodecsPlugin` preserves the original PostgreSQL casing (via `coerceToGraphQLName(value)`). This means custom enum values like `app`, `core`, `module` appear lowercase in GraphQL instead of `APP`, `CORE`, `MODULE` as they did in v4.

The fix delegates to the previous inflector (to retain all special character/symbol handling) and then applies `.toUpperCase()` to the result.

## Review & Testing Checklist for Human

- [ ] **Verify this matches v4 behavior**: Confirm that v4 used simple `.toUpperCase()` and not a more nuanced CONSTANT_CASE transform (e.g., `myValue` → `MYVALUE` vs `MY_VALUE`). If your Postgres enums use camelCase or mixed-case values, the output may differ from expectations.
- [ ] **Check impact on non-custom enums**: This affects *all* enum values in the schema (OrderBy enums like `ID_ASC`, filter enums, etc.). These should already be uppercase so `.toUpperCase()` should be a no-op, but worth spot-checking.
- [ ] **Test with a running schema**: Spin up a PostGraphile server with custom enum types and verify the GraphQL schema shows uppercase values. The build passes but there are no unit/integration tests covering this inflector.

### Notes
- Link to Devin run: https://app.devin.ai/sessions/9842845c47f54bdeb5a1aed39e1f53e7
- Requested by: @pyramation