### PR TITLE
chore: upgrade js-yaml 3.x → 4.x and csv-parser 2.x → 3.x in csv-to-pg

### DIFF
--- a/packages/csv-to-pg/package.json
+++ b/packages/csv-to-pg/package.json
@@ -45,9 +45,9 @@
   "dependencies": {
     "@pgsql/types": "^17.6.2",
     "@pgsql/utils": "^17.8.13",
-    "csv-parser": "^2.3.3",
+    "csv-parser": "^3.2.0",
     "inquirerer": "^4.5.2",
-    "js-yaml": "^3.14.0",
+    "js-yaml": "^4.1.0",
     "pgsql-deparser": "^17.18.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,7 +174,7 @@ importers:
         version: 5.2.1
       grafserv:
         specifier: 1.0.0-rc.6
-        version: 1.0.0-rc.6(@types/node@22.19.11)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(grafast@1.0.0-rc.7(graphql@16.13.0))(graphile-config@1.0.0-rc.5)(graphql@16.13.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))(ws@8.19.0)
+        version: 1.0.0-rc.6(@types/node@25.3.3)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(grafast@1.0.0-rc.7(graphql@16.13.0))(graphile-config@1.0.0-rc.5)(graphql@16.13.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))(ws@8.19.0)
       lru-cache:
         specifier: ^11.2.6
         version: 11.2.6
@@ -183,7 +183,7 @@ importers:
         version: link:../../postgres/pg-cache/dist
       postgraphile:
         specifier: 5.0.0-rc.7
-        version: 5.0.0-rc.7(853bfb5f6928535d2602be94c7020fe8)
+        version: 5.0.0-rc.7(56415cfaef0e792e7fc3250b8cf6023f)
     devDependencies:
       '@types/express':
         specifier: ^5.0.6
@@ -196,7 +196,7 @@ importers:
         version: 3.1.14
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.19.11)(typescript@5.9.3)
+        version: 10.9.2(@types/node@25.3.3)(typescript@5.9.3)
     publishDirectory: dist
 
   graphile/graphile-misc-plugins:
@@ -489,7 +489,7 @@ importers:
         version: 0.1.12
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.19.11)(typescript@5.9.3)
+        version: 10.9.2(@types/node@25.3.3)(typescript@5.9.3)
     publishDirectory: dist
 
   graphile/graphile-search-plugin:
@@ -573,7 +573,7 @@ importers:
         version: 1.0.0-rc.7(graphql@16.13.0)
       grafserv:
         specifier: 1.0.0-rc.6
-        version: 1.0.0-rc.6(@types/node@22.19.11)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(grafast@1.0.0-rc.7(graphql@16.13.0))(graphile-config@1.0.0-rc.5)(graphql@16.13.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))(ws@8.19.0)
+        version: 1.0.0-rc.6(@types/node@25.3.3)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(grafast@1.0.0-rc.7(graphql@16.13.0))(graphile-config@1.0.0-rc.5)(graphql@16.13.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))(ws@8.19.0)
       graphile-build:
         specifier: 5.0.0-rc.4
         version: 5.0.0-rc.4(grafast@1.0.0-rc.7(graphql@16.13.0))(graphile-config@1.0.0-rc.5)(graphql@16.13.0)
@@ -624,7 +624,7 @@ importers:
         version: 5.0.0-rc.4
       postgraphile:
         specifier: 5.0.0-rc.7
-        version: 5.0.0-rc.7(853bfb5f6928535d2602be94c7020fe8)
+        version: 5.0.0-rc.7(56415cfaef0e792e7fc3250b8cf6023f)
       postgraphile-plugin-connection-filter:
         specifier: 3.0.0-rc.1
         version: 3.0.0-rc.1
@@ -655,7 +655,7 @@ importers:
         version: 3.1.14
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.19.11)(typescript@5.9.3)
+        version: 10.9.2(@types/node@25.3.3)(typescript@5.9.3)
     publishDirectory: dist
 
   graphile/graphile-sql-expression-validator:
@@ -906,7 +906,7 @@ importers:
         version: 5.2.1
       grafserv:
         specifier: 1.0.0-rc.6
