### PR TITLE
feat(codegen): add CLI entry point generation option (cli.entryPoint)

### DIFF
--- a/graphql/codegen/src/core/codegen/cli/index.ts
+++ b/graphql/codegen/src/core/codegen/cli/index.ts
@@ -11,7 +11,7 @@ import {
   generateMultiTargetContextCommand,
 } from './infra-generator';
 import { generateTableCommand } from './table-command-generator';
-import { generateUtilsFile, generateNodeFetchFile } from './utils-generator';
+import { generateUtilsFile, generateNodeFetchFile, generateEntryPointFile } from './utils-generator';
 
 export interface GenerateCliOptions {
   tables: CleanTable[];
@@ -91,6 +91,13 @@ export function generateCli(options: GenerateCliOptions): GenerateCliResult {
   );
   files.push(commandMapFile);
 
+  // Generate entry point if configured
+  const generateEntryPoint =
+    typeof cliConfig === 'object' && !!cliConfig.entryPoint;
+  if (generateEntryPoint) {
+    files.push(generateEntryPointFile());
+  }
+
   return {
     files,
     stats: {
@@ -123,6 +130,8 @@ export interface GenerateMultiTargetCliOptions {
   targets: MultiTargetCliTarget[];
   /** Enable NodeHttpAdapter for *.localhost subdomain routing */
   nodeHttpAdapter?: boolean;
+  /** Generate a runnable index.ts entry point */
+  entryPoint?: boolean;
 }
 
 export function resolveBuiltinNames(
@@ -232,6 +241,11 @@ export function generateMultiTargetCli(
   });
   files.push(commandMapFile);
 
+  // Generate entry point if configured
+  if (options.entryPoint) {
+    files.push(generateEntryPointFile());
+  }
+
   return {
     files,
     stats: {
@@ -267,5 +281,5 @@ export {
 export type { MultiTargetDocsInput } from './docs-generator';
 export { resolveDocsConfig } from '../docs-utils';
 export type { GeneratedDocFile, McpTool } from '../docs-utils';
-export { generateUtilsFile } from './utils-generator';
+export { generateUtilsFile, generateEntryPointFile } from './utils-generator';
 export type { GeneratedFile, MultiTargetExecutorInput } from './executor-generator';

--- a/graphql/codegen/src/core/codegen/cli/utils-generator.ts
+++ b/graphql/codegen/src/core/codegen/cli/utils-generator.ts
@@ -76,3 +76,21 @@ export function generateNodeFetchFile(): GeneratedFile {
     ),
   };
 }
+
+/**
+ * Generate an index.ts entry point file for the CLI.
+ *
+ * Creates a runnable entry point that imports the command map,
+ * handles --version and --tty flags, and starts the CLI.
+ * This is off by default (cliEntryPoint: false) since many projects
+ * provide their own entry point with custom configuration.
+ */
+export function generateEntryPointFile(): GeneratedFile {
+  return {
+    fileName: 'index.ts',
+    content: readTemplateFile(
+      'cli-entry.ts',
+      'CLI entry point',
+    ),
+  };
+}

--- a/graphql/codegen/src/core/codegen/templates/cli-entry.ts
+++ b/graphql/codegen/src/core/codegen/templates/cli-entry.ts
@@ -1,0 +1,32 @@
+/**
+ * CLI entry point for running the generated CLI application.
+ *
+ * Creates an inquirerer CLI instance with the generated command map,
+ * handles --version and --tty flags, and runs the CLI.
+ *
+ * NOTE: This file is read at codegen time and written to output.
+ * Any changes here will affect all generated CLI entry points.
+ */
+
+import { CLI, CLIOptions } from 'inquirerer';
+import { commands } from './commands';
+
+if (process.argv.includes('--version') || process.argv.includes('-v')) {
+  console.log('0.0.1');
+  process.exit(0);
+}
+
+// Check for --tty false to enable non-interactive mode (noTty)
+const ttyIdx = process.argv.indexOf('--tty');
+const noTty = ttyIdx !== -1 && process.argv[ttyIdx + 1] === 'false';
+
+const options: Partial<CLIOptions> = {
+  noTty,
+  minimistOpts: { alias: { v: 'version', h: 'help' } },
+};
+
+const app = new CLI(commands, options);
+app.run().catch((e) => {
+  console.error('Unexpected error:', e);
+  process.exit(1);
+});

--- a/graphql/codegen/src/core/codegen/templates/cli-entry.ts
+++ b/graphql/codegen/src/core/codegen/templates/cli-entry.ts
@@ -8,11 +8,12 @@
  * Any changes here will affect all generated CLI entry points.
  */
 
-import { CLI, CLIOptions } from 'inquirerer';
+import { CLI, CLIOptions, getPackageJson } from 'inquirerer';
 import { commands } from './commands';
 
 if (process.argv.includes('--version') || process.argv.includes('-v')) {
-  console.log('0.0.1');
+  const pkg = getPackageJson(__dirname);
+  console.log(pkg.version);
   process.exit(0);
 }
 

--- a/graphql/codegen/src/core/generate.ts
+++ b/graphql/codegen/src/core/generate.ts
@@ -696,6 +696,7 @@ export async function generateMulti(
       builtinNames: cliConfig.builtinNames,
       targets: cliTargets,
       nodeHttpAdapter: multiNodeHttpAdapter,
+      entryPoint: cliConfig.entryPoint,
     });
 
     const cliFilesToWrite = files.map((file) => ({

--- a/graphql/codegen/src/types/config.ts
+++ b/graphql/codegen/src/types/config.ts
@@ -199,6 +199,15 @@ export interface CliConfig {
    *           context -> 'context' (renamed to 'env' on collision)
    */
   builtinNames?: BuiltinNames;
+
+  /**
+   * Generate a runnable index.ts entry point for the CLI.
+   * When true, generates an index.ts that imports the command map,
+   * handles --version and --tty flags, and starts the inquirerer CLI.
+   * Useful for projects that want a ready-to-run CLI without a custom entry point.
+   * @default false
+   */
+  entryPoint?: boolean;
 }
 
 /**


### PR DESCRIPTION
# feat(codegen): add CLI entry point generation option (`cli.entryPoint`)

## Summary

Adds a new opt-in `entryPoint` boolean to `CliConfig` (default `false`). When enabled, codegen generates an `index.ts` entry point file that bootstraps the CLI using `inquirerer`, handling `--version`, `--tty false`, and error reporting.

This follows the existing template-copy pattern used by `cli-utils.ts` and `node-fetch.ts` — the template lives in `src/core/codegen/templates/cli-entry.ts` and is read/header-replaced at codegen time.

Wired into both `generateCli()` (single-target) and `generateMultiTargetCli()` (multi-target) code paths, and passed through `generateMulti()` in `generate.ts`.

**Motivation:** Eliminates the runtime entry point generation hack in the constructive-hub CLI e2e test script (lines 44–69 of `test-cli-e2e.sh`), which manually creates this file at test time.

## Updates since last revision

- **Replaced hardcoded `'0.0.1'` version** with `getPackageJson(__dirname)` from `inquirerer`, matching the exact pattern used by `cnc` and `pgpm` CLIs. The generated entry point now reads the actual version from the nearest `package.json` at runtime.

## Review & Testing Checklist for Human

- [ ] **`getPackageJson(__dirname)` runtime behavior** — the generated `index.ts` calls `getPackageJson(__dirname)` to resolve the version for `--version`. Verify that when the generated CLI is compiled/bundled (e.g. via `tsx` or `tsc`), `__dirname` resolves to a path where a `package.json` is discoverable. If the CLI is run directly from source (e.g. `npx tsx cli/index.ts`), the nearest `package.json` might be the workspace root rather than the CLI-specific one.
- [ ] **No new tests** — 301 existing tests pass, but none exercise `entryPoint: true`. Consider adding a snapshot test that verifies the generated `index.ts` content.
- [ ] **`index.ts` filename collision** — verify no other codegen output produces an `index.ts` in the CLI output directory, since `generateEntryPointFile()` writes to `index.ts`.
- [ ] **Single-target path guard** — in `generateCli()`, the check is `typeof cliConfig === 'object' && !!cliConfig.entryPoint`. Confirm this is correct for all call sites (when `cliConfig` is `true` vs an object).

### Suggested test plan
1. Add `entryPoint: true` to a codegen config YAML and run generation
2. Verify the generated `index.ts` contains the expected imports (`getPackageJson`) and CLI bootstrap
3. Verify `entryPoint: false` (or omitted) produces no `index.ts`
4. Run the generated CLI with `--version` and confirm it prints the version from the nearest `package.json`

### Notes
- Build passes (`pnpm build`), all 301 tests pass (`pnpm test`), no snapshot changes
- Link to Devin run: https://app.devin.ai/sessions/d41228699b3a46de9e73cc13dda02882
- Requested by: @pyramation