### PR TITLE
fix(export): use extensionName for services schema prefix instead of metaExtensionName

### DIFF
--- a/pgpm/core/src/export/export-migrations.ts
+++ b/pgpm/core/src/export/export-migrations.ts
@@ -335,7 +335,11 @@ const exportMigrationsToDisk = async ({
 
     const metaReplacer = makeReplacer({
       schemas: metaSchemasForReplacement,
-      name: metaExtensionName
+      name: metaExtensionName,
+      // Use extensionName for schema prefix — the services metadata references
+      // schemas owned by the application package (e.g. agent_db_auth_public),
+      // not the services package (agent_db_services_auth_public)
+      schemaPrefix: name
     });
 
     // Create separate files for each table type
@@ -527,6 +531,14 @@ interface Schema {
 interface MakeReplacerOptions {
   schemas: Schema[];
   name: string;
+  /**
+   * Optional prefix for schema name replacement.
+   * When provided, schema names are replaced using this prefix instead of `name`.
+   * This is needed for the services/meta package where `name` is the services
+   * extension name (e.g. "agent-db-services") but schemas should use the
+   * application extension prefix (e.g. "agent-db" → "agent_db_auth_public").
+   */
+  schemaPrefix?: string;
 }
 
 interface ReplacerResult {
@@ -606,11 +618,12 @@ const preparePackage = async ({
 /**
  * Generates a function for replacing schema names and extension names in strings.
  */
-const makeReplacer = ({ schemas, name }: MakeReplacerOptions): ReplacerResult => {
+const makeReplacer = ({ schemas, name, schemaPrefix }: MakeReplacerOptions): ReplacerResult => {
   const replacements: [string, string] = ['constructive-extension-name', name];
+  const prefix = schemaPrefix || name;
   const schemaReplacers: [string, string][] = schemas.map((schema) => [
     schema.schema_name,
-    toSnakeCase(`${name}_${schema.name}`)
+    toSnakeCase(`${prefix}_${schema.name}`)
   ]);
 
   const replace: [RegExp, string][] = [...schemaReplacers, replacements].map(


### PR DESCRIPTION
# fix(export): use extensionName for services schema prefix

## Summary

Fixes a schema naming bug in `exportMigrationsToDisk` where the services/meta package replacer used `metaExtensionName` as the schema prefix instead of `extensionName`.

**Before:** Exporting an app named `agent-db` with services named `agent-db-services` produced incorrect schema references in the services SQL:
```
agent_db_services_auth_public   ← wrong
agent_db_services_auth_private  ← wrong
```

**After:** Services metadata correctly references schemas owned by the application package:
```
agent_db_auth_public   ← correct
agent_db_auth_private  ← correct
```

The fix adds an optional `schemaPrefix` parameter to `makeReplacer`. When provided, schema names use this prefix instead of `name`. The `name` parameter still controls the `constructive-extension-name` → extension name replacement (so the services package name is preserved correctly). This is fully backward compatible — callers that don't pass `schemaPrefix` behave identically to before.

**Why constructive-db wasn't visibly affected:** constructive-db's `renameSchemas()` pre-renames DB schemas to `constructive_*` before export, and `extensionName` is `constructive`. So the metaReplacer's replacement `constructive_auth_public` → `toSnakeCase('constructive-services_auth_public')` = `constructive_services_auth_public` **does** technically produce the wrong output — but this may have been masked by other factors (e.g., `skipSchemaRenaming: true` in the RLS path, or the services package not being re-exported recently).

## Review & Testing Checklist for Human

- [ ] **Verify constructive-db export is unaffected**: Run the constructive-db export/introspection pipeline (`generate:constructive` or equivalent) and confirm the services package still has `constructive_auth_public` (not `constructive_services_auth_public`). This is the highest-risk regression path.
- [ ] **Verify `constructive-extension-name` replacement still works**: The `name` param (= `metaExtensionName`) is still used for the literal string replacement. Check that the services package's control file and metadata still reference the correct services extension name (not the app name).
- [ ] **Test agent-os export end-to-end**: Run `run-export.ts` against a provisioned agent-os database with the updated `@pgpmjs/core` and confirm schema names in `packages/agent-db-services/deploy/migrate/` use `agent_db_auth_public` (not `agent_db_services_auth_public`).

### Notes
- [Link to Devin session](https://app.devin.ai/sessions/2b96fabbdaf4455fa4de78f248020902)
- Requested by: @pyramation
- The agent-os repo currently has a post-export workaround (sed-style replacement in `run-export.ts`) that can be removed once this fix is published