### PR TITLE
feat: add secure_table_provision to export functionality

### DIFF
--- a/pgpm/core/src/export/export-meta.ts
+++ b/pgpm/core/src/export/export-meta.ts
@@ -857,6 +857,28 @@ const config: Record<string, TableConfig> = {
       fields: 'uuid[]'
     }
   },
+  secure_table_provision: {
+    schema: 'metaschema_modules_public',
+    table: 'secure_table_provision',
+    fields: {
+      id: 'uuid',
+      database_id: 'uuid',
+      schema_id: 'uuid',
+      table_id: 'uuid',
+      table_name: 'text',
+      node_type: 'text',
+      use_rls: 'boolean',
+      node_data: 'jsonb',
+      grant_roles: 'text[]',
+      grant_privileges: 'jsonb',
+      policy_type: 'text',
+      policy_privileges: 'text[]',
+      policy_role: 'text',
+      policy_permissive: 'boolean',
+      policy_data: 'jsonb',
+      out_fields: 'uuid[]'
+    }
+  },
   table_template_module: {
     schema: 'metaschema_modules_public',
     table: 'table_template_module',
@@ -1043,6 +1065,7 @@ export const exportMeta = async ({ opts, dbname, database_id }: ExportMetaParams
   await queryAndParse('crypto_auth_module', `SELECT * FROM metaschema_modules_public.crypto_auth_module WHERE database_id = $1`);
   await queryAndParse('field_module', `SELECT * FROM metaschema_modules_public.field_module WHERE database_id = $1`);
   await queryAndParse('table_template_module', `SELECT * FROM metaschema_modules_public.table_template_module WHERE database_id = $1`);
+  await queryAndParse('secure_table_provision', `SELECT * FROM metaschema_modules_public.secure_table_provision WHERE database_id = $1`);
   await queryAndParse('uuid_module', `SELECT * FROM metaschema_modules_public.uuid_module WHERE database_id = $1`);
   await queryAndParse('default_ids_module', `SELECT * FROM metaschema_modules_public.default_ids_module WHERE database_id = $1`);
   await queryAndParse('denormalized_table_field', `SELECT * FROM metaschema_modules_public.denormalized_table_field WHERE database_id = $1`);

--- a/pgpm/core/src/export/export-migrations.ts
+++ b/pgpm/core/src/export/export-migrations.ts
@@ -408,6 +408,7 @@ SET session_replication_role TO DEFAULT;`;
       'crypto_auth_module',
       'field_module',
       'table_module',
+      'secure_table_provision',
       'user_profiles_module',
       'user_settings_module',
       'organization_settings_module',


### PR DESCRIPTION
# feat: add secure_table_provision to export functionality

## Summary

Adds `secure_table_provision` to the pgpm export pipeline so that databases using the new table provisioning system (replacing the deprecated `table_module`) get their provision rows exported correctly.

Three changes, all following the existing pattern for other `metaschema_modules_public` tables:

1. **`export-meta.ts` config** — new `secure_table_provision` entry with all 16 typed columns (`schema_id`, `table_name`, `node_type`, `use_rls`, `node_data`, `grant_roles`, `grant_privileges`, `policy_type`, `policy_privileges`, `policy_role`, `policy_permissive`, `policy_data`, `out_fields`, etc.)
2. **`export-meta.ts` queryAndParse** — added `SELECT * FROM metaschema_modules_public.secure_table_provision WHERE database_id = $1` call
3. **`export-migrations.ts` tableOrder** — inserted `'secure_table_provision'` after `'table_module'`

The existing `table_module` entry is left in place since it is deprecated but not yet removed.

## Review & Testing Checklist for Human

- [ ] Verify the 16 field names and types in the config entry match the actual `secure_table_provision` DDL (cross-reference with `constructive-db/pgpm-modules/metaschema-modules/deploy/.../secure_table_provision/table.sql`)
- [ ] Run an export against a database that has `secure_table_provision` rows and confirm the generated SQL is correct
- [ ] Confirm placement in `tableOrder` (after `table_module`, before `user_profiles_module`) produces valid migration ordering — `secure_table_provision` has FK deps on `database`, `schema`, and `table`, all of which appear earlier

### Notes

Part of a broader `table_module` → `secure_table_provision` deprecation effort spanning 3 repos (constructive-db, pgpm-modules, constructive).

- Link to Devin run: https://app.devin.ai/sessions/1659e6f718364e00b1457099515d570c
- Requested by: @pyramation