### PR TITLE
fix(graphile-schema): route buildSchemaSDL pool through pg-cache for proper cleanup

### DIFF
--- a/graphile/graphile-schema/src/build-schema.ts
+++ b/graphile/graphile-schema/src/build-schema.ts
@@ -2,7 +2,7 @@ import deepmerge from 'deepmerge'
 import { printSchema } from 'graphql'
 import { ConstructivePreset, makePgService } from 'graphile-settings'
 import { makeSchema } from 'graphile-build'
-import { buildConnectionString } from 'pg-cache'
+import { getPgPool } from 'pg-cache'
 import { getPgEnvOptions } from 'pg-env'
 import type { GraphileConfig } from 'graphile-config'
 
@@ -17,19 +17,18 @@ export async function buildSchemaSDL(opts: BuildSchemaOptions): Promise<string> 
   const schemas = Array.isArray(opts.schemas) ? opts.schemas : []
 
   const config = getPgEnvOptions({ database })
-  const connectionString = buildConnectionString(
-    config.user,
-    config.password,
-    config.host,
-    config.port,
-    config.database,
-  )
+
+  // Create the pool through pg-cache so it is tracked and can be cleaned up
+  // by callers via pgCache.delete(database) before dropping ephemeral databases.
+  // Without this, makePgService creates its own internal pool that isn't released,
+  // causing "database has active sessions" errors during ephemeral DB teardown.
+  const pool = getPgPool(config)
 
   const basePreset: GraphileConfig.Preset = {
     extends: [ConstructivePreset],
     pgServices: [
       makePgService({
-        connectionString,
+        pool,
         schemas,
       }),
     ],


### PR DESCRIPTION
## Summary

Fixes the "database has active sessions" / `terminating connection due to administrator command` errors that occur during `pnpm generate` in ephemeral DB codegen flows (e.g., `sdk/constructive-schema`).

**Root cause**: `buildSchemaSDL` passed a `connectionString` to `makePgService`, which caused PostGraphile to create its own internal pg Pool. This pool was invisible to `pg-cache`, so when ephemeral DB teardown ran `pgCache.delete(database)` + `dropdb`, PostGraphile's connections remained open → `dropdb` failed → `pg_terminate_backend` killed them → the Node.js process received fatal `57P01` errors.

**Fix**: Create the pool via `getPgPool()` (which registers it in `pgCache`) and pass it directly to `makePgService({ pool, schemas })`. Now the existing cleanup code in `pgpm-module.ts` and `generate.ts` properly closes PostGraphile's pool before dropping the ephemeral database.

## Review & Testing Checklist for Human

- [ ] **Verify `makePgService({ pool })` behaves identically to `makePgService({ connectionString })`** — PostGraphile's `@dataplan/pg` adaptor accepts both, but confirm there are no subtle differences in pool configuration or connection handling that could affect schema introspection results.
- [ ] **Test `pnpm generate` in `sdk/constructive-schema` (constructive-db)** — this is the exact workflow that was blowing up. Confirm it completes without `57P01` errors and the ephemeral database is cleanly dropped.
- [ ] **Verify non-ephemeral `buildSchemaSDL` callers still work** — e.g., direct database introspection via `DatabaseSchemaSource`. The pool is now cached in pg-cache for those cases too; confirm no regressions.

### Notes
- The pool error handler added in `getPgPool` (which logs `57P01` at debug level instead of crashing) acts as a safety net, but the real fix is preventing those errors from occurring in the first place by closing the pool before `dropdb`.
- `getPgPool` caches pools by database name, so repeated calls to `buildSchemaSDL` for the same database will reuse the same pool. This is the intended behavior and matches how all other pg-cache consumers work.

Link to Devin session: https://app.devin.ai/sessions/a8cbad4ea6f2434b87fc29ac082105fd
Requested by: @pyramation