### PR TITLE
chore: remove all deprecated code, backward-compat aliases, and legacy shims

### DIFF
--- a/graphile/graphile-postgis/src/plugins/detect-extension.ts
+++ b/graphile/graphile-postgis/src/plugins/detect-extension.ts
@@ -4,7 +4,6 @@ import type { PgCodec } from '@dataplan/pg';
 import type { GraphileConfig } from 'graphile-config';
 import type { PostgisExtensionInfo } from '../types';
 
-// Re-export for backward compat — other plugins import from here
 export type { PostgisExtensionInfo } from '../types';
 
 /**

--- a/graphile/graphile-search/src/codecs/tsvector-codec.ts
+++ b/graphile/graphile-search/src/codecs/tsvector-codec.ts
@@ -8,7 +8,7 @@
  * HIDE_BY_DEFAULT). This plugin:
  *
  * 1. Creates codecs for tsvector/tsquery via gather.hooks.pgCodecs_findPgCodec
- *    (kept for backward compatibility with older versions; rc.8+ handles this
+ *    (rc.8+ handles this
  *    natively so the hook returns early when event.pgCodec is already set)
  * 2. Registers a custom "FullText" scalar type for tsvector columns
  * 3. Maps tsvector codec to the FullText scalar (isolating filter operators)

--- a/graphile/graphile-settings/src/plugins/custom-inflector.ts
+++ b/graphile/graphile-settings/src/plugins/custom-inflector.ts
@@ -478,7 +478,3 @@ export const InflektPlugin: GraphileConfig.Plugin = {
 export const InflektPreset: GraphileConfig.Preset = {
   plugins: [InflektPlugin],
 };
-
-// Re-export for backwards compatibility
-export const CustomInflectorPlugin = InflektPlugin;
-export const CustomInflectorPreset = InflektPreset;

--- a/graphile/graphile-settings/src/plugins/index.ts
+++ b/graphile/graphile-settings/src/plugins/index.ts
@@ -11,8 +11,6 @@ export { MinimalPreset } from './minimal-preset';
 export {
   InflektPlugin,
   InflektPreset,
-  CustomInflectorPlugin,
-  CustomInflectorPreset,
 } from './custom-inflector';
 
 // Conflict detector for multi-schema setups

--- a/graphile/graphile-settings/src/presets/constructive-preset.ts
+++ b/graphile/graphile-settings/src/presets/constructive-preset.ts
@@ -45,10 +45,6 @@ import { constructiveUploadFieldDefinitions } from '../upload-resolver';
  * - pg_trgm fuzzy matching (similarTo/wordSimilarTo on text columns, similarity score fields,
  *   orderBy similarity — zero config, typo-tolerant)
  *
- * DEPRECATED:
- * - The `condition` argument has been removed. All filtering lives under `filter`.
- *   PgConditionArgumentPlugin and PgConditionCustomFieldsPlugin are disabled.
- *
  * RELATION FILTERS:
  * - Enabled via connectionFilterRelations: true
  * - Forward: filter child by parent (e.g. allOrders(filter: { clientByClientId: { name: { startsWith: "Acme" } } }))

--- a/graphile/graphile-test/src/context.ts
+++ b/graphile/graphile-test/src/context.ts
@@ -87,7 +87,7 @@ interface V4Result<TData = unknown> {
  * - They may have `locations: undefined` instead of omitting the field
  * - They don't always include locations even when nodes are available
  *
- * This normalizes errors to match v4 format for backward compatibility.
+ * This normalizes errors to match v4 format.
  *
  * @param error - The GraphQL error to format
  * @param document - The original document (used to derive locations from path)
@@ -153,7 +153,7 @@ function formatErrorToV4(error: GraphQLError, document?: DocumentNode): V4Format
 
 /**
  * Normalize an ExecutionResult to match v4 PostGraphile output format.
- * This ensures backward compatibility with existing tests and consumers.
+ * This ensures existing tests and consumers work correctly.
  *
  * @param result - The execution result from grafast
  * @param document - The original document (used to derive locations from path)
@@ -333,7 +333,7 @@ export const runGraphQLInContext = async <T = ExecutionResult>({
     }
   }
 
-  // Normalize the result to match v4 PostGraphile format for backward compatibility
+  // Normalize the result to match v4 PostGraphile format
   return normalizeResult<T>(result, document);
 };
 

--- a/graphile/graphile-test/src/index.ts
+++ b/graphile/graphile-test/src/index.ts
@@ -19,7 +19,6 @@ export type {
   GraphQLQueryUnwrappedFnObj,
   GraphQLResponse,
   GraphQLTestContext,
-  LegacyGraphileOptions,
   Variables,
 } from './types';
 export { seed, snapshot } from 'pgsql-test';

--- a/graphile/graphile-test/src/types.ts
+++ b/graphile/graphile-test/src/types.ts
@@ -26,61 +26,18 @@ export interface GraphQLTestContext {
 }
 
 /**
- * Legacy v4-style GraphQL options for backward compatibility.
- *
- * @deprecated Use `preset` instead for v5 configuration.
- */
-export interface LegacyGraphileOptions {
-  /**
-   * V4-style plugins to append.
-   * These plugins use the builder.hook() API which is NOT compatible with v5.
-   * For v5, convert these to proper v5 plugins and use the `preset` option instead.
-   *
-   * @deprecated Use preset.plugins for v5 plugins
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  appendPlugins?: any[];
-  /**
-   * V4-style graphile build options.
-   *
-   * @deprecated Use preset.schema for v5 schema options
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  graphileBuildOptions?: Record<string, any>;
-  /**
-   * V4-style PostGraphile options override.
-   *
-   * @deprecated Use preset for v5 configuration
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  overrideSettings?: Record<string, any>;
-}
-
-/**
  * Input for GraphQL test connections.
- *
- * Supports both v5 preset-based configuration (recommended) and
- * legacy v4-style configuration (deprecated, for backward compatibility).
  */
+
 export interface GetConnectionsInput {
   useRoot?: boolean;
   schemas: string[];
   authRole?: string;
   /**
-   * V5 preset configuration (recommended).
+   * V5 preset configuration.
    * Can include extends, plugins, schema options, etc.
    */
   preset?: GraphileConfig.Preset;
-  /**
-   * Legacy v4-style graphile options for backward compatibility.
-   *
-   * NOTE: v4-style plugins (using builder.hook()) are NOT compatible with v5.
-   * If you use appendPlugins with v4 plugins, they will be ignored.
-   * Convert your plugins to v5 format and use the `preset` option instead.
-   *
-   * @deprecated Use preset for v5 configuration
-   */
-  graphile?: LegacyGraphileOptions;
 }
 
 export interface GraphQLResponse<T> {

--- a/graphile/node-type-registry/README.md
+++ b/graphile/node-type-registry/README.md
@@ -73,13 +73,3 @@ Generate SQL seed scripts for `node_type_registry` table:
 ```bash
 cd graphile/node-type-registry && pnpm generate:seed --pgpm ../../constructive-db/packages/metaschema
 ```
-
-## Preset (deprecated)
-
-> **Note:** The `NodeTypeRegistryPreset` is no longer the recommended approach.
-> Use the generated TypeScript types instead (see above). The preset remains
-> available for backward compatibility but will be removed in a future version.
-
-```typescript
-import { NodeTypeRegistryPreset } from 'node-type-registry/preset';
-```

--- a/graphql/codegen/src/core/index.ts
+++ b/graphql/codegen/src/core/index.ts
@@ -17,7 +17,7 @@ export * from './ast';
 export * from './custom-ast';
 
 // Query builder
-export { MetaObject, QueryBuilder } from './query-builder';
+export { MetaObject, QueryBuilder } from '@constructive-io/graphql-query';
 
 // Meta object utilities
 export { convertFromMetaSchema, validateMetaObject } from './meta-object';

--- a/graphql/codegen/src/core/query-builder.ts
+++ b/graphql/codegen/src/core/query-builder.ts
@@ -1,7 +1,0 @@
-/**
- * Re-export QueryBuilder from @constructive-io/graphql-query.
- *
- * The QueryBuilder class and MetaObject namespace now live in graphql-query.
- * Re-exported here for backward compatibility.
- */
-export { QueryBuilder, MetaObject } from '@constructive-io/graphql-query';

--- a/graphql/codegen/src/core/types.ts
+++ b/graphql/codegen/src/core/types.ts
@@ -1,9 +1,5 @@
 /**
  * Re-export core types from @constructive-io/graphql-query.
- *
- * This file used to contain the canonical type definitions. They now live in
- * the `graphql-query` package and are re-exported here for backward
- * compatibility so existing codegen consumers continue to work unchanged.
  */
 
 // Re-export everything from the canonical source
@@ -34,8 +30,3 @@ export {
   isGraphQLVariables,
   type StrictRecord,
 } from '@constructive-io/graphql-query';
-
-// Backward-compatible alias: codegen historically used `IntrospectionSchema`
-// while graphql-query renamed it to `QueryIntrospectionSchema` to avoid
-// collision with the standard GraphQL IntrospectionSchema type.
-export { type QueryIntrospectionSchema as IntrospectionSchema } from '@constructive-io/graphql-query';

--- a/graphql/playwright-test/src/get-connections.ts
+++ b/graphql/playwright-test/src/get-connections.ts
@@ -57,7 +57,6 @@ const createConnectionsWithServerBase = async (
       defaultDatabaseId: 'test-database',
       ...(input.authRole && { anonRole: input.authRole, roleName: input.authRole })
     },
-    ...(input.graphile && { graphile: input.graphile as any })
   });
 
   // Start the HTTP server

