### PR TITLE
feat: add .agents/skills/ directory + fix codegen output path to .agents/skills/

### DIFF
--- a/.agents/skills/constructive-monorepo-setup/SKILL.md
+++ b/.agents/skills/constructive-monorepo-setup/SKILL.md
@@ -1,0 +1,77 @@
+# Constructive Monorepo Setup
+
+Set up the Constructive monorepo for local development and testing.
+
+## Prerequisites
+
+- Node.js 20+
+- pnpm 9+
+- Docker (for PostgreSQL)
+- pgpm CLI (`npm install -g pgpm`)
+
+## Quick Start
+
+```bash
+# 1. Install dependencies
+pnpm install
+
+# 2. Start PostgreSQL via pgpm Docker
+pgpm docker start --image docker.io/constructiveio/postgres-plus:18 --recreate
+
+# 3. Load environment variables
+eval "$(pgpm env)"
+
+# 4. Bootstrap admin users for testing
+pgpm admin-users bootstrap --yes
+pgpm admin-users add --test --yes
+
+# 5. Build the monorepo
+pnpm build
+
+# 6. Run tests in a specific package
+cd packages/<yourmodule>
+pnpm test
+```
+
+## Docker Image
+
+Use `docker.io/constructiveio/postgres-plus:18` which includes PostgreSQL with PostGIS, pgvector, pg_textsearch, pg_trgm, btree_gin, and uuid-ossp extensions.
+
+For detailed Docker and pgpm usage, see the [pgpm skill](https://github.com/constructive-io/constructive-skills/tree/main/.agents/skills/pgpm) in the public skills repo.
+
+## Monorepo Navigation
+
+See [AGENTS.md](../../AGENTS.md) at the repo root for the full navigation guide covering:
+- Package layout (`packages/*`, `pgpm/*`, `graphql/*`, `postgres/*`, `graphile/*`)
+- Entry points (PGPM CLI, Constructive CLI, GraphQL Server)
+- Environment configuration patterns
+- Testing framework selection guide
+
+## Code Generation (SDK)
+
+To regenerate the GraphQL SDK after schema changes:
+
+```bash
+# Generate types, hooks, ORM, and CLI from a running GraphQL endpoint
+cnc codegen
+```
+
+Skills are auto-generated to `.agents/skills/` when `docs.skills: true` is set in the codegen config.
+
+For detailed codegen configuration, see the [constructive-graphql skill](https://github.com/constructive-io/constructive-skills/tree/main/.agents/skills/constructive-graphql) — specifically the [codegen.md reference](https://github.com/constructive-io/constructive-skills/tree/main/.agents/skills/constructive-graphql/references/codegen.md).
+
+## Graphile Plugin Development
+
+Graphile plugins live under `graphile/*`. For PostGIS plugin development and testing, see the [constructive-graphql skill](https://github.com/constructive-io/constructive-skills/tree/main/.agents/skills/constructive-graphql) — specifically the [search-postgis.md reference](https://github.com/constructive-io/constructive-skills/tree/main/.agents/skills/constructive-graphql/references/search-postgis.md).
+
+## Testing
+
+See [AGENTS.md](../../AGENTS.md) for the testing framework selection guide. For comprehensive database testing patterns, see the [constructive-testing skill](https://github.com/constructive-io/constructive-skills/tree/main/.agents/skills/constructive-testing).
+
+## Related Skills
+
+- [pgpm](https://github.com/constructive-io/constructive-skills/tree/main/.agents/skills/pgpm) — Docker, migrations, deploy/verify/revert
+- [constructive-graphql](https://github.com/constructive-io/constructive-skills/tree/main/.agents/skills/constructive-graphql) — Codegen, search, PostGIS
+- [constructive-testing](https://github.com/constructive-io/constructive-skills/tree/main/.agents/skills/constructive-testing) — pgsql-test, drizzle-orm-test
+- [constructive-tooling](https://github.com/constructive-io/constructive-skills/tree/main/.agents/skills/constructive-tooling) — pnpm workspace, makage builds
+- [constructive-setup](https://github.com/constructive-io/constructive-skills/tree/main/.agents/skills/constructive-setup) — Full setup guide (public skills repo)

--- a/graphql/codegen/src/core/generate.ts
+++ b/graphql/codegen/src/core/generate.ts
@@ -113,7 +113,7 @@ function resolveSkillsOutputDir(
       : path.resolve(workspaceRoot, config.skillsPath);
   }
 
-  return path.resolve(workspaceRoot, 'skills');
+  return path.resolve(workspaceRoot, '.agents/skills');
 }
 
 export async function generate(

--- a/graphql/codegen/src/types/config.ts
+++ b/graphql/codegen/src/types/config.ts
@@ -426,7 +426,7 @@ export interface GraphQLSDKConfigTarget {
   /**
    * Custom path for generated skill files.
    * When set, skills are written to this directory.
-   * When undefined (default), skills are written to {workspaceRoot}/skills/
+   * When undefined (default), skills are written to {workspaceRoot}/.agents/skills/
    * where workspaceRoot is auto-detected by walking up from the output directory
    * looking for pnpm-workspace.yaml, lerna.json, or package.json with workspaces.
    */


### PR DESCRIPTION
## Summary

Two changes to improve agent skill auto-discovery in the Constructive monorepo:

1. **Fix codegen default output path** — `resolveSkillsOutputDir()` in `graphql/codegen/src/core/generate.ts` now defaults to `.agents/skills/` instead of `skills/`. This aligns codegen-generated skills with the `.agents/skills/<name>/SKILL.md` convention used by Devin, Claude Code, Cursor, and Copilot for auto-discovery.

2. **Add `.agents/skills/constructive-monorepo-setup/SKILL.md`** — A lightweight setup skill that cross-references public skills (pgpm, constructive-graphql, constructive-testing, etc.) without duplicating content. Provides quick-start commands for local dev.

**Note:** The existing `skills/` directory (14 codegen-generated skill dirs) is left in place — it will be superseded on the next codegen run, which will write to `.agents/skills/` instead.

## Review & Testing Checklist for Human

- [ ] **Breaking change for downstream projects**: Any project using `@constructive-io/graphql-codegen` without an explicit `skillsPath` will now output skills to `.agents/skills/` instead of `skills/`. Verify this is acceptable for all consumers, or consider whether `skillsPath` overrides are needed in existing codegen configs.
- [ ] **Stale `skills/` directory**: This PR does not remove or migrate the existing `skills/` directory (14 dirs: `cli-admin`, `hooks-public`, `orm-objects`, etc.). Decide whether to clean it up in this PR or leave it for the next codegen run.
- [ ] **Verify codegen consumers**: Run `cnc codegen` (or equivalent) against a live endpoint after merging to confirm skills are written to `.agents/skills/` correctly.

### Notes

- The codegen change is a single string literal swap (`'skills'` → `'.agents/skills'`). No type, import, or logic changes.
- The `skillsPath` config option still works as an override — only the default changes.
- Companion PRs exist in `constructive-skills` (#67, #68), `constructive-private-skills` (#25), `constructive-db` (#654), and `constructive-sdk-agentic-flow` (#17) for the same `.agents/skills/` migration.

Link to Devin session: https://app.devin.ai/sessions/d0a20ee2e5194f4e8c342c6bc12fea07
Requested by: @pyramation