### PR TITLE
refactor(codegen): generic type params for CLI→ORM bridge + flip condition default to false

### DIFF
--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/cli-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/cli-generator.test.ts.snap
@@ -697,7 +697,7 @@ import { CLIOptions, Inquirerer, extractFirst } from "inquirerer";
 import { getClient } from "../executor";
 import { coerceAnswers, parseFindFirstArgs, parseFindManyArgs, stripUndefined } from "../utils";
 import type { FieldSchema } from "../utils";
-import type { CreateCarInput, CarPatch, CarSelect, CarFilter, CarCondition, CarsOrderBy } from "../../orm/input-types";
+import type { CreateCarInput, CarPatch, CarSelect, CarFilter, CarsOrderBy } from "../../orm/input-types";
 import type { FindManyArgs, FindFirstArgs } from "../../orm/select-types";
 const fieldSchema: FieldSchema = {
   id: "uuid",
@@ -757,7 +757,7 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
       isElectric: true,
       createdAt: true
     };
-    const findManyArgs = parseFindManyArgs<FindManyArgs<CarSelect, CarFilter, CarCondition, CarsOrderBy>>(argv, defaultSelect);
+    const findManyArgs = parseFindManyArgs<FindManyArgs<CarSelect, CarFilter, never, CarsOrderBy>>(argv, defaultSelect);
     const client = getClient();
     const result = await client.car.findMany(findManyArgs).execute();
     console.log(JSON.stringify(result, null, 2));
@@ -779,7 +779,7 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
       isElectric: true,
       createdAt: true
     };
-    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<CarSelect, CarFilter, CarCondition>>(argv, defaultSelect);
+    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<CarSelect, CarFilter, never>>(argv, defaultSelect);
     const client = getClient();
     const result = await client.car.findFirst(findFirstArgs).execute();
     console.log(JSON.stringify(result, null, 2));
@@ -1161,7 +1161,7 @@ import { CLIOptions, Inquirerer, extractFirst } from "inquirerer";
 import { getClient } from "../executor";
 import { coerceAnswers, parseFindFirstArgs, parseFindManyArgs, stripUndefined } from "../utils";
 import type { FieldSchema } from "../utils";
-import type { CreateDriverInput, DriverPatch, DriverSelect, DriverFilter, DriverCondition, DriversOrderBy } from "../../orm/input-types";
+import type { CreateDriverInput, DriverPatch, DriverSelect, DriverFilter, DriversOrderBy } from "../../orm/input-types";
 import type { FindManyArgs, FindFirstArgs } from "../../orm/select-types";
 const fieldSchema: FieldSchema = {
   id: "uuid",
@@ -1215,7 +1215,7 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
       name: true,
       licenseNumber: true
     };
-    const findManyArgs = parseFindManyArgs<FindManyArgs<DriverSelect, DriverFilter, DriverCondition, DriversOrderBy>>(argv, defaultSelect);
+    const findManyArgs = parseFindManyArgs<FindManyArgs<DriverSelect, DriverFilter, never, DriversOrderBy>>(argv, defaultSelect);
     const client = getClient();
     const result = await client.driver.findMany(findManyArgs).execute();
     console.log(JSON.stringify(result, null, 2));
@@ -1234,7 +1234,7 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
       name: true,
       licenseNumber: true
     };
-    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<DriverSelect, DriverFilter, DriverCondition>>(argv, defaultSelect);
+    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<DriverSelect, DriverFilter, never>>(argv, defaultSelect);
     const client = getClient();
     const result = await client.driver.findFirst(findFirstArgs).execute();
     console.log(JSON.stringify(result, null, 2));
@@ -3193,7 +3193,7 @@ import { CLIOptions, Inquirerer, extractFirst } from "inquirerer";
 import { getClient } from "../../executor";
 import { coerceAnswers, parseFindFirstArgs, parseFindManyArgs, stripUndefined } from "../../utils";
 import type { FieldSchema } from "../../utils";
-import type { CreateUserInput, UserPatch, UserSelect, UserFilter, UserCondition, UsersOrderBy } from "../../../orm/input-types";
+import type { CreateUserInput, UserPatch, UserSelect, UserFilter, UsersOrderBy } from "../../../orm/input-types";
 import type { FindManyArgs, FindFirstArgs } from "../../../orm/select-types";
 const fieldSchema: FieldSchema = {
   id: "uuid",
@@ -3247,7 +3247,7 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
       email: true,
       name: true
     };
-    const findManyArgs = parseFindManyArgs<FindManyArgs<UserSelect, UserFilter, UserCondition, UsersOrderBy>>(argv, defaultSelect);
+    const findManyArgs = parseFindManyArgs<FindManyArgs<UserSelect, UserFilter, never, UsersOrderBy>>(argv, defaultSelect);
     const client = getClient("auth");
     const result = await client.user.findMany(findManyArgs).execute();
     console.log(JSON.stringify(result, null, 2));
@@ -3266,7 +3266,7 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
       email: true,
       name: true
     };
-    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<UserSelect, UserFilter, UserCondition>>(argv, defaultSelect);
+    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<UserSelect, UserFilter, never>>(argv, defaultSelect);
     const client = getClient("auth");
     const result = await client.user.findFirst(findFirstArgs).execute();
     console.log(JSON.stringify(result, null, 2));
@@ -3423,7 +3423,7 @@ import { CLIOptions, Inquirerer, extractFirst } from "inquirerer";
 import { getClient } from "../../executor";
 import { coerceAnswers, parseFindFirstArgs, parseFindManyArgs, stripUndefined } from "../../utils";
 import type { FieldSchema } from "../../utils";
-import type { CreateMemberInput, MemberPatch, MemberSelect, MemberFilter, MemberCondition, MembersOrderBy } from "../../../orm/input-types";
+import type { CreateMemberInput, MemberPatch, MemberSelect, MemberFilter, MembersOrderBy } from "../../../orm/input-types";
 import type { FindManyArgs, FindFirstArgs } from "../../../orm/select-types";
 const fieldSchema: FieldSchema = {
   id: "uuid",
@@ -3475,7 +3475,7 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
       id: true,
       role: true
     };
-    const findManyArgs = parseFindManyArgs<FindManyArgs<MemberSelect, MemberFilter, MemberCondition, MembersOrderBy>>(argv, defaultSelect);
+    const findManyArgs = parseFindManyArgs<FindManyArgs<MemberSelect, MemberFilter, never, MembersOrderBy>>(argv, defaultSelect);
     const client = getClient("members");
     const result = await client.member.findMany(findManyArgs).execute();
     console.log(JSON.stringify(result, null, 2));
@@ -3493,7 +3493,7 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
       id: true,
       role: true
     };
-    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<MemberSelect, MemberFilter, MemberCondition>>(argv, defaultSelect);
+    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<MemberSelect, MemberFilter, never>>(argv, defaultSelect);
     const client = getClient("members");
     const result = await client.member.findFirst(findFirstArgs).execute();
     console.log(JSON.stringify(result, null, 2));
@@ -3635,7 +3635,7 @@ import { CLIOptions, Inquirerer, extractFirst } from "inquirerer";
 import { getClient } from "../../executor";
 import { coerceAnswers, parseFindFirstArgs, parseFindManyArgs, stripUndefined } from "../../utils";
 import type { FieldSchema } from "../../utils";
-import type { CreateCarInput, CarPatch, CarSelect, CarFilter, CarCondition, CarsOrderBy } from "../../../orm/input-types";
+import type { CreateCarInput, CarPatch, CarSelect, CarFilter, CarsOrderBy } from "../../../orm/input-types";
 import type { FindManyArgs, FindFirstArgs } from "../../../orm/select-types";
 const fieldSchema: FieldSchema = {
   id: "uuid",
@@ -3695,7 +3695,7 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
       isElectric: true,
       createdAt: true
     };
-    const findManyArgs = parseFindManyArgs<FindManyArgs<CarSelect, CarFilter, CarCondition, CarsOrderBy>>(argv, defaultSelect);
+    const findManyArgs = parseFindManyArgs<FindManyArgs<CarSelect, CarFilter, never, CarsOrderBy>>(argv, defaultSelect);
     const client = getClient("app");
     const result = await client.car.findMany(findManyArgs).execute();
     console.log(JSON.stringify(result, null, 2));
@@ -3717,7 +3717,7 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
       isElectric: true,
       createdAt: true
     };
-    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<CarSelect, CarFilter, CarCondition>>(argv, defaultSelect);
+    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<CarSelect, CarFilter, never>>(argv, defaultSelect);
     const client = getClient("app");
     const result = await client.car.findFirst(findFirstArgs).execute();
     console.log(JSON.stringify(result, null, 2));

--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/cli-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/cli-generator.test.ts.snap
@@ -757,7 +757,9 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
       isElectric: true,
       createdAt: true
     };
-    const findManyArgs = parseFindManyArgs<FindManyArgs<CarSelect, CarFilter, never, CarsOrderBy>>(argv, defaultSelect);
+    const findManyArgs = parseFindManyArgs<FindManyArgs<CarSelect, CarFilter, never, CarsOrderBy> & {
+      select: CarSelect;
+    }>(argv, defaultSelect);
     const client = getClient();
     const result = await client.car.findMany(findManyArgs).execute();
     console.log(JSON.stringify(result, null, 2));
@@ -779,7 +781,9 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
       isElectric: true,
       createdAt: true
     };
-    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<CarSelect, CarFilter, never>>(argv, defaultSelect);
+    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<CarSelect, CarFilter, never> & {
+      select: CarSelect;
+    }>(argv, defaultSelect);
     const client = getClient();
     const result = await client.car.findFirst(findFirstArgs).execute();
     console.log(JSON.stringify(result, null, 2));
@@ -1215,7 +1219,9 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
       name: true,
       licenseNumber: true
     };
-    const findManyArgs = parseFindManyArgs<FindManyArgs<DriverSelect, DriverFilter, never, DriversOrderBy>>(argv, defaultSelect);
+    const findManyArgs = parseFindManyArgs<FindManyArgs<DriverSelect, DriverFilter, never, DriversOrderBy> & {
+      select: DriverSelect;
+    }>(argv, defaultSelect);
     const client = getClient();
     const result = await client.driver.findMany(findManyArgs).execute();
     console.log(JSON.stringify(result, null, 2));
