### PR TITLE
feat(codegen): add AbortSignal and per-request headers to NodeHttpAdapter

### DIFF
--- a/graphql/codegen/src/core/codegen/templates/node-fetch.ts
+++ b/graphql/codegen/src/core/codegen/templates/node-fetch.ts
@@ -43,13 +43,20 @@ function isLocalhostSubdomain(hostname: string): boolean {
 
 /**
  * Make an HTTP/HTTPS request using native Node modules.
+ * Supports optional AbortSignal for request cancellation.
  */
 function makeRequest(
   url: URL,
   options: http.RequestOptions,
   body: string,
+  signal?: AbortSignal,
 ): Promise<HttpResponse> {
   return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new Error('The operation was aborted'));
+      return;
+    }
+
     const protocol = url.protocol === 'https:' ? https : http;
 
     const req = protocol.request(url, options, (res) => {
@@ -68,9 +75,31 @@ function makeRequest(
     });
 
     req.on('error', reject);
+
+    if (signal) {
+      const onAbort = () => {
+        req.destroy(new Error('The operation was aborted'));
+      };
+      signal.addEventListener('abort', onAbort, { once: true });
+      req.on('close', () => {
+        signal.removeEventListener('abort', onAbort);
+      });
+    }
+
     req.write(body);
     req.end();
   });
+}
+
+/**
+ * Options for individual execute calls.
+ * Allows per-request header overrides and request cancellation.
+ */
+export interface NodeHttpExecuteOptions {
+  /** Additional headers to include in this request only */
+  headers?: Record<string, string>;
+  /** AbortSignal for request cancellation */
+  signal?: AbortSignal;
 }
 
 /**
@@ -94,12 +123,14 @@ export class NodeHttpAdapter implements GraphQLAdapter {
   async execute<T>(
     document: string,
     variables?: Record<string, unknown>,
+    options?: NodeHttpExecuteOptions,
   ): Promise<QueryResult<T>> {
     const requestUrl = new URL(this.url.href);
     const requestHeaders: Record<string, string> = {
       'Content-Type': 'application/json',
       Accept: 'application/json',
       ...this.headers,
+      ...options?.headers,
     };
 
     // For *.localhost subdomains, rewrite hostname and inject Host header
@@ -118,7 +149,12 @@ export class NodeHttpAdapter implements GraphQLAdapter {
       headers: requestHeaders,
     };
 
-    const response = await makeRequest(requestUrl, requestOptions, body);
+    const response = await makeRequest(
+      requestUrl,
+      requestOptions,
+      body,
+      options?.signal,
+    );
 
     if (response.statusCode < 200 || response.statusCode >= 300) {
       return {


### PR DESCRIPTION
# feat(codegen): add AbortSignal and per-request headers to NodeHttpAdapter

## Summary

Adds two capabilities to `NodeHttpAdapter` in the codegen `node-fetch.ts` template that were present in the old `browserCompatible=false` implementation but missing from the current adapter:

1. **AbortSignal support** — callers can cancel in-flight `node:http` requests (important for CLI Ctrl+C and React Query component unmount).
2. **Per-request header overrides** — callers can pass one-off headers to a single `execute()` call without mutating the adapter instance.

Both are exposed via a new optional `NodeHttpExecuteOptions` parameter on `execute()`. The base `GraphQLAdapter` interface is **not** changed — the extra optional parameter is backward-compatible.

Changes are confined to a single template file (`node-fetch.ts`) that is copied verbatim into generated output at codegen time.

## Review & Testing Checklist for Human

- [ ] **Verify `execute()` signature stays compatible with `GraphQLAdapter` interface** — the third optional param should not break assignability, but confirm TypeScript is happy in a generated project that uses `NodeHttpAdapter` as a `GraphQLAdapter`.
- [ ] **Verify AbortSignal cleanup** — on normal completion, `req.on('close')` removes the abort listener. On abort, `req.destroy()` triggers `close` which also cleans up. Confirm no leak path exists (e.g., if the promise rejects before the request is created).
- [ ] **Test with a real codegen run** — since this is a template file excluded from TS compilation, the only way to validate types is to run codegen and compile the output. Generate a project with `nodeHttpAdapter: true` and verify the output compiles and the new options work at runtime.

### Notes
- The template file (`node-fetch.ts`) is excluded from the codegen package's own `tsconfig.json`, so package-level `tsc` will not catch type errors in this file.
- Caller sites (executor-generator, ORM index) do not yet pass these new options through — they remain available for direct usage of `NodeHttpAdapter` by consuming applications.
- ESLint config in the codegen package appears to be broken pre-existing (missing `eslint.config.js` for ESLint v9); unrelated to this change.

Link to Devin run: https://app.devin.ai/sessions/73d9c02182a240e3857850d776bad754
Requested by: @pyramation