### PR TITLE
feat: add uuidv7 to SQL expression validator, remove pgpm-uuid references

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   postgres:
     container_name: postgres
-    image: ghcr.io/constructive-io/docker/postgres-plus:18
+    image: docker.io/constructiveio/postgres-plus:18
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   postgres:
     container_name: postgres
-    image: ghcr.io/constructive-io/docker/postgres-plus:17
+    image: ghcr.io/constructive-io/docker/postgres-plus:18
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password

--- a/graphile/graphile-sql-expression-validator/__tests__/validator.test.ts
+++ b/graphile/graphile-sql-expression-validator/__tests__/validator.test.ts
@@ -10,6 +10,7 @@ describe('DEFAULT_ALLOWED_FUNCTIONS', () => {
     expect(DEFAULT_ALLOWED_FUNCTIONS).toEqual([
       'uuid_generate_v4',
       'gen_random_uuid',
+      'uuidv7',
       'now',
       'clock_timestamp',
       'statement_timestamp',
@@ -20,8 +21,8 @@ describe('DEFAULT_ALLOWED_FUNCTIONS', () => {
     ]);
   });
 
-  it('should have exactly 9 functions', () => {
-    expect(DEFAULT_ALLOWED_FUNCTIONS).toHaveLength(9);
+  it('should have exactly 10 functions', () => {
+    expect(DEFAULT_ALLOWED_FUNCTIONS).toHaveLength(10);
   });
 
   it('should NOT contain setseed (makes random() predictable)', () => {

--- a/graphile/graphile-sql-expression-validator/src/validator.ts
+++ b/graphile/graphile-sql-expression-validator/src/validator.ts
@@ -64,6 +64,7 @@ interface AstNodeValidationResult {
 export const DEFAULT_ALLOWED_FUNCTIONS = [
   'uuid_generate_v4',
   'gen_random_uuid',
+  'uuidv7',
   'now',
   'clock_timestamp',
   'statement_timestamp',

--- a/pgpm/core/src/export/export-migrations.ts
+++ b/pgpm/core/src/export/export-migrations.ts
@@ -29,7 +29,6 @@ const DB_REQUIRED_EXTENSIONS = [
   'vector',
   'metaschema-schema',
   'pgpm-inflection',
-  'pgpm-uuid',
   'pgpm-utils',
   'pgpm-database-jobs',
   'pgpm-jwt-claims',

--- a/pgpm/core/src/modules/modules.ts
+++ b/pgpm/core/src/modules/modules.ts
@@ -19,8 +19,7 @@ export const PGPM_MODULE_MAP: Record<string, string> = {
   'pgpm-stamps': '@pgpm/stamps',
   'pgpm-totp': '@pgpm/totp',
   'pgpm-types': '@pgpm/types',
-  'pgpm-utils': '@pgpm/utils',
-  'pgpm-uuid': '@pgpm/uuid'
+  'pgpm-utils': '@pgpm/utils'
 };
 
 /**


### PR DESCRIPTION
## Summary

Companion PR to [constructive-db#589](https://github.com/constructive-io/constructive-db/pull/589) (PG18 `uuidv7()` migration). Updates the `constructive` repo to:

1. **Allow `uuidv7()` in SQL DEFAULT expressions** — adds `'uuidv7'` to `DEFAULT_ALLOWED_FUNCTIONS` in the SQL expression validator so fields with `DEFAULT uuidv7()` pass validation.
2. **Remove `pgpm-uuid` from required extensions** — exported migrations no longer list `pgpm-uuid` as a dependency since the custom UUID module has been removed from constructive-db.
3. **Remove `pgpm-uuid` from module map** — `PGPM_MODULE_MAP` no longer maps `pgpm-uuid` to `@pgpm/uuid`, so `pgpm install` won't attempt to install the removed package.
4. **Upgrade docker-compose to PG18 (public image)** — `docker-compose.yml` now uses `docker.io/constructiveio/postgres-plus:18` (publicly accessible) instead of `ghcr.io/.../postgres-plus:17`. The public image is appropriate here since docker-compose is for local development, not CI.

Test fixtures in `__fixtures__/sqitch/simple-w-exts/` still reference `pgpm-uuid` — this is intentional as they represent realistic installed-extension scenarios for module resolution tests.

## Review & Testing Checklist for Human

- [ ] **Deployment ordering**: This PR and the [dashboard PR](https://github.com/constructive-io/dashboard/pull/184) should be deployed after constructive-db#589 is merged and PG18 is live. Deploying against a pre-PG18 database where `uuidv7()` doesn't exist will cause field creation to fail at INSERT time.
- [ ] **Verify no other code paths depend on `pgpm-uuid` being in `PGPM_MODULE_MAP` or `DB_REQUIRED_EXTENSIONS`** — grep for `pgpm-uuid` outside of `__fixtures__/` and confirm nothing else references it.
- [ ] **Run `pnpm test` in `graphile/graphile-sql-expression-validator`** to confirm all tests pass with the updated allowlist (now 10 functions).
- [ ] **Verify `docker.io/constructiveio/postgres-plus:18` is pullable** — run `docker pull docker.io/constructiveio/postgres-plus:18` locally to confirm the public image exists.

### Notes
- `uuid_generate_v4` and `gen_random_uuid` are intentionally kept in the allowlist for backward compatibility with existing field definitions.
- The `__fixtures__` references to `pgpm-uuid` test the module resolution logic and are independent of whether the module is actually used in production.
- CI workflows use `ghcr.io/constructive-io/docker/postgres-plus:18` (requires GitHub keys); `docker-compose.yml` uses the public `docker.io` mirror for local dev without authentication.

Link to Devin session: https://app.devin.ai/sessions/15a3e842d67a434da19033908ebf8eb0
Requested by: @pyramation