### PR TITLE
fix(codegen): filter conflict detection by configured schemas & preserve db config merging

### DIFF
--- a/graphile/graphile-settings/src/plugins/custom-inflector.ts
+++ b/graphile/graphile-settings/src/plugins/custom-inflector.ts
@@ -130,39 +130,6 @@ export const InflektPlugin: GraphileConfig.Plugin = {
       },
 
       /**
-       * Restore PostGraphile's default schema prefix logic for functions.
-       *
-       * Our _schemaPrefix override returns '' for all schemas to give clean
-       * table names. However, this strips prefixes from functions too, causing
-       * resource naming collisions when a function and table share the same
-       * base name across schemas (e.g., actions_public.table_grant() collides
-       * with metaschema_public.table_grant table).
-       *
-       * Fix: bypass our _schemaPrefix override for functions and use
-       * PostGraphile's default prefix logic instead.
-       */
-      functionResourceName(_previous, options: any, details: any) {
-        const { serviceName, pgProc } = details;
-        const { tags } = pgProc.getTagsAndDescription();
-
-        if (typeof tags.name === 'string') {
-          return tags.name;
-        }
-
-        const pgNamespace = pgProc.getNamespace();
-
-        if (!pgNamespace) {
-          return pgProc.proname;
-        }
-
-        const pgService = (options.pgServices ?? []).find((db: any) => db.name === serviceName);
-        const primarySchema = pgService?.schemas?.[0] ?? 'public';
-        const databasePrefix = serviceName === 'main' ? '' : `${serviceName}_`;
-        const schemaPrefix = pgNamespace.nspname === primarySchema ? '' : `${pgNamespace.nspname}_`;
-        return `${databasePrefix}${schemaPrefix}${pgProc.proname}`;
-      },
-
-      /**
        * Keep `id` columns as `id` instead of renaming to `rowId`.
        *
        * WHY THIS EXISTS:

--- a/graphile/graphile-settings/src/plugins/custom-inflector.ts
+++ b/graphile/graphile-settings/src/plugins/custom-inflector.ts
@@ -130,6 +130,39 @@ export const InflektPlugin: GraphileConfig.Plugin = {
       },
 
       /**
+       * Restore PostGraphile's default schema prefix logic for functions.
+       *
+       * Our _schemaPrefix override returns '' for all schemas to give clean
+       * table names. However, this strips prefixes from functions too, causing
+       * resource naming collisions when a function and table share the same
+       * base name across schemas (e.g., actions_public.table_grant() collides
+       * with metaschema_public.table_grant table).
+       *
+       * Fix: bypass our _schemaPrefix override for functions and use
+       * PostGraphile's default prefix logic instead.
+       */
+      functionResourceName(_previous, options: any, details: any) {
+        const { serviceName, pgProc } = details;
+        const { tags } = pgProc.getTagsAndDescription();
+
+        if (typeof tags.name === 'string') {
+          return tags.name;
+        }
+
+        const pgNamespace = pgProc.getNamespace();
+
+        if (!pgNamespace) {
+          return pgProc.proname;
+        }
+
+        const pgService = (options.pgServices ?? []).find((db: any) => db.name === serviceName);
+        const primarySchema = pgService?.schemas?.[0] ?? 'public';
+        const databasePrefix = serviceName === 'main' ? '' : `${serviceName}_`;
+        const schemaPrefix = pgNamespace.nspname === primarySchema ? '' : `${pgNamespace.nspname}_`;
+        return `${databasePrefix}${schemaPrefix}${pgProc.proname}`;
+      },
+
+      /**
        * Keep `id` columns as `id` instead of renaming to `rowId`.
        *
        * WHY THIS EXISTS:

--- a/graphql/codegen/src/cli/index.ts
+++ b/graphql/codegen/src/cli/index.ts
@@ -114,10 +114,11 @@ export const commands = async (
       let hasError = false;
       for (const name of names) {
         console.log(`\n[${name}]`);
-        const result = await generate({
-          ...targets[name],
-          ...cliOptions,
-        } as GraphQLSDKConfigTarget);
+        const targetConfig = { ...targets[name], ...cliOptions } as GraphQLSDKConfigTarget;
+        if (targets[name].db && targetConfig.db) {
+          targetConfig.db = { ...targets[name].db, ...targetConfig.db };
+        }
+        const result = await generate(targetConfig);
         printResult(result);
         if (!result.success) hasError = true;
       }

--- a/graphql/codegen/src/cli/shared.ts
+++ b/graphql/codegen/src/cli/shared.ts
@@ -202,7 +202,10 @@ export function buildDbConfig(
 ): Record<string, unknown> {
   const { schemas, apiNames, ...rest } = options;
   if (schemas || apiNames) {
-    return { ...rest, db: { schemas, apiNames } };
+    return {
+      ...rest,
+      db: filterDefined({ schemas, apiNames } as Record<string, unknown>),
+    };
   }
   return rest;
 }
@@ -259,5 +262,9 @@ export function buildGenerateOptions(
   const camelized = camelizeArgv(answers);
   const normalized = normalizeCodegenListOptions(camelized);
   const withDb = buildDbConfig(normalized);
-  return { ...fileConfig, ...withDb } as GraphQLSDKConfigTarget;
+  const merged = { ...fileConfig, ...withDb } as GraphQLSDKConfigTarget;
+  if (fileConfig.db && merged.db) {
+    merged.db = { ...fileConfig.db, ...merged.db };
+  }
+  return merged;
 }


### PR DESCRIPTION
# fix(codegen): filter conflict detection by configured schemas & preserve db config merging

## Summary

Clean extraction of functional changes from #720, with all linting/formatting-only changes removed.

**ConflictDetectorPlugin (`conflict-detector.ts`)**: Filters codec conflict detection to only check schemas listed in `pgServices.schemas`, preventing false-positive warnings from unrelated schemas.

**Codegen CLI (`index.ts`, `shared.ts`)**: Fixes `db` config merging so file-config `db` fields (e.g., `pgpm` settings) aren't silently dropped when CLI args also contribute `db` properties. Also wraps `buildDbConfig` output with `filterDefined` to prevent `undefined` values from overwriting real config during merge.

## Updates since last revision

- Removed `functionResourceName` override from `InflektPlugin` — all resource names (tables and functions) remain flat with no schema prefixes, per project convention.

## Review & Testing Checklist for Human

- [ ] **Verify `(build as any).resolvedPreset?.pgServices`** in conflict-detector is the correct path to access configured services at schema build time — this uses an `any` cast and the path may not be stable across PostGraphile versions
- [ ] **Test codegen with multi-target config** where file config has `db.pgpm` settings and CLI passes `--schemas` — confirm `db.pgpm` is preserved in the merged config
- [ ] **Confirm the one-level-deep `db` merge** (`{ ...fileConfig.db, ...merged.db }`) is sufficient — if `db` contains nested objects beyond `schemas`/`apiNames`/`pgpm`, they would be overwritten rather than merged
- [ ] **Verify `filterDefined` in `buildDbConfig`** doesn't break downstream consumers that may distinguish between a key being `undefined` vs. absent

### Notes
- Extracted from PR #720 — same functional changes (minus `functionResourceName`), with all quote style (`'` → `"`) and whitespace/formatting diffs removed
- No new tests added; relies on existing test suites passing
- `custom-inflector.ts` is intentionally unchanged — no schema prefixes on functions or tables

Link to Devin run: https://app.devin.ai/sessions/741db16bcb8b43eaa343b3a5befd80c1
Requested by: @pyramation