### PR TITLE
fix: composite PK detection + filter type-safety from schema source of truth

### DIFF
--- a/graphql/codegen/src/core/codegen/orm/input-types-generator.ts
+++ b/graphql/codegen/src/core/codegen/orm/input-types-generator.ts
@@ -1077,10 +1077,38 @@ function getFilterTypeForField(fieldType: string, isArray = false): string {
 }
 
 /**
- * Build properties for a table filter interface
+ * Build properties for a table filter interface.
+ *
+ * When typeRegistry is available, uses the schema's filter input type as
+ * the sole source of truth — this captures plugin-injected filter fields
+ * (e.g., bm25Body, tsvTsv, trgmName, vectorEmbedding, geom) that are not
+ * present on the entity type itself. Same pattern as buildOrderByValues().
  */
-function buildTableFilterProperties(table: Table): InterfaceProperty[] {
+function buildTableFilterProperties(
+  table: Table,
+  typeRegistry?: TypeRegistry,
+): InterfaceProperty[] {
   const filterName = getFilterTypeName(table);
+
+  // When the schema's filter type is available, use it as the source of truth
+  if (typeRegistry) {
+    const filterType = typeRegistry.get(filterName);
+    if (filterType?.kind === 'INPUT_OBJECT' && filterType.inputFields) {
+      const properties: InterfaceProperty[] = [];
+      for (const field of filterType.inputFields) {
+        const tsType = typeRefToTs(field.type);
+        properties.push({
+          name: field.name,
+          type: tsType,
+          optional: true,
+          description: stripSmartComments(field.description, true),
+        });
+      }
+      return properties;
+    }
+  }
+
+  // Fallback: derive from table fields when schema filter type is not available
   const properties: InterfaceProperty[] = [];
 
   for (const field of table.fields) {
@@ -1105,13 +1133,19 @@ function buildTableFilterProperties(table: Table): InterfaceProperty[] {
 /**
  * Generate table filter type statements
  */
-function generateTableFilterTypes(tables: Table[]): t.Statement[] {
+function generateTableFilterTypes(
+  tables: Table[],
+  typeRegistry?: TypeRegistry,
+): t.Statement[] {
   const statements: t.Statement[] = [];
 
   for (const table of tables) {
     const filterName = getFilterTypeName(table);
     statements.push(
-      createExportedInterface(filterName, buildTableFilterProperties(table)),
+      createExportedInterface(
+        filterName,
+        buildTableFilterProperties(table, typeRegistry),
+      ),
     );
   }
 
@@ -1957,6 +1991,54 @@ function generateConnectionFieldsMap(
 // ============================================================================
 
 /**
+ * Collect extra input type names referenced by plugin-injected filter fields.
+ *
+ * When the schema's filter type is used as source of truth, plugin-injected
+ * fields reference custom filter types (e.g., Bm25BodyFilter, TsvectorFilter,
+ * GeometryFilter) that also need to be generated. This function discovers
+ * those types by comparing the schema's filter type fields against the
+ * standard scalar filter types.
+ */
+function collectFilterExtraInputTypes(
+  tables: Table[],
+  typeRegistry: TypeRegistry,
+): Set<string> {
+  const extraTypes = new Set<string>();
+
+  for (const table of tables) {
+    const filterTypeName = getFilterTypeName(table);
+    const filterType = typeRegistry.get(filterTypeName);
+    if (
+      !filterType ||
+      filterType.kind !== 'INPUT_OBJECT' ||
+      !filterType.inputFields
+    ) {
+      continue;
+    }
+
+    const tableFieldNames = new Set(
+      table.fields
+        .filter((f) => !isRelationField(f.name, table))
+        .map((f) => f.name),
+    );
+
+    for (const field of filterType.inputFields) {
+      // Skip standard column-derived fields and logical operators
+      if (tableFieldNames.has(field.name)) continue;
+      if (['and', 'or', 'not'].includes(field.name)) continue;
+
+      // Collect the base type name of this extra field
+      const baseName = getTypeBaseName(field.type);
+      if (baseName && !SCALAR_NAMES.has(baseName)) {
+        extraTypes.add(baseName);
+      }
+    }
+  }
+
+  return extraTypes;
+}
+
+/**
  * Collect extra input type names referenced by plugin-injected condition fields.
  *
  * When plugins (like VectorSearchPlugin) inject fields into condition types,
@@ -2048,7 +2130,9 @@ export function generateInputTypesFile(
     statements.push(...generateEntitySelectTypes(tablesList, tableByName));
 
     // 4. Table filter types
-    statements.push(...generateTableFilterTypes(tablesList));
+    // Pass typeRegistry to use schema's filter type as source of truth,
+    // capturing plugin-injected filter fields (e.g., bm25, tsvector, trgm, vector, geom)
+    statements.push(...generateTableFilterTypes(tablesList, typeRegistry));
 
     // 4b. Table condition types (simple equality filter)
     // Pass typeRegistry to merge plugin-injected condition fields
@@ -2071,8 +2155,17 @@ export function generateInputTypesFile(
   statements.push(...generateConnectionFieldsMap(tablesList, tableByName));
 
   // 7. Custom input types from TypeRegistry
-  // Also include any extra types referenced by plugin-injected condition fields
+  // Also include any extra types referenced by plugin-injected filter/condition fields
   const mergedUsedInputTypes = new Set(usedInputTypes);
+  if (hasTables) {
+    const filterExtraTypes = collectFilterExtraInputTypes(
+      tablesList,
+      typeRegistry,
+    );
+    for (const typeName of filterExtraTypes) {
+      mergedUsedInputTypes.add(typeName);
+    }
+  }
   if (hasTables && conditionEnabled) {
     const conditionExtraTypes = collectConditionExtraInputTypes(
       tablesList,

--- a/graphql/query/src/introspect/infer-tables.ts
+++ b/graphql/query/src/introspect/infer-tables.ts
@@ -723,19 +723,19 @@ function inferConstraints(
   const updateInput = typeMap.get(updateInputName);
   const deleteInput = typeMap.get(deleteInputName);
 
-  const keyInputField =
-    inferPrimaryKeyFromInputObject(updateInput) ||
-    inferPrimaryKeyFromInputObject(deleteInput);
+  // Prefer Delete input (fewer non-PK fields) over Update input
+  const keyFields =
+    inferPrimaryKeyFromInputObject(deleteInput).length > 0
+      ? inferPrimaryKeyFromInputObject(deleteInput)
+      : inferPrimaryKeyFromInputObject(updateInput);
 
-  if (keyInputField) {
+  if (keyFields.length > 0) {
     primaryKey.push({
       name: 'primary',
-      fields: [
-        {
-          name: keyInputField.name,
-          type: convertToCleanFieldType(keyInputField.type),
-        },
-      ],
+      fields: keyFields.map((f) => ({
+        name: f.name,
+        type: convertToCleanFieldType(f.type),
+      })),
     });
   }
 
@@ -769,27 +769,28 @@ function inferConstraints(
 }
 
 /**
- * Infer a single-row lookup key from an Update/Delete input object.
+ * Infer primary key fields from an Update/Delete input object.
  *
  * Priority:
  * 1. Canonical keys: id, nodeId, rowId
- * 2. Single non-patch/non-clientMutationId scalar-ish field
+ * 2. All non-patch/non-clientMutationId fields (supports composite keys)
  *
- * If multiple possible key fields remain, return null to avoid guessing.
+ * Returns all candidate key fields, enabling composite PK detection
+ * for junction tables like PostTag(postId, tagId).
  */
 function inferPrimaryKeyFromInputObject(
   inputType: IntrospectionType | undefined,
-): IntrospectionInputValue | null {
+): IntrospectionInputValue[] {
   const inputFields = inputType?.inputFields ?? [];
-  if (inputFields.length === 0) return null;
+  if (inputFields.length === 0) return [];
 
   const canonicalKey = inputFields.find(
     (field) =>
       field.name === 'id' || field.name === 'nodeId' || field.name === 'rowId',
   );
-  if (canonicalKey) return canonicalKey;
+  if (canonicalKey) return [canonicalKey];
 
-  const candidates = inputFields.filter((field) => {
+  return inputFields.filter((field) => {
     if (field.name === 'clientMutationId') return false;
 
     const baseTypeName = getBaseTypeName(field.type);
@@ -801,8 +802,6 @@ function inferPrimaryKeyFromInputObject(
 
     return true;
   });
-
-  return candidates.length === 1 ? candidates[0] : null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Two targeted fixes in the ORM codegen introspection pipeline:

**1. Composite primary key detection** (`infer-tables.ts`)
`inferPrimaryKeyFromInputObject` previously returned `null` when multiple candidate key fields existed (e.g., junction table `PostTag` with `postId + tagId`). Now returns **all** candidate fields, enabling composite PK detection. Prefers `DeleteInput` over `UpdateInput` as signal source since it has fewer non-PK fields to filter out.

**2. Plugin filter type-safety** (`input-types-generator.ts`)
`buildTableFilterProperties` previously only generated filter fields from `table.fields` (entity columns), missing plugin-injected fields like `bm25Body`, `tsvTsv`, `trgmName`, `vectorEmbedding`, `geom`, etc. Now uses the schema's `{Entity}Filter` input type from the TypeRegistry as **sole source of truth** when available — same pattern as `buildOrderByValues()`. Adds `collectFilterExtraInputTypes()` to discover custom filter types (e.g., `Bm25BodyFilter`) that need generation.

Both changes are backward compatible: composite PK detection is additive, and filter generation falls back to the existing `table.fields`-based approach when TypeRegistry is absent.

## Review & Testing Checklist for Human

- [ ] **Verify `typeRefToTs` resolves plugin filter types correctly** — the schema path uses `typeRefToTs(field.type)` for ALL filter fields (including `and`/`or`/`not` self-referential types and plugin types like `Bm25BodyFilter`). Confirm the generated TypeScript matches what the old fallback path would produce for standard fields, and that plugin types resolve to valid type names.
- [ ] **Confirm composite PK assumption is safe** — the fix assumes that after filtering out `clientMutationId` and patch fields from `DeleteInput`, ALL remaining fields are PK fields. This is correct for PostGraphile's standard Delete inputs, but verify no plugins inject extra non-PK fields into Delete input types.
- [ ] **Check `hasValidPrimaryKey()` behavior** — it returns `false` for composite keys (`pk.fields.length === 1` check at `utils.ts:456`). This means single-row query hooks still won't generate for junction tables. Verify this is intentional and that the M:N add/remove path doesn't depend on `hasValidPrimaryKey()`.
- [ ] **Run `orm-test` suite against a real schema with plugins** to verify both fixes end-to-end: plugin filter fields appear typed in generated `input-types.ts`, and junction table composite PKs show up in `constraints.primaryKey`.

### Notes
- `inferPrimaryKeyFromInputObject(deleteInput)` is called twice in the ternary on lines 728-730. Minor inefficiency — could cache the result, but not a correctness issue.
- No new tests are included in this PR. The fixes were validated via `pnpm build` (all packages compile). Integration testing against a live schema with plugins would provide stronger confidence.

Link to Devin session: https://app.devin.ai/sessions/745d2d10b699452091e24131ba5edef2
Requested by: @pyramation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/constructive-io/constructive/pull/879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
