### PR TITLE
Add best practices to AGENTS.md: env configuration and testing guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,8 +62,83 @@ This guide helps AI agents quickly navigate the Constructive monorepo. Construct
 - Generate types/SDK: `cnc codegen`
 - Export schema SDL: `cnc get-graphql-schema`
 
+## Best Practices
+
+### Environment Configuration
+
+Always use the unified environment configuration system — never read `process.env` directly for config values.
+
+- **PGPM packages** (`pgpm/*`): `import { getEnvOptions } from '@pgpmjs/env'`
+- **GraphQL/Constructive packages** (`graphql/*`, `packages/cli`): `import { getEnvOptions } from '@constructive-io/graphql-env'`
+- **PostgreSQL tools** (`postgres/*`): `import { getPgEnvOptions } from 'pg-env'` or `@pgpmjs/env`
+
+The system provides typed defaults, config file discovery (`pgpm.json`), env var parsing, and a clean merge hierarchy: **defaults → config file → env vars → runtime overrides**.
+
+```typescript
+// GOOD
+import { getEnvOptions } from '@pgpmjs/env';
+const opts = getEnvOptions({ pg: { database: 'mydb' } });
+
+// BAD — scattered, untyped, no defaults
+const host = process.env.PGHOST || 'localhost';
+const port = parseInt(process.env.PGPORT || '5432');
+```
+
+### Testing
+
+Constructive provides a layered testing framework stack. **Always use the appropriate framework** — never manually create `pg.Pool` or `pg.Client` instances in tests.
+
+#### Which Framework to Use
+
+| Scenario | Framework | Import |
+|----------|-----------|--------|
+| Raw SQL, RLS policies, database functions | `pgsql-test` | `import { getConnections } from 'pgsql-test'` |
+| PostGraphile schema, basic GraphQL queries | `graphile-test` | `import { getConnections } from 'graphile-test'` |
+| GraphQL with Constructive plugins (search, pgvector, etc.) | `@constructive-io/graphql-test` | `import { getConnections } from '@constructive-io/graphql-test'` |
+| HTTP endpoints, auth headers, middleware | `@constructive-io/graphql-server-test` | `import { getConnections } from '@constructive-io/graphql-server-test'` |
+
+Each layer builds on `pgsql-test` underneath — they all create isolated test databases with proper teardown.
+
+#### Required Test Hooks
+
+Always include `beforeEach`/`afterEach` hooks to ensure test isolation via savepoints:
+
+```typescript
+import { getConnections, PgTestClient } from 'pgsql-test';
+
+let pg: PgTestClient;
+let db: PgTestClient;
+let teardown: () => Promise<void>;
+
+beforeAll(async () => {
+  ({ pg, db, teardown } = await getConnections());
+});
+
+afterAll(async () => {
+  await teardown();
+});
+
+beforeEach(async () => {
+  await pg.beforeEach();
+  await db.beforeEach();
+});
+
+afterEach(async () => {
+  await db.afterEach();
+  await pg.afterEach();
+});
+```
+
+#### Anti-Patterns to Avoid
+
+- **Never** create `new pg.Pool()` or `new pg.Client()` in tests — use `getConnections()` from the appropriate framework
+- **Never** use `getPgPool()` from `pg-cache` in tests — that's for production connection pooling
+- **Never** manually create/drop databases in tests — `pgsql-test` handles this automatically
+- **Never** skip `beforeEach`/`afterEach` hooks — tests will leak state to each other
+- **Never** construct connection strings manually — use the env configuration system
+
 ## Tips
 
 1. Start with `pgpm/core/AGENTS.md` to understand the migration and plan model.
-2. Use `packages/cli/AGENTS.md` to understand Constructive’s command routing.
+2. Use `packages/cli/AGENTS.md` to understand Constructive's command routing.
 3. Use `postgres/pgsql-test/AGENTS.md` for patterns around isolated test DBs and seeding.


### PR DESCRIPTION
## Summary

Adds a **Best Practices** section to the root `AGENTS.md` with two subsections:

1. **Environment Configuration** — Documents the unified env config system and which package to import depending on where you're working (`@pgpmjs/env` for PGPM packages, `@constructive-io/graphql-env` for GraphQL/Constructive packages, `pg-env` for postgres tools). Includes a good/bad code example.

2. **Testing** — Documents the four-layer testing framework hierarchy (`pgsql-test` → `graphile-test` → `@constructive-io/graphql-test` → `@constructive-io/graphql-server-test`), the required `beforeEach`/`afterEach` hook pattern, and a list of anti-patterns to avoid (manual `pg.Pool` creation, using `pg-cache` in tests, skipping hooks, etc.).

This is a companion to [constructive-skills#57](https://github.com/constructive-io/constructive-skills/pull/57) which adds detailed `constructive-env` and `constructive-testing` skills.

## Review & Testing Checklist for Human

- [ ] **Verify package import paths are correct** — confirm that `@pgpmjs/env`, `@constructive-io/graphql-env`, `pg-env`, `pgsql-test`, `graphile-test`, `@constructive-io/graphql-test`, and `@constructive-io/graphql-server-test` are the actual importable package names in this monorepo
- [ ] **Verify the test hooks boilerplate** matches the canonical pattern used across existing tests (ordering of `beforeEach`/`afterEach` for `pg` vs `db`)
- [ ] **Check that the "which package to import" guidance** (`pgpm/*` → `@pgpmjs/env`, `graphql/*` → `@constructive-io/graphql-env`, `postgres/*` → `pg-env`) matches actual usage across the monorepo — particularly whether `pg-env` is the right recommendation for `postgres/*` packages

### Notes

- Documentation-only change — no code modified, no CI impact expected.
- The anti-patterns listed (manual `pg.Pool`, `pg-cache` in tests, manual DB create/drop) were identified from actual instances found in the codebase (e.g., `postgres/introspectron/__tests__/introspect.test.ts`).

Link to Devin session: https://app.devin.ai/sessions/534e3c7cdabd4b70afea0c91e615ef0b
Requested by: @pyramation