### PR TITLE
fix: update @pgpmjs/core export config for grantee_name rename and add default_privilege table

### DIFF
--- a/pgpm/core/src/export/export-meta.ts
+++ b/pgpm/core/src/export/export-meta.ts
@@ -161,7 +161,7 @@ const config: Record<string, TableConfig> = {
       database_id: 'uuid',
       table_id: 'uuid',
       name: 'text',
-      role_name: 'text',
+      grantee_name: 'text',
       privilege: 'text',
       permissive: 'boolean',
       disabled: 'boolean',
@@ -338,8 +338,22 @@ const config: Record<string, TableConfig> = {
       database_id: 'uuid',
       table_id: 'uuid',
       privilege: 'text',
-      role_name: 'text',
-      field_ids: 'uuid[]'
+      grantee_name: 'text',
+      field_ids: 'uuid[]',
+      is_grant: 'boolean'
+    }
+  },
+  default_privilege: {
+    schema: 'metaschema_public',
+    table: 'default_privilege',
+    fields: {
+      id: 'uuid',
+      database_id: 'uuid',
+      schema_id: 'uuid',
+      object_type: 'text',
+      privilege: 'text',
+      grantee_name: 'text',
+      is_grant: 'boolean'
     }
   },
   // =============================================================================
@@ -1026,6 +1040,7 @@ export const exportMeta = async ({ opts, dbname, database_id }: ExportMetaParams
   await queryAndParse('full_text_search', `SELECT * FROM metaschema_public.full_text_search WHERE database_id = $1`);
   await queryAndParse('schema_grant', `SELECT * FROM metaschema_public.schema_grant WHERE database_id = $1`);
   await queryAndParse('table_grant', `SELECT * FROM metaschema_public.table_grant WHERE database_id = $1`);
+  await queryAndParse('default_privilege', `SELECT * FROM metaschema_public.default_privilege WHERE database_id = $1`);
 
   // =============================================================================
   // services_public tables

--- a/pgpm/core/src/export/export-migrations.ts
+++ b/pgpm/core/src/export/export-migrations.ts
@@ -378,6 +378,7 @@ SET session_replication_role TO DEFAULT;`;
       'full_text_search',
       'schema_grant',
       'table_grant',
+      'default_privilege',
       'domains',
       'sites',
       'apis',


### PR DESCRIPTION
# fix: update export config for grantee_name rename and default_privilege

## Summary

Upstream the changes from the `@pgpmjs/core` pnpm patch in [constructive-db#542](https://github.com/constructive-io/constructive-db/pull/542) into the source package. That PR renamed `role_name` → `grantee_name` on `table_grant`, `view_grant`, and `policy` tables in `metaschema_public`, added `is_grant` to `table_grant`/`view_grant`, and created a new `default_privilege` table.

**Changes in `export-meta.ts`:**
- `policy` config: `role_name` → `grantee_name`
- `table_grant` config: `role_name` → `grantee_name`, add `is_grant: 'boolean'`
- New `default_privilege` table config (schema_id, object_type, privilege, grantee_name, is_grant)
- Add `queryAndParse` call for `default_privilege` after `table_grant`

**Changes in `export-migrations.ts`:**
- Add `'default_privilege'` to `tableOrder` after `'table_grant'`

`services_public.apis.role_name` is intentionally unchanged (different semantic context — API owner role, not a privilege grantee).

## Review & Testing Checklist for Human

**⚠️ 3 items — this is a config-only change but cannot be tested without the companion DB schema changes.**

- [ ] **Verify field lists match the actual DB schema** — The `default_privilege` fields (`id`, `database_id`, `schema_id`, `object_type`, `privilege`, `grantee_name`, `is_grant`) must exactly match the columns on `metaschema_public.default_privilege` as deployed by constructive-db#542. Same for `table_grant` (now has `grantee_name` + `is_grant`) and `policy` (now has `grantee_name`). Any mismatch will cause `buildDynamicFields` to silently drop columns.
- [ ] **`view_grant` is still not in the export config** — The companion PR added `is_grant` and renamed `role_name` → `grantee_name` on `view_grant` too, but `view_grant` was never in the export config to begin with. Confirm this is intentional (i.e., view grants are not exported via this path).
- [ ] **Test end-to-end** — After publishing, update `constructive-db` to use the new version, remove the `patches/@pgpmjs__core@6.3.0.patch`, and run the full CI suite to confirm the generate step still passes without the patch.

### Notes
- Companion PR: [constructive-db#542](https://github.com/constructive-io/constructive-db/pull/542)
- Once this is published, the pnpm patch in constructive-db can be removed
- Requested by @pyramation
- Link to Devin run: https://app.devin.ai/sessions/524a9467df8d4672b945db65f0081960