### PR TITLE
feat(pgpm): add --shm-size flag to docker start (default 2g)

### DIFF
--- a/pgpm/cli/src/commands/docker.ts
+++ b/pgpm/cli/src/commands/docker.ts
@@ -19,11 +19,13 @@ Options:
   --port <port>      Host port mapping (default: 5432)
   --user <user>      PostgreSQL user (default: postgres)
   --password <pass>  PostgreSQL password (default: password)
+  --shm-size <size>  Shared memory size for container (default: 2g)
   --recreate         Remove and recreate container on start
 
 Examples:
   pgpm docker start                           Start default PostgreSQL container
   pgpm docker start --port 5433               Start on custom port
+  pgpm docker start --shm-size 4g             Start with 4GB shared memory
   pgpm docker start --recreate                Remove and recreate container
   pgpm docker stop                            Stop PostgreSQL container
 `;
@@ -34,6 +36,7 @@ interface DockerRunOptions {
   port: number;
   user: string;
   password: string;
+  shmSize: string;
   recreate?: boolean;
 }
 
@@ -106,7 +109,7 @@ async function containerExists(name: string): Promise<boolean> {
 }
 
 async function startContainer(options: DockerRunOptions): Promise<void> {
-  const { name, image, port, user, password, recreate } = options;
+  const { name, image, port, user, password, shmSize, recreate } = options;
 
   const dockerAvailable = await checkDockerAvailable();
   if (!dockerAvailable) {
@@ -147,6 +150,7 @@ async function startContainer(options: DockerRunOptions): Promise<void> {
     'run',
     '-d',
     '--name', name,
+    '--shm-size', shmSize,
     '-e', `POSTGRES_USER=${user}`,
     '-e', `POSTGRES_PASSWORD=${password}`,
     '-p', `${port}:5432`,
@@ -215,11 +219,12 @@ export default async (
   const port = typeof args.port === 'number' ? args.port : 5432;
   const user = (args.user as string) || 'postgres';
   const password = (args.password as string) || 'password';
+  const shmSize = (args['shm-size'] as string) || (args.shmSize as string) || '2g';
   const recreate = args.recreate === true;
 
   switch (subcommand) {
   case 'start':
-    await startContainer({ name, image, port, user, password, recreate });
+    await startContainer({ name, image, port, user, password, shmSize, recreate });
     break;
 
   case 'stop':


### PR DESCRIPTION
## Summary

Adds a `--shm-size` CLI flag to `pgpm docker start` with a default of `2g`. Docker's default shared memory allocation is 64MB, which causes PostgreSQL to fail with `could not resize shared memory segment: No space left on device` during bulk `COPY` operations — particularly when restoring large vector embedding data (768-dimensional arrays).

The flag is passed through to `docker run --shm-size` and can be overridden (e.g. `pgpm docker start --shm-size 4g`).

## Review & Testing Checklist for Human

- [ ] **Verify arg parsing for hyphenated flag**: The code checks both `args['shm-size']` and `args.shmSize` — confirm which key the `inquirerer` argv parser actually produces for `--shm-size`, and that a user-provided value actually overrides the `2g` default rather than silently falling through.
- [ ] **Existing stopped containers won't pick up the new shm_size** — `--shm-size` is only passed to `docker run` (new container path, line 150), not `docker start` (existing container path, line 136). Users with an existing container need `--recreate` to benefit. Consider whether this should be documented or handled differently.
- [ ] **2g default on low-memory machines**: The default bumps from 64MB to 2GB. This is shared memory allocation, not actual RAM usage, but verify this is reasonable for typical dev machines.

Suggested test plan:
1. `pgpm docker start --recreate` → verify `docker inspect postgres | grep ShmSize` shows `2147483648` (2GB)
2. `pgpm docker start --shm-size 512m --recreate` → verify the override works
3. Attempt a bulk `pg_restore --data-only` with vector embedding data to confirm the original error is resolved

### Notes

- This is a behavioral change: new containers will now get 2GB shm by default instead of Docker's 64MB. This is intentional — 64MB is insufficient for non-trivial PostgreSQL workloads.
- No input validation is added for the `--shm-size` value; Docker itself will reject invalid values with a clear error message.

Link to Devin session: https://app.devin.ai/sessions/ddfef2717ea945a8b0076a98dbcc5264
Requested by: @pyramation