### PR TITLE
fix(codegen): add select param and JSON input parsing to custom command generator

### DIFF
--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/cli-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/cli-generator.test.ts.snap
@@ -1151,7 +1151,9 @@ export default async (argv: Partial<Record<string, unknown>>, prompter: Inquirer
       process.exit(0);
     }
     const client = getClient();
-    const result = await client.query.currentUser({}).execute();
+    const result = await client.query.currentUser({}, {
+      select: {}
+    }).execute();
     console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     console.error("Failed: currentUser");
@@ -1395,7 +1397,11 @@ export default async (argv: Partial<Record<string, unknown>>, prompter: Inquirer
       required: true
     }]);
     const client = getClient();
-    const result = await client.mutation.login(answers).execute();
+    const result = await client.mutation.login(answers, {
+      select: {
+        clientMutationId: true
+      }
+    }).execute();
     console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     console.error("Failed: login");
@@ -3555,7 +3561,11 @@ export default async (argv: Partial<Record<string, unknown>>, prompter: Inquirer
       required: true
     }]);
     const client = getClient("auth");
-    const result = await client.mutation.login(answers).execute();
+    const result = await client.mutation.login(answers, {
+      select: {
+        clientMutationId: true
+      }
+    }).execute();
     if (argv.saveToken && result) {
       const tokenValue = result.token || result.jwtToken || result.accessToken;
       if (tokenValue) {

--- a/graphql/codegen/src/core/codegen/cli/custom-command-generator.ts
+++ b/graphql/codegen/src/core/codegen/cli/custom-command-generator.ts
@@ -3,7 +3,7 @@ import { toKebabCase } from 'komoji';
 
 import { generateCode } from '../babel-ast';
 import { getGeneratedFileHeader } from '../utils';
-import type { CleanOperation } from '../../../types/schema';
+import type { CleanOperation, CleanTypeRef } from '../../../types/schema';
 import type { GeneratedFile } from './executor-generator';
 import { buildQuestionsArray } from './arg-mapper';
 
@@ -100,10 +100,50 @@ function buildErrorCatch(errorMessage: string): t.CatchClause {
   );
 }
 
+/**
+ * Unwrap NON_NULL / LIST wrappers to get the underlying named type.
+ */
+function unwrapType(ref: CleanTypeRef): CleanTypeRef {
+  if ((ref.kind === 'NON_NULL' || ref.kind === 'LIST') && ref.ofType) {
+    return unwrapType(ref.ofType);
+  }
+  return ref;
+}
+
+/**
+ * Build a select object expression from return-type fields.
+ * If the return type has known fields, generates { field1: true, field2: true, ... }.
+ * Falls back to { clientMutationId: true } for mutations without known fields.
+ */
+function buildSelectObject(
+  returnType: CleanTypeRef,
+  isMutation: boolean,
+): t.ObjectExpression {
+  const base = unwrapType(returnType);
+  if (base.fields && base.fields.length > 0) {
+    return t.objectExpression(
+      base.fields.map((f) =>
+        t.objectProperty(t.identifier(f.name), t.booleanLiteral(true)),
+      ),
+    );
+  }
+  // Fallback: all PostGraphile mutation payloads have clientMutationId
+  if (isMutation) {
+    return t.objectExpression([
+      t.objectProperty(
+        t.identifier('clientMutationId'),
+        t.booleanLiteral(true),
+      ),
+    ]);
+  }
+  return t.objectExpression([]);
+}
+
 function buildOrmCustomCall(
   opKind: 'query' | 'mutation',
   opName: string,
   argsExpr: t.Expression,
+  selectExpr: t.ObjectExpression,
 ): t.Expression {
   return t.callExpression(
     t.memberExpression(
@@ -115,7 +155,12 @@ function buildOrmCustomCall(
           ),
           t.identifier(opName),
         ),
-        [argsExpr],
+        [
+          argsExpr,
+          t.objectExpression([
+            t.objectProperty(t.identifier('select'), selectExpr),
+          ]),
+        ],
       ),
       t.identifier('execute'),
     ),
@@ -139,12 +184,28 @@ export function generateCustomCommand(op: CleanOperation, options?: CustomComman
     imports.push('getStore');
   }
 
+  // Check if any argument is an INPUT_OBJECT (i.e. takes JSON input like { input: SomeInput })
+  const hasInputObjectArg = op.args.some((arg) => {
+    const base = unwrapType(arg.type);
+    return base.kind === 'INPUT_OBJECT';
+  });
+
+  const utilsPath = options?.executorImportPath
+    ? options.executorImportPath.replace(/\/executor$/, '/utils')
+    : '../utils';
+
   statements.push(
     createImportDeclaration('inquirerer', ['CLIOptions', 'Inquirerer']),
   );
   statements.push(
     createImportDeclaration(executorPath, imports),
   );
+
+  if (hasInputObjectArg) {
+    statements.push(
+      createImportDeclaration(utilsPath, ['parseMutationInput']),
+    );
+  }
 
   const questionsArray =
     op.args.length > 0
@@ -224,17 +285,36 @@ export function generateCustomCommand(op: CleanOperation, options?: CustomComman
     ]),
   );
 
