### PR TITLE
fix(codegen): use resolved entity name for manyToMany rightTable instead of re-singularizing

### DIFF
--- a/graphile/node-type-registry/src/blueprint-types.generated.ts
+++ b/graphile/node-type-registry/src/blueprint-types.generated.ts
@@ -88,6 +88,18 @@ export interface DataEmbeddingParams {
   job_task_name?: string;
   /* Strategy for tracking embedding staleness. column: embedding_stale boolean. null: set embedding to NULL. hash: md5 hash of source fields. */
   stale_strategy?: "column" | "null" | "hash";
+  /* Chunking configuration for long-text embedding. Creates an embedding_chunks record that drives automatic text splitting and per-chunk embedding. Omit to skip chunking. */
+  chunks?: {
+    /* Name of the text content column in the chunks table */content_field_name?: string;
+    /* Maximum number of characters per chunk */chunk_size?: number;
+    /* Number of overlapping characters between consecutive chunks */chunk_overlap?: number;
+    /* Strategy for splitting text into chunks */chunk_strategy?: "fixed" | "sentence" | "paragraph" | "semantic";
+    /* Metadata fields from parent to copy into chunks */metadata_fields?: {
+      [key: string]: unknown;
+    };
+    /* Whether to auto-enqueue a chunking job on insert/update */enqueue_chunking_job?: boolean;
+    /* Task identifier for the chunking job queue */chunking_task_name?: string;
+  };
 }
 /** Adds a tsvector column with GIN index and automatic trigger population from source fields. Enables PostgreSQL full-text search with configurable weights and language support. Leverages the existing metaschema full_text_search infrastructure. */
 export interface DataFullTextSearchParams {
@@ -143,6 +155,17 @@ export interface DataSearchParams {
     metric?: "cosine" | "l2" | "ip";
     source_fields?: string[];
     search_score_weight?: number;
+    /* Chunking configuration for long-text embedding. Creates an embedding_chunks record that drives automatic text splitting and per-chunk embedding. Omit to skip chunking. */chunks?: {
+      /* Name of the text content column in the chunks table */content_field_name?: string;
+      /* Maximum number of characters per chunk */chunk_size?: number;
+      /* Number of overlapping characters between consecutive chunks */chunk_overlap?: number;
+      /* Strategy for splitting text into chunks */chunk_strategy?: "fixed" | "sentence" | "paragraph" | "semantic";
+      /* Metadata fields from parent to copy into chunks */metadata_fields?: {
+        [key: string]: unknown;
+      };
+      /* Whether to auto-enqueue a chunking job on insert/update */enqueue_chunking_job?: boolean;
+      /* Task identifier for the chunking job queue */chunking_task_name?: string;
+    };
   };
   /* Field names to tag with @trgmSearch for fuzzy/typo-tolerant matching */
   trgm_fields?: string[];

--- a/graphile/node-type-registry/src/data/data-embedding.ts
+++ b/graphile/node-type-registry/src/data/data-embedding.ts
@@ -74,6 +74,52 @@ export const DataEmbedding: NodeTypeDefinition = {
         ],
         "description": "Strategy for tracking embedding staleness. column: embedding_stale boolean. null: set embedding to NULL. hash: md5 hash of source fields.",
         "default": "column"
+      },
+      "chunks": {
+        "type": "object",
+        "description": "Chunking configuration for long-text embedding. Creates an embedding_chunks record that drives automatic text splitting and per-chunk embedding. Omit to skip chunking.",
+        "properties": {
+          "content_field_name": {
+            "type": "string",
+            "description": "Name of the text content column in the chunks table",
+            "default": "content"
+          },
+          "chunk_size": {
+            "type": "integer",
+            "description": "Maximum number of characters per chunk",
+            "default": 1000
+          },
+          "chunk_overlap": {
+            "type": "integer",
+            "description": "Number of overlapping characters between consecutive chunks",
+            "default": 200
+          },
+          "chunk_strategy": {
+            "type": "string",
+            "enum": [
+              "fixed",
+              "sentence",
+              "paragraph",
+              "semantic"
+            ],
+            "description": "Strategy for splitting text into chunks",
+            "default": "fixed"
+          },
+          "metadata_fields": {
+            "type": "object",
+            "description": "Metadata fields from parent to copy into chunks"
+          },
+          "enqueue_chunking_job": {
+            "type": "boolean",
+            "description": "Whether to auto-enqueue a chunking job on insert/update",
+            "default": true
+          },
+          "chunking_task_name": {
+            "type": "string",
+            "description": "Task identifier for the chunking job queue",
+            "default": "generate_chunks"
+          }
+        }
       }
     }
   },

