### PR TITLE
fix: correct findOne docs to use top-level PK instead of where wrapper

### DIFF
--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/cli-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/cli-generator.test.ts.snap
@@ -4263,7 +4263,7 @@ Access: \`db.car\`
 \`\`\`
 METHODS:
   db.car.findMany({ select, where?, orderBy?, first?, offset? })
-  db.car.findOne({ where: { id }, select })
+  db.car.findOne({ id, select })
   db.car.create({ data: { make, model, year, isElectric }, select })
   db.car.update({ where: { id }, data, select })
   db.car.delete({ where: { id } })
@@ -4297,7 +4297,7 @@ Access: \`db.driver\`
 \`\`\`
 METHODS:
   db.driver.findMany({ select, where?, orderBy?, first?, offset? })
-  db.driver.findOne({ where: { id }, select })
+  db.driver.findOne({ id, select })
   db.driver.create({ data: { name, licenseNumber }, select })
   db.driver.update({ where: { id }, data, select })
   db.driver.delete({ where: { id } })
@@ -4417,7 +4417,7 @@ CRUD operations for Car records.
 const items = await db.car.findMany({ select: { id: true, make: true, model: true, year: true, isElectric: true, createdAt: true } }).execute();
 
 // Get one by id
-const item = await db.car.findOne({ where: { id: '<value>' }, select: { id: true, make: true, model: true, year: true, isElectric: true, createdAt: true } }).execute();
+const item = await db.car.findOne({ id: '<value>', select: { id: true, make: true, model: true, year: true, isElectric: true, createdAt: true } }).execute();
 
 // Create
 const created = await db.car.create({ data: { make: '<value>', model: '<value>', year: '<value>', isElectric: '<value>' }, select: { id: true } }).execute();
@@ -4448,7 +4448,7 @@ CRUD operations for Driver records.
 const items = await db.driver.findMany({ select: { id: true, name: true, licenseNumber: true } }).execute();
 
 // Get one by id
-const item = await db.driver.findOne({ where: { id: '<value>' }, select: { id: true, name: true, licenseNumber: true } }).execute();
+const item = await db.driver.findOne({ id: '<value>', select: { id: true, name: true, licenseNumber: true } }).execute();
 
 // Create
 const created = await db.driver.create({ data: { name: '<value>', licenseNumber: '<value>' }, select: { id: true } }).execute();
@@ -4512,7 +4512,7 @@ ORM operations for Car records
 
 \`\`\`typescript
 db.car.findMany({ select: { id: true } }).execute()
-db.car.findOne({ where: { id: '<value>' }, select: { id: true } }).execute()
+db.car.findOne({ id: '<value>', select: { id: true } }).execute()
 db.car.create({ data: { make: '<value>', model: '<value>', year: '<value>', isElectric: '<value>' }, select: { id: true } }).execute()
 db.car.update({ where: { id: '<value>' }, data: { make: '<new>' }, select: { id: true } }).execute()
 db.car.delete({ where: { id: '<value>' } }).execute()
@@ -4550,7 +4550,7 @@ ORM operations for Driver records
 
 \`\`\`typescript
 db.driver.findMany({ select: { id: true } }).execute()
-db.driver.findOne({ where: { id: '<value>' }, select: { id: true } }).execute()
+db.driver.findOne({ id: '<value>', select: { id: true } }).execute()
 db.driver.create({ data: { name: '<value>', licenseNumber: '<value>' }, select: { id: true } }).execute()
 db.driver.update({ where: { id: '<value>' }, data: { name: '<new>' }, select: { id: true } }).execute()
 db.driver.delete({ where: { id: '<value>' } }).execute()

--- a/graphql/codegen/src/core/codegen/orm/docs-generator.ts
+++ b/graphql/codegen/src/core/codegen/orm/docs-generator.ts
@@ -82,7 +82,7 @@ export function generateOrmReadme(
       lines.push('');
       lines.push(`// Get one by ${pk.name}`);
       lines.push(
-        `const item = await db.${singularName}.findOne({ where: { ${pk.name}: '<value>' }, select: { ${scalarFields.map((f) => `${f.name}: true`).join(', ')} } }).execute();`,
+        `const item = await db.${singularName}.findOne({ ${pk.name}: '<value>', select: { ${scalarFields.map((f) => `${f.name}: true`).join(', ')} } }).execute();`,
       );
       lines.push('');
       lines.push(`// Create`);
@@ -202,7 +202,7 @@ export function generateOrmAgentsDocs(
       `  db.${singularName}.findMany({ select, where?, orderBy?, first?, offset? })`,
     );
     lines.push(
-      `  db.${singularName}.findOne({ where: { ${pk.name} }, select })`,
+      `  db.${singularName}.findOne({ ${pk.name}, select })`,
     );
     lines.push(
       `  db.${singularName}.create({ data: { ${editableFields.map((f) => f.name).join(', ')} }, select })`,
@@ -465,7 +465,7 @@ export function generateOrmSkills(
         language: 'typescript',
         usage: [
           `db.${lcFirst(singularName)}.findMany({ select: { id: true } }).execute()`,
-          `db.${lcFirst(singularName)}.findOne({ where: { ${pk.name}: '<value>' }, select: { id: true } }).execute()`,
+          `db.${lcFirst(singularName)}.findOne({ ${pk.name}: '<value>', select: { id: true } }).execute()`,
           `db.${lcFirst(singularName)}.create({ data: { ${editableFields.map((f) => `${f.name}: '<value>'`).join(', ')} }, select: { id: true } }).execute()`,
           `db.${lcFirst(singularName)}.update({ where: { ${pk.name}: '<value>' }, data: { ${editableFields[0]?.name || 'field'}: '<new>' }, select: { id: true } }).execute()`,
           `db.${lcFirst(singularName)}.delete({ where: { ${pk.name}: '<value>' } }).execute()`,


### PR DESCRIPTION
## Summary

The ORM docs generator (`docs-generator.ts`) was emitting `findOne({ where: { id: '<value>' }, ... })` in generated documentation, but the actual SDK signature produced by `model-generator.ts` is `findOne({ id: '<value>', select: ... })` — the primary key is a top-level parameter, not nested under `where`.

This fix updates three doc generation functions to emit the correct signature:
- `generateOrmReadme` — README.md code examples
- `generateOrmAgentsDocs` — AGENTS.md method signatures
- `generateOrmSkills` — per-table skill file usage snippets

Snapshot tests in `cli-generator.test.ts` were updated to match the corrected output (4 snapshots).

Closes constructive-io/constructive-planning#623

## Review & Testing Checklist for Human

- [ ] Verify the corrected `findOne` signature (`{ pk, select }`) matches what `model-generator.ts` actually generates — cross-reference with a generated model file like `sdk/constructive-sdk/src/admin/orm/models/invite.ts` (line ~100)
- [ ] Decide whether the already-committed `.md` skill/README files in `constructive-sdk` (and `constructive-db`) need to be regenerated as part of this PR or as a follow-up. This PR only fixes the generator — existing generated docs still contain the old `where` syntax.
- [ ] Spot-check that `update` and `delete` methods still correctly use `where` in the generated docs (only `findOne` should have changed)

### Notes
- The SDK runtime code is **not** affected — only generated documentation was wrong
- `constructive-db` doesn't appear to call `findOne` in its tests, which is why this never surfaced as a test failure
- Link to Devin run: https://app.devin.ai/sessions/3a915cb6aef041428e0cdecd87f9e12c
- Requested by: @pyramation