### PR TITLE
feat(codegen): generate embedder config reference for CLI docs

### DIFF
--- a/graphql/codegen/src/core/codegen/cli/docs-generator.ts
+++ b/graphql/codegen/src/core/codegen/cli/docs-generator.ts
@@ -370,6 +370,64 @@ export function generateSkills(
     }),
   });
 
+  // Embedder reference (generated once when any table has Vector fields)
+  const hasEmbeddings = tables.some((t) =>
+    categorizeSpecialFields(t, registry).some((g) => g.category === 'embedding'),
+  );
+  if (hasEmbeddings) {
+    referenceNames.push('embedder');
+    files.push({
+      fileName: `${skillName}/references/embedder.md`,
+      content: buildSkillReference({
+        title: 'Embedder Configuration',
+        description:
+          `Configure text-to-vector embedding for \`--auto-embed\` support in ${toolName}.\n\n` +
+          'When an embedder is configured, you can pass plain text to vector fields and ' +
+          'the CLI will automatically convert it to an embedding vector.\n\n' +
+          '**Supported providers:** ollama, openai\n\n' +
+          '**Configuration methods:** appstash config (persisted per-context) or environment variables',
+        usage: [
+          `# Configure via appstash config (persisted per-context)`,
+          `${toolName} config set embedder.provider <provider>`,
+          `${toolName} config set embedder.model <model>`,
+          `${toolName} config set embedder.baseUrl <url>`,
+          '',
+          `# Or configure via environment variables`,
+          `EMBEDDER_PROVIDER=<provider> EMBEDDER_MODEL=<model> EMBEDDER_BASE_URL=<url> ${toolName} <command>`,
+        ],
+        examples: [
+          {
+            description: 'Ollama with nomic-embed-text (open-source, local)',
+            code: [
+              `# Start Ollama locally and pull the model`,
+              `ollama pull nomic-embed-text`,
+              '',
+              `# Register the embedder`,
+              `${toolName} config set embedder.provider ollama`,
+              `${toolName} config set embedder.model nomic-embed-text`,
+              `${toolName} config set embedder.baseUrl http://localhost:11434`,
+              '',
+              `# Now use --auto-embed with any vector field`,
+              `${toolName} ${toKebabCase(getTableNames(tables[0]).singularName)} search "my query" --auto-embed`,
+            ],
+          },
+          {
+            description: 'OpenAI with an API key',
+            code: [
+              `# Register the embedder`,
+              `${toolName} config set embedder.provider openai`,
+              `${toolName} config set embedder.model text-embedding-3-small`,
+              `${toolName} config set embedder.apiKey sk-proj-...your-api-key`,
+              '',
+              `# Or use environment variables`,
+              `EMBEDDER_PROVIDER=openai EMBEDDER_MODEL=text-embedding-3-small EMBEDDER_API_KEY=sk-proj-...your-api-key ${toolName} ${toKebabCase(getTableNames(tables[0]).singularName)} search "my query" --auto-embed`,
+            ],
+          },
+        ],
+      }),
+    });
+  }
+
   // Table references
   for (const table of tables) {
     const { singularName } = getTableNames(table);
@@ -988,6 +1046,68 @@ export function generateMultiTargetSkills(
       ],
     }),
   });