--- a/graphile/node-type-registry/src/data/data-search.ts
+++ b/graphile/node-type-registry/src/data/data-search.ts
@@ -108,6 +108,52 @@ export const DataSearch: NodeTypeDefinition = {
           "search_score_weight": {
             "type": "number",
             "default": 1
+          },
+          "chunks": {
+            "type": "object",
+            "description": "Chunking configuration for long-text embedding. Creates an embedding_chunks record that drives automatic text splitting and per-chunk embedding. Omit to skip chunking.",
+            "properties": {
+              "content_field_name": {
+                "type": "string",
+                "description": "Name of the text content column in the chunks table",
+                "default": "content"
+              },
+              "chunk_size": {
+                "type": "integer",
+                "description": "Maximum number of characters per chunk",
+                "default": 1000
+              },
+              "chunk_overlap": {
+                "type": "integer",
+                "description": "Number of overlapping characters between consecutive chunks",
+                "default": 200
+              },
+              "chunk_strategy": {
+                "type": "string",
+                "enum": [
+                  "fixed",
+                  "sentence",
+                  "paragraph",
+                  "semantic"
+                ],
+                "description": "Strategy for splitting text into chunks",
+                "default": "fixed"
+              },
+              "metadata_fields": {
+                "type": "object",
+                "description": "Metadata fields from parent to copy into chunks"
+              },
+              "enqueue_chunking_job": {
+                "type": "boolean",
+                "description": "Whether to auto-enqueue a chunking job on insert/update",
+                "default": true
+              },
+              "chunking_task_name": {
+                "type": "string",
+                "description": "Task identifier for the chunking job queue",
+                "default": "generate_chunks"
+              }
+            }
           }
         }
       },

--- a/graphql/query/src/introspect/infer-tables.ts
+++ b/graphql/query/src/introspect/infer-tables.ts
@@ -540,14 +540,11 @@ function inferHasManyOrManyToMany(
   const isManyToMany = field.name.includes('By') && field.name.includes('And');
 
   if (isManyToMany) {
-    // For ManyToMany, extract the actual entity name from the field name prefix
-    // Field name pattern: {relatedEntities}By{JunctionTable}{Keys}
-    // e.g., "usersByMembershipActorIdAndEntityId" → "users" → "User"
-    // e.g., "productsByOrderItemOrderIdAndProductId" → "products" → "Product"
-    const prefixMatch = field.name.match(/^([a-z]+)By/i);
-    const actualEntityName = prefixMatch
-      ? singularize(ucFirst(prefixMatch[1]))
-      : relatedEntityName;
+    // Use the entity name already resolved from the connection type mapping.
+    // This is more reliable than re-singularizing from the field name prefix,
+    // which can produce incorrect inflections (e.g. "codebases" → "Codebasis"
+    // instead of the correct "Codebase").
+    const actualEntityName = relatedEntityName;
 
     // Try to extract junction table from field name
     // Pattern: {relatedEntities}By{JunctionTable}{Keys}


### PR DESCRIPTION
## Summary

Fixes a bug where manyToMany `rightTable` values in the inferred table metadata used incorrect inflections (e.g. `Codebasis` instead of `Codebase`), causing type errors in generated SDKs.

The `inferHasManyOrManyToMany` function was extracting the entity name from the GraphQL field name prefix via regex, then re-singularizing it with `inflekt`. For irregular plurals like `codebases`, `singularize("Codebases")` produced `"Codebasis"` instead of `"Codebase"`.

The fix: use `relatedEntityName`, which is already correctly resolved from the `connectionToEntity` map (derived from the connection type's `nodes` field) earlier in the same function. This is the same resolution path already used for `hasMany` relations.

## Review & Testing Checklist for Human
- [ ] Verify there is no edge case where the connection type doesn't appear in `connectionToEntity` but the field-name prefix regex would have produced the correct entity name. The fallback on line 532-537 still calls `singularize`, so unresolved connection types would still get wrong inflections — confirm this is acceptable.
- [ ] Consider whether a regression test for an irregular plural (e.g. `codebasesByXxxAndYyy` → `Codebase` not `Codebasis`) should be added to `infer-tables.test.ts`.
- [ ] After merging, re-run the agentic-db export pipeline to confirm the generated SDK no longer contains `Codebasis` type references.

### Notes
- All 312 existing codegen tests pass, including the manyToMany test asserting `rightTable === 'Product'`.
- The existing test uses a regular plural (`products` → `Product`) so it didn't catch this bug. The bug only manifests with words where `singularize` produces an incorrect result (like `codebases` → `Codebasis`).

Link to Devin session: https://app.devin.ai/sessions/6dd1a19fd02948fda1fee04c955f4bf2
Requested by: @pyramation