-        version: 1.0.0-rc.6(@types/node@22.19.11)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(grafast@1.0.0-rc.7(graphql@16.13.0))(graphile-config@1.0.0-rc.5)(graphql@16.13.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))(ws@8.19.0)
+        version: 1.0.0-rc.6(@types/node@25.3.3)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(grafast@1.0.0-rc.7(graphql@16.13.0))(graphile-config@1.0.0-rc.5)(graphql@16.13.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))(ws@8.19.0)
       graphile-cache:
         specifier: workspace:^
         version: link:../../graphile/graphile-cache/dist
@@ -927,7 +927,7 @@ importers:
         version: link:../../postgres/pg-env/dist
       postgraphile:
         specifier: 5.0.0-rc.7
-        version: 5.0.0-rc.7(853bfb5f6928535d2602be94c7020fe8)
+        version: 5.0.0-rc.7(56415cfaef0e792e7fc3250b8cf6023f)
     devDependencies:
       '@types/express':
         specifier: ^5.0.6
@@ -940,7 +940,7 @@ importers:
         version: 3.1.14
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.19.11)(typescript@5.9.3)
+        version: 10.9.2(@types/node@25.3.3)(typescript@5.9.3)
     publishDirectory: dist
 
   graphql/gql-ast:
@@ -1132,7 +1132,7 @@ importers:
         version: 1.0.0-rc.7(graphql@16.13.0)
       grafserv:
         specifier: 1.0.0-rc.6
-        version: 1.0.0-rc.6(@types/node@22.19.11)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(grafast@1.0.0-rc.7(graphql@16.13.0))(graphile-config@1.0.0-rc.5)(graphql@16.13.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))(ws@8.19.0)
+        version: 1.0.0-rc.6(@types/node@25.3.3)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(grafast@1.0.0-rc.7(graphql@16.13.0))(graphile-config@1.0.0-rc.5)(graphql@16.13.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))(ws@8.19.0)
       graphile-build:
         specifier: 5.0.0-rc.4
         version: 5.0.0-rc.4(grafast@1.0.0-rc.7(graphql@16.13.0))(graphile-config@1.0.0-rc.5)(graphql@16.13.0)
@@ -1180,7 +1180,7 @@ importers:
         version: 5.0.0-rc.4
       postgraphile:
         specifier: 5.0.0-rc.7
-        version: 5.0.0-rc.7(853bfb5f6928535d2602be94c7020fe8)
+        version: 5.0.0-rc.7(56415cfaef0e792e7fc3250b8cf6023f)
       postgraphile-plugin-connection-filter:
         specifier: 3.0.0-rc.1
         version: 3.0.0-rc.1
@@ -1220,7 +1220,7 @@ importers:
         version: 3.1.14
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.19.11)(typescript@5.9.3)
+        version: 10.9.2(@types/node@25.3.3)(typescript@5.9.3)
     publishDirectory: dist
 
   graphql/server-test:
@@ -1612,7 +1612,7 @@ importers:
         version: 7.2.2
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.19.11)(typescript@5.9.3)
+        version: 10.9.2(@types/node@25.3.3)(typescript@5.9.3)
     publishDirectory: dist
 
   jobs/knative-job-worker:
@@ -1792,14 +1792,14 @@ importers:
         specifier: ^17.8.13
         version: 17.8.13
       csv-parser:
-        specifier: ^2.3.3
-        version: 2.3.5
+        specifier: ^3.2.0
+        version: 3.2.0
       inquirerer:
         specifier: ^4.5.2
         version: 4.5.2
       js-yaml:
-        specifier: ^3.14.0
-        version: 3.14.2
+        specifier: ^4.1.0
+        version: 4.1.1
       pgsql-deparser:
         specifier: ^17.18.0
         version: 17.18.0
@@ -1903,7 +1903,7 @@ importers:
         version: 0.1.12
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.19.11)(typescript@5.9.3)
+        version: 10.9.2(@types/node@25.3.3)(typescript@5.9.3)
     publishDirectory: dist
 
   packages/smtppostmaster:
@@ -1932,7 +1932,7 @@ importers:
         version: 3.18.1
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.19.11)(typescript@5.9.3)
+        version: 10.9.2(@types/node@25.3.3)(typescript@5.9.3)
     publishDirectory: dist
 
   packages/url-domains:
@@ -5963,9 +5963,9 @@ packages:
   csv-parse@6.1.0:
     resolution: {integrity: sha512-CEE+jwpgLn+MmtCpVcPtiCZpVtB6Z2OKPTr34pycYYoL7sxdOkXDdQ4lRiw6ioC0q6BLqhc6cKweCVvral8yhw==}
 
