### PR TITLE
fix(graphql-codegen): re-export input types from generated ORM index

### DIFF
--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/client-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/client-generator.test.ts.snap
@@ -15,6 +15,7 @@ export { GraphQLRequestError } from "./client";
 export { QueryBuilder } from "./query-builder";
 export * from "./select-types";
 export * from "./models";
+export * from "./types";
 /**
  * Create an ORM client instance
  *
@@ -63,6 +64,7 @@ export { GraphQLRequestError } from "./client";
 export { QueryBuilder } from "./query-builder";
 export * from "./select-types";
 export * from "./models";
+export * from "./types";
 export { createQueryOperations } from "./query";
 export { createMutationOperations } from "./mutation";
 /**

--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/client-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/client-generator.test.ts.snap
@@ -16,6 +16,7 @@ export { QueryBuilder } from "./query-builder";
 export * from "./select-types";
 export * from "./models";
 export * from "./types";
+export type { ConnectionResult, PageInfo } from "./select-types";
 /**
  * Create an ORM client instance
  *
@@ -65,6 +66,7 @@ export { QueryBuilder } from "./query-builder";
 export * from "./select-types";
 export * from "./models";
 export * from "./types";
+export type { ConnectionResult, PageInfo } from "./select-types";
 export { createQueryOperations } from "./query";
 export { createMutationOperations } from "./mutation";
 /**

--- a/graphql/codegen/src/core/codegen/orm/client-generator.ts
+++ b/graphql/codegen/src/core/codegen/orm/client-generator.ts
@@ -219,6 +219,25 @@ export function generateCreateClientFile(
   // Re-export all input types (SecureTableProvision, RelationProvision, Blueprint, etc.)
   statements.push(t.exportAllDeclaration(t.stringLiteral('./types')));
 
+  // Explicitly resolve ambiguity for types exported by both select-types and types/input-types
+  // (ConnectionResult, PageInfo are defined in both — prefer the select-types versions)
+  const ambiguousTypeExport = t.exportNamedDeclaration(
+    null,
+    [
+      t.exportSpecifier(
+        t.identifier('ConnectionResult'),
+        t.identifier('ConnectionResult'),
+      ),
+      t.exportSpecifier(
+        t.identifier('PageInfo'),
+        t.identifier('PageInfo'),
+      ),
+    ],
+    t.stringLiteral('./select-types'),
+  );
+  ambiguousTypeExport.exportKind = 'type';
+  statements.push(ambiguousTypeExport);
+
   // Re-export NodeHttpAdapter when enabled (for use in any Node.js application)
   if (options?.nodeHttpAdapter) {
     statements.push(

--- a/graphql/codegen/src/core/codegen/orm/client-generator.ts
+++ b/graphql/codegen/src/core/codegen/orm/client-generator.ts
@@ -216,6 +216,9 @@ export function generateCreateClientFile(
   // Re-export all models
   statements.push(t.exportAllDeclaration(t.stringLiteral('./models')));
 
+  // Re-export all input types (SecureTableProvision, RelationProvision, Blueprint, etc.)
+  statements.push(t.exportAllDeclaration(t.stringLiteral('./types')));
+
   // Re-export NodeHttpAdapter when enabled (for use in any Node.js application)
   if (options?.nodeHttpAdapter) {
     statements.push(


### PR DESCRIPTION
## Summary

The generated ORM `index.ts` was missing `export * from './types'`, which meant input types like `SecureTableProvision`, `RelationProvision`, `Blueprint`, `Field`, `Index`, `Policy`, `FullTextSearch`, etc. were **not accessible** through the SDK's public namespace.

Previously, only `select-types` and `models` were re-exported from the ORM index. The `types.ts` barrel (which chains to `input-types.ts` via `export * from './input-types'`) was generated but never wired into the index — so consumers couldn't do:

```typescript
import type { public_ } from '@constructive-io/sdk';
type STP = public_.SecureTableProvision; // ❌ TS2724: has no exported member
```

### Changes
- `client-generator.ts`: Added `export * from './types'` to the generated ORM `index.ts`
- Added explicit `export type { ConnectionResult, PageInfo } from './select-types'` to resolve TS2308 ambiguity (both `select-types` and `input-types` define these interfaces; the explicit re-export tells TypeScript to prefer the `select-types` versions)
- Updated 2 test snapshots to match

### Name collision fix

A naive `export * from './types'` causes TS2308 errors because `ConnectionResult` and `PageInfo` are defined in both `select-types.ts` (template) and `input-types.ts` (generated from schema). TypeScript's recommended resolution is an explicit named re-export, which is what this PR adds. Verified locally against `@constructive-io/sdk@0.11.1` — `tsc --noEmit` passes cleanly on a downstream consumer after patching.

## Review & Testing Checklist for Human

- [ ] **Check for additional name collisions**: Only `ConnectionResult` and `PageInfo` were found to conflict between `select-types` and `input-types`. After regenerating the SDK, run `tsc --noEmit` on a downstream consumer (e.g. `agentic-db`) to confirm no other names clash. The check was done against SDK 0.11.1 — a fresh regeneration may surface new conflicts if types were added since.
- [ ] **Regenerate + publish**: After merging, regenerate the SDK and verify that `import type { public_ } from '@constructive-io/sdk'; type T = public_.SecureTableProvision;` compiles cleanly.
- [ ] **Verify `input-types` standalone usage**: Confirm that files importing directly from `./input-types` (e.g. model files, custom-ops) still compile, since `ConnectionResult`/`PageInfo` remain declared there (just also explicitly re-exported from `select-types` in the index).

### Notes
- The `types.ts` barrel file was already being generated by `generateTypesBarrel()` in `barrel.ts` — it just was never re-exported from the ORM `index.ts`. This fix wires it in.
- Downstream consumer (`agentic-db`) is blocked on this fix to replace hand-rolled type definitions with SDK imports.

Link to Devin session: https://app.devin.ai/sessions/ce1b2dafd42341bea5d7793b0c05ba6c
Requested by: @pyramation