### PR TITLE
feat(codegen): replace generic `<value>` placeholders with type-aware placeholders

### DIFF
--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/cli-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/cli-generator.test.ts.snap
@@ -281,10 +281,10 @@ CRUD operations for Car records via myapp CLI
 
 \`\`\`bash
 myapp car list
-myapp car get --id <value>
-myapp car create --make <value> --model <value> --year <value> --isElectric <value>
-myapp car update --id <value> [--make <value>] [--model <value>] [--year <value>] [--isElectric <value>]
-myapp car delete --id <value>
+myapp car get --id <UUID>
+myapp car create --make <String> --model <String> --year <Int> --isElectric <Boolean>
+myapp car update --id <UUID> [--make <String>] [--model <String>] [--year <Int>] [--isElectric <Boolean>]
+myapp car delete --id <UUID>
 \`\`\`
 
 ## Examples
@@ -298,7 +298,7 @@ myapp car list
 ### Create a car
 
 \`\`\`bash
-myapp car create --make <value> --model <value> --year <value> --isElectric <value>
+myapp car create --make <String> --model <String> --year <Int> --isElectric <Boolean>
 \`\`\`
 
 ### Get a car by id
@@ -320,10 +320,10 @@ CRUD operations for Driver records via myapp CLI
 
 \`\`\`bash
 myapp driver list
-myapp driver get --id <value>
-myapp driver create --name <value> --licenseNumber <value>
-myapp driver update --id <value> [--name <value>] [--licenseNumber <value>]
-myapp driver delete --id <value>
+myapp driver get --id <UUID>
+myapp driver create --name <String> --licenseNumber <String>
+myapp driver update --id <UUID> [--name <String>] [--licenseNumber <String>]
+myapp driver delete --id <UUID>
 \`\`\`
 
 ## Examples
@@ -337,7 +337,7 @@ myapp driver list
 ### Create a driver
 
 \`\`\`bash
-myapp driver create --name <value> --licenseNumber <value>
+myapp driver create --name <String> --licenseNumber <String>
 \`\`\`
 
 ### Get a driver by id
@@ -381,7 +381,7 @@ Authenticate a user
 ## Usage
 
 \`\`\`bash
-myapp login --email <value> --password <value>
+myapp login --email <String> --password <String>
 \`\`\`
 
 ## Examples
@@ -389,7 +389,7 @@ myapp login --email <value> --password <value>
 ### Run login
 
 \`\`\`bash
-myapp login --email <value> --password <value>
+myapp login --email <String> --password <String>
 \`\`\`
 "
 `;
