### PR TITLE
fix: remove double quotes from pgpm env output

### DIFF
--- a/pgpm/cli/src/commands/env.ts
+++ b/pgpm/cli/src/commands/env.ts
@@ -57,8 +57,7 @@ function configToEnvVars(config: PgConfig): Record<string, string> {
 function printExports(config: PgConfig): void {
   const envVars = configToEnvVars(config);
   for (const [key, value] of Object.entries(envVars)) {
-    const escapedValue = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-    console.log(`export ${key}="${escapedValue}"`);
+    console.log(`export ${key}=${value}`);
   }
 }
 


### PR DESCRIPTION
## Summary

Removes the double-quote wrapping from `pgpm env` export statements. Previously the output was:

```
export PGHOST="localhost"
export PGPORT="5432"
```

Now it outputs:

```
export PGHOST=localhost
export PGPORT=5432
```

The escaping logic for backslashes and embedded quotes within values was also removed since the quotes are no longer present.

## Review & Testing Checklist for Human

- [ ] **Edge case: passwords with spaces or shell metacharacters.** The old code quoted and escaped values defensively. The new code outputs bare values. If a profile ever has a password like `my password` or `p@ss$word`, `eval "$(pgpm env)"` will break. Verify this is acceptable for all current and expected profiles (default + supabase).
- [ ] Run `pgpm env` and `pgpm env --supabase` locally and confirm clean output

### Notes
- [Devin run](https://app.devin.ai/sessions/5aca832a6b2a4e3cbc89842fa6562466)
- Requested by @pyramation