+  // For mutations with INPUT_OBJECT args (like `input: SignUpInput`),
+  // parse JSON strings from CLI into proper objects
+  if (hasInputObjectArg && op.args.length > 0) {
+    bodyStatements.push(
+      t.variableDeclaration('const', [
+        t.variableDeclarator(
+          t.identifier('parsedAnswers'),
+          t.callExpression(t.identifier('parseMutationInput'), [
+            t.identifier('answers'),
+          ]),
+        ),
+      ]),
+    );
+  }
+
   const argsExpr =
     op.args.length > 0
-      ? t.identifier('answers')
+      ? (hasInputObjectArg
+          ? t.identifier('parsedAnswers')
+          : t.identifier('answers'))
       : t.objectExpression([]);
+
+  const selectExpr = buildSelectObject(op.returnType, op.kind === 'mutation');
 
   bodyStatements.push(
     t.variableDeclaration('const', [
       t.variableDeclarator(
         t.identifier('result'),
         t.awaitExpression(
-          buildOrmCustomCall(opKind, op.name, argsExpr),
+          buildOrmCustomCall(opKind, op.name, argsExpr, selectExpr),
         ),
       ),
     ]),


### PR DESCRIPTION
# fix(codegen): add select param and JSON input parsing to custom command generator

## Summary

Generated CLI commands for custom mutations/queries (e.g. `signUp`, `login`, `currentUser`) were crashing at runtime with `Cannot read properties of undefined (reading 'select')` because the ORM functions require `(args, { select: {...} })` but the codegen only passed a single `args` argument.

This adds three things to `custom-command-generator.ts`:

1. **`select` parameter** — All ORM calls now receive `{ select: {...} }` as the second argument, built from the operation's return type fields when available, falling back to `{ clientMutationId: true }` for mutations or `{}` for queries.
2. **JSON input parsing** — Mutations with `INPUT_OBJECT` args (like `input: SignUpInput`) now import and call `parseMutationInput()` from utils to parse JSON string CLI input into proper objects.
3. **`unwrapType` helper** — Recursively unwraps `NON_NULL`/`LIST` wrappers to inspect the underlying type kind.

Table CRUD commands (already fixed in #733) are unaffected — this only changes the custom operation command generator.

## Review & Testing Checklist for Human

- [ ] **Verify `select: {}` is valid for query operations** — When `returnType.fields` is not populated (common case in test fixtures), queries get an empty select `{}`. Confirm the ORM/QueryBuilder handles this correctly and doesn't produce an invalid empty GraphQL selection set. This is the highest-risk part of the change since the unit tests don't exercise this with a real schema that populates return type fields.
- [ ] **Test the `parseMutationInput` path end-to-end** — The unit tests only cover mutations with SCALAR args (email/password), not INPUT_OBJECT args. The `hasInputObjectArg` detection, conditional `parseMutationInput` import, and `parsedAnswers` variable path are not exercised by existing codegen tests. Recommend testing with a real schema that has `input: SomeInput` style mutations (like `signUp` in constructive-db via [#510](https://github.com/constructive-io/constructive-db/pull/510)).
- [ ] **Verify `utilsPath` derivation** — The import path for `parseMutationInput` is derived via `executorImportPath.replace(/\/executor$/, '/utils')`. Confirm this produces correct paths for both single-target (`../utils`) and multi-target (`../../utils`) layouts.
- [ ] **Verify `returnType.fields` population in real codegen** — The test fixtures use `createTypeRef('OBJECT', 'LoginPayload')` with no `fields`, so the `buildSelectObject` fallback paths are always taken in tests. Check whether the real introspection pipeline populates `fields` on custom operation return types, or if the fallbacks (`clientMutationId` / empty `{}`) are always what gets generated in practice.

### Notes

- 301/301 codegen tests pass, 3 snapshots updated
- 42/42 CI checks green
- The companion PR to test this end-to-end in constructive-db is [constructive-db#510](https://github.com/constructive-io/constructive-db/pull/510) (20/20 CI green)
- [Link to Devin run](https://app.devin.ai/sessions/d41228699b3a46de9e73cc13dda02882)
- Requested by @pyramation