### PR TITLE
fix: remove dbname from sites and apis export config

### DIFF
--- a/pgpm/core/src/export/export-meta.ts
+++ b/pgpm/core/src/export/export-meta.ts
@@ -368,8 +368,7 @@ const config: Record<string, TableConfig> = {
       og_image: 'image',
       favicon: 'upload',
       apple_touch_icon: 'image',
-      logo: 'image',
-      dbname: 'text'
+      logo: 'image'
     }
   },
   apis: {
@@ -379,7 +378,6 @@ const config: Record<string, TableConfig> = {
       id: 'uuid',
       database_id: 'uuid',
       name: 'text',
-      dbname: 'text',
       is_public: 'boolean',
       role_name: 'text',
       anon_role: 'text'


### PR DESCRIPTION
# fix: exclude dbname from sites and apis export config

## Summary

Removes `dbname` from the `sites` and `apis` field configs in `export-meta.ts` so that generated migration INSERT statements no longer include this column.

The `dbname` column on both `services_public.sites` and `services_public.apis` has `DEFAULT current_database()`. During introspection, the test database receives a random name (e.g. `db-<uuid>`), so each regeneration produces a different `dbname` value in the exported SQL — causing non-deterministic diffs like:

```diff
-  'db-36872286-e08e-45ad-b233-dc528a2a44e7'
+  'db-82d5fdf2-499d-4b03-9ef5-f4322005352a'
```

With `dbname` removed from the config, the column is omitted from generated INSERTs entirely. At deploy time, `current_database()` provides the correct value via the column DEFAULT.

## Review & Testing Checklist for Human

- [ ] Verify that no deployment scripts or runtime code depend on `dbname` being explicitly present in the migration INSERT statements (rather than relying on the column DEFAULT)
- [ ] After publishing this version, regenerate migrations in `constructive-db` and confirm `apis.sql` / `sites.sql` no longer contain `dbname` and produce stable output across runs
- [ ] Check that the `csv-to-pg` `Parser` correctly omits columns not listed in `fields` (i.e., confirm `SELECT *` rows with extra columns don't cause errors when `dbname` is absent from the config)

### Notes
- This only fixes the upstream package (`@pgpmjs/core`). The `constructive-db` repo will need its dependency updated and migrations regenerated to see the effect.
- [Link to Devin run](https://app.devin.ai/sessions/f6b3fd877f1243aebe2eed87f4e152be)
- Requested by: @pyramation