### PR TITLE
fix(cli): fix --no-tty flag not being recognized in init command

### DIFF
--- a/pgpm/cli/src/commands/init/index.ts
+++ b/pgpm/cli/src/commands/init/index.ts
@@ -74,7 +74,7 @@ async function handleInit(argv: Partial<Record<string, any>>, prompter: Inquirer
   const { cwd = process.cwd() } = argv;
   const templateRepo = (argv.repo as string) ?? DEFAULT_TEMPLATE_REPO;
   const branch = argv.fromBranch as string | undefined;
-  const noTty = Boolean((argv as any).noTty || argv['no-tty'] || process.env.CI === 'true');
+  const noTty = Boolean((argv as any).noTty || argv['no-tty'] || argv.tty === false || process.env.CI === 'true');
   const useBoilerplatePrompt = Boolean(argv.boilerplate);
   const createWorkspace = Boolean(argv.createWorkspace || argv['create-workspace'] || argv.w);
 
@@ -413,7 +413,7 @@ async function handleModuleInit(
     }
 
     if (!resolvedWorkspacePath) {
-      const noTty = Boolean((argv as any).noTty || argv['no-tty'] || process.env.CI === 'true');
+      const noTty = Boolean((argv as any).noTty || argv['no-tty'] || argv.tty === false || process.env.CI === 'true');
 
       // Handle --create-workspace flag: create workspace first, then module
       if (ctx.createWorkspace && (workspaceType === 'pgpm' || workspaceType === 'pnpm')) {

--- a/pgpm/cli/src/commands/init/workspace.ts
+++ b/pgpm/cli/src/commands/init/workspace.ts
@@ -54,7 +54,7 @@ export default async function runWorkspaceSetup(
       workspaceName: answers.name
     },
     toolName: DEFAULT_TEMPLATE_TOOL_NAME,
-    noTty: Boolean((argv as any).noTty || argv['no-tty'] || process.env.CI === 'true'),
+    noTty: Boolean((argv as any).noTty || argv['no-tty'] || argv.tty === false || process.env.CI === 'true'),
     cwd,
     prompter
   });


### PR DESCRIPTION
## Problem
The `--no-tty` flag was not working when running `pgpm init` commands. Users expecting non-interactive mode with `--no-tty` would still get interactive prompts.

## Root Cause
minimist parses `--no-<name>` flags differently than expected:
- `--no-tty` is parsed as `{ tty: false }`, NOT `{ 'no-tty': true }`

The original code checked for `argv['no-tty']`, which would always be `undefined`, causing the flag to be silently ignored.

## Solution
Added `argv.tty === false` check to correctly detect the `--no-tty` flag:

```typescript
// Before (bug)
const noTty = Boolean(argv.noTty || argv['no-tty'] || process.env.CI);

// After (fixed)
const noTty = Boolean(argv.noTty || argv['no-tty'] || argv.tty === false || process.env.CI);
```

## Files Changed
- pgpm/cli/src/commands/init/index.ts (2 occurrences)
- pgpm/cli/src/commands/init/workspace.ts (1 occurrence)