### PR TITLE
refactor(server): remove schema naming env var forwarding from pgSettings

### DIFF
--- a/graphql/server/src/middleware/graphile.ts
+++ b/graphql/server/src/middleware/graphile.ts
@@ -153,15 +153,6 @@ const buildPreset = (
       const req = (requestContext as { expressv4?: { req?: Request } })?.expressv4?.req;
       const context: Record<string, string> = {};
 
-      // Schema naming strategy settings (for local development).
-      // See constructive-db: get_available_schema_hash / create_schema_trigger.
-      if (process.env.CONSTRUCTIVE_SIMPLE_SCHEMA_NAMES) {
-        context['constructive.simple_schema_names'] = process.env.CONSTRUCTIVE_SIMPLE_SCHEMA_NAMES;
-      }
-      if (process.env.CONSTRUCTIVE_SCHEMA_USE_UNDERSCORES) {
-        context['constructive.schema_use_underscores'] = process.env.CONSTRUCTIVE_SCHEMA_USE_UNDERSCORES;
-      }
-
       if (req) {
         if (req.databaseId) {
           context['jwt.claims.database_id'] = req.databaseId;


### PR DESCRIPTION
## Summary

Removes the `CONSTRUCTIVE_SIMPLE_SCHEMA_NAMES` and `CONSTRUCTIVE_SCHEMA_USE_UNDERSCORES` environment variable forwarding from the GraphQL server's `pgSettings` context (added in PR #816).

These schema naming strategy settings are now configured at the **database level** via `ALTER DATABASE SET` during provision, so every PostgreSQL connection inherits them automatically. The server no longer needs to act as a pass-through for these values, keeping it generic and decoupled from schema naming concerns.

**What changed:** 9 lines removed from `graphql/server/src/middleware/graphile.ts` — the two `if (process.env.CONSTRUCTIVE_*)` blocks in `buildPreset`'s `context` callback. No new code added.

## Review & Testing Checklist for Human

- [ ] **Verify all active databases have `ALTER DATABASE SET` configured** — Any database that was relying on `CONSTRUCTIVE_SIMPLE_SCHEMA_NAMES` / `CONSTRUCTIVE_SCHEMA_USE_UNDERSCORES` env vars on the server must now have equivalent database-level settings (`constructive.simple_schema_names`, `constructive.schema_use_underscores`). Without this, schema creation will revert to default behavior (hash suffixes, dashes). Check with: `psql <dbname> -c "SELECT name, setting FROM pg_db_role_setting WHERE setdatabase = (SELECT oid FROM pg_database WHERE datname = '<dbname>')"` or `SHOW constructive.simple_schema_names;`
- [ ] **Confirm no other consumers depend on these env vars** — Grep across deployment configs, docker-compose files, CI pipelines, and Kubernetes manifests for `CONSTRUCTIVE_SIMPLE_SCHEMA_NAMES` or `CONSTRUCTIVE_SCHEMA_USE_UNDERSCORES` to ensure nothing else references them.
- [ ] **Test a provision + schema creation cycle** — After deploying this change, provision a new database and verify schema names are still clean (e.g., `myapp_app_public` not `myapp_1234567_app_public`).

### Notes
- This is the inverse of PR #816 — that PR added env var forwarding; this PR removes it in favor of the database-level approach.
- Build passes clean (full `pnpm build`).
- Requested by: @pyramation
- [Devin Session](https://app.devin.ai/sessions/2b96fabbdaf4455fa4de78f248020902)