### PR TITLE
fix(pg-cache): allow cache to reopen after close for process survival

### DIFF
--- a/postgres/pg-cache/src/lru.ts
+++ b/postgres/pg-cache/src/lru.ts
@@ -105,6 +105,9 @@ export class PgPoolCacheManager {
     this.closed = true;
     this.clear();
     await this.waitForDisposals();
+    // Re-open the cache so it can accept new entries if the process
+    // survives the shutdown signal (e.g. during provisioning or restart).
+    this.closed = false;
   }
 
   async waitForDisposals(): Promise<void> {
@@ -141,9 +144,14 @@ export const close = async (verbose = false): Promise<void> => {
   if (closePromise.promise) return closePromise.promise;
 
   closePromise.promise = (async () => {
-    if (verbose) log.info('Closing pg cache...');
-    await pgCache.close();
-    if (verbose) log.success('PG cache disposed.');
+    try {
+      if (verbose) log.info('Closing pg cache...');
+      await pgCache.close();
+      if (verbose) log.success('PG cache disposed.');
+    } finally {
+      // Reset so close() can be called again if the process survives.
+      closePromise.promise = null;
+    }
   })();
 
   return closePromise.promise;


### PR DESCRIPTION
# fix(pg-cache): allow cache to reopen after close for process survival

## Summary

Fixes a server crash: `Error: Cannot add to cache after it has been closed (key: postgres)`.

`PgPoolCacheManager.close()` permanently set `closed = true` with no reset path. When SIGTERM fires but the process doesn't exit (e.g., during provisioning or restart under load), all subsequent `getPgPool()` calls throw because `set()` is guarded by the `closed` flag. The module-level `closePromise` was also never reset, preventing future `close()` cycles from running.

**Changes (2 lines of logic in `postgres/pg-cache/src/lru.ts`):**
- Reset `this.closed = false` after `waitForDisposals()` completes in `PgPoolCacheManager.close()`, so the cache can accept new entries post-shutdown
- Wrap module-level `close()` body in `try/finally` to reset `closePromise.promise = null`, matching the existing pattern in `graphile-cache.ts`

## Review & Testing Checklist for Human

- [ ] **Concurrent shutdown race**: Verify that a `set()` call arriving *during* an active `close()` (between `this.closed = true` and `this.closed = false`) still correctly throws, and only succeeds after disposal completes
- [ ] **Repeated SIGTERM**: Confirm that receiving a second SIGTERM after the cache reopens triggers a proper new close cycle (the `closePromise` reset + `closed = false` should allow this)
- [ ] **Manual test**: Kill and restart the server process under load during provisioning to confirm the crash no longer occurs

### Notes
- The fix is intentionally minimal — two assignments and a `try/finally` wrapper
- The `graphile-cache` package already uses this `finally` reset pattern (line 283 of `graphile-cache.ts`); this PR aligns `pg-cache` with that convention
- Trailing newline added to end of file (formatting only)

Requested by: @pyramation
[Link to Devin Session](https://app.devin.ai/sessions/fe6bd16e4f5642b4b396e2c7b3bfa928)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/constructive-io/constructive/pull/787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
