### PR TITLE
fix(codegen): preserve migrate-client src/index.ts during regeneration

### DIFF
--- a/sdk/constructive-sdk/package.json
+++ b/sdk/constructive-sdk/package.json
@@ -26,7 +26,7 @@
     "build:dev": "makage build --dev",
     "pregenerate": "rimraf src/admin src/auth src/objects src/public src/index.ts",
     "generate": "pnpm run pregenerate && tsx scripts/generate-sdk.ts",
-    "pregenerate:migrate-client": "rimraf ../migrate-client/src/migrate ../migrate-client/src/index.ts",
+    "pregenerate:migrate-client": "rimraf ../migrate-client/src/migrate",
     "generate:migrate-client": "pnpm run pregenerate:migrate-client && tsx scripts/generate-migrate-client.ts",
     "lint": "eslint . --fix",
     "test": "jest --passWithNoTests",

--- a/sdk/constructive-sdk/scripts/generate-migrate-client.ts
+++ b/sdk/constructive-sdk/scripts/generate-migrate-client.ts
@@ -6,6 +6,8 @@
  * so that migrate-client itself has zero codegen dependency — avoiding
  * circular deps when pgpm/core imports @pgpmjs/migrate-client.
  */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import {
   generateMulti,
   expandSchemaDirToMultiTarget,
@@ -63,6 +65,19 @@ async function main() {
   if (realError) {
     console.error('\nGeneration failed');
     process.exit(1);
+  }
+
+  // generateMulti only writes a root barrel when there are multiple targets.
+  // migrate-client has a single target ("migrate"), so we must write
+  // src/index.ts ourselves to keep the package entry-point intact.
+  const successfulNames = results.filter((r) => r.result.success).map((r) => r.name);
+  if (successfulNames.length > 0) {
+    const indexPath = path.resolve(OUTPUT_DIR, 'index.ts');
+    const barrel = successfulNames
+      .map((name) => `export * from './${name}';`)
+      .join('\n');
+    fs.writeFileSync(indexPath, barrel + '\n', 'utf-8');
+    console.log(`Wrote root barrel: ${indexPath}`);
   }
 
   console.log('\nMigrate-client ORM generation completed successfully!');


### PR DESCRIPTION
## Summary

The `pregenerate:migrate-client` script was deleting `src/index.ts` alongside the generated `src/migrate/` directory. Since `generateMulti` only writes a root barrel when there are **multiple** targets, the single-target migrate-client never got its `index.ts` regenerated — breaking any consumer that imports `@pgpmjs/migrate-client` (e.g. `pgpm/export`).

This is the root cause of the build failure in [PR #904](https://github.com/constructive-io/constructive/pull/904):
```
pgpm/export build: src/export-graphql.ts(13,30): error TS2307: Cannot find module '@pgpmjs/migrate-client'
```

**Two changes:**
1. **`package.json`**: Remove `../migrate-client/src/index.ts` from the `pregenerate:migrate-client` rimraf — it's the hand-written package entry point, not generated output.
2. **`generate-migrate-client.ts`**: Write the root barrel (`export * from './migrate'`) after codegen as a safety net, matching what `generateMulti` does for multi-target outputs.

## Review & Testing Checklist for Human

- [ ] **Verify `path.resolve(OUTPUT_DIR, 'index.ts')` resolves correctly**: `OUTPUT_DIR` is `'../migrate-client/src'` (relative). The script runs via pnpm from `sdk/constructive-sdk/`, so it should resolve to `sdk/migrate-client/src/index.ts`. Confirm this is correct in the CI environment.
- [ ] **Re-run schema propagation (PR #904) after merging** to confirm `pgpm/export` builds successfully with the regenerated migrate-client.
- [ ] **Consider whether `generateMulti` should also handle the single-target case** in the codegen core (line 831 of `generate.ts`: `if (names.length > 1)`). This PR fixes the symptom for migrate-client specifically, but any future single-target codegen consumer would hit the same issue.

### Notes
- The barrel content is trivially `export * from './migrate';\n` — matching the existing `src/index.ts` that was being deleted.
- `pnpm build` passes locally across the full workspace with this change.

Link to Devin session: https://app.devin.ai/sessions/6c7e6bf137a34786827fc77a43a7a84a
Requested by: @pyramation