--- a/graphql/query/src/generators/index.ts
+++ b/graphql/query/src/generators/index.ts
@@ -12,8 +12,6 @@ export {
   cleanTableToMetaObject,
   createASTQueryBuilder,
   generateIntrospectionSchema,
-  toCamelCasePlural,
-  toOrderByTypeName,
 } from './select';
 
 // Mutation generators (CREATE, UPDATE, DELETE)
@@ -34,6 +32,7 @@ export {
 // Naming helpers (server-aware inflection)
 export {
   normalizeInflectionValue,
+  toCamelCasePlural,
   toCamelCaseSingular,
   toCreateMutationName,
   toUpdateMutationName,
@@ -42,6 +41,7 @@ export {
   toUpdateInputTypeName,
   toDeleteInputTypeName,
   toFilterTypeName,
+  toOrderByTypeName,
   toPatchFieldName,
   toOrderByEnumValue,
 } from './naming-helpers';

--- a/graphql/query/src/generators/select.ts
+++ b/graphql/query/src/generators/select.ts
@@ -41,8 +41,6 @@ import {
   toUpdateMutationName,
 } from './naming-helpers';
 
-// Re-export naming helpers for backwards compatibility
-export { toCamelCasePlural, toOrderByTypeName } from './naming-helpers';
 
 /**
  * Convert Table to MetaObject format for QueryBuilder

--- a/graphql/query/src/index.ts
+++ b/graphql/query/src/index.ts
@@ -27,7 +27,6 @@ export * from './types';
 
 // Meta object utilities (convert, validate)
 export * as MetaObject from './meta-object';
-// Also export meta-object functions directly for codegen backward compatibility
 export { convertFromMetaSchema } from './meta-object/convert';
 export { validateMetaObject, type ValidationResult } from './meta-object/validate';
 

--- a/graphql/server/src/server.ts
+++ b/graphql/server/src/server.ts
@@ -54,7 +54,7 @@ const log = new Logger('server');
  *   server: { port: 4000 }
  * });
  *
- * // Using PgpmOptions (backward compatible)
+ * // Using PgpmOptions
  * GraphQLServer(pgpmOptions);
  * ```
  */

--- a/packages/cli/test-utils/index.ts
+++ b/packages/cli/test-utils/index.ts
@@ -1,6 +1,6 @@
 export * from './fixtures';
 
-// Re-export test utilities from @inquirerer/test for backwards compatibility
+// Re-export test utilities from @inquirerer/test
 export {
   KEY_SEQUENCES,
   setupTests,

--- a/pgpm/cli/src/commands/init/workspace.ts
+++ b/pgpm/cli/src/commands/init/workspace.ts
@@ -32,8 +32,7 @@ export default async function runWorkspaceSetup(
 
   const templateRepo = (argv.repo as string) ?? DEFAULT_TEMPLATE_REPO;
   // Don't set default template - let scaffoldTemplate use metadata-driven resolution
-  // Support both --template (new) and --template-path (deprecated) for backward compatibility
-  const template = (argv.template || argv.templatePath) as string | undefined;
+  const template = (argv.template) as string | undefined;
 
   // Register workspace.dirname resolver so boilerplate templates can use it via defaultFrom/setFrom
   // This provides the intended workspace directory name before the folder is created

--- a/pgpm/cli/src/index.ts
+++ b/pgpm/cli/src/index.ts
@@ -36,7 +36,6 @@ export const options: Partial<CLIOptions> = {
       v: 'version',
       h: 'help',
       'from-branch': 'fromBranch',
-      // Support both --template and --template-path (deprecated) for backward compatibility
       'template-path': 'template',
       t: 'template',
       // -w for --create-workspace flag

--- a/pgpm/cli/test-utils/index.ts
+++ b/pgpm/cli/test-utils/index.ts
@@ -3,7 +3,7 @@ export * from './fixtures';
 export * from './init-argv';
 export * from './TestDatabase';
 
-// Re-export test utilities from @inquirerer/test for backwards compatibility
+// Re-export test utilities from @inquirerer/test
 export {
   KEY_SEQUENCES,
   setupTests,

--- a/pgpm/core/src/files/plan/parser.ts
+++ b/pgpm/core/src/files/plan/parser.ts
@@ -311,7 +311,8 @@ export function resolveReference(
 }
 
 /**
- * Simple plan file parser without validation (for backwards compatibility)
+ * Simple plan file parser without validation.
+ * Returns a PlanFile (without tags) for callers that don't need tag data.
  */
 export function parsePlanFileSimple(planPath: string): PlanFile {
   const result = parsePlanFile(planPath);

--- a/pgpm/core/src/files/plan/writer.ts
+++ b/pgpm/core/src/files/plan/writer.ts
@@ -153,8 +153,3 @@ export function generateTagLineContent(tag: Tag): string {
   
   return line;
 }
-
-/**
- * @deprecated Use writePgpmPlan instead. This alias is kept for backwards compatibility.
- */
-export const writeSqitchPlan = writePgpmPlan;

--- a/pgpm/core/src/files/sql/writer.ts
+++ b/pgpm/core/src/files/sql/writer.ts
@@ -130,8 +130,3 @@ ${useTx ? 'COMMIT;' : ''}
 `;
   fs.writeFileSync(actualFile, content);
 };
-
-/**
- * @deprecated Use writePgpmFiles instead. This alias is kept for backwards compatibility.
- */
-export const writeSqitchFiles = writePgpmFiles;

--- a/pgpm/core/src/files/types/index.ts
+++ b/pgpm/core/src/files/types/index.ts
@@ -58,8 +58,3 @@ export interface PgpmRow {
   deps?: string[];
   name?: string;
 }
-
-/**
- * @deprecated Use PgpmRow instead. This alias is kept for backwards compatibility.
- */
-export type SqitchRow = PgpmRow;

--- a/pgpm/core/src/migrate/utils/transaction.ts
+++ b/pgpm/core/src/migrate/utils/transaction.ts
@@ -4,7 +4,7 @@ import { Pool, PoolClient } from 'pg';
 
 import { formatQueryHistory, truncateErrorOutput } from './errors';
 
-// Re-export error formatting functions for backward compatibility
+// Re-export error formatting functions
 export { formatQueryHistory, truncateErrorOutput } from './errors';
 
 const log = new Logger('migrate:transaction');

--- a/pgpm/types/src/pgpm.ts
+++ b/pgpm/types/src/pgpm.ts
@@ -49,10 +49,6 @@ export interface PgTestClientContext {
   [key: string]: string | null | undefined;
 }
 
-/**
-* @deprecated Use PgTestClientContext instead (typo fix)
-*/
-export type PgTextClientContext = PgTestClientContext;
 
 /**
  * Role mapping configuration for database security


### PR DESCRIPTION
## Summary

Removes all deprecated code, backward-compatibility aliases, type shims, and legacy interfaces across the monorepo. The build passes with these deletions.

**Deleted exports/symbols:**
- `writeSqitchFiles`, `writeSqitchPlan` (aliases for `writePgpmFiles`/`writePgpmPlan`)
- `SqitchRow` type alias (for `PgpmRow`)
- `PgTextClientContext` type alias (typo fix alias for `PgTestClientContext`)
- `CustomInflectorPlugin`, `CustomInflectorPreset` (aliases for `InflektPlugin`/`InflektPreset`)
- `LegacyGraphileOptions` interface + `graphile` field from `GetConnectionsInput`
- `IntrospectionSchema` type alias from codegen (alias for `QueryIntrospectionSchema`)
- `codegen/src/core/query-builder.ts` re-export shim file (deleted entirely)
- Deprecated `NodeTypeRegistryPreset` section from README

**Other changes:**
- Moved `toCamelCasePlural`/`toOrderByTypeName` exports from `select.ts` re-export to canonical `naming-helpers` source in `generators/index.ts`
- Removed `input.graphile` legacy options forwarding from `playwright-test`
- Removed `--template-path` deprecation comments from CLI (alias itself still registered)
- Cleaned up "backward compat" phrasing from comments across ~10 files

## Review & Testing Checklist for Human

- [ ] **External consumers of removed symbols**: Grep any downstream repos/apps that import `CustomInflectorPlugin`, `CustomInflectorPreset`, `LegacyGraphileOptions`, `SqitchRow`, `writeSqitchFiles`, `writeSqitchPlan`, `PgTextClientContext`, or `IntrospectionSchema`. The monorepo build passes, but external consumers will break silently at their next build.
- [ ] **`--template-path` CLI alias inconsistency**: The deprecation comment was removed from `pgpm/cli/src/index.ts` but the alias `'template-path': 'template'` is still registered on line 37. Decide whether to remove the alias entirely (breaking) or keep it as a silent alias.
- [ ] **`graphile` field removal from playwright-test**: Verify no existing Playwright test suites pass legacy `graphile` options via `GetConnectionsInput`. The `input.graphile` spread was removed from `get-connections.ts:60`.
- [ ] **Run the test suite** (`pnpm test` or targeted package tests) — only `pnpm build` was verified, not tests.

### Notes
- The `convertFromMetaSchema`/`validateMetaObject` direct exports from `graphql/query` were initially removed as "backward-compat" but had to be restored because `graphql/codegen` imports them directly. They are part of the active public API, not legacy shims.

Link to Devin session: https://app.devin.ai/sessions/9d1d1d33bd734370af00f8c60d72316b
Requested by: @pyramation