### PR TITLE
Fix/codegen schema filtering

### DIFF
--- a/graphql/codegen/src/cli/index.ts
+++ b/graphql/codegen/src/cli/index.ts
@@ -114,10 +114,11 @@ export const commands = async (
       let hasError = false;
       for (const name of names) {
         console.log(`\n[${name}]`);
-        const result = await generate({
-          ...targets[name],
-          ...cliOptions,
-        } as GraphQLSDKConfigTarget);
+        const targetConfig = { ...targets[name], ...cliOptions } as GraphQLSDKConfigTarget;
+        if (targets[name].db && targetConfig.db) {
+          targetConfig.db = { ...targets[name].db, ...targetConfig.db };
+        }
+        const result = await generate(targetConfig);
         printResult(result);
         if (!result.success) hasError = true;
       }

--- a/graphql/codegen/src/cli/shared.ts
+++ b/graphql/codegen/src/cli/shared.ts
@@ -202,7 +202,10 @@ export function buildDbConfig(
 ): Record<string, unknown> {
   const { schemas, apiNames, ...rest } = options;
   if (schemas || apiNames) {
-    return { ...rest, db: { schemas, apiNames } };
+    return {
+      ...rest,
+      db: filterDefined({ schemas, apiNames } as Record<string, unknown>),
+    };
   }
   return rest;
 }
@@ -259,5 +262,9 @@ export function buildGenerateOptions(
   const camelized = camelizeArgv(answers);
   const normalized = normalizeCodegenListOptions(camelized);
   const withDb = buildDbConfig(normalized);
-  return { ...fileConfig, ...withDb } as GraphQLSDKConfigTarget;
+  const merged = { ...fileConfig, ...withDb } as GraphQLSDKConfigTarget;
+  if (fileConfig.db && merged.db) {
+    merged.db = { ...fileConfig.db, ...merged.db };
+  }
+  return merged;
 }


### PR DESCRIPTION
## Summary

- Fix PostGraphile v5 resource registry crash (`Attempted to add a second resource named "table_grant"`) when a function and a table share the same base name across schemas.
- Add a `functionResourceName` override to `InflektPlugin` that restores schema prefixes **for functions** while keeping clean, unprefixed names **for tables**.
- Filter `ConflictDetectorPlugin` by configured `pgServices.schemas` to prevent false-positive warnings from unrelated schemas.

## Problem

`InflektPlugin._schemaPrefix` currently returns `''` for all schemas to give tables clean GraphQL names. However, `PostGraphile`’s `functionResourceName` also uses `_schemaPrefix`, which means **functions lose their schema prefix too**.

When a function and a table share the same base name across schemas (e.g. `actions_public.table_grant()` and `metaschema_public.table_grant`), both end up with the resource name `table_grant`, and PostGraphile’s flat registry throws.

## Solution

Override `functionResourceName` in `InflektPlugin` to bypass our `_schemaPrefix` override and use PostGraphile’s default prefix logic **for functions only**:

| Resource | Schema | Resource Name | GraphQL Name |
|---|---|---|---|
| `metaschema_public.table_grant` (table) | primary (`schemas[0]`) | `table_grant` | `TableGrant` |
| `actions_public.table_grant()` (function) | non-primary | `actions_public_table_grant` | `actionsPublicTableGrant` |

Functions in the primary schema still get clean names (no prefix). Functions in non-primary schemas get their schema name as a prefix, preventing collisions with same-named tables.

## Test plan

- `graphile-settings` builds successfully
- `graphql/codegen` — 230 tests pass, 75 snapshots match
- `constructive-db/sdk/constructive-sdk` — `pnpm run generate` completes (72 tables, 82 queries, 314 mutations)
- `constructive-db/application/app` — 101 tests pass (4 test suites have pre-existing TS type errors unrelated to this change)