### PR TITLE
feat(codegen): wire condition arg through ORM query builder for findMany/findFirst

### DIFF
--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/client-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/client-generator.test.ts.snap
@@ -276,9 +276,10 @@ export interface PageInfo {
   endCursor?: string | null;
 }
 
-export interface FindManyArgs<TSelect, TWhere, TOrderBy> {
+export interface FindManyArgs<TSelect, TWhere, TCondition, TOrderBy> {
   select?: TSelect;
   where?: TWhere;
+  condition?: TCondition;
   orderBy?: TOrderBy[];
   first?: number;
   last?: number;
@@ -287,9 +288,10 @@ export interface FindManyArgs<TSelect, TWhere, TOrderBy> {
   offset?: number;
 }
 
-export interface FindFirstArgs<TSelect, TWhere> {
+export interface FindFirstArgs<TSelect, TWhere, TCondition> {
   select?: TSelect;
   where?: TWhere;
+  condition?: TCondition;
 }
 
 export interface CreateArgs<TSelect, TData> {

--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/model-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/model-generator.test.ts.snap
@@ -9,11 +9,11 @@ exports[`model-generator generates model with all CRUD methods 1`] = `
 import { OrmClient } from "../client";
 import { QueryBuilder, buildFindManyDocument, buildFindFirstDocument, buildFindOneDocument, buildCreateDocument, buildUpdateByPkDocument, buildDeleteByPkDocument } from "../query-builder";
 import type { ConnectionResult, FindManyArgs, FindFirstArgs, CreateArgs, UpdateArgs, DeleteArgs, InferSelectResult, StrictSelect } from "../select-types";
-import type { User, UserWithRelations, UserSelect, UserFilter, UsersOrderBy, CreateUserInput, UpdateUserInput, UserPatch } from "../input-types";
+import type { User, UserWithRelations, UserSelect, UserFilter, UserCondition, UsersOrderBy, CreateUserInput, UpdateUserInput, UserPatch } from "../input-types";
 import { connectionFieldsMap } from "../input-types";
 export class UserModel {
   constructor(private client: OrmClient) {}
-  findMany<S extends UserSelect>(args: FindManyArgs<S, UserFilter, UsersOrderBy> & {
+  findMany<S extends UserSelect>(args: FindManyArgs<S, UserFilter, UserCondition, UsersOrderBy> & {
     select: S;
   } & StrictSelect<S, UserSelect>): QueryBuilder<{
     users: ConnectionResult<InferSelectResult<UserWithRelations, S>>;
@@ -23,13 +23,14 @@ export class UserModel {
       variables
     } = buildFindManyDocument("User", "users", args.select, {
       where: args?.where,
+      condition: args?.condition,
       orderBy: args?.orderBy as string[] | undefined,
       first: args?.first,
       last: args?.last,
       after: args?.after,
       before: args?.before,
       offset: args?.offset
-    }, "UserFilter", "UsersOrderBy", connectionFieldsMap);
+    }, "UserFilter", "UsersOrderBy", connectionFieldsMap, "UserCondition");
     return new QueryBuilder({
       client: this.client,
       operation: "query",
@@ -39,7 +40,7 @@ export class UserModel {
       variables
     });
   }
-  findFirst<S extends UserSelect>(args: FindFirstArgs<S, UserFilter> & {
+  findFirst<S extends UserSelect>(args: FindFirstArgs<S, UserFilter, UserCondition> & {
     select: S;
   } & StrictSelect<S, UserSelect>): QueryBuilder<{
     users: {
@@ -50,8 +51,9 @@ export class UserModel {
       document,
       variables
     } = buildFindFirstDocument("User", "users", args.select, {
-      where: args?.where
-    }, "UserFilter", connectionFieldsMap);
+      where: args?.where,
+      condition: args?.condition
+    }, "UserFilter", connectionFieldsMap, "UserCondition");
     return new QueryBuilder({
       client: this.client,
       operation: "query",
@@ -156,11 +158,11 @@ exports[`model-generator generates model without update/delete when not availabl
 import { OrmClient } from "../client";
 import { QueryBuilder, buildFindManyDocument, buildFindFirstDocument, buildFindOneDocument, buildCreateDocument, buildUpdateByPkDocument, buildDeleteByPkDocument } from "../query-builder";
 import type { ConnectionResult, FindManyArgs, FindFirstArgs, CreateArgs, UpdateArgs, DeleteArgs, InferSelectResult, StrictSelect } from "../select-types";
-import type { AuditLog, AuditLogWithRelations, AuditLogSelect, AuditLogFilter, AuditLogsOrderBy, CreateAuditLogInput, UpdateAuditLogInput, AuditLogPatch } from "../input-types";
+import type { AuditLog, AuditLogWithRelations, AuditLogSelect, AuditLogFilter, AuditLogCondition, AuditLogsOrderBy, CreateAuditLogInput, UpdateAuditLogInput, AuditLogPatch } from "../input-types";
 import { connectionFieldsMap } from "../input-types";
 export class AuditLogModel {
   constructor(private client: OrmClient) {}
-  findMany<S extends AuditLogSelect>(args: FindManyArgs<S, AuditLogFilter, AuditLogsOrderBy> & {
+  findMany<S extends AuditLogSelect>(args: FindManyArgs<S, AuditLogFilter, AuditLogCondition, AuditLogsOrderBy> & {
     select: S;
   } & StrictSelect<S, AuditLogSelect>): QueryBuilder<{
     auditLogs: ConnectionResult<InferSelectResult<AuditLogWithRelations, S>>;
@@ -170,13 +172,14 @@ export class AuditLogModel {
       variables
     } = buildFindManyDocument("AuditLog", "auditLogs", args.select, {
       where: args?.where,
+      condition: args?.condition,
       orderBy: args?.orderBy as string[] | undefined,
       first: args?.first,
       last: args?.last,
       after: args?.after,
       before: args?.before,
       offset: args?.offset
-    }, "AuditLogFilter", "AuditLogsOrderBy", connectionFieldsMap);
+    }, "AuditLogFilter", "AuditLogsOrderBy", connectionFieldsMap, "AuditLogCondition");
     return new QueryBuilder({
       client: this.client,
       operation: "query",
@@ -186,7 +189,7 @@ export class AuditLogModel {
       variables
     });
   }
-  findFirst<S extends AuditLogSelect>(args: FindFirstArgs<S, AuditLogFilter> & {
+  findFirst<S extends AuditLogSelect>(args: FindFirstArgs<S, AuditLogFilter, AuditLogCondition> & {
     select: S;
   } & StrictSelect<S, AuditLogSelect>): QueryBuilder<{
     auditLogs: {
@@ -197,8 +200,9 @@ export class AuditLogModel {
       document,
       variables
     } = buildFindFirstDocument("AuditLog", "auditLogs", args.select, {
-      where: args?.where
-    }, "AuditLogFilter", connectionFieldsMap);
+      where: args?.where,
+      condition: args?.condition
+    }, "AuditLogFilter", connectionFieldsMap, "AuditLogCondition");
     return new QueryBuilder({
       client: this.client,
       operation: "query",
@@ -259,11 +263,11 @@ exports[`model-generator handles custom query/mutation names 1`] = `
 import { OrmClient } from "../client";
 import { QueryBuilder, buildFindManyDocument, buildFindFirstDocument, buildFindOneDocument, buildCreateDocument, buildUpdateByPkDocument, buildDeleteByPkDocument } from "../query-builder";
 import type { ConnectionResult, FindManyArgs, FindFirstArgs, CreateArgs, UpdateArgs, DeleteArgs, InferSelectResult, StrictSelect } from "../select-types";
-import type { Organization, OrganizationWithRelations, OrganizationSelect, OrganizationFilter, OrganizationsOrderBy, CreateOrganizationInput, UpdateOrganizationInput, OrganizationPatch } from "../input-types";
+import type { Organization, OrganizationWithRelations, OrganizationSelect, OrganizationFilter, OrganizationCondition, OrganizationsOrderBy, CreateOrganizationInput, UpdateOrganizationInput, OrganizationPatch } from "../input-types";
 import { connectionFieldsMap } from "../input-types";
 export class OrganizationModel {
   constructor(private client: OrmClient) {}
-  findMany<S extends OrganizationSelect>(args: FindManyArgs<S, OrganizationFilter, OrganizationsOrderBy> & {
+  findMany<S extends OrganizationSelect>(args: FindManyArgs<S, OrganizationFilter, OrganizationCondition, OrganizationsOrderBy> & {
     select: S;
   } & StrictSelect<S, OrganizationSelect>): QueryBuilder<{
     allOrganizations: ConnectionResult<InferSelectResult<OrganizationWithRelations, S>>;
@@ -273,13 +277,14 @@ export class OrganizationModel {
       variables
     } = buildFindManyDocument("Organization", "allOrganizations", args.select, {
       where: args?.where,
+      condition: args?.condition,
       orderBy: args?.orderBy as string[] | undefined,
       first: args?.first,
       last: args?.last,
       after: args?.after,
       before: args?.before,
       offset: args?.offset
-    }, "OrganizationFilter", "OrganizationsOrderBy", connectionFieldsMap);
+    }, "OrganizationFilter", "OrganizationsOrderBy", connectionFieldsMap, "OrganizationCondition");
     return new QueryBuilder({
       client: this.client,
       operation: "query",
@@ -289,7 +294,7 @@ export class OrganizationModel {
       variables
     });
   }
-  findFirst<S extends OrganizationSelect>(args: FindFirstArgs<S, OrganizationFilter> & {
+  findFirst<S extends OrganizationSelect>(args: FindFirstArgs<S, OrganizationFilter, OrganizationCondition> & {
     select: S;
   } & StrictSelect<S, OrganizationSelect>): QueryBuilder<{
     allOrganizations: {
@@ -300,8 +305,9 @@ export class OrganizationModel {
       document,
       variables
     } = buildFindFirstDocument("Organization", "allOrganizations", args.select, {
-      where: args?.where
-    }, "OrganizationFilter", connectionFieldsMap);
+      where: args?.where,
+      condition: args?.condition
+    }, "OrganizationFilter", connectionFieldsMap, "OrganizationCondition");
     return new QueryBuilder({
       client: this.client,
       operation: "query",

--- a/graphql/codegen/src/__tests__/codegen/model-generator.test.ts
+++ b/graphql/codegen/src/__tests__/codegen/model-generator.test.ts
@@ -232,4 +232,42 @@ describe('model-generator', () => {
     expect(result.content).toContain('UpdateProductInput');
     expect(result.content).toContain('ProductPatch');
   });
+
+  it('imports and wires Condition type for findMany and findFirst', () => {
+    const table = createTable({
+      name: 'Contact',
+      fields: [
+        { name: 'id', type: fieldTypes.uuid },
+        { name: 'name', type: fieldTypes.string },
+      ],
+      query: {
+        all: 'contacts',
+        one: 'contact',
+        create: 'createContact',
+        update: 'updateContact',
+        delete: 'deleteContact',
+      },
+    });
+
+    const result = generateModelFile(table, false);
+
+    // Condition type should be imported
+    expect(result.content).toContain('ContactCondition');
+
+    // findMany should include condition in its args type
+    expect(result.content).toContain(
+      'FindManyArgs<S, ContactFilter, ContactCondition, ContactsOrderBy>',
+    );
+
+    // findFirst should include condition in its args type
+    expect(result.content).toContain(
+      'FindFirstArgs<S, ContactFilter, ContactCondition>',
+    );
+
+    // condition should be forwarded in the body args object
+    expect(result.content).toContain('condition: args?.condition');
+
+    // conditionTypeName should be passed as a string literal to the document builder
+    expect(result.content).toContain('"ContactCondition"');
+  });
 });

--- a/graphql/codegen/src/__tests__/codegen/query-builder.test.ts
+++ b/graphql/codegen/src/__tests__/codegen/query-builder.test.ts
@@ -38,12 +38,12 @@ function buildConnectionSelections(nodeSelections: FieldNode[]): FieldNode[] {
 }
 
 function addVariable(
-  spec: { varName: string; argName?: string; typeName: string; value: unknown },
+  spec: { varName: string; argName?: string; typeName?: string; value: unknown },
   definitions: VariableDefinitionNode[],
   args: ArgumentNode[],
   variables: Record<string, unknown>,
 ): void {
-  if (spec.value === undefined) return;
+  if (spec.value === undefined || !spec.typeName) return;
   definitions.push(
     t.variableDefinition({
       variable: t.variable({ name: spec.varName }),
@@ -123,14 +123,15 @@ function buildSelections(
   return fields;
 }
 
-function buildFindManyDocument<TSelect, TWhere>(
+function buildFindManyDocument<TSelect, TWhere, TCondition>(
   operationName: string,
   queryField: string,
   select: TSelect,
-  args: { where?: TWhere; first?: number; orderBy?: string[] },
+  args: { where?: TWhere; condition?: TCondition; first?: number; orderBy?: string[] },
   filterTypeName: string,
   orderByTypeName: string,
   connectionFieldsMap?: Record<string, Record<string, string>>,
+  conditionTypeName?: string,
 ): { document: string; variables: Record<string, unknown> } {
   const selections = select
     ? buildSelections(
@@ -143,6 +144,16 @@ function buildFindManyDocument<TSelect, TWhere>(
   const queryArgs: ArgumentNode[] = [];
   const variables: Record<string, unknown> = {};
 
+  addVariable(
+    {
+      varName: 'condition',
+      typeName: conditionTypeName,
+      value: args.condition,
+    },
+    variableDefinitions,
+    queryArgs,
+    variables,
+  );
   addVariable(
     {
       varName: 'where',
@@ -556,6 +567,52 @@ describe('query-builder', () => {
         first: 10,
         orderBy: ['NAME_ASC'],
       });
+    });
+
+    it('includes condition variable when conditionTypeName is provided', () => {
+      const { document, variables } = buildFindManyDocument(
+        'Contacts',
+        'contacts',
+        { id: true, name: true },
+        {
+          condition: { embeddingNearby: { vector: [0.1, 0.2], metric: 'COSINE' } },
+          where: { name: { equalTo: 'test' } },
+          first: 5,
+        },
+        'ContactFilter',
+        'ContactsOrderBy',
+        undefined,
+        'ContactCondition',
+      );
+
+      // condition variable should appear in the query
+      expect(document).toContain('$condition: ContactCondition');
+      expect(document).toContain('condition: $condition');
+      // filter should still work alongside condition
+      expect(document).toContain('$where: ContactFilter');
+      expect(document).toContain('filter: $where');
+      // variables should include both
+      expect(variables.condition).toEqual({
+        embeddingNearby: { vector: [0.1, 0.2], metric: 'COSINE' },
+      });
+      expect(variables.where).toEqual({ name: { equalTo: 'test' } });
+    });
+
+    it('omits condition variable when not provided', () => {
+      const { document } = buildFindManyDocument(
+        'Users',
+        'users',
+        { id: true },
+        { first: 10 },
+        'UserFilter',
+        'UsersOrderBy',
+        undefined,
+        'UserCondition',
+      );
+
+      // condition should NOT appear since no value was provided
+      expect(document).not.toContain('$condition');
+      expect(document).not.toContain('condition:');
     });
   });
 

--- a/graphql/codegen/src/core/codegen/orm/model-generator.ts
+++ b/graphql/codegen/src/core/codegen/orm/model-generator.ts
@@ -175,6 +175,7 @@ export function generateModelFile(
   const selectTypeName = `${typeName}Select`;
   const relationTypeName = `${typeName}WithRelations`;
   const whereTypeName = getFilterTypeName(table);
+  const conditionTypeName = `${typeName}Condition`;
   const orderByTypeName = getOrderByTypeName(table);
   const createInputTypeName = `Create${typeName}Input`;
   const updateInputTypeName = `Update${typeName}Input`;
@@ -228,6 +229,7 @@ export function generateModelFile(
         relationTypeName,
         selectTypeName,
         whereTypeName,
+        conditionTypeName,
         orderByTypeName,
         createInputTypeName,
         updateInputTypeName,
@@ -270,6 +272,7 @@ export function generateModelFile(
         t.tsTypeParameterInstantiation([
           sel,
           t.tsTypeReference(t.identifier(whereTypeName)),
+          t.tsTypeReference(t.identifier(conditionTypeName)),
           t.tsTypeReference(t.identifier(orderByTypeName)),
         ]),
       );
@@ -323,6 +326,15 @@ export function generateModelFile(
           t.optionalMemberExpression(
             t.identifier('args'),
             t.identifier('where'),
+            false,
+            true,
+          ),
+        ),
+        t.objectProperty(
+          t.identifier('condition'),
+          t.optionalMemberExpression(
+            t.identifier('args'),
+            t.identifier('condition'),
             false,
             true,
           ),
@@ -391,6 +403,7 @@ export function generateModelFile(
       t.stringLiteral(whereTypeName),
       t.stringLiteral(orderByTypeName),
       t.identifier('connectionFieldsMap'),
+      t.stringLiteral(conditionTypeName),
     ];
     classBody.push(
       createClassMethod(
@@ -417,6 +430,7 @@ export function generateModelFile(
         t.tsTypeParameterInstantiation([
           sel,
           t.tsTypeReference(t.identifier(whereTypeName)),
+          t.tsTypeReference(t.identifier(conditionTypeName)),
         ]),
       );
     const retType = (sel: t.TSType) =>
@@ -477,9 +491,19 @@ export function generateModelFile(
             true,
           ),
         ),
+        t.objectProperty(
+          t.identifier('condition'),
+          t.optionalMemberExpression(
+            t.identifier('args'),
+            t.identifier('condition'),
+            false,
+            true,
+          ),
+        ),
       ]),
       t.stringLiteral(whereTypeName),
       t.identifier('connectionFieldsMap'),
+      t.stringLiteral(conditionTypeName),
     ];
     classBody.push(
       createClassMethod(

--- a/graphql/codegen/src/core/codegen/orm/select-types.ts
+++ b/graphql/codegen/src/core/codegen/orm/select-types.ts
@@ -201,9 +201,10 @@ export interface PageInfo {
 /**
  * Arguments for findMany operations
  */
-export interface FindManyArgs<TSelect, TWhere, TOrderBy> {
+export interface FindManyArgs<TSelect, TWhere, TCondition, TOrderBy> {
   select?: TSelect;
   where?: TWhere;
+  condition?: TCondition;
   orderBy?: TOrderBy[];
   first?: number;
   last?: number;
@@ -215,9 +216,10 @@ export interface FindManyArgs<TSelect, TWhere, TOrderBy> {
 /**
  * Arguments for findFirst/findUnique operations
  */
-export interface FindFirstArgs<TSelect, TWhere> {
+export interface FindFirstArgs<TSelect, TWhere, TCondition> {
   select?: TSelect;
   where?: TWhere;
+  condition?: TCondition;
 }
 
 /**

--- a/graphql/codegen/src/core/codegen/templates/query-builder.ts
+++ b/graphql/codegen/src/core/codegen/templates/query-builder.ts
@@ -201,12 +201,13 @@ export function buildSelections(
 // Document Builders
 // ============================================================================
 
-export function buildFindManyDocument<TSelect, TWhere>(
+export function buildFindManyDocument<TSelect, TWhere, TCondition>(
   operationName: string,
   queryField: string,
   select: TSelect,
   args: {
     where?: TWhere;
+    condition?: TCondition;
     orderBy?: string[];
     first?: number;
     last?: number;
@@ -217,6 +218,7 @@ export function buildFindManyDocument<TSelect, TWhere>(
   filterTypeName: string,
   orderByTypeName: string,
   connectionFieldsMap?: Record<string, Record<string, string>>,
+  conditionTypeName?: string,
 ): { document: string; variables: Record<string, unknown> } {
   const selections = select
     ? buildSelections(
@@ -230,6 +232,16 @@ export function buildFindManyDocument<TSelect, TWhere>(
   const queryArgs: ArgumentNode[] = [];
   const variables: Record<string, unknown> = {};
 
+  addVariable(
+    {
+      varName: 'condition',
+      typeName: conditionTypeName,
+      value: args.condition,
+    },
+    variableDefinitions,
+    queryArgs,
+    variables,
+  );
   addVariable(
     {
       varName: 'where',
@@ -308,13 +320,14 @@ export function buildFindManyDocument<TSelect, TWhere>(
   return { document: print(document), variables };
 }
 
-export function buildFindFirstDocument<TSelect, TWhere>(
+export function buildFindFirstDocument<TSelect, TWhere, TCondition>(
   operationName: string,
   queryField: string,
   select: TSelect,
-  args: { where?: TWhere },
+  args: { where?: TWhere; condition?: TCondition },
   filterTypeName: string,
   connectionFieldsMap?: Record<string, Record<string, string>>,
+  conditionTypeName?: string,
 ): { document: string; variables: Record<string, unknown> } {
   const selections = select
     ? buildSelections(
@@ -331,6 +344,16 @@ export function buildFindFirstDocument<TSelect, TWhere>(
   // Always add first: 1 for findFirst
   addVariable(
     { varName: 'first', typeName: 'Int', value: 1 },
+    variableDefinitions,
+    queryArgs,
+    variables,
+  );
+  addVariable(
+    {
+      varName: 'condition',
+      typeName: conditionTypeName,
+      value: args.condition,
+    },
     variableDefinitions,
     queryArgs,
     variables,
@@ -799,7 +822,7 @@ function buildConnectionSelections(nodeSelections: FieldNode[]): FieldNode[] {
 interface VariableSpec {
   varName: string;
   argName?: string;
-  typeName: string;
+  typeName?: string;
   value: unknown;
 }
 
@@ -850,7 +873,7 @@ function addVariable(
   args: ArgumentNode[],
   variables: Record<string, unknown>,
 ): void {
-  if (spec.value === undefined) return;
+  if (spec.value === undefined || !spec.typeName) return;
 
   definitions.push(
     t.variableDefinition({

--- a/graphql/codegen/src/core/codegen/templates/select-types.ts
+++ b/graphql/codegen/src/core/codegen/templates/select-types.ts
@@ -21,9 +21,10 @@ export interface PageInfo {
   endCursor?: string | null;
 }
 
-export interface FindManyArgs<TSelect, TWhere, TOrderBy> {
+export interface FindManyArgs<TSelect, TWhere, TCondition, TOrderBy> {
   select?: TSelect;
   where?: TWhere;
+  condition?: TCondition;
   orderBy?: TOrderBy[];
   first?: number;
   last?: number;
@@ -32,9 +33,10 @@ export interface FindManyArgs<TSelect, TWhere, TOrderBy> {
   offset?: number;
 }
 
-export interface FindFirstArgs<TSelect, TWhere> {
+export interface FindFirstArgs<TSelect, TWhere, TCondition> {
   select?: TSelect;
   where?: TWhere;
+  condition?: TCondition;
 }
 
 export interface CreateArgs<TSelect, TData> {


### PR DESCRIPTION
# feat(codegen): wire condition arg through ORM query builder for findMany/findFirst

## Summary

Adds `TCondition` generic parameter support to the ORM layer so that generated model classes can accept and forward `condition` arguments (e.g., `embeddingNearby` for vector search, `bm25Body` for BM25) through `findMany` and `findFirst` operations.

**Changes across 4 source files:**

- **`select-types.ts`** (template + ORM): Added `TCondition` generic and `condition?: TCondition` field to `FindManyArgs` and `FindFirstArgs`
- **`query-builder.ts`**: Added `conditionTypeName` parameter and `addVariable()` call for `condition` in both `buildFindManyDocument` and `buildFindFirstDocument`. Made `VariableSpec.typeName` optional with a guard so condition is cleanly skipped when not provided.
- **`model-generator.ts`**: Wires `${TypeName}Condition` into imports, generic type params, body arg forwarding, and document builder calls for both `findMany` and `findFirst`

**3 new tests + 4 updated snapshots:**
- Model-generator test verifying condition type import, generic params, arg forwarding, and conditionTypeName string literal
- Query-builder tests verifying condition variable appears in generated GraphQL when provided, and is omitted when absent

## Review & Testing Checklist for Human

- [ ] **Verify `VariableSpec.typeName` change is safe**: Changed from `typeName: string` to `typeName?: string` in `query-builder.ts` (line 825). The `addVariable` guard (`!spec.typeName`) prevents runtime errors, but confirm no other callers depend on `typeName` being required at the type level.
- [ ] **Verify condition variable ordering**: In `buildFindManyDocument`, condition is added *before* where/filter. In `buildFindFirstDocument`, condition is added *after* where/filter. GraphQL doesn't care about variable order, but confirm this inconsistency is acceptable.
- [ ] **Verify `${typeName}Condition` naming convention**: The condition type name is hardcoded as `${typeName}Condition` in model-generator (line 178). Confirm this matches what PostGraphile actually generates for all table types.
- [ ] **End-to-end verification**: Run the codegen against an actual schema with vector/BM25 condition types and verify the generated ORM client accepts condition args and produces valid GraphQL queries.

### Notes
- This is a clean reimplementation of the condition arg support that was originally added by another agent on `codegen/vectors-v2`, with proper code style and comprehensive tests
- Based on PR #791 (`devin/1773279354-fix-vector-codegen-v2`)
- Requested by: @pyramation
- Session: https://app.devin.ai/sessions/c3e55218c0a94d99a5d678a374506930