### PR TITLE
fix(pgpm): clear update cache after pgpm update and use semver comparison

### DIFF
--- a/pgpm/cli/src/commands.ts
+++ b/pgpm/cli/src/commands.ts
@@ -1,6 +1,7 @@
 import { checkForUpdates } from '@inquirerer/utils';
 import { CLIOptions, Inquirerer, ParsedArgs, cliExitWithError, extractFirst, getPackageJson } from 'inquirerer';
 import { teardownPgPools } from 'pg-cache';
+import semver from 'semver';
 
 import add from './commands/add';
 import adminUsers from './commands/admin-users';
@@ -116,8 +117,11 @@ export const commands = async (argv: Partial<ParsedArgs>, prompter: Inquirerer, 
         pkgVersion: pkg.version,
         toolName: 'pgpm',
       });
-      if (updateResult.hasUpdate && updateResult.message) {
-        console.warn(updateResult.message);
+      if (updateResult.latestVersion
+        && semver.valid(updateResult.latestVersion)
+        && semver.valid(pkg.version)
+        && semver.gt(updateResult.latestVersion, pkg.version)) {
+        console.warn(`Update available: ${pkg.version} -> ${updateResult.latestVersion}`);
         console.warn('Run pgpm update to upgrade.');
       }
     } catch {

--- a/pgpm/cli/src/commands/update.ts
+++ b/pgpm/cli/src/commands/update.ts
@@ -1,6 +1,9 @@
 import { Logger } from '@pgpmjs/logger';
 import { CLIOptions, Inquirerer, cliExitWithError, getPackageJson } from 'inquirerer';
+import { appstash } from 'appstash';
 import { spawn } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
 import { fetchLatestVersion } from '../utils/npm-version';
 
 const log = new Logger('update');
@@ -65,6 +68,12 @@ export default async (
 
   try {
     await runNpmInstall(pkgName, registry);
+
+    try {
+      const cacheFile = path.join(appstash('pgpm').cache, 'update-check.json');
+      if (fs.existsSync(cacheFile)) fs.unlinkSync(cacheFile);
+    } catch {}
+
     const latest = await fetchLatestVersion(pkgName);
     if (latest) {
       log.success(`Successfully updated ${pkgName} to version ${latest}.`);


### PR DESCRIPTION
## Summary

Two small fixes for the `pgpm update` check:

1. **Stale cache after update**: After `pgpm update` succeeds, the update-check cache (`~/.pgpm/cache/update-check.json`) was not cleared, so subsequent commands kept showing "update available" until the 24h TTL expired. Now we delete the cache file after a successful install using `appstash` (already a dependency) to resolve the cache path.

2. **String-based version comparison**: The upstream `checkForUpdates` in `@inquirerer/utils` uses JS string comparison (`>`) which silently fails for multi-digit semver segments (e.g., `"3.10.0" > "3.9.0"` is `false`). Instead of trusting `updateResult.hasUpdate`, we now use `semver.gt()` on the returned `latestVersion` directly. `semver` is already a dependency of `pgpm/cli`.

This is a minimal alternative to #704, which added `execFile` calls (the CLI invoking itself), new exported functions, and 222 lines of tests. This PR achieves the same result in ~13 lines across 2 files with no new dependencies or exports.

## Review & Testing Checklist for Human

- [ ] Verify the cache path `appstash('pgpm').cache + '/update-check.json'` matches what `@inquirerer/utils` `checkForUpdates` writes to (it should — both call `appstash('pgpm')`)
- [ ] End-to-end: run `pgpm update`, then immediately run another pgpm command (e.g. `pgpm --help`) and confirm no stale "update available" prompt appears
- [ ] Verify the `semver` default import works correctly with the existing `"semver": "^7.6.2"` dependency and `@types/semver` in devDependencies

### Notes
- The upstream string comparison bug still lives in `@inquirerer/utils` `checkForUpdates` — this PR works around it at the call site. A proper fix upstream would let us revert the `semver` workaround in `commands.ts`.
- Requested by: @pyramation
- [Link to Devin run](https://app.devin.ai/sessions/cfbf9c357b62415486e42e4beba4f698)