### PR TITLE
fix(codegen): pass typeRegistry to CLI generation for proper required/optional field detection

### DIFF
--- a/graphql/codegen/src/core/generate.ts
+++ b/graphql/codegen/src/core/generate.ts
@@ -15,7 +15,7 @@ import { deployPgpm } from 'pgsql-seed';
 
 import type { CliConfig, DbConfig, GraphQLSDKConfigTarget, PgpmConfig } from '../types/config';
 import { getConfigOptions } from '../types/config';
-import type { CleanOperation, CleanTable } from '../types/schema';
+import type { CleanOperation, CleanTable, TypeRegistry } from '../types/schema';
 import { generate as generateReactQueryFiles } from './codegen';
 import { generateRootBarrel } from './codegen/barrel';
 import { generateCli as generateCliFiles, generateMultiTargetCli } from './codegen/cli';
@@ -79,6 +79,7 @@ export interface GenerateResult {
     customOperations: {
       queries: CleanOperation[];
       mutations: CleanOperation[];
+      typeRegistry?: TypeRegistry;
     };
   };
 }
@@ -292,6 +293,7 @@ export async function generate(
         mutations: customOperations.mutations,
       },
       config: { ...config, nodeHttpAdapter: useNodeHttpAdapter },
+      typeRegistry: customOperations.typeRegistry,
     });
     filesToWrite.push(
       ...files.map((file) => ({
@@ -439,6 +441,7 @@ export async function generate(
       customOperations: {
         queries: customOperations.queries,
         mutations: customOperations.mutations,
+        typeRegistry: customOperations.typeRegistry,
       },
     },
   };
@@ -676,6 +679,7 @@ export async function generateMulti(
           tables: result.pipelineData.tables,
           customOperations: result.pipelineData.customOperations,
           isAuthTarget,
+          typeRegistry: result.pipelineData.customOperations.typeRegistry,
         });
       }
     }


### PR DESCRIPTION
# fix(codegen): pass typeRegistry to CLI generation for field nullability

## Summary

The CLI table command generator has a `getFieldsWithDefaults()` function that uses the `TypeRegistry` from introspection to determine which fields are nullable or have database defaults — and marks those as `required: false` in generated CLI prompts. However, the `typeRegistry` was never actually plumbed through to the CLI generator. It was passed to React Query hooks and ORM generation, but omitted from the CLI path.

This caused **all** fields in CLI `create` commands to be marked `required: true`, even nullable GraphQL fields like `inheritsId: UUID` (no `!`). Users were forced to provide values for optional fields, and in the case of foreign keys, providing a placeholder UUID would violate FK constraints.

**Four-line fix across one file (`generate.ts`):**
1. Add `typeRegistry` to the `pipelineData.customOperations` type in `GenerateResult`
2. Pass `typeRegistry` to `generateCliFiles()` in the single-target path
3. Include `typeRegistry` in the `pipelineData` return value so multi-target can access it
4. Pass `typeRegistry` from `pipelineData` into `cliTargets` in `generateMulti()`

## Review & Testing Checklist for Human

- [ ] **Verify the generated CLI output changes as expected**: After publishing, regenerate the CLI for constructive-db and confirm that nullable fields (e.g. `inheritsId`, `label`, `smartTags`, `category`, `module`, `scope`, `tags`) now show `required: false` in create commands
- [ ] **Confirm no regression on required fields**: Fields with `!` in GraphQL (e.g. `schemaId: UUID!`, `name: String!`) should still be `required: true`
- [ ] **Test multi-target path**: If you have a multi-target codegen config, verify the typeRegistry flows through correctly there too

### Notes
- 301/301 existing tests pass, TypeScript compiles cleanly
- The unit tests don't cover this specific plumbing gap (they test the generator in isolation with typeRegistry already injected). An integration test that runs the full `generate()` pipeline and checks CLI output would catch this class of bug in the future.
- Link to Devin run: https://app.devin.ai/sessions/d41228699b3a46de9e73cc13dda02882
- Requested by: @pyramation