### PR TITLE
fix: remove created_at from hierarchy_module export config

### DIFF
--- a/pgpm/core/src/export/export-meta.ts
+++ b/pgpm/core/src/export/export-meta.ts
@@ -671,8 +671,7 @@ const config: Record<string, TableConfig> = {
       rebuild_hierarchy_function: 'text',
       get_subordinates_function: 'text',
       get_managers_function: 'text',
-      is_manager_of_function: 'text',
-      created_at: 'timestamptz'
+      is_manager_of_function: 'text'
     }
   },
   membership_types_module: {


### PR DESCRIPTION
# fix: remove created_at from hierarchy_module export config

## Summary

Removes `created_at: 'timestamptz'` from the `hierarchy_module` field config in `export-meta.ts`. This was the **only** module table that exported `created_at`. Since the column uses `DEFAULT now()`, it produced a non-deterministic timestamp in the generated migration SQL every time `exportMeta` ran, causing `constructive-db`'s `pnpm generate:constructive` to produce different output on each run.

All other module tables (`users_module`, `memberships_module`, `sessions_module`, etc.) already omit `created_at` from their export configs.

## Review & Testing Checklist for Human

- [ ] **Verify nothing downstream reads `created_at` from the exported `hierarchy_module` migration SQL** — if any deploy or seed script expects this field in the INSERT statement, removing it will break. Search for consumers of the generated `hierarchy_module.sql` migrate file.
- [ ] **After publishing this change, regenerate in `constructive-db`** — run `pnpm generate:constructive` twice in `constructive-db` (with the updated `@pgpmjs/core`) and confirm the output is byte-identical between runs and the `hierarchy_module.sql` no longer contains a `created_at` value.

### Notes

- Companion PR in constructive-db: https://github.com/constructive-io/constructive-db/pull/544 (adds `ORDER BY` clauses and two-phase introspection for full determinism)
- The constructive-db PR currently includes a trigger-based workaround (setting `created_at` to epoch in deterministic mode) that should be reverted once this `@pgpmjs/core` change is published and the dependency is bumped.

Link to Devin run: https://app.devin.ai/sessions/3de151634672469484d34e25c882bfa1
Requested by: @pyramation