### PR TITLE
fix(graphile-settings): standalone UppercaseEnumsPlugin for v4 CONSTANT_CASE enum values

### DIFF
--- a/graphile/graphile-settings/src/plugins/index.ts
+++ b/graphile/graphile-settings/src/plugins/index.ts
@@ -63,6 +63,12 @@ export {
 } from './pg-type-mappings';
 export type { TypeMapping } from './pg-type-mappings';
 
+// Uppercase enum values to match v4 CONSTANT_CASE convention
+export {
+  UppercaseEnumsPlugin,
+  UppercaseEnumsPreset,
+} from './uppercase-enums';
+
 // Search plugin for tsvector full-text search conditions (includes TsvectorCodec)
 export {
   PgSearchPlugin,

--- a/graphile/graphile-settings/src/plugins/uppercase-enums.ts
+++ b/graphile/graphile-settings/src/plugins/uppercase-enums.ts
@@ -1,0 +1,33 @@
+import type { GraphileConfig } from 'graphile-config';
+
+/**
+ * Plugin that uppercases PostgreSQL enum values in the GraphQL schema.
+ *
+ * WHY THIS EXISTS:
+ * In PostGraphile v4, custom PostgreSQL enum values (e.g., 'app', 'core', 'module')
+ * were automatically uppercased to CONSTANT_CASE ('APP', 'CORE', 'MODULE').
+ * In PostGraphile v5, the default `enumValue` inflector preserves the original
+ * PostgreSQL casing via `coerceToGraphQLName(value)`, resulting in lowercase
+ * enum values in the GraphQL schema.
+ *
+ * This plugin overrides the `enumValue` inflector to uppercase the result,
+ * restoring v4 behavior. It delegates to the previous inflector first to
+ * retain all special character handling (asterisks, symbols, etc.).
+ */
+export const UppercaseEnumsPlugin: GraphileConfig.Plugin = {
+  name: 'UppercaseEnumsPlugin',
+  version: '1.0.0',
+
+  inflection: {
+    replace: {
+      enumValue(previous, _options, value, codec) {
+        const result = previous!(value, codec);
+        return result.toUpperCase();
+      },
+    },
+  },
+};
+
+export const UppercaseEnumsPreset: GraphileConfig.Preset = {
+  plugins: [UppercaseEnumsPlugin],
+};

--- a/graphile/graphile-settings/src/presets/constructive-preset.ts
+++ b/graphile/graphile-settings/src/presets/constructive-preset.ts
@@ -10,6 +10,7 @@ import { ManyToManyOptInPreset } from '../plugins/many-to-many-preset';
 import { MetaSchemaPreset } from '../plugins/meta-schema';
 import { PgSearchPreset } from 'graphile-search-plugin';
 import { PgTypeMappingsPreset } from '../plugins/pg-type-mappings';
+import { UppercaseEnumsPreset } from '../plugins/uppercase-enums';
 
 /**
  * Constructive PostGraphile v5 Preset
@@ -61,6 +62,7 @@ export const ConstructivePreset: GraphileConfig.Preset = {
     MetaSchemaPreset,
     PgSearchPreset({ pgSearchPrefix: 'fullText' }),
     PgTypeMappingsPreset,
+    UppercaseEnumsPreset,
   ],
   /**
    * Disable relation filter plugins from postgraphile-plugin-connection-filter.


### PR DESCRIPTION
# fix(graphile-settings): add UppercaseEnumsPlugin for v4 CONSTANT_CASE enums

## Summary

Adds a standalone `UppercaseEnumsPlugin` that overrides PostGraphile v5's `enumValue` inflector to uppercase enum values, restoring the v4 behavior where PostgreSQL enum values like `app`, `core`, `module` become `APP`, `CORE`, `MODULE` in the GraphQL schema.

In v5, the default `enumValue` inflector in `PgCodecsPlugin` just calls `coerceToGraphQLName(value)`, which preserves the original Postgres casing. This plugin delegates to the previous inflector (retaining special character handling) then applies `.toUpperCase()`.

Three files changed:
- **New:** `plugins/uppercase-enums.ts` — standalone plugin + preset
- **Modified:** `plugins/index.ts` — re-exports the new plugin
- **Modified:** `presets/constructive-preset.ts` — adds `UppercaseEnumsPreset` to the main preset

This is an alternative to [PR #702](https://github.com/constructive-io/constructive/pull/702), which inlined the same logic into `InflektPlugin`. This approach keeps it as a separate, independently toggleable plugin.

## Review & Testing Checklist for Human

- [ ] **Verify behavior with a live schema**: No integration test exists — spin up PostGraphile with a custom enum type (e.g., `CREATE TYPE module_type AS ENUM ('app', 'core', 'module')`) and confirm the GraphQL schema shows `APP`, `CORE`, `MODULE`
- [ ] **Check impact on non-custom enums**: `.toUpperCase()` is applied to *all* enum values (OrderBy enums like `ID_ASC`, filter enums, etc.). These should already be uppercase so it should be a no-op, but worth spot-checking that nothing breaks
- [ ] **Confirm v4 parity for mixed-case enums**: If any Postgres enums use camelCase values like `myValue`, this produces `MYVALUE` (not `MY_VALUE`). Verify this matches v4's behavior — v4 also did a simple uppercase, not a CONSTANT_CASE transform

### Notes
- The `previous!` non-null assertion is safe because `PgCodecsPlugin` always defines `enumValue`, but if the plugin ordering ever changes this could throw
- Link to Devin run: https://app.devin.ai/sessions/9842845c47f54bdeb5a1aed39e1f53e7
- Requested by: @pyramation