### PR TITLE
fix(graphql): route makePgService pools through pg-cache in explorer and server

### DIFF
--- a/graphql/explorer/src/server.ts
+++ b/graphql/explorer/src/server.ts
@@ -6,7 +6,7 @@ import express, { Express, NextFunction, Request, Response } from 'express';
 import { createGraphileInstance, graphileCache, GraphileCacheEntry } from 'graphile-cache';
 import { makePgService } from 'graphile-settings';
 import type { GraphileConfig } from 'graphile-config';
-import { buildConnectionString, getPgPool } from 'pg-cache';
+import { getPgPool } from 'pg-cache';
 import { getPgEnvOptions } from 'pg-env';
 
 import { printDatabases, printSchemas } from './render';
@@ -32,19 +32,16 @@ export const GraphQLExplorer = (rawOpts: ConstructiveOptions = {}): Express => {
       ...pg,
       database: dbname,
     });
-    const connectionString = buildConnectionString(
-      pgConfig.user,
-      pgConfig.password,
-      pgConfig.host,
-      pgConfig.port,
-      pgConfig.database
-    );
+
+    // Route through pg-cache so the pool is tracked and can be cleaned up
+    // properly, preventing leaked connections during database teardown.
+    const pool = getPgPool(pgConfig);
 
     const basePreset = getGraphilePreset(opts);
     const preset: GraphileConfig.Preset = {
       ...basePreset,
       pgServices: [
-        makePgService({ connectionString, schemas: [schemaname] }),
+        makePgService({ pool, schemas: [schemaname] }),
       ],
       grafserv: {
         graphqlPath: '/graphql',

--- a/graphql/server/src/middleware/graphile.ts
+++ b/graphql/server/src/middleware/graphile.ts
@@ -7,7 +7,7 @@ import type { GraphQLError, GraphQLFormattedError } from 'grafast/graphql';
 import { createGraphileInstance, type GraphileCacheEntry, graphileCache } from 'graphile-cache';
 import type { GraphileConfig } from 'graphile-config';
 import { ConstructivePreset, makePgService } from 'graphile-settings';
-import { buildConnectionString } from 'pg-cache';
+import { getPgPool } from 'pg-cache';
 import { getPgEnvOptions } from 'pg-env';
 import './types'; // for Request type
 import { isGraphqlObservabilityEnabled } from '../diagnostics/observability';
@@ -127,7 +127,7 @@ const reqLabel = (req: Request): string => (req.requestId ? `[${req.requestId}]`
  * Build a PostGraphile v5 preset for a tenant.
  */
 const buildPreset = (
-  connectionString: string,
+  pool: import('pg').Pool,
   schemas: string[],
   anonRole: string,
   roleName: string,
@@ -136,7 +136,7 @@ const buildPreset = (
   extends: [ConstructivePreset],
   pgServices: [
     makePgService({
-      connectionString,
+      pool,
       schemas,
     }),
   ],
@@ -263,16 +263,13 @@ export const graphile = (opts: ConstructiveOptions): RequestHandler => {
         ...opts.pg,
         database: dbname,
       });
-      const connectionString = buildConnectionString(
-        pgConfig.user,
-        pgConfig.password,
-        pgConfig.host,
-        pgConfig.port,
-        pgConfig.database,
-      );
+
+      // Route through pg-cache so the pool is tracked and can be cleaned up
+      // properly, preventing leaked connections during database teardown.
+      const pool = getPgPool(pgConfig);
 
       // Create promise and store in in-flight map BEFORE try block
-      const preset = buildPreset(connectionString, schema || [], anonRole, roleName);
+      const preset = buildPreset(pool, schema || [], anonRole, roleName);
       const creationPromise = observeGraphileBuild(
         {
           cacheKey: key,


### PR DESCRIPTION
## Summary

Follow-up to #860. Applies the same fix to two more call sites where `makePgService({ connectionString })` created PostGraphile-internal pools invisible to `pg-cache`:

- **`graphql/explorer/src/server.ts`** — the GraphQL Explorer's dynamic schema introspection
- **`graphql/server/src/middleware/graphile.ts`** — the main GraphQL server middleware (`buildPreset`)

Both now use `getPgPool(pgConfig)` to obtain a pg-cache-tracked pool and pass it via `makePgService({ pool })`.

A third instance in `graphql/query/src/executor.ts` was identified but intentionally left out: it has no external consumers, doesn't depend on `pg-cache`, and uses a different lifecycle (`postgraphile()` + `pgl.release()`).

## Review & Testing Checklist for Human

- [ ] **Verify `makePgService({ pool })` behaves identically to `makePgService({ connectionString })`** — PostGraphile's `@dataplan/pg` adaptor accepts both, but confirm there are no subtle differences in pool configuration, connection limits, or adaptor behavior (e.g., does PostGraphile call `pool.end()` on release when it doesn't own the pool?).
- [ ] **Pool sharing implications** — `getPgPool` caches by database name. Multiple PostGraphile instances hitting the same database (e.g., different schemas in the explorer, or multiple tenants in the server) will now share a single pool. Previously each `makePgService({ connectionString })` call created an independent pool. Verify this doesn't cause connection starvation under concurrent load.
- [ ] **Test the explorer**: navigate to a database/schema in the GraphQL Explorer and confirm introspection + GraphiQL still work.
- [ ] **Test the server**: confirm the main GraphQL API endpoint still serves queries correctly for at least one tenant.

### Notes
- The `buildPreset` signature in `graphile.ts` changed its first parameter from `connectionString: string` to `pool: import('pg').Pool`. This is internal-only (not exported).
- The `buildConnectionString` import is removed from both files since it's no longer needed.

Link to Devin session: https://app.devin.ai/sessions/a8cbad4ea6f2434b87fc29ac082105fd
Requested by: @pyramation