### PR TITLE
fix: revert type re-exports from ORM indexes, restore migrate-client entry point

### DIFF
--- a/sdk/constructive-cli/src/admin/orm/index.ts
+++ b/sdk/constructive-cli/src/admin/orm/index.ts
@@ -44,8 +44,6 @@ export { GraphQLRequestError } from './client';
 export { QueryBuilder } from './query-builder';
 export * from './select-types';
 export * from './models';
-export * from './types';
-export type { ConnectionResult, PageInfo } from './select-types';
 export { NodeHttpAdapter } from './node-fetch';
 export { createQueryOperations } from './query';
 export { createMutationOperations } from './mutation';

--- a/sdk/constructive-cli/src/auth/orm/index.ts
+++ b/sdk/constructive-cli/src/auth/orm/index.ts
@@ -19,8 +19,6 @@ export { GraphQLRequestError } from './client';
 export { QueryBuilder } from './query-builder';
 export * from './select-types';
 export * from './models';
-export * from './types';
-export type { ConnectionResult, PageInfo } from './select-types';
 export { NodeHttpAdapter } from './node-fetch';
 export { createQueryOperations } from './query';
 export { createMutationOperations } from './mutation';

--- a/sdk/constructive-cli/src/objects/orm/index.ts
+++ b/sdk/constructive-cli/src/objects/orm/index.ts
@@ -17,8 +17,6 @@ export { GraphQLRequestError } from './client';
 export { QueryBuilder } from './query-builder';
 export * from './select-types';
 export * from './models';
-export * from './types';
-export type { ConnectionResult, PageInfo } from './select-types';
 export { NodeHttpAdapter } from './node-fetch';
 export { createQueryOperations } from './query';
 export { createMutationOperations } from './mutation';

--- a/sdk/constructive-cli/src/public/orm/index.ts
+++ b/sdk/constructive-cli/src/public/orm/index.ts
@@ -119,8 +119,6 @@ export { GraphQLRequestError } from './client';
 export { QueryBuilder } from './query-builder';
 export * from './select-types';
 export * from './models';
-export * from './types';
-export type { ConnectionResult, PageInfo } from './select-types';
 export { NodeHttpAdapter } from './node-fetch';
 export { createQueryOperations } from './query';
 export { createMutationOperations } from './mutation';

--- a/sdk/constructive-react/src/admin/orm/index.ts
+++ b/sdk/constructive-react/src/admin/orm/index.ts
@@ -44,8 +44,6 @@ export { GraphQLRequestError } from './client';
 export { QueryBuilder } from './query-builder';
 export * from './select-types';
 export * from './models';
-export * from './types';
-export type { ConnectionResult, PageInfo } from './select-types';
 export { createQueryOperations } from './query';
 export { createMutationOperations } from './mutation';
 /**

--- a/sdk/constructive-react/src/auth/orm/index.ts
+++ b/sdk/constructive-react/src/auth/orm/index.ts
@@ -19,8 +19,6 @@ export { GraphQLRequestError } from './client';
 export { QueryBuilder } from './query-builder';
 export * from './select-types';
 export * from './models';
-export * from './types';
-export type { ConnectionResult, PageInfo } from './select-types';
 export { createQueryOperations } from './query';
 export { createMutationOperations } from './mutation';
 /**

--- a/sdk/constructive-react/src/objects/orm/index.ts
+++ b/sdk/constructive-react/src/objects/orm/index.ts
@@ -17,8 +17,6 @@ export { GraphQLRequestError } from './client';
 export { QueryBuilder } from './query-builder';
 export * from './select-types';
 export * from './models';
-export * from './types';
-export type { ConnectionResult, PageInfo } from './select-types';
 export { createQueryOperations } from './query';
 export { createMutationOperations } from './mutation';
 /**

--- a/sdk/constructive-react/src/public/orm/index.ts
+++ b/sdk/constructive-react/src/public/orm/index.ts
@@ -119,8 +119,6 @@ export { GraphQLRequestError } from './client';
 export { QueryBuilder } from './query-builder';
 export * from './select-types';
 export * from './models';
-export * from './types';
-export type { ConnectionResult, PageInfo } from './select-types';
 export { createQueryOperations } from './query';
 export { createMutationOperations } from './mutation';
 /**

--- a/sdk/migrate-client/src/index.ts
+++ b/sdk/migrate-client/src/index.ts
@@ -1,0 +1,1 @@
+export * from './migrate';

--- a/sdk/migrate-client/src/migrate/orm/index.ts
+++ b/sdk/migrate-client/src/migrate/orm/index.ts
@@ -13,8 +13,6 @@ export { GraphQLRequestError } from './client';
 export { QueryBuilder } from './query-builder';
 export * from './select-types';
 export * from './models';
-export * from './types';
-export type { ConnectionResult, PageInfo } from './select-types';
 export { createMutationOperations } from './mutation';
 /**
  * Create an ORM client instance


### PR DESCRIPTION
## Summary

The previous revert of commit `d0c5a9f74` ("types") only fixed the **codegen template** but missed two things:

1. **9 already-generated ORM index files** still had `export * from './types'` and `export type { ConnectionResult, PageInfo } from './select-types'` — causing ~80+ TS2308 name collision errors at build time
2. **`sdk/migrate-client/src/index.ts`** was deleted in that same commit and never restored — causing `tsc` to fail with "No inputs were found in config file"

This PR removes the leftover `export * from './types'` lines from all 9 generated ORM index files (`constructive-cli`, `constructive-react`, `migrate-client`) and restores the deleted `migrate-client` entry point.

## Review & Testing Checklist for Human

- [ ] Run `pnpm build` from repo root — should complete with zero errors (previously failed on `sdk/migrate-client` and any package importing from ORM barrels)
- [ ] Verify the codegen template (`graphql/codegen/src/core/codegen/orm/client-generator.ts`) does NOT contain `export * from './types'` — this was fixed in a prior revert and is not part of this diff, but confirms future regenerations will be correct
- [ ] Spot-check that `sdk/migrate-client/src/index.ts` content (`export * from './migrate'`) matches what existed before `d0c5a9f74`

### Notes

- The `export * from './types'` approach was fundamentally broken: `input-types.ts` contains 2000+ generated types that collide with names in `select-types.ts` and shared hooks types. This cannot be fixed with explicit re-exports at scale.
- The `types.ts` barrel file still exists in each ORM directory and remains importable directly — it's just not re-exported through the main ORM index to avoid collisions.
- These are generated files, but the codegen template was already corrected, so future regenerations will not reintroduce these lines.

Link to Devin session: https://app.devin.ai/sessions/ce1b2dafd42341bea5d7793b0c05ba6c
Requested by: @pyramation