### PR TITLE
refactor: replace WeakMap with Grafast meta system + adopt Benjie's plugin patterns

### DIFF
--- a/graphile/graphile-pg-textsearch-plugin/src/bm25-search.ts
+++ b/graphile/graphile-pg-textsearch-plugin/src/bm25-search.ts
@@ -21,12 +21,16 @@
  * that is populated by Bm25CodecPlugin during the gather phase.
  *
  * ARCHITECTURE NOTE:
- * Condition field apply functions run during a deferred phase (SQL generation)
- * on a queryBuilder proxy — NOT on the real PgSelectStep. The score field plan
- * runs earlier, during Grafast's planning phase, on the real PgSelectStep.
+ * Uses the Grafast meta system (setMeta/getMeta) to pass data between
+ * the condition apply phase and the output field plan, following the
+ * pattern from Benjie's postgraphile-plugin-fulltext-filter reference.
  *
- * To bridge these two phases we use a module-level WeakMap keyed by the SQL
- * alias object (shared between proxy and PgSelectStep via reference identity).
+ * 1. Condition apply (deferred/SQL-gen phase): adds BM25 score to the query
+ *    builder's SELECT list via selectAndReturnIndex, stores { selectIndex }
+ *    in meta via qb.setMeta(key, { selectIndex }).
+ * 2. Output field plan (planning phase): calls $select.getMeta(key) which
+ *    returns a Grafast Step that resolves at execution time.
+ * 3. lambda([$details, $row]) reads the score from row[details.selectIndex].
  */
 
 import 'graphile-build';
@@ -38,17 +42,12 @@ import { bm25IndexStore, bm25ExtensionDetected } from './bm25-codec';
 import { QuoteUtils } from '@pgsql/quotes';
 
 /**
- * WeakMap keyed by SQL alias object (shared reference between
- * the queryBuilder proxy and PgSelectStep).
- *
- * Stores per-query BM25 search state so the score field's lambda
- * can read the computed score value at execution time.
+ * Interface for the meta value stored by the condition apply via setMeta
+ * and read by the output field plan via getMeta.
  */
-interface Bm25ScoreSlot {
-  /** Map of fieldName -> index into the select list */
-  indices: Record<string, number>;
+interface Bm25ScoreDetails {
+  selectIndex: number;
 }
-const bm25ScoreSlots = new WeakMap<object, Bm25ScoreSlot>();
 
 /**
  * Checks if a given codec attribute has a BM25 index.
@@ -75,18 +74,38 @@ function isTextCodec(codec: any): boolean {
 }
 
 /**
- * Navigates from a PgSelectSingleStep up to the PgSelectStep.
- * Uses duck-typing to avoid dependency on exact class names across rc versions.
+ * Walks from a PgCondition up to the PgSelectQueryBuilder.
+ * Uses the .parent property on PgCondition to traverse up the chain,
+ * following Benjie's pattern from postgraphile-plugin-fulltext-filter.
+ *
+ * Returns the query builder if found, or null if the traversal fails.
  */
-function getPgSelectStep($someStep: any): any | null {
-  let $step = $someStep;
+function getQueryBuilder(
+  build: any,
+  $condition: any
+): any | null {
+  const PgCondition = build.dataplanPg?.PgCondition;
+  if (!PgCondition) return null;
 
-  if ($step && typeof $step.getClassStep === 'function') {
-    $step = $step.getClassStep();
+  let current = $condition;
+  const { alias } = current;
+
+  // Walk up through nested PgConditions (e.g. and/or/not)
+  while (
+    current &&
+    current instanceof PgCondition &&
+    current.alias === alias
+  ) {
+    current = (current as any).parent;
   }
 
-  if ($step && typeof $step.orderBy === 'function' && $step.id !== undefined) {
-    return $step;
+  // Verify we found a query builder with matching alias
+  if (
+    current &&
+    typeof current.selectAndReturnIndex === 'function' &&
+    current.alias === alias
+  ) {
+    return current;
   }
 
   return null;
@@ -165,7 +184,6 @@ export function createBm25SearchPlugin(
          */
         GraphQLObjectType_fields(fields, build, context) {
           const {
-            sql,
             inflection,
             graphql: { GraphQLFloat },
             grafast: { constant, lambda },
@@ -194,6 +212,7 @@ export function createBm25SearchPlugin(
               attributeName,
             });
             const fieldName = inflection.camelCase(`bm25-${baseFieldName}-score`);
+            const metaKey = `__bm25_score_${baseFieldName}`;
 
             newFields = build.extend(
               newFields,
@@ -204,7 +223,10 @@ export function createBm25SearchPlugin(
                     description: `BM25 relevance score when searching \`${baseFieldName}\`. Returns negative values (more negative = more relevant). Returns null when no BM25 search condition is active.`,
                     type: GraphQLFloat,
                     plan($step: any) {
-                      const $select = getPgSelectStep($step);
+                      const $row = $step;
+                      const $select = typeof $row.getClassStep === 'function'
+                        ? $row.getClassStep()
+                        : null;
                       if (!$select) return constant(null);
 
                       if (
@@ -213,34 +235,28 @@ export function createBm25SearchPlugin(
                         $select.setInliningForbidden();
                       }
 
-                      // Initialise the WeakMap slot for this query
-                      const alias = $select.alias;
-                      if (!bm25ScoreSlots.has(alias)) {
-                        bm25ScoreSlots.set(alias, {
-                          indices: Object.create(null),
-                        });
-                      }
+                      // Use the meta system to retrieve score details.
+                      // getMeta returns a Grafast Step that resolves at
+                      // execution time to the value set by setMeta in
+                      // the condition apply phase.
+                      const $details = $select.getMeta(metaKey);
 
-                      const capturedField = baseFieldName;
-                      const capturedAlias = alias;
                       return lambda(
-                        $step,
-                        (row: any) => {
-                          if (row == null) return null;
-                          const slot =
-                            bm25ScoreSlots.get(capturedAlias);
+                        [$details, $row],
+                        ([details, row]: readonly [any, any]) => {
+                          const d = details as Bm25ScoreDetails | null;
                           if (
-                            !slot ||
-                            slot.indices[capturedField] === undefined
-                          )
+                            d == null ||
+                            row == null ||
+                            d.selectIndex == null
+                          ) {
                             return null;
-                          const rawValue =
-                            row[slot.indices[capturedField]];
+                          }
+                          const rawValue = row[d.selectIndex];
                           return rawValue == null
                             ? null
                             : parseFloat(rawValue);
-                        },
-                        true
+                        }
                       );
                     },
                   })
@@ -366,6 +382,7 @@ export function createBm25SearchPlugin(
               codec: pgCodec as any,
               attributeName,
             });
+            const scoreMetaKey = `__bm25_score_${baseFieldName}`;
 
             newFields = build.extend(
               newFields,
@@ -413,43 +430,34 @@ export function createBm25SearchPlugin(
                         );
                       }
 
-                      // Add score to the SELECT list
-                      const $parent =
-                        $condition.dangerouslyGetParent();
-                      if (
-                        typeof $parent.selectAndReturnIndex ===
-                        'function'
-                      ) {
+                      // Get the query builder via meta-safe traversal
+                      const qb = getQueryBuilder(build, $condition);
+                      if (qb) {
+                        // Add score to the SELECT list
                         const wrappedScoreSql = sql`${sql.parens(scoreExpr)}::text`;
-                        const scoreIndex =
-                          $parent.selectAndReturnIndex(
-                            wrappedScoreSql
-                          );
-
-                        // Store index in alias-keyed WeakMap
-                        const slot = bm25ScoreSlots.get(
-                          $condition.alias
+                        const scoreIndex = qb.selectAndReturnIndex(
+                          wrappedScoreSql
                         );
-                        if (slot) {
-                          slot.indices[baseFieldName] =
-                            scoreIndex;
-                        }
+
+                        // Store the select index in meta (replaces WeakMap)
+                        qb.setMeta(scoreMetaKey, {
+                          selectIndex: scoreIndex,
+                        } as Bm25ScoreDetails);
                       }
 
                       // ORDER BY score: only add when the user
                       // explicitly requested score ordering via
                       // the BM25_<COLUMN>_SCORE_ASC/DESC enum values.
-                      const metaKey = `bm25_order_${baseFieldName}`;
-                      const explicitDir =
-                        typeof $parent.getMetaRaw === 'function'
-                          ? $parent.getMetaRaw(metaKey)
-                          : undefined;
-                      if (explicitDir) {
-                        $parent.orderBy({
-                          fragment: scoreExpr,
-                          codec: TYPES.float,
-                          direction: explicitDir,
-                        });
+                      if (qb && typeof qb.getMetaRaw === 'function') {
+                        const orderMetaKey = `bm25_order_${baseFieldName}`;
+                        const explicitDir = qb.getMetaRaw(orderMetaKey);
+                        if (explicitDir) {
+                          qb.orderBy({
+                            fragment: scoreExpr,
+                            codec: TYPES.float,
+                            direction: explicitDir,
+                          });
+                        }
                       }
                     },
                   }

--- a/graphile/graphile-pg-textsearch-plugin/src/bm25-search.ts
+++ b/graphile/graphile-pg-textsearch-plugin/src/bm25-search.ts
@@ -135,7 +135,6 @@ function getQueryBuilder(
   if (
     current &&
     typeof current.selectAndReturnIndex === 'function' &&
-    typeof current.where === 'function' &&
     current.alias === alias
   ) {
     return current;

--- a/graphile/graphile-pg-textsearch-plugin/src/bm25-search.ts
+++ b/graphile/graphile-pg-textsearch-plugin/src/bm25-search.ts
@@ -36,10 +36,41 @@
 import 'graphile-build';
 import 'graphile-build-pg';
 import { TYPES } from '@dataplan/pg';
+import type { PgCodecWithAttributes } from '@dataplan/pg';
 import type { GraphileConfig } from 'graphile-config';
 import type { Bm25SearchPluginOptions, Bm25IndexInfo } from './types';
 import { bm25IndexStore, bm25ExtensionDetected } from './bm25-codec';
 import { QuoteUtils } from '@pgsql/quotes';
+
+// ─── TypeScript Namespace Augmentations ──────────────────────────────────────
+
+declare global {
+  namespace GraphileBuild {
+    interface Inflection {
+      /** Name for the BM25 score field (e.g. "bm25BodyScore") */
+      pgBm25Score(this: Inflection, fieldName: string): string;
+      /** Name for orderBy enum value for BM25 score */
+      pgBm25OrderByScoreEnum(
+        this: Inflection,
+        codec: PgCodecWithAttributes,
+        attributeName: string,
+        ascending: boolean,
+      ): string;
+    }
+    interface ScopeObjectFieldsField {
+      isPgBm25ScoreField?: boolean;
+    }
+    interface BehaviorStrings {
+      'attributeBm25Score:select': true;
+      'attributeBm25Score:orderBy': true;
+    }
+  }
+  namespace GraphileConfig {
+    interface Plugins {
+      Bm25SearchPlugin: true;
+    }
+  }
+}
 
 /**
  * Interface for the meta value stored by the condition apply via setMeta
@@ -100,9 +131,11 @@ function getQueryBuilder(
   }
 
   // Verify we found a query builder with matching alias
+  // Using duck-typing (isPgSelectQueryBuilder) per Benjie's pattern
   if (
     current &&
     typeof current.selectAndReturnIndex === 'function' &&
+    typeof current.where === 'function' &&
     current.alias === alias
   ) {
     return current;
@@ -129,7 +162,69 @@ export function createBm25SearchPlugin(
       'PgAttributesPlugin',
     ],
 
+    // ─── Custom Inflection Methods ─────────────────────────────────────
+    inflection: {
+      add: {
+        pgBm25Score(_preset, fieldName) {
+          return this.camelCase(`bm25-${fieldName}-score`);
+        },
+        pgBm25OrderByScoreEnum(_preset, codec, attributeName, ascending) {
+          const columnName = this._attributeName({
+            codec,
+            attributeName,
+            skipRowId: true,
+          });
+          return this.constantCase(
+            `bm25_${columnName}_score_${ascending ? 'asc' : 'desc'}`,
+          );
+        },
+      },
+    },
+
     schema: {
+      // ─── Behavior Registry ─────────────────────────────────────────────
+      behaviorRegistry: {
+        add: {
+          'attributeBm25Score:select': {
+            description:
+              'Should the BM25 score be exposed for this attribute',
+            entities: ['pgCodecAttribute'],
+          },
+          'attributeBm25Score:orderBy': {
+            description:
+              'Should you be able to order by the BM25 score for this attribute',
+            entities: ['pgCodecAttribute'],
+          },
+        },
+      },
+      entityBehavior: {
+        pgCodecAttribute: {
+          inferred: {
+            provides: ['default'],
+            before: ['inferred', 'override', 'PgAttributesPlugin'],
+            callback(behavior, [codec, attributeName], _build) {
+              const attr = codec.attributes[attributeName];
+              const codecName = attr.codec?.name;
+              if (codecName === 'text' || codecName === 'varchar' || codecName === 'bpchar') {
+                // Check if this attribute has a BM25 index
+                const pg = codec?.extensions?.pg;
+                if (pg) {
+                  const key = `${pg.schemaName}.${pg.name}.${attributeName}`;
+                  if (bm25IndexStore.has(key)) {
+                    return [
+                      'attributeBm25Score:orderBy',
+                      'attributeBm25Score:select',
+                      behavior,
+                    ];
+                  }
+                }
+              }
+              return behavior;
+            },
+          },
+        },
+      },
+
       hooks: {
         init(_, build) {
           const {
@@ -186,39 +281,57 @@ export function createBm25SearchPlugin(
           const {
             inflection,
             graphql: { GraphQLFloat },
-            grafast: { constant, lambda },
+            grafast: { lambda },
           } = build;
           const {
-            scope: { isPgClassType, pgCodec },
+            scope: { isPgClassType, pgCodec: rawPgCodec },
             fieldWithHooks,
           } = context;
 
-          if (!isPgClassType || !pgCodec?.attributes) {
+          if (!isPgClassType || !rawPgCodec?.attributes) {
             return fields;
           }
+
+          const codec = rawPgCodec as PgCodecWithAttributes;
+          const behavior = (build as any).behavior;
 
           let newFields = fields;
 
           for (const [attributeName, attribute] of Object.entries(
-            pgCodec.attributes as Record<string, any>
+            codec.attributes as Record<string, any>
           )) {
             if (!isTextCodec(attribute.codec)) continue;
 
-            const bm25Index = getBm25IndexForAttribute(pgCodec, attributeName);
+            const bm25Index = getBm25IndexForAttribute(codec, attributeName);
             if (!bm25Index) continue;
 
+            // Check behavior registry — skip if user opted out
+            if (
+              behavior &&
+              typeof behavior.pgCodecAttributeMatches === 'function' &&
+              !behavior.pgCodecAttributeMatches(
+                [codec, attributeName],
+                'attributeBm25Score:select',
+              )
+            ) {
+              continue;
+            }
+
             const baseFieldName = inflection.attribute({
-              codec: pgCodec as any,
+              codec: codec as any,
               attributeName,
             });
-            const fieldName = inflection.camelCase(`bm25-${baseFieldName}-score`);
+            const fieldName = inflection.pgBm25Score(baseFieldName);
             const metaKey = `__bm25_score_${baseFieldName}`;
 
             newFields = build.extend(
               newFields,
               {
                 [fieldName]: fieldWithHooks(
-                  { fieldName } as any,
+                  {
+                    fieldName,
+                    isPgBm25ScoreField: true,
+                  } as any,
                   () => ({
                     description: `BM25 relevance score when searching \`${baseFieldName}\`. Returns negative values (more negative = more relevant). Returns null when no BM25 search condition is active.`,
                     type: GraphQLFloat,
@@ -227,7 +340,7 @@ export function createBm25SearchPlugin(
                       const $select = typeof $row.getClassStep === 'function'
                         ? $row.getClassStep()
                         : null;
-                      if (!$select) return constant(null);
+                      if (!$select) return build.grafast.constant(null);
 
                       if (
                         typeof $select.setInliningForbidden === 'function'
@@ -235,10 +348,6 @@ export function createBm25SearchPlugin(
                         $select.setInliningForbidden();
                       }
 
-                      // Use the meta system to retrieve score details.
-                      // getMeta returns a Grafast Step that resolves at
-                      // execution time to the value set by setMeta in
-                      // the condition apply phase.
                       const $details = $select.getMeta(metaKey);
 
                       return lambda(
@@ -255,14 +364,14 @@ export function createBm25SearchPlugin(
                           const rawValue = row[d.selectIndex];
                           return rawValue == null
                             ? null
-                            : parseFloat(rawValue);
+                            : TYPES.float.fromPg(rawValue as string);
                         }
                       );
                     },
                   })
                 ),
               },
-              `Bm25SearchPlugin adding score field '${fieldName}' for '${attributeName}' on '${pgCodec.name}'`
+              `Bm25SearchPlugin adding score field '${fieldName}' for '${attributeName}' on '${codec.name}'`
             );
           }
 
@@ -276,25 +385,40 @@ export function createBm25SearchPlugin(
         GraphQLEnumType_values(values, build, context) {
           const { inflection } = build;
           const {
-            scope: { isPgRowSortEnum, pgCodec },
+            scope: { isPgRowSortEnum, pgCodec: rawPgCodec },
           } = context;
 
-          if (!isPgRowSortEnum || !pgCodec?.attributes) {
+          if (!isPgRowSortEnum || !rawPgCodec?.attributes) {
             return values;
           }
+
+          const codec = rawPgCodec as PgCodecWithAttributes;
+          const behavior = (build as any).behavior;
 
           let newValues = values;
 
           for (const [attributeName, attribute] of Object.entries(
-            pgCodec.attributes as Record<string, any>
+            codec.attributes as Record<string, any>
           )) {
             if (!isTextCodec(attribute.codec)) continue;
 
-            const bm25Index = getBm25IndexForAttribute(pgCodec, attributeName);
+            const bm25Index = getBm25IndexForAttribute(codec, attributeName);
             if (!bm25Index) continue;
 
+            // Check behavior registry
+            if (
+              behavior &&
+              typeof behavior.pgCodecAttributeMatches === 'function' &&
+              !behavior.pgCodecAttributeMatches(
+                [codec, attributeName],
+                'attributeBm25Score:orderBy',
+              )
+            ) {
+              continue;
+            }
+
             const fieldName = inflection.attribute({
-              codec: pgCodec as any,
+              codec: codec as any,
               attributeName,
             });
             const metaKey = `bm25_order_${fieldName}`;
@@ -305,12 +429,8 @@ export function createBm25SearchPlugin(
                 }
               };
 
-            const ascName = inflection.constantCase(
-              `bm25_${attributeName}_score_asc`
-            );
-            const descName = inflection.constantCase(
-              `bm25_${attributeName}_score_desc`
-            );
+            const ascName = inflection.pgBm25OrderByScoreEnum(codec, attributeName, true);
+            const descName = inflection.pgBm25OrderByScoreEnum(codec, attributeName, false);
 
             newValues = build.extend(
               newValues,
@@ -330,7 +450,7 @@ export function createBm25SearchPlugin(
                   },
                 },
               },
-              `Bm25SearchPlugin adding score orderBy for '${attributeName}' on '${pgCodec.name}'`
+              `Bm25SearchPlugin adding score orderBy for '${attributeName}' on '${codec.name}'`
             );
           }
 
@@ -432,14 +552,17 @@ export function createBm25SearchPlugin(
 
                       // Get the query builder via meta-safe traversal
                       const qb = getQueryBuilder(build, $condition);
-                      if (qb) {
+
+                      // Only inject SELECT expressions when in "normal" mode
+                      // (not aggregate mode). Following Benjie's qb.mode check.
+                      if (qb && qb.mode === 'normal') {
                         // Add score to the SELECT list
                         const wrappedScoreSql = sql`${sql.parens(scoreExpr)}::text`;
                         const scoreIndex = qb.selectAndReturnIndex(
                           wrappedScoreSql
                         );
 
-                        // Store the select index in meta (replaces WeakMap)
+                        // Store the select index in meta
                         qb.setMeta(scoreMetaKey, {
                           selectIndex: scoreIndex,
                         } as Bm25ScoreDetails);
@@ -448,7 +571,7 @@ export function createBm25SearchPlugin(
                       // ORDER BY score: only add when the user
                       // explicitly requested score ordering via
                       // the BM25_<COLUMN>_SCORE_ASC/DESC enum values.
-                      if (qb && typeof qb.getMetaRaw === 'function') {
+                      if (qb && qb.mode === 'normal' && typeof qb.getMetaRaw === 'function') {
                         const orderMetaKey = `bm25_order_${baseFieldName}`;
                         const explicitDir = qb.getMetaRaw(orderMetaKey);
                         if (explicitDir) {

--- a/graphile/graphile-pg-textsearch-plugin/src/bm25-search.ts
+++ b/graphile/graphile-pg-textsearch-plugin/src/bm25-search.ts
@@ -571,7 +571,7 @@ export function createBm25SearchPlugin(
                       // ORDER BY score: only add when the user
                       // explicitly requested score ordering via
                       // the BM25_<COLUMN>_SCORE_ASC/DESC enum values.
-                      if (qb && qb.mode === 'normal' && typeof qb.getMetaRaw === 'function') {
+                      if (qb && typeof qb.getMetaRaw === 'function') {
                         const orderMetaKey = `bm25_order_${baseFieldName}`;
                         const explicitDir = qb.getMetaRaw(orderMetaKey);
                         if (explicitDir) {

--- a/graphile/graphile-pgvector-plugin/src/vector-search.ts
+++ b/graphile/graphile-pgvector-plugin/src/vector-search.ts
@@ -27,8 +27,39 @@
 import 'graphile-build';
 import 'graphile-build-pg';
 import { TYPES } from '@dataplan/pg';
+import type { PgCodecWithAttributes } from '@dataplan/pg';
 import type { GraphileConfig } from 'graphile-config';
 import type { VectorSearchPluginOptions } from './types';
+
+// ─── TypeScript Namespace Augmentations ──────────────────────────────────────
+
+declare global {
+  namespace GraphileBuild {
+    interface Inflection {
+      /** Name for the distance field (e.g. "embeddingDistance") */
+      pgVectorDistance(this: Inflection, fieldName: string): string;
+      /** Name for orderBy enum value for vector distance */
+      pgVectorOrderByDistanceEnum(
+        this: Inflection,
+        codec: PgCodecWithAttributes,
+        attributeName: string,
+        ascending: boolean,
+      ): string;
+    }
+    interface ScopeObjectFieldsField {
+      isPgVectorDistanceField?: boolean;
+    }
+    interface BehaviorStrings {
+      'attributeVectorDistance:select': true;
+      'attributeVectorDistance:orderBy': true;
+    }
+  }
+  namespace GraphileConfig {
+    interface Plugins {
+      VectorSearchPlugin: true;
+    }
+  }
+}
 
 /**
  * Interface for the meta value stored by the condition apply via setMeta
@@ -81,9 +112,11 @@ function getQueryBuilder(
   }
 
   // Verify we found a query builder with matching alias
+  // Using duck-typing (isPgSelectQueryBuilder) per Benjie's pattern
   if (
     current &&
     typeof current.selectAndReturnIndex === 'function' &&
+    typeof current.where === 'function' &&
     current.alias === alias
   ) {
     return current;
@@ -114,7 +147,61 @@ export function createVectorSearchPlugin(
       'PgAttributesPlugin',
     ],
 
+    // ─── Custom Inflection Methods ─────────────────────────────────────
+    inflection: {
+      add: {
+        pgVectorDistance(_preset, fieldName) {
+          return this.camelCase(`${fieldName}-distance`);
+        },
+        pgVectorOrderByDistanceEnum(_preset, codec, attributeName, ascending) {
+          const columnName = this._attributeName({
+            codec,
+            attributeName,
+            skipRowId: true,
+          });
+          return this.constantCase(
+            `${columnName}_distance_${ascending ? 'asc' : 'desc'}`,
+          );
+        },
+      },
+    },
+
     schema: {
+      // ─── Behavior Registry ─────────────────────────────────────────────
+      behaviorRegistry: {
+        add: {
+          'attributeVectorDistance:select': {
+            description:
+              'Should the vector distance be exposed for this attribute',
+            entities: ['pgCodecAttribute'],
+          },
+          'attributeVectorDistance:orderBy': {
+            description:
+              'Should you be able to order by the vector distance for this attribute',
+            entities: ['pgCodecAttribute'],
+          },
+        },
+      },
+      entityBehavior: {
+        pgCodecAttribute: {
+          inferred: {
+            provides: ['default'],
+            before: ['inferred', 'override', 'PgAttributesPlugin'],
+            callback(behavior, [codec, attributeName], _build) {
+              const attr = codec.attributes[attributeName];
+              if (attr.codec?.name === 'vector') {
+                return [
+                  'attributeVectorDistance:orderBy',
+                  'attributeVectorDistance:select',
+                  behavior,
+                ];
+              }
+              return behavior;
+            },
+          },
+        },
+      },
+
       hooks: {
         init(_, build) {
           const {
@@ -197,36 +284,54 @@ export function createVectorSearchPlugin(
           const {
             inflection,
             graphql: { GraphQLFloat },
-            grafast: { constant, lambda },
+            grafast: { lambda },
           } = build;
           const {
-            scope: { isPgClassType, pgCodec },
+            scope: { isPgClassType, pgCodec: rawPgCodec },
             fieldWithHooks,
           } = context;
 
-          if (!isPgClassType || !pgCodec?.attributes) {
+          if (!isPgClassType || !rawPgCodec?.attributes) {
             return fields;
           }
+
+          const codec = rawPgCodec as PgCodecWithAttributes;
+          const behavior = (build as any).behavior;
 
           let newFields = fields;
 
           for (const [attributeName, attribute] of Object.entries(
-            pgCodec.attributes as Record<string, any>
+            codec.attributes as Record<string, any>
           )) {
             if (!isVectorCodec(attribute.codec)) continue;
 
+            // Check behavior registry — skip if user opted out
+            if (
+              behavior &&
+              typeof behavior.pgCodecAttributeMatches === 'function' &&
+              !behavior.pgCodecAttributeMatches(
+                [codec, attributeName],
+                'attributeVectorDistance:select',
+              )
+            ) {
+              continue;
+            }
+
             const baseFieldName = inflection.attribute({
-              codec: pgCodec as any,
+              codec: codec as any,
               attributeName,
             });
-            const fieldName = inflection.camelCase(`${baseFieldName}-distance`);
+            const fieldName = inflection.pgVectorDistance(baseFieldName);
             const metaKey = `__vector_distance_${baseFieldName}`;
 
             newFields = build.extend(
               newFields,
               {
                 [fieldName]: fieldWithHooks(
-                  { fieldName } as any,
+                  {
+                    fieldName,
+                    isPgVectorDistanceField: true,
+                  } as any,
                   () => ({
                     description: `Vector distance when filtered by \`${baseFieldName}\` nearby condition. Returns null when no nearby condition is active.`,
                     type: GraphQLFloat,
@@ -235,7 +340,7 @@ export function createVectorSearchPlugin(
                       const $select = typeof $row.getClassStep === 'function'
                         ? $row.getClassStep()
                         : null;
-                      if (!$select) return constant(null);
+                      if (!$select) return build.grafast.constant(null);
 
                       if (
                         typeof $select.setInliningForbidden === 'function'
@@ -243,10 +348,6 @@ export function createVectorSearchPlugin(
                         $select.setInliningForbidden();
                       }
 
-                      // Use the meta system to retrieve distance details.
-                      // getMeta returns a Grafast Step that resolves at
-                      // execution time to the value set by setMeta in
-                      // the condition apply phase.
                       const $details = $select.getMeta(metaKey);
 
                       return lambda(
@@ -263,14 +364,14 @@ export function createVectorSearchPlugin(
                           const rawValue = row[d.selectIndex];
                           return rawValue == null
                             ? null
-                            : parseFloat(rawValue);
+                            : TYPES.float.fromPg(rawValue as string);
                         }
                       );
                     },
                   })
                 ),
               },
-              `VectorSearchPlugin adding distance field '${fieldName}' for '${attributeName}' on '${pgCodec.name}'`
+              `VectorSearchPlugin adding distance field '${fieldName}' for '${attributeName}' on '${codec.name}'`
             );
           }
 
@@ -284,22 +385,37 @@ export function createVectorSearchPlugin(
         GraphQLEnumType_values(values, build, context) {
           const { inflection } = build;
           const {
-            scope: { isPgRowSortEnum, pgCodec },
+            scope: { isPgRowSortEnum, pgCodec: rawPgCodec },
           } = context;
 
-          if (!isPgRowSortEnum || !pgCodec?.attributes) {
+          if (!isPgRowSortEnum || !rawPgCodec?.attributes) {
             return values;
           }
+
+          const codec = rawPgCodec as PgCodecWithAttributes;
+          const behavior = (build as any).behavior;
 
           let newValues = values;
 
           for (const [attributeName, attribute] of Object.entries(
-            pgCodec.attributes as Record<string, any>
+            codec.attributes as Record<string, any>
           )) {
             if (!isVectorCodec(attribute.codec)) continue;
 
+            // Check behavior registry
+            if (
+              behavior &&
+              typeof behavior.pgCodecAttributeMatches === 'function' &&
+              !behavior.pgCodecAttributeMatches(
+                [codec, attributeName],
+                'attributeVectorDistance:orderBy',
+              )
+            ) {
+              continue;
+            }
+
             const fieldName = inflection.attribute({
-              codec: pgCodec as any,
+              codec: codec as any,
               attributeName,
             });
             const metaKey = `vector_order_${fieldName}`;
@@ -310,12 +426,8 @@ export function createVectorSearchPlugin(
                 }
               };
 
-            const ascName = inflection.constantCase(
-              `${attributeName}_distance_asc`
-            );
-            const descName = inflection.constantCase(
-              `${attributeName}_distance_desc`
-            );
+            const ascName = inflection.pgVectorOrderByDistanceEnum(codec, attributeName, true);
+            const descName = inflection.pgVectorOrderByDistanceEnum(codec, attributeName, false);
 
             newValues = build.extend(
               newValues,
@@ -335,7 +447,7 @@ export function createVectorSearchPlugin(
                   },
                 },
               },
-              `VectorSearchPlugin adding distance orderBy for '${attributeName}' on '${pgCodec.name}'`
+              `VectorSearchPlugin adding distance orderBy for '${attributeName}' on '${codec.name}'`
             );
           }
 
@@ -438,14 +550,17 @@ export function createVectorSearchPlugin(
 
                       // Get the query builder via meta-safe traversal
                       const qb = getQueryBuilder(build, $condition);
-                      if (qb) {
+
+                      // Only inject SELECT expressions when in "normal" mode
+                      // (not aggregate mode). Following Benjie's qb.mode check.
+                      if (qb && qb.mode === 'normal') {
                         // Add distance to the SELECT list
                         const wrappedDistanceSql = sql`${sql.parens(distanceExpr)}::text`;
                         const distanceIndex = qb.selectAndReturnIndex(
                           wrappedDistanceSql
                         );
 
-                        // Store the select index in meta (replaces WeakMap)
+                        // Store the select index in meta
                         qb.setMeta(distanceMetaKey, {
                           selectIndex: distanceIndex,
                         } as VectorDistanceDetails);
@@ -454,7 +569,7 @@ export function createVectorSearchPlugin(
                       // ORDER BY distance: only add when the user
                       // explicitly requested distance ordering via
                       // the EMBEDDING_DISTANCE_ASC/DESC enum values.
-                      if (qb && typeof qb.getMetaRaw === 'function') {
+                      if (qb && qb.mode === 'normal' && typeof qb.getMetaRaw === 'function') {
                         const orderMetaKey = `vector_order_${baseFieldName}`;
                         const explicitDir = qb.getMetaRaw(orderMetaKey);
                         if (explicitDir) {

--- a/graphile/graphile-pgvector-plugin/src/vector-search.ts
+++ b/graphile/graphile-pgvector-plugin/src/vector-search.ts
@@ -17,6 +17,10 @@
  * 4. **<COLUMN>_DISTANCE_ASC/DESC** orderBy enum values
  *    - Orders results by vector distance when a nearby condition is active
  *
+ * Uses the Grafast meta system (setMeta/getMeta) to pass data between
+ * the condition apply phase and the output field plan, following the
+ * pattern from Benjie's postgraphile-plugin-fulltext-filter reference.
+ *
  * Follows the same patterns as graphile-search-plugin (for tsvector columns).
  */
 
@@ -25,6 +29,14 @@ import 'graphile-build-pg';
 import { TYPES } from '@dataplan/pg';
 import type { GraphileConfig } from 'graphile-config';
 import type { VectorSearchPluginOptions } from './types';
+
+/**
+ * Interface for the meta value stored by the condition apply via setMeta
+ * and read by the output field plan via getMeta.
+ */
+interface VectorDistanceDetails {
+  selectIndex: number;
+}
 
 /**
  * pgvector distance operators.
@@ -43,35 +55,42 @@ function isVectorCodec(codec: any): boolean {
 }
 
 /**
- * Navigates from a PgSelectSingleStep up to the PgSelectStep.
- * Uses duck-typing to avoid dependency on exact class names across rc versions.
+ * Walks from a PgCondition up to the PgSelectQueryBuilder.
+ * Uses the .parent property on PgCondition to traverse up the chain,
+ * following Benjie's pattern from postgraphile-plugin-fulltext-filter.
+ *
+ * Returns the query builder if found, or null if the traversal fails.
  */
-function getPgSelectStep($someStep: any): any | null {
-  let $step = $someStep;
+function getQueryBuilder(
+  build: any,
+  $condition: any
+): any | null {
+  const PgCondition = build.dataplanPg?.PgCondition;
+  if (!PgCondition) return null;
 
-  if ($step && typeof $step.getClassStep === 'function') {
-    $step = $step.getClassStep();
+  let current = $condition;
+  const { alias } = current;
+
+  // Walk up through nested PgConditions (e.g. and/or/not)
+  while (
+    current &&
+    current instanceof PgCondition &&
+    current.alias === alias
+  ) {
+    current = (current as any).parent;
   }
 
-  if ($step && typeof $step.orderBy === 'function' && $step.id !== undefined) {
-    return $step;
+  // Verify we found a query builder with matching alias
+  if (
+    current &&
+    typeof current.selectAndReturnIndex === 'function' &&
+    current.alias === alias
+  ) {
+    return current;
   }
 
   return null;
 }
-
-/**
- * WeakMap keyed by SQL alias object (shared reference between
- * the queryBuilder proxy and PgSelectStep).
- *
- * Stores per-query vector search state so the distance field's lambda
- * can read the computed distance value at execution time.
- */
-interface VectorDistanceSlot {
-  /** Map of fieldName -> index into the select list */
-  indices: Record<string, number>;
-}
-const vectorDistanceSlots = new WeakMap<object, VectorDistanceSlot>();
 
 /**
  * Creates the vector search plugin with the given options.
@@ -176,7 +195,6 @@ export function createVectorSearchPlugin(
          */
         GraphQLObjectType_fields(fields, build, context) {
           const {
-            sql,
             inflection,
             graphql: { GraphQLFloat },
             grafast: { constant, lambda },
@@ -202,6 +220,7 @@ export function createVectorSearchPlugin(
               attributeName,
             });
             const fieldName = inflection.camelCase(`${baseFieldName}-distance`);
+            const metaKey = `__vector_distance_${baseFieldName}`;
 
             newFields = build.extend(
               newFields,
@@ -212,7 +231,10 @@ export function createVectorSearchPlugin(
                     description: `Vector distance when filtered by \`${baseFieldName}\` nearby condition. Returns null when no nearby condition is active.`,
                     type: GraphQLFloat,
                     plan($step: any) {
-                      const $select = getPgSelectStep($step);
+                      const $row = $step;
+                      const $select = typeof $row.getClassStep === 'function'
+                        ? $row.getClassStep()
+                        : null;
                       if (!$select) return constant(null);
 
                       if (
@@ -221,34 +243,28 @@ export function createVectorSearchPlugin(
                         $select.setInliningForbidden();
                       }
 
-                      // Initialise the WeakMap slot for this query
-                      const alias = $select.alias;
-                      if (!vectorDistanceSlots.has(alias)) {
-                        vectorDistanceSlots.set(alias, {
-                          indices: Object.create(null),
-                        });
-                      }
+                      // Use the meta system to retrieve distance details.
+                      // getMeta returns a Grafast Step that resolves at
+                      // execution time to the value set by setMeta in
+                      // the condition apply phase.
+                      const $details = $select.getMeta(metaKey);
 
-                      const capturedField = baseFieldName;
-                      const capturedAlias = alias;
                       return lambda(
-                        $step,
-                        (row: any) => {
-                          if (row == null) return null;
-                          const slot =
-                            vectorDistanceSlots.get(capturedAlias);
+                        [$details, $row],
+                        ([details, row]: readonly [any, any]) => {
+                          const d = details as VectorDistanceDetails | null;
                           if (
-                            !slot ||
-                            slot.indices[capturedField] === undefined
-                          )
+                            d == null ||
+                            row == null ||
+                            d.selectIndex == null
+                          ) {
                             return null;
-                          const rawValue =
-                            row[slot.indices[capturedField]];
+                          }
+                          const rawValue = row[d.selectIndex];
                           return rawValue == null
                             ? null
                             : parseFloat(rawValue);
-                        },
-                        true
+                        }
                       );
                     },
                   })
@@ -366,6 +382,7 @@ export function createVectorSearchPlugin(
               codec: pgCodec as any,
               attributeName,
             });
+            const distanceMetaKey = `__vector_distance_${baseFieldName}`;
 
             newFields = build.extend(
               newFields,
@@ -419,43 +436,34 @@ export function createVectorSearchPlugin(
                         );
                       }
 
-                      // Add distance to the SELECT list
-                      const $parent =
-                        $condition.dangerouslyGetParent();
-                      if (
-                        typeof $parent.selectAndReturnIndex ===
-                        'function'
-                      ) {
+                      // Get the query builder via meta-safe traversal
+                      const qb = getQueryBuilder(build, $condition);
+                      if (qb) {
+                        // Add distance to the SELECT list
                         const wrappedDistanceSql = sql`${sql.parens(distanceExpr)}::text`;
-                        const distanceIndex =
-                          $parent.selectAndReturnIndex(
-                            wrappedDistanceSql
-                          );
-
-                        // Store index in alias-keyed WeakMap
-                        const slot = vectorDistanceSlots.get(
-                          $condition.alias
+                        const distanceIndex = qb.selectAndReturnIndex(
+                          wrappedDistanceSql
                         );
-                        if (slot) {
-                          slot.indices[baseFieldName] =
-                            distanceIndex;
-                        }
+
+                        // Store the select index in meta (replaces WeakMap)
+                        qb.setMeta(distanceMetaKey, {
+                          selectIndex: distanceIndex,
+                        } as VectorDistanceDetails);
                       }
 
                       // ORDER BY distance: only add when the user
                       // explicitly requested distance ordering via
                       // the EMBEDDING_DISTANCE_ASC/DESC enum values.
-                      const metaKey = `vector_order_${baseFieldName}`;
-                      const explicitDir =
-                        typeof $parent.getMetaRaw === 'function'
-                          ? $parent.getMetaRaw(metaKey)
-                          : undefined;
-                      if (explicitDir) {
-                        $parent.orderBy({
-                          fragment: distanceExpr,
-                          codec: TYPES.float,
-                          direction: explicitDir,
-                        });
+                      if (qb && typeof qb.getMetaRaw === 'function') {
+                        const orderMetaKey = `vector_order_${baseFieldName}`;
+                        const explicitDir = qb.getMetaRaw(orderMetaKey);
+                        if (explicitDir) {
+                          qb.orderBy({
+                            fragment: distanceExpr,
+                            codec: TYPES.float,
+                            direction: explicitDir,
+                          });
+                        }
                       }
                     },
                   }

--- a/graphile/graphile-pgvector-plugin/src/vector-search.ts
+++ b/graphile/graphile-pgvector-plugin/src/vector-search.ts
@@ -116,7 +116,6 @@ function getQueryBuilder(
   if (
     current &&
     typeof current.selectAndReturnIndex === 'function' &&
-    typeof current.where === 'function' &&
     current.alias === alias
   ) {
     return current;

--- a/graphile/graphile-pgvector-plugin/src/vector-search.ts
+++ b/graphile/graphile-pgvector-plugin/src/vector-search.ts
@@ -569,7 +569,7 @@ export function createVectorSearchPlugin(
                       // ORDER BY distance: only add when the user
                       // explicitly requested distance ordering via
                       // the EMBEDDING_DISTANCE_ASC/DESC enum values.
-                      if (qb && qb.mode === 'normal' && typeof qb.getMetaRaw === 'function') {
+                      if (qb && typeof qb.getMetaRaw === 'function') {
                         const orderMetaKey = `vector_order_${baseFieldName}`;
                         const explicitDir = qb.getMetaRaw(orderMetaKey);
                         if (explicitDir) {

--- a/graphile/graphile-search-plugin/src/plugin.ts
+++ b/graphile/graphile-search-plugin/src/plugin.ts
@@ -18,15 +18,17 @@
  *
  * ARCHITECTURE NOTE:
  * Uses the Grafast meta system (setMeta/getMeta) to pass data between
- * the condition apply phase and the output field plan, following the
- * pattern from Benjie's postgraphile-plugin-fulltext-filter reference.
+ * the condition apply phase, the orderBy enum apply, and the output field
+ * plan, following the pattern from Benjie's postgraphile-plugin-fulltext-filter.
  *
- * 1. Condition apply (deferred/SQL-gen phase): adds ts_rank to the query
- *    builder's SELECT list via selectAndReturnIndex, stores { selectIndex }
- *    in meta via qb.setMeta(key, { selectIndex }).
- * 2. Output field plan (planning phase): calls $select.getMeta(key) which
+ * 1. Condition apply (runs first): adds ts_rank to the query builder's
+ *    SELECT list via selectAndReturnIndex, stores { selectIndex, scoreFragment }
+ *    in meta via qb.setMeta(key, { selectIndex, scoreFragment }).
+ * 2. OrderBy enum apply (runs second): reads the scoreFragment from meta
+ *    and calls qb.orderBy({ fragment, codec, direction }) directly.
+ * 3. Output field plan (planning phase): calls $select.getMeta(key) which
  *    returns a Grafast Step that resolves at execution time.
- * 3. lambda([$details, $row]) reads the rank from row[details.selectIndex].
+ * 4. lambda([$details, $row]) reads the rank from row[details.selectIndex].
  */
 
 import 'graphile-build';
@@ -85,6 +87,24 @@ declare global {
  */
 interface FtsRankDetails {
   selectIndex: number;
+  scoreFragment: SQL;
+}
+
+/**
+ * Direction flag stored by the orderBy enum apply at planning time.
+ *
+ * PostGraphile processes orderBy enum applies at PLANNING time (receiving
+ * PgSelectStep), but condition applies at EXECUTION time (receiving a runtime
+ * proxy). The proxy's meta is initialized from PgSelectStep._meta, so data
+ * stored at planning time IS available at execution time.
+ *
+ * Flow:
+ * 1. Enum apply (planning): stores direction in PgSelectStep._meta
+ * 2. PgSelectStep._meta gets copied to proxy's meta closure
+ * 3. Condition apply (execution): reads direction from proxy, adds ORDER BY
+ */
+interface FtsOrderByRequest {
+  direction: 'ASC' | 'DESC';
 }
 
 function isTsvectorCodec(codec: any): boolean {
@@ -208,16 +228,17 @@ export function createPgSearchPlugin(
       },
       entityBehavior: {
         pgCodecAttribute: {
-          inferred: {
-            provides: ['default'],
-            before: ['inferred', 'override', 'PgAttributesPlugin'],
-            callback(behavior, [codec, attributeName], build) {
+          override: {
+            provides: ['PgSearchPlugin'],
+            after: ['inferred'],
+            before: ['override'],
+            callback(behavior, [codec, attributeName]) {
               const attr = codec.attributes[attributeName];
-              if (attr.codec === (build as any).dataplanPg.TYPES.tsvector) {
+              if (isTsvectorCodec(attr.codec)) {
                 return [
+                  behavior,
                   'attributeFtsRank:orderBy',
                   'attributeFtsRank:select',
-                  behavior,
                 ];
               }
               return behavior;
@@ -225,17 +246,18 @@ export function createPgSearchPlugin(
           },
         },
         pgResource: {
-          inferred: {
-            provides: ['default'],
-            before: ['inferred', 'override', 'PgProceduresPlugin'],
-            callback(behavior, resource, build) {
+          override: {
+            provides: ['PgSearchPlugin'],
+            after: ['inferred'],
+            before: ['override'],
+            callback(behavior, resource) {
               if (!(resource as any).parameters) {
                 return behavior;
               }
-              if ((resource as any).codec !== (build as any).dataplanPg.TYPES.tsvector) {
+              if (!isTsvectorCodec((resource as any).codec)) {
                 return behavior;
               }
-              return ['procFtsRank:orderBy', 'procFtsRank:select', behavior];
+              return [behavior, 'procFtsRank:orderBy', 'procFtsRank:select'];
             },
           },
         },
@@ -412,7 +434,9 @@ export function createPgSearchPlugin(
 
         GraphQLEnumType_values(values, build, context) {
           const {
+            sql,
             inflection,
+            dataplanPg: { TYPES: DP_TYPES },
           } = build;
 
           const {
@@ -428,6 +452,28 @@ export function createPgSearchPlugin(
           const pgRegistry = (build as any).input?.pgRegistry;
 
           let newValues = values;
+
+          // The enum apply runs at PLANNING time (receives PgSelectStep).
+          // It stores a direction flag in meta. The condition apply runs at
+          // EXECUTION time (receives proxy whose meta was copied from
+          // PgSelectStep._meta). The condition apply reads this flag and
+          // adds the ORDER BY with the scoreFragment it computes.
+          const makeApply =
+            (fieldName: string, direction: 'ASC' | 'DESC') =>
+            (queryBuilder: any) => {
+              const orderMetaKey = `__fts_orderBy_${fieldName}`;
+              queryBuilder.setMeta(orderMetaKey, {
+                direction,
+              } as FtsOrderByRequest);
+            };
+
+          const makeSpec = (fieldName: string, direction: 'ASC' | 'DESC') => ({
+            extensions: {
+              grafast: {
+                apply: makeApply(fieldName, direction),
+              },
+            },
+          });
 
           // ── Direct tsvector columns ──
           for (const [attributeName, attribute] of Object.entries(
@@ -448,34 +494,14 @@ export function createPgSearchPlugin(
             }
 
             const fieldName = inflection.attribute({ codec: codec as any, attributeName });
-            const metaKey = `fts_order_${fieldName}`;
-            const makePlan = (direction: 'ASC' | 'DESC') =>
-              (step: any) => {
-                if (typeof step.setMeta === 'function') {
-                  step.setMeta(metaKey, direction);
-                }
-              };
-
-            const ascName = inflection.constantCase(`${attributeName}_rank_asc`);
-            const descName = inflection.constantCase(`${attributeName}_rank_desc`);
+            const ascName = inflection.pgTsvOrderByColumnRankEnum(codec as any, attributeName, true);
+            const descName = inflection.pgTsvOrderByColumnRankEnum(codec as any, attributeName, false);
 
             newValues = build.extend(
               newValues,
               {
-                [ascName]: {
-                  extensions: {
-                    grafast: {
-                      apply: makePlan('ASC'),
-                    },
-                  },
-                },
-                [descName]: {
-                  extensions: {
-                    grafast: {
-                      apply: makePlan('DESC'),
-                    },
-                  },
-                },
+                [ascName]: makeSpec(fieldName, 'ASC'),
+                [descName]: makeSpec(fieldName, 'DESC'),
               },
               `PgSearchPlugin adding rank orderBy for '${attributeName}' on '${codec.name}'`
             );
@@ -503,35 +529,15 @@ export function createPgSearchPlugin(
             );
 
             for (const resource of tsvProcs) {
-              const baseFieldName = inflection.computedAttributeField({ resource: resource as any });
-              const metaKey = `fts_order_${baseFieldName}`;
-              const makePlan = (direction: 'ASC' | 'DESC') =>
-                (step: any) => {
-                  if (typeof step.setMeta === 'function') {
-                    step.setMeta(metaKey, direction);
-                  }
-                };
-
+              const fieldName = inflection.computedAttributeField({ resource: resource as any });
               const ascName = inflection.pgTsvOrderByComputedColumnRankEnum(codec, resource as any, true);
               const descName = inflection.pgTsvOrderByComputedColumnRankEnum(codec, resource as any, false);
 
               newValues = build.extend(
                 newValues,
                 {
-                  [ascName]: {
-                    extensions: {
-                      grafast: {
-                        apply: makePlan('ASC'),
-                      },
-                    },
-                  },
-                  [descName]: {
-                    extensions: {
-                      grafast: {
-                        apply: makePlan('DESC'),
-                      },
-                    },
-                  },
+                  [ascName]: makeSpec(fieldName, 'ASC'),
+                  [descName]: makeSpec(fieldName, 'DESC'),
                 },
                 `PgSearchPlugin adding rank orderBy for computed column '${(resource as any).name}' on '${codec.name}'`
               );
@@ -602,33 +608,35 @@ export function createPgSearchPlugin(
                       // WHERE: column @@ tsquery
                       $condition.where(sql`${columnExpr} @@ ${tsquery}`);
 
-                      // Get the query builder via meta-safe traversal
+                      // Get the query builder (execution-time proxy) via
+                      // meta-safe traversal.
                       const qb = getQueryBuilder(build, $condition);
                       if (qb) {
                         // Add ts_rank to the SELECT list
-                        const rankSql = sql`ts_rank(${columnExpr}, ${tsquery})`;
-                        const wrappedRankSql = sql`${sql.parens(rankSql)}::text`;
+                        const scoreFragment = sql`ts_rank(${columnExpr}, ${tsquery})`;
+                        const wrappedRankSql = sql`${sql.parens(scoreFragment)}::text`;
                         const rankIndex = qb.selectAndReturnIndex(wrappedRankSql);
 
-                        // Store the select index in meta
-                        qb.setMeta(rankMetaKey, {
+                        const rankDetails: FtsRankDetails = {
                           selectIndex: rankIndex,
-                        } as FtsRankDetails);
-                      }
+                          scoreFragment,
+                        };
 
-                      // ORDER BY ts_rank: only add when the user explicitly
-                      // requested rank ordering via the FULL_TEXT_RANK_ASC/DESC
-                      // enum values. The enum's apply stores direction in meta
-                      // during planning; if no meta is set, skip the orderBy
-                      // entirely so cursors remain stable across pages.
-                      if (qb && typeof qb.getMetaRaw === 'function') {
-                        const orderMetaKey = `fts_order_${baseFieldName}`;
-                        const explicitDir = qb.getMetaRaw(orderMetaKey);
-                        if (explicitDir) {
+                        // Store via qb.setMeta for the output field plan.
+                        // ($select.getMeta() creates a deferred Step that works
+                        // across the proxy/step boundary at execution time.)
+                        qb.setMeta(rankMetaKey, rankDetails);
+
+                        // Check if the orderBy enum stored a direction flag
+                        // at planning time. The flag was set on PgSelectStep._meta
+                        // and copied into this proxy's meta closure.
+                        const orderMetaKey = `__fts_orderBy_${baseFieldName}`;
+                        const orderRequest = qb.getMetaRaw(orderMetaKey) as FtsOrderByRequest | undefined;
+                        if (orderRequest) {
                           qb.orderBy({
-                            fragment: sql`ts_rank(${columnExpr}, ${tsquery})`,
-                            codec: TYPES.float4,
-                            direction: explicitDir,
+                            codec: (build as any).dataplanPg?.TYPES?.float,
+                            fragment: scoreFragment,
+                            direction: orderRequest.direction,
                           });
                         }
                       }

--- a/graphile/graphile-search-plugin/src/plugin.ts
+++ b/graphile/graphile-search-plugin/src/plugin.ts
@@ -121,11 +121,9 @@ function getQueryBuilder(
   }
 
   // Verify we found a query builder with matching alias
-  // Using duck-typing (isPgSelectQueryBuilder) per Benjie's pattern
   if (
     current &&
     typeof current.selectAndReturnIndex === 'function' &&
-    typeof current.where === 'function' &&
     current.alias === alias
   ) {
     return current;
@@ -301,7 +299,7 @@ export function createPgSearchPlugin(
             origin: string,
           ) {
             const metaKey = `__fts_ranks_${baseFieldName}`;
-            build.extend(
+            fields = build.extend(
               fields,
               {
                 [fieldName]: fieldWithHooks(
@@ -378,8 +376,6 @@ export function createPgSearchPlugin(
           }
 
           // ── Computed columns (functions returning tsvector) ──
-          // Following Benjie's pattern: find pgResources that are functions
-          // returning tsvector whose first parameter matches this codec.
           if (pgRegistry) {
             const tsvProcs = Object.values(pgRegistry.pgResources).filter(
               (r: any): boolean => {
@@ -460,8 +456,8 @@ export function createPgSearchPlugin(
                 }
               };
 
-            const ascName = inflection.pgTsvOrderByColumnRankEnum(codec, attributeName, true);
-            const descName = inflection.pgTsvOrderByColumnRankEnum(codec, attributeName, false);
+            const ascName = inflection.constantCase(`${attributeName}_rank_asc`);
+            const descName = inflection.constantCase(`${attributeName}_rank_desc`);
 
             newValues = build.extend(
               newValues,
@@ -608,10 +604,7 @@ export function createPgSearchPlugin(
 
                       // Get the query builder via meta-safe traversal
                       const qb = getQueryBuilder(build, $condition);
-
-                      // Only inject SELECT expressions when in "normal" mode
-                      // (not aggregate mode). Following Benjie's qb.mode check.
-                      if (qb && qb.mode === 'normal') {
+                      if (qb) {
                         // Add ts_rank to the SELECT list
                         const rankSql = sql`ts_rank(${columnExpr}, ${tsquery})`;
                         const wrappedRankSql = sql`${sql.parens(rankSql)}::text`;

--- a/graphile/graphile-search-plugin/src/plugin.ts
+++ b/graphile/graphile-search-plugin/src/plugin.ts
@@ -17,18 +17,16 @@
  * search fields for each tsvector column found on a table's codec.
  *
  * ARCHITECTURE NOTE:
- * Condition field apply functions run during a deferred phase (SQL generation)
- * on a queryBuilder proxy — NOT on the real PgSelectStep. The rank field plan
- * runs earlier, during Grafast's planning phase, on the real PgSelectStep.
+ * Uses the Grafast meta system (setMeta/getMeta) to pass data between
+ * the condition apply phase and the output field plan, following the
+ * pattern from Benjie's postgraphile-plugin-fulltext-filter reference.
  *
- * To bridge these two phases we use a module-level WeakMap keyed by the SQL
- * alias object (shared between proxy and PgSelectStep via reference identity).
- *
- * The rank field plan creates a `lambda` step that reads the row tuple at a
- * dynamically-determined index. The condition apply adds `ts_rank(...)` to
- * the SQL SELECT list via `proxy.selectAndReturnIndex()` and stores the
- * resulting index in the WeakMap slot. At execution time the lambda reads
- * the rank value from that index.
+ * 1. Condition apply (deferred/SQL-gen phase): adds ts_rank to the query
+ *    builder's SELECT list via selectAndReturnIndex, stores { selectIndex }
+ *    in meta via qb.setMeta(key, { selectIndex }).
+ * 2. Output field plan (planning phase): calls $select.getMeta(key) which
+ *    returns a Grafast Step that resolves at execution time.
+ * 3. lambda([$details, $row]) reads the rank from row[details.selectIndex].
  */
 
 import 'graphile-build';
@@ -39,26 +37,12 @@ import type { SQL } from 'pg-sql2';
 import type { PgSearchPluginOptions } from './types';
 
 /**
- * Module-level WeakMap keyed by SQL alias object (shared reference between
- * the queryBuilder proxy and PgSelectStep via buildTheQueryCore).
- *
- * CRITICAL INVARIANT: SQL alias objects MUST have unique identity per query
- * execution. If PostGraphile ever pools or caches alias references across
- * queries, rank values could leak between requests.
- *
- * 1. Rank field plan (planning phase): initialises the slot keyed by alias.
- * 2. OrderBy enum apply (planning phase): stores direction in PgSelectStep meta.
- * 3. Condition apply (deferred/SQL-gen phase): adds ts_rank to the proxy's
- *    select list via selectAndReturnIndex, stores the index in `indices`.
- *    If the user explicitly requested rank ordering (meta set in step 2),
- *    adds ORDER BY ts_rank with the requested direction.
- * 4. Rank field lambda (execute phase): reads row[indices[field]] for the value.
+ * Interface for the meta value stored by the condition apply via setMeta
+ * and read by the output field plan via getMeta.
  */
-interface FtsRankSlot {
-  /** Map of fieldName → index into info.selects (set during condition apply) */
-  indices: Record<string, number>;
+interface FtsRankDetails {
+  selectIndex: number;
 }
-const ftsRankSlots = new WeakMap<object, FtsRankSlot>();
 
 function isTsvectorCodec(codec: any): boolean {
   return (
@@ -68,18 +52,38 @@ function isTsvectorCodec(codec: any): boolean {
 }
 
 /**
- * Navigates from a PgSelectSingleStep up to the PgSelectStep.
- * Uses duck-typing to avoid dependency on exact class names across rc versions.
+ * Walks from a PgCondition up to the PgSelectQueryBuilder.
+ * Uses the .parent property on PgCondition to traverse up the chain,
+ * following Benjie's pattern from postgraphile-plugin-fulltext-filter.
+ *
+ * Returns the query builder if found, or null if the traversal fails.
  */
-function getPgSelectStep($someStep: any): any | null {
-  let $step = $someStep;
+function getQueryBuilder(
+  build: any,
+  $condition: any
+): any | null {
+  const PgCondition = build.dataplanPg?.PgCondition;
+  if (!PgCondition) return null;
 
-  if ($step && typeof $step.getClassStep === 'function') {
-    $step = $step.getClassStep();
+  let current = $condition;
+  const { alias } = current;
+
+  // Walk up through nested PgConditions (e.g. and/or/not)
+  while (
+    current &&
+    current instanceof PgCondition &&
+    current.alias === alias
+  ) {
+    current = (current as any).parent;
   }
 
-  if ($step && typeof $step.orderBy === 'function' && $step.id !== undefined) {
-    return $step;
+  // Verify we found a query builder with matching alias
+  if (
+    current &&
+    typeof current.selectAndReturnIndex === 'function' &&
+    current.alias === alias
+  ) {
+    return current;
   }
 
   return null;
@@ -135,7 +139,6 @@ export function createPgSearchPlugin(
 
         GraphQLObjectType_fields(fields, build, context) {
           const {
-            sql,
             inflection,
             graphql: { GraphQLFloat },
             grafast: { constant, lambda },
@@ -158,6 +161,7 @@ export function createPgSearchPlugin(
 
             const baseFieldName = inflection.attribute({ codec: pgCodec as any, attributeName });
             const fieldName = inflection.camelCase(`${baseFieldName}-rank`);
+            const metaKey = `__fts_ranks_${baseFieldName}`;
 
             newFields = build.extend(
               newFields,
@@ -168,35 +172,37 @@ export function createPgSearchPlugin(
                     description: `Full-text search ranking when filtered by \`${baseFieldName}\`. Returns null when no search condition is active.`,
                     type: GraphQLFloat,
                     plan($step: any) {
-                      const $select = getPgSelectStep($step);
+                      const $row = $step;
+                      const $select = typeof $row.getClassStep === 'function'
+                        ? $row.getClassStep()
+                        : null;
                       if (!$select) return constant(null);
 
                       if (typeof $select.setInliningForbidden === 'function') {
                         $select.setInliningForbidden();
                       }
 
-                      // Initialise the WeakMap slot for this query, keyed by the
-                      // SQL alias (same object ref on PgSelectStep and the proxy).
-                      const alias = $select.alias;
-                      if (!ftsRankSlots.has(alias)) {
-                        ftsRankSlots.set(alias, {
-                          indices: Object.create(null),
-                        });
-                      }
+                      // Use the meta system to retrieve rank details.
+                      // getMeta returns a Grafast Step that resolves at
+                      // execution time to the value set by setMeta in
+                      // the condition apply phase.
+                      const $details = $select.getMeta(metaKey);
 
-                      // Return a lambda that reads the rank value from the result
-                      // row at a dynamically-determined index. The index is set
-                      // by the condition apply (deferred phase) via the proxy's
-                      // selectAndReturnIndex, and stored in the WeakMap slot.
-                      const capturedField = baseFieldName;
-                      const capturedAlias = alias;
-                      return lambda($step, (row: any) => {
-                        if (row == null) return null;
-                        const slot = ftsRankSlots.get(capturedAlias);
-                        if (!slot || slot.indices[capturedField] === undefined) return null;
-                        const rawValue = row[slot.indices[capturedField]];
-                        return rawValue == null ? null : parseFloat(rawValue);
-                      }, true);
+                      return lambda(
+                        [$details, $row],
+                        ([details, row]: readonly [any, any]) => {
+                          const d = details as FtsRankDetails | null;
+                          if (
+                            d == null ||
+                            row == null ||
+                            d.selectIndex == null
+                          ) {
+                            return null;
+                          }
+                          const rawValue = row[d.selectIndex];
+                          return rawValue == null ? null : parseFloat(rawValue);
+                        }
+                      );
                     },
                   })
                 ),
@@ -307,6 +313,7 @@ export function createPgSearchPlugin(
               `${pgSearchPrefix}_${attributeName}`
             );
             const baseFieldName = inflection.attribute({ codec: pgCodec as any, attributeName });
+            const rankMetaKey = `__fts_ranks_${baseFieldName}`;
 
             newFields = build.extend(
               newFields,
@@ -330,22 +337,18 @@ export function createPgSearchPlugin(
                       // WHERE: column @@ tsquery
                       $condition.where(sql`${columnExpr} @@ ${tsquery}`);
 
-                      // Add ts_rank to the SELECT list via the proxy's
-                      // selectAndReturnIndex. This runs during the deferred
-                      // SQL-generation phase, so the expression goes into
-                      // info.selects (the live array used for SQL generation).
-                      const $parent = $condition.dangerouslyGetParent();
-                      if (typeof $parent.selectAndReturnIndex === 'function') {
+                      // Get the query builder via meta-safe traversal
+                      const qb = getQueryBuilder(build, $condition);
+                      if (qb) {
+                        // Add ts_rank to the SELECT list
                         const rankSql = sql`ts_rank(${columnExpr}, ${tsquery})`;
                         const wrappedRankSql = sql`${sql.parens(rankSql)}::text`;
-                        const rankIndex = $parent.selectAndReturnIndex(wrappedRankSql);
+                        const rankIndex = qb.selectAndReturnIndex(wrappedRankSql);
 
-                        // Store the index in the alias-keyed WeakMap slot so
-                        // the rank field's lambda can read it at execute time.
-                        const slot = ftsRankSlots.get($condition.alias);
-                        if (slot) {
-                          slot.indices[baseFieldName] = rankIndex;
-                        }
+                        // Store the select index in meta (replaces WeakMap)
+                        qb.setMeta(rankMetaKey, {
+                          selectIndex: rankIndex,
+                        } as FtsRankDetails);
                       }
 
                       // ORDER BY ts_rank: only add when the user explicitly
@@ -353,16 +356,16 @@ export function createPgSearchPlugin(
                       // enum values. The enum's apply stores direction in meta
                       // during planning; if no meta is set, skip the orderBy
                       // entirely so cursors remain stable across pages.
-                      const metaKey = `fts_order_${baseFieldName}`;
-                      const explicitDir = typeof $parent.getMetaRaw === 'function'
-                        ? $parent.getMetaRaw(metaKey)
-                        : undefined;
-                      if (explicitDir) {
-                        $parent.orderBy({
-                          fragment: sql`ts_rank(${columnExpr}, ${tsquery})`,
-                          codec: TYPES.float4,
-                          direction: explicitDir,
-                        });
+                      if (qb && typeof qb.getMetaRaw === 'function') {
+                        const orderMetaKey = `fts_order_${baseFieldName}`;
+                        const explicitDir = qb.getMetaRaw(orderMetaKey);
+                        if (explicitDir) {
+                          qb.orderBy({
+                            fragment: sql`ts_rank(${columnExpr}, ${tsquery})`,
+                            codec: TYPES.float4,
+                            direction: explicitDir,
+                          });
+                        }
                       }
                     },
                   }

--- a/graphile/graphile-search-plugin/src/plugin.ts
+++ b/graphile/graphile-search-plugin/src/plugin.ts
@@ -32,9 +32,52 @@
 import 'graphile-build';
 import 'graphile-build-pg';
 import { TYPES } from '@dataplan/pg';
+import type { PgCodecWithAttributes, PgResource } from '@dataplan/pg';
 import type { GraphileConfig } from 'graphile-config';
 import type { SQL } from 'pg-sql2';
 import type { PgSearchPluginOptions } from './types';
+
+// ─── TypeScript Namespace Augmentations ──────────────────────────────────────
+// Following Benjie's pattern for proper type safety across the plugin system.
+
+declare global {
+  namespace GraphileBuild {
+    interface Inflection {
+      /** Name for the FullText scalar type */
+      fullTextScalarTypeName(this: Inflection): string;
+      /** Name for the rank field (e.g. "bodyRank") */
+      pgTsvRank(this: Inflection, fieldName: string): string;
+      /** Name for orderBy enum value for column rank */
+      pgTsvOrderByColumnRankEnum(
+        this: Inflection,
+        codec: PgCodecWithAttributes,
+        attributeName: string,
+        ascending: boolean,
+      ): string;
+      /** Name for orderBy enum value for computed column rank */
+      pgTsvOrderByComputedColumnRankEnum(
+        this: Inflection,
+        codec: PgCodecWithAttributes,
+        resource: PgResource,
+        ascending: boolean,
+      ): string;
+    }
+    interface ScopeObjectFieldsField {
+      isPgTSVRankField?: boolean;
+    }
+    interface BehaviorStrings {
+      'attributeFtsRank:select': true;
+      'procFtsRank:select': true;
+      'attributeFtsRank:orderBy': true;
+      'procFtsRank:orderBy': true;
+    }
+  }
+  namespace GraphileConfig {
+    interface Plugins {
+      PgSearchPlugin: true;
+    }
+  }
+}
 
 /**
  * Interface for the meta value stored by the condition apply via setMeta
@@ -78,9 +121,11 @@ function getQueryBuilder(
   }
 
   // Verify we found a query builder with matching alias
+  // Using duck-typing (isPgSelectQueryBuilder) per Benjie's pattern
   if (
     current &&
     typeof current.selectAndReturnIndex === 'function' &&
+    typeof current.where === 'function' &&
     current.alias === alias
   ) {
     return current;
@@ -104,7 +149,100 @@ export function createPgSearchPlugin(
       'Generates search conditions for tsvector columns in PostGraphile v5',
     after: ['PgAttributesPlugin', 'PgConnectionArgFilterPlugin', 'PgConnectionArgFilterOperatorsPlugin', 'AddConnectionFilterOperatorPlugin'],
 
+    // ─── Custom Inflection Methods ─────────────────────────────────────
+    // Makes field naming configurable and overridable by downstream plugins.
+    inflection: {
+      add: {
+        fullTextScalarTypeName() {
+          return fullTextScalarName;
+        },
+        pgTsvRank(_preset, fieldName) {
+          return this.camelCase(`${fieldName}-rank`);
+        },
+        pgTsvOrderByColumnRankEnum(_preset, codec, attributeName, ascending) {
+          const columnName = this._attributeName({
+            codec,
+            attributeName,
+            skipRowId: true,
+          });
+          return this.constantCase(
+            `${columnName}_rank_${ascending ? 'asc' : 'desc'}`,
+          );
+        },
+        pgTsvOrderByComputedColumnRankEnum(_preset, _codec, resource, ascending) {
+          const columnName = this.computedAttributeField({
+            resource,
+          });
+          return this.constantCase(
+            `${columnName}_rank_${ascending ? 'asc' : 'desc'}`,
+          );
+        },
+      },
+    },
+
     schema: {
+      // ─── Behavior Registry ─────────────────────────────────────────────
+      // Declarative control over which columns get FTS features.
+      // Users can opt out per-column via `@behavior -attributeFtsRank:select`.
+      behaviorRegistry: {
+        add: {
+          'attributeFtsRank:select': {
+            description:
+              'Should the full text search rank be exposed for this attribute',
+            entities: ['pgCodecAttribute'],
+          },
+          'procFtsRank:select': {
+            description:
+              'Should the full text search rank be exposed for this computed column function',
+            entities: ['pgResource'],
+          },
+          'attributeFtsRank:orderBy': {
+            description:
+              'Should you be able to order by the FTS rank for this attribute',
+            entities: ['pgCodecAttribute'],
+          },
+          'procFtsRank:orderBy': {
+            description:
+              'Should you be able to order by the FTS rank for this computed column function',
+            entities: ['pgResource'],
+          },
+        },
+      },
+      entityBehavior: {
+        pgCodecAttribute: {
+          inferred: {
+            provides: ['default'],
+            before: ['inferred', 'override', 'PgAttributesPlugin'],
+            callback(behavior, [codec, attributeName], build) {
+              const attr = codec.attributes[attributeName];
+              if (attr.codec === (build as any).dataplanPg.TYPES.tsvector) {
+                return [
+                  'attributeFtsRank:orderBy',
+                  'attributeFtsRank:select',
+                  behavior,
+                ];
+              }
+              return behavior;
+            },
+          },
+        },
+        pgResource: {
+          inferred: {
+            provides: ['default'],
+            before: ['inferred', 'override', 'PgProceduresPlugin'],
+            callback(behavior, resource, build) {
+              if (!(resource as any).parameters) {
+                return behavior;
+              }
+              if ((resource as any).codec !== (build as any).dataplanPg.TYPES.tsvector) {
+                return behavior;
+              }
+              return ['procFtsRank:orderBy', 'procFtsRank:select', behavior];
+            },
+          },
+        },
+      },
+
       hooks: {
         init(_, build) {
           const {
@@ -141,33 +279,36 @@ export function createPgSearchPlugin(
           const {
             inflection,
             graphql: { GraphQLFloat },
-            grafast: { constant, lambda },
+            grafast: { lambda },
           } = build;
           const {
-            scope: { isPgClassType, pgCodec },
+            scope: { isPgClassType, pgCodec: rawPgCodec },
             fieldWithHooks,
           } = context;
 
-          if (!isPgClassType || !pgCodec?.attributes) {
+          if (!isPgClassType || !rawPgCodec?.attributes) {
             return fields;
           }
 
-          let newFields = fields;
+          const codec = rawPgCodec as PgCodecWithAttributes;
+          const behavior = (build as any).behavior;
+          const pgRegistry = (build as any).input?.pgRegistry;
 
-          for (const [attributeName, attribute] of Object.entries(
-            pgCodec.attributes as Record<string, any>
-          )) {
-            if (!isTsvectorCodec(attribute.codec)) continue;
-
-            const baseFieldName = inflection.attribute({ codec: pgCodec as any, attributeName });
-            const fieldName = inflection.camelCase(`${baseFieldName}-rank`);
+          // Helper to add a rank field for a given base field name
+          function addTsvField(
+            baseFieldName: string,
+            fieldName: string,
+            origin: string,
+          ) {
             const metaKey = `__fts_ranks_${baseFieldName}`;
-
-            newFields = build.extend(
-              newFields,
+            build.extend(
+              fields,
               {
                 [fieldName]: fieldWithHooks(
-                  { fieldName } as any,
+                  {
+                    fieldName,
+                    isPgTSVRankField: true,
+                  } as any,
                   () => ({
                     description: `Full-text search ranking when filtered by \`${baseFieldName}\`. Returns null when no search condition is active.`,
                     type: GraphQLFloat,
@@ -176,16 +317,12 @@ export function createPgSearchPlugin(
                       const $select = typeof $row.getClassStep === 'function'
                         ? $row.getClassStep()
                         : null;
-                      if (!$select) return constant(null);
+                      if (!$select) return build.grafast.constant(null);
 
                       if (typeof $select.setInliningForbidden === 'function') {
                         $select.setInliningForbidden();
                       }
 
-                      // Use the meta system to retrieve rank details.
-                      // getMeta returns a Grafast Step that resolves at
-                      // execution time to the value set by setMeta in
-                      // the condition apply phase.
                       const $details = $select.getMeta(metaKey);
 
                       return lambda(
@@ -200,56 +337,131 @@ export function createPgSearchPlugin(
                             return null;
                           }
                           const rawValue = row[d.selectIndex];
-                          return rawValue == null ? null : parseFloat(rawValue);
+                          return rawValue == null
+                            ? null
+                            : TYPES.float.fromPg(rawValue as string);
                         }
                       );
                     },
                   })
                 ),
               },
-              `PgSearchPlugin adding rank field '${fieldName}' for '${attributeName}' on '${pgCodec.name}'`
+              origin
             );
           }
 
-          return newFields;
+          // ── Direct tsvector columns ──
+          for (const [attributeName, attribute] of Object.entries(
+            codec.attributes as Record<string, any>
+          )) {
+            if (!isTsvectorCodec(attribute.codec)) continue;
+
+            // Check behavior registry — skip if user opted out
+            if (
+              behavior &&
+              typeof behavior.pgCodecAttributeMatches === 'function' &&
+              !behavior.pgCodecAttributeMatches(
+                [codec, attributeName],
+                'attributeFtsRank:select',
+              )
+            ) {
+              continue;
+            }
+
+            const baseFieldName = inflection.attribute({ codec: codec as any, attributeName });
+            const fieldName = inflection.pgTsvRank(baseFieldName);
+            addTsvField(
+              baseFieldName,
+              fieldName,
+              `PgSearchPlugin adding rank field for ${attributeName}`,
+            );
+          }
+
+          // ── Computed columns (functions returning tsvector) ──
+          // Following Benjie's pattern: find pgResources that are functions
+          // returning tsvector whose first parameter matches this codec.
+          if (pgRegistry) {
+            const tsvProcs = Object.values(pgRegistry.pgResources).filter(
+              (r: any): boolean => {
+                if (r.codec !== (build as any).dataplanPg?.TYPES?.tsvector) return false;
+                if (!r.parameters) return false;
+                if (!r.parameters[0]) return false;
+                if (r.parameters[0].codec !== codec) return false;
+                if (
+                  behavior &&
+                  typeof behavior.pgResourceMatches === 'function'
+                ) {
+                  if (!behavior.pgResourceMatches(r, 'typeField')) return false;
+                  if (!behavior.pgResourceMatches(r, 'procFtsRank:select'))
+                    return false;
+                }
+                if (typeof r.from !== 'function') return false;
+                return true;
+              },
+            );
+
+            for (const resource of tsvProcs) {
+              const baseFieldName = inflection.computedAttributeField({ resource: resource as any });
+              const fieldName = inflection.pgTsvRank(baseFieldName);
+              addTsvField(
+                baseFieldName,
+                fieldName,
+                `PgSearchPlugin adding rank field for computed column ${(resource as any).name} on ${(context as any).Self.name}`,
+              );
+            }
+          }
+
+          return fields;
         },
 
         GraphQLEnumType_values(values, build, context) {
           const {
-            sql,
             inflection,
           } = build;
 
           const {
-            scope: { isPgRowSortEnum, pgCodec },
+            scope: { isPgRowSortEnum, pgCodec: rawPgCodec },
           } = context;
 
-          if (!isPgRowSortEnum || !pgCodec?.attributes) {
+          if (!isPgRowSortEnum || !rawPgCodec?.attributes) {
             return values;
           }
 
+          const codec = rawPgCodec as PgCodecWithAttributes;
+          const behavior = (build as any).behavior;
+          const pgRegistry = (build as any).input?.pgRegistry;
+
           let newValues = values;
 
+          // ── Direct tsvector columns ──
           for (const [attributeName, attribute] of Object.entries(
-            pgCodec.attributes as Record<string, any>
+            codec.attributes as Record<string, any>
           )) {
             if (!isTsvectorCodec(attribute.codec)) continue;
 
-            const fieldName = inflection.attribute({ codec: pgCodec as any, attributeName });
+            // Check behavior registry
+            if (
+              behavior &&
+              typeof behavior.pgCodecAttributeMatches === 'function' &&
+              !behavior.pgCodecAttributeMatches(
+                [codec, attributeName],
+                'attributeFtsRank:orderBy',
+              )
+            ) {
+              continue;
+            }
+
+            const fieldName = inflection.attribute({ codec: codec as any, attributeName });
             const metaKey = `fts_order_${fieldName}`;
             const makePlan = (direction: 'ASC' | 'DESC') =>
               (step: any) => {
-                // The enum apply runs during the PLANNING phase on PgSelectStep.
-                // Store the requested direction in PgSelectStep._meta so that
-                // the condition apply (deferred phase) can read it via the
-                // proxy's getMetaRaw and add the actual ORDER BY clause.
                 if (typeof step.setMeta === 'function') {
                   step.setMeta(metaKey, direction);
                 }
               };
 
-            const ascName = inflection.constantCase(`${attributeName}_rank_asc`);
-            const descName = inflection.constantCase(`${attributeName}_rank_desc`);
+            const ascName = inflection.pgTsvOrderByColumnRankEnum(codec, attributeName, true);
+            const descName = inflection.pgTsvOrderByColumnRankEnum(codec, attributeName, false);
 
             newValues = build.extend(
               newValues,
@@ -269,8 +481,65 @@ export function createPgSearchPlugin(
                   },
                 },
               },
-              `PgSearchPlugin adding rank orderBy for '${attributeName}' on '${pgCodec.name}'`
+              `PgSearchPlugin adding rank orderBy for '${attributeName}' on '${codec.name}'`
             );
+          }
+
+          // ── Computed columns returning tsvector ──
+          if (pgRegistry) {
+            const tsvProcs = Object.values(pgRegistry.pgResources).filter(
+              (r: any): boolean => {
+                if (r.codec !== (build as any).dataplanPg?.TYPES?.tsvector) return false;
+                if (!r.parameters) return false;
+                if (!r.parameters[0]) return false;
+                if (r.parameters[0].codec !== codec) return false;
+                if (
+                  behavior &&
+                  typeof behavior.pgResourceMatches === 'function'
+                ) {
+                  if (!behavior.pgResourceMatches(r, 'typeField')) return false;
+                  if (!behavior.pgResourceMatches(r, 'procFtsRank:orderBy'))
+                    return false;
+                }
+                if (typeof r.from !== 'function') return false;
+                return true;
+              },
+            );
+
+            for (const resource of tsvProcs) {
+              const baseFieldName = inflection.computedAttributeField({ resource: resource as any });
+              const metaKey = `fts_order_${baseFieldName}`;
+              const makePlan = (direction: 'ASC' | 'DESC') =>
+                (step: any) => {
+                  if (typeof step.setMeta === 'function') {
+                    step.setMeta(metaKey, direction);
+                  }
+                };
+
+              const ascName = inflection.pgTsvOrderByComputedColumnRankEnum(codec, resource as any, true);
+              const descName = inflection.pgTsvOrderByComputedColumnRankEnum(codec, resource as any, false);
+
+              newValues = build.extend(
+                newValues,
+                {
+                  [ascName]: {
+                    extensions: {
+                      grafast: {
+                        apply: makePlan('ASC'),
+                      },
+                    },
+                  },
+                  [descName]: {
+                    extensions: {
+                      grafast: {
+                        apply: makePlan('DESC'),
+                      },
+                    },
+                  },
+                },
+                `PgSearchPlugin adding rank orderBy for computed column '${(resource as any).name}' on '${codec.name}'`
+              );
+            }
           }
 
           return newValues;
@@ -339,13 +608,16 @@ export function createPgSearchPlugin(
 
                       // Get the query builder via meta-safe traversal
                       const qb = getQueryBuilder(build, $condition);
-                      if (qb) {
+
+                      // Only inject SELECT expressions when in "normal" mode
+                      // (not aggregate mode). Following Benjie's qb.mode check.
+                      if (qb && qb.mode === 'normal') {
                         // Add ts_rank to the SELECT list
                         const rankSql = sql`ts_rank(${columnExpr}, ${tsquery})`;
                         const wrappedRankSql = sql`${sql.parens(rankSql)}::text`;
                         const rankIndex = qb.selectAndReturnIndex(wrappedRankSql);
 
-                        // Store the select index in meta (replaces WeakMap)
+                        // Store the select index in meta
                         qb.setMeta(rankMetaKey, {
                           selectIndex: rankIndex,
                         } as FtsRankDetails);
@@ -356,7 +628,7 @@ export function createPgSearchPlugin(
                       // enum values. The enum's apply stores direction in meta
                       // during planning; if no meta is set, skip the orderBy
                       // entirely so cursors remain stable across pages.
-                      if (qb && typeof qb.getMetaRaw === 'function') {
+                      if (qb && qb.mode === 'normal' && typeof qb.getMetaRaw === 'function') {
                         const orderMetaKey = `fts_order_${baseFieldName}`;
                         const explicitDir = qb.getMetaRaw(orderMetaKey);
                         if (explicitDir) {

--- a/graphile/graphile-search-plugin/src/plugin.ts
+++ b/graphile/graphile-search-plugin/src/plugin.ts
@@ -628,7 +628,7 @@ export function createPgSearchPlugin(
                       // enum values. The enum's apply stores direction in meta
                       // during planning; if no meta is set, skip the orderBy
                       // entirely so cursors remain stable across pages.
-                      if (qb && qb.mode === 'normal' && typeof qb.getMetaRaw === 'function') {
+                      if (qb && typeof qb.getMetaRaw === 'function') {
                         const orderMetaKey = `fts_order_${baseFieldName}`;
                         const explicitDir = qb.getMetaRaw(orderMetaKey);
                         if (explicitDir) {


### PR DESCRIPTION
# refactor: replace WeakMap with Grafast meta system + adopt Benjie's plugin patterns

## Summary

Replaces the module-level `WeakMap` pattern with PostGraphile's built-in `setMeta`/`getMeta` system for passing computed data (rank/distance/score indices) between the condition apply phase and the output field plan. This follows the pattern recommended by Benjie (Graphile maintainer) in his [postgraphile-plugin-fulltext-filter](https://github.com/benjie/postgraphile-plugin-fulltext-filter/blob/469d9d30df189ff5572d710a4ba2aec61f57b748/src/index.ts#L433-L448) reference implementation.

All three search plugins receive identical changes:
- **`graphile-search-plugin`** (tsvector full-text search)
- **`graphile-pgvector-plugin`** (pgvector similarity search)
- **`graphile-pg-textsearch-plugin`** (BM25 ranked search)

**What changed internally:**
- Removed module-level `WeakMap` + slot interfaces
- Removed `getPgSelectStep()` duck-typing helper
- Added `getQueryBuilder(build, $condition)` which walks `PgCondition.parent` chain (via `build.dataplanPg.PgCondition` instanceof)
- Condition apply now calls `qb.setMeta(key, { selectIndex })` instead of storing in WeakMap
- Output field plan now uses `$select.getMeta(key)` (returns a Grafast Step) with `lambda([$details, $row], ...)` instead of closure-captured WeakMap lookup
- Replaced `$condition.dangerouslyGetParent()` with `getQueryBuilder()` for a more stable traversal pattern

**No API changes intended** — GraphQL schema (field names, input types, orderBy enums) should remain identical, but see review checklist item about inflection methods.

## Benjie's Plugin Pattern Improvements

Six improvements from Benjie's reference implementation, applied across all three plugins:

1. **TypeScript namespace augmentations** — `declare global` blocks for `GraphileBuild.Inflection`, `BehaviorStrings`, `ScopeObjectFieldsField`, and `GraphileConfig.Plugins` interfaces
2. **Custom inflection methods** — Named, overridable methods for field/enum naming (e.g. `pgTsvRank`, `pgVectorDistance`, `pgBm25Score`, `pgTsvOrderByColumnRankEnum`, etc.)
3. **Behavior registry + entity behavior** — Declarative opt-in/opt-out system via smart tags (e.g. `@behavior -attributeFtsRank:select` to hide rank field for a specific column). By default everything is auto-exposed (no behavior change for existing schemas).
4. **`qb.mode === 'normal'` check** — Prevents injecting SELECT expressions into aggregate queries. Applied only to the `selectAndReturnIndex` / `setMeta` block (pgvector + BM25 plugins); intentionally **not** applied to the ORDER BY meta-read block.
5. **`TYPES.float.fromPg()` instead of `parseFloat()`** — Proper codec conversion instead of JS-level parsing
6. **Computed column (proc) support** (tsvector only) — Auto-discovers PostgreSQL functions returning tsvector whose first parameter matches the table codec, adds rank fields for them

## Updates since last revision

### Fix: orderBy enum timing mismatch (graphile-search-plugin)

Root cause identified and fixed for the `"sort by full text rank orderBy enums works"` test failure.

**The problem:** The orderBy enum `apply` runs at **planning time** (receives `PgSelectStep`), while the condition `apply` runs at **execution time** (receives a runtime proxy). These two objects have separate meta stores, so they cannot share data via `setMeta`/`getMetaRaw` directly between each other.


**The solution:** Leverage the fact that `PgSelectStep._meta` gets **copied** to the proxy's meta closure during execution. Flow:
1. **Enum apply** (planning time, PgSelectStep): stores direction flag in `PgSelectStep._meta` via `setMeta`
2. **PgSelectStep._meta** gets copied to `proxy.meta` via `getStaticInfo` → `buildTheQueryCore`
3. **Condition apply** (execution time, proxy): reads direction flag from `proxy.getMetaRaw`, adds ORDER BY with `scoreFragment`

This fixes the test — ASC and DESC now produce different result orderings. Also removes the stale `_ftsRankBridge` WeakMap that was attempted as an intermediate fix but didn't work.

**Note:** pgvector and BM25 plugins already had the correct pattern and did not need this fix.

### Entity behavior phase change

Changed `entityBehavior` callbacks from `inferred` phase to `override` phase with `after: ['inferred'], before: ['override']` ordering. This ensures the behavior additions (e.g. `'attributeFtsRank:select'`) are prepended to the behavior array before any user-specified overrides, allowing users to negate them with smart tags.

### Codec identity check improvement

Replaced direct codec identity comparisons (e.g. `attr.codec === build.dataplanPg.TYPES.tsvector`) with `isTsvectorCodec()` helper that checks `codec.extensions.pg.name === 'tsvector'`. More robust across PostGraphile RC versions.

## Review & Testing Checklist for Human

This PR cannot be fully tested locally (requires PostgreSQL + pgvector/pg_textsearch extensions in CI). Priority items for review:

- [ ] **CRITICAL: Verify inflection methods don't change GraphQL schema** — The new custom inflection methods (e.g. `pgTsvOrderByColumnRankEnum`) call `this._attributeName({codec, attributeName, skipRowId: true})` instead of using raw `attributeName`. If `_attributeName` produces different output than the raw attribute name, orderBy enum names will change, breaking clients. Compare a GraphQL introspection query before/after this PR to confirm field/enum names are identical.
- [ ] **CRITICAL: Verify CI passes for all 3 plugins** — Integration tests are the only verification that the meta system + behavior registry + orderBy timing work correctly end-to-end. The `filter.test.ts` failure was caught by CI and fixed; ensure no other edge cases exist.
- [ ] **CRITICAL: Verify orderBy enum timing assumption** — The fix relies on `PgSelectStep._meta` being copied to the execution-time proxy's meta closure. This is confirmed by reading PostGraphile source (lines 1322 + 1785 of `pgSelect.js`) but could break if PostGraphile internals change. If orderBy enums stop working in future PostGraphile versions, this is the first place to check.
- [ ] **Check entity behavior phase ordering** — The behavior callbacks now use `override` phase with `after: ['inferred']`. If other plugins also use `override` phase, the ordering might cause behaviors to be evaluated in unexpected order. Verify rank/distance/score fields still appear on expected columns.
- [ ] **Verify computed column discovery** (tsvector only) — If your schema has PostgreSQL functions returning tsvector (e.g. `CREATE FUNCTION article_combined_search(article) RETURNS tsvector ...`), verify that rank fields appear for them and work correctly.

### Notes

- **Session:** https://app.devin.ai/sessions/7f9b6b69895d49b7b3f7fddf52f5d4f6
- **Requested by:** @pyramation
- The `@pgsql/quotes` TypeScript error in BM25 plugin is pre-existing on main (not caused by this PR) — BM25 plugin cannot be built locally but CI has the necessary dependencies
- `getQueryBuilder()` is duplicated across all 3 files (not extracted to shared utility) — could be refactored in a follow-up
- The behavior registry is strictly additive — users can opt out per-column, but by default everything is auto-exposed (no breaking changes)
- Computed column support only applies to tsvector plugin (not pgvector/BM25) since vector/score-returning functions are less common