### PR TITLE
feat(node-type-registry): fully procedural structural type derivation from introspection JSON

### DIFF
--- a/graphile/node-type-registry/src/codegen/generate-types.ts
+++ b/graphile/node-type-registry/src/codegen/generate-types.ts
@@ -329,7 +329,7 @@ function findTable(
   schemaName: string,
   tableName: string
 ): IntrospectionTableMeta | undefined {
-  return tables.find((t) => t.schemaName === schemaName && t.name === tableName);
+  return tables.find((tbl) => tbl.schemaName === schemaName && tbl.name === tableName);
 }
 
 function buildBlueprintField(

--- a/graphile/node-type-registry/src/codegen/generate-types.ts
+++ b/graphile/node-type-registry/src/codegen/generate-types.ts
@@ -14,19 +14,38 @@
  * when building blueprint JSON.  The API itself accepts plain JSONB.
  *
  * Usage:
- *   npx ts-node src/codegen/generate-types.ts [--outdir <dir>]
+ *   npx ts-node src/codegen/generate-types.ts [--outdir <dir>] [--introspection <path>]
  */
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const generate = require('@babel/generator').default ?? require('@babel/generator');
 import * as t from '@babel/types';
-import { writeFileSync, mkdirSync, existsSync } from 'fs';
+import { writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import { generateTypeScriptTypes } from 'schema-typescript';
 import type { JSONSchema as SchemaTS_JSONSchema } from 'schema-typescript';
 
 import { allNodeTypes } from '../index';
 import type { NodeTypeDefinition } from '../types';
+
+// ---------------------------------------------------------------------------
+// Introspection types (subset of TableMeta from graphile-settings)
+// ---------------------------------------------------------------------------
+
+interface IntrospectionFieldMeta {
+  name: string;
+  type: { pgType: string; gqlType: string; isArray: boolean };
+  isNotNull: boolean;
+  hasDefault: boolean;
+}
+
+interface IntrospectionTableMeta {
+  name: string;
+  schemaName: string;
+  fields: IntrospectionFieldMeta[];
+  primaryKeyConstraints: { fields: { name: string }[] }[];
+  foreignKeyConstraints: { fields: { name: string }[] }[];
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -194,68 +213,203 @@ function generateParamsInterfaces(
 }
 
 // ---------------------------------------------------------------------------
-// Static structural types (BlueprintField, BlueprintPolicy, etc.)
+// Introspection-driven structural type derivation
 // ---------------------------------------------------------------------------
 
-function buildBlueprintField(): t.ExportNamedDeclaration {
+/** Map PostgreSQL type names to TypeScript type annotations. */
+function pgTypeToTSType(pgType: string, isArray: boolean): t.TSType {
+  let base: t.TSType;
+  switch (pgType) {
+    case 'bool':
+    case 'boolean':
+      base = t.tsBooleanKeyword();
+      break;
+    case 'int2':
+    case 'int4':
+    case 'int8':
+    case 'integer':
+    case 'smallint':
+    case 'bigint':
+    case 'float4':
+    case 'float8':
+    case 'float':
+    case 'double precision':
+    case 'numeric':
+    case 'real':
+      base = t.tsNumberKeyword();
+      break;
+    case 'jsonb':
+    case 'json':
+      base = recordType(t.tsStringKeyword(), t.tsUnknownKeyword());
+      break;
+    default:
+      base = t.tsStringKeyword();
+      break;
+  }
+  return isArray ? t.tsArrayType(base) : base;
+}
+
+/**
+ * Columns to exclude when deriving structural types from introspection.
+ * These are internal DB columns, not part of the blueprint JSONB input.
+ */
+const INTERNAL_COLUMNS = new Set([
+  'id',
+  'database_id',
+  'table_id',
+  'schema_id',
+  'field_id',
+  'field_ids',
+  'out_fields',
+  'smart_tags',
+  'category',
+  'module',
+  'scope',
+  'tags',
+  'include_field_ids',
+  'field_order',
+  'disabled',
+  'chk',
+  'chk_expr',
+  'default_value_ast',
+]);
+
+/** Derive a TS interface from an introspection table's columns. */
+function deriveInterfaceFromTable(
+  table: IntrospectionTableMeta,
+  interfaceName: string,
+  description: string,
+  overrides?: Record<string, { tsType?: t.TSType; doc?: string; optional?: boolean; required?: boolean }>
+): t.ExportNamedDeclaration {
+  const pkFields = new Set(
+    table.primaryKeyConstraints.flatMap((pk) => pk.fields.map((f) => f.name))
+  );
+  const fkFields = new Set(
+    table.foreignKeyConstraints.flatMap((fk) => fk.fields.map((f) => f.name))
+  );
+
+  const members: t.TSTypeElement[] = [];
+
+  for (const field of table.fields) {
+    // Skip internal columns
+    if (INTERNAL_COLUMNS.has(field.name)) continue;
+    if (pkFields.has(field.name)) continue;
+    if (fkFields.has(field.name)) continue;
+
+    const override = overrides?.[field.name];
+
+    const tsType = override?.tsType ?? pgTypeToTSType(field.type.pgType, field.type.isArray);
+    const doc = override?.doc ?? `Derived from ${table.schemaName}.${table.name}.${field.name} (${field.type.pgType}).`;
+
+    // Determine optionality: required if NOT NULL and no default, unless overridden
+    let isRequired: boolean;
+    if (override?.optional !== undefined) {
+      isRequired = !override.optional;
+    } else if (override?.required !== undefined) {
+      isRequired = override.required;
+    } else {
+      isRequired = field.isNotNull && !field.hasDefault;
+    }
+
+    const prop = isRequired
+      ? requiredProp(field.name, tsType)
+      : optionalProp(field.name, tsType);
+    members.push(addJSDoc(prop, doc));
+  }
+
+  return addJSDoc(exportInterface(interfaceName, members), description);
+}
+
+// ---------------------------------------------------------------------------
+// Structural types — introspection-driven or static fallback
+// ---------------------------------------------------------------------------
+
+function findTable(
+  tables: IntrospectionTableMeta[],
+  schemaName: string,
+  tableName: string
+): IntrospectionTableMeta | undefined {
+  return tables.find((t) => t.schemaName === schemaName && t.name === tableName);
+}
+
+function buildBlueprintField(
+  introspection?: IntrospectionTableMeta[]
+): t.ExportNamedDeclaration {
+  const table = introspection && findTable(introspection, 'metaschema_public', 'field');
+  if (table) {
+    return deriveInterfaceFromTable(
+      table,
+      'BlueprintField',
+      'A custom field (column) to add to a blueprint table. Derived from metaschema_public.field.',
+      {
+        name: { required: true, doc: 'The column name.' },
+        type: { required: true, doc: 'The PostgreSQL type (e.g., "text", "integer", "boolean", "uuid").' },
+        is_required: { optional: true, doc: 'Whether the column has a NOT NULL constraint.' },
+        default_value: { optional: true, doc: 'SQL default value expression (e.g., "true", "now()").' },
+        description: { optional: true, doc: 'Comment/description for this field.' },
+        label: { optional: true, doc: 'Display label for this field.' },
+        api_required: { optional: true, doc: 'Whether the field is required in the API (enforced at GraphQL level).' },
+        min: { optional: true, doc: 'Minimum value constraint (character_length for text, value for numbers).' },
+        max: { optional: true, doc: 'Maximum value constraint (character_length for text, value for numbers).' },
+        regexp: { optional: true, doc: 'Regex pattern CHECK constraint for text/citext fields.' },
+      }
+    );
+  }
+  // Static fallback
   return addJSDoc(
     exportInterface('BlueprintField', [
       addJSDoc(requiredProp('name', t.tsStringKeyword()), 'The column name.'),
-      addJSDoc(
-        requiredProp('type', t.tsStringKeyword()),
-        'The PostgreSQL type (e.g., "text", "integer", "boolean", "uuid").'
-      ),
-      addJSDoc(
-        optionalProp('is_not_null', t.tsBooleanKeyword()),
-        'Whether the column has a NOT NULL constraint.'
-      ),
-      addJSDoc(
-        optionalProp('default_value', t.tsStringKeyword()),
-        'SQL default value expression (e.g., "true", "now()").'
-      ),
-      addJSDoc(
-        optionalProp('description', t.tsStringKeyword()),
-        'Comment/description for this field.'
-      ),
+      addJSDoc(requiredProp('type', t.tsStringKeyword()), 'The PostgreSQL type (e.g., "text", "integer", "boolean", "uuid").'),
+      addJSDoc(optionalProp('is_required', t.tsBooleanKeyword()), 'Whether the column has a NOT NULL constraint.'),
+      addJSDoc(optionalProp('default_value', t.tsStringKeyword()), 'SQL default value expression (e.g., "true", "now()").'),
+      addJSDoc(optionalProp('description', t.tsStringKeyword()), 'Comment/description for this field.'),
     ]),
     'A custom field (column) to add to a blueprint table.'
   );
 }
 
 function buildBlueprintPolicy(
-  authzNodes: NodeTypeDefinition[]
+  authzNodes: NodeTypeDefinition[],
+  introspection?: IntrospectionTableMeta[]
 ): t.ExportNamedDeclaration {
   const policyTypeAnnotation =
     authzNodes.length > 0
       ? strUnion(authzNodes.map((nt) => nt.name))
       : t.tsStringKeyword();
 
+  const table = introspection && findTable(introspection, 'metaschema_public', 'policy');
+  if (table) {
+    return deriveInterfaceFromTable(
+      table,
+      'BlueprintPolicy',
+      'An RLS policy entry for a blueprint table. Derived from metaschema_public.policy.',
+      {
+        policy_type: {
+          tsType: policyTypeAnnotation,
+          required: true,
+          doc: 'Authz* policy type name (e.g., "AuthzDirectOwner", "AuthzAllowAll").'
+        },
+        name: { optional: true, doc: 'Optional custom name for this policy.' },
+        grantee_name: { optional: true, doc: 'Role for this policy.' },
+        privilege: { optional: true, doc: 'Privilege this policy applies to.' },
+        permissive: { optional: true, doc: 'Whether this policy is permissive (true) or restrictive (false).' },
+        data: {
+          tsType: recordType(t.tsStringKeyword(), t.tsUnknownKeyword()),
+          optional: true,
+          doc: 'Policy-specific data (structure varies by policy type).'
+        },
+      }
+    );
+  }
+  // Static fallback
   return addJSDoc(
     exportInterface('BlueprintPolicy', [
-      addJSDoc(
-        requiredProp('$type', policyTypeAnnotation),
-        'Authz* policy type name (e.g., "AuthzDirectOwner", "AuthzAllowAll").'
-      ),
-      addJSDoc(
-        optionalProp('policy_role', t.tsStringKeyword()),
-        'Role for this policy. Defaults to "authenticated".'
-      ),
-      addJSDoc(
-        optionalProp('permissive', t.tsBooleanKeyword()),
-        'Whether this policy is permissive (true) or restrictive (false).'
-      ),
-      addJSDoc(
-        optionalProp('policy_name', t.tsStringKeyword()),
-        'Optional custom name for this policy.'
-      ),
-      addJSDoc(
-        optionalProp('privileges', t.tsArrayType(t.tsStringKeyword())),
-        'Privileges this policy applies to.'
-      ),
-      addJSDoc(
-        optionalProp('data', recordType(t.tsStringKeyword(), t.tsUnknownKeyword())),
-        'Policy-specific data (structure varies by policy type).'
-      ),
+      addJSDoc(requiredProp('policy_type', policyTypeAnnotation), 'Authz* policy type name (e.g., "AuthzDirectOwner", "AuthzAllowAll").'),
+      addJSDoc(optionalProp('policy_role', t.tsStringKeyword()), 'Role for this policy. Defaults to "authenticated".'),
+      addJSDoc(optionalProp('permissive', t.tsBooleanKeyword()), 'Whether this policy is permissive (true) or restrictive (false).'),
+      addJSDoc(optionalProp('policy_name', t.tsStringKeyword()), 'Optional custom name for this policy.'),
+      addJSDoc(optionalProp('privileges', t.tsArrayType(t.tsStringKeyword())), 'Privileges this policy applies to.'),
+      addJSDoc(optionalProp('data', recordType(t.tsStringKeyword(), t.tsUnknownKeyword())), 'Policy-specific data (structure varies by policy type).'),
     ]),
     'An RLS policy entry for a blueprint table.'
   );
@@ -304,41 +458,49 @@ function buildBlueprintFullTextSearch(): t.ExportNamedDeclaration {
   );
 }
 
-function buildBlueprintIndex(): t.ExportNamedDeclaration {
+function buildBlueprintIndex(
+  introspection?: IntrospectionTableMeta[]
+): t.ExportNamedDeclaration {
+  const table = introspection && findTable(introspection, 'metaschema_public', 'index');
+  if (table) {
+    return deriveInterfaceFromTable(
+      table,
+      'BlueprintIndex',
+      'An index definition within a blueprint. Derived from metaschema_public.index.',
+      {
+        name: { optional: true, doc: 'Optional custom name for the index.' },
+        access_method: { required: true, doc: 'Index access method (e.g., "BTREE", "GIN", "GIST", "HNSW", "BM25").' },
+        is_unique: { optional: true, doc: 'Whether this is a unique index.' },
+        op_classes: { optional: true, doc: 'Operator classes for the index columns.' },
+        index_params: {
+          tsType: recordType(t.tsStringKeyword(), t.tsUnknownKeyword()),
+          optional: true,
+          doc: 'Index parameter expressions.'
+        },
+        where_clause: {
+          tsType: recordType(t.tsStringKeyword(), t.tsUnknownKeyword()),
+          optional: true,
+          doc: 'Partial index WHERE clause (AST).'
+        },
+        options: {
+          tsType: recordType(t.tsStringKeyword(), t.tsUnknownKeyword()),
+          optional: true,
+          doc: 'Additional index-specific options.'
+        },
+      }
+    );
+  }
+  // Static fallback
   return addJSDoc(
     exportInterface('BlueprintIndex', [
-      addJSDoc(
-        requiredProp('table_ref', t.tsStringKeyword()),
-        'Reference key of the table this index belongs to.'
-      ),
-      addJSDoc(
-        optionalProp('column', t.tsStringKeyword()),
-        'Single column name for the index. Mutually exclusive with "columns".'
-      ),
-      addJSDoc(
-        optionalProp('columns', t.tsArrayType(t.tsStringKeyword())),
-        'Array of column names for a multi-column index. Mutually exclusive with "column".'
-      ),
-      addJSDoc(
-        requiredProp('access_method', t.tsStringKeyword()),
-        'Index access method (e.g., "BTREE", "GIN", "GIST", "HNSW", "BM25").'
-      ),
-      addJSDoc(
-        optionalProp('is_unique', t.tsBooleanKeyword()),
-        'Whether this is a unique index.'
-      ),
-      addJSDoc(
-        optionalProp('name', t.tsStringKeyword()),
-        'Optional custom name for the index.'
-      ),
-      addJSDoc(
-        optionalProp('op_classes', t.tsArrayType(t.tsStringKeyword())),
-        'Operator classes for the index columns.'
-      ),
-      addJSDoc(
-        optionalProp('options', recordType(t.tsStringKeyword(), t.tsUnknownKeyword())),
-        'Additional index-specific options.'
-      ),
+      addJSDoc(requiredProp('table_ref', t.tsStringKeyword()), 'Reference key of the table this index belongs to.'),
+      addJSDoc(optionalProp('column', t.tsStringKeyword()), 'Single column name for the index.'),
+      addJSDoc(optionalProp('columns', t.tsArrayType(t.tsStringKeyword())), 'Array of column names for a multi-column index.'),
+      addJSDoc(requiredProp('access_method', t.tsStringKeyword()), 'Index access method (e.g., "BTREE", "GIN", "GIST", "HNSW", "BM25").'),
+      addJSDoc(optionalProp('is_unique', t.tsBooleanKeyword()), 'Whether this is a unique index.'),
+      addJSDoc(optionalProp('name', t.tsStringKeyword()), 'Optional custom name for the index.'),
+      addJSDoc(optionalProp('op_classes', t.tsArrayType(t.tsStringKeyword())), 'Operator classes for the index columns.'),
+      addJSDoc(optionalProp('options', recordType(t.tsStringKeyword(), t.tsUnknownKeyword())), 'Additional index-specific options.'),
     ]),
     'An index definition within a blueprint.'
   );
@@ -543,7 +705,7 @@ function sectionComment(title: string): t.Statement {
 // Main generator
 // ---------------------------------------------------------------------------
 
-function buildProgram(): string {
+function buildProgram(introspection?: IntrospectionTableMeta[]): string {
   const statements: t.Statement[] = [];
 
   // Group node types by category
@@ -576,13 +738,16 @@ function buildProgram(): string {
     statements.push(...generateParamsInterfaces(nts));
   }
 
-  // -- Static structural types --
-  statements.push(sectionComment('Static structural types'));
-  statements.push(buildBlueprintField());
-  statements.push(buildBlueprintPolicy(authzNodes));
+  // -- Structural types (introspection-driven when available) --
+  const introspectionSource = introspection
+    ? 'Derived from introspection JSON'
+    : 'Static fallback (no introspection provided)';
+  statements.push(sectionComment(`Structural types — ${introspectionSource}`));
+  statements.push(buildBlueprintField(introspection));
+  statements.push(buildBlueprintPolicy(authzNodes, introspection));
   statements.push(buildBlueprintFtsSource());
   statements.push(buildBlueprintFullTextSearch());
-  statements.push(buildBlueprintIndex());
+  statements.push(buildBlueprintIndex(introspection));
 
   // -- Node types discriminated union --
   statements.push(
@@ -631,7 +796,19 @@ function main() {
   const outdir =
     outdirIdx !== -1 ? args[outdirIdx + 1] : join(__dirname, '..');
 
-  const content = buildProgram();
+  const introspectionIdx = args.indexOf('--introspection');
+  let introspection: IntrospectionTableMeta[] | undefined;
+  if (introspectionIdx !== -1 && args[introspectionIdx + 1]) {
+    const introspectionPath = args[introspectionIdx + 1];
+    console.log(`Reading introspection from ${introspectionPath}`);
+    const raw = readFileSync(introspectionPath, 'utf-8');
+    introspection = JSON.parse(raw) as IntrospectionTableMeta[];
+    console.log(`Loaded ${introspection.length} tables from introspection`);
+  } else {
+    console.log('No --introspection flag; using static fallback types');
+  }
+
+  const content = buildProgram(introspection);
   const filename = 'blueprint-types.generated.ts';
   const filepath = join(outdir, filename);
 

--- a/graphile/node-type-registry/src/codegen/generate-types.ts
+++ b/graphile/node-type-registry/src/codegen/generate-types.ts
@@ -37,14 +37,15 @@ interface IntrospectionFieldMeta {
   type: { pgType: string; gqlType: string; isArray: boolean };
   isNotNull: boolean;
   hasDefault: boolean;
+  isPrimaryKey: boolean;
+  isForeignKey: boolean;
+  description: string | null;
 }
 
 interface IntrospectionTableMeta {
   name: string;
   schemaName: string;
   fields: IntrospectionFieldMeta[];
-  primaryKeyConstraints: { fields: { name: string }[] }[];
-  foreignKeyConstraints: { fields: { name: string }[] }[];
 }
 
 // ---------------------------------------------------------------------------
@@ -250,66 +251,31 @@ function pgTypeToTSType(pgType: string, isArray: boolean): t.TSType {
 }
 
 /**
- * Columns to exclude when deriving structural types from introspection.
- * These are internal DB columns, not part of the blueprint JSONB input.
+ * Derive a TS interface from an introspection table's columns.
+ *
+ * Fully procedural — uses field metadata to determine:
+ *   - Which columns to skip (isPrimaryKey || isForeignKey)
+ *   - Required vs optional (isNotNull && !hasDefault)
+ *   - JSDoc from PG column comments (description)
+ *
+ * Special-case overrides (e.g. typed discriminants) can be passed via
+ * `typeOverrides` for columns that need a non-default TS type.
  */
-const INTERNAL_COLUMNS = new Set([
-  'id',
-  'database_id',
-  'table_id',
-  'schema_id',
-  'field_id',
-  'field_ids',
-  'out_fields',
-  'smart_tags',
-  'category',
-  'module',
-  'scope',
-  'tags',
-  'include_field_ids',
-  'field_order',
-  'disabled',
-  'chk',
-  'chk_expr',
-  'default_value_ast',
-]);
-
-/** Derive a TS interface from an introspection table's columns. */
 function deriveInterfaceFromTable(
   table: IntrospectionTableMeta,
   interfaceName: string,
   description: string,
-  overrides?: Record<string, { tsType?: t.TSType; doc?: string; optional?: boolean; required?: boolean }>
+  typeOverrides?: Record<string, t.TSType>
 ): t.ExportNamedDeclaration {
-  const pkFields = new Set(
-    table.primaryKeyConstraints.flatMap((pk) => pk.fields.map((f) => f.name))
-  );
-  const fkFields = new Set(
-    table.foreignKeyConstraints.flatMap((fk) => fk.fields.map((f) => f.name))
-  );
-
   const members: t.TSTypeElement[] = [];
 
   for (const field of table.fields) {
-    // Skip internal columns
-    if (INTERNAL_COLUMNS.has(field.name)) continue;
-    if (pkFields.has(field.name)) continue;
-    if (fkFields.has(field.name)) continue;
+    // Skip PK and FK columns — these are internal to the DB schema
+    if (field.isPrimaryKey || field.isForeignKey) continue;
 
-    const override = overrides?.[field.name];
-
-    const tsType = override?.tsType ?? pgTypeToTSType(field.type.pgType, field.type.isArray);
-    const doc = override?.doc ?? `Derived from ${table.schemaName}.${table.name}.${field.name} (${field.type.pgType}).`;
-
-    // Determine optionality: required if NOT NULL and no default, unless overridden
-    let isRequired: boolean;
-    if (override?.optional !== undefined) {
-      isRequired = !override.optional;
-    } else if (override?.required !== undefined) {
-      isRequired = override.required;
-    } else {
-      isRequired = field.isNotNull && !field.hasDefault;
-    }
+    const tsType = typeOverrides?.[field.name] ?? pgTypeToTSType(field.type.pgType, field.type.isArray);
+    const doc = field.description ?? `${table.schemaName}.${table.name}.${field.name} (${field.type.pgType})`;
+    const isRequired = field.isNotNull && !field.hasDefault;
 
     const prop = isRequired
       ? requiredProp(field.name, tsType)
@@ -341,18 +307,6 @@ function buildBlueprintField(
       table,
       'BlueprintField',
       'A custom field (column) to add to a blueprint table. Derived from metaschema_public.field.',
-      {
-        name: { required: true, doc: 'The column name.' },
-        type: { required: true, doc: 'The PostgreSQL type (e.g., "text", "integer", "boolean", "uuid").' },
-        is_required: { optional: true, doc: 'Whether the column has a NOT NULL constraint.' },
-        default_value: { optional: true, doc: 'SQL default value expression (e.g., "true", "now()").' },
-        description: { optional: true, doc: 'Comment/description for this field.' },
-        label: { optional: true, doc: 'Display label for this field.' },
-        api_required: { optional: true, doc: 'Whether the field is required in the API (enforced at GraphQL level).' },
-        min: { optional: true, doc: 'Minimum value constraint (character_length for text, value for numbers).' },
-        max: { optional: true, doc: 'Maximum value constraint (character_length for text, value for numbers).' },
-        regexp: { optional: true, doc: 'Regex pattern CHECK constraint for text/citext fields.' },
-      }
     );
   }
   // Static fallback
@@ -384,21 +338,11 @@ function buildBlueprintPolicy(
       'BlueprintPolicy',
       'An RLS policy entry for a blueprint table. Derived from metaschema_public.policy.',
       {
-        policy_type: {
-          tsType: policyTypeAnnotation,
-          required: true,
-          doc: 'Authz* policy type name (e.g., "AuthzDirectOwner", "AuthzAllowAll").'
-        },
-        name: { optional: true, doc: 'Optional custom name for this policy.' },
-        grantee_name: { optional: true, doc: 'Role for this policy.' },
-        privilege: { optional: true, doc: 'Privilege this policy applies to.' },
-        permissive: { optional: true, doc: 'Whether this policy is permissive (true) or restrictive (false).' },
-        data: {
-          tsType: recordType(t.tsStringKeyword(), t.tsUnknownKeyword()),
-          optional: true,
-          doc: 'Policy-specific data (structure varies by policy type).'
-        },
-      }
+        // policy_type gets a typed union of known Authz* node names
+        policy_type: policyTypeAnnotation,
+        // data is untyped JSONB — use Record<string, unknown>
+        data: recordType(t.tsStringKeyword(), t.tsUnknownKeyword()),
+      },
     );
   }
   // Static fallback
@@ -468,26 +412,11 @@ function buildBlueprintIndex(
       'BlueprintIndex',
       'An index definition within a blueprint. Derived from metaschema_public.index.',
       {
-        name: { optional: true, doc: 'Optional custom name for the index.' },
-        access_method: { required: true, doc: 'Index access method (e.g., "BTREE", "GIN", "GIST", "HNSW", "BM25").' },
-        is_unique: { optional: true, doc: 'Whether this is a unique index.' },
-        op_classes: { optional: true, doc: 'Operator classes for the index columns.' },
-        index_params: {
-          tsType: recordType(t.tsStringKeyword(), t.tsUnknownKeyword()),
-          optional: true,
-          doc: 'Index parameter expressions.'
-        },
-        where_clause: {
-          tsType: recordType(t.tsStringKeyword(), t.tsUnknownKeyword()),
-          optional: true,
-          doc: 'Partial index WHERE clause (AST).'
-        },
-        options: {
-          tsType: recordType(t.tsStringKeyword(), t.tsUnknownKeyword()),
-          optional: true,
-          doc: 'Additional index-specific options.'
-        },
-      }
+        // JSONB columns get Record<string, unknown> instead of the default
+        index_params: recordType(t.tsStringKeyword(), t.tsUnknownKeyword()),
+        where_clause: recordType(t.tsStringKeyword(), t.tsUnknownKeyword()),
+        options: recordType(t.tsStringKeyword(), t.tsUnknownKeyword()),
+      },
     );
   }
   // Static fallback


### PR DESCRIPTION
## Summary

Adds an `--introspection <path>` CLI flag to `generate-types.ts`. When provided with a `TableMeta[]` JSON file (produced by `buildIntrospectionJSON()` from graphile-schema), `BlueprintField`, `BlueprintPolicy`, and `BlueprintIndex` interfaces are **derived from the actual metaschema table columns** instead of being hand-coded.

Key additions:
- `IntrospectionFieldMeta` / `IntrospectionTableMeta` — local type definitions matching the shape of the introspection JSON, including `isPrimaryKey`, `isForeignKey`, and `description` fields on each column
- `pgTypeToTSType()` — maps PG type names (`bool`, `int4`, `jsonb`, etc.) to TS AST type annotations
- `deriveInterfaceFromTable()` — **fully procedural** function that reads a table's columns from introspection and emits a TS interface:
  - Skips columns where `isPrimaryKey || isForeignKey` (no hardcoded exclusion lists)
  - Derives required/optional from `isNotNull && !hasDefault` (no per-field overrides)
  - Uses PG column comments (`description`) for JSDoc (no hardcoded doc strings)
  - Accepts an optional `typeOverrides` map for columns needing non-default TS types (e.g. `policy_type` → Authz* union, JSONB columns → `Record<string, unknown>`)
- Static fallback preserved when `--introspection` is not provided (backward compatible)

Also fixes the static fallback: `BlueprintField.is_not_null` → `is_required`, `BlueprintPolicy.$type` → `policy_type` (matching the actual SQL column names).

### Updates since last revision
- **Removed `INTERNAL_COLUMNS` hardcoded set entirely** — column exclusion is now fully procedural via `field.isPrimaryKey || field.isForeignKey`
- **Removed per-field override objects** from `deriveInterfaceFromTable()` — the old `overrides` parameter (with `{tsType, doc, optional, required}` per field) is replaced by a minimal `typeOverrides?: Record<string, t.TSType>` for the rare columns that need a non-default TS type
- **JSDoc now comes from PG column comments** (`field.description`) instead of hardcoded strings; falls back to `schema.table.column (pgType)` when no comment exists
- **`IntrospectionTableMeta` simplified** — removed `primaryKeyConstraints` / `foreignKeyConstraints` arrays; PK/FK info now lives on each `IntrospectionFieldMeta` field directly
- **Depends on PR #915** (graphile-settings) which adds `isPrimaryKey`, `isForeignKey`, `description` to the `FieldMeta` type and populates them from Graphile v5 codec attributes
- **BlueprintFtsSource / BlueprintFullTextSearch intentionally static** — `BlueprintFtsSource` is a client-side shape (array of `{field, weight, lang}` objects) that `construct_blueprint` flattens into the `full_text_search` table's parallel arrays (`field_ids`, `weights`, `langs`). There is no DB table for the pre-flattened form, so derivation is not applicable. These types only live in `node-type-registry` for SDK/provisioning consumers — generated databases never import them.

## Review & Testing Checklist for Human

- [ ] **End-to-end verification needed**: This has NOT been tested against a real introspection JSON file. Run `pnpm generate:introspection` in constructive-db (after merging PR #915 and publishing graphile-settings), then run `generate-types.ts --introspection <path>` and diff the output against the static fallback to verify the derived types are correct and complete.
- [ ] **Local `IntrospectionFieldMeta` could drift from upstream**: The type is defined locally (not imported from graphile-settings) to avoid a runtime dependency. If `FieldMeta`'s shape changes in graphile-settings, this local definition won't break at compile time — it will silently produce wrong results. Verify the local shape matches the current `FieldMeta` after merging #915.
- [ ] **PG column comments coverage**: JSDoc quality depends on `COMMENT ON COLUMN` being set on metaschema tables (`metaschema_public.field`, `metaschema_public.policy`, `metaschema_public.index`). Columns without comments will get a generic fallback doc string (`schema.table.column (pgType)`). Verify the important user-facing columns have comments defined.
- [ ] **`pgTypeToTSType` coverage**: The mapping handles common PG types (`bool`, `int*`, `float*`, `jsonb`, `json`, `numeric`, `text`, etc.) but anything unrecognized falls through to `string`. Verify no metaschema columns use exotic types that would produce an incorrect mapping.

**Suggested test plan:** After merging PR #915 and publishing graphile-settings, run the full codegen pipeline in constructive-db with `--introspection` and diff the generated `blueprint-types.generated.ts` against the current static output. The derived interfaces should match (modulo JSDoc wording).

### Notes
- Only two categories of `typeOverrides` remain: (1) `policy_type` gets a typed union of known Authz* node names instead of plain `string`, and (2) JSONB columns (`data`, `index_params`, `where_clause`, `options`) get `Record<string, unknown>` instead of the default `pgTypeToTSType` mapping. All other field metadata (optionality, docs, inclusion) is fully procedural.
- Merge order: PR #915 first (graphile-settings), then this PR.

Link to Devin session: https://app.devin.ai/sessions/ce1b2dafd42341bea5d7793b0c05ba6c
Requested by: @pyramation