### PR TITLE
feat: wire tablesMeta through pipeline, enrich M:N relations, add ORM add/remove junction methods

### DIFF
--- a/graphql/codegen/src/core/codegen/orm/model-generator.ts
+++ b/graphql/codegen/src/core/codegen/orm/model-generator.ts
@@ -17,6 +17,8 @@ import {
   getTableNames,
   hasValidPrimaryKey,
   lcFirst,
+  toPascalCase,
+  ucFirst,
 } from '../utils';
 
 export interface GeneratedModelFile {
@@ -165,6 +167,7 @@ export function generateModelFile(
   table: Table,
   _useSharedTypes: boolean,
   options?: { condition?: boolean },
+  allTables?: Table[],
 ): GeneratedModelFile {
   const conditionEnabled = options?.condition !== false;
   const { typeName, singularName, pluralName } = getTableNames(table);
@@ -196,16 +199,23 @@ export function generateModelFile(
   const statements: t.Statement[] = [];
 
   statements.push(createImportDeclaration('../client', ['OrmClient']));
+  const m2nRels = table.relations.manyToMany.filter(
+    (r) => r.junctionLeftKeyFields?.length && r.junctionRightKeyFields?.length,
+  );
+  const hasM2n = m2nRels.length > 0;
+
+  const queryBuilderImports = [
+    'QueryBuilder',
+    'buildFindManyDocument',
+    'buildFindFirstDocument',
+    'buildFindOneDocument',
+    'buildCreateDocument',
+    'buildUpdateByPkDocument',
+    'buildDeleteByPkDocument',
+    ...(hasM2n ? ['buildJunctionRemoveDocument'] : []),
+  ];
   statements.push(
-    createImportDeclaration('../query-builder', [
-      'QueryBuilder',
-      'buildFindManyDocument',
-      'buildFindFirstDocument',
-      'buildFindOneDocument',
-      'buildCreateDocument',
-      'buildUpdateByPkDocument',
-      'buildDeleteByPkDocument',
-    ]),
+    createImportDeclaration('../query-builder', queryBuilderImports),
   );
   statements.push(
     createImportDeclaration(
@@ -982,6 +992,166 @@ export function generateModelFile(
     );
   }
 
+  // ── M:N add/remove methods ────────────────────────────────────────────
+  for (const rel of m2nRels) {
+    if (!rel.fieldName) continue;
+
+    const junctionTable = allTables?.find((tb) => tb.name === rel.junctionTable);
+    if (!junctionTable) continue;
+
+    const junctionNames = getTableNames(junctionTable);
+    const junctionCreateMutation = junctionTable.query?.create ?? `create${junctionNames.typeName}`;
+    const junctionCreateInputType = `Create${junctionNames.typeName}Input`;
+    const junctionDeleteMutation = junctionTable.query?.delete;
+    const junctionDeleteInputType = `Delete${junctionNames.typeName}Input`;
+    const junctionSingular = junctionNames.singularName;
+
+    // Derive a friendly singular name from the fieldName (e.g., "tags" → "Tag")
+    const relSingular = ucFirst(rel.fieldName.replace(/s$/, ''));
+
+    const leftKeys = rel.junctionLeftKeyFields!;
+    const rightKeys = rel.junctionRightKeyFields!;
+    const leftPkFields = rel.leftKeyFields ?? ['id'];
+    const rightPkFields = rel.rightKeyFields ?? ['id'];
+
+    // ── add<Relation> ───────────────────────────────────────────────
+    {
+      // Parameters: one param per left PK + one param per right PK
+      const params: t.Identifier[] = [];
+      for (const lk of leftPkFields) {
+        const p = t.identifier(lk);
+        p.typeAnnotation = t.tsTypeAnnotation(t.tsStringKeyword());
+        params.push(p);
+      }
+      for (const rk of rightPkFields) {
+        const p = t.identifier(rk === leftPkFields[0] ? `right${ucFirst(rk)}` : rk);
+        p.typeAnnotation = t.tsTypeAnnotation(t.tsStringKeyword());
+        params.push(p);
+      }
+
+      // Build the junction row data object: { junctionLeftKey: leftPk, junctionRightKey: rightPk }
+      const dataProps: t.ObjectProperty[] = [];
+      for (let i = 0; i < leftKeys.length; i++) {
+        dataProps.push(
+          t.objectProperty(t.identifier(leftKeys[i]), t.identifier(params[i].name)),
+        );
+      }
+      for (let i = 0; i < rightKeys.length; i++) {
+        dataProps.push(
+          t.objectProperty(
+            t.identifier(rightKeys[i]),
+            t.identifier(params[leftPkFields.length + i].name),
+          ),
+        );
+      }
+
+      const body: t.Statement[] = [
+        t.variableDeclaration('const', [
+          t.variableDeclarator(
+            t.objectPattern([
+              t.objectProperty(t.identifier('document'), t.identifier('document'), false, true),
+              t.objectProperty(t.identifier('variables'), t.identifier('variables'), false, true),
+            ]),
+            t.callExpression(t.identifier('buildCreateDocument'), [
+              t.stringLiteral(junctionNames.typeName),
+              t.stringLiteral(junctionCreateMutation),
+              t.stringLiteral(junctionSingular),
+              t.objectExpression([t.objectProperty(t.identifier('id'), t.booleanLiteral(true))]),
+              t.objectExpression(dataProps),
+              t.stringLiteral(junctionCreateInputType),
+            ]),
+          ),
+        ]),
+        t.returnStatement(
+          t.newExpression(t.identifier('QueryBuilder'), [
+            t.objectExpression([
+              t.objectProperty(
+                t.identifier('client'),
+                t.memberExpression(t.thisExpression(), t.identifier('client')),
+              ),
+              t.objectProperty(t.identifier('operation'), t.stringLiteral('mutation')),
+              t.objectProperty(t.identifier('operationName'), t.stringLiteral(junctionNames.typeName)),
+              t.objectProperty(t.identifier('fieldName'), t.stringLiteral(junctionCreateMutation)),
+              t.objectProperty(t.identifier('document'), t.identifier('document'), false, true),
+              t.objectProperty(t.identifier('variables'), t.identifier('variables'), false, true),
+            ]),
+          ]),
+        ),
+      ];
+
+      const method = t.classMethod('method', t.identifier(`add${relSingular}`), params, t.blockStatement(body));
+      method.async = true;
+      classBody.push(method);
+    }
+
+    // ── remove<Relation> ────────────────────────────────────────────
+    if (junctionDeleteMutation) {
+      const params: t.Identifier[] = [];
+      for (const lk of leftPkFields) {
+        const p = t.identifier(lk);
+        p.typeAnnotation = t.tsTypeAnnotation(t.tsStringKeyword());
+        params.push(p);
+      }
+      for (const rk of rightPkFields) {
+        const p = t.identifier(rk === leftPkFields[0] ? `right${ucFirst(rk)}` : rk);
+        p.typeAnnotation = t.tsTypeAnnotation(t.tsStringKeyword());
+        params.push(p);
+      }
+
+      // Build the keys object for junction delete
+      const keysProps: t.ObjectProperty[] = [];
+      for (let i = 0; i < leftKeys.length; i++) {
+        keysProps.push(
+          t.objectProperty(t.identifier(leftKeys[i]), t.identifier(params[i].name)),
+        );
+      }
+      for (let i = 0; i < rightKeys.length; i++) {
+        keysProps.push(
+          t.objectProperty(
+            t.identifier(rightKeys[i]),
+            t.identifier(params[leftPkFields.length + i].name),
+          ),
+        );
+      }
+
+      const body: t.Statement[] = [
+        t.variableDeclaration('const', [
+          t.variableDeclarator(
+            t.objectPattern([
+              t.objectProperty(t.identifier('document'), t.identifier('document'), false, true),
+              t.objectProperty(t.identifier('variables'), t.identifier('variables'), false, true),
+            ]),
+            t.callExpression(t.identifier('buildJunctionRemoveDocument'), [
+              t.stringLiteral(junctionNames.typeName),
+              t.stringLiteral(junctionDeleteMutation),
+              t.objectExpression(keysProps),
+              t.stringLiteral(junctionDeleteInputType),
+            ]),
+          ),
+        ]),
+        t.returnStatement(
+          t.newExpression(t.identifier('QueryBuilder'), [
+            t.objectExpression([
+              t.objectProperty(
+                t.identifier('client'),
+                t.memberExpression(t.thisExpression(), t.identifier('client')),
+              ),
+              t.objectProperty(t.identifier('operation'), t.stringLiteral('mutation')),
+              t.objectProperty(t.identifier('operationName'), t.stringLiteral(junctionNames.typeName)),
+              t.objectProperty(t.identifier('fieldName'), t.stringLiteral(junctionDeleteMutation)),
+              t.objectProperty(t.identifier('document'), t.identifier('document'), false, true),
+              t.objectProperty(t.identifier('variables'), t.identifier('variables'), false, true),
+            ]),
+          ]),
+        ),
+      ];
+
+      const method = t.classMethod('method', t.identifier(`remove${relSingular}`), params, t.blockStatement(body));
+      method.async = true;
+      classBody.push(method);
+    }
+  }
+
   const classDecl = t.classDeclaration(
     t.identifier(modelName),
     null,
@@ -1005,5 +1175,5 @@ export function generateAllModelFiles(
   useSharedTypes: boolean,
   options?: { condition?: boolean },
 ): GeneratedModelFile[] {
-  return tables.map((table) => generateModelFile(table, useSharedTypes, options));
+  return tables.map((table) => generateModelFile(table, useSharedTypes, options, tables));
 }

--- a/graphql/codegen/src/core/codegen/orm/model-generator.ts
+++ b/graphql/codegen/src/core/codegen/orm/model-generator.ts
@@ -17,7 +17,6 @@ import {
   getTableNames,
   hasValidPrimaryKey,
   lcFirst,
-  toPascalCase,
   ucFirst,
 } from '../utils';
 
@@ -1079,9 +1078,9 @@ export function generateModelFile(
         ),
       ];
 
-      const method = t.classMethod('method', t.identifier(`add${relSingular}`), params, t.blockStatement(body));
-      method.async = true;
-      classBody.push(method);
+      classBody.push(
+        t.classMethod('method', t.identifier(`add${relSingular}`), params, t.blockStatement(body)),
+      );
     }
 
     // ── remove<Relation> ────────────────────────────────────────────
@@ -1146,9 +1145,9 @@ export function generateModelFile(
         ),
       ];
 
-      const method = t.classMethod('method', t.identifier(`remove${relSingular}`), params, t.blockStatement(body));
-      method.async = true;
-      classBody.push(method);
+      classBody.push(
+        t.classMethod('method', t.identifier(`remove${relSingular}`), params, t.blockStatement(body)),
+      );
     }
   }
 

