### PR TITLE
feat(graphile-schema): add buildIntrospectionJSON() for database metadata export

### DIFF
--- a/graphile/graphile-schema/src/build-introspection.ts
+++ b/graphile/graphile-schema/src/build-introspection.ts
@@ -1,0 +1,36 @@
+import type { TableMeta } from 'graphile-settings'
+import { _cachedTablesMeta } from 'graphile-settings'
+import { buildSchemaSDL } from './build-schema'
+import type { BuildSchemaOptions } from './build-schema'
+
+export type { BuildSchemaOptions as BuildIntrospectionOptions }
+
+/**
+ * Build introspection metadata for all tables visible in the given schemas.
+ *
+ * Internally calls `buildSchemaSDL()` which triggers the MetaSchemaPlugin
+ * gather hook, populating `_cachedTablesMeta` as a side-effect. The cached
+ * metadata is then returned as a plain array of `TableMeta` objects.
+ *
+ * The result includes every table's fields, types, constraints, indexes,
+ * relations, inflection names, and query entry-points — the same data
+ * exposed by the `_meta` GraphQL query at runtime.
+ *
+ * @example
+ * ```ts
+ * import { buildIntrospectionJSON } from 'graphile-schema';
+ * import fs from 'fs';
+ *
+ * const tables = await buildIntrospectionJSON({
+ *   database: 'my_db',
+ *   schemas: ['public', 'app_public'],
+ * });
+ * fs.writeFileSync('introspection.json', JSON.stringify(tables, null, 2));
+ * ```
+ */
+export async function buildIntrospectionJSON(
+  opts: BuildSchemaOptions
+): Promise<TableMeta[]> {
+  await buildSchemaSDL(opts)
+  return [..._cachedTablesMeta]
+}

--- a/graphile/graphile-schema/src/index.ts
+++ b/graphile/graphile-schema/src/index.ts
@@ -1,5 +1,22 @@
 export { buildSchemaSDL } from './build-schema';
 export type { BuildSchemaOptions } from './build-schema';
+export { buildIntrospectionJSON } from './build-introspection';
 export { _cachedTablesMeta } from 'graphile-settings';
+export type {
+  TableMeta,
+  FieldMeta,
+  TypeMeta,
+  IndexMeta,
+  ConstraintsMeta,
+  PrimaryKeyConstraintMeta,
+  UniqueConstraintMeta,
+  ForeignKeyConstraintMeta,
+  RelationsMeta,
+  BelongsToRelation,
+  HasRelation,
+  ManyToManyRelation,
+  InflectionMeta,
+  QueryMeta,
+} from 'graphile-settings';
 export { fetchEndpointSchemaSDL } from './fetch-endpoint-schema';
 export type { FetchEndpointSchemaOptions } from './fetch-endpoint-schema';

--- a/graphile/graphile-settings/src/plugins/index.ts
+++ b/graphile/graphile-settings/src/plugins/index.ts
@@ -54,6 +54,22 @@ export {
   MetaSchemaPlugin,
   MetaSchemaPreset,
 } from './meta-schema';
+export type {
+  TableMeta,
+  FieldMeta,
+  TypeMeta,
+  IndexMeta,
+  ConstraintsMeta,
+  PrimaryKeyConstraintMeta,
+  UniqueConstraintMeta,
+  ForeignKeyConstraintMeta,
+  RelationsMeta,
+  BelongsToRelation,
+  HasRelation,
+  ManyToManyRelation,
+  InflectionMeta,
+  QueryMeta,
+} from './meta-schema/types';
 
 // PG type mappings for custom PostgreSQL types (email, url, etc.)
 export {


### PR DESCRIPTION
## Summary

Adds `buildIntrospectionJSON()` to `graphile-schema` — a thin wrapper around `buildSchemaSDL()` that returns the `TableMeta[]` array populated by `MetaSchemaPlugin` during the schema build. This enables downstream consumers (e.g. `constructive-db`'s `generate:schemas` pipeline) to export structured introspection JSON alongside `.graphql` SDL files, which can then drive blueprint type codegen instead of hand-coding structural types.

**Changes:**
- **New file** `graphile-schema/src/build-introspection.ts` — `buildIntrospectionJSON(opts)` calls `buildSchemaSDL`, then returns a shallow copy of `_cachedTablesMeta`
- **`graphile-settings/src/plugins/index.ts`** — re-exports all 14 meta-schema types (`TableMeta`, `FieldMeta`, `TypeMeta`, etc.)
- **`graphile-schema/src/index.ts`** — re-exports `buildIntrospectionJSON` + all meta-schema types from `graphile-settings`

## Review & Testing Checklist for Human

- [ ] **Side-effect reliance**: `buildIntrospectionJSON` depends on `buildSchemaSDL` populating the module-level `_cachedTablesMeta` as a side-effect. Verify this is acceptable for your use case (concurrent calls would clobber the shared cache). Only a shallow copy is returned — mutations to nested objects would affect the cache.
- [ ] **Type completeness**: Confirm all types from `meta-schema/types.ts` that downstream consumers need are included in the 14 re-exported types. If the types file has additional exports (sub-types of `QueryMeta`, etc.), they may need to be added later.
- [ ] **No tests included**: This PR has no unit tests for `buildIntrospectionJSON`. Consider whether a test (even a smoke test verifying the function returns a non-empty array against a test database) should be added before or after merge.

### Notes
- This is the first half of a two-repo effort. The follow-up PR on `constructive-db` will call `buildIntrospectionJSON()` in `generate-schemas.ts` and write the result to `introspection.json`, which `generate-types.ts` will then consume to derive blueprint structural types.
- `BuildIntrospectionOptions` is a type alias for the existing `BuildSchemaOptions` — introduced for API clarity so callers don't need to know the SDL function is involved.

Link to Devin session: https://app.devin.ai/sessions/ce1b2dafd42341bea5d7793b0c05ba6c
Requested by: @pyramation