### PR TITLE
fix(codegen): handle array types, computed fields, and orderBy enums in input-types-generator

### DIFF
--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/input-types-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/input-types-generator.test.ts.snap
@@ -249,7 +249,7 @@ export interface Post {
   content?: string | null;
   authorId?: string | null;
   publishedAt?: string | null;
-  tags?: string | null;
+  tags?: string[] | null;
 }
 export interface Comment {
   id: string;
@@ -358,7 +358,7 @@ export interface PostFilter {
   content?: StringFilter;
   authorId?: UUIDFilter;
   publishedAt?: DatetimeFilter;
-  tags?: StringFilter;
+  tags?: StringListFilter;
   and?: PostFilter[];
   or?: PostFilter[];
   not?: PostFilter;
@@ -436,7 +436,7 @@ export interface CreatePostInput {
     content?: string;
     authorId: string;
     publishedAt?: string;
-    tags?: string;
+    tags?: string[];
   };
 }
 export interface PostPatch {
@@ -444,7 +444,7 @@ export interface PostPatch {
   content?: string | null;
   authorId?: string | null;
   publishedAt?: string | null;
-  tags?: string | null;
+  tags?: string[] | null;
 }
 export interface UpdatePostInput {
   clientMutationId?: string;
@@ -2131,7 +2131,7 @@ export interface Post {
   content?: string | null;
   authorId?: string | null;
   publishedAt?: string | null;
-  tags?: string | null;
+  tags?: string[] | null;
 }
 export interface Category {
   id: string;
@@ -2197,7 +2197,7 @@ export interface PostFilter {
   content?: StringFilter;
   authorId?: UUIDFilter;
   publishedAt?: DatetimeFilter;
-  tags?: StringFilter;
+  tags?: StringListFilter;
   and?: PostFilter[];
   or?: PostFilter[];
   not?: PostFilter;
@@ -2235,7 +2235,7 @@ export interface CreatePostInput {
     content?: string;
     authorId: string;
     publishedAt?: string;
-    tags?: string;
+    tags?: string[];
   };
 }
 export interface PostPatch {
@@ -2243,7 +2243,7 @@ export interface PostPatch {
   content?: string | null;
   authorId?: string | null;
   publishedAt?: string | null;
-  tags?: string | null;
+  tags?: string[] | null;
 }
 export interface UpdatePostInput {
   clientMutationId?: string;

--- a/graphql/codegen/src/core/codegen/orm/input-types-generator.ts
+++ b/graphql/codegen/src/core/codegen/orm/input-types-generator.ts
@@ -27,6 +27,7 @@ import {
   getFilterTypeName,
   getGeneratedFileHeader,
   getOrderByTypeName,
+  getPatchTypeName,
   getPrimaryKeyInfo,
   getTableNames,
   isRelationField,
@@ -604,7 +605,10 @@ function buildEntityProperties(table: CleanTable): InterfaceProperty[] {
 
     const fieldType =
       typeof field.type === 'string' ? field.type : field.type.gqlType;
-    const tsType = scalarToInputTs(fieldType);
+    const isArray =
+      typeof field.type !== 'string' && field.type.isArray;
+    const baseTsType = scalarToInputTs(fieldType);
+    const tsType = isArray ? `${baseTsType}[]` : baseTsType;
     const isNullable = field.name !== 'id' && field.name !== 'nodeId';
 
     properties.push({
@@ -1068,8 +1072,8 @@ function generateEntitySelectTypes(
 /**
  * Map field type to filter type
  */
-function getFilterTypeForField(fieldType: string): string {
-  return scalarToFilterType(fieldType) ?? 'StringFilter';
+function getFilterTypeForField(fieldType: string, isArray = false): string {
+  return scalarToFilterType(fieldType, isArray) ?? 'StringFilter';
 }
 
 /**
@@ -1082,9 +1086,11 @@ function buildTableFilterProperties(table: CleanTable): InterfaceProperty[] {
   for (const field of table.fields) {
     const fieldType =
       typeof field.type === 'string' ? field.type : field.type.gqlType;
+    const isArray =
+      typeof field.type !== 'string' && field.type.isArray;
     if (isRelationField(field.name, table)) continue;
 
-    const filterType = getFilterTypeForField(fieldType);
+    const filterType = getFilterTypeForField(fieldType, isArray);
     properties.push({ name: field.name, type: filterType, optional: true });
   }
 
@@ -1215,6 +1221,17 @@ function buildOrderByValues(
   table: CleanTable,
   typeRegistry?: TypeRegistry,
 ): string[] {
+  // When the schema's orderBy enum is available, use it as the source of truth
+  // instead of naively generating values for every field.
+  if (typeRegistry) {
+    const orderByTypeName = getOrderByTypeName(table);
+    const orderByType = typeRegistry.get(orderByTypeName);
+    if (orderByType?.kind === 'ENUM' && orderByType.enumValues) {
+      return [...orderByType.enumValues];
+    }
+  }
+
+  // Fallback: derive from table fields when schema enum is not available
   const values: string[] = ['PRIMARY_KEY_ASC', 'PRIMARY_KEY_DESC', 'NATURAL'];
 
   for (const field of table.fields) {
@@ -1222,21 +1239,6 @@ function buildOrderByValues(
     const upperSnake = field.name.replace(/([A-Z])/g, '_$1').toUpperCase();
     values.push(`${upperSnake}_ASC`);
     values.push(`${upperSnake}_DESC`);
-  }
-
-  // Merge any additional values from the schema's orderBy enum type
-  // (e.g., plugin-added values like EMBEDDING_DISTANCE_ASC/DESC)
-  if (typeRegistry) {
-    const orderByTypeName = getOrderByTypeName(table);
-    const orderByType = typeRegistry.get(orderByTypeName);
-    if (orderByType?.kind === 'ENUM' && orderByType.enumValues) {
-      const existingValues = new Set(values);
-      for (const value of orderByType.enumValues) {
-        if (!existingValues.has(value)) {
-          values.push(value);
-        }
-      }
-    }
   }
 
   return values;
@@ -1292,7 +1294,10 @@ function buildCreateDataFieldsFromTable(
 
     const fieldType =
       typeof field.type === 'string' ? field.type : field.type.gqlType;
-    const tsType = scalarToInputTs(fieldType);
+    const isArray =
+      typeof field.type !== 'string' && field.type.isArray;
+    const baseTsType = scalarToInputTs(fieldType);
+    const tsType = isArray ? `${baseTsType}[]` : baseTsType;
     const isOptional = !field.name.endsWith('Id');
 
     fields.push({ name: field.name, type: tsType, optional: isOptional });
@@ -1423,9 +1428,45 @@ function buildCreateInputInterface(
 }
 
 /**
- * Build Patch type properties
+ * Build Patch type properties.
+ *
+ * Prefers reading from the GraphQL schema's Patch input type when available
+ * (via typeRegistry), which correctly excludes computed/virtual fields.
+ * Falls back to deriving from table fields if the schema type is not found.
  */
-function buildPatchProperties(table: CleanTable): InterfaceProperty[] {
+function buildPatchProperties(
+  table: CleanTable,
+  typeRegistry?: TypeRegistry,
+): InterfaceProperty[] {
+  // Try to read from the schema's Patch input type first
+  if (typeRegistry) {
+    const patchTypeName = getPatchTypeName(table);
+    const patchType = typeRegistry.get(patchTypeName);
+    if (
+      patchType?.kind === 'INPUT_OBJECT' &&
+      patchType.inputFields
+    ) {
+      const properties: InterfaceProperty[] = [];
+      for (const field of patchType.inputFields) {
+        if (
+          EXCLUDED_MUTATION_FIELDS.includes(
+            field.name as (typeof EXCLUDED_MUTATION_FIELDS)[number],
+          )
+        )
+          continue;
+
+        const tsType = typeRefToTs(field.type);
+        properties.push({
+          name: field.name,
+          type: `${tsType} | null`,
+          optional: true,
+        });
+      }
+      return properties;
+    }
+  }
+
+  // Fallback: derive from table fields
   const properties: InterfaceProperty[] = [];
 
   for (const field of table.fields) {
@@ -1439,7 +1480,10 @@ function buildPatchProperties(table: CleanTable): InterfaceProperty[] {
 
     const fieldType =
       typeof field.type === 'string' ? field.type : field.type.gqlType;
-    const tsType = scalarToInputTs(fieldType);
+    const isArray =
+      typeof field.type !== 'string' && field.type.isArray;
+    const baseTsType = scalarToInputTs(fieldType);
+    const tsType = isArray ? `${baseTsType}[]` : baseTsType;
 
     properties.push({
       name: field.name,
@@ -1472,7 +1516,7 @@ function generateCrudInputTypes(
 
   // Patch interface
   statements.push(
-    createExportedInterface(patchName, buildPatchProperties(table)),
+    createExportedInterface(patchName, buildPatchProperties(table, typeRegistry)),
   );
 
   // Update input - v5 uses entity-specific patch field names (e.g., "userPatch")


### PR DESCRIPTION
## Summary

Fixes 6 bugs in the ORM `input-types-generator.ts` where generated TypeScript types diverged from the GraphQL schema:

1. **Array field types**: `field.type.isArray` was never checked in entity types, patch types, filter types, or create input fallback. Fields like `deps: [String]` generated as `string` instead of `string[]`.
2. **Filter types for arrays**: `scalarToFilterType()` supports an `isArray` parameter but it was never passed `true`, so array fields got `StringFilter` instead of `StringListFilter`.
3. **Patch includes computed fields**: `buildPatchProperties()` derived fields from `table.fields` (which includes plugin-injected computed fields like trgm similarity scores). Now reads from the schema's Patch input type via `typeRegistry` when available, matching how `buildCreateDataFieldsFromSchema()` already works for Create inputs.
4. **OrderBy has extra values**: `buildOrderByValues()` generated `FIELD_ASC/DESC` for every column then merged schema enum values. Now uses the schema enum as source of truth when available, since PostGraphile only includes orderable columns.

## Review & Testing Checklist for Human

- [ ] **Patch schema-based path is untested**: The new `buildPatchProperties` schema-based path (lines 1438-1463) uses `typeRefToTs()` to read from the TypeRegistry's Patch input type, but the existing test fixtures don't include a Patch type in the TypeRegistry — only the fallback path is exercised by unit tests. Consider adding a test with a Patch input in the registry.
- [ ] **OrderBy behavioral change**: The old logic generated values for all fields then merged schema extras. The new logic uses the schema enum exclusively when available (fallback unchanged). Verify this doesn't drop valid orderBy values in cases where the schema enum might be incomplete or missing entries.
- [ ] **Run codegen end-to-end** against a real schema (e.g. `cnc codegen` on the migrate-client or another workspace) and diff the output to confirm array fields, filters, patches, and orderBy enums now match the `.graphql` schema exactly.

### Notes
- The `isArray` property existed on `CleanFieldType` but was completely unused in `input-types-generator.ts` before this change.
- `buildCreateDataFieldsFromSchema()` (the primary Create input path) already handled arrays correctly via `typeRefToTs()`. Only the table-field fallback (`buildCreateDataFieldsFromTable`) had the bug, also fixed here.
- 3 test suites fail pre-existingly due to missing workspace deps (`@pgpmjs/core`, `pgsql-client`, `pgsql-seed`) — unrelated to these changes.

Link to Devin session: https://app.devin.ai/sessions/772428a7ed2d4463b22ab00caa63663a
Requested by: @pyramation