### PR TITLE
fix(codegen): fix CLI codegen bugs + refactor utils to template-copy pattern

### DIFF
--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/cli-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/cli-generator.test.ts.snap
@@ -690,7 +690,7 @@ async function handleSetToken(argv: Partial<Record<string, unknown>>, prompter: 
     tokenValue = answer.token;
   }
   store.setCredentials(current.name, {
-    token: String.call(tokenValue || "").trim()
+    token: String(tokenValue || "").trim()
   });
   console.log(\`Token saved for context: \${current.name}\`);
 }
@@ -741,6 +741,15 @@ exports[`cli-generator generates commands/car.ts 1`] = `
  */
 import { CLIOptions, Inquirerer, extractFirst } from "inquirerer";
 import { getClient } from "../executor";
+import { coerceAnswers, stripUndefined } from "../utils";
+const fieldSchema = {
+  id: "uuid",
+  make: "string",
+  model: "string",
+  year: "int",
+  isElectric: "boolean",
+  createdAt: "string"
+};
 const usage = "\\ncar <command>\\n\\nCommands:\\n  list                  List all car records\\n  get                   Get a car by ID\\n  create                Create a new car\\n  update                Update an existing car\\n  delete                Delete a car\\n\\n  --help, -h            Show this help message\\n";
 export default async (argv: Partial<Record<string, unknown>>, prompter: Inquirerer, _options: CLIOptions) => {
   if (argv.help || argv.h) {
@@ -832,7 +841,7 @@ async function handleGet(argv: Partial<Record<string, unknown>>, prompter: Inqui
 }
 async function handleCreate(argv: Partial<Record<string, unknown>>, prompter: Inquirerer) {
   try {
-    const answers = await prompter.prompt(argv, [{
+    const rawAnswers = await prompter.prompt(argv, [{
       type: "text",
       name: "make",
       message: "make",
@@ -853,13 +862,15 @@ async function handleCreate(argv: Partial<Record<string, unknown>>, prompter: In
       message: "isElectric",
       required: true
     }]);
+    const answers = coerceAnswers(rawAnswers, fieldSchema);
+    const cleanedData = stripUndefined(answers, fieldSchema);
     const client = getClient();
     const result = await client.car.create({
       data: {
-        make: answers.make,
-        model: answers.model,
-        year: answers.year,
-        isElectric: answers.isElectric
+        make: cleanedData.make,
+        model: cleanedData.model,
+        year: cleanedData.year,
+        isElectric: cleanedData.isElectric
       },
       select: {
         id: true,
@@ -881,7 +892,7 @@ async function handleCreate(argv: Partial<Record<string, unknown>>, prompter: In
 }
 async function handleUpdate(argv: Partial<Record<string, unknown>>, prompter: Inquirerer) {
   try {
-    const answers = await prompter.prompt(argv, [{
+    const rawAnswers = await prompter.prompt(argv, [{
       type: "text",
       name: "id",
       message: "id",
@@ -907,14 +918,18 @@ async function handleUpdate(argv: Partial<Record<string, unknown>>, prompter: In
       message: "isElectric",
       required: false
     }]);
+    const answers = coerceAnswers(rawAnswers, fieldSchema);
+    const cleanedData = stripUndefined(answers, fieldSchema);
     const client = getClient();
     const result = await client.car.update({
-      id: answers.id,
+      where: {
+        id: answers.id as string
+      },
       data: {
-        make: answers.make,
-        model: answers.model,
-        year: answers.year,
-        isElectric: answers.isElectric
+        make: cleanedData.make,
+        model: cleanedData.model,
+        year: cleanedData.year,
+        isElectric: cleanedData.isElectric
       },
       select: {
         id: true,
@@ -936,15 +951,18 @@ async function handleUpdate(argv: Partial<Record<string, unknown>>, prompter: In
 }
 async function handleDelete(argv: Partial<Record<string, unknown>>, prompter: Inquirerer) {
   try {
-    const answers = await prompter.prompt(argv, [{
+    const rawAnswers = await prompter.prompt(argv, [{
       type: "text",
       name: "id",
       message: "id",
       required: true
     }]);
+    const answers = coerceAnswers(rawAnswers, fieldSchema);
     const client = getClient();
     const result = await client.car.delete({
-      id: answers.id,
+      where: {
+        id: answers.id as string
+      },
       select: {
         id: true
       }
@@ -1153,6 +1171,12 @@ exports[`cli-generator generates commands/driver.ts 1`] = `
  */
 import { CLIOptions, Inquirerer, extractFirst } from "inquirerer";
 import { getClient } from "../executor";
+import { coerceAnswers, stripUndefined } from "../utils";
+const fieldSchema = {
+  id: "uuid",
+  name: "string",
+  licenseNumber: "string"
+};
 const usage = "\\ndriver <command>\\n\\nCommands:\\n  list                  List all driver records\\n  get                   Get a driver by ID\\n  create                Create a new driver\\n  update                Update an existing driver\\n  delete                Delete a driver\\n\\n  --help, -h            Show this help message\\n";
 export default async (argv: Partial<Record<string, unknown>>, prompter: Inquirerer, _options: CLIOptions) => {
   if (argv.help || argv.h) {
@@ -1238,7 +1262,7 @@ async function handleGet(argv: Partial<Record<string, unknown>>, prompter: Inqui
 }
 async function handleCreate(argv: Partial<Record<string, unknown>>, prompter: Inquirerer) {
   try {
-    const answers = await prompter.prompt(argv, [{
+    const rawAnswers = await prompter.prompt(argv, [{
       type: "text",
       name: "name",
       message: "name",
@@ -1249,11 +1273,13 @@ async function handleCreate(argv: Partial<Record<string, unknown>>, prompter: In
       message: "licenseNumber",
       required: true
     }]);
+    const answers = coerceAnswers(rawAnswers, fieldSchema);
+    const cleanedData = stripUndefined(answers, fieldSchema);
     const client = getClient();
     const result = await client.driver.create({
       data: {
-        name: answers.name,
-        licenseNumber: answers.licenseNumber
+        name: cleanedData.name,
+        licenseNumber: cleanedData.licenseNumber
       },
       select: {
         id: true,
@@ -1272,7 +1298,7 @@ async function handleCreate(argv: Partial<Record<string, unknown>>, prompter: In
 }
 async function handleUpdate(argv: Partial<Record<string, unknown>>, prompter: Inquirerer) {
   try {
-    const answers = await prompter.prompt(argv, [{
+    const rawAnswers = await prompter.prompt(argv, [{
       type: "text",
       name: "id",
       message: "id",
@@ -1288,12 +1314,16 @@ async function handleUpdate(argv: Partial<Record<string, unknown>>, prompter: In
       message: "licenseNumber",
       required: false
     }]);
+    const answers = coerceAnswers(rawAnswers, fieldSchema);
+    const cleanedData = stripUndefined(answers, fieldSchema);
     const client = getClient();
     const result = await client.driver.update({
-      id: answers.id,
+      where: {
+        id: answers.id as string
+      },
       data: {
-        name: answers.name,
-        licenseNumber: answers.licenseNumber
+        name: cleanedData.name,
+        licenseNumber: cleanedData.licenseNumber
       },
       select: {
         id: true,
@@ -1312,15 +1342,18 @@ async function handleUpdate(argv: Partial<Record<string, unknown>>, prompter: In
 }
 async function handleDelete(argv: Partial<Record<string, unknown>>, prompter: Inquirerer) {
   try {
-    const answers = await prompter.prompt(argv, [{
+    const rawAnswers = await prompter.prompt(argv, [{
       type: "text",
       name: "id",
       message: "id",
       required: true
     }]);
+    const answers = coerceAnswers(rawAnswers, fieldSchema);
     const client = getClient();
     const result = await client.driver.delete({
-      id: answers.id,
+      where: {
+        id: answers.id as string
+      },
       select: {
         id: true
       }
@@ -3166,7 +3199,7 @@ async function handleSetToken(argv: Partial<Record<string, unknown>>, prompter: 
     tokenValue = answer.token;
   }
   store.setCredentials(current.name, {
-    token: String.call(tokenValue || "").trim()
+    token: String(tokenValue || "").trim()
   });
   console.log(\`Token saved for context: \${current.name}\`);
 }
@@ -3555,6 +3588,12 @@ exports[`multi-target cli generator generates target-prefixed table commands 1`]
  */
 import { CLIOptions, Inquirerer, extractFirst } from "inquirerer";
 import { getClient } from "../../executor";
+import { coerceAnswers, stripUndefined } from "../../utils";
+const fieldSchema = {
+  id: "uuid",
+  email: "string",
+  name: "string"
+};
 const usage = "\\nuser <command>\\n\\nCommands:\\n  list                  List all user records\\n  get                   Get a user by ID\\n  create                Create a new user\\n  update                Update an existing user\\n  delete                Delete a user\\n\\n  --help, -h            Show this help message\\n";
 export default async (argv: Partial<Record<string, unknown>>, prompter: Inquirerer, _options: CLIOptions) => {
   if (argv.help || argv.h) {
@@ -3640,7 +3679,7 @@ async function handleGet(argv: Partial<Record<string, unknown>>, prompter: Inqui
 }
 async function handleCreate(argv: Partial<Record<string, unknown>>, prompter: Inquirerer) {
   try {
-    const answers = await prompter.prompt(argv, [{
+    const rawAnswers = await prompter.prompt(argv, [{
       type: "text",
       name: "email",
       message: "email",
@@ -3651,11 +3690,13 @@ async function handleCreate(argv: Partial<Record<string, unknown>>, prompter: In
       message: "name",
       required: true
     }]);
+    const answers = coerceAnswers(rawAnswers, fieldSchema);
+    const cleanedData = stripUndefined(answers, fieldSchema);
     const client = getClient("auth");
     const result = await client.user.create({
       data: {
-        email: answers.email,
-        name: answers.name
+        email: cleanedData.email,
+        name: cleanedData.name
       },
       select: {
         id: true,
@@ -3674,7 +3715,7 @@ async function handleCreate(argv: Partial<Record<string, unknown>>, prompter: In
 }
 async function handleUpdate(argv: Partial<Record<string, unknown>>, prompter: Inquirerer) {
   try {
-    const answers = await prompter.prompt(argv, [{
+    const rawAnswers = await prompter.prompt(argv, [{
       type: "text",
       name: "id",
       message: "id",
@@ -3690,12 +3731,16 @@ async function handleUpdate(argv: Partial<Record<string, unknown>>, prompter: In
       message: "name",
       required: false
     }]);
+    const answers = coerceAnswers(rawAnswers, fieldSchema);
+    const cleanedData = stripUndefined(answers, fieldSchema);
     const client = getClient("auth");
     const result = await client.user.update({
-      id: answers.id,
+      where: {
+        id: answers.id as string
+      },
       data: {
-        email: answers.email,
-        name: answers.name
+        email: cleanedData.email,
+        name: cleanedData.name
       },
       select: {
         id: true,
@@ -3714,15 +3759,18 @@ async function handleUpdate(argv: Partial<Record<string, unknown>>, prompter: In
 }
 async function handleDelete(argv: Partial<Record<string, unknown>>, prompter: Inquirerer) {
   try {
-    const answers = await prompter.prompt(argv, [{
+    const rawAnswers = await prompter.prompt(argv, [{
       type: "text",
       name: "id",
       message: "id",
       required: true
     }]);
+    const answers = coerceAnswers(rawAnswers, fieldSchema);
     const client = getClient("auth");
     const result = await client.user.delete({
-      id: answers.id,
+      where: {
+        id: answers.id as string
+      },
       select: {
         id: true
       }
@@ -3746,6 +3794,11 @@ exports[`multi-target cli generator generates target-prefixed table commands 2`]
  */
 import { CLIOptions, Inquirerer, extractFirst } from "inquirerer";
 import { getClient } from "../../executor";
+import { coerceAnswers, stripUndefined } from "../../utils";
+const fieldSchema = {
+  id: "uuid",
+  role: "string"
+};
 const usage = "\\nmember <command>\\n\\nCommands:\\n  list                  List all member records\\n  get                   Get a member by ID\\n  create                Create a new member\\n  update                Update an existing member\\n  delete                Delete a member\\n\\n  --help, -h            Show this help message\\n";
 export default async (argv: Partial<Record<string, unknown>>, prompter: Inquirerer, _options: CLIOptions) => {
   if (argv.help || argv.h) {
@@ -3829,16 +3882,18 @@ async function handleGet(argv: Partial<Record<string, unknown>>, prompter: Inqui
 }
 async function handleCreate(argv: Partial<Record<string, unknown>>, prompter: Inquirerer) {
   try {
-    const answers = await prompter.prompt(argv, [{
+    const rawAnswers = await prompter.prompt(argv, [{
       type: "text",
       name: "role",
       message: "role",
       required: true
     }]);
+    const answers = coerceAnswers(rawAnswers, fieldSchema);
+    const cleanedData = stripUndefined(answers, fieldSchema);
     const client = getClient("members");
     const result = await client.member.create({
       data: {
-        role: answers.role
+        role: cleanedData.role
       },
       select: {
         id: true,
@@ -3856,7 +3911,7 @@ async function handleCreate(argv: Partial<Record<string, unknown>>, prompter: In
 }
 async function handleUpdate(argv: Partial<Record<string, unknown>>, prompter: Inquirerer) {
   try {
-    const answers = await prompter.prompt(argv, [{
+    const rawAnswers = await prompter.prompt(argv, [{
       type: "text",
       name: "id",
       message: "id",
@@ -3867,11 +3922,15 @@ async function handleUpdate(argv: Partial<Record<string, unknown>>, prompter: In
       message: "role",
       required: false
     }]);
+    const answers = coerceAnswers(rawAnswers, fieldSchema);
+    const cleanedData = stripUndefined(answers, fieldSchema);
     const client = getClient("members");
     const result = await client.member.update({
-      id: answers.id,
+      where: {
+        id: answers.id as string
+      },
       data: {
-        role: answers.role
+        role: cleanedData.role
       },
       select: {
         id: true,
@@ -3889,15 +3948,18 @@ async function handleUpdate(argv: Partial<Record<string, unknown>>, prompter: In
 }
 async function handleDelete(argv: Partial<Record<string, unknown>>, prompter: Inquirerer) {
   try {
-    const answers = await prompter.prompt(argv, [{
+    const rawAnswers = await prompter.prompt(argv, [{
       type: "text",
       name: "id",
       message: "id",
       required: true
     }]);
+    const answers = coerceAnswers(rawAnswers, fieldSchema);
     const client = getClient("members");
     const result = await client.member.delete({
-      id: answers.id,
+      where: {
+        id: answers.id as string
+      },
       select: {
         id: true
       }
@@ -3921,6 +3983,15 @@ exports[`multi-target cli generator generates target-prefixed table commands 3`]
  */
 import { CLIOptions, Inquirerer, extractFirst } from "inquirerer";
 import { getClient } from "../../executor";
+import { coerceAnswers, stripUndefined } from "../../utils";
+const fieldSchema = {
+  id: "uuid",
+  make: "string",
+  model: "string",
+  year: "int",
+  isElectric: "boolean",
+  createdAt: "string"
+};
 const usage = "\\ncar <command>\\n\\nCommands:\\n  list                  List all car records\\n  get                   Get a car by ID\\n  create                Create a new car\\n  update                Update an existing car\\n  delete                Delete a car\\n\\n  --help, -h            Show this help message\\n";
 export default async (argv: Partial<Record<string, unknown>>, prompter: Inquirerer, _options: CLIOptions) => {
   if (argv.help || argv.h) {
@@ -4012,7 +4083,7 @@ async function handleGet(argv: Partial<Record<string, unknown>>, prompter: Inqui
 }
 async function handleCreate(argv: Partial<Record<string, unknown>>, prompter: Inquirerer) {
   try {
-    const answers = await prompter.prompt(argv, [{
+    const rawAnswers = await prompter.prompt(argv, [{
       type: "text",
       name: "make",
       message: "make",
@@ -4033,13 +4104,15 @@ async function handleCreate(argv: Partial<Record<string, unknown>>, prompter: In
       message: "isElectric",
       required: true
     }]);
+    const answers = coerceAnswers(rawAnswers, fieldSchema);
+    const cleanedData = stripUndefined(answers, fieldSchema);
     const client = getClient("app");
     const result = await client.car.create({
       data: {
-        make: answers.make,
-        model: answers.model,
-        year: answers.year,
-        isElectric: answers.isElectric
+        make: cleanedData.make,
+        model: cleanedData.model,
+        year: cleanedData.year,
+        isElectric: cleanedData.isElectric
       },
       select: {
         id: true,
@@ -4061,7 +4134,7 @@ async function handleCreate(argv: Partial<Record<string, unknown>>, prompter: In
 }
 async function handleUpdate(argv: Partial<Record<string, unknown>>, prompter: Inquirerer) {
   try {
-    const answers = await prompter.prompt(argv, [{
+    const rawAnswers = await prompter.prompt(argv, [{
       type: "text",
       name: "id",
       message: "id",
@@ -4087,14 +4160,18 @@ async function handleUpdate(argv: Partial<Record<string, unknown>>, prompter: In
       message: "isElectric",
       required: false
     }]);
+    const answers = coerceAnswers(rawAnswers, fieldSchema);
+    const cleanedData = stripUndefined(answers, fieldSchema);
     const client = getClient("app");
     const result = await client.car.update({
-      id: answers.id,
+      where: {
+        id: answers.id as string
+      },
       data: {
-        make: answers.make,
-        model: answers.model,
-        year: answers.year,
-        isElectric: answers.isElectric
+        make: cleanedData.make,
+        model: cleanedData.model,
+        year: cleanedData.year,
+        isElectric: cleanedData.isElectric
       },
       select: {
         id: true,
@@ -4116,15 +4193,18 @@ async function handleUpdate(argv: Partial<Record<string, unknown>>, prompter: In
 }
 async function handleDelete(argv: Partial<Record<string, unknown>>, prompter: Inquirerer) {
   try {
-    const answers = await prompter.prompt(argv, [{
+    const rawAnswers = await prompter.prompt(argv, [{
       type: "text",
       name: "id",
       message: "id",
       required: true
     }]);
+    const answers = coerceAnswers(rawAnswers, fieldSchema);
     const client = getClient("app");
     const result = await client.car.delete({
-      id: answers.id,
+      where: {
+        id: answers.id as string
+      },
       select: {
         id: true
       }

--- a/graphql/codegen/src/__tests__/codegen/cli-generator.test.ts
+++ b/graphql/codegen/src/__tests__/codegen/cli-generator.test.ts
@@ -157,8 +157,8 @@ describe('cli-generator', () => {
       tables: 2,
       customQueries: 1,
       customMutations: 1,
-      infraFiles: 3,
-      totalFiles: 8,
+      infraFiles: 4,
+      totalFiles: 9,
     });
   });
 
@@ -254,6 +254,7 @@ describe('cli-generator', () => {
       'commands/driver.ts',
       'commands/login.ts',
       'executor.ts',
+      'utils.ts',
     ]);
   });
 });
@@ -537,8 +538,8 @@ describe('multi-target cli generator', () => {
       tables: 3,
       customQueries: 1,
       customMutations: 1,
-      infraFiles: 3,
-      totalFiles: 9,
+      infraFiles: 4,
+      totalFiles: 10,
     });
   });
 
@@ -560,6 +561,7 @@ describe('multi-target cli generator', () => {
       'commands/credentials.ts',
       'commands/members/member.ts',
       'executor.ts',
+      'utils.ts',
     ]);
   });
 

--- a/graphql/codegen/src/core/codegen/cli/index.ts
+++ b/graphql/codegen/src/core/codegen/cli/index.ts
@@ -11,6 +11,7 @@ import {
   generateMultiTargetContextCommand,
 } from './infra-generator';
 import { generateTableCommand } from './table-command-generator';
+import { generateUtilsFile } from './utils-generator';
 
 export interface GenerateCliOptions {
   tables: CleanTable[];
@@ -44,6 +45,9 @@ export function generateCli(options: GenerateCliOptions): GenerateCliResult {
 
   const executorFile = generateExecutorFile(toolName);
   files.push(executorFile);
+
+  const utilsFile = generateUtilsFile();
+  files.push(utilsFile);
 
   const contextFile = generateContextCommand(toolName);
   files.push(contextFile);
@@ -79,7 +83,7 @@ export function generateCli(options: GenerateCliOptions): GenerateCliResult {
       tables: tables.length,
       customQueries: customOperations?.queries.length ?? 0,
       customMutations: customOperations?.mutations.length ?? 0,
-      infraFiles: 3,
+      infraFiles: 4,
       totalFiles: files.length,
     },
   };
@@ -136,6 +140,9 @@ export function generateMultiTargetCli(
   }));
   const executorFile = generateMultiTargetExecutorFile(toolName, executorInputs);
   files.push(executorFile);
+
+  const utilsFile = generateUtilsFile();
+  files.push(utilsFile);
 
   const contextFile = generateMultiTargetContextCommand(
     toolName,
@@ -205,7 +212,7 @@ export function generateMultiTargetCli(
       tables: totalTables,
       customQueries: totalQueries,
       customMutations: totalMutations,
-      infraFiles: 3,
+      infraFiles: 4,
       totalFiles: files.length,
     },
   };
@@ -234,4 +241,5 @@ export {
 export type { MultiTargetDocsInput } from './docs-generator';
 export { resolveDocsConfig } from '../docs-utils';
 export type { GeneratedDocFile, McpTool } from '../docs-utils';
+export { generateUtilsFile } from './utils-generator';
 export type { GeneratedFile, MultiTargetExecutorInput } from './executor-generator';

--- a/graphql/codegen/src/core/codegen/cli/infra-generator.ts
+++ b/graphql/codegen/src/core/codegen/cli/infra-generator.ts
@@ -1645,10 +1645,7 @@ function buildSetTokenHandler(): t.FunctionDeclaration {
               t.callExpression(
                 t.memberExpression(
                   t.callExpression(
-                    t.memberExpression(
-                      t.identifier('String'),
-                      t.identifier('call'),
-                    ),
+                    t.identifier('String'),
                     [
                       t.logicalExpression(
                         '||',

--- a/graphql/codegen/src/core/codegen/cli/utils-generator.ts
+++ b/graphql/codegen/src/core/codegen/cli/utils-generator.ts
@@ -1,0 +1,146 @@
+import { getGeneratedFileHeader } from '../utils';
+import type { GeneratedFile } from './executor-generator';
+
+/**
+ * Generate a utils.ts file with runtime helpers for CLI commands.
+ * Includes type coercion (string CLI args -> proper GraphQL types),
+ * field filtering (strip extra minimist fields like _ and tty),
+ * and mutation input parsing.
+ */
+export function generateUtilsFile(): GeneratedFile {
+  const header = getGeneratedFileHeader(
+    'CLI utility functions for type coercion and input handling',
+  );
+
+  const code = `
+export type FieldType = 'string' | 'boolean' | 'int' | 'float' | 'json' | 'uuid' | 'enum';
+
+export interface FieldSchema {
+  [fieldName: string]: FieldType;
+}
+
+/**
+ * Coerce CLI string arguments to their proper GraphQL types based on a field schema.
+ * CLI args always arrive as strings from minimist, but GraphQL expects
+ * Boolean, Int, Float, JSON, etc.
+ */
+export function coerceAnswers(
+  answers: Record<string, unknown>,
+  schema: FieldSchema,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...answers };
+
+  for (const [key, value] of Object.entries(result)) {
+    const fieldType = schema[key];
+    if (!fieldType || value === undefined || value === null) continue;
+
+    const strValue = String(value);
+
+    // Empty strings become undefined for non-string types
+    if (strValue === '' && fieldType !== 'string') {
+      result[key] = undefined;
+      continue;
+    }
+
+    switch (fieldType) {
+      case 'boolean':
+        if (typeof value === 'boolean') break;
+        result[key] = strValue === 'true' || strValue === '1' || strValue === 'yes';
+        break;
+      case 'int':
+        if (typeof value === 'number') break;
+        {
+          const parsed = parseInt(strValue, 10);
+          result[key] = isNaN(parsed) ? undefined : parsed;
+        }
+        break;
+      case 'float':
+        if (typeof value === 'number') break;
+        {
+          const parsed = parseFloat(strValue);
+          result[key] = isNaN(parsed) ? undefined : parsed;
+        }
+        break;
+      case 'json':
+        if (typeof value === 'object') break;
+        if (strValue === '') {
+          result[key] = undefined;
+        } else {
+          try {
+            result[key] = JSON.parse(strValue);
+          } catch {
+            result[key] = undefined;
+          }
+        }
+        break;
+      case 'uuid':
+        // Empty UUIDs become undefined
+        if (strValue === '') {
+          result[key] = undefined;
+        }
+        break;
+      case 'enum':
+        // Enums stay as strings but empty ones become undefined
+        if (strValue === '') {
+          result[key] = undefined;
+        }
+        break;
+      default:
+        // String type: empty strings also become undefined to avoid
+        // sending empty strings for optional fields
+        if (strValue === '') {
+          result[key] = undefined;
+        }
+        break;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Strip undefined values and filter to only schema-defined keys.
+ * This removes extra fields injected by minimist (like _, tty, etc.)
+ * and any fields that were coerced to undefined.
+ */
+export function stripUndefined(
+  obj: Record<string, unknown>,
+  schema?: FieldSchema,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  const allowedKeys = schema ? new Set(Object.keys(schema)) : null;
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined) continue;
+    if (allowedKeys && !allowedKeys.has(key)) continue;
+    result[key] = value;
+  }
+
+  return result;
+}
+
+/**
+ * Parse mutation input from CLI.
+ * Custom mutation commands receive an \`input\` field as a JSON string
+ * from the CLI prompt. This parses it into a proper object.
+ */
+export function parseMutationInput(
+  answers: Record<string, unknown>,
+): Record<string, unknown> {
+  if (typeof answers.input === 'string') {
+    try {
+      const parsed = JSON.parse(answers.input);
+      return { ...answers, input: parsed };
+    } catch {
+      return answers;
+    }
+  }
+  return answers;
+}
+`;
+
+  return {
+    fileName: 'utils.ts',
+    content: header + '\n' + code,
+  };
+}

--- a/graphql/codegen/src/core/codegen/cli/utils-generator.ts
+++ b/graphql/codegen/src/core/codegen/cli/utils-generator.ts
@@ -1,146 +1,61 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
 import { getGeneratedFileHeader } from '../utils';
 import type { GeneratedFile } from './executor-generator';
 
 /**
+ * Find the cli-utils template file path.
+ * Templates are at ../templates/ relative to this file in both src/ and dist/.
+ */
+function findTemplateFile(templateName: string): string {
+  const templatePath = path.join(__dirname, '../templates', templateName);
+
+  if (fs.existsSync(templatePath)) {
+    return templatePath;
+  }
+
+  throw new Error(
+    `Could not find template file: ${templateName}. ` +
+      `Searched in: ${templatePath}`,
+  );
+}
+
+/**
+ * Read a template file and replace the header with generated file header.
+ * Follows the same pattern as ORM client-generator.ts readTemplateFile().
+ */
+function readTemplateFile(templateName: string, description: string): string {
+  const templatePath = findTemplateFile(templateName);
+  let content = fs.readFileSync(templatePath, 'utf-8');
+
+  // Replace the source file header comment with the generated file header
+  // Match the header pattern used in template files
+  const headerPattern =
+    /\/\*\*[\s\S]*?\* NOTE: This file is read at codegen time and written to output\.[\s\S]*?\*\/\n*/;
+
+  content = content.replace(
+    headerPattern,
+    getGeneratedFileHeader(description) + '\n',
+  );
+
+  return content;
+}
+
+/**
  * Generate a utils.ts file with runtime helpers for CLI commands.
+ * Reads from the templates directory (cli-utils.ts) for proper type checking.
+ *
  * Includes type coercion (string CLI args -> proper GraphQL types),
  * field filtering (strip extra minimist fields like _ and tty),
  * and mutation input parsing.
  */
 export function generateUtilsFile(): GeneratedFile {
-  const header = getGeneratedFileHeader(
-    'CLI utility functions for type coercion and input handling',
-  );
-
-  const code = `
-export type FieldType = 'string' | 'boolean' | 'int' | 'float' | 'json' | 'uuid' | 'enum';
-
-export interface FieldSchema {
-  [fieldName: string]: FieldType;
-}
-
-/**
- * Coerce CLI string arguments to their proper GraphQL types based on a field schema.
- * CLI args always arrive as strings from minimist, but GraphQL expects
- * Boolean, Int, Float, JSON, etc.
- */
-export function coerceAnswers(
-  answers: Record<string, unknown>,
-  schema: FieldSchema,
-): Record<string, unknown> {
-  const result: Record<string, unknown> = { ...answers };
-
-  for (const [key, value] of Object.entries(result)) {
-    const fieldType = schema[key];
-    if (!fieldType || value === undefined || value === null) continue;
-
-    const strValue = String(value);
-
-    // Empty strings become undefined for non-string types
-    if (strValue === '' && fieldType !== 'string') {
-      result[key] = undefined;
-      continue;
-    }
-
-    switch (fieldType) {
-      case 'boolean':
-        if (typeof value === 'boolean') break;
-        result[key] = strValue === 'true' || strValue === '1' || strValue === 'yes';
-        break;
-      case 'int':
-        if (typeof value === 'number') break;
-        {
-          const parsed = parseInt(strValue, 10);
-          result[key] = isNaN(parsed) ? undefined : parsed;
-        }
-        break;
-      case 'float':
-        if (typeof value === 'number') break;
-        {
-          const parsed = parseFloat(strValue);
-          result[key] = isNaN(parsed) ? undefined : parsed;
-        }
-        break;
-      case 'json':
-        if (typeof value === 'object') break;
-        if (strValue === '') {
-          result[key] = undefined;
-        } else {
-          try {
-            result[key] = JSON.parse(strValue);
-          } catch {
-            result[key] = undefined;
-          }
-        }
-        break;
-      case 'uuid':
-        // Empty UUIDs become undefined
-        if (strValue === '') {
-          result[key] = undefined;
-        }
-        break;
-      case 'enum':
-        // Enums stay as strings but empty ones become undefined
-        if (strValue === '') {
-          result[key] = undefined;
-        }
-        break;
-      default:
-        // String type: empty strings also become undefined to avoid
-        // sending empty strings for optional fields
-        if (strValue === '') {
-          result[key] = undefined;
-        }
-        break;
-    }
-  }
-
-  return result;
-}
-
-/**
- * Strip undefined values and filter to only schema-defined keys.
- * This removes extra fields injected by minimist (like _, tty, etc.)
- * and any fields that were coerced to undefined.
- */
-export function stripUndefined(
-  obj: Record<string, unknown>,
-  schema?: FieldSchema,
-): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-  const allowedKeys = schema ? new Set(Object.keys(schema)) : null;
-
-  for (const [key, value] of Object.entries(obj)) {
-    if (value === undefined) continue;
-    if (allowedKeys && !allowedKeys.has(key)) continue;
-    result[key] = value;
-  }
-
-  return result;
-}
-
-/**
- * Parse mutation input from CLI.
- * Custom mutation commands receive an \`input\` field as a JSON string
- * from the CLI prompt. This parses it into a proper object.
- */
-export function parseMutationInput(
-  answers: Record<string, unknown>,
-): Record<string, unknown> {
-  if (typeof answers.input === 'string') {
-    try {
-      const parsed = JSON.parse(answers.input);
-      return { ...answers, input: parsed };
-    } catch {
-      return answers;
-    }
-  }
-  return answers;
-}
-`;
-
   return {
     fileName: 'utils.ts',
-    content: header + '\n' + code,
+    content: readTemplateFile(
+      'cli-utils.ts',
+      'CLI utility functions for type coercion and input handling',
+    ),
   };
 }

--- a/graphql/codegen/src/core/codegen/templates/cli-utils.ts
+++ b/graphql/codegen/src/core/codegen/templates/cli-utils.ts
@@ -1,0 +1,144 @@
+/**
+ * CLI utility functions for type coercion and input handling
+ *
+ * This is the RUNTIME code that gets copied to generated output.
+ * Provides helpers for CLI commands: type coercion (string CLI args -> proper
+ * GraphQL types), field filtering (strip extra minimist fields), and
+ * mutation input parsing.
+ *
+ * NOTE: This file is read at codegen time and written to output.
+ * Any changes here will affect all generated CLI utils.
+ */
+
+export type FieldType =
+  | 'string'
+  | 'boolean'
+  | 'int'
+  | 'float'
+  | 'json'
+  | 'uuid'
+  | 'enum';
+
+export interface FieldSchema {
+  [fieldName: string]: FieldType;
+}
+
+/**
+ * Coerce CLI string arguments to their proper GraphQL types based on a field schema.
+ * CLI args always arrive as strings from minimist, but GraphQL expects
+ * Boolean, Int, Float, JSON, etc.
+ */
+export function coerceAnswers(
+  answers: Record<string, unknown>,
+  schema: FieldSchema,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...answers };
+
+  for (const [key, value] of Object.entries(result)) {
+    const fieldType = schema[key];
+    if (!fieldType || value === undefined || value === null) continue;
+
+    const strValue = String(value);
+
+    // Empty strings become undefined for non-string types
+    if (strValue === '' && fieldType !== 'string') {
+      result[key] = undefined;
+      continue;
+    }
+
+    switch (fieldType) {
+      case 'boolean':
+        if (typeof value === 'boolean') break;
+        result[key] =
+          strValue === 'true' || strValue === '1' || strValue === 'yes';
+        break;
+      case 'int':
+        if (typeof value === 'number') break;
+        {
+          const parsed = parseInt(strValue, 10);
+          result[key] = isNaN(parsed) ? undefined : parsed;
+        }
+        break;
+      case 'float':
+        if (typeof value === 'number') break;
+        {
+          const parsed = parseFloat(strValue);
+          result[key] = isNaN(parsed) ? undefined : parsed;
+        }
+        break;
+      case 'json':
+        if (typeof value === 'object') break;
+        if (strValue === '') {
+          result[key] = undefined;
+        } else {
+          try {
+            result[key] = JSON.parse(strValue);
+          } catch {
+            result[key] = undefined;
+          }
+        }
+        break;
+      case 'uuid':
+        // Empty UUIDs become undefined
+        if (strValue === '') {
+          result[key] = undefined;
+        }
+        break;
+      case 'enum':
+        // Enums stay as strings but empty ones become undefined
+        if (strValue === '') {
+          result[key] = undefined;
+        }
+        break;
+      default:
+        // String type: empty strings also become undefined to avoid
+        // sending empty strings for optional fields
+        if (strValue === '') {
+          result[key] = undefined;
+        }
+        break;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Strip undefined values and filter to only schema-defined keys.
+ * This removes extra fields injected by minimist (like _, tty, etc.)
+ * and any fields that were coerced to undefined.
+ */
+export function stripUndefined(
+  obj: Record<string, unknown>,
+  schema?: FieldSchema,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  const allowedKeys = schema ? new Set(Object.keys(schema)) : null;
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === undefined) continue;
+    if (allowedKeys && !allowedKeys.has(key)) continue;
+    result[key] = value;
+  }
+
+  return result;
+}
+
+/**
+ * Parse mutation input from CLI.
+ * Custom mutation commands receive an `input` field as a JSON string
+ * from the CLI prompt. This parses it into a proper object.
+ */
+export function parseMutationInput(
+  answers: Record<string, unknown>,
+): Record<string, unknown> {
+  if (typeof answers.input === 'string') {
+    try {
+      const parsed = JSON.parse(answers.input);
+      return { ...answers, input: parsed };
+    } catch {
+      return answers;
+    }
+  }
+  return answers;
+}


### PR DESCRIPTION
# fix(codegen): fix CLI codegen bugs + refactor utils to template-copy pattern

## Summary

Upstreams five bugs discovered during end-to-end CLI testing in [constructive-db#509](https://github.com/constructive-io/constructive-db/pull/509) into the codegen AST templates so future CLI generation produces correct code out of the box.

| Bug | File | Fix |
|---|---|---|
| `String.call(val)` returns `undefined` — tokens never stored | `infra-generator.ts` | `String.call(val)` → `String(val)` |
| `update()`/`delete()` called with `{ id }` instead of `{ where: { id } }` | `table-command-generator.ts` | Wrap PK in `where` object |
| CLI args are always strings but GraphQL expects Boolean/Int/JSON/etc | `table-command-generator.ts` + new `utils-generator.ts` | Generate per-table `fieldSchema`, pipe through `coerceAnswers()` |
| Extra minimist fields (`_`, `tty`) leak into mutation data | `table-command-generator.ts` + new `utils-generator.ts` | `stripUndefined()` filters to schema-defined keys only |
| Create mutations used raw `answers` instead of cleaned data | `table-command-generator.ts` | Use `cleanedData` (post-coercion, post-filtering) for data props |


**Key changes:**
- **infra-generator.ts**: Fixed `String.call()` → `String()` in `buildSetTokenHandler` (line 1648)
- **table-command-generator.ts**: 
  - Added `buildFieldSchemaObject()` to generate runtime type schemas from table fields
  - Fixed update/delete to use `{ where: { id } }` ORM signature
  - Added type coercion pipeline: `rawAnswers` → `coerceAnswers()` → `answers` → `stripUndefined()` → `cleanedData`
  - Import `coerceAnswers`, `stripUndefined` from `../utils` or `../../utils` (target-aware)
- **templates/cli-utils.ts** (NEW): Real TypeScript file with `coerceAnswers()`, `stripUndefined()`, `parseMutationInput()` runtime helpers — type-checked at build time, consistent with the existing ORM template-copy pattern (`templates/orm-client.ts`, `templates/query-builder.ts`, etc.)
- **utils-generator.ts** (REFACTORED): Now uses `readTemplateFile('cli-utils.ts')` instead of embedding code as a string template. Follows the same `findTemplateFile` / `readTemplateFile` / header-replacement pattern as `orm/client-generator.ts`.
- **index.ts**: Wired `generateUtilsFile()` into both single-target and multi-target CLI generation
- **Tests**: Updated file count expectations and snapshots (301/301 tests pass)

## Review & Testing Checklist for Human

- [ ] **Verify ORM signature**: Confirm that `client.table.update({ where: { id }, data })` and `client.table.delete({ where: { id } })` match the actual ORM API. This was tested in constructive-db but worth double-checking the ORM source.
- [ ] **Review `parseMutationInput` dead code**: The generated `utils.ts` includes `parseMutationInput()` but it's never imported by generated table commands. It was used in hand-patched custom mutation commands in constructive-db. Should we wire it up for custom mutations in the codegen, or remove it?
- [ ] **Review `as string` type assertion**: Update/delete handlers cast `answers.id as string` in the generated code. This assumes `id` is always a string after coercion (true for UUID type). Is this safe or should we use runtime validation?
- [ ] **Test empty string behavior**: `coerceAnswers()` converts empty strings to `undefined` for ALL types including strings. This prevents sending `""` for optional fields, but means you can never intentionally set a string field to empty. Is this the desired behavior?
- [ ] **Regenerate constructive-db CLI**: Run the codegen on constructive-db schema and verify the generated output matches the manually patched code from PR #509. This confirms the codegen produces correct output end-to-end.

### Notes

- All 301 unit tests pass with updated snapshots
- Build passes, templates are copied to dist/ via `copy:templates` script
- The template-copy refactor provides type checking, IDE support, and testability for the utils code (was just a string before)
- Lint check failed due to pre-existing ESLint 9 migration issue (unrelated to this PR)

---

**Link to Devin run**: https://app.devin.ai/sessions/d41228699b3a46de9e73cc13dda02882  
**Requested by**: @pyramation