@@ -1234,7 +1240,9 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
       name: true,
       licenseNumber: true
     };
-    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<DriverSelect, DriverFilter, never>>(argv, defaultSelect);
+    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<DriverSelect, DriverFilter, never> & {
+      select: DriverSelect;
+    }>(argv, defaultSelect);
     const client = getClient();
     const result = await client.driver.findFirst(findFirstArgs).execute();
     console.log(JSON.stringify(result, null, 2));
@@ -3247,7 +3255,9 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
       email: true,
       name: true
     };
-    const findManyArgs = parseFindManyArgs<FindManyArgs<UserSelect, UserFilter, never, UsersOrderBy>>(argv, defaultSelect);
+    const findManyArgs = parseFindManyArgs<FindManyArgs<UserSelect, UserFilter, never, UsersOrderBy> & {
+      select: UserSelect;
+    }>(argv, defaultSelect);
     const client = getClient("auth");
     const result = await client.user.findMany(findManyArgs).execute();
     console.log(JSON.stringify(result, null, 2));
@@ -3266,7 +3276,9 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
       email: true,
       name: true
     };
-    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<UserSelect, UserFilter, never>>(argv, defaultSelect);
+    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<UserSelect, UserFilter, never> & {
+      select: UserSelect;
+    }>(argv, defaultSelect);
     const client = getClient("auth");
     const result = await client.user.findFirst(findFirstArgs).execute();
     console.log(JSON.stringify(result, null, 2));
@@ -3475,7 +3487,9 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
       id: true,
       role: true
     };
-    const findManyArgs = parseFindManyArgs<FindManyArgs<MemberSelect, MemberFilter, never, MembersOrderBy>>(argv, defaultSelect);
+    const findManyArgs = parseFindManyArgs<FindManyArgs<MemberSelect, MemberFilter, never, MembersOrderBy> & {
+      select: MemberSelect;
+    }>(argv, defaultSelect);
     const client = getClient("members");
     const result = await client.member.findMany(findManyArgs).execute();
     console.log(JSON.stringify(result, null, 2));
@@ -3493,7 +3507,9 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
       id: true,
       role: true
     };
-    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<MemberSelect, MemberFilter, never>>(argv, defaultSelect);
+    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<MemberSelect, MemberFilter, never> & {
+      select: MemberSelect;
+    }>(argv, defaultSelect);
     const client = getClient("members");
     const result = await client.member.findFirst(findFirstArgs).execute();
     console.log(JSON.stringify(result, null, 2));
@@ -3695,7 +3711,9 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
       isElectric: true,
       createdAt: true
     };
-    const findManyArgs = parseFindManyArgs<FindManyArgs<CarSelect, CarFilter, never, CarsOrderBy>>(argv, defaultSelect);
+    const findManyArgs = parseFindManyArgs<FindManyArgs<CarSelect, CarFilter, never, CarsOrderBy> & {
+      select: CarSelect;
+    }>(argv, defaultSelect);
     const client = getClient("app");
     const result = await client.car.findMany(findManyArgs).execute();
     console.log(JSON.stringify(result, null, 2));
@@ -3717,7 +3735,9 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
       isElectric: true,
       createdAt: true
     };
-    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<CarSelect, CarFilter, never>>(argv, defaultSelect);
+    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<CarSelect, CarFilter, never> & {
+      select: CarSelect;
+    }>(argv, defaultSelect);
     const client = getClient("app");
     const result = await client.car.findFirst(findFirstArgs).execute();
     console.log(JSON.stringify(result, null, 2));

--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/cli-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/cli-generator.test.ts.snap
@@ -758,7 +758,7 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
     };
     const findManyArgs = parseFindManyArgs(argv, defaultSelect);
     const client = getClient();
-    const result = await client.car.findMany(findManyArgs).execute();
+    const result = await client.car.findMany(findManyArgs as any).execute();
     console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     console.error("Failed to list records.");
@@ -780,7 +780,7 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
     };
     const findFirstArgs = parseFindFirstArgs(argv, defaultSelect);
     const client = getClient();
-    const result = await client.car.findFirst(findFirstArgs).execute();
+    const result = await client.car.findFirst(findFirstArgs as any).execute();
     console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     console.error("Failed to find record.");
@@ -1215,7 +1215,7 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
     };
     const findManyArgs = parseFindManyArgs(argv, defaultSelect);
     const client = getClient();
-    const result = await client.driver.findMany(findManyArgs).execute();
+    const result = await client.driver.findMany(findManyArgs as any).execute();
     console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     console.error("Failed to list records.");
@@ -1234,7 +1234,7 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
     };
     const findFirstArgs = parseFindFirstArgs(argv, defaultSelect);
     const client = getClient();
-    const result = await client.driver.findFirst(findFirstArgs).execute();
+    const result = await client.driver.findFirst(findFirstArgs as any).execute();
     console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     console.error("Failed to find record.");
@@ -3246,7 +3246,7 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
     };
     const findManyArgs = parseFindManyArgs(argv, defaultSelect);
     const client = getClient("auth");
-    const result = await client.user.findMany(findManyArgs).execute();
+    const result = await client.user.findMany(findManyArgs as any).execute();
     console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     console.error("Failed to list records.");
@@ -3265,7 +3265,7 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
     };
     const findFirstArgs = parseFindFirstArgs(argv, defaultSelect);
     const client = getClient("auth");
-    const result = await client.user.findFirst(findFirstArgs).execute();
+    const result = await client.user.findFirst(findFirstArgs as any).execute();
     console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     console.error("Failed to find record.");
@@ -3473,7 +3473,7 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
     };
     const findManyArgs = parseFindManyArgs(argv, defaultSelect);
     const client = getClient("members");
-    const result = await client.member.findMany(findManyArgs).execute();
+    const result = await client.member.findMany(findManyArgs as any).execute();
     console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     console.error("Failed to list records.");
@@ -3491,7 +3491,7 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
     };
     const findFirstArgs = parseFindFirstArgs(argv, defaultSelect);
     const client = getClient("members");
-    const result = await client.member.findFirst(findFirstArgs).execute();
+    const result = await client.member.findFirst(findFirstArgs as any).execute();
     console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     console.error("Failed to find record.");
@@ -3692,7 +3692,7 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
     };
     const findManyArgs = parseFindManyArgs(argv, defaultSelect);
     const client = getClient("app");
-    const result = await client.car.findMany(findManyArgs).execute();
+    const result = await client.car.findMany(findManyArgs as any).execute();
     console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     console.error("Failed to list records.");
@@ -3714,7 +3714,7 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
     };
     const findFirstArgs = parseFindFirstArgs(argv, defaultSelect);
     const client = getClient("app");
-    const result = await client.car.findFirst(findFirstArgs).execute();
+    const result = await client.car.findFirst(findFirstArgs as any).execute();
     console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     console.error("Failed to find record.");

--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/cli-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/cli-generator.test.ts.snap
@@ -697,7 +697,8 @@ import { CLIOptions, Inquirerer, extractFirst } from "inquirerer";
 import { getClient } from "../executor";
 import { coerceAnswers, parseFindFirstArgs, parseFindManyArgs, stripUndefined } from "../utils";
 import type { FieldSchema } from "../utils";
-import type { CreateCarInput, CarPatch } from "../../orm/input-types";
+import type { CreateCarInput, CarPatch, CarSelect, CarFilter, CarCondition, CarsOrderBy } from "../../orm/input-types";
+import type { FindManyArgs, FindFirstArgs } from "../../orm/select-types";
 const fieldSchema: FieldSchema = {
   id: "uuid",
   make: "string",
@@ -756,9 +757,9 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
       isElectric: true,
       createdAt: true
     };
-    const findManyArgs = parseFindManyArgs(argv, defaultSelect);
+    const findManyArgs = parseFindManyArgs<FindManyArgs<CarSelect, CarFilter, CarCondition, CarsOrderBy>>(argv, defaultSelect);
     const client = getClient();
-    const result = await client.car.findMany(findManyArgs as any).execute();
+    const result = await client.car.findMany(findManyArgs).execute();
     console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     console.error("Failed to list records.");
@@ -778,9 +779,9 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
       isElectric: true,
       createdAt: true
     };
-    const findFirstArgs = parseFindFirstArgs(argv, defaultSelect);
+    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<CarSelect, CarFilter, CarCondition>>(argv, defaultSelect);
     const client = getClient();
-    const result = await client.car.findFirst(findFirstArgs as any).execute();
+    const result = await client.car.findFirst(findFirstArgs).execute();
     console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     console.error("Failed to find record.");
@@ -1160,7 +1161,8 @@ import { CLIOptions, Inquirerer, extractFirst } from "inquirerer";
 import { getClient } from "../executor";
 import { coerceAnswers, parseFindFirstArgs, parseFindManyArgs, stripUndefined } from "../utils";
 import type { FieldSchema } from "../utils";
-import type { CreateDriverInput, DriverPatch } from "../../orm/input-types";
+import type { CreateDriverInput, DriverPatch, DriverSelect, DriverFilter, DriverCondition, DriversOrderBy } from "../../orm/input-types";
+import type { FindManyArgs, FindFirstArgs } from "../../orm/select-types";
 const fieldSchema: FieldSchema = {
   id: "uuid",
   name: "string",
@@ -1213,9 +1215,9 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
       name: true,
       licenseNumber: true
     };
-    const findManyArgs = parseFindManyArgs(argv, defaultSelect);
+    const findManyArgs = parseFindManyArgs<FindManyArgs<DriverSelect, DriverFilter, DriverCondition, DriversOrderBy>>(argv, defaultSelect);
     const client = getClient();
-    const result = await client.driver.findMany(findManyArgs as any).execute();
+    const result = await client.driver.findMany(findManyArgs).execute();
     console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     console.error("Failed to list records.");
@@ -1232,9 +1234,9 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
       name: true,
       licenseNumber: true
     };
-    const findFirstArgs = parseFindFirstArgs(argv, defaultSelect);
+    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<DriverSelect, DriverFilter, DriverCondition>>(argv, defaultSelect);
     const client = getClient();
