### PR TITLE
fix(node-type-registry): grant_privileges type is string[][] not string[]

### DIFF
--- a/graphile/node-type-registry/src/blueprint-types.generated.ts
+++ b/graphile/node-type-registry/src/blueprint-types.generated.ts
@@ -559,8 +559,8 @@ export interface RelationManyToManyParams {
   };
   /* Database roles to grant privileges to. Forwarded to secure_table_provision as-is. Default: [authenticated] */
   grant_roles?: string[];
-  /* Privilege grants for the junction table. Forwarded to secure_table_provision as-is. Default: select/insert/delete for all columns */
-  grant_privileges?: string[];
+  /* Privilege grants for the junction table as [verb, columns] tuples (e.g. [['select','*'],['insert','*']]). Forwarded to secure_table_provision as-is. Default: select/insert/delete for all columns */
+  grant_privileges?: string[][];
   /* RLS policy type for the junction table. Forwarded to secure_table_provision as-is. NULL means no policy. */
   policy_type?: string;
   /* Privileges the policy applies to. Forwarded to secure_table_provision as-is. NULL means derived from grant_privileges verbs. */
@@ -643,7 +643,7 @@ export interface ViewCompositeParams {
 }
 /**
  * ===========================================================================
- * Static structural types
+ * Structural types — Static fallback (no _meta provided)
  * ===========================================================================
  */
 ;
@@ -663,7 +663,7 @@ export interface BlueprintField {
 /** An RLS policy entry for a blueprint table. */
 export interface BlueprintPolicy {
   /** Authz* policy type name (e.g., "AuthzDirectOwner", "AuthzAllowAll"). */
-  $type: "AuthzDirectOwner" | "AuthzDirectOwnerAny" | "AuthzMembership" | "AuthzEntityMembership" | "AuthzRelatedEntityMembership" | "AuthzOrgHierarchy" | "AuthzTemporal" | "AuthzPublishable" | "AuthzMemberList" | "AuthzRelatedMemberList" | "AuthzAllowAll" | "AuthzDenyAll" | "AuthzComposite" | "AuthzPeerOwnership" | "AuthzRelatedPeerOwnership";
+  policy_type: "AuthzDirectOwner" | "AuthzDirectOwnerAny" | "AuthzMembership" | "AuthzEntityMembership" | "AuthzRelatedEntityMembership" | "AuthzOrgHierarchy" | "AuthzTemporal" | "AuthzPublishable" | "AuthzMemberList" | "AuthzRelatedMemberList" | "AuthzAllowAll" | "AuthzDenyAll" | "AuthzComposite" | "AuthzPeerOwnership" | "AuthzRelatedPeerOwnership";
   /** Role for this policy. Defaults to "authenticated". */
   policy_role?: string;
   /** Whether this policy is permissive (true) or restrictive (false). */
@@ -697,9 +697,9 @@ export interface BlueprintFullTextSearch {
 export interface BlueprintIndex {
   /** Reference key of the table this index belongs to. */
   table_ref: string;
-  /** Single column name for the index. Mutually exclusive with "columns". */
+  /** Single column name for the index. */
   column?: string;
-  /** Array of column names for a multi-column index. Mutually exclusive with "column". */
+  /** Array of column names for a multi-column index. */
   columns?: string[];
   /** Index access method (e.g., "BTREE", "GIN", "GIST", "HNSW", "BM25"). */
   access_method: string;

--- a/graphile/node-type-registry/src/relation/relation-many-to-many.ts
+++ b/graphile/node-type-registry/src/relation/relation-many-to-many.ts
@@ -58,7 +58,13 @@ export const RelationManyToMany: NodeTypeDefinition = {
       },
       "grant_privileges": {
         "type": "array",
-        "description": "Privilege grants for the junction table. Forwarded to secure_table_provision as-is. Default: select/insert/delete for all columns"
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "description": "Privilege grants for the junction table as [verb, columns] tuples (e.g. [['select','*'],['insert','*']]). Forwarded to secure_table_provision as-is. Default: select/insert/delete for all columns"
       },
       "policy_type": {
         "type": "string",


### PR DESCRIPTION
## Summary

Fixes the JSON schema for `RelationManyToMany.grant_privileges` which was missing its `items` definition, causing codegen to produce `string[]` instead of the correct `string[][]`.

The actual runtime usage is an array of `[verb, columns]` tuples — e.g. `[['select','*'],['insert','*']]` — so the schema now specifies `items: { type: "array", items: { type: "string" } }`.

The regenerated `blueprint-types.generated.ts` also picks up cosmetic changes from recently merged PRs (#914, #915) that are now on main (`$type` → `policy_type` on `BlueprintPolicy`, section comment updates, minor JSDoc tweaks on `BlueprintIndex`).

## Review & Testing Checklist for Human

- [ ] **`$type` → `policy_type` rename on `BlueprintPolicy`**: The regenerated file renames this field. Verify that all consumers (agentic-db, constructive-db blueprints, `construct_blueprint()` SQL) already expect `policy_type` and not `$type`. If any consumer still uses `$type`, this is a breaking change.
- [ ] **`grant_privileges` correctness**: Confirm that `construct_blueprint()` and `secure_table_provision` actually consume `grant_privileges` as a 2D array (array of `[verb, columns]` tuples). If the server flattens or interprets it differently, the type could still be wrong.

### Notes
- The source change is only in `relation-many-to-many.ts` (6 lines added to the JSON schema `items` definition). Everything in `blueprint-types.generated.ts` is regenerated output.
- Discovered while updating agentic-db to `node-type-registry@0.6.0` — the M2M relations with `grant_privileges: [['select','*'], ...]` failed type checking.

Link to Devin session: https://app.devin.ai/sessions/ce1b2dafd42341bea5d7793b0c05ba6c
Requested by: @pyramation