### PR TITLE
feat: update RelationManyToMany types - replace node_type/node_data with nodes[] array

### DIFF
--- a/graphql/node-type-registry/src/blueprint-types.generated.ts
+++ b/graphql/node-type-registry/src/blueprint-types.generated.ts
@@ -558,7 +558,7 @@ export interface RelationHasManyParams {
   /* Whether the FK field is NOT NULL */
   is_required?: boolean;
 }
-/** Creates a junction table between source and target tables with auto-derived naming and FK fields. The trigger creates a bare table (no implicit DataId or any node_type), adds FK fields to both tables, optionally creates a composite PK (use_composite_key), then forwards all security config to secure_table_provision as-is. The trigger never injects values the caller did not provide. Junction table FKs always CASCADE on delete. */
+/** Creates a junction table between source and target tables with auto-derived naming and FK fields. The trigger creates a bare table (no implicit DataId), adds FK fields to both tables, optionally creates a composite PK (use_composite_key), then forwards all security config to secure_table_provision as-is. The trigger never injects values the caller did not provide. Junction table FKs always CASCADE on delete. */
 export interface RelationManyToManyParams {
   /* First table in the M:N relationship */
   source_table_id: string;
@@ -572,14 +572,12 @@ export interface RelationManyToManyParams {
   source_field_name?: string;
   /* FK field name on junction for target table. Auto-derived if omitted (e.g., tags derives tag_id) */
   target_field_name?: string;
-  /* When true, creates a composite PK from the two FK fields. When false, no PK is created by the trigger (use node_type=DataId for UUID PK). Mutually exclusive with node_type=DataId. */
+  /* When true, creates a composite PK from the two FK fields. When false, no PK is created by the trigger (use nodes with DataId for UUID PK). Mutually exclusive with nodes containing DataId. */
   use_composite_key?: boolean;
-  /* Generator for field creation on junction table. Forwarded to secure_table_provision as-is. Examples: DataId, DataEntityMembership, DataDirectOwner. NULL means no additional fields. */
-  node_type?: string;
-  /* Configuration for the generator. Forwarded to secure_table_provision as-is. Only used when node_type is set. */
-  node_data?: {
+  /* Array of node objects for field creation on junction table. Each object has a $type key (e.g. DataId, DataEntityMembership) and optional data keys. Forwarded to secure_table_provision as-is. Empty array means no additional fields. */
+  nodes?: {
     [key: string]: unknown;
-  };
+  }[];
   /* Database roles to grant privileges to. Forwarded to secure_table_provision as-is. Default: [authenticated] */
   grant_roles?: string[];
   /* Privilege grants for the junction table as [verb, columns] tuples (e.g. [['select','*'],['insert','*']]). Forwarded to secure_table_provision as-is. Default: select/insert/delete for all columns */

--- a/graphql/node-type-registry/src/relation/relation-many-to-many.ts
+++ b/graphql/node-type-registry/src/relation/relation-many-to-many.ts
@@ -5,7 +5,7 @@ export const RelationManyToMany: NodeTypeDefinition = {
   "slug": "relation_many_to_many",
   "category": "relation",
   "display_name": "Many to Many",
-  "description": "Creates a junction table between source and target tables with auto-derived naming and FK fields. The trigger creates a bare table (no implicit DataId or any node_type), adds FK fields to both tables, optionally creates a composite PK (use_composite_key), then forwards all security config to secure_table_provision as-is. The trigger never injects values the caller did not provide. Junction table FKs always CASCADE on delete.",
+  "description": "Creates a junction table between source and target tables with auto-derived naming and FK fields. The trigger creates a bare table (no implicit DataId), adds FK fields to both tables, optionally creates a composite PK (use_composite_key), then forwards all security config to secure_table_provision as-is. The trigger never injects values the caller did not provide. Junction table FKs always CASCADE on delete.",
   "parameter_schema": {
     "type": "object",
     "properties": {
@@ -38,16 +38,15 @@ export const RelationManyToMany: NodeTypeDefinition = {
       },
       "use_composite_key": {
         "type": "boolean",
-        "description": "When true, creates a composite PK from the two FK fields. When false, no PK is created by the trigger (use node_type=DataId for UUID PK). Mutually exclusive with node_type=DataId.",
+        "description": "When true, creates a composite PK from the two FK fields. When false, no PK is created by the trigger (use nodes with DataId for UUID PK). Mutually exclusive with nodes containing DataId.",
         "default": false
       },
-      "node_type": {
-        "type": "string",
-        "description": "Generator for field creation on junction table. Forwarded to secure_table_provision as-is. Examples: DataId, DataEntityMembership, DataDirectOwner. NULL means no additional fields."
-      },
-      "node_data": {
-        "type": "object",
-        "description": "Configuration for the generator. Forwarded to secure_table_provision as-is. Only used when node_type is set."
+      "nodes": {
+        "type": "array",
+        "items": {
+          "type": "object"
+        },
+        "description": "Array of node objects for field creation on junction table. Each object has a $type key (e.g. DataId, DataEntityMembership) and optional data keys. Forwarded to secure_table_provision as-is. Empty array means no additional fields."
       },
       "grant_roles": {
         "type": "array",


### PR DESCRIPTION
## Summary

Updates the `RelationManyToMany` node type definition and generated blueprint types to replace the single `node_type` (string) + `node_data` (object) parameters with a `nodes` array of objects. Each object in the array has a `$type` key identifying the generator (e.g. `DataId`, `DataEntityMembership`) plus optional data keys.

This matches the DB schema change in constructive-db PR #723, which redesigns `relation_provision.node_type`/`node_data` columns into a single `nodes jsonb` column.

**Files changed:**
- `graphql/node-type-registry/src/relation/relation-many-to-many.ts` — source definition
- `graphql/node-type-registry/src/blueprint-types.generated.ts` — regenerated via `pnpm generate:types`

## Review & Testing Checklist for Human

- [ ] **Verify `nodes` type shape matches DB expectation**: The generated TS type is `{ [key: string]: unknown }[]` — it does NOT enforce `$type` at the type level (the codegen derives from the JSON Schema `"type": "array", "items": { "type": "object" }`). Confirm this is acceptable or if the schema should be tightened to require `$type`.
- [ ] **Merge alongside constructive-db PR #723**: These two PRs are companions — merging one without the other will cause type/schema mismatch. Merge constructive-db first, then this.

### Notes
- This is a **breaking change** — any code referencing `node_type` or `node_data` on `RelationManyToManyParams` will fail to compile. This is intentional (pre-launch, no backward compat).
- The generated file was produced by running `pnpm generate:types` in `graphql/node-type-registry/`, not hand-edited.

Link to Devin session: https://app.devin.ai/sessions/094d88b562a04a2fa55dc2e4d85f7b8d
Requested by: @pyramation