+
+  // Embedder reference (generated once when any target has tables with Vector fields)
+  const allTargetTables = targets.flatMap((t) => t.tables);
+  const hasEmbeddings = allTargetTables.some((t) =>
+    categorizeSpecialFields(t, registry).some((g) => g.category === 'embedding'),
+  );
+  if (hasEmbeddings) {
+    const firstTableName = allTargetTables.length > 0
+      ? toKebabCase(getTableNames(allTargetTables[0]).singularName)
+      : 'model';
+    commonReferenceNames.push('embedder');
+    files.push({
+      fileName: `${commonSkillName}/references/embedder.md`,
+      content: buildSkillReference({
+        title: 'Embedder Configuration',
+        description:
+          `Configure text-to-vector embedding for \`--auto-embed\` support in ${toolName}.\n\n` +
+          'When an embedder is configured, you can pass plain text to vector fields and ' +
+          'the CLI will automatically convert it to an embedding vector.\n\n' +
+          '**Supported providers:** ollama, openai\n\n' +
+          '**Configuration methods:** appstash config (persisted per-context) or environment variables',
+        usage: [
+          `# Configure via appstash config (persisted per-context)`,
+          `${toolName} ${builtinNames.config} set embedder.provider <provider>`,
+          `${toolName} ${builtinNames.config} set embedder.model <model>`,
+          `${toolName} ${builtinNames.config} set embedder.baseUrl <url>`,
+          '',
+          `# Or configure via environment variables`,
+          `EMBEDDER_PROVIDER=<provider> EMBEDDER_MODEL=<model> EMBEDDER_BASE_URL=<url> ${toolName} <command>`,
+        ],
+        examples: [
+          {
+            description: 'Ollama with nomic-embed-text (open-source, local)',
+            code: [
+              `# Start Ollama locally and pull the model`,
+              `ollama pull nomic-embed-text`,
+              '',
+              `# Register the embedder`,
+              `${toolName} ${builtinNames.config} set embedder.provider ollama`,
+              `${toolName} ${builtinNames.config} set embedder.model nomic-embed-text`,
+              `${toolName} ${builtinNames.config} set embedder.baseUrl http://localhost:11434`,
+              '',
+              `# Now use --auto-embed with any vector field`,
+              `${toolName} ${targets[0]?.name ? `${targets[0].name}:` : ''}${firstTableName} search "my query" --auto-embed`,
+            ],
+          },
+          {
+            description: 'OpenAI with an API key',
+            code: [
+              `# Register the embedder`,
+              `${toolName} ${builtinNames.config} set embedder.provider openai`,
+              `${toolName} ${builtinNames.config} set embedder.model text-embedding-3-small`,
+              `${toolName} ${builtinNames.config} set embedder.apiKey sk-proj-...your-api-key`,
+              '',
+              `# Or use environment variables`,
+              `EMBEDDER_PROVIDER=openai EMBEDDER_MODEL=text-embedding-3-small EMBEDDER_API_KEY=sk-proj-...your-api-key ${toolName} ${targets[0]?.name ? `${targets[0].name}:` : ''}${firstTableName} search "my query" --auto-embed`,
+            ],
+          },
+        ],
+      }),
+    });
+  }
 
   // Common SKILL.md
   files.push({


### PR DESCRIPTION
## Summary

Adds a one-time `embedder.md` skill reference to the CLI docs generator, produced alongside the existing `context.md`, `auth.md`, and `config.md` infrastructure references. The reference is only generated when any table in the schema has Vector fields (detected via `categorizeSpecialFields` with `category === 'embedding'`).

Both codegen paths are updated:
- **`generateSkills`** (single-target CLIs)
- **`generateMultiTargetSkills`** (multi-target CLIs like `csdk`)

The generated reference includes two examples:
1. **Ollama + nomic-embed-text** on localhost (open-source, local)
2. **OpenAI** with an API key

## Review & Testing Checklist for Human

- [ ] **OpenAI provider not yet implemented in runtime:** The examples reference `openai` as a supported provider and `embedder.apiKey` as a config key, but `templates/embedder.ts` only handles `ollama` in `buildEmbedder()` and `EmbedderConfig` has no `apiKey` field. Decide whether these examples should be aspirational or removed until runtime support lands.
- [ ] **Verify generated output:** Run codegen against a schema with Vector fields (e.g. agentic-db) and confirm `embedder.md` appears exactly once in the skill references directory, not duplicated per-table.
- [ ] **`tables[0]` access in single-target path:** When `hasEmbeddings` is true, `tables[0]` is used for the example command. This should always be safe (embedding implies ≥1 table), but worth a glance.

### Notes

- The duplication between single-target and multi-target blocks follows the existing pattern used by context/auth/config references in the same file.
- After this merges, re-running codegen on agentic-db will produce the embedder configuration docs automatically.

Link to Devin session: https://app.devin.ai/sessions/dadc6f4634e844739846793b8c75ca86
Requested by: @pyramation