### PR TITLE
fix: resolve RLS auth for all API endpoints, not just public

### DIFF
--- a/graphql/server/src/middleware/api.ts
+++ b/graphql/server/src/middleware/api.ts
@@ -80,13 +80,13 @@ const API_LIST_SQL = `
 `;
 
 const RLS_MODULE_SQL = `
-  SELECT 
+  SELECT
     rm.authenticate,
     rm.authenticate_strict,
     ps.schema_name as private_schema_name
   FROM metaschema_modules_public.rls_module rm
   LEFT JOIN metaschema_public.schema ps ON rm.private_schema_id = ps.id
-  WHERE rm.api_id = $1
+  WHERE rm.database_id = $1
   LIMIT 1
 `;
 
@@ -323,7 +323,7 @@ const resolveApiNameHeader = async (ctx: ResolveContext): Promise<ApiStructure |
     return null;
   }
 
-  const rlsModule = await queryRlsModule(pool, row.api_id);
+  const rlsModule = await queryRlsModule(pool, row.database_id);
   log.debug(`[api-name-lookup] resolved schemas: [${row.schemas?.join(', ')}], rlsModule: ${rlsModule ? 'found' : 'none'}`);
   return toApiStructure(row, opts, rlsModule);
 };
@@ -348,7 +348,7 @@ const resolveDomainLookup = async (ctx: ResolveContext): Promise<ApiStructure | 
     return null;
   }
 
-  const rlsModule = await queryRlsModule(pool, row.api_id);
+  const rlsModule = await queryRlsModule(pool, row.database_id);
   log.debug(`[domain-lookup] resolved schemas: [${row.schemas?.join(', ')}], rlsModule: ${rlsModule ? 'found' : 'none'}`);
   return toApiStructure(row, opts, rlsModule);
 };


### PR DESCRIPTION
Problem: PostGraphile middleware skipped JWT authentication for all API endpoints except public, causing requests to run as anonymous role. This meant RLS policies were not
  enforced on app, admin, and auth API endpoints.

  Root cause: RLS_MODULE_SQL in graphql/server/src/middleware/api.ts queried metaschema_modules_public.rls_module WHERE rm.api_id = $1. The rls_module table only contains one row
  per database, created by provision_database_modules with api_id set to the public API. When the middleware queried for any other API's ID (app, admin, auth), the query returned
  no rows → rlsModule = undefined → auth.ts skipped authentication entirely.

  Why it wasn't caught earlier: The public API is the default and most commonly used endpoint. The app API (lean endpoint for user-defined tables) is a newer addition. The
  database layer correctly propagates RLS config to services_public.api_modules for all authenticated APIs via the insert_rls_module trigger, but the middleware never read from
  that table.

  Fix: Changed the WHERE clause from rm.api_id = $1 to rm.database_id = $1 and updated both callsites to pass database_id instead of api_id. Since auth functions (authenticate,
  authenticate_strict) are database-level (shared across all APIs in a database), querying by database_id correctly returns the RLS config for any API endpoint.