--- a/graphql/codegen/src/core/codegen/orm/model-generator.ts
+++ b/graphql/codegen/src/core/codegen/orm/model-generator.ts
@@ -11,6 +11,10 @@ import { singularize } from 'inflekt';
 import type { Table } from '../../../types/schema';
 import { asConst, generateCode } from '../babel-ast';
 import {
+  getCreateInputTypeName,
+  getCreateMutationName,
+  getDeleteInputTypeName,
+  getDeleteMutationName,
   getFilterTypeName,
   getGeneratedFileHeader,
   getOrderByTypeName,
@@ -203,7 +207,11 @@ export function generateModelFile(
   const m2nRels = table.relations.manyToMany.filter(
     (r) => r.junctionLeftKeyFields?.length && r.junctionRightKeyFields?.length,
   );
-  const hasM2n = m2nRels.length > 0;
+  // Check if any remove methods will actually be generated (need junction table with delete mutation)
+  const needsJunctionRemove = m2nRels.some((r) => {
+    const jt = allTables?.find((tb) => tb.name === r.junctionTable);
+    return jt?.query?.delete != null;
+  });
 
   const queryBuilderImports = [
     'QueryBuilder',
@@ -213,7 +221,7 @@ export function generateModelFile(
     'buildCreateDocument',
     'buildUpdateByPkDocument',
     'buildDeleteByPkDocument',
-    ...(hasM2n ? ['buildJunctionRemoveDocument'] : []),
+    ...(needsJunctionRemove ? ['buildJunctionRemoveDocument'] : []),
   ];
   statements.push(
     createImportDeclaration('../query-builder', queryBuilderImports),
@@ -1001,10 +1009,10 @@ export function generateModelFile(
     if (!junctionTable) continue;
 
     const junctionNames = getTableNames(junctionTable);
-    const junctionCreateMutation = junctionTable.query?.create ?? `create${junctionNames.typeName}`;
-    const junctionCreateInputType = `Create${junctionNames.typeName}Input`;
-    const junctionDeleteMutation = junctionTable.query?.delete;
-    const junctionDeleteInputType = `Delete${junctionNames.typeName}Input`;
+    const junctionCreateMutation = getCreateMutationName(junctionTable);
+    const junctionCreateInputType = getCreateInputTypeName(junctionTable);
+    const junctionDeleteMutation = junctionTable.query?.delete ?? getDeleteMutationName(junctionTable);
+    const junctionDeleteInputType = getDeleteInputTypeName(junctionTable);
     const junctionSingular = junctionNames.singularName;
 
     // Derive a friendly singular name from the fieldName (e.g., "tags" → "Tag", "categories" → "Category")
@@ -1015,18 +1023,26 @@ export function generateModelFile(
     const leftPkFields = rel.leftKeyFields ?? ['id'];
     const rightPkFields = rel.rightKeyFields ?? ['id'];
 
+    // Resolve actual PK types from left (current) and right tables
+    const leftPkInfo = getPrimaryKeyInfo(table);
+    const rightTable = allTables?.find((tb) => tb.name === rel.rightTable);
+    const rightPkInfo = rightTable ? getPrimaryKeyInfo(rightTable) : [];
+
     // ── add<Relation> ───────────────────────────────────────────────
     {
-      // Parameters: one param per left PK + one param per right PK
+      // Parameters: one param per left PK + one param per right PK, with actual types
       const params: t.Identifier[] = [];
-      for (const lk of leftPkFields) {
-        const p = t.identifier(lk);
-        p.typeAnnotation = t.tsTypeAnnotation(t.tsStringKeyword());
+      for (let i = 0; i < leftPkFields.length; i++) {
+        const p = t.identifier(leftPkFields[i]);
+        const pkInfo = leftPkInfo.find((pk) => pk.name === leftPkFields[i]);
+        p.typeAnnotation = t.tsTypeAnnotation(tsTypeFromPrimitive(pkInfo?.tsType ?? 'string'));
         params.push(p);
       }
-      for (const rk of rightPkFields) {
+      for (let i = 0; i < rightPkFields.length; i++) {
+        const rk = rightPkFields[i];
         const p = t.identifier(rk === leftPkFields[0] ? `right${ucFirst(rk)}` : rk);
-        p.typeAnnotation = t.tsTypeAnnotation(t.tsStringKeyword());
+        const pkInfo = rightPkInfo.find((pk) => pk.name === rk);
+        p.typeAnnotation = t.tsTypeAnnotation(tsTypeFromPrimitive(pkInfo?.tsType ?? 'string'));
         params.push(p);
       }
 
@@ -1086,16 +1102,19 @@ export function generateModelFile(
     }
 
     // ── remove<Relation> ────────────────────────────────────────────
-    if (junctionDeleteMutation) {
+    if (junctionTable.query?.delete) {
       const params: t.Identifier[] = [];
-      for (const lk of leftPkFields) {
-        const p = t.identifier(lk);
-        p.typeAnnotation = t.tsTypeAnnotation(t.tsStringKeyword());
+      for (let i = 0; i < leftPkFields.length; i++) {
+        const p = t.identifier(leftPkFields[i]);
+        const pkInfo = leftPkInfo.find((pk) => pk.name === leftPkFields[i]);
+        p.typeAnnotation = t.tsTypeAnnotation(tsTypeFromPrimitive(pkInfo?.tsType ?? 'string'));
         params.push(p);
       }
-      for (const rk of rightPkFields) {
+      for (let i = 0; i < rightPkFields.length; i++) {
+        const rk = rightPkFields[i];
         const p = t.identifier(rk === leftPkFields[0] ? `right${ucFirst(rk)}` : rk);
-        p.typeAnnotation = t.tsTypeAnnotation(t.tsStringKeyword());
+        const pkInfo = rightPkInfo.find((pk) => pk.name === rk);
+        p.typeAnnotation = t.tsTypeAnnotation(tsTypeFromPrimitive(pkInfo?.tsType ?? 'string'));
         params.push(p);
       }
 

--- a/graphql/codegen/src/core/codegen/orm/model-generator.ts
+++ b/graphql/codegen/src/core/codegen/orm/model-generator.ts
@@ -6,6 +6,8 @@
  */
 import * as t from '@babel/types';
 
+import { singularize } from 'inflekt';
+
 import type { Table } from '../../../types/schema';
 import { asConst, generateCode } from '../babel-ast';
 import {
@@ -1005,8 +1007,8 @@ export function generateModelFile(
     const junctionDeleteInputType = `Delete${junctionNames.typeName}Input`;
     const junctionSingular = junctionNames.singularName;
 
-    // Derive a friendly singular name from the fieldName (e.g., "tags" → "Tag")
-    const relSingular = ucFirst(rel.fieldName.replace(/s$/, ''));
+    // Derive a friendly singular name from the fieldName (e.g., "tags" → "Tag", "categories" → "Category")
+    const relSingular = ucFirst(singularize(rel.fieldName));
 
     const leftKeys = rel.junctionLeftKeyFields!;
     const rightKeys = rel.junctionRightKeyFields!;

--- a/graphql/codegen/src/core/codegen/templates/query-builder.ts
+++ b/graphql/codegen/src/core/codegen/templates/query-builder.ts
@@ -655,6 +655,25 @@ export function buildDeleteByPkDocument<TSelect = undefined>(
   };
 }
 
+export function buildJunctionRemoveDocument(
+  operationName: string,
+  mutationField: string,
+  keys: Record<string, unknown>,
+  inputTypeName: string,
+): { document: string; variables: Record<string, unknown> } {
+  return {
+    document: buildInputMutationDocument({
+      operationName,
+      mutationField,
+      inputTypeName,
+      resultSelections: [t.field({ name: 'clientMutationId' })],
+    }),
+    variables: {
+      input: keys,
+    },
+  };
+}
+
 export function buildCustomDocument<TSelect, TArgs>(
   operationType: 'query' | 'mutation',
   operationName: string,

--- a/graphql/codegen/src/core/introspect/enrich-relations.ts
+++ b/graphql/codegen/src/core/introspect/enrich-relations.ts
@@ -1,0 +1,42 @@
+/**
+ * M:N Relation Enrichment
+ *
+ * After table inference from introspection, enriches ManyToManyRelation objects
+ * with junction key field metadata from _cachedTablesMeta (MetaSchemaPlugin).
+ */
+import type { Table } from '../../types/schema';
+import type { MetaTableInfo } from './source/types';
+
+/**
+ * Enrich M:N relations with junction key field metadata from _meta.
+ * Mutates the tables array in-place.
+ */
+export function enrichManyToManyRelations(
+  tables: Table[],
+  tablesMeta?: MetaTableInfo[],
+): void {
+  if (!tablesMeta?.length) return;
+
+  const metaByName = new Map(tablesMeta.map((m) => [m.name, m]));
+
+  for (const table of tables) {
+    const meta = metaByName.get(table.name);
+    if (!meta?.relations.manyToMany.length) continue;
+
+    for (const rel of table.relations.manyToMany) {
+      const metaRel = meta.relations.manyToMany.find(
+        (m) => m.fieldName === rel.fieldName,
+      );
+      if (!metaRel) continue;
+
+      rel.junctionLeftKeyFields = metaRel.junctionLeftKeyAttributes.map(
+        (a) => a.name,
+      );
+      rel.junctionRightKeyFields = metaRel.junctionRightKeyAttributes.map(
+        (a) => a.name,
+      );
+      rel.leftKeyFields = metaRel.leftKeyAttributes.map((a) => a.name);
+      rel.rightKeyFields = metaRel.rightKeyAttributes.map((a) => a.name);
+    }
+  }
+}

--- a/graphql/codegen/src/core/pipeline/index.ts
+++ b/graphql/codegen/src/core/pipeline/index.ts
@@ -14,6 +14,7 @@ import type {
   Table,
   TypeRegistry,
 } from '../../types/schema';
+import { enrichManyToManyRelations } from '../introspect/enrich-relations';
 import { inferTablesFromIntrospection } from '../introspect/infer-tables';
 import type { SchemaSource } from '../introspect/source';
 import { filterTables } from '../introspect/transform';
@@ -112,7 +113,7 @@ export async function runCodegenPipeline(
 
   // 1. Fetch introspection from source
   log(`Fetching schema from ${source.describe()}...`);
-  const { introspection } = await source.fetch();
+  const { introspection, tablesMeta } = await source.fetch();
 
   // 2. Infer tables from introspection (replaces _meta)
   log('Inferring table metadata from schema...');
@@ -120,6 +121,12 @@ export async function runCodegenPipeline(
   let tables = inferTablesFromIntrospection(introspection, { comments: commentsEnabled });
   const totalTables = tables.length;
   log(`  Found ${totalTables} tables`);
+
+  // 2a. Enrich M:N relations with junction key metadata from _meta
+  if (tablesMeta?.length) {
+    enrichManyToManyRelations(tables, tablesMeta);
+    log(`  Enriched M:N relations from _meta (${tablesMeta.length} tables)`);
+  }
 
   // 3. Filter tables by config (combine exclude and systemExclude)
   tables = filterTables(tables, config.tables.include, [


### PR DESCRIPTION
## Summary

PR 3 of the v5 relations feature. Consumes the `tablesMeta` plumbing added in PR 2 (#863) to enrich M:N relations with junction key field metadata, then generates `add<Relation>`/`remove<Relation>` ORM methods that delegate to the junction table's existing CRUD mutations.

**4 files changed across 3 concerns:**

1. **Pipeline wiring** (`pipeline/index.ts`): Destructures `tablesMeta` from `source.fetch()` and calls the new enrichment step after table inference but before filtering.

2. **M:N enrichment** (`enrich-relations.ts` — new): Matches `tablesMeta` entries to inferred tables by name, then populates `junctionLeftKeyFields`, `junctionRightKeyFields`, `leftKeyFields`, `rightKeyFields` on each `ManyToManyRelation`.

3. **ORM codegen** (`model-generator.ts`, `query-builder.ts`): For each enriched M:N relation on a table, generates `add<Singular>` and `remove<Singular>` class methods. `add` calls `buildCreateDocument` against the junction table; `remove` calls a new `buildJunctionRemoveDocument` helper. Only emits methods when junction key metadata is present (graceful no-op for non-enriched relations). Uses the existing codegen utilities (`getCreateMutationName`, `getDeleteMutationName`, `getCreateInputTypeName`, `getDeleteInputTypeName`, `getPrimaryKeyInfo`, `tsTypeFromPrimitive`) and `inflekt.singularize()` for consistent, correct naming throughout.

### Updates since last revision
- Removed dead `toPascalCase` import that would fail lint
- Removed `async = true` on add/remove methods to match existing CRUD method pattern
- Replaced naive `rel.fieldName.replace(/s$/, '')` with `inflekt.singularize()` for correct handling of irregular plurals (e.g., `categories` → `addCategory`)
- **PK type resolution**: Replaced hardcoded `t.tsStringKeyword()` with `getPrimaryKeyInfo()` + `tsTypeFromPrimitive()` to resolve actual PK types from left/right tables (e.g., integer PKs now correctly typed as `number`)
- **Consistent naming utilities**: Replaced manual `\`Create${typeName}Input\`` string construction with `getCreateInputTypeName()`, `getDeleteInputTypeName()`, `getCreateMutationName()`, `getDeleteMutationName()` — hooks into the same inflector-based naming used by all other codegen
- **Conditional import**: `buildJunctionRemoveDocument` is now only imported when at least one remove method will actually be generated (guards on `junctionTable.query?.delete`), preventing unused-import lint errors in generated output
- Removed redundant `leftTable` lookup (`table` is already the left table)

## Review & Testing Checklist for Human

- [ ] **`{ id: true }` hardcoded as select in `add` method**: The `buildCreateDocument` call passes `{ id: true }` as the result selection. Junction tables with composite PKs and no `id` column would produce an invalid query. Verify junction tables always have an `id` field in the generated schema.
- [ ] **No new unit tests**: Existing 317 tests pass, but no tests were added for `enrichManyToManyRelations`, `buildJunctionRemoveDocument`, or M:N method generation. Consider whether snapshot tests for generated model output with M:N relations are needed.
- [ ] **PK type fallback**: When the right table isn't found in `allTables` (or a PK field name doesn't match), the type falls back to `string`. Verify this is acceptable for all expected junction table configurations.
- [ ] **Recommended test plan**: Run `pnpm generate` or `pnpm generate-orm` against a project with provisioned M:N relations (e.g., `project_tags` junction between `projects` and `tags`). Inspect the generated model file to verify `addTag`/`removeTag` methods produce correct GraphQL documents with the right junction field mappings and correctly-typed parameters.

### Notes
- `remove<Relation>` is only generated when the junction table has a delete mutation (`junctionTable.query?.delete` is non-null). This is the correct guard — some junction tables may have delete disabled.
- Enrichment is a no-op when `tablesMeta` is absent (e.g., endpoint/file sources that don't provide `_meta`), so this is fully backward compatible.
- `junctionDeleteMutation` is computed with a `getDeleteMutationName()` fallback, but it's only used inside the `if (junctionTable.query?.delete)` guard where `.query.delete` is always truthy — so the fallback is effectively dead code. Harmless but could be tightened.

Link to Devin session: https://app.devin.ai/sessions/745d2d10b699452091e24131ba5edef2
Requested by: @pyramation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/constructive-io/constructive/pull/867" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
