### PR TITLE
Deduplicate tables in MetaSchemaPlugin `_meta` output

### DIFF
--- a/graphile/graphile-settings/src/plugins/meta-schema.ts
+++ b/graphile/graphile-settings/src/plugins/meta-schema.ts
@@ -204,10 +204,16 @@ export const MetaSchemaPlugin: GraphileConfig.Plugin = {
 
         // Collect all table metadata at build time
         const tablesMeta: TableMeta[] = [];
+        const seenCodecs = new Set();
 
         for (const resource of Object.values(pgRegistry.pgResources) as any[]) {
           // Skip resources without codec or attributes
           if (!resource.codec?.attributes || resource.codec?.isAnonymous) continue;
+          // Skip non-table resources (unique lookups, virtual, functions)
+          if (resource.parameters || resource.isVirtual || resource.isUnique) continue;
+          // Deduplicate: multiple resources can share the same codec
+          if (seenCodecs.has(resource.codec)) continue;
+          seenCodecs.add(resource.codec);
 
           // Safely access extensions - may be undefined for some resources
           const pgExtensions = resource.codec?.extensions?.pg as { schemaName?: string } | undefined;


### PR DESCRIPTION
# PR: Deduplicate tables in MetaSchemaPlugin `_meta` output

## Summary

The `_meta` query could emit duplicate table entries because `pgRegistry.pgResources` contains multiple resource objects sharing the same codec (table). PostGraphile V5 creates separate resources for collection access, unique-row lookups (`isUnique`), virtual resources (`isVirtual`), and function-based resources (`parameters`). The init hook iterated over all of them, producing repeated table metadata.

## Problem

The iteration loop had only basic filtering:

```typescript
for (const resource of Object.values(pgRegistry.pgResources) as any[]) {
  if (!resource.codec?.attributes || resource.codec?.isAnonymous) continue;
  // processes every resource, including isUnique/isVirtual variants
}
```

For a table like `users`, PostGraphile may create resources for: `users` (collection), `userById` (unique lookup), `userByEmail` (unique lookup). All share the same `users` codec, resulting in 3 identical entries in `_meta.tables`.

## Solution

Two-layer deduplication matching PostGraphile's own `pgTableResource` approach (`PgBasicsPlugin.js:286`):

1. **Filter out non-table resources**: skip `parameters` (functions), `isVirtual`, and `isUnique` resources — these are not real table entries
2. **`seenCodecs` Set**: safety net to catch any remaining duplicates where multiple resources share the same codec

```typescript
const seenCodecs = new Set();
for (const resource of Object.values(pgRegistry.pgResources) as any[]) {
  if (!resource.codec?.attributes || resource.codec?.isAnonymous) continue;
  if (resource.parameters || resource.isVirtual || resource.isUnique) continue;
  if (seenCodecs.has(resource.codec)) continue;
  seenCodecs.add(resource.codec);
  // ...
}
```

## Changed files

- `graphile/graphile-settings/src/plugins/meta-schema.ts`

## Dashboard impact

The dashboard consumes `_meta.tables` in several places that assume each table appears exactly once:

1. **Table lookups** (`query-builder.ts:339`) - `_meta.tables.find(t => t.name === model)` returns the first match. With duplicates, it still works but wastes memory and iteration. Without duplicates, lookups are correct and efficient.

2. **Schema metadata caching** (`schema-slice` in Zustand) - The `_meta` response is cached in Zustand state and persisted to localStorage. Duplicate table entries bloat the cache size and the localStorage payload. For a database with 92 tables, if each table has 2-3 resources, the `_meta` response could be 2-3x larger than necessary.

3. **`convertFromMetaSchema()`** (`meta-object/convert.ts`) - Transforms the raw `_meta` response into the internal `MetaObject`. Duplicate tables would produce duplicate entries in the converted object, leading to redundant processing downstream.

4. **Table list UI** - The dashboard's table navigation and starred-tables feature enumerate `_meta.tables`. Duplicates would show the same table multiple times in the sidebar and table selector.

5. **Relation resolution** - When resolving FK relations, the dashboard looks up referenced tables by name in `_meta.tables`. Duplicates don't break this but add unnecessary noise to the data structure.

6. **Query generation** - `query-generator.ts` uses `_meta` table metadata to determine available fields, constraints, and relations. A cleaner, deduplicated table list means less data to parse and faster query construction.

## Test plan

- [x] `graphile-settings` builds successfully
- [x] Codegen tests pass (230/230)
- [x] Dashboard tests pass (968/968)
- [x] No codegen regeneration needed
