### PR TITLE
feat: remove include_id from Data* modules and blueprint types

### DIFF
--- a/graphql/node-type-registry/README.md
+++ b/graphql/node-type-registry/README.md
@@ -35,7 +35,7 @@ const definition: BlueprintDefinition = {
       nodes: [
         'DataId',
         'DataTimestamps',
-        { $type: 'DataDirectOwner', data: { include_id: false } },
+        'DataDirectOwner',
       ],
       fields: [
         { name: 'title', type: 'text', is_not_null: true },

--- a/graphql/node-type-registry/src/blueprint-types.generated.ts
+++ b/graphql/node-type-registry/src/blueprint-types.generated.ts
@@ -21,8 +21,6 @@ export interface DataIdParams {
 export interface DataDirectOwnerParams {
   /* Column name for owner ID */
   owner_field_name?: string;
-  /* If true, also adds a UUID primary key column with auto-generation */
-  include_id?: boolean;
   /* If true, adds a foreign key constraint from owner_id to the users table */
   include_user_fk?: boolean;
 }
@@ -30,39 +28,27 @@ export interface DataDirectOwnerParams {
 export interface DataEntityMembershipParams {
   /* Column name for entity ID */
   entity_field_name?: string;
-  /* If true, also adds a UUID primary key column with auto-generation */
-  include_id?: boolean;
   /* If true, adds a foreign key constraint from entity_id to the users table */
   include_user_fk?: boolean;
 }
 /** Combines direct ownership with entity scoping. Adds both owner_id and entity_id columns. Enables AuthzDirectOwner, AuthzEntityMembership, and AuthzOrgHierarchy authorization. Particularly useful for OrgHierarchy where a user owns a row (owner_id) within an entity (entity_id), and managers above can see subordinate-owned records via the hierarchy closure table. */
 export interface DataOwnershipInEntityParams {
-  /* If true, also adds a UUID primary key column with auto-generation */
-  include_id?: boolean;
   /* If true, adds foreign key constraints from owner_id and entity_id to the users table */
   include_user_fk?: boolean;
 }
 /** Adds automatic timestamp tracking with created_at and updated_at columns. */
 export interface DataTimestampsParams {
-  /* If true, also adds a UUID primary key column with auto-generation */
-  include_id?: boolean;
 }
 /** Adds user tracking for creates/updates with created_by and updated_by columns. */
 export interface DataPeoplestampsParams {
-  /* If true, also adds a UUID primary key column with auto-generation */
-  include_id?: boolean;
   /* If true, adds foreign key constraints from created_by and updated_by to the users table */
   include_user_fk?: boolean;
 }
 /** Adds publish state columns (is_published, published_at) for content visibility. Enables AuthzPublishable and AuthzTemporal authorization. */
 export interface DataPublishableParams {
-  /* If true, also adds a UUID primary key column with auto-generation */
-  include_id?: boolean;
 }
 /** Adds soft delete support with deleted_at and is_deleted columns. */
 export interface DataSoftDeleteParams {
-  /* If true, also adds a UUID primary key column with auto-generation */
-  include_id?: boolean;
 }
 /** Adds a vector embedding column with HNSW or IVFFlat index for similarity search. Supports configurable dimensions, distance metrics (cosine, l2, ip), stale tracking strategies (column, null, hash), and automatic job enqueue triggers for embedding generation. */
 export interface DataEmbeddingParams {

--- a/graphql/node-type-registry/src/data/data-direct-owner.ts
+++ b/graphql/node-type-registry/src/data/data-direct-owner.ts
@@ -14,11 +14,6 @@ export const DataDirectOwner: NodeTypeDefinition = {
         "description": "Column name for owner ID",
         "default": "owner_id"
       },
-      "include_id": {
-        "type": "boolean",
-        "description": "If true, also adds a UUID primary key column with auto-generation",
-        "default": true
-      },
       "include_user_fk": {
         "type": "boolean",
         "description": "If true, adds a foreign key constraint from owner_id to the users table",

--- a/graphql/node-type-registry/src/data/data-entity-membership.ts
+++ b/graphql/node-type-registry/src/data/data-entity-membership.ts
@@ -14,11 +14,6 @@ export const DataEntityMembership: NodeTypeDefinition = {
         "description": "Column name for entity ID",
         "default": "entity_id"
       },
-      "include_id": {
-        "type": "boolean",
-        "description": "If true, also adds a UUID primary key column with auto-generation",
-        "default": true
-      },
       "include_user_fk": {
         "type": "boolean",
         "description": "If true, adds a foreign key constraint from entity_id to the users table",

--- a/graphql/node-type-registry/src/data/data-ownership-in-entity.ts
+++ b/graphql/node-type-registry/src/data/data-ownership-in-entity.ts
@@ -9,11 +9,6 @@ export const DataOwnershipInEntity: NodeTypeDefinition = {
   "parameter_schema": {
     "type": "object",
     "properties": {
-      "include_id": {
-        "type": "boolean",
-        "description": "If true, also adds a UUID primary key column with auto-generation",
-        "default": true
-      },
       "include_user_fk": {
         "type": "boolean",
         "description": "If true, adds foreign key constraints from owner_id and entity_id to the users table",

--- a/graphql/node-type-registry/src/data/data-peoplestamps.ts
+++ b/graphql/node-type-registry/src/data/data-peoplestamps.ts
@@ -9,11 +9,6 @@ export const DataPeoplestamps: NodeTypeDefinition = {
   "parameter_schema": {
     "type": "object",
     "properties": {
-      "include_id": {
-        "type": "boolean",
-        "description": "If true, also adds a UUID primary key column with auto-generation",
-        "default": true
-      },
       "include_user_fk": {
         "type": "boolean",
         "description": "If true, adds foreign key constraints from created_by and updated_by to the users table",

--- a/graphql/node-type-registry/src/data/data-publishable.ts
+++ b/graphql/node-type-registry/src/data/data-publishable.ts
@@ -8,13 +8,7 @@ export const DataPublishable: NodeTypeDefinition = {
   "description": "Adds publish state columns (is_published, published_at) for content visibility. Enables AuthzPublishable and AuthzTemporal authorization.",
   "parameter_schema": {
     "type": "object",
-    "properties": {
-      "include_id": {
-        "type": "boolean",
-        "description": "If true, also adds a UUID primary key column with auto-generation",
-        "default": true
-      }
-    }
+    "properties": {}
   },
   "tags": [
     "publishing",

--- a/graphql/node-type-registry/src/data/data-soft-delete.ts
+++ b/graphql/node-type-registry/src/data/data-soft-delete.ts
@@ -8,13 +8,7 @@ export const DataSoftDelete: NodeTypeDefinition = {
   "description": "Adds soft delete support with deleted_at and is_deleted columns.",
   "parameter_schema": {
     "type": "object",
-    "properties": {
-      "include_id": {
-        "type": "boolean",
-        "description": "If true, also adds a UUID primary key column with auto-generation",
-        "default": true
-      }
-    }
+    "properties": {}
   },
   "tags": [
     "schema"

--- a/graphql/node-type-registry/src/data/data-timestamps.ts
+++ b/graphql/node-type-registry/src/data/data-timestamps.ts
@@ -8,13 +8,7 @@ export const DataTimestamps: NodeTypeDefinition = {
   "description": "Adds automatic timestamp tracking with created_at and updated_at columns.",
   "parameter_schema": {
     "type": "object",
-    "properties": {
-      "include_id": {
-        "type": "boolean",
-        "description": "If true, also adds a UUID primary key column with auto-generation",
-        "default": true
-      }
-    }
+    "properties": {}
   },
   "tags": [
     "timestamps",


### PR DESCRIPTION
## Summary

Removes the `include_id` parameter from all 7 Data\* module definitions that previously had it. Users must now explicitly include `DataId` as a separate node instead of relying on implicit primary key creation via `include_id: true`.

**Affected modules:** `DataTimestamps`, `DataDirectOwner`, `DataSoftDelete`, `DataPublishable`, `DataPeoplestamps`, `DataEntityMembership`, `DataOwnershipInEntity`

**Files changed:**
- 7 Data\* definition files — removed `include_id` from `parameter_schema.properties`
- `blueprint-types.generated.ts` — removed `include_id?: boolean` from 7 param interfaces
- `README.md` — updated example to use string shorthand instead of `{ $type: 'DataDirectOwner', data: { include_id: false } }`

**Companion PR:** constructive-db [#722](https://github.com/constructive-io/constructive-db/pull/722) removes `include_id` from the SQL generators. These two PRs should be merged together.

## Review & Testing Checklist for Human

- [ ] **Merge together with constructive-db #722** — the TS types here must match the SQL generators. Merging one without the other creates a mismatch.
- [ ] **Search application code for `include_id` usage** — any existing blueprint definitions or `secure_table_provision` INSERTs that pass `include_id` need to be updated to use explicit `DataId` instead.
- [ ] **Generated SDK types in `sdk/`** still reference `include_id` in comments (schema-types.ts, input-types.ts, public.graphql). These are generated from the DB schema and will be regenerated after constructive-db #722 is deployed — confirm this happens.

**Test plan:** After merging both PRs, deploy and run `construct_blueprint()` on a blueprint that uses `DataId` + `DataTimestamps` + `DataDirectOwner` (no `include_id`). Verify the table gets a UUID PK from `DataId` and that timestamps/ownership columns are created without errors.

### Notes
- This is a breaking change, acceptable per pre-launch policy (no backwards compatibility needed).
- `DataTimestampsParams`, `DataPublishableParams`, and `DataSoftDeleteParams` are now empty interfaces — these modules have no remaining configurable parameters.
- `blueprint-types.generated.ts` was edited manually rather than via `pnpm generate:types`. The edits are straightforward deletions but you may want to re-run the generator to confirm parity.

Link to Devin session: https://app.devin.ai/sessions/094d88b562a04a2fa55dc2e4d85f7b8d
Requested by: @pyramation