### PR TITLE
fix: generate TypeScript types for custom scalar filter types (EmailFilter, ImageFilter, UploadFilter)

### DIFF
--- a/graphql/codegen/src/core/codegen/orm/input-types-generator.ts
+++ b/graphql/codegen/src/core/codegen/orm/input-types-generator.ts
@@ -19,7 +19,7 @@ import type {
   TypeRegistry,
 } from '../../../types/schema';
 import { addJSDocComment, addLineComment, generateCode } from '../babel-ast';
-import { SCALAR_NAMES, scalarToFilterType, scalarToTsType } from '../scalars';
+import { BASE_FILTER_TYPE_NAMES, SCALAR_NAMES, scalarToFilterType, scalarToTsType } from '../scalars';
 import { getTypeBaseName } from '../type-resolver';
 import {
   getCreateInputTypeName,
@@ -2016,20 +2016,15 @@ function collectFilterExtraInputTypes(
       continue;
     }
 
-    const tableFieldNames = new Set(
-      table.fields
-        .filter((f) => !isRelationField(f.name, table))
-        .map((f) => f.name),
-    );
-
     for (const field of filterType.inputFields) {
-      // Skip standard column-derived fields and logical operators
-      if (tableFieldNames.has(field.name)) continue;
+      // Skip logical operators (and/or/not reference the table's own filter type)
       if (['and', 'or', 'not'].includes(field.name)) continue;
 
-      // Collect the base type name of this extra field
+      // Collect any filter type that isn't already generated as a base scalar filter
+      // This catches both plugin-injected fields (bm25Body, tsvTsv) AND regular columns
+      // whose custom scalar types have their own filter types (e.g., ConstructiveInternalTypeEmailFilter)
       const baseName = getTypeBaseName(field.type);
-      if (baseName && !SCALAR_NAMES.has(baseName)) {
+      if (baseName && !SCALAR_NAMES.has(baseName) && !BASE_FILTER_TYPE_NAMES.has(baseName)) {
         extraTypes.add(baseName);
       }
     }


### PR DESCRIPTION
## Summary

Fixes `TS2552: Cannot find name 'ConstructiveInternalTypeEmailFilter'` (and `ImageFilter`, `UploadFilter`) build errors in SDK codegen output.

**Root cause:** `collectFilterExtraInputTypes()` skipped fields matching table column names, assuming only plugin-injected fields could reference non-standard filter types. But regular columns with custom scalar types (e.g., `ConstructiveInternalTypeEmail`) also have custom filter types in the schema (`ConstructiveInternalTypeEmailFilter`) that need TypeScript definitions generated.

**Fix:** Remove the `tableFieldNames` skip. Instead, check ALL filter fields (except `and`/`or`/`not`) and collect any referenced type that isn't a known GraphQL scalar or an already-generated base filter type (`BASE_FILTER_TYPE_NAMES`).

## Review & Testing Checklist for Human

- [ ] **Verify no duplicate type declarations**: Removing the `tableFieldNames` guard means relation-derived filter fields (e.g., `memberByContactId: MemberFilter`) will also be collected. These should be de-duplicated downstream by `tableCrudTypes` in `generateCustomInputTypes`, but verify no duplicate `export type/interface` declarations appear in generated output.
- [ ] **Verify `BASE_FILTER_TYPE_NAMES` covers all `SCALAR_FILTER_CONFIGS` names**: The new guard relies on `BASE_FILTER_TYPE_NAMES` (from `scalars.ts`) to skip already-generated scalar filter types. If any name in `SCALAR_FILTER_CONFIGS` is missing from `BASE_FILTER_TYPE_NAMES`, it would be collected and potentially duplicated.
- [ ] **Test against real schema**: The unit tests (317 pass) use a simple example schema without custom scalar types. Regenerate the SDK for `constructive-db` (admin/migrate/public schemas) to confirm `ConstructiveInternalTypeEmailFilter`, `ConstructiveInternalTypeImageFilter`, and `ConstructiveInternalTypeUploadFilter` are now generated and the build succeeds.

### Notes

- The `collectConditionExtraInputTypes()` function (for condition types) still has the `tableFieldNames` guard. Condition fields for standard columns use raw scalar types (not custom filter types), so the same bug doesn't apply there. However, if custom scalar condition types emerge in the future, the same fix may be needed.

Link to Devin session: https://app.devin.ai/sessions/745d2d10b699452091e24131ba5edef2
Requested by: @pyramation