### PR TITLE
docs(grant_privileges): update blueprint table grants description to mention full CRUD default

### DIFF
--- a/graphile/node-type-registry/src/blueprint-types.generated.ts
+++ b/graphile/node-type-registry/src/blueprint-types.generated.ts
@@ -897,7 +897,7 @@ export interface BlueprintTable {
   policies?: BlueprintPolicy[];
   /** Database roles to grant privileges to. Defaults to ["authenticated"]. */
   grant_roles?: string[];
-  /** Privilege grants as [verb, column] tuples or objects. */
+  /** Privilege grants as [verb, column] tuples or objects. Defaults to full CRUD (select/insert/update/delete for all columns). */
   grants?: unknown[];
   /** Whether to enable RLS on this table. Defaults to true. */
   use_rls?: boolean;

--- a/graphile/node-type-registry/src/codegen/generate-types.ts
+++ b/graphile/node-type-registry/src/codegen/generate-types.ts
@@ -566,7 +566,7 @@ function buildBlueprintTable(): t.ExportNamedDeclaration {
       ),
       addJSDoc(
         optionalProp('grants', t.tsArrayType(t.tsUnknownKeyword())),
-        'Privilege grants as [verb, column] tuples or objects.'
+        'Privilege grants as [verb, column] tuples or objects. Defaults to full CRUD (select/insert/update/delete for all columns).'
       ),
       addJSDoc(
         optionalProp('use_rls', t.tsBooleanKeyword()),


### PR DESCRIPTION
## Summary

Updates the JSDoc description for `BlueprintTable.grants` to document that the default is now full CRUD (`select/insert/update/delete` for all columns), matching the behavioral change in [constructive-db#713](https://github.com/constructive-io/constructive-db/pull/713).

Two files changed (source + generated output):
- `generate-types.ts`: updated the static description string
- `blueprint-types.generated.ts`: updated the generated JSDoc comment

No behavioral changes — documentation only.

## Review & Testing Checklist for Human

- [ ] Merge [constructive-db#713](https://github.com/constructive-io/constructive-db/pull/713) first (or together) — that PR contains the actual default change; this PR just documents it
- [ ] Verify `pnpm generate:types` in `graphile/node-type-registry` produces the same output as the hand-edited generated file (optional, low risk since it's a single comment change)

### Notes
- M:N junction table description (`relation-many-to-many.ts`) was intentionally **not** changed — it correctly says "Default: select/insert/delete" since junction tables omit UPDATE by design.

Link to Devin session: https://app.devin.ai/sessions/8ce3d5fe3c304df3bca72896972f083f
Requested by: @pyramation