@@ -1409,7 +1409,7 @@ const { data, isLoading } = useCarsQuery({
 
 // Get one car
 const { data: item } = useCarQuery({
-  id: '<value>',
+  id: '<UUID>',
   selection: { fields: { id: true, make: true, model: true, year: true, isElectric: true, createdAt: true } },
 });
 
@@ -1417,7 +1417,7 @@ const { data: item } = useCarQuery({
 const { mutate: create } = useCreateCarMutation({
   selection: { fields: { id: true } },
 });
-create({ make: '<value>', model: '<value>', year: '<value>', isElectric: '<value>' });
+create({ make: '<String>', model: '<String>', year: '<Int>', isElectric: '<Boolean>' });
 \`\`\`
 
 ### Driver
@@ -1430,7 +1430,7 @@ const { data, isLoading } = useDriversQuery({
 
 // Get one driver
 const { data: item } = useDriverQuery({
-  id: '<value>',
+  id: '<UUID>',
   selection: { fields: { id: true, name: true, licenseNumber: true } },
 });
 
@@ -1438,7 +1438,7 @@ const { data: item } = useDriverQuery({
 const { mutate: create } = useCreateDriverMutation({
   selection: { fields: { id: true } },
 });
-create({ name: '<value>', licenseNumber: '<value>' });
+create({ name: '<String>', licenseNumber: '<String>' });
 \`\`\`
 
 ## Custom Operation Hooks
@@ -1485,7 +1485,7 @@ React Query hooks for Car data operations
 
 \`\`\`typescript
 useCarsQuery({ selection: { fields: { id: true, make: true, model: true, year: true, isElectric: true, createdAt: true } } })
-useCarQuery({ id: '<value>', selection: { fields: { id: true, make: true, model: true, year: true, isElectric: true, createdAt: true } } })
+useCarQuery({ id: '<UUID>', selection: { fields: { id: true, make: true, model: true, year: true, isElectric: true, createdAt: true } } })
 useCreateCarMutation({ selection: { fields: { id: true } } })
 useUpdateCarMutation({ selection: { fields: { id: true } } })
 useDeleteCarMutation({})
@@ -1507,7 +1507,7 @@ const { data, isLoading } = useCarsQuery({
 const { mutate } = useCreateCarMutation({
   selection: { fields: { id: true } },
 });
-mutate({ make: '<value>', model: '<value>', year: '<value>', isElectric: '<value>' });
+mutate({ make: '<String>', model: '<String>', year: '<Int>', isElectric: '<Boolean>' });
 \`\`\`
 "
 `;
@@ -1523,7 +1523,7 @@ React Query hooks for Driver data operations
 
 \`\`\`typescript
 useDriversQuery({ selection: { fields: { id: true, name: true, licenseNumber: true } } })
-useDriverQuery({ id: '<value>', selection: { fields: { id: true, name: true, licenseNumber: true } } })
+useDriverQuery({ id: '<UUID>', selection: { fields: { id: true, name: true, licenseNumber: true } } })
 useCreateDriverMutation({ selection: { fields: { id: true } } })
 useUpdateDriverMutation({ selection: { fields: { id: true } } })
 useDeleteDriverMutation({})
@@ -1545,7 +1545,7 @@ const { data, isLoading } = useDriversQuery({
 const { mutate } = useCreateDriverMutation({
   selection: { fields: { id: true } },
 });
-mutate({ name: '<value>', licenseNumber: '<value>' });
+mutate({ name: '<String>', licenseNumber: '<String>' });
 \`\`\`
 "
 `;
@@ -1583,7 +1583,7 @@ Authenticate a user
 ## Usage
 
 \`\`\`typescript
-const { mutate } = useLoginMutation(); mutate({ email: '<value>', password: '<value>' });
+const { mutate } = useLoginMutation(); mutate({ email: '<String>', password: '<String>' });
 \`\`\`
 
 ## Examples
@@ -1592,7 +1592,7 @@ const { mutate } = useLoginMutation(); mutate({ email: '<value>', password: '<va
 
 \`\`\`typescript
 const { mutate, isLoading } = useLoginMutation();
-mutate({ email: '<value>', password: '<value>' });
+mutate({ email: '<String>', password: '<String>' });
 \`\`\`
 "
 `;
@@ -2654,10 +2654,10 @@ CRUD operations for User records via myapp CLI (auth target)
 
 \`\`\`bash
 myapp auth:user list
-myapp auth:user get --id <value>
-myapp auth:user create --email <value> --name <value>
-myapp auth:user update --id <value> [--email <value>] [--name <value>]
-myapp auth:user delete --id <value>
+myapp auth:user get --id <UUID>
+myapp auth:user create --email <String> --name <String>
+myapp auth:user update --id <UUID> [--email <String>] [--name <String>]
+myapp auth:user delete --id <UUID>
 \`\`\`
 
 ## Examples
@@ -2671,7 +2671,7 @@ myapp auth:user list
 ### Create a user
 
 \`\`\`bash
-myapp auth:user create --email <value> --name <value>
+myapp auth:user create --email <String> --name <String>
 \`\`\`
 ",
     "fileName": "cli-auth/references/user.md",
@@ -2709,8 +2709,8 @@ Authenticate a user (auth target)
 ## Usage
 
 \`\`\`bash
-myapp auth:login --email <value> --password <value>
-myapp auth:login --email <value> --password <value> --save-token
+myapp auth:login --email <String> --password <String>
+myapp auth:login --email <String> --password <String> --save-token
 \`\`\`
 
 ## Examples
@@ -2718,7 +2718,7 @@ myapp auth:login --email <value> --password <value> --save-token
 ### Run login
 
 \`\`\`bash
-myapp auth:login --email <value> --password <value>
+myapp auth:login --email <String> --password <String>
 \`\`\`
 ",
     "fileName": "cli-auth/references/login.md",
@@ -2782,10 +2782,10 @@ CRUD operations for Member records via myapp CLI (members target)
 
 \`\`\`bash
 myapp members:member list
-myapp members:member get --id <value>
-myapp members:member create --role <value>
-myapp members:member update --id <value> [--role <value>]
-myapp members:member delete --id <value>
+myapp members:member get --id <UUID>
+myapp members:member create --role <String>
+myapp members:member update --id <UUID> [--role <String>]
+myapp members:member delete --id <UUID>
 \`\`\`
 
 ## Examples
@@ -2799,7 +2799,7 @@ myapp members:member list
 ### Create a member
 
 \`\`\`bash
-myapp members:member create --role <value>
+myapp members:member create --role <String>
 \`\`\`
 ",
     "fileName": "cli-members/references/member.md",
@@ -2861,10 +2861,10 @@ CRUD operations for Car records via myapp CLI (app target)
 
 \`\`\`bash
 myapp app:car list
-myapp app:car get --id <value>
-myapp app:car create --make <value> --model <value> --year <value> --isElectric <value>
-myapp app:car update --id <value> [--make <value>] [--model <value>] [--year <value>] [--isElectric <value>]
-myapp app:car delete --id <value>
+myapp app:car get --id <UUID>
+myapp app:car create --make <String> --model <String> --year <Int> --isElectric <Boolean>
+myapp app:car update --id <UUID> [--make <String>] [--model <String>] [--year <Int>] [--isElectric <Boolean>]
+myapp app:car delete --id <UUID>
 \`\`\`
 
 ## Examples
@@ -2878,7 +2878,7 @@ myapp app:car list
 ### Create a car
 
 \`\`\`bash
-myapp app:car create --make <value> --model <value> --year <value> --isElectric <value>
+myapp app:car create --make <String> --model <String> --year <Int> --isElectric <Boolean>
 \`\`\`
 ",
     "fileName": "cli-app/references/car.md",
@@ -4254,16 +4254,16 @@ CRUD operations for Car records.
 const items = await db.car.findMany({ select: { id: true, make: true, model: true, year: true, isElectric: true, createdAt: true } }).execute();
 
 // Get one by id
-const item = await db.car.findOne({ id: '<value>', select: { id: true, make: true, model: true, year: true, isElectric: true, createdAt: true } }).execute();
+const item = await db.car.findOne({ id: '<UUID>', select: { id: true, make: true, model: true, year: true, isElectric: true, createdAt: true } }).execute();
 
 // Create
-const created = await db.car.create({ data: { make: '<value>', model: '<value>', year: '<value>', isElectric: '<value>' }, select: { id: true } }).execute();
+const created = await db.car.create({ data: { make: '<String>', model: '<String>', year: '<Int>', isElectric: '<Boolean>' }, select: { id: true } }).execute();
 
 // Update
-const updated = await db.car.update({ where: { id: '<value>' }, data: { make: '<new-value>' }, select: { id: true } }).execute();
+const updated = await db.car.update({ where: { id: '<UUID>' }, data: { make: '<String>' }, select: { id: true } }).execute();
 
 // Delete
-const deleted = await db.car.delete({ where: { id: '<value>' } }).execute();
+const deleted = await db.car.delete({ where: { id: '<UUID>' } }).execute();
 \`\`\`
 
 ### \`db.driver\`
@@ -4285,16 +4285,16 @@ CRUD operations for Driver records.
 const items = await db.driver.findMany({ select: { id: true, name: true, licenseNumber: true } }).execute();
 
 // Get one by id
-const item = await db.driver.findOne({ id: '<value>', select: { id: true, name: true, licenseNumber: true } }).execute();
+const item = await db.driver.findOne({ id: '<UUID>', select: { id: true, name: true, licenseNumber: true } }).execute();
 
 // Create
-const created = await db.driver.create({ data: { name: '<value>', licenseNumber: '<value>' }, select: { id: true } }).execute();
+const created = await db.driver.create({ data: { name: '<String>', licenseNumber: '<String>' }, select: { id: true } }).execute();
 
 // Update
-const updated = await db.driver.update({ where: { id: '<value>' }, data: { name: '<new-value>' }, select: { id: true } }).execute();
+const updated = await db.driver.update({ where: { id: '<UUID>' }, data: { name: '<String>' }, select: { id: true } }).execute();
 
 // Delete
-const deleted = await db.driver.delete({ where: { id: '<value>' } }).execute();
+const deleted = await db.driver.delete({ where: { id: '<UUID>' } }).execute();
 \`\`\`
 
 ## Custom Operations
@@ -4323,7 +4323,7 @@ Authenticate a user
   | \`password\` | String (required) |
 
 \`\`\`typescript
-const result = await db.mutation.login({ email: '<value>', password: '<value>' }).execute();
+const result = await db.mutation.login({ email: '<String>', password: '<String>' }).execute();
 \`\`\`
 
 ---
@@ -4349,10 +4349,10 @@ ORM operations for Car records
 
 \`\`\`typescript
 db.car.findMany({ select: { id: true } }).execute()
-db.car.findOne({ id: '<value>', select: { id: true } }).execute()
-db.car.create({ data: { make: '<value>', model: '<value>', year: '<value>', isElectric: '<value>' }, select: { id: true } }).execute()
-db.car.update({ where: { id: '<value>' }, data: { make: '<new>' }, select: { id: true } }).execute()
-db.car.delete({ where: { id: '<value>' } }).execute()
+db.car.findOne({ id: '<UUID>', select: { id: true } }).execute()
+db.car.create({ data: { make: '<String>', model: '<String>', year: '<Int>', isElectric: '<Boolean>' }, select: { id: true } }).execute()
+db.car.update({ where: { id: '<UUID>' }, data: { make: '<String>' }, select: { id: true } }).execute()
+db.car.delete({ where: { id: '<UUID>' } }).execute()
 \`\`\`
 
 ## Examples
@@ -4369,7 +4369,7 @@ const items = await db.car.findMany({
 
 \`\`\`typescript
 const item = await db.car.create({
-  data: { make: 'value', model: 'value', year: 'value', isElectric: 'value' },
+  data: { make: '<String>', model: '<String>', year: '<Int>', isElectric: '<Boolean>' },
   select: { id: true }
 }).execute();
 \`\`\`
@@ -4387,10 +4387,10 @@ ORM operations for Driver records
 
 \`\`\`typescript
 db.driver.findMany({ select: { id: true } }).execute()
-db.driver.findOne({ id: '<value>', select: { id: true } }).execute()
-db.driver.create({ data: { name: '<value>', licenseNumber: '<value>' }, select: { id: true } }).execute()
-db.driver.update({ where: { id: '<value>' }, data: { name: '<new>' }, select: { id: true } }).execute()
-db.driver.delete({ where: { id: '<value>' } }).execute()
+db.driver.findOne({ id: '<UUID>', select: { id: true } }).execute()
+db.driver.create({ data: { name: '<String>', licenseNumber: '<String>' }, select: { id: true } }).execute()
+db.driver.update({ where: { id: '<UUID>' }, data: { name: '<String>' }, select: { id: true } }).execute()
+db.driver.delete({ where: { id: '<UUID>' } }).execute()
 \`\`\`
 
 ## Examples
@@ -4407,7 +4407,7 @@ const items = await db.driver.findMany({
 
 \`\`\`typescript
 const item = await db.driver.create({
-  data: { name: 'value', licenseNumber: 'value' },
+  data: { name: '<String>', licenseNumber: '<String>' },
   select: { id: true }
 }).execute();
 \`\`\`
@@ -4447,7 +4447,7 @@ Authenticate a user
 ## Usage
 
 \`\`\`typescript
-db.mutation.login({ email: '<value>', password: '<value>' }).execute()
+db.mutation.login({ email: '<String>', password: '<String>' }).execute()
 \`\`\`
 
 ## Examples
@@ -4455,7 +4455,7 @@ db.mutation.login({ email: '<value>', password: '<value>' }).execute()
 ### Run login
 
 \`\`\`typescript
-const result = await db.mutation.login({ email: '<value>', password: '<value>' }).execute();
+const result = await db.mutation.login({ email: '<String>', password: '<String>' }).execute();
 \`\`\`
 "
 `;
@@ -4480,10 +4480,10 @@ import { db } from './orm';
 
 // Available models: car, driver
 db.<model>.findMany({ select: { id: true } }).execute()
-db.<model>.findOne({ id: '<value>', select: { id: true } }).execute()
+db.<model>.findOne({ id: '<UUID>', select: { id: true } }).execute()
 db.<model>.create({ data: { ... }, select: { id: true } }).execute()
-db.<model>.update({ where: { id: '<value>' }, data: { ... }, select: { id: true } }).execute()
-db.<model>.delete({ where: { id: '<value>' } }).execute()
+db.<model>.update({ where: { id: '<UUID>' }, data: { ... }, select: { id: true } }).execute()
+db.<model>.delete({ where: { id: '<UUID>' } }).execute()
 \`\`\`
 
 ## Examples

--- a/graphql/codegen/src/core/codegen/cli/docs-generator.ts
+++ b/graphql/codegen/src/core/codegen/cli/docs-generator.ts
@@ -5,6 +5,7 @@ import {
   flattenArgs,
   flattenedArgsToFlags,
   cleanTypeName,
+  fieldPlaceholder,
   getEditableFields,
   getSearchFields,
   categorizeSpecialFields,
@@ -621,8 +622,8 @@ export function generateSkills(
     const editableFields = getEditableFields(table, registry);
     const defaultFields = getFieldsWithDefaults(table, registry);
     const createFlags = [
-      ...editableFields.filter((f) => !defaultFields.has(f.name)).map((f) => `--${f.name} <value>`),
-      ...editableFields.filter((f) => defaultFields.has(f.name)).map((f) => `[--${f.name} <value>]`),
+      ...editableFields.filter((f) => !defaultFields.has(f.name)).map((f) => `--${f.name} <${cleanTypeName(f.type.gqlType)}>`),
+      ...editableFields.filter((f) => defaultFields.has(f.name)).map((f) => `[--${f.name} <${cleanTypeName(f.type.gqlType)}>]`),
     ].join(' ');
 
     referenceNames.push(kebab);
@@ -640,10 +641,10 @@ export function generateSkills(
         description: skillSpecialDesc,
         usage: [
           `${toolName} ${kebab} list`,
-          `${toolName} ${kebab} get --${pk.name} <value>`,
+          `${toolName} ${kebab} get --${pk.name} <${cleanTypeName(pk.gqlType)}>`,
           `${toolName} ${kebab} create ${createFlags}`,
-          `${toolName} ${kebab} update --${pk.name} <value> ${editableFields.map((f) => `[--${f.name} <value>]`).join(' ')}`,
-          `${toolName} ${kebab} delete --${pk.name} <value>`,
+          `${toolName} ${kebab} update --${pk.name} <${cleanTypeName(pk.gqlType)}> ${editableFields.map((f) => `[--${f.name} <${cleanTypeName(f.type.gqlType)}>]`).join(' ')}`,
+          `${toolName} ${kebab} delete --${pk.name} <${cleanTypeName(pk.gqlType)}>`,
         ],
         examples: [
           {
@@ -1519,8 +1520,8 @@ export function generateMultiTargetSkills(
       const editableFields = getEditableFields(table, registry);
       const defaultFields = getFieldsWithDefaults(table, registry);
       const createFlags = [
-        ...editableFields.filter((f) => !defaultFields.has(f.name)).map((f) => `--${f.name} <value>`),
-        ...editableFields.filter((f) => defaultFields.has(f.name)).map((f) => `[--${f.name} <value>]`),
+        ...editableFields.filter((f) => !defaultFields.has(f.name)).map((f) => `--${f.name} <${cleanTypeName(f.type.gqlType)}>`),
+        ...editableFields.filter((f) => defaultFields.has(f.name)).map((f) => `[--${f.name} <${cleanTypeName(f.type.gqlType)}>]`),
       ].join(' ');
       const cmd = `${tgt.name}:${kebab}`;
 
@@ -1539,10 +1540,10 @@ export function generateMultiTargetSkills(
           description: mtSkillSpecialDesc,
           usage: [
             `${toolName} ${cmd} list`,
-            `${toolName} ${cmd} get --${pk.name} <value>`,
+            `${toolName} ${cmd} get --${pk.name} <${cleanTypeName(pk.gqlType)}>`,
             `${toolName} ${cmd} create ${createFlags}`,
-            `${toolName} ${cmd} update --${pk.name} <value> ${editableFields.map((f) => `[--${f.name} <value>]`).join(' ')}`,
-            `${toolName} ${cmd} delete --${pk.name} <value>`,
+            `${toolName} ${cmd} update --${pk.name} <${cleanTypeName(pk.gqlType)}> ${editableFields.map((f) => `[--${f.name} <${cleanTypeName(f.type.gqlType)}>]`).join(' ')}`,
+            `${toolName} ${cmd} delete --${pk.name} <${cleanTypeName(pk.gqlType)}>`,
           ],
           examples: [
             {

--- a/graphql/codegen/src/core/codegen/docs-utils.ts
+++ b/graphql/codegen/src/core/codegen/docs-utils.ts
@@ -421,10 +421,63 @@ export function flattenArgs(args: CleanArgument[], registry?: TypeRegistry): Fla
 
 /**
  * Build CLI flags string from flattened args.
- * e.g. '--input.email <value> --input.password <value>'
+ * e.g. '--input.email <String> --input.password <String>'
  */
 export function flattenedArgsToFlags(flatArgs: FlattenedArg[]): string {
-  return flatArgs.map((a) => `--${a.flag} <value>`).join(' ');
+  return flatArgs.map((a) => `--${a.flag} <${a.type}>`).join(' ');
+}
+
+// ---------------------------------------------------------------------------
+// Type-aware placeholder helpers for code examples
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a type-aware placeholder for a table field value in code examples.
+ * Returns a quoted placeholder string, e.g. `'<UUID>'`, `'<String>'`, `'<Int>'`.
+ */
+export function fieldPlaceholder(field: CleanField): string {
+  return `'<${cleanTypeName(field.type.gqlType)}>'`;
+}
+
+/**
+ * Generate a type-aware placeholder for a primary key value in code examples.
+ * PrimaryKeyField has `gqlType` directly (not nested under `.type`).
+ */
+export function pkPlaceholder(pk: { gqlType: string }): string {
+  return `'<${cleanTypeName(pk.gqlType)}>'`;
+}
+
+/**
+ * Generate a type-aware placeholder for an operation argument value.
+ *
+ * - Scalar args: `'<String>'`
+ * - INPUT_OBJECT with resolvable fields (up to a limit): `{ email: '<String>', password: '<String>' }`
+ * - INPUT_OBJECT without resolvable fields: `'<TypeName>'`
+ *
+ * The result is a ready-to-embed JS expression (quotes included for scalars).
+ */
+export function argPlaceholder(arg: CleanArgument, registry?: TypeRegistry): string {
+  const { inner } = unwrapNonNull(arg.type);
+
+  if (inner.kind === 'INPUT_OBJECT') {
+    const fields = resolveInputFields(inner, registry);
+    if (fields && fields.length > 0) {
+      const meaningful = fields.filter((f) => f.name !== 'clientMutationId');
+      if (meaningful.length > 0 && meaningful.length <= 5) {
+        const parts = meaningful.map((f) => {
+          const typeName = cleanTypeName(getScalarTypeName(f.type));
+          return `${f.name}: '<${typeName}>'`;
+        });
+        return '{ ' + parts.join(', ') + ' }';
+      }
+    }
+    if (inner.name) {
+      return `'<${cleanTypeName(inner.name)}>'`;
+    }
+  }
+
+  const typeName = cleanTypeName(getScalarTypeName(arg.type));
+  return `'<${typeName}>'`;
 }
 
 export function gqlTypeToJsonSchemaType(gqlType: string): string {

--- a/graphql/codegen/src/core/codegen/hooks-docs-generator.ts
+++ b/graphql/codegen/src/core/codegen/hooks-docs-generator.ts
@@ -1,10 +1,13 @@
 import { toKebabCase } from 'komoji';
 
-import type { CleanOperation, CleanTable } from '../../types/schema';
+import type { CleanOperation, CleanTable, TypeRegistry } from '../../types/schema';
 import {
   buildSkillFile,
   buildSkillReference,
   formatArgType,
+  fieldPlaceholder,
+  pkPlaceholder,
+  argPlaceholder,
   getReadmeHeader,
   getReadmeFooter,
   gqlTypeToJsonSchemaType,
@@ -35,6 +38,7 @@ function getCustomHookName(op: CleanOperation): string {
 export function generateHooksReadme(
   tables: CleanTable[],
   customOperations: CleanOperation[],
+  registry?: TypeRegistry,
 ): GeneratedDocFile {
   const lines: string[] = [];
 
@@ -122,7 +126,7 @@ export function generateHooksReadme(
         lines.push(
           `const { data: item } = ${getSingleQueryHookName(table)}({`,
         );
-        lines.push(`  ${pk.name}: '<value>',`);
+        lines.push(`  ${pk.name}: ${pkPlaceholder(pk)},`);
         lines.push(
           `  selection: { fields: { ${scalarFields.map((f) => `${f.name}: true`).join(', ')} } },`,
         );
@@ -139,7 +143,7 @@ export function generateHooksReadme(
       );
       lines.push('});');
       lines.push(
-        `create({ ${scalarFields.filter((f) => f.name !== pk.name && f.name !== 'nodeId' && f.name !== 'createdAt' && f.name !== 'updatedAt').map((f) => `${f.name}: '<value>'`).join(', ')} });`,
+        `create({ ${scalarFields.filter((f) => f.name !== pk.name && f.name !== 'nodeId' && f.name !== 'createdAt' && f.name !== 'updatedAt').map((f) => `${f.name}: ${fieldPlaceholder(f)}`).join(', ')} });`,
       );
       lines.push('```');
       lines.push('');
@@ -372,6 +376,7 @@ export function generateHooksSkills(
   tables: CleanTable[],
   customOperations: CleanOperation[],
   targetName: string,
+  registry?: TypeRegistry,
 ): GeneratedDocFile[] {
   const files: GeneratedDocFile[] = [];
   const skillName = `hooks-${targetName}`;
@@ -399,7 +404,7 @@ export function generateHooksSkills(
           `${getListQueryHookName(table)}({ selection: { fields: { ${selectFields} } } })`,
           ...(hasValidPrimaryKey(table)
             ? [
-                `${getSingleQueryHookName(table)}({ ${pk.name}: '<value>', selection: { fields: { ${selectFields} } } })`,
+                `${getSingleQueryHookName(table)}({ ${pk.name}: ${pkPlaceholder(pk)}, selection: { fields: { ${selectFields} } } })`,
               ]
             : []),
           `${getCreateMutationHookName(table)}({ selection: { fields: { ${pk.name}: true } } })`,
@@ -425,7 +430,7 @@ export function generateHooksSkills(
               `const { mutate } = ${getCreateMutationHookName(table)}({`,
               `  selection: { fields: { ${pk.name}: true } },`,
               '});',
-              `mutate({ ${scalarFields.filter((f) => f.name !== pk.name && f.name !== 'nodeId' && f.name !== 'createdAt' && f.name !== 'updatedAt').map((f) => `${f.name}: '<value>'`).join(', ')} });`,
+              `mutate({ ${scalarFields.filter((f) => f.name !== pk.name && f.name !== 'nodeId' && f.name !== 'createdAt' && f.name !== 'updatedAt').map((f) => `${f.name}: ${fieldPlaceholder(f)}`).join(', ')} });`,
             ],
           },
         ],
@@ -438,7 +443,7 @@ export function generateHooksSkills(
     const hookName = getCustomHookName(op);
     const callArgs =
       op.args.length > 0
-        ? `{ ${op.args.map((a) => `${a.name}: '<value>'`).join(', ')} }`
+        ? `{ ${op.args.map((a) => `${a.name}: ${argPlaceholder(a, registry)}`).join(', ')} }`
         : '';
 
     const refName = toKebabCase(op.name);

--- a/graphql/codegen/src/core/codegen/orm/docs-generator.ts
+++ b/graphql/codegen/src/core/codegen/orm/docs-generator.ts
@@ -1,10 +1,13 @@
 import { toKebabCase } from 'komoji';
 
-import type { CleanOperation, CleanTable } from '../../../types/schema';
+import type { CleanOperation, CleanTable, TypeRegistry } from '../../../types/schema';
 import {
   buildSkillFile,
   buildSkillReference,
   formatArgType,
+  fieldPlaceholder,
+  pkPlaceholder,
+  argPlaceholder,
   getEditableFields,
   categorizeSpecialFields,
   buildSpecialFieldsMarkdown,
@@ -24,6 +27,7 @@ import {
 export function generateOrmReadme(
   tables: CleanTable[],
   customOperations: CleanOperation[],
+  registry?: TypeRegistry,
 ): GeneratedDocFile {
   const lines: string[] = [];
 
@@ -87,22 +91,22 @@ export function generateOrmReadme(
       lines.push('');
       lines.push(`// Get one by ${pk.name}`);
       lines.push(
-        `const item = await db.${singularName}.findOne({ ${pk.name}: '<value>', select: { ${scalarFields.map((f) => `${f.name}: true`).join(', ')} } }).execute();`,
+        `const item = await db.${singularName}.findOne({ ${pk.name}: ${pkPlaceholder(pk)}, select: { ${scalarFields.map((f) => `${f.name}: true`).join(', ')} } }).execute();`,
       );
       lines.push('');
       lines.push(`// Create`);
       lines.push(
-        `const created = await db.${singularName}.create({ data: { ${editableFields.map((f) => `${f.name}: '<value>'`).join(', ')} }, select: { ${pk.name}: true } }).execute();`,
+        `const created = await db.${singularName}.create({ data: { ${editableFields.map((f) => `${f.name}: ${fieldPlaceholder(f)}`).join(', ')} }, select: { ${pk.name}: true } }).execute();`,
       );
       lines.push('');
       lines.push(`// Update`);
       lines.push(
-        `const updated = await db.${singularName}.update({ where: { ${pk.name}: '<value>' }, data: { ${editableFields[0]?.name || 'field'}: '<new-value>' }, select: { ${pk.name}: true } }).execute();`,
+        `const updated = await db.${singularName}.update({ where: { ${pk.name}: ${pkPlaceholder(pk)} }, data: { ${editableFields[0]?.name || 'field'}: ${editableFields[0] ? fieldPlaceholder(editableFields[0]) : "'<String>'"} }, select: { ${pk.name}: true } }).execute();`,
       );
       lines.push('');
       lines.push(`// Delete`);
       lines.push(
-        `const deleted = await db.${singularName}.delete({ where: { ${pk.name}: '<value>' } }).execute();`,
+        `const deleted = await db.${singularName}.delete({ where: { ${pk.name}: ${pkPlaceholder(pk)} } }).execute();`,
       );
       lines.push('```');
       lines.push('');
@@ -132,7 +136,7 @@ export function generateOrmReadme(
         lines.push('');
         lines.push('```typescript');
         lines.push(
-          `const result = await db.${accessor}.${op.name}({ ${op.args.map((a) => `${a.name}: '<value>'`).join(', ')} }).execute();`,
+          `const result = await db.${accessor}.${op.name}({ ${op.args.map((a) => `${a.name}: ${argPlaceholder(a, registry)}`).join(', ')} }).execute();`,
         );
         lines.push('```');
       } else {
@@ -358,6 +362,7 @@ export function generateOrmSkills(
   tables: CleanTable[],
   customOperations: CleanOperation[],
   targetName: string,
+  registry?: TypeRegistry,
 ): GeneratedDocFile[] {
   const files: GeneratedDocFile[] = [];
   const skillName = `orm-${targetName}`;
@@ -388,10 +393,10 @@ export function generateOrmSkills(
         language: 'typescript',
         usage: [
           `db.${modelName}.findMany({ select: { id: true } }).execute()`,
-          `db.${modelName}.findOne({ ${pk.name}: '<value>', select: { id: true } }).execute()`,
-          `db.${modelName}.create({ data: { ${editableFields.map((f) => `${f.name}: '<value>'`).join(', ')} }, select: { id: true } }).execute()`,
-          `db.${modelName}.update({ where: { ${pk.name}: '<value>' }, data: { ${editableFields[0]?.name || 'field'}: '<new>' }, select: { id: true } }).execute()`,
-          `db.${modelName}.delete({ where: { ${pk.name}: '<value>' } }).execute()`,
+          `db.${modelName}.findOne({ ${pk.name}: ${pkPlaceholder(pk)}, select: { id: true } }).execute()`,
+          `db.${modelName}.create({ data: { ${editableFields.map((f) => `${f.name}: ${fieldPlaceholder(f)}`).join(', ')} }, select: { id: true } }).execute()`,
+          `db.${modelName}.update({ where: { ${pk.name}: ${pkPlaceholder(pk)} }, data: { ${editableFields[0]?.name || 'field'}: ${editableFields[0] ? fieldPlaceholder(editableFields[0]) : "'<String>'"} }, select: { id: true } }).execute()`,
+          `db.${modelName}.delete({ where: { ${pk.name}: ${pkPlaceholder(pk)} } }).execute()`,
         ],
         examples: [
           {
@@ -406,7 +411,7 @@ export function generateOrmSkills(
             description: `Create a ${singularName}`,
             code: [
               `const item = await db.${modelName}.create({`,
-              `  data: { ${editableFields.map((f) => `${f.name}: 'value'`).join(', ')} },`,
+              `  data: { ${editableFields.map((f) => `${f.name}: ${fieldPlaceholder(f)}`).join(', ')} },`,
               `  select: { ${pk.name}: true }`,
               '}).execute();',
             ],
@@ -421,7 +426,7 @@ export function generateOrmSkills(
     const accessor = op.kind === 'query' ? 'query' : 'mutation';
     const callArgs =
       op.args.length > 0
-        ? `{ ${op.args.map((a) => `${a.name}: '<value>'`).join(', ')} }`
+        ? `{ ${op.args.map((a) => `${a.name}: ${argPlaceholder(a, registry)}`).join(', ')} }`
         : '';
 
     const refName = toKebabCase(op.name);
@@ -459,10 +464,10 @@ export function generateOrmSkills(
           '',
           `// Available models: ${tableNames.slice(0, 8).join(', ')}${tableNames.length > 8 ? ', ...' : ''}`,
           `db.<model>.findMany({ select: { id: true } }).execute()`,
-          `db.<model>.findOne({ id: '<value>', select: { id: true } }).execute()`,
+          `db.<model>.findOne({ id: '<UUID>', select: { id: true } }).execute()`,
           `db.<model>.create({ data: { ... }, select: { id: true } }).execute()`,
-          `db.<model>.update({ where: { id: '<value>' }, data: { ... }, select: { id: true } }).execute()`,
-          `db.<model>.delete({ where: { id: '<value>' } }).execute()`,
+          `db.<model>.update({ where: { id: '<UUID>' }, data: { ... }, select: { id: true } }).execute()`,
+          `db.<model>.delete({ where: { id: '<UUID>' } }).execute()`,
         ],
         examples: [
           {

--- a/graphql/codegen/src/core/generate.ts
+++ b/graphql/codegen/src/core/generate.ts
@@ -348,7 +348,7 @@ export async function generate(
 
   if (runOrm) {
     if (docsConfig.readme) {
-      const readme = generateOrmReadme(tables, allCustomOps);
+      const readme = generateOrmReadme(tables, allCustomOps, customOperations.typeRegistry);
       filesToWrite.push({ path: path.posix.join('orm', readme.fileName), content: readme.content });
     }
     if (docsConfig.agents) {
@@ -359,7 +359,7 @@ export async function generate(
       allMcpTools.push(...getOrmMcpTools(tables, allCustomOps));
     }
     if (docsConfig.skills) {
-      for (const skill of generateOrmSkills(tables, allCustomOps, targetName)) {
+      for (const skill of generateOrmSkills(tables, allCustomOps, targetName, customOperations.typeRegistry)) {
         skillsToWrite.push({ path: skill.fileName, content: skill.content });
       }
     }
@@ -367,7 +367,7 @@ export async function generate(
 
   if (runReactQuery) {
     if (docsConfig.readme) {
-      const readme = generateHooksReadme(tables, allCustomOps);
+      const readme = generateHooksReadme(tables, allCustomOps, customOperations.typeRegistry);
       filesToWrite.push({ path: path.posix.join('hooks', readme.fileName), content: readme.content });
     }
     if (docsConfig.agents) {
@@ -378,7 +378,7 @@ export async function generate(
       allMcpTools.push(...getHooksMcpTools(tables, allCustomOps));
     }
     if (docsConfig.skills) {
-      for (const skill of generateHooksSkills(tables, allCustomOps, targetName)) {
+      for (const skill of generateHooksSkills(tables, allCustomOps, targetName, customOperations.typeRegistry)) {
         skillsToWrite.push({ path: skill.fileName, content: skill.content });
       }
     }


### PR DESCRIPTION
## Summary

Generated documentation and skill reference files previously used generic `<value>` placeholders in all code examples, which were non-descriptive. This PR replaces them with type-aware placeholders derived from the GraphQL schema (e.g. `<UUID>`, `<String>`, `<Int>`, `<Boolean>`).

**Before:** `db.car.findOne({ id: '<value>' ... })`
**After:** `db.car.findOne({ id: '<UUID>' ... })`

Three new helpers were added to `docs-utils.ts`:
- `fieldPlaceholder(field)` — for table fields (`CleanField` with `type.gqlType`)
- `pkPlaceholder(pk)` — for primary key fields (`PrimaryKeyField` with direct `gqlType`)
- `argPlaceholder(arg, registry?)` — for operation arguments; expands `INPUT_OBJECT` types into constituent fields when ≤5 fields, otherwise shows the type name

`flattenedArgsToFlags()` was also updated to use `<TypeName>` in CLI flag docs.

The `TypeRegistry` is now threaded through `generate.ts` → ORM/hooks doc generators so `argPlaceholder` can resolve INPUT_OBJECT fields.

## Review & Testing Checklist for Human

- [ ] **Verify `argPlaceholder` INPUT_OBJECT expansion**: The function expands input objects with ≤5 fields (excluding `clientMutationId`). Run codegen against a schema with input types to confirm the sign-in example now shows `{ email: '<String>', password: '<String>' }` instead of `'<value>'`
- [ ] **Confirm `pkPlaceholder` vs `fieldPlaceholder` distinction is correct everywhere**: `PrimaryKeyField` has `gqlType` at top level while `CleanField` nests it under `.type.gqlType`. Grep for `pkPlaceholder` and `fieldPlaceholder` usage to verify no mismatches
- [ ] **Check ORM update examples**: The update code examples changed from `'<new-value>'` (semantic hint) to the field's actual type placeholder — verify this tradeoff is acceptable
- [ ] **Run full codegen against a real schema** (e.g. the auth schema that produces `sign-in.md`) to verify the actual output matches expectations

### Notes
- Semantic placeholders in CLI config/auth commands (`<key>`, `<value>`, `<token>`, `<name>`) are intentionally unchanged — they describe the semantic role, not a typed field
- The hardcoded `'<UUID>'` in generic SKILL.md examples (`db.<model>.findOne({ id: '<UUID>' ...})`) assumes UUID primary keys, which is the common case
- 6 test failures in CI are pre-existing module resolution issues (e.g. `@pgpmjs/core`, `pg-cache`) unrelated to this change

Link to Devin session: https://app.devin.ai/sessions/6acc9cfe2eb74b44819e6c7e3d747d68
Requested by: @pyramation