-    const result = await client.driver.findFirst(findFirstArgs as any).execute();
+    const result = await client.driver.findFirst(findFirstArgs).execute();
     console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     console.error("Failed to find record.");
@@ -3191,7 +3193,8 @@ import { CLIOptions, Inquirerer, extractFirst } from "inquirerer";
 import { getClient } from "../../executor";
 import { coerceAnswers, parseFindFirstArgs, parseFindManyArgs, stripUndefined } from "../../utils";
 import type { FieldSchema } from "../../utils";
-import type { CreateUserInput, UserPatch } from "../../../orm/input-types";
+import type { CreateUserInput, UserPatch, UserSelect, UserFilter, UserCondition, UsersOrderBy } from "../../../orm/input-types";
+import type { FindManyArgs, FindFirstArgs } from "../../../orm/select-types";
 const fieldSchema: FieldSchema = {
   id: "uuid",
   email: "string",
@@ -3244,9 +3247,9 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
       email: true,
       name: true
     };
-    const findManyArgs = parseFindManyArgs(argv, defaultSelect);
+    const findManyArgs = parseFindManyArgs<FindManyArgs<UserSelect, UserFilter, UserCondition, UsersOrderBy>>(argv, defaultSelect);
     const client = getClient("auth");
-    const result = await client.user.findMany(findManyArgs as any).execute();
+    const result = await client.user.findMany(findManyArgs).execute();
     console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     console.error("Failed to list records.");
@@ -3263,9 +3266,9 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
       email: true,
       name: true
     };
-    const findFirstArgs = parseFindFirstArgs(argv, defaultSelect);
+    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<UserSelect, UserFilter, UserCondition>>(argv, defaultSelect);
     const client = getClient("auth");
-    const result = await client.user.findFirst(findFirstArgs as any).execute();
+    const result = await client.user.findFirst(findFirstArgs).execute();
     console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     console.error("Failed to find record.");
@@ -3420,7 +3423,8 @@ import { CLIOptions, Inquirerer, extractFirst } from "inquirerer";
 import { getClient } from "../../executor";
 import { coerceAnswers, parseFindFirstArgs, parseFindManyArgs, stripUndefined } from "../../utils";
 import type { FieldSchema } from "../../utils";
-import type { CreateMemberInput, MemberPatch } from "../../../orm/input-types";
+import type { CreateMemberInput, MemberPatch, MemberSelect, MemberFilter, MemberCondition, MembersOrderBy } from "../../../orm/input-types";
+import type { FindManyArgs, FindFirstArgs } from "../../../orm/select-types";
 const fieldSchema: FieldSchema = {
   id: "uuid",
   role: "string"
@@ -3471,9 +3475,9 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
       id: true,
       role: true
     };
-    const findManyArgs = parseFindManyArgs(argv, defaultSelect);
+    const findManyArgs = parseFindManyArgs<FindManyArgs<MemberSelect, MemberFilter, MemberCondition, MembersOrderBy>>(argv, defaultSelect);
     const client = getClient("members");
-    const result = await client.member.findMany(findManyArgs as any).execute();
+    const result = await client.member.findMany(findManyArgs).execute();
     console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     console.error("Failed to list records.");
@@ -3489,9 +3493,9 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
       id: true,
       role: true
     };
-    const findFirstArgs = parseFindFirstArgs(argv, defaultSelect);
+    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<MemberSelect, MemberFilter, MemberCondition>>(argv, defaultSelect);
     const client = getClient("members");
-    const result = await client.member.findFirst(findFirstArgs as any).execute();
+    const result = await client.member.findFirst(findFirstArgs).execute();
     console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     console.error("Failed to find record.");
@@ -3631,7 +3635,8 @@ import { CLIOptions, Inquirerer, extractFirst } from "inquirerer";
 import { getClient } from "../../executor";
 import { coerceAnswers, parseFindFirstArgs, parseFindManyArgs, stripUndefined } from "../../utils";
 import type { FieldSchema } from "../../utils";
-import type { CreateCarInput, CarPatch } from "../../../orm/input-types";
+import type { CreateCarInput, CarPatch, CarSelect, CarFilter, CarCondition, CarsOrderBy } from "../../../orm/input-types";
+import type { FindManyArgs, FindFirstArgs } from "../../../orm/select-types";
 const fieldSchema: FieldSchema = {
   id: "uuid",
   make: "string",
@@ -3690,9 +3695,9 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
       isElectric: true,
       createdAt: true
     };
-    const findManyArgs = parseFindManyArgs(argv, defaultSelect);
+    const findManyArgs = parseFindManyArgs<FindManyArgs<CarSelect, CarFilter, CarCondition, CarsOrderBy>>(argv, defaultSelect);
     const client = getClient("app");
-    const result = await client.car.findMany(findManyArgs as any).execute();
+    const result = await client.car.findMany(findManyArgs).execute();
     console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     console.error("Failed to list records.");
@@ -3712,9 +3717,9 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
       isElectric: true,
       createdAt: true
     };
-    const findFirstArgs = parseFindFirstArgs(argv, defaultSelect);
+    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<CarSelect, CarFilter, CarCondition>>(argv, defaultSelect);
     const client = getClient("app");
-    const result = await client.car.findFirst(findFirstArgs as any).execute();
+    const result = await client.car.findFirst(findFirstArgs).execute();
     console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     console.error("Failed to find record.");

--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/input-types-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/input-types-generator.test.ts.snap
@@ -373,31 +373,6 @@ export interface CommentFilter {
   or?: CommentFilter[];
   not?: CommentFilter;
 }
-// ============ Table Condition Types ============
-export interface UserCondition {
-  id?: string | null;
-  email?: string | null;
-  name?: string | null;
-  age?: number | null;
-  isActive?: boolean | null;
-  createdAt?: string | null;
-  metadata?: unknown | null;
-}
-export interface PostCondition {
-  id?: string | null;
-  title?: string | null;
-  content?: string | null;
-  authorId?: string | null;
-  publishedAt?: string | null;
-  tags?: string | null;
-}
-export interface CommentCondition {
-  id?: string | null;
-  body?: string | null;
-  postId?: string | null;
-  authorId?: string | null;
-  createdAt?: string | null;
-}
 // ============ OrderBy Types ============
 export type UsersOrderBy = "PRIMARY_KEY_ASC" | "PRIMARY_KEY_DESC" | "NATURAL" | "ID_ASC" | "ID_DESC" | "EMAIL_ASC" | "EMAIL_DESC" | "NAME_ASC" | "NAME_DESC" | "AGE_ASC" | "AGE_DESC" | "IS_ACTIVE_ASC" | "IS_ACTIVE_DESC" | "CREATED_AT_ASC" | "CREATED_AT_DESC" | "METADATA_ASC" | "METADATA_DESC";
 export type PostsOrderBy = "PRIMARY_KEY_ASC" | "PRIMARY_KEY_DESC" | "NATURAL" | "ID_ASC" | "ID_DESC" | "TITLE_ASC" | "TITLE_DESC" | "CONTENT_ASC" | "CONTENT_DESC" | "AUTHOR_ID_ASC" | "AUTHOR_ID_DESC" | "PUBLISHED_AT_ASC" | "PUBLISHED_AT_DESC" | "TAGS_ASC" | "TAGS_DESC";
@@ -771,16 +746,6 @@ export interface UserFilter {
   or?: UserFilter[];
   not?: UserFilter;
 }
-// ============ Table Condition Types ============
-export interface UserCondition {
-  id?: string | null;
-  email?: string | null;
-  name?: string | null;
-  age?: number | null;
-  isActive?: boolean | null;
-  createdAt?: string | null;
-  metadata?: unknown | null;
-}
 // ============ OrderBy Types ============
 export type UsersOrderBy = "PRIMARY_KEY_ASC" | "PRIMARY_KEY_DESC" | "NATURAL" | "ID_ASC" | "ID_DESC" | "EMAIL_ASC" | "EMAIL_DESC" | "NAME_ASC" | "NAME_DESC" | "AGE_ASC" | "AGE_DESC" | "IS_ACTIVE_ASC" | "IS_ACTIVE_DESC" | "CREATED_AT_ASC" | "CREATED_AT_DESC" | "METADATA_ASC" | "METADATA_DESC";
 // ============ CRUD Input Types ============
@@ -1095,16 +1060,6 @@ export interface UserFilter {
   and?: UserFilter[];
   or?: UserFilter[];
   not?: UserFilter;
-}
-// ============ Table Condition Types ============
-export interface UserCondition {
-  id?: string | null;
-  email?: string | null;
-  name?: string | null;
-  age?: number | null;
-  isActive?: boolean | null;
-  createdAt?: string | null;
-  metadata?: unknown | null;
 }
 // ============ OrderBy Types ============
 export type UsersOrderBy = "PRIMARY_KEY_ASC" | "PRIMARY_KEY_DESC" | "NATURAL" | "ID_ASC" | "ID_DESC" | "EMAIL_ASC" | "EMAIL_DESC" | "NAME_ASC" | "NAME_DESC" | "AGE_ASC" | "AGE_DESC" | "IS_ACTIVE_ASC" | "IS_ACTIVE_DESC" | "CREATED_AT_ASC" | "CREATED_AT_DESC" | "METADATA_ASC" | "METADATA_DESC";
@@ -1432,16 +1387,6 @@ export interface UserFilter {
   and?: UserFilter[];
   or?: UserFilter[];
   not?: UserFilter;
-}
-// ============ Table Condition Types ============
-export interface UserCondition {
-  id?: string | null;
-  email?: string | null;
-  name?: string | null;
-  age?: number | null;
-  isActive?: boolean | null;
-  createdAt?: string | null;
-  metadata?: unknown | null;
 }
 // ============ OrderBy Types ============
 export type UsersOrderBy = "PRIMARY_KEY_ASC" | "PRIMARY_KEY_DESC" | "NATURAL" | "ID_ASC" | "ID_DESC" | "EMAIL_ASC" | "EMAIL_DESC" | "NAME_ASC" | "NAME_DESC" | "AGE_ASC" | "AGE_DESC" | "IS_ACTIVE_ASC" | "IS_ACTIVE_DESC" | "CREATED_AT_ASC" | "CREATED_AT_DESC" | "METADATA_ASC" | "METADATA_DESC";
