### PR TITLE
fix(codegen): use deepmerge for CLI config merging

### DIFF
--- a/graphql/codegen/src/cli/index.ts
+++ b/graphql/codegen/src/cli/index.ts
@@ -9,7 +9,7 @@ import { CLI, CLIOptions, getPackageJson, Inquirerer } from 'inquirerer';
 
 import { findConfigFile, loadConfigFile } from '../core/config';
 import { generate } from '../core/generate';
-import type { GraphQLSDKConfigTarget } from '../types/config';
+import { mergeConfig, type GraphQLSDKConfigTarget } from '../types/config';
 import {
   buildDbConfig,
   buildGenerateOptions,
@@ -114,10 +114,9 @@ export const commands = async (
       let hasError = false;
       for (const name of names) {
         console.log(`\n[${name}]`);
-        const result = await generate({
-          ...targets[name],
-          ...cliOptions,
-        } as GraphQLSDKConfigTarget);
+        const result = await generate(
+          mergeConfig(targets[name], cliOptions as GraphQLSDKConfigTarget),
+        );
         printResult(result);
         if (!result.success) hasError = true;
       }

--- a/graphql/codegen/src/cli/shared.ts
+++ b/graphql/codegen/src/cli/shared.ts
@@ -9,7 +9,7 @@ import { inflektTree } from 'inflekt/transform-keys';
 import type { Question } from 'inquirerer';
 
 import type { GenerateResult } from '../core/generate';
-import type { GraphQLSDKConfigTarget } from '../types/config';
+import { mergeConfig, type GraphQLSDKConfigTarget } from '../types/config';
 
 export const splitCommas = (
   input: string | undefined,
@@ -202,7 +202,10 @@ export function buildDbConfig(
 ): Record<string, unknown> {
   const { schemas, apiNames, ...rest } = options;
   if (schemas || apiNames) {
-    return { ...rest, db: { schemas, apiNames } };
+    return {
+      ...rest,
+      db: filterDefined({ schemas, apiNames } as Record<string, unknown>),
+    };
   }
   return rest;
 }
@@ -259,5 +262,5 @@ export function buildGenerateOptions(
   const camelized = camelizeArgv(answers);
   const normalized = normalizeCodegenListOptions(camelized);
   const withDb = buildDbConfig(normalized);
-  return { ...fileConfig, ...withDb } as GraphQLSDKConfigTarget;
+  return mergeConfig(fileConfig, withDb as GraphQLSDKConfigTarget);
 }


### PR DESCRIPTION
## Summary

Replaces manual spread-operator merging (`{ ...fileConfig, ...cliOptions }`) with `deepmerge` (via the existing `mergeConfig` utility) when combining file-based config with CLI arguments. This ensures nested objects like `db.pgpm` survive when the CLI only provides sibling keys like `db.schemas`.

Previously, shallow spreading would silently drop nested config — e.g., a file config with `db: { pgpm: { modulePath: '...' }, schemas: [...] }` merged with CLI `db: { schemas: [...] }` would lose `pgpm` entirely.

Also restores `filterDefined` in `buildDbConfig` so that `undefined` CLI values (e.g. `apiNames` when only `--schemas` is passed) are stripped before merge, preventing them from clobbering defined file-config values during deep merge.

**Affected paths:** CLI single-target (`buildGenerateOptions`) and CLI multi-target (inline loop in `commands`). Programmatic `generate()` calls are unaffected — they already go through `getConfigOptions` which uses `deepmerge`.

## Review & Testing Checklist for Human

- [ ] **Verify `mergeConfig` deep-merge behavior with real multi-target configs** — `mergeConfig` uses `deepmerge` with `replaceArrays` (source wins). Confirm that CLI array overrides (e.g. `--schemas x,y`) fully replace file-config arrays rather than concatenating. Also check that nested non-array fields (`tables.include`, `headers`, `hooks`) merge correctly.
- [ ] **Check that `filterDefined` stripping `null` (not just `undefined`) is intentional** — the filter condition is `v !== undefined && v !== null`. If a CLI user explicitly passes `--schemas ""` that normalizes to `undefined` and gets stripped, which seems correct. But if `null` is ever a meaningful value, it would be lost.
- [ ] **Test the CLI with a config file that has `db.pgpm` + run with `--schemas` flag** — this is the scenario that motivated the change. Confirm `pgpm.modulePath` is preserved in the merged config.

### Notes

This PR addresses the CLI config-merging side of a broader issue where `db.schemas` filtering was being ignored during SDK generation. The root cause in constructive-db (its `generate-sdk.ts` script hardcodes all schemas instead of loading the config file) requires a separate fix in that repo.

[Link to Devin run](https://app.devin.ai/sessions/741db16bcb8b43eaa343b3a5befd80c1) · Requested by @pyramation