### PR TITLE
feat: pass schema naming strategy env vars to pgSettings

### DIFF
--- a/graphql/server/src/middleware/graphile.ts
+++ b/graphql/server/src/middleware/graphile.ts
@@ -151,6 +151,15 @@ const buildPreset = (
       const req = (requestContext as { expressv4?: { req?: Request } })?.expressv4?.req;
       const context: Record<string, string> = {};
 
+      // Schema naming strategy settings (for local development).
+      // See constructive-db: get_available_schema_hash / create_schema_trigger.
+      if (process.env.CONSTRUCTIVE_SIMPLE_SCHEMA_NAMES) {
+        context['constructive.simple_schema_names'] = process.env.CONSTRUCTIVE_SIMPLE_SCHEMA_NAMES;
+      }
+      if (process.env.CONSTRUCTIVE_SCHEMA_USE_UNDERSCORES) {
+        context['constructive.schema_use_underscores'] = process.env.CONSTRUCTIVE_SCHEMA_USE_UNDERSCORES;
+      }
+
       if (req) {
         if (req.databaseId) {
           context['jwt.claims.database_id'] = req.databaseId;


### PR DESCRIPTION
## Summary

Forwards two environment variables into PostgreSQL session context via `pgSettings`, enabling the schema naming strategy customization added in [constructive-db#576](https://github.com/constructive-io/constructive-db/pull/576).

When set, these env vars are included in every PG session as `SET LOCAL` variables:
- `CONSTRUCTIVE_SIMPLE_SCHEMA_NAMES` → `constructive.simple_schema_names` — skips hash suffix for multi-tenant schema names
- `CONSTRUCTIVE_SCHEMA_USE_UNDERSCORES` → `constructive.schema_use_underscores` — uses underscores instead of dashes

Both are no-ops when unset. Intended for local development only.

## Review & Testing Checklist for Human

- [ ] Verify the env var settings are placed **before** the `if (req)` block intentionally — they're global session settings, not per-request, so this is correct but worth confirming the intent
- [ ] Confirm constructive-db PR #576 has been merged/deployed, since the PG triggers that read these settings live there

### Notes
- No tests added — the change is purely pass-through (env var → pgSettings dict). The SQL-side behavior is tested via constructive-db CI.
- If someone sets `CONSTRUCTIVE_SIMPLE_SCHEMA_NAMES=false`, it still gets forwarded, but the SQL trigger checks `= 'true'` so it's correctly ignored.

Link to Devin session: https://app.devin.ai/sessions/5675853a0d16427d85ca6d32b3188097
Requested by: @pyramation