### PR TITLE
docs(blueprint): update grants JSDoc to reflect empty default (no grants)

### DIFF
--- a/graphile/node-type-registry/src/blueprint-types.generated.ts
+++ b/graphile/node-type-registry/src/blueprint-types.generated.ts
@@ -897,7 +897,7 @@ export interface BlueprintTable {
   policies?: BlueprintPolicy[];
   /** Database roles to grant privileges to. Defaults to ["authenticated"]. */
   grant_roles?: string[];
-  /** Privilege grants as [verb, column] tuples or objects. Defaults to full CRUD (select/insert/update/delete for all columns). */
+  /** Privilege grants as [verb, column] tuples or objects. Defaults to empty (no grants — callers must explicitly specify). */
   grants?: unknown[];
   /** Whether to enable RLS on this table. Defaults to true. */
   use_rls?: boolean;

--- a/graphile/node-type-registry/src/codegen/generate-types.ts
+++ b/graphile/node-type-registry/src/codegen/generate-types.ts
@@ -566,7 +566,7 @@ function buildBlueprintTable(): t.ExportNamedDeclaration {
       ),
       addJSDoc(
         optionalProp('grants', t.tsArrayType(t.tsUnknownKeyword())),
-        'Privilege grants as [verb, column] tuples or objects. Defaults to full CRUD (select/insert/update/delete for all columns).'
+        'Privilege grants as [verb, column] tuples or objects. Defaults to empty (no grants — callers must explicitly specify).'
       ),
       addJSDoc(
         optionalProp('use_rls', t.tsBooleanKeyword()),


### PR DESCRIPTION
## Summary

Updates the `grants` JSDoc in `BlueprintTable` from "Defaults to full CRUD" to "Defaults to empty (no grants — callers must explicitly specify)" to match the companion change in [constructive-db](https://github.com/constructive-io/constructive-db) where `construct_blueprint` now defaults to `'[]'::jsonb` instead of full CRUD.

Both the generated file and the codegen source are updated consistently.

## Review & Testing Checklist for Human

- [ ] Verify the companion constructive-db PR (reverting `construct_blueprint` grants default to empty) is merged before or alongside this PR
- [ ] Confirm the JSDoc wording matches the actual SQL behavior — `construct_blueprint` should now apply no grants when `grants` is omitted from a blueprint table entry

### Notes

- This is a docs-only change (JSDoc comments). No runtime behavior change in this repo.
- The previous PR #930 updated these comments to say "full CRUD" — this reverts that to "empty" to preserve the idempotent paradigm where grants are opt-in only.

Link to Devin session: https://app.devin.ai/sessions/8ce3d5fe3c304df3bca72896972f083f
Requested by: @pyramation