### PR TITLE
fix(codegen): preserve db.pgpm when merging CLI args with file config

### DIFF
--- a/graphql/codegen/src/cli/index.ts
+++ b/graphql/codegen/src/cli/index.ts
@@ -114,10 +114,11 @@ export const commands = async (
       let hasError = false;
       for (const name of names) {
         console.log(`\n[${name}]`);
-        const result = await generate({
-          ...targets[name],
-          ...cliOptions,
-        } as GraphQLSDKConfigTarget);
+        const targetConfig = { ...targets[name], ...cliOptions } as GraphQLSDKConfigTarget;
+        if (targets[name].db && targetConfig.db) {
+          targetConfig.db = { ...targets[name].db, ...targetConfig.db };
+        }
+        const result = await generate(targetConfig);
         printResult(result);
         if (!result.success) hasError = true;
       }

--- a/graphql/codegen/src/cli/shared.ts
+++ b/graphql/codegen/src/cli/shared.ts
@@ -202,7 +202,10 @@ export function buildDbConfig(
 ): Record<string, unknown> {
   const { schemas, apiNames, ...rest } = options;
   if (schemas || apiNames) {
-    return { ...rest, db: { schemas, apiNames } };
+    return {
+      ...rest,
+      db: filterDefined({ schemas, apiNames } as Record<string, unknown>),
+    };
   }
   return rest;
 }
@@ -259,5 +262,9 @@ export function buildGenerateOptions(
   const camelized = camelizeArgv(answers);
   const normalized = normalizeCodegenListOptions(camelized);
   const withDb = buildDbConfig(normalized);
-  return { ...fileConfig, ...withDb } as GraphQLSDKConfigTarget;
+  const merged = { ...fileConfig, ...withDb } as GraphQLSDKConfigTarget;
+  if (fileConfig.db && merged.db) {
+    merged.db = { ...fileConfig.db, ...merged.db };
+  }
+  return merged;
 }


### PR DESCRIPTION
# fix(codegen): preserve db.pgpm when merging CLI args with file config

## Summary

When using the CLI (`cnc codegen` or standalone `graphql-codegen`) with a config file containing `db.pgpm`, the `buildGenerateOptions` function was dropping the `pgpm` config during the flatten/rebuild cycle:

1. `seedArgvFromConfig` flattens `db` → extracts only `schemas`/`apiNames`, drops `pgpm`, `config`, `keepDb`
2. `buildGenerateOptions` rebuilds `db` with only `{schemas, apiNames}`
3. `{ ...fileConfig, ...withDb }` overwrites `fileConfig.db` entirely with the incomplete `db`

This caused pgpm-based configs to silently fall back to database mode, connecting to whatever database the environment points to instead of creating an ephemeral PGPM deployment.

**Changes:**
- `buildGenerateOptions`: deep-merges `db` from file config with CLI-derived `db` so `pgpm`, `keepDb`, `config` are preserved
- `buildDbConfig`: filters undefined values from the CLI `db` object so they don't overwrite file config values
- Multi-target CLI path (`cli/index.ts`): same deep-merge fix applied

## Review & Testing Checklist for Human

- [ ] **Verify this fixes the reported issue**: The user reported that `schemas` is ignored when using pgpm source in constructive-db's `sdk/constructive-sdk`. The script (`generate-sdk.ts`) calls `generate()` directly and does NOT go through the CLI path fixed here. **Please confirm whether the issue reproduces via `cnc codegen` (CLI with config file) or `pnpm generate` (direct script)**—this fix only addresses the CLI path.
- [ ] **Test with pgpm config file**: Run `cnc codegen` in a directory with a `graphql-sdk.config.ts` that has `db.pgpm` and `db.schemas` — verify the pgpm module path is preserved and the correct ephemeral database is used.
- [ ] **Test schema filtering end-to-end**: With `schemas: ['constructive_public']` in the config, verify that only `constructive_public` objects appear in the generated schema (not all 12+ schemas).
- [ ] **Naming conflict**: The `actions_public.table_grant` (function) vs `metaschema_public.table_grant` (table) PostGraphile v5 resource naming conflict is a separate issue that exists when both schemas are in the list. This PR does not address that conflict.

### Notes

- Build passes (`pnpm build`)
- Could not test end-to-end (requires pgpm + Docker + PostgreSQL)
- If the direct `generate()` script path also has the issue, the root cause may be elsewhere (possibly in PostGraphile v5's handling of `makePgService` schemas)

Requested by: @pyramation
[Link to Devin run](https://app.devin.ai/sessions/467080f279b64f0b9d1b7600cc050971)