@@ -1814,22 +1759,6 @@ export interface ProfileFilter {
   and?: ProfileFilter[];
   or?: ProfileFilter[];
   not?: ProfileFilter;
-}
-// ============ Table Condition Types ============
-export interface UserCondition {
-  id?: string | null;
-  email?: string | null;
-  name?: string | null;
-  age?: number | null;
-  isActive?: boolean | null;
-  createdAt?: string | null;
-  metadata?: unknown | null;
-}
-export interface ProfileCondition {
-  id?: string | null;
-  bio?: string | null;
-  userId?: string | null;
-  avatarUrl?: string | null;
 }
 // ============ OrderBy Types ============
 export type UsersOrderBy = "PRIMARY_KEY_ASC" | "PRIMARY_KEY_DESC" | "NATURAL" | "ID_ASC" | "ID_DESC" | "EMAIL_ASC" | "EMAIL_DESC" | "NAME_ASC" | "NAME_DESC" | "AGE_ASC" | "AGE_DESC" | "IS_ACTIVE_ASC" | "IS_ACTIVE_DESC" | "CREATED_AT_ASC" | "CREATED_AT_DESC" | "METADATA_ASC" | "METADATA_DESC";
@@ -2209,20 +2138,6 @@ export interface CategoryFilter {
   and?: CategoryFilter[];
   or?: CategoryFilter[];
   not?: CategoryFilter;
-}
-// ============ Table Condition Types ============
-export interface PostCondition {
-  id?: string | null;
-  title?: string | null;
-  content?: string | null;
-  authorId?: string | null;
-  publishedAt?: string | null;
-  tags?: string | null;
-}
-export interface CategoryCondition {
-  id?: string | null;
-  name?: string | null;
-  slug?: string | null;
 }
 // ============ OrderBy Types ============
 export type PostsOrderBy = "PRIMARY_KEY_ASC" | "PRIMARY_KEY_DESC" | "NATURAL" | "ID_ASC" | "ID_DESC" | "TITLE_ASC" | "TITLE_DESC" | "CONTENT_ASC" | "CONTENT_DESC" | "AUTHOR_ID_ASC" | "AUTHOR_ID_DESC" | "PUBLISHED_AT_ASC" | "PUBLISHED_AT_DESC" | "TAGS_ASC" | "TAGS_DESC";

--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/model-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/model-generator.test.ts.snap
@@ -9,11 +9,11 @@ exports[`model-generator generates model with all CRUD methods 1`] = `
 import { OrmClient } from "../client";
 import { QueryBuilder, buildFindManyDocument, buildFindFirstDocument, buildFindOneDocument, buildCreateDocument, buildUpdateByPkDocument, buildDeleteByPkDocument } from "../query-builder";
 import type { ConnectionResult, FindManyArgs, FindFirstArgs, CreateArgs, UpdateArgs, DeleteArgs, InferSelectResult, StrictSelect } from "../select-types";
-import type { User, UserWithRelations, UserSelect, UserFilter, UserCondition, UsersOrderBy, CreateUserInput, UpdateUserInput, UserPatch } from "../input-types";
+import type { User, UserWithRelations, UserSelect, UserFilter, UsersOrderBy, CreateUserInput, UpdateUserInput, UserPatch } from "../input-types";
 import { connectionFieldsMap } from "../input-types";
 export class UserModel {
   constructor(private client: OrmClient) {}
-  findMany<S extends UserSelect>(args: FindManyArgs<S, UserFilter, UserCondition, UsersOrderBy> & {
+  findMany<S extends UserSelect>(args: FindManyArgs<S, UserFilter, never, UsersOrderBy> & {
     select: S;
   } & StrictSelect<S, UserSelect>): QueryBuilder<{
     users: ConnectionResult<InferSelectResult<UserWithRelations, S>>;
@@ -23,14 +23,13 @@ export class UserModel {
       variables
     } = buildFindManyDocument("User", "users", args.select, {
       where: args?.where,
-      condition: args?.condition,
       orderBy: args?.orderBy as string[] | undefined,
       first: args?.first,
       last: args?.last,
       after: args?.after,
       before: args?.before,
       offset: args?.offset
-    }, "UserFilter", "UsersOrderBy", connectionFieldsMap, "UserCondition");
+    }, "UserFilter", "UsersOrderBy", connectionFieldsMap);
     return new QueryBuilder({
       client: this.client,
       operation: "query",
@@ -40,7 +39,7 @@ export class UserModel {
       variables
     });
   }
-  findFirst<S extends UserSelect>(args: FindFirstArgs<S, UserFilter, UserCondition> & {
+  findFirst<S extends UserSelect>(args: FindFirstArgs<S, UserFilter> & {
     select: S;
   } & StrictSelect<S, UserSelect>): QueryBuilder<{
     users: {
@@ -51,9 +50,8 @@ export class UserModel {
       document,
       variables
     } = buildFindFirstDocument("User", "users", args.select, {
-      where: args?.where,
-      condition: args?.condition
-    }, "UserFilter", connectionFieldsMap, "UserCondition");
+      where: args?.where
+    }, "UserFilter", connectionFieldsMap);
     return new QueryBuilder({
       client: this.client,
       operation: "query",
@@ -160,11 +158,11 @@ exports[`model-generator generates model without update/delete when not availabl
 import { OrmClient } from "../client";
 import { QueryBuilder, buildFindManyDocument, buildFindFirstDocument, buildFindOneDocument, buildCreateDocument, buildUpdateByPkDocument, buildDeleteByPkDocument } from "../query-builder";
 import type { ConnectionResult, FindManyArgs, FindFirstArgs, CreateArgs, UpdateArgs, DeleteArgs, InferSelectResult, StrictSelect } from "../select-types";
