### PR TITLE
fix(node-type-registry): BlueprintField uses is_required, not is_not_null

### DIFF
--- a/graphile/node-type-registry/src/blueprint-types.generated.ts
+++ b/graphile/node-type-registry/src/blueprint-types.generated.ts
@@ -654,7 +654,7 @@ export interface BlueprintField {
   /** The PostgreSQL type (e.g., "text", "integer", "boolean", "uuid"). */
   type: string;
   /** Whether the column has a NOT NULL constraint. */
-  is_not_null?: boolean;
+  is_required?: boolean;
   /** SQL default value expression (e.g., "true", "now()"). */
   default_value?: string;
   /** Comment/description for this field. */

--- a/graphile/node-type-registry/src/codegen/generate-types.ts
+++ b/graphile/node-type-registry/src/codegen/generate-types.ts
@@ -206,7 +206,7 @@ function buildBlueprintField(): t.ExportNamedDeclaration {
         'The PostgreSQL type (e.g., "text", "integer", "boolean", "uuid").'
       ),
       addJSDoc(
-        optionalProp('is_not_null', t.tsBooleanKeyword()),
+        optionalProp('is_required', t.tsBooleanKeyword()),
         'Whether the column has a NOT NULL constraint.'
       ),
       addJSDoc(


### PR DESCRIPTION
## Summary

Fixes the `BlueprintField` generated type to use `is_required` instead of `is_not_null` for the NOT NULL constraint flag.

The `construct_blueprint()` SQL function passes field JSONB objects directly into `secure_table_provision`, which reads the `"is_required"` key (per its column comment). The `metaschema_public.field` table also uses `is_required`. The `is_not_null` name only exists in the low-level PostgreSQL AST package (`ColumnDef` parse tree nodes) — a completely different layer.

**Changes:**
- `generate-types.ts`: `optionalProp('is_not_null', ...)` → `optionalProp('is_required', ...)`
- `blueprint-types.generated.ts`: regenerated (single field rename)

## Review & Testing Checklist for Human

- [ ] Confirm that `construct_blueprint()` and `secure_table_provision` read `is_required` (not `is_not_null`) from field JSONB — check the column comment on `secure_table_provision.fields` and the `metaschema.create_field()` function
- [ ] If any downstream consumer (e.g. agentic-db) already adopted `is_not_null` from the previous publish, those will need updating too

### Notes
- Companion fix needed in agentic-db PR #41 which renamed `is_required` → `is_not_null` based on the incorrect generated type

Link to Devin session: https://app.devin.ai/sessions/ce1b2dafd42341bea5d7793b0c05ba6c
Requested by: @pyramation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/constructive-io/constructive/pull/910" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
