### PR TITLE
chore: update default Docker image to constructiveio/postgres-plus:18

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -120,7 +120,7 @@ jobs:
 
     services:
       pg_db:
-        image: pyramation/postgres:17
+        image: ghcr.io/constructive-io/docker/postgres-plus:18
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password

--- a/graphile/graphile-pg-textsearch-plugin/README.md
+++ b/graphile/graphile-pg-textsearch-plugin/README.md
@@ -117,7 +117,7 @@ CREATE INDEX articles_body_idx ON articles USING bm25(body)
 ## Testing
 
 ```sh
-# requires pyramation/postgres:17 Docker image with pg_textsearch pre-installed
+# requires constructiveio/postgres-plus:18 Docker image with pg_textsearch pre-installed
 pnpm --filter graphile-pg-textsearch-plugin test
 ```
 

--- a/pgpm/cli/src/commands/docker.ts
+++ b/pgpm/cli/src/commands/docker.ts
@@ -15,7 +15,7 @@ Subcommands:
 Options:
   --help, -h         Show this help message
   --name <name>      Container name (default: postgres)
-  --image <image>    Docker image (default: pyramation/postgres:17)
+  --image <image>    Docker image (default: constructiveio/postgres-plus:18)
   --port <port>      Host port mapping (default: 5432)
   --user <user>      PostgreSQL user (default: postgres)
   --password <pass>  PostgreSQL password (default: password)
@@ -211,7 +211,7 @@ export default async (
     return;
   }
   const name = (args.name as string) || 'postgres';
-  const image = (args.image as string) || 'pyramation/postgres:17';
+  const image = (args.image as string) || 'constructiveio/postgres-plus:18';
   const port = typeof args.port === 'number' ? args.port : 5432;
   const user = (args.user as string) || 'postgres';
   const password = (args.password as string) || 'password';


### PR DESCRIPTION
# chore: update default Docker image to postgres-plus:18

## Summary

Replaces all references to `pyramation/postgres:17` with the new `postgres-plus:18` image across CI, the pgpm CLI, and documentation.

Two image variants are used intentionally:
- **CI workflow**: `ghcr.io/constructive-io/docker/postgres-plus:18` (private GHCR, for GitHub Actions)
- **pgpm CLI / docs**: `constructiveio/postgres-plus:18` (public Docker Hub, for local development)

The `postgres-plus:18` image ships Postgres 18 with PostGIS, pgvector, and pg_textsearch pre-installed.

**Files changed (3):**
- `.github/workflows/run-tests.yaml` — CI service container image
- `pgpm/cli/src/commands/docker.ts` — default image in help text and runtime default
- `graphile/graphile-pg-textsearch-plugin/README.md` — testing docs

## Review & Testing Checklist for Human

- [ ] **Verify both images exist and are accessible**: Confirm `ghcr.io/constructive-io/docker/postgres-plus:18` is pullable from GitHub Actions runners, and `constructiveio/postgres-plus:18` is pullable publicly from Docker Hub. If either is missing or misconfigured, all CI or local dev will break.
- [ ] **Postgres 17 → 18 behavioral changes**: This upgrades the Postgres version for all 40+ CI test jobs. Spot-check that no tests depend on Postgres 17-specific behavior. CI passing is a good signal but not conclusive for edge cases.
- [ ] **Verify GHCR vs Docker Hub images are equivalent**: The two registries should serve the same image contents. Confirm they're built from the same Dockerfile/source.

### Notes
- A historical reference to `pyramation/postgres:17` remains in `pgpm/cli/CHANGELOG.md` — this is intentionally left as-is since it's a historical changelog entry.
- This PR is intentionally scoped to just the image swap. Matrix changes (adding `graphile-settings`, `graphile-connection-filter` to CI) are handled in separate PRs (#807, #806).

**Link to Devin Session:** https://app.devin.ai/sessions/cf88f3fd383b4421a5169ed01612899d
**Requested by:** @pyramation