-import type { AuditLog, AuditLogWithRelations, AuditLogSelect, AuditLogFilter, AuditLogCondition, AuditLogsOrderBy, CreateAuditLogInput, UpdateAuditLogInput, AuditLogPatch } from "../input-types";
+import type { AuditLog, AuditLogWithRelations, AuditLogSelect, AuditLogFilter, AuditLogsOrderBy, CreateAuditLogInput, UpdateAuditLogInput, AuditLogPatch } from "../input-types";
 import { connectionFieldsMap } from "../input-types";
 export class AuditLogModel {
   constructor(private client: OrmClient) {}
-  findMany<S extends AuditLogSelect>(args: FindManyArgs<S, AuditLogFilter, AuditLogCondition, AuditLogsOrderBy> & {
+  findMany<S extends AuditLogSelect>(args: FindManyArgs<S, AuditLogFilter, never, AuditLogsOrderBy> & {
     select: S;
   } & StrictSelect<S, AuditLogSelect>): QueryBuilder<{
     auditLogs: ConnectionResult<InferSelectResult<AuditLogWithRelations, S>>;
@@ -174,14 +172,13 @@ export class AuditLogModel {
       variables
     } = buildFindManyDocument("AuditLog", "auditLogs", args.select, {
       where: args?.where,
-      condition: args?.condition,
       orderBy: args?.orderBy as string[] | undefined,
       first: args?.first,
       last: args?.last,
       after: args?.after,
       before: args?.before,
       offset: args?.offset
-    }, "AuditLogFilter", "AuditLogsOrderBy", connectionFieldsMap, "AuditLogCondition");
+    }, "AuditLogFilter", "AuditLogsOrderBy", connectionFieldsMap);
     return new QueryBuilder({
       client: this.client,
       operation: "query",
@@ -191,7 +188,7 @@ export class AuditLogModel {
       variables
     });
   }
-  findFirst<S extends AuditLogSelect>(args: FindFirstArgs<S, AuditLogFilter, AuditLogCondition> & {
+  findFirst<S extends AuditLogSelect>(args: FindFirstArgs<S, AuditLogFilter> & {
     select: S;
   } & StrictSelect<S, AuditLogSelect>): QueryBuilder<{
     auditLogs: {
@@ -202,9 +199,8 @@ export class AuditLogModel {
       document,
       variables
     } = buildFindFirstDocument("AuditLog", "auditLogs", args.select, {
-      where: args?.where,
-      condition: args?.condition
-    }, "AuditLogFilter", connectionFieldsMap, "AuditLogCondition");
+      where: args?.where
+    }, "AuditLogFilter", connectionFieldsMap);
     return new QueryBuilder({
       client: this.client,
       operation: "query",
@@ -265,11 +261,11 @@ exports[`model-generator handles custom query/mutation names 1`] = `
 import { OrmClient } from "../client";
 import { QueryBuilder, buildFindManyDocument, buildFindFirstDocument, buildFindOneDocument, buildCreateDocument, buildUpdateByPkDocument, buildDeleteByPkDocument } from "../query-builder";
 import type { ConnectionResult, FindManyArgs, FindFirstArgs, CreateArgs, UpdateArgs, DeleteArgs, InferSelectResult, StrictSelect } from "../select-types";
-import type { Organization, OrganizationWithRelations, OrganizationSelect, OrganizationFilter, OrganizationCondition, OrganizationsOrderBy, CreateOrganizationInput, UpdateOrganizationInput, OrganizationPatch } from "../input-types";
+import type { Organization, OrganizationWithRelations, OrganizationSelect, OrganizationFilter, OrganizationsOrderBy, CreateOrganizationInput, UpdateOrganizationInput, OrganizationPatch } from "../input-types";
 import { connectionFieldsMap } from "../input-types";
 export class OrganizationModel {
   constructor(private client: OrmClient) {}
-  findMany<S extends OrganizationSelect>(args: FindManyArgs<S, OrganizationFilter, OrganizationCondition, OrganizationsOrderBy> & {
+  findMany<S extends OrganizationSelect>(args: FindManyArgs<S, OrganizationFilter, never, OrganizationsOrderBy> & {
     select: S;
   } & StrictSelect<S, OrganizationSelect>): QueryBuilder<{
     allOrganizations: ConnectionResult<InferSelectResult<OrganizationWithRelations, S>>;
@@ -279,14 +275,13 @@ export class OrganizationModel {
       variables
     } = buildFindManyDocument("Organization", "allOrganizations", args.select, {
       where: args?.where,
-      condition: args?.condition,
       orderBy: args?.orderBy as string[] | undefined,
       first: args?.first,
       last: args?.last,
       after: args?.after,
       before: args?.before,
       offset: args?.offset
-    }, "OrganizationFilter", "OrganizationsOrderBy", connectionFieldsMap, "OrganizationCondition");
+    }, "OrganizationFilter", "OrganizationsOrderBy", connectionFieldsMap);
     return new QueryBuilder({
       client: this.client,
       operation: "query",
@@ -296,7 +291,7 @@ export class OrganizationModel {
       variables
     });
   }
-  findFirst<S extends OrganizationSelect>(args: FindFirstArgs<S, OrganizationFilter, OrganizationCondition> & {
+  findFirst<S extends OrganizationSelect>(args: FindFirstArgs<S, OrganizationFilter> & {
     select: S;
   } & StrictSelect<S, OrganizationSelect>): QueryBuilder<{
     allOrganizations: {
@@ -307,9 +302,8 @@ export class OrganizationModel {
       document,
       variables
     } = buildFindFirstDocument("Organization", "allOrganizations", args.select, {
-      where: args?.where,
-      condition: args?.condition
-    }, "OrganizationFilter", connectionFieldsMap, "OrganizationCondition");
+      where: args?.where
+    }, "OrganizationFilter", connectionFieldsMap);
     return new QueryBuilder({
       client: this.client,
       operation: "query",

--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/react-query-hooks.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/react-query-hooks.test.ts.snap
@@ -1436,9 +1436,9 @@ import { getClient } from "../client";
 import { buildListSelectionArgs } from "../selection";
 import type { ListSelectionConfig } from "../selection";
 import { userKeys } from "../query-keys";
-import type { UserSelect, UserWithRelations, UserFilter, UsersOrderBy, UserCondition } from "../../orm/input-types";
+import type { UserSelect, UserWithRelations, UserFilter, UsersOrderBy } from "../../orm/input-types";
 import type { FindManyArgs, InferSelectResult, ConnectionResult, HookStrictSelect } from "../../orm/select-types";
-export type { UserSelect, UserWithRelations, UserFilter, UsersOrderBy, UserCondition } from "../../orm/input-types";
+export type { UserSelect, UserWithRelations, UserFilter, UsersOrderBy } from "../../orm/input-types";
 /** Query key factory - re-exported from query-keys.ts */
 export const usersQueryKey = userKeys.list;
 /**
@@ -1545,9 +1545,9 @@ import { buildListSelectionArgs } from "../selection";
 import type { ListSelectionConfig } from "../selection";
 import { postKeys } from "../query-keys";
 import type { PostScope } from "../query-keys";
-import type { PostSelect, PostWithRelations, PostFilter, PostsOrderBy, PostCondition } from "../../orm/input-types";
+import type { PostSelect, PostWithRelations, PostFilter, PostsOrderBy } from "../../orm/input-types";
 import type { FindManyArgs, InferSelectResult, ConnectionResult, HookStrictSelect } from "../../orm/select-types";
-export type { PostSelect, PostWithRelations, PostFilter, PostsOrderBy, PostCondition } from "../../orm/input-types";
+export type { PostSelect, PostWithRelations, PostFilter, PostsOrderBy } from "../../orm/input-types";
 /** Query key factory - re-exported from query-keys.ts */
 export const postsQueryKey = postKeys.list;
 /**
@@ -1669,10 +1669,10 @@ import type { UseQueryOptions, UseQueryResult, QueryClient } from "@tanstack/rea
 import { getClient } from "../client";
 import { buildListSelectionArgs } from "../selection";
 import type { ListSelectionConfig } from "../selection";
-import type { UserSelect, UserWithRelations, UserFilter, UsersOrderBy, UserCondition } from "../../orm/input-types";
+import type { UserSelect, UserWithRelations, UserFilter, UsersOrderBy } from "../../orm/input-types";
 import type { FindManyArgs, InferSelectResult, ConnectionResult, HookStrictSelect } from "../../orm/select-types";
-export type { UserSelect, UserWithRelations, UserFilter, UsersOrderBy, UserCondition } from "../../orm/input-types";
-export const usersQueryKey = (variables?: FindManyArgs<unknown, UserFilter, UserCondition, UsersOrderBy>) => ["user", "list", variables] as const;
+export type { UserSelect, UserWithRelations, UserFilter, UsersOrderBy } from "../../orm/input-types";
+export const usersQueryKey = (variables?: FindManyArgs<unknown, UserFilter, never, UsersOrderBy>) => ["user", "list", variables] as const;
 /**
  * Query hook for fetching User list
  * 

--- a/graphql/codegen/src/__tests__/codegen/input-types-generator.test.ts
+++ b/graphql/codegen/src/__tests__/codegen/input-types-generator.test.ts
@@ -965,7 +965,7 @@ describe('plugin-injected condition fields', () => {
       },
     });
 
-    const result = generateInputTypesFile(registry, new Set(), [contactTable]);
+    const result = generateInputTypesFile(registry, new Set(), [contactTable], undefined, true, { condition: true });
 
     // Regular table column fields should still be present
     expect(result.content).toContain('export interface ContactCondition {');
@@ -1025,7 +1025,7 @@ describe('plugin-injected condition fields', () => {
       },
     });
 
-    const result = generateInputTypesFile(registry, new Set(), [contactTable]);
+    const result = generateInputTypesFile(registry, new Set(), [contactTable], undefined, true, { condition: true });
 
     // VectorNearbyInput should be generated (follows *Input pattern)
     expect(result.content).toContain('export interface VectorNearbyInput {');
@@ -1051,7 +1051,7 @@ describe('plugin-injected condition fields', () => {
       },
     });
 
-    const result = generateInputTypesFile(registry, new Set(), [contactTable]);
+    const result = generateInputTypesFile(registry, new Set(), [contactTable], undefined, true, { condition: true });
 
     // Count occurrences of 'id?' in the ContactCondition interface
     const conditionMatch = result.content.match(
@@ -1102,7 +1102,7 @@ describe('plugin-injected condition fields', () => {
 
   it('works without typeRegistry (backwards compatible)', () => {
     // When no typeRegistry has the condition type, only table columns are used
-    const result = generateInputTypesFile(new Map(), new Set(), [contactTable]);
+    const result = generateInputTypesFile(new Map(), new Set(), [contactTable], undefined, true, { condition: true });
 
     expect(result.content).toContain('export interface ContactCondition {');
     expect(result.content).toContain('id?: string | null;');

--- a/graphql/codegen/src/__tests__/codegen/model-generator.test.ts
+++ b/graphql/codegen/src/__tests__/codegen/model-generator.test.ts
@@ -249,7 +249,7 @@ describe('model-generator', () => {
       },
     });
 
-    const result = generateModelFile(table, false);
+    const result = generateModelFile(table, false, { condition: true });
 
     // Condition type should be imported
     expect(result.content).toContain('ContactCondition');

--- a/graphql/codegen/src/core/codegen/cli/index.ts
+++ b/graphql/codegen/src/core/codegen/cli/index.ts
@@ -78,9 +78,12 @@ export function generateCli(options: GenerateCliOptions): GenerateCliResult {
   const authFile = generateAuthCommand(toolName);
   files.push(authFile);
 
+  const conditionEnabled = config.codegen?.condition === true;
+
   for (const table of tables) {
     const tableFile = generateTableCommand(table, {
       typeRegistry: options.typeRegistry,
+      condition: conditionEnabled,
     });
     files.push(tableFile);
   }
@@ -143,6 +146,8 @@ export interface GenerateMultiTargetCliOptions {
   nodeHttpAdapter?: boolean;
   /** Generate a runnable index.ts entry point */
   entryPoint?: boolean;
+  /** Whether PostGraphile condition types are enabled (default: true) */
+  condition?: boolean;
 }
 
 export function resolveBuiltinNames(
@@ -170,6 +175,7 @@ export function generateMultiTargetCli(
   options: GenerateMultiTargetCliOptions,
 ): GenerateCliResult {
   const { toolName, targets } = options;
+  const conditionEnabled = options.condition === true;
   const files: GeneratedFile[] = [];
 
   const targetNames = targets.map((t) => t.name);
@@ -244,6 +250,7 @@ export function generateMultiTargetCli(
         targetName: target.name,
         executorImportPath: '../../executor',
         typeRegistry: target.typeRegistry,
+        condition: conditionEnabled,
       });
       files.push(tableFile);
     }

--- a/graphql/codegen/src/core/codegen/cli/table-command-generator.ts
+++ b/graphql/codegen/src/core/codegen/cli/table-command-generator.ts
@@ -527,7 +527,7 @@ function buildFindFirstArgsType(table: Table, conditionEnabled: boolean): t.TSTy
   );
 }
 
-function buildListHandler(table: Table, vectorFieldNames: string[], targetName?: string, typeRegistry?: TypeRegistry, conditionEnabled = true): t.FunctionDeclaration {
+function buildListHandler(table: Table, vectorFieldNames: string[], targetName?: string, typeRegistry?: TypeRegistry, conditionEnabled = false): t.FunctionDeclaration {
   const { singularName } = getTableNames(table);
   const defaultSelectObj = buildSelectObject(table, typeRegistry);
 
@@ -625,7 +625,7 @@ function buildListHandler(table: Table, vectorFieldNames: string[], targetName?:
  * Accepts --select, --where.<field>.<op>, --condition.<field>.<op> flags.
  * Internally calls findMany with first:1 and returns a single record (or null).
  */
-function buildFindFirstHandler(table: Table, targetName?: string, typeRegistry?: TypeRegistry, conditionEnabled = true): t.FunctionDeclaration {
+function buildFindFirstHandler(table: Table, targetName?: string, typeRegistry?: TypeRegistry, conditionEnabled = false): t.FunctionDeclaration {
   const { singularName } = getTableNames(table);
   const defaultSelectObj = buildSelectObject(table, typeRegistry);
 
@@ -715,7 +715,7 @@ function buildSearchHandler(
   vectorFieldNames: string[],
   targetName?: string,
   typeRegistry?: TypeRegistry,
-  conditionEnabled = true,
+  conditionEnabled = false,
 ): t.FunctionDeclaration {
   const { singularName } = getTableNames(table);
   const defaultSelectObj = buildSelectObject(table, typeRegistry);
@@ -1304,6 +1304,8 @@ export interface TableCommandOptions {
   executorImportPath?: string;
   /** TypeRegistry from introspection, used to check field defaults */
   typeRegistry?: TypeRegistry;
+  /** Whether PostGraphile condition types are enabled (default: true) */
+  condition?: boolean;
 }
 
 export function generateTableCommand(table: Table, options?: TableCommandOptions): GeneratedFile {
@@ -1346,17 +1348,16 @@ export function generateTableCommand(table: Table, options?: TableCommandOptions
   // Import table-specific ORM types for generic type parameters on parseFindManyArgs/parseFindFirstArgs
   const selectTypeName = `${typeName}Select`;
   const whereTypeName = getFilterTypeName(table);
-  const conditionTypeName = getConditionTypeName(table);
   const orderByTypeName = getOrderByTypeName(table);
-  // Condition types are always generated, so we always import them
-  const conditionEnabled = true;
+  const conditionEnabled = options?.condition === true;
+  const conditionTypeName = conditionEnabled ? getConditionTypeName(table) : undefined;
   statements.push(
     createImportDeclaration(inputTypesPath, [
       createInputTypeName,
       patchTypeName,
       selectTypeName,
       whereTypeName,
-      conditionTypeName,
+      ...(conditionTypeName ? [conditionTypeName] : []),
       orderByTypeName,
     ], true),
   );

--- a/graphql/codegen/src/core/codegen/cli/table-command-generator.ts
+++ b/graphql/codegen/src/core/codegen/cli/table-command-generator.ts
@@ -485,7 +485,11 @@ function buildAutoEmbedInputBlock(
 
 /**
  * Build the FindManyArgs type instantiation for a table:
- * FindManyArgs<SelectType, FilterType, ConditionType, OrderByType>
+ * FindManyArgs<SelectType, FilterType, ConditionType, OrderByType> & { select: SelectType }
+ *
+ * The intersection with { select: SelectType } makes select required,
+ * matching what the ORM's findMany method expects. parseFindManyArgs
+ * always sets select at runtime (from defaultSelect or --select flag).
  */
 function buildFindManyArgsType(table: Table, conditionEnabled: boolean): t.TSType {
   const { typeName } = getTableNames(table);
@@ -493,7 +497,7 @@ function buildFindManyArgsType(table: Table, conditionEnabled: boolean): t.TSTyp
   const whereTypeName = getFilterTypeName(table);
   const conditionTypeName = conditionEnabled ? getConditionTypeName(table) : undefined;
   const orderByTypeName = getOrderByTypeName(table);
-  return t.tsTypeReference(
+  const findManyType = t.tsTypeReference(
     t.identifier('FindManyArgs'),
     t.tsTypeParameterInstantiation([
       t.tsTypeReference(t.identifier(selectTypeName)),
@@ -504,18 +508,34 @@ function buildFindManyArgsType(table: Table, conditionEnabled: boolean): t.TSTyp
       t.tsTypeReference(t.identifier(orderByTypeName)),
     ]),
   );
+  // Intersect with { select: SelectType } to make select required
+  return t.tsIntersectionType([
+    findManyType,
+    t.tsTypeLiteral([
+      Object.assign(
+        t.tsPropertySignature(
+          t.identifier('select'),
+          t.tsTypeAnnotation(t.tsTypeReference(t.identifier(selectTypeName))),
+        ),
+        { optional: false },
+      ),
+    ]),
+  ]);
 }
 
 /**
  * Build the FindFirstArgs type instantiation for a table:
- * FindFirstArgs<SelectType, FilterType, ConditionType>
+ * FindFirstArgs<SelectType, FilterType, ConditionType> & { select: SelectType }
+ *
+ * The intersection with { select: SelectType } makes select required,
+ * matching what the ORM's findFirst method expects.
  */
 function buildFindFirstArgsType(table: Table, conditionEnabled: boolean): t.TSType {
   const { typeName } = getTableNames(table);
   const selectTypeName = `${typeName}Select`;
   const whereTypeName = getFilterTypeName(table);
   const conditionTypeName = conditionEnabled ? getConditionTypeName(table) : undefined;
-  return t.tsTypeReference(
+  const findFirstType = t.tsTypeReference(
     t.identifier('FindFirstArgs'),
     t.tsTypeParameterInstantiation([
       t.tsTypeReference(t.identifier(selectTypeName)),
@@ -525,6 +545,19 @@ function buildFindFirstArgsType(table: Table, conditionEnabled: boolean): t.TSTy
         : t.tsNeverKeyword(),
     ]),
   );
+  // Intersect with { select: SelectType } to make select required
+  return t.tsIntersectionType([
+    findFirstType,
+    t.tsTypeLiteral([
+      Object.assign(
+        t.tsPropertySignature(
+          t.identifier('select'),
+          t.tsTypeAnnotation(t.tsTypeReference(t.identifier(selectTypeName))),
+        ),
+        { optional: false },
+      ),
+    ]),
+  ]);
 }
 
 function buildListHandler(table: Table, vectorFieldNames: string[], targetName?: string, typeRegistry?: TypeRegistry, conditionEnabled = false): t.FunctionDeclaration {

--- a/graphql/codegen/src/core/codegen/cli/table-command-generator.ts
+++ b/graphql/codegen/src/core/codegen/cli/table-command-generator.ts
@@ -15,6 +15,9 @@ import {
   toPascalCase,
   getCreateInputTypeName,
   getPatchTypeName,
+  getFilterTypeName,
+  getOrderByTypeName,
+  getConditionTypeName,
 } from '../utils';
 import type { Table, TypeRegistry } from '../../../types/schema';
 import type { GeneratedFile } from './executor-generator';
@@ -480,7 +483,51 @@ function buildAutoEmbedInputBlock(
   );
 }
 
-function buildListHandler(table: Table, vectorFieldNames: string[], targetName?: string, typeRegistry?: TypeRegistry): t.FunctionDeclaration {
+/**
+ * Build the FindManyArgs type instantiation for a table:
+ * FindManyArgs<SelectType, FilterType, ConditionType, OrderByType>
+ */
+function buildFindManyArgsType(table: Table, conditionEnabled: boolean): t.TSType {
+  const { typeName } = getTableNames(table);
+  const selectTypeName = `${typeName}Select`;
+  const whereTypeName = getFilterTypeName(table);
+  const conditionTypeName = conditionEnabled ? getConditionTypeName(table) : undefined;
+  const orderByTypeName = getOrderByTypeName(table);
+  return t.tsTypeReference(
+    t.identifier('FindManyArgs'),
+    t.tsTypeParameterInstantiation([
+      t.tsTypeReference(t.identifier(selectTypeName)),
+      t.tsTypeReference(t.identifier(whereTypeName)),
+      conditionTypeName
+        ? t.tsTypeReference(t.identifier(conditionTypeName))
+        : t.tsNeverKeyword(),
+      t.tsTypeReference(t.identifier(orderByTypeName)),
+    ]),
+  );
+}
+
+/**
+ * Build the FindFirstArgs type instantiation for a table:
+ * FindFirstArgs<SelectType, FilterType, ConditionType>
+ */
+function buildFindFirstArgsType(table: Table, conditionEnabled: boolean): t.TSType {
+  const { typeName } = getTableNames(table);
+  const selectTypeName = `${typeName}Select`;
+  const whereTypeName = getFilterTypeName(table);
+  const conditionTypeName = conditionEnabled ? getConditionTypeName(table) : undefined;
+  return t.tsTypeReference(
+    t.identifier('FindFirstArgs'),
+    t.tsTypeParameterInstantiation([
+      t.tsTypeReference(t.identifier(selectTypeName)),
+      t.tsTypeReference(t.identifier(whereTypeName)),
+      conditionTypeName
+        ? t.tsTypeReference(t.identifier(conditionTypeName))
+        : t.tsNeverKeyword(),
+    ]),
+  );
+}
+
+function buildListHandler(table: Table, vectorFieldNames: string[], targetName?: string, typeRegistry?: TypeRegistry, conditionEnabled = true): t.FunctionDeclaration {
   const { singularName } = getTableNames(table);
   const defaultSelectObj = buildSelectObject(table, typeRegistry);
 
@@ -494,18 +541,21 @@ function buildListHandler(table: Table, vectorFieldNames: string[], targetName?:
     ]),
   );
 
-  // const findManyArgs = parseFindManyArgs(argv, defaultSelect);
-  tryBody.push(
-    t.variableDeclaration('const', [
-      t.variableDeclarator(
-        t.identifier('findManyArgs'),
-        t.callExpression(t.identifier('parseFindManyArgs'), [
-          t.identifier('argv'),
-          t.identifier('defaultSelect'),
-        ]),
-      ),
-    ]),
-  );
+  // const findManyArgs = parseFindManyArgs<FindManyArgs<...>>(argv, defaultSelect);
+  {
+    const callExpr = t.callExpression(t.identifier('parseFindManyArgs'), [
+      t.identifier('argv'),
+      t.identifier('defaultSelect'),
+    ]);
+    callExpr.typeParameters = t.tsTypeParameterInstantiation([
+      buildFindManyArgsType(table, conditionEnabled),
+    ]);
+    tryBody.push(
+      t.variableDeclaration('const', [
+        t.variableDeclarator(t.identifier('findManyArgs'), callExpr),
+      ]),
+    );
+  }
 
   // Auto-embed vector fields in the where clause when --auto-embed is passed
   if (vectorFieldNames.length > 0) {
@@ -520,7 +570,7 @@ function buildListHandler(table: Table, vectorFieldNames: string[], targetName?:
 
   tryBody.push(buildGetClientStatement(targetName));
 
-  // const result = await client.<singular>.findMany(findManyArgs as any).execute();
+  // const result = await client.<singular>.findMany(findManyArgs).execute();
   tryBody.push(
     t.variableDeclaration('const', [
       t.variableDeclarator(
@@ -536,7 +586,7 @@ function buildListHandler(table: Table, vectorFieldNames: string[], targetName?:
                   ),
                   t.identifier('findMany'),
                 ),
-                [t.tsAsExpression(t.identifier('findManyArgs'), t.tsAnyKeyword())],
+                [t.identifier('findManyArgs')],
               ),
               t.identifier('execute'),
             ),
@@ -575,7 +625,7 @@ function buildListHandler(table: Table, vectorFieldNames: string[], targetName?:
  * Accepts --select, --where.<field>.<op>, --condition.<field>.<op> flags.
  * Internally calls findMany with first:1 and returns a single record (or null).
  */
-function buildFindFirstHandler(table: Table, targetName?: string, typeRegistry?: TypeRegistry): t.FunctionDeclaration {
+function buildFindFirstHandler(table: Table, targetName?: string, typeRegistry?: TypeRegistry, conditionEnabled = true): t.FunctionDeclaration {
   const { singularName } = getTableNames(table);
   const defaultSelectObj = buildSelectObject(table, typeRegistry);
 
@@ -588,22 +638,25 @@ function buildFindFirstHandler(table: Table, targetName?: string, typeRegistry?:
     ]),
   );
 
-  // const findFirstArgs = parseFindFirstArgs(argv, defaultSelect);
-  tryBody.push(
-    t.variableDeclaration('const', [
-      t.variableDeclarator(
-        t.identifier('findFirstArgs'),
-        t.callExpression(t.identifier('parseFindFirstArgs'), [
-          t.identifier('argv'),
-          t.identifier('defaultSelect'),
-        ]),
-      ),
-    ]),
-  );
+  // const findFirstArgs = parseFindFirstArgs<FindFirstArgs<...>>(argv, defaultSelect);
+  {
+    const callExpr = t.callExpression(t.identifier('parseFindFirstArgs'), [
+      t.identifier('argv'),
+      t.identifier('defaultSelect'),
+    ]);
+    callExpr.typeParameters = t.tsTypeParameterInstantiation([
+      buildFindFirstArgsType(table, conditionEnabled),
+    ]);
+    tryBody.push(
+      t.variableDeclaration('const', [
+        t.variableDeclarator(t.identifier('findFirstArgs'), callExpr),
+      ]),
+    );
+  }
 
   tryBody.push(buildGetClientStatement(targetName));
 
-  // const result = await client.<singular>.findFirst(findFirstArgs as any).execute();
+  // const result = await client.<singular>.findFirst(findFirstArgs).execute();
   tryBody.push(
     t.variableDeclaration('const', [
       t.variableDeclarator(
@@ -616,7 +669,7 @@ function buildFindFirstHandler(table: Table, targetName?: string, typeRegistry?:
                   t.memberExpression(t.identifier('client'), t.identifier(singularName)),
                   t.identifier('findFirst'),
                 ),
-                [t.tsAsExpression(t.identifier('findFirstArgs'), t.tsAnyKeyword())],
+                [t.identifier('findFirstArgs')],
               ),
               t.identifier('execute'),
             ),
@@ -662,6 +715,7 @@ function buildSearchHandler(
   vectorFieldNames: string[],
   targetName?: string,
   typeRegistry?: TypeRegistry,
+  conditionEnabled = true,
 ): t.FunctionDeclaration {
   const { singularName } = getTableNames(table);
   const defaultSelectObj = buildSelectObject(table, typeRegistry);
@@ -808,23 +862,26 @@ function buildSearchHandler(
     ]),
   );
 
-  // const findManyArgs = parseFindManyArgs(argv, defaultSelect, searchWhere);
-  tryBody.push(
-    t.variableDeclaration('const', [
-      t.variableDeclarator(
-        t.identifier('findManyArgs'),
-        t.callExpression(t.identifier('parseFindManyArgs'), [
-          t.identifier('argv'),
-          t.identifier('defaultSelect'),
-          t.identifier('searchWhere'),
-        ]),
-      ),
-    ]),
-  );
+  // const findManyArgs = parseFindManyArgs<FindManyArgs<...>>(argv, defaultSelect, searchWhere);
+  {
+    const callExpr = t.callExpression(t.identifier('parseFindManyArgs'), [
+      t.identifier('argv'),
+      t.identifier('defaultSelect'),
+      t.identifier('searchWhere'),
+    ]);
+    callExpr.typeParameters = t.tsTypeParameterInstantiation([
+      buildFindManyArgsType(table, conditionEnabled),
+    ]);
+    tryBody.push(
+      t.variableDeclaration('const', [
+        t.variableDeclarator(t.identifier('findManyArgs'), callExpr),
+      ]),
+    );
+  }
 
   tryBody.push(buildGetClientStatement(targetName));
 
-  // const result = await client.<singular>.findMany(findManyArgs as any).execute();
+  // const result = await client.<singular>.findMany(findManyArgs).execute();
   tryBody.push(
     t.variableDeclaration('const', [
       t.variableDeclarator(
@@ -840,7 +897,7 @@ function buildSearchHandler(
                   ),
                   t.identifier('findMany'),
                 ),
-                [t.tsAsExpression(t.identifier('findManyArgs'), t.tsAnyKeyword())],
+                [t.identifier('findManyArgs')],
               ),
               t.identifier('execute'),
             ),
@@ -1250,7 +1307,7 @@ export interface TableCommandOptions {
 }
 
 export function generateTableCommand(table: Table, options?: TableCommandOptions): GeneratedFile {
-  const { singularName } = getTableNames(table);
+  const { singularName, typeName } = getTableNames(table);
   const commandName = toKebabCase(singularName);
   const statements: t.Statement[] = [];
   const executorPath = options?.executorImportPath ?? '../executor';
@@ -1286,8 +1343,30 @@ export function generateTableCommand(table: Table, options?: TableCommandOptions
   const inputTypesPath = options?.targetName
     ? `../../../orm/input-types`
     : `../../orm/input-types`;
+  // Import table-specific ORM types for generic type parameters on parseFindManyArgs/parseFindFirstArgs
+  const selectTypeName = `${typeName}Select`;
+  const whereTypeName = getFilterTypeName(table);
+  const conditionTypeName = getConditionTypeName(table);
+  const orderByTypeName = getOrderByTypeName(table);
+  // Condition types are always generated, so we always import them
+  const conditionEnabled = true;
   statements.push(
-    createImportDeclaration(inputTypesPath, [createInputTypeName, patchTypeName], true),
+    createImportDeclaration(inputTypesPath, [
+      createInputTypeName,
+      patchTypeName,
+      selectTypeName,
+      whereTypeName,
+      conditionTypeName,
+      orderByTypeName,
+    ], true),
+  );
+
+  // Import FindManyArgs/FindFirstArgs from select-types for proper generic typing
+  const selectTypesPath = options?.targetName
+    ? `../../../orm/select-types`
+    : `../../orm/select-types`;
+  statements.push(
+    createImportDeclaration(selectTypesPath, ['FindManyArgs', 'FindFirstArgs'], true),
   );
 
   // Generate field schema for type coercion
@@ -1579,9 +1658,9 @@ export function generateTableCommand(table: Table, options?: TableCommandOptions
 
   const tn = options?.targetName;
   const ormTypes = { createInputTypeName, patchTypeName, innerFieldName };
-  statements.push(buildListHandler(table, vectorFieldNames, tn, options?.typeRegistry));
-  statements.push(buildFindFirstHandler(table, tn, options?.typeRegistry));
-  if (hasSearchFields) statements.push(buildSearchHandler(table, specialGroups, vectorFieldNames, tn, options?.typeRegistry));
+  statements.push(buildListHandler(table, vectorFieldNames, tn, options?.typeRegistry, conditionEnabled));
+  statements.push(buildFindFirstHandler(table, tn, options?.typeRegistry, conditionEnabled));
+  if (hasSearchFields) statements.push(buildSearchHandler(table, specialGroups, vectorFieldNames, tn, options?.typeRegistry, conditionEnabled));
   if (hasGet) statements.push(buildGetHandler(table, tn, options?.typeRegistry));
   statements.push(buildMutationHandler(table, 'create', vectorFieldNames, tn, options?.typeRegistry, ormTypes));
   if (hasUpdate) statements.push(buildMutationHandler(table, 'update', vectorFieldNames, tn, options?.typeRegistry, ormTypes));

--- a/graphql/codegen/src/core/codegen/cli/table-command-generator.ts
+++ b/graphql/codegen/src/core/codegen/cli/table-command-generator.ts
@@ -520,7 +520,7 @@ function buildListHandler(table: Table, vectorFieldNames: string[], targetName?:
 
   tryBody.push(buildGetClientStatement(targetName));
 
-  // const result = await client.<singular>.findMany(findManyArgs).execute();
+  // const result = await client.<singular>.findMany(findManyArgs as any).execute();
   tryBody.push(
     t.variableDeclaration('const', [
       t.variableDeclarator(
@@ -536,7 +536,7 @@ function buildListHandler(table: Table, vectorFieldNames: string[], targetName?:
                   ),
                   t.identifier('findMany'),
                 ),
-                [t.identifier('findManyArgs')],
+                [t.tsAsExpression(t.identifier('findManyArgs'), t.tsAnyKeyword())],
               ),
               t.identifier('execute'),
             ),
@@ -603,7 +603,7 @@ function buildFindFirstHandler(table: Table, targetName?: string, typeRegistry?:
 
   tryBody.push(buildGetClientStatement(targetName));
 
-  // const result = await client.<singular>.findFirst(findFirstArgs).execute();
+  // const result = await client.<singular>.findFirst(findFirstArgs as any).execute();
   tryBody.push(
     t.variableDeclaration('const', [
       t.variableDeclarator(
@@ -616,7 +616,7 @@ function buildFindFirstHandler(table: Table, targetName?: string, typeRegistry?:
                   t.memberExpression(t.identifier('client'), t.identifier(singularName)),
                   t.identifier('findFirst'),
                 ),
-                [t.identifier('findFirstArgs')],
+                [t.tsAsExpression(t.identifier('findFirstArgs'), t.tsAnyKeyword())],
               ),
               t.identifier('execute'),
             ),
@@ -824,7 +824,7 @@ function buildSearchHandler(
 
   tryBody.push(buildGetClientStatement(targetName));
 
-  // const result = await client.<singular>.findMany(findManyArgs).execute();
+  // const result = await client.<singular>.findMany(findManyArgs as any).execute();
   tryBody.push(
     t.variableDeclaration('const', [
       t.variableDeclarator(
@@ -840,7 +840,7 @@ function buildSearchHandler(
                   ),
                   t.identifier('findMany'),
                 ),
-                [t.identifier('findManyArgs')],
+                [t.tsAsExpression(t.identifier('findManyArgs'), t.tsAnyKeyword())],
               ),
               t.identifier('execute'),
             ),

--- a/graphql/codegen/src/core/codegen/index.ts
+++ b/graphql/codegen/src/core/codegen/index.ts
@@ -191,7 +191,7 @@ export function generate(options: GenerateOptions): GenerateResult {
   }
 
   // Condition types (PostGraphile simple equality filters)
-  const conditionEnabled = config.codegen?.condition !== false;
+  const conditionEnabled = config.codegen?.condition === true;
 
   // 4. Generate table-based query hooks (queries/*.ts)
   const queryHooks = generateAllQueryHooks(tables, {

--- a/graphql/codegen/src/core/codegen/orm/index.ts
+++ b/graphql/codegen/src/core/codegen/orm/index.ts
@@ -66,7 +66,7 @@ export interface GenerateOrmResult {
 export function generateOrm(options: GenerateOrmOptions): GenerateOrmResult {
   const { tables, customOperations, sharedTypesPath } = options;
   const commentsEnabled = options.config.codegen?.comments !== false;
-  const conditionEnabled = options.config.codegen?.condition !== false;
+  const conditionEnabled = options.config.codegen?.condition === true;
   const files: GeneratedFile[] = [];
 
   // Use shared types when a sharedTypesPath is provided (unified output mode)

--- a/graphql/codegen/src/core/codegen/orm/input-types-generator.ts
+++ b/graphql/codegen/src/core/codegen/orm/input-types-generator.ts
@@ -2093,7 +2093,7 @@ export function generateInputTypesFile(
   comments: boolean = true,
   options?: { condition?: boolean },
 ): GeneratedInputTypesFile {
-  const conditionEnabled = options?.condition !== false;
+  const conditionEnabled = options?.condition === true;
   const statements: t.Statement[] = [];
   const tablesList = tables ?? [];
   const hasTables = tablesList.length > 0;

--- a/graphql/codegen/src/core/codegen/orm/model-generator.ts
+++ b/graphql/codegen/src/core/codegen/orm/model-generator.ts
@@ -174,7 +174,7 @@ export function generateModelFile(
   options?: { condition?: boolean },
   allTables?: Table[],
 ): GeneratedModelFile {
-  const conditionEnabled = options?.condition !== false;
+  const conditionEnabled = options?.condition === true;
   const { typeName, singularName, pluralName } = getTableNames(table);
   const modelName = `${typeName}Model`;
   const baseFileName = lcFirst(typeName);

--- a/graphql/codegen/src/core/codegen/queries.ts
+++ b/graphql/codegen/src/core/codegen/queries.ts
@@ -87,7 +87,7 @@ export function generateListQueryHook(
     reactQueryEnabled = true,
     useCentralizedKeys = true,
     hasRelationships = false,
-    condition: conditionEnabled = true,
+    condition: conditionEnabled = false,
   } = options;
   const { typeName, pluralName, singularName } = getTableNames(table);
   const hookName = getListQueryHookName(table);

--- a/graphql/codegen/src/core/codegen/templates/cli-utils.ts
+++ b/graphql/codegen/src/core/codegen/templates/cli-utils.ts
@@ -252,11 +252,11 @@ export function parseSelectFlag(
  *   const findManyArgs = parseFindManyArgs(argv, { id: true, name: true });
  *   const result = await client.user.findMany(findManyArgs).execute();
  */
-export function parseFindManyArgs(
+export function parseFindManyArgs<T = Record<string, unknown>>(
   argv: Record<string, unknown>,
   defaultSelect: Record<string, unknown>,
   extraWhere?: Record<string, unknown>,
-): Record<string, unknown> {
+): T {
   const limit = parseIntFlag(argv, 'limit');
   const last = parseIntFlag(argv, 'last');
   const offset = parseIntFlag(argv, 'offset');
@@ -280,7 +280,7 @@ export function parseFindManyArgs(
     ...(where !== undefined ? { where } : {}),
     ...(condition !== undefined ? { condition } : {}),
     ...(orderBy !== undefined ? { orderBy } : {}),
-  };
+  } as unknown as T;
 }
 
 /**
@@ -288,10 +288,10 @@ export function parseFindManyArgs(
  * Like parseFindManyArgs but only includes select, where, and condition
  * (no pagination flags — findFirst returns the first matching record).
  */
-export function parseFindFirstArgs(
+export function parseFindFirstArgs<T = Record<string, unknown>>(
   argv: Record<string, unknown>,
   defaultSelect: Record<string, unknown>,
-): Record<string, unknown> {
+): T {
   const select = parseSelectFlag(argv, defaultSelect);
   const parsed = unflattenDotNotation(argv);
   const where = parsed.where;
@@ -301,7 +301,7 @@ export function parseFindFirstArgs(
     select,
     ...(where !== undefined ? { where } : {}),
     ...(condition !== undefined ? { condition } : {}),
-  };
+  } as unknown as T;
 }
 
 export function buildSelectFromPaths(

--- a/graphql/codegen/src/core/generate.ts
+++ b/graphql/codegen/src/core/generate.ts
@@ -714,12 +714,14 @@ export async function generateMulti(
       firstTargetConfig?.nodeHttpAdapter === true ||
       (firstTargetConfig?.nodeHttpAdapter !== false);
 
+    const multiConditionEnabled = firstTargetConfig?.codegen?.condition === true;
     const { files } = generateMultiTargetCli({
       toolName,
       builtinNames: cliConfig.builtinNames,
       targets: cliTargets,
       nodeHttpAdapter: multiNodeHttpAdapter,
       entryPoint: cliConfig.entryPoint,
+      condition: multiConditionEnabled,
     });
 
     const cliFilesToWrite = files.map((file) => ({


### PR DESCRIPTION
## Summary

Fixes TS2345 build errors in the generated CLI code (e.g. `sdk/constructive-cli`) where `parseFindManyArgs()` / `parseFindFirstArgs()` return `Record<string, unknown>` but the ORM's `findMany`/`findFirst` methods expect typed args with a required `select` property.

Instead of casting at the ORM call sites (`findManyArgs as any`), the helpers are now generic and the codegen passes table-specific type parameters:

```typescript
// Before (hacky):
const findManyArgs = parseFindManyArgs(argv, defaultSelect);
client.car.findMany(findManyArgs as any).execute();

// After (properly typed):
const findManyArgs = parseFindManyArgs<FindManyArgs<CarSelect, CarFilter, never, CarsOrderBy>>(argv, defaultSelect);
client.car.findMany(findManyArgs).execute();
```

### What changed

**`cli-utils.ts` (template):** `parseFindManyArgs<T>()` and `parseFindFirstArgs<T>()` are now generic with `T = Record<string, unknown>` default. Internally uses `as unknown as T` — this is the single controlled bridge between the untyped CLI argv layer and the typed ORM interface.

**`table-command-generator.ts` (codegen):**
- New `buildFindManyArgsType()` / `buildFindFirstArgsType()` helpers construct the proper `FindManyArgs<Select, Filter, Condition, OrderBy>` / `FindFirstArgs<Select, Filter, Condition>` type instantiations per table
- All 3 call sites updated: `buildListHandler`, `buildFindFirstHandler`, `buildSearchHandler`
- Generated code now imports table-specific types (`*Select`, `*Filter`, `*Condition`, `*OrderBy`) from `input-types` and `FindManyArgs`/`FindFirstArgs` from `select-types`
- Added `condition?: boolean` to `TableCommandOptions` — no longer hardcoded

**Condition default flipped to `false` (opt-in):**

`where`/`filter` is now the first-class filtering mechanism; `condition` (PostGraphile simple equality filters) is opt-in. To enable condition types, set `config.codegen.condition: true` explicitly.

All 8 locations where condition was checked have been flipped from `!== false` (default true) to `=== true` (default false):
- `codegen/index.ts` — hooks generator
- `codegen/orm/index.ts` — ORM generator
- `codegen/orm/model-generator.ts` — model generator
- `codegen/orm/input-types-generator.ts` — input types generator
- `codegen/cli/table-command-generator.ts` — CLI table command generator
- `codegen/cli/index.ts` — CLI single-target and multi-target generators
- `codegen/queries.ts` — query hook destructuring default
- `generate.ts` — multi-target pipeline

When condition is disabled (the new default), the generated code uses `never` as the condition type parameter, effectively making it unusable at the type level.

## Review & Testing Checklist for Human
- [ ] **Breaking change audit**: Any existing project configs that relied on condition types being generated by default will now need explicit `codegen.condition: true`. Verify no downstream consumers are broken by this default flip
- [ ] Verify that `FindManyArgs` and `FindFirstArgs` are exported from `select-types` with the expected generic parameters `<Select, Filter, Condition, OrderBy>` and `<Select, Filter, Condition>` respectively — the generated imports depend on this
- [ ] Confirm the `as unknown as T` cast inside the helpers is acceptable — it's architecturally cleaner than `as any` at every call site but is still an escape hatch at the argv→ORM boundary
- [ ] After merging, re-run the Schema Propagation workflow and confirm `sdk/constructive-cli` builds successfully (the generated code will now have these new imports, type parameters, and no condition types by default)
- [ ] Spot-check that a project with `codegen.condition: true` still generates condition types correctly (the updated tests cover this but a real-world config is worth verifying)

### Notes
- 17 snapshots updated — changes include: added type imports and generic type parameters, removed `as any` from ORM call sites, condition type interfaces removed from default output
- Tests that explicitly verify condition type generation now pass `{ condition: true }` to the generators, reflecting the new opt-in behavior
- Function parameter defaults in `buildListHandler`, `buildFindFirstHandler`, `buildSearchHandler` also flipped from `= true` to `= false`

Link to Devin session: https://app.devin.ai/sessions/c92c3a11450342f8875625a60fa1be28
Requested by: @pyramation