### PR TITLE
fix: terminate backends before dropping databases and close pg-cache pools in codegen

### DIFF
--- a/graphql/codegen/src/core/generate.ts
+++ b/graphql/codegen/src/core/generate.ts
@@ -10,6 +10,7 @@ import path from 'node:path';
 import { buildClientSchema, printSchema } from 'graphql';
 
 import { PgpmPackage } from '@pgpmjs/core';
+import { pgCache } from 'pg-cache';
 import { createEphemeralDb, type EphemeralDbResult } from 'pgsql-client';
 import { deployPgpm } from 'pgsql-seed';
 
@@ -840,6 +841,10 @@ export async function generateMulti(
   } finally {
     for (const shared of sharedSources.values()) {
       const keepDb = Object.values(configs).some((c) => c.db?.keepDb);
+      // Release pg-cache pool for this ephemeral database before dropping
+      // deployPgpm() caches connections that must be closed first
+      pgCache.delete(shared.ephemeralDb.config.database);
+      await pgCache.waitForDisposals();
       shared.ephemeralDb.teardown({ keepDb });
     }
   }

--- a/graphql/codegen/src/core/introspect/source/pgpm-module.ts
+++ b/graphql/codegen/src/core/introspect/source/pgpm-module.ts
@@ -9,7 +9,7 @@
  */
 import { PgpmPackage } from '@pgpmjs/core';
 import { buildSchema, introspectionFromSchema } from 'graphql';
-import { getPgPool } from 'pg-cache';
+import { getPgPool, pgCache } from 'pg-cache';
 import { createEphemeralDb, type EphemeralDbResult } from 'pgsql-client';
 import { deployPgpm } from 'pgsql-seed';
 
@@ -251,6 +251,11 @@ export class PgpmModuleSchemaSource implements SchemaSource {
 
       return { introspection };
     } finally {
+      // Release pg-cache pool for this ephemeral database before dropping
+      // deployPgpm() and getPgPool() cache connections that must be closed first
+      pgCache.delete(dbConfig.database);
+      await pgCache.waitForDisposals();
+
       // Clean up the ephemeral database
       teardown({ keepDb });
 

--- a/postgres/pgsql-client/src/admin.ts
+++ b/postgres/pgsql-client/src/admin.ts
@@ -58,9 +58,22 @@ export class DbAdmin {
     try {
       this.run(`dropdb "${name}"`);
     } catch (err: any) {
-      if (!err.message.includes('does not exist')) {
-        log.warn(`Could not drop database ${name}: ${err.message}`);
+      if (err.message.includes('does not exist')) {
+        return;
       }
+      if (err.message.includes('is being accessed by other users')) {
+        log.warn(`Database ${name} has active sessions, terminating backends and retrying drop...`);
+        try {
+          this.run(
+            `psql -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${name}' AND pid <> pg_backend_pid();"`
+          );
+          this.run(`dropdb "${name}"`);
+        } catch (retryErr: any) {
+          log.warn(`Could not drop database ${name} after terminating backends: ${retryErr.message}`);
+        }
+        return;
+      }
+      log.warn(`Could not drop database ${name}: ${err.message}`);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes the systemic `dropdb` failure when ephemeral databases have lingering connections:

```
dropdb: error: database removal failed: ERROR: database "codegen_pgpm_..." is being accessed by other users
DETAIL: There are 2 other sessions using the database.
```

**Two-layer fix:**

1. **Safety net in `DbAdmin.safeDropDb()`** (`pgsql-client`): When `dropdb` fails due to active sessions, terminates backends via `pg_terminate_backend` and retries — only in the catch path, so the happy path is unchanged and we get log visibility into when this happens.

2. **Proper pool cleanup in codegen PGPM paths** (`graphql/codegen`): `deployPgpm()` and `getPgPool()` cache connections in `pg-cache` that were never released before the ephemeral database was dropped. Now explicitly calls `pgCache.delete(dbName)` + `waitForDisposals()` before teardown in both `PgpmModuleSchemaSource.fetch()` and `generateMulti()` shared source cleanup.

## Review & Testing Checklist for Human

- [ ] **Verify `pgCache.delete()` key matches `getPgPool()` key**: `getPgPool()` caches by `config.database` (the database name). The cleanup uses `dbConfig.database` / `shared.ephemeralDb.config.database`. Confirm these always resolve to the same key.
- [ ] **PostGraphile internal pool**: `buildSchemaSDL()` → `makeSchema()` creates its own connection via `makePgService` that is *not* in pg-cache. The `safeDropDb` terminate-and-retry is the only safety net for these. Consider whether `makeSchema` should be patched to release its pool, or if the safety net is sufficient.
- [ ] **Test with a real codegen PGPM workflow**: Run a codegen that uses `pgpmModulePath` or `pgpmWorkspacePath` and verify the ephemeral database is cleanly dropped without the "is being accessed" warning.

### Notes
- The `safeDropDb` terminate-and-retry pattern already existed in `pgpm test-packages` and `pgpm kill` commands — this just brings it to the core `DbAdmin` class so all consumers benefit.
- The retry is single-attempt. In theory, new connections could be established between `pg_terminate_backend` and the retry `dropdb`, but this is extremely unlikely during test/codegen cleanup.

Link to Devin session: https://app.devin.ai/sessions/ca50a2babd834e40a9d5d00b379bd459
Requested by: @pyramation