### PR TITLE
fix(graphile-postgis): detect PostGIS when only geography codecs are present

### DIFF
--- a/graphile/graphile-postgis/src/plugins/connection-filter-operators.ts
+++ b/graphile/graphile-postgis/src/plugins/connection-filter-operators.ts
@@ -1,5 +1,7 @@
 import 'graphile-build';
+import 'graphile-build-pg';
 import 'graphile-connection-filter';
+import type { PgCodec } from '@dataplan/pg';
 import type {
   ConnectionFilterOperatorFactory,
   ConnectionFilterOperatorRegistration,
@@ -225,7 +227,10 @@ export function createPostgisOperatorFactory(): ConnectionFilterOperatorFactory 
       geography: []
     };
 
-    const codecPairs: [string, typeof geometryCodec][] = [['geometry', geometryCodec]];
+    const codecPairs: [string, PgCodec][] = [];
+    if (geometryCodec) {
+      codecPairs.push(['geometry', geometryCodec]);
+    }
     if (geographyCodec) {
       codecPairs.push(['geography', geographyCodec]);
     }

--- a/graphile/graphile-postgis/src/plugins/detect-extension.ts
+++ b/graphile/graphile-postgis/src/plugins/detect-extension.ts
@@ -43,13 +43,17 @@ export const PostgisExtensionDetectionPlugin: GraphileConfig.Plugin = {
             schemaName = pg.schemaName || 'public';
           } else if (pg.name === 'geography') {
             geographyCodec = codec;
+            if (!geometryCodec) {
+              schemaName = pg.schemaName || 'public';
+            }
           }
         }
 
-        // PostGIS requires at least the geometry codec to be present.
-        // Geography is optional — not all databases use geography columns,
-        // so PostGraphile may not introspect the geography type at all.
-        if (!geometryCodec) {
+        // PostGIS is detected when at least one of geometry or geography
+        // codecs is present. Some databases use only geography columns
+        // (e.g. use_geography: true in DataPostGIS), so PostGraphile may
+        // introspect geography but not geometry.
+        if (!geometryCodec && !geographyCodec) {
           return build;
         }
 

--- a/graphile/graphile-postgis/src/plugins/within-distance-operator.ts
+++ b/graphile/graphile-postgis/src/plugins/within-distance-operator.ts
@@ -1,5 +1,7 @@
 import 'graphile-build';
+import 'graphile-build-pg';
 import 'graphile-connection-filter';
+import type { PgCodec } from '@dataplan/pg';
 import type {
   ConnectionFilterOperatorFactory,
   ConnectionFilterOperatorRegistration,
@@ -57,7 +59,10 @@ export function createWithinDistanceOperatorFactory(): ConnectionFilterOperatorF
       geography: []
     };
 
-    const codecPairs: [string, typeof geometryCodec][] = [['geometry', geometryCodec]];
+    const codecPairs: [string, PgCodec][] = [];
+    if (geometryCodec) {
+      codecPairs.push(['geometry', geometryCodec]);
+    }
     if (geographyCodec) {
       codecPairs.push(['geography', geographyCodec]);
     }

--- a/graphile/graphile-postgis/src/types.ts
+++ b/graphile/graphile-postgis/src/types.ts
@@ -23,9 +23,9 @@ export interface GisFieldValue {
 export interface PostgisExtensionInfo {
   /** The schema name where PostGIS is installed (e.g. 'public') */
   schemaName: string;
-  /** The geometry codec from the registry */
-  geometryCodec: PgCodec;
-  /** The geography codec from the registry (optional — not all databases use geography columns) */
+  /** The geometry codec from the registry (null if only geography columns are used) */
+  geometryCodec: PgCodec | null;
+  /** The geography codec from the registry (null if only geometry columns are used) */
   geographyCodec: PgCodec | null;
 }
 


### PR DESCRIPTION
## Summary

`PostgisExtensionDetectionPlugin` previously required a `geometry` codec to detect PostGIS. Databases that exclusively use `geography` columns (e.g. all `DataPostGIS` nodes with `use_geography: true`, as in agentic-db) never have a `geometry` codec introspected, so PostGIS detection silently failed. This produced warnings like:

> Do not know how to convert PgCodec 'geography' into a GraphQL type

**Root cause:** The detection guard was `if (!geometryCodec) return build` — now changed to `if (!geometryCodec && !geographyCodec) return build`.

**Changes across 4 files:**
- **`types.ts`**: `geometryCodec` is now `PgCodec | null` (was `PgCodec`), symmetric with `geographyCodec`
- **`detect-extension.ts`**: Accept either codec for detection; extract `schemaName` from geography codec when geometry is absent
- **`connection-filter-operators.ts`** / **`within-distance-operator.ts`**: Conditionally push `geometryCodec` into codec pairs only when non-null (matches existing `geographyCodec` pattern)

## Review & Testing Checklist for Human

- [ ] **Verify no other consumers of `PostgisExtensionInfo.geometryCodec` outside this package assume it is non-null.** The type changed from `PgCodec` to `PgCodec | null` — the build passes across the monorepo, but confirm no external packages depend on it being non-null at runtime.
- [ ] **Verify `register-types.ts` line 97** — it already filters nulls via `.filter((c): c is PgCodec => c !== null)`, but confirm this is the only place that iterates over both codecs.
- [ ] **Test with agentic-db integration tests** after this is published — run the integration test suite and confirm the geography codec warnings are gone and `location_geo` fields appear in the GraphQL schema.

### Notes
- All 208 graphile-postgis unit tests and 35 preset-integration tests pass locally.
- Full monorepo build succeeds with no type errors.
- No new tests were added for the geography-only detection path specifically — existing tests cover the geometry+geography case and the no-PostGIS case. Consider adding a geography-only unit test to `detect-extension.test.ts` if desired.

Link to Devin session: https://app.devin.ai/sessions/6dd1a19fd02948fda1fee04c955f4bf2
Requested by: @pyramation