-  csv-parser@2.3.5:
-    resolution: {integrity: sha512-LCHolC4AlNwL+5EuD5LH2VVNKpD8QixZW2zzK1XmrVYUaslFY4c5BooERHOCIubG9iv/DAyFjs4x0HvWNZuyWg==}
-    engines: {node: '>= 8.16.0'}
+  csv-parser@3.2.0:
+    resolution: {integrity: sha512-fgKbp+AJbn1h2dcAHKIdKNSSjfp43BZZykXsCjzALjKy80VXQNHPFJ6T9Afwdzoj24aMkq8GwDS7KGcDPpejrA==}
+    engines: {node: '>= 10'}
     hasBin: true
 
   dargs@7.0.0:
@@ -9193,9 +9193,6 @@ packages:
 
   through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
-
-  through2@3.0.2:
-    resolution: {integrity: sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
@@ -12767,7 +12764,6 @@ snapshots:
   '@types/node@25.3.3':
     dependencies:
       undici-types: 7.18.2
-    optional: true
 
   '@types/nodemailer@7.0.11':
     dependencies:
@@ -13705,10 +13701,7 @@ snapshots:
 
   csv-parse@6.1.0: {}
 
-  csv-parser@2.3.5:
-    dependencies:
-      minimist: 1.2.8
-      through2: 3.0.2
+  csv-parser@3.2.0: {}
 
   dargs@7.0.0: {}
 
@@ -17667,11 +17660,6 @@ snapshots:
       readable-stream: 2.3.8
       xtend: 4.0.2
 
-  through2@3.0.2:
-    dependencies:
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-
   through@2.3.8: {}
 
   tinyglobby@0.2.12:
@@ -17738,6 +17726,24 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 22.19.11
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+
+  ts-node@10.9.2(@types/node@25.3.3)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 25.3.3
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -17818,8 +17824,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici-types@7.18.2:
-    optional: true
+  undici-types@7.18.2: {}
 
   undici@7.22.0: {}
 


### PR DESCRIPTION
## Summary

Bumps two major dependencies in the `csv-to-pg` package:

| Package | From | To | Breaking changes |
|---------|------|----|-----------------|
| `js-yaml` | `^3.14.0` (resolved 3.14.2) | `^4.1.0` (resolved 4.1.1) | `safeLoad()` → `load()`, unsafe types removed from default schema |
| `csv-parser` | `^2.3.3` (resolved 2.3.5) | `^3.2.0` (resolved 3.2.0) | Minimum Node bumped to 10; streaming API unchanged |

**No source code changes were needed.** The codebase already uses `import { load as parseYAML } from 'js-yaml'` (the v4 API name), and csv-parser is used via the standard `createReadStream().pipe(csv(opts))` streaming pattern which is unchanged in v3.

The csv-parser upgrade also cleans up transitive deps — it no longer pulls in `minimist` or `through2@3.0.2`.

## Review & Testing Checklist for Human

- [ ] **js-yaml behavior change**: In v3, `load()` was the *unsafe* variant (allowed `!!js/function`, `!!js/regexp`, etc). In v4, `load()` is the *safe* variant (equivalent to old `safeLoad()`). If any YAML config files consumed by `csv-to-pg`'s `readConfig()` use custom JS types, they will now throw. Verify your YAML configs only use standard YAML types.
- [ ] **Lockfile `@types/node` drift**: The lockfile shows several transitive resolutions shifting from `@types/node@22.19.11` to `@types/node@25.3.3` (in `ts-node`, `grafserv`, `postgraphile` resolution strings). This appears to be a pnpm lockfile artifact from regeneration, not an intentional change. Verify these don't introduce unwanted Node 25 types into packages that should target Node 22.
- [ ] **Run `csv-to-pg` tests**: `cd packages/csv-to-pg && pnpm test` — CI will cover this, but worth a manual check since both upgrades are major versions with no source code changes to validate compatibility.

### Notes


- Build passed locally with `pnpm build`
- CI not yet verified — waiting for checks to complete
- The csv-parser v3 upgrade has been in production for many projects (it's a mature package), and the streaming API is backward-compatible

Requested by: @pyramation  
[Link to Devin Session](https://app.devin.ai/sessions/340b015e22704a5cac3125dfebcf1ebd)