### PR TITLE
feat(graphql-server): add dev-only /debug/memory endpoint for OOM debugging

### DIFF
--- a/graphql/server/src/middleware/debug-memory.ts
+++ b/graphql/server/src/middleware/debug-memory.ts
@@ -1,0 +1,62 @@
+import { getNodeEnv } from '@constructive-io/graphql-env';
+import { Logger } from '@pgpmjs/logger';
+import { svcCache } from '@pgpmjs/server-utils';
+import type { RequestHandler } from 'express';
+import { getCacheStats } from 'graphile-cache';
+import { getInFlightCount, getInFlightKeys } from './graphile';
+
+const log = new Logger('debug-memory');
+
+const toMB = (bytes: number): string => `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+
+/**
+ * Development-only debug endpoint for monitoring memory usage and cache state.
+ *
+ * Mounts GET /debug/memory which returns:
+ * - Node.js process memory (heap, RSS, external, array buffers)
+ * - Graphile cache stats (size, max, TTL, keys with ages)
+ * - Service cache size
+ * - In-flight handler creation count
+ * - Process uptime
+ *
+ * This endpoint is only available when NODE_ENV=development.
+ * In production, it returns 404.
+ */
+export const debugMemory: RequestHandler = (_req, res) => {
+  if (getNodeEnv() !== 'development') {
+    res.status(404).send('Not found');
+    return;
+  }
+
+  const mem = process.memoryUsage();
+  const cacheStats = getCacheStats();
+  const now = Date.now();
+
+  const response = {
+    memory: {
+      heapUsed: toMB(mem.heapUsed),
+      heapTotal: toMB(mem.heapTotal),
+      rss: toMB(mem.rss),
+      external: toMB(mem.external),
+      arrayBuffers: toMB(mem.arrayBuffers),
+    },
+    graphileCache: {
+      size: cacheStats.size,
+      max: cacheStats.max,
+      ttl: `${(cacheStats.ttl / 1000 / 60).toFixed(0)} min`,
+      keys: cacheStats.keys,
+    },
+    svcCache: {
+      size: svcCache.size,
+    },
+    inFlight: {
+      count: getInFlightCount(),
+      keys: getInFlightKeys(),
+    },
+    uptime: `${(process.uptime() / 60).toFixed(1)} min`,
+    timestamp: new Date().toISOString(),
+  };
+
+  log.debug('Memory snapshot:', response);
+  res.json(response);
+};

--- a/graphql/server/src/middleware/debug-memory.ts
+++ b/graphql/server/src/middleware/debug-memory.ts
@@ -30,7 +30,6 @@ export const debugMemory: RequestHandler = (_req, res) => {
 
   const mem = process.memoryUsage();
   const cacheStats = getCacheStats();
-  const now = Date.now();
 
   const response = {
     memory: {

--- a/graphql/server/src/server.ts
+++ b/graphql/server/src/server.ts
@@ -22,6 +22,7 @@ import { flush, flushService } from './middleware/flush';
 import { graphile } from './middleware/graphile';
 import { multipartBridge } from './middleware/multipart-bridge';
 import { createUploadAuthenticateMiddleware, uploadRoute } from './middleware/upload';
+import { debugMemory } from './middleware/debug-memory';
 import { normalizeServerOptions } from './options';
 
 const log = new Logger('server');
@@ -127,6 +128,7 @@ class Server {
     });
 
     healthz(app);
+    app.get('/debug/memory', debugMemory);
     app.use(favicon);
     trustProxy(app, effectiveOpts.server.trustProxy);
     // Warn if a global CORS override is set in production


### PR DESCRIPTION
# feat(graphql-server): add dev-only /debug/memory endpoint

## Summary

Adds a `GET /debug/memory` endpoint to the GraphQL server that returns a JSON snapshot of Node.js heap usage and Graphile cache state. Gated to `NODE_ENV=development` only (returns 404 otherwise). Motivated by the OOM crash reported in constructive-io/constructive-planning#654 — this endpoint lets you `curl` or `watch` memory while parallel agents are running to correlate heap growth with cache size.

**Response shape:**
```json
{
  "memory": { "heapUsed": "847.2 MB", "heapTotal": "1024.0 MB", "rss": "1100.3 MB", ... },
  "graphileCache": { "size": 5, "max": 15, "ttl": "5 min", "keys": ["auth-efb-...localhost", ...] },
  "svcCache": { "size": 3 },
  "inFlight": { "count": 1, "keys": ["api:db2:dashboard"] },
  "uptime": "12.3 min",
  "timestamp": "2026-02-28T..."
}
```

**Files changed:**
- `graphql/server/src/middleware/debug-memory.ts` — new middleware (61 lines)
- `graphql/server/src/server.ts` — import + mount the route

## Updates since last revision

- Removed unused `const now = Date.now()` variable from `debug-memory.ts`.

## Review & Testing Checklist for Human

- [ ] **Production safety**: The dev guard is a runtime check (`getNodeEnv() !== 'development'`), not a conditional mount — the route is always registered. Verify this is acceptable, or consider wrapping the `app.get(...)` mount in a `NODE_ENV` check in `server.ts` instead so the route doesn't exist at all in production.
- [ ] **Information exposure**: Cache keys contain domain names, database IDs, and API names. Confirm you're comfortable exposing these on an unauthenticated endpoint in dev.
- [ ] **Test plan**: Start the server with `NODE_ENV=development`, run `curl http://localhost:3000/debug/memory | jq .` and confirm the response shape. Optionally run with `NODE_ENV=production` and confirm you get a 404.

### Notes
- No automated tests added — this is a dev-only diagnostic endpoint with no business logic.
- Lint/ESLint could not be verified at the package level due to a pre-existing missing `eslint.config.js` in `graphql/server/` (the monorepo uses `.eslintrc.json` at root but ESLint v9 in the package expects the new config format).
- [Link to Devin run](https://app.devin.ai/sessions/6ac98020b1864b399f8ee3dbc83e714b)
- Requested by @pyramation