### PR TITLE
fix(codegen): exclude computed fields from default CLI select objects

### DIFF
--- a/graphql/codegen/src/core/codegen/cli/table-command-generator.ts
+++ b/graphql/codegen/src/core/codegen/cli/table-command-generator.ts
@@ -6,7 +6,10 @@ import {
   getGeneratedFileHeader,
   getPrimaryKeyInfo,
   getScalarFields,
+  getSelectableScalarFields,
   getTableNames,
+  getWritableFieldNames,
+  resolveInnerInputType,
   ucFirst,
   lcFirst,
   getCreateInputTypeName,
@@ -151,10 +154,7 @@ function buildFieldSchemaObject(table: CleanTable): t.ObjectExpression {
 }
 
 function buildSelectObject(table: CleanTable, typeRegistry?: TypeRegistry): t.ObjectExpression {
-  const writableFields = getWritableFieldNames(table, typeRegistry);
-  const fields = getScalarFields(table).filter(
-    (f) => writableFields === null || writableFields.has(f.name),
-  );
+  const fields = getSelectableScalarFields(table, typeRegistry);
   return t.objectExpression(
     fields.map((f) =>
       t.objectProperty(t.identifier(f.name), t.booleanLiteral(true)),
@@ -426,38 +426,6 @@ function buildGetHandler(table: CleanTable, targetName?: string, typeRegistry?: 
   );
 }
 
-/**
- * Get the set of field names that have defaults in the create input type.
- * Looks up the CreateXInput -> inner input type (e.g. DatabaseInput) in the
- * TypeRegistry and checks each field's defaultValue from introspection.
- */
-/**
- * Resolve the inner input type from a CreateXInput or UpdateXInput type.
- * The CreateXInput has an inner field (e.g. "database" of type DatabaseInput)
- * that contains the actual field definitions.
- */
-export function resolveInnerInputType(
-  inputTypeName: string,
-  typeRegistry: TypeRegistry,
-): { name: string; fields: Set<string> } | null {
-  const inputType = typeRegistry.get(inputTypeName);
-  if (!inputType?.inputFields) return null;
-
-  for (const inputField of inputType.inputFields) {
-    const innerTypeName = inputField.type.name
-      || inputField.type.ofType?.name
-      || inputField.type.ofType?.ofType?.name;
-    if (!innerTypeName) continue;
-
-    const innerType = typeRegistry.get(innerTypeName);
-    if (!innerType?.inputFields) continue;
-
-    const fields = new Set(innerType.inputFields.map((f) => f.name));
-    return { name: innerTypeName, fields };
-  }
-  return null;
-}
-
 export function getFieldsWithDefaults(
   table: CleanTable,
   typeRegistry?: TypeRegistry,
@@ -482,22 +450,6 @@ export function getFieldsWithDefaults(
   }
 
   return fieldsWithDefaults;
-}
-
-/**
- * Get the set of field names that actually exist in the create/update input type.
- * Fields not in this set (e.g. computed fields like searchTsvRank, hashUuid)
- * should be excluded from the data object in create/update handlers.
- */
-function getWritableFieldNames(
-  table: CleanTable,
-  typeRegistry?: TypeRegistry,
-): Set<string> | null {
-  if (!typeRegistry) return null;
-
-  const createInputTypeName = getCreateInputTypeName(table);
-  const resolved = resolveInnerInputType(createInputTypeName, typeRegistry);
-  return resolved?.fields ?? null;
 }
 
 function buildMutationHandler(

--- a/graphql/codegen/src/core/codegen/cli/table-command-generator.ts
+++ b/graphql/codegen/src/core/codegen/cli/table-command-generator.ts
@@ -150,8 +150,11 @@ function buildFieldSchemaObject(table: CleanTable): t.ObjectExpression {
   );
 }
 
-function buildSelectObject(table: CleanTable): t.ObjectExpression {
-  const fields = getScalarFields(table);
+function buildSelectObject(table: CleanTable, typeRegistry?: TypeRegistry): t.ObjectExpression {
+  const writableFields = getWritableFieldNames(table, typeRegistry);
+  const fields = getScalarFields(table).filter(
+    (f) => writableFields === null || writableFields.has(f.name),
+  );
   return t.objectExpression(
     fields.map((f) =>
       t.objectProperty(t.identifier(f.name), t.booleanLiteral(true)),
@@ -305,9 +308,9 @@ function buildSubcommandSwitch(
   return t.switchStatement(t.identifier('subcommand'), cases);
 }
 
-function buildListHandler(table: CleanTable, targetName?: string): t.FunctionDeclaration {
+function buildListHandler(table: CleanTable, targetName?: string, typeRegistry?: TypeRegistry): t.FunctionDeclaration {
   const { singularName } = getTableNames(table);
-  const selectObj = buildSelectObject(table);
+  const selectObj = buildSelectObject(table, typeRegistry);
 
   const tryBody: t.Statement[] = [
     buildGetClientStatement(targetName),
@@ -349,11 +352,11 @@ function buildListHandler(table: CleanTable, targetName?: string): t.FunctionDec
   );
 }
 
-function buildGetHandler(table: CleanTable, targetName?: string): t.FunctionDeclaration {
+function buildGetHandler(table: CleanTable, targetName?: string, typeRegistry?: TypeRegistry): t.FunctionDeclaration {
   const { singularName } = getTableNames(table);
   const pkFields = getPrimaryKeyInfo(table);
   const pk = pkFields[0];
-  const selectObj = buildSelectObject(table);
+  const selectObj = buildSelectObject(table, typeRegistry);
 
   const promptQuestion = t.objectExpression([
     t.objectProperty(t.identifier('type'), t.stringLiteral('text')),
@@ -589,7 +592,7 @@ function buildMutationHandler(
       ? t.objectExpression([
           t.objectProperty(t.identifier(pk.name), t.booleanLiteral(true)),
         ])
-      : buildSelectObject(table);
+      : buildSelectObject(table, typeRegistry);
 
   let ormArgs: t.ObjectExpression;
 
@@ -1013,8 +1016,8 @@ export function generateTableCommand(table: CleanTable, options?: TableCommandOp
 
   const tn = options?.targetName;
   const ormTypes = { createInputTypeName, patchTypeName, innerFieldName };
-  statements.push(buildListHandler(table, tn));
-  if (hasGet) statements.push(buildGetHandler(table, tn));
+  statements.push(buildListHandler(table, tn, options?.typeRegistry));
+  if (hasGet) statements.push(buildGetHandler(table, tn, options?.typeRegistry));
   statements.push(buildMutationHandler(table, 'create', tn, options?.typeRegistry, ormTypes));
   if (hasUpdate) statements.push(buildMutationHandler(table, 'update', tn, options?.typeRegistry, ormTypes));
   if (hasDelete) statements.push(buildMutationHandler(table, 'delete', tn, options?.typeRegistry, ormTypes));

--- a/graphql/codegen/src/core/codegen/utils.ts
+++ b/graphql/codegen/src/core/codegen/utils.ts
@@ -7,6 +7,7 @@ import type {
   CleanField,
   CleanFieldType,
   CleanTable,
+  TypeRegistry,
 } from '../../types/schema';
 import { scalarToFilterType, scalarToTsType } from './scalars';
 
@@ -333,6 +334,68 @@ export function isRelationField(fieldName: string, table: CleanTable): boolean {
  */
 export function getScalarFields(table: CleanTable): CleanField[] {
   return table.fields.filter((f) => !isRelationField(f.name, table));
+}
+
+/**
+ * Resolve the inner input type from a CreateXInput.
+ * PostGraphile create inputs wrap the actual field definitions in an inner type
+ * (e.g. CreateUserInput -> { user: UserInput }) — this resolves that inner type
+ * and returns the set of field names it contains.
+ */
+export function resolveInnerInputType(
+  inputTypeName: string,
+  typeRegistry: TypeRegistry,
+): { name: string; fields: Set<string> } | null {
+  const inputType = typeRegistry.get(inputTypeName);
+  if (!inputType?.inputFields) return null;
+
+  for (const inputField of inputType.inputFields) {
+    const innerTypeName = inputField.type.name
+      || inputField.type.ofType?.name
+      || inputField.type.ofType?.ofType?.name;
+    if (!innerTypeName) continue;
+
+    const innerType = typeRegistry.get(innerTypeName);
+    if (!innerType?.inputFields) continue;
+
+    const fields = new Set(innerType.inputFields.map((f) => f.name));
+    return { name: innerTypeName, fields };
+  }
+  return null;
+}
+
+/**
+ * Get the set of field names that actually exist in the create input type.
+ * Fields not in this set (e.g. computed fields like searchTsvRank, hashUuid)
+ * are plugin-added computed fields that don't correspond to real database columns.
+ * Returns null when no typeRegistry is provided (caller should treat as "no filtering").
+ */
+export function getWritableFieldNames(
+  table: CleanTable,
+  typeRegistry?: TypeRegistry,
+): Set<string> | null {
+  if (!typeRegistry) return null;
+
+  const createInputTypeName = getCreateInputTypeName(table);
+  const resolved = resolveInnerInputType(createInputTypeName, typeRegistry);
+  return resolved?.fields ?? null;
+}
+
+/**
+ * Get scalar fields that represent actual database columns (not computed/plugin-added).
+ * When a TypeRegistry is provided, filters out fields that don't exist in the
+ * create input type — these are computed fields added by plugins (e.g. search scores,
+ * hash UUIDs) that aren't real columns and shouldn't appear in default selections.
+ * Without a TypeRegistry, falls back to all scalar fields.
+ */
+export function getSelectableScalarFields(
+  table: CleanTable,
+  typeRegistry?: TypeRegistry,
+): CleanField[] {
+  const writableFields = getWritableFieldNames(table, typeRegistry);
+  return getScalarFields(table).filter(
+    (f) => writableFields === null || writableFields.has(f.name),
+  );
 }
 
 /**


### PR DESCRIPTION
# fix(codegen): exclude computed fields from default CLI select objects

## Summary

Generated CLI handlers (`handleList`, `handleGet`, and mutation response selects) were including computed fields like `descriptionTrgmSimilarity`, `prefixTrgmSimilarity`, and `searchScore` in their default `select` objects. These fields are added by the unified search plugin and return `null` unless a search filter is active — they're noise in default CLI output.

The fix uses the `typeRegistry` (already available in `generateTableCommand`) to determine which fields exist in the create input type. Fields not present in the create input are considered computed/plugin-added and are excluded from default selections. When `typeRegistry` is not provided, the behavior is unchanged (all scalar fields selected).

**New shared helpers in `utils.ts`:**
- `resolveInnerInputType(inputTypeName, typeRegistry)` — resolves PostGraphile's `CreateXInput → { x: XInput }` wrapper to get the actual field set
- `getWritableFieldNames(table, typeRegistry?)` — returns the set of field names present in the create input type, or `null` if no registry
- `getSelectableScalarFields(table, typeRegistry?)` — composes `getScalarFields` + `getWritableFieldNames` into a single reusable call

These were previously private/duplicated inside `table-command-generator.ts`. Now any generator (CLI, docs, hooks, ORM) can reuse them.

**Changed functions in `table-command-generator.ts`:**
- `buildSelectObject(table)` → `buildSelectObject(table, typeRegistry?)` — now calls `getSelectableScalarFields`
- `buildListHandler` / `buildGetHandler` — accept and forward `typeRegistry`
- `buildMutationHandler` — its `buildSelectObject(table)` call now also passes `typeRegistry`
- Removed local `resolveInnerInputType` and `getWritableFieldNames` (now imported from `utils.ts`)

## Review & Testing Checklist for Human

- [ ] **Verify `createdAt`/`updatedAt` are not over-excluded**: The filter uses "fields present in the create input type" as the inclusion set. If `createdAt`/`updatedAt` are excluded from create inputs (common for auto-managed timestamps), they will also disappear from the default `select` in list/get handlers. **Run codegen against a real schema** and inspect the generated `handleList` output to confirm important read-only fields are still present. This is the highest-risk item in this PR.
- [ ] **Confirm fallback behavior when `typeRegistry` is undefined**: `getWritableFieldNames` returns `null` when no registry is provided, which makes the filter a no-op. Verify that codegen paths without a `typeRegistry` (e.g., tests using fixtures) still generate correct output.
- [ ] **Regenerate CLI commands against the dashboard/production schema** to verify the actual generated output looks correct — search score fields are gone, but all expected columns remain.

### Notes
- The existing 315 codegen tests all pass, but they likely exercise the `typeRegistry = undefined` fallback path (no-op filter), so they **do not validate the new filtering behavior** against a real schema with computed fields.
- The `buildMutationHandler` previously had access to `typeRegistry` for filtering `editableFields` (what goes in the `data` object), but its `select` object wasn't filtered. Now the mutation response select is also filtered, which is consistent.
- `getFieldsWithDefaults` remains in `table-command-generator.ts` but now imports `resolveInnerInputType` from `utils.ts` instead of using a local copy.

---
**Devin Session**: https://app.devin.ai/sessions/cf88f3fd383b4421a5169ed01612899d
**Requested by**: @pyramation