### PR TITLE
chore: remove dead procedure and limit_function table exports

### DIFF
--- a/pgpm/core/src/export/export-meta.ts
+++ b/pgpm/core/src/export/export-meta.ts
@@ -222,34 +222,6 @@ const config: Record<string, TableConfig> = {
       security: 'int'
     }
   },
-  limit_function: {
-    schema: 'metaschema_public',
-    table: 'limit_function',
-    fields: {
-      id: 'uuid',
-      database_id: 'uuid',
-      table_id: 'uuid',
-      name: 'text',
-      label: 'text',
-      description: 'text',
-      data: 'jsonb',
-      security: 'int'
-    }
-  },
-  procedure: {
-    schema: 'metaschema_public',
-    table: 'procedure',
-    fields: {
-      id: 'uuid',
-      database_id: 'uuid',
-      name: 'text',
-      argnames: 'text[]',
-      argtypes: 'text[]',
-      argdefaults: 'text[]',
-      lang_name: 'text',
-      definition: 'text'
-    }
-  },
   foreign_key_constraint: {
     schema: 'metaschema_public',
     table: 'foreign_key_constraint',
@@ -1030,8 +1002,6 @@ export const exportMeta = async ({ opts, dbname, database_id }: ExportMetaParams
   await queryAndParse('trigger', `SELECT * FROM metaschema_public.trigger WHERE database_id = $1`);
   await queryAndParse('trigger_function', `SELECT * FROM metaschema_public.trigger_function WHERE database_id = $1`);
   await queryAndParse('rls_function', `SELECT * FROM metaschema_public.rls_function WHERE database_id = $1`);
-  await queryAndParse('limit_function', `SELECT * FROM metaschema_public.limit_function WHERE database_id = $1`);
-  await queryAndParse('procedure', `SELECT * FROM metaschema_public.procedure WHERE database_id = $1`);
   await queryAndParse('foreign_key_constraint', `SELECT * FROM metaschema_public.foreign_key_constraint WHERE database_id = $1`);
   await queryAndParse('primary_key_constraint', `SELECT * FROM metaschema_public.primary_key_constraint WHERE database_id = $1`);
   await queryAndParse('unique_constraint', `SELECT * FROM metaschema_public.unique_constraint WHERE database_id = $1`);

--- a/pgpm/core/src/export/export-migrations.ts
+++ b/pgpm/core/src/export/export-migrations.ts
@@ -369,8 +369,6 @@ SET session_replication_role TO DEFAULT;`;
       'trigger',
       'trigger_function',
       'rls_function',
-      'limit_function',
-      'procedure',
       'foreign_key_constraint',
       'primary_key_constraint',
       'unique_constraint',


### PR DESCRIPTION
## Summary

Removes the `procedure` and `limit_function` table configurations from the pgpm export pipeline. These tables are being removed as dead code from `constructive-db` — they had zero business logic references (no triggers, no inserts, no queries outside of this export config).

**Changes:**
- `export-meta.ts`: Removed `limit_function` and `procedure` from the `config` object and their `queryAndParse` calls
- `export-migrations.ts`: Removed both from the `tableOrder` array

**Companion PR:** constructive-io/constructive-db (removes the actual table definitions, triggers, RLS policies, and auto-generated grant files)

## Review & Testing Checklist for Human

- [ ] Verify that no other code in this repo references `limit_function` or `procedure` tables (e.g. in types, tests, or other export utilities)
- [ ] Confirm the companion constructive-db PR removing these tables is merged before publishing this change, to avoid the export attempting to query non-existent tables against an already-updated DB

### Notes

- Requested by: @pyramation
- [Link to Devin run](https://app.devin.ai/sessions/524a9467df8d4672b945db65f0081960)