### PR TITLE
feat: throw error on duplicate module names in workspace

### DIFF
--- a/pgpm/core/src/core/class/pgpm.ts
+++ b/pgpm/core/src/core/class/pgpm.ts
@@ -284,16 +284,29 @@ export class PgpmPackage {
     if (!this.workspacePath || !this.config) return [];
 
     const dirs = this.loadAllowedDirs();
-    const results: PgpmPackage[] = [];
+    const seen = new Map<string, PgpmPackage[]>();
 
     for (const dir of dirs) {
       const proj = new PgpmPackage(dir);
       if (proj.isInModule()) {
-        results.push(proj);
+        const name = proj.getModuleName();
+        if (!seen.has(name)) {
+          seen.set(name, []);
+        }
+        seen.get(name)!.push(proj);
       }
     }
 
-    return results;
+    // Error on duplicate module names, similar to pnpm/yarn workspace duplicate package errors
+    const duplicates = Array.from(seen.entries()).filter(([, projs]) => projs.length > 1);
+    if (duplicates.length > 0) {
+      for (const [name, projs] of duplicates) {
+        const paths = projs.map(p => `    - ${p.cwd}`).join('\n');
+        throw errors.DUPLICATE_MODULE({ name, paths });
+      }
+    }
+
+    return Array.from(seen.values()).map(projs => projs[0]);
   }
 
   /**
@@ -318,17 +331,14 @@ export class PgpmPackage {
       filesByName.get(moduleName)!.push(file);
     });
 
-    // For each module name, pick the shortest path in case of collisions
+    // Error on duplicate module names, similar to pnpm/yarn workspace duplicate package errors
     const selectedFiles = new Map<string, string>();
     filesByName.forEach((files, moduleName) => {
       if (files.length === 1) {
         selectedFiles.set(moduleName, files[0]);
       } else {
-        // Multiple files with same name - pick shortest path
-        const shortestFile = files.reduce((shortest, current) => 
-          current.length < shortest.length ? current : shortest
-        );
-        selectedFiles.set(moduleName, shortestFile);
+        const paths = files.map(f => `    - ${path.dirname(f)}`).join('\n');
+        throw errors.DUPLICATE_MODULE({ name: moduleName, paths });
       }
     });
 

--- a/pgpm/types/src/error-factory.ts
+++ b/pgpm/types/src/error-factory.ts
@@ -145,6 +145,13 @@ export const errors = {
       `${type ? `${type} file` : 'File'} not found: ${filePath}`,
     404
   ),
+
+  DUPLICATE_MODULE: makeError(
+    'DUPLICATE_MODULE',
+    ({ name, paths }: { name: string, paths: string }) =>
+      `Multiple modules share the name "${name}". Each module in a workspace must have a unique name.\n  Found in:\n${paths}`,
+    400
+  ),
 };
 
 // throw errors.MODULE_NOT_FOUND({ name: 'auth' });


### PR DESCRIPTION
## Summary

Adds a `DUPLICATE_MODULE` error that is thrown when multiple modules in a pgpm workspace share the same `.control` file name, similar to how pnpm/yarn workspaces reject duplicate package names.

**Before:** `getModules()` silently returned all duplicates (causing duplicate entries in `pgpm deploy`'s interactive prompt), and `listModules()` silently picked the shortest path.

**After:** Both methods throw a `DUPLICATE_MODULE` error listing the conflicting paths.

Two files changed:
- `pgpm/types/src/error-factory.ts` — new `DUPLICATE_MODULE` error definition
- `pgpm/core/src/core/class/pgpm.ts` — duplicate detection in `getModules()` and `listModules()`

## Review & Testing Checklist for Human

- [ ] **`listModules()` behavior change**: The old code *intentionally* handled naming collisions by picking the shortest path (lines 334-343 before). This PR replaces that with a hard error. Verify this is the desired behavior — any workspace with legitimately duplicated `.control` file names (e.g. nested node_modules, symlinks) will now fail instead of deduplicating gracefully.
- [ ] **Breaking change scope**: Any existing workspace that has duplicate module names will start failing on any command that calls `getModules()` or `listModules()`. Confirm no existing workspaces besides agentic-db are affected, or that this is acceptable.
- [ ] **`getModuleName()` reliability in `getModules()`**: The new code calls `proj.getModuleName()` on each `PgpmPackage` instance. Verify this works correctly for all module types (the original code didn't need the module name, just `isInModule()`).
- [ ] **No unit tests added** — consider whether test coverage for the new error path is needed.
- [ ] **Test manually**: Set up a workspace with two directories containing `.control` files that share the same base name, run `pgpm deploy`, and confirm the error message is clear and actionable.

### Notes
- Only the first duplicate group triggers the error (the `for` loop throws immediately). Users with multiple duplicate groups will need to fix them one at a time.
- The error uses HTTP code 400 consistent with other validation errors in the factory.

Link to Devin session: https://app.devin.ai/sessions/c26111a26a9a44f891534104a809dcdb
Requested by: @pyramation