### PR TITLE
feat: add LRU bucket metadata cache to presigned-url-plugin

### DIFF
--- a/graphile/graphile-presigned-url-plugin/src/index.ts
+++ b/graphile/graphile-presigned-url-plugin/src/index.ts
@@ -30,7 +30,7 @@
 export { PresignedUrlPlugin, createPresignedUrlPlugin } from './plugin';
 export { createDownloadUrlPlugin } from './download-url-field';
 export { PresignedUrlPreset } from './preset';
-export { getStorageModuleConfig, clearStorageModuleCache } from './storage-module-cache';
+export { getStorageModuleConfig, getBucketConfig, clearStorageModuleCache, clearBucketCache } from './storage-module-cache';
 export { generatePresignedPutUrl, generatePresignedGetUrl, headObject } from './s3-signer';
 export type {
   BucketConfig,

--- a/graphile/graphile-presigned-url-plugin/src/plugin.ts
+++ b/graphile/graphile-presigned-url-plugin/src/plugin.ts
@@ -23,7 +23,7 @@ import { extendSchema, gql } from 'graphile-utils';
 import { Logger } from '@pgpmjs/logger';
 
 import type { PresignedUrlPluginOptions } from './types';
-import { getStorageModuleConfig } from './storage-module-cache';
+import { getStorageModuleConfig, getBucketConfig } from './storage-module-cache';
 import { generatePresignedPutUrl, headObject } from './s3-signer';
 
 const log = new Logger('graphile-presigned-url:plugin');
@@ -188,20 +188,11 @@ export function createPresignedUrlPlugin(
                   }
                 }
 
-                // --- Look up the bucket (RLS enforced) ---
-                const bucketResult = await pgClient.query(
-                  `SELECT id, type, is_public, owner_id, allowed_mime_types, max_file_size
-                   FROM ${storageConfig.bucketsQualifiedName}
-                   WHERE key = $1
-                   LIMIT 1`,
-                  [bucketKey],
-                );
-
-                if (bucketResult.rows.length === 0) {
+                // --- Look up the bucket (cached; first miss queries via RLS) ---
+                const bucket = await getBucketConfig(pgClient, storageConfig, databaseId, bucketKey);
+                if (!bucket) {
                   throw new Error('BUCKET_NOT_FOUND');
                 }
-
-                const bucket = bucketResult.rows[0];
 
                 // --- Validate content type against bucket's allowed_mime_types ---
                 if (bucket.allowed_mime_types && bucket.allowed_mime_types.length > 0) {

--- a/graphile/graphile-presigned-url-plugin/src/storage-module-cache.ts
+++ b/graphile/graphile-presigned-url-plugin/src/storage-module-cache.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@pgpmjs/logger';
 import { LRUCache } from 'lru-cache';
-import type { StorageModuleConfig } from './types';
+import type { StorageModuleConfig, BucketConfig } from './types';
 
 const log = new Logger('graphile-presigned-url:cache');
 
@@ -125,9 +125,115 @@ export async function getStorageModuleConfig(
   return config;
 }
 
+// --- Bucket metadata cache ---
+
 /**
- * Clear the storage module cache (useful for testing or schema changes).
+ * LRU cache for per-database bucket metadata.
+ *
+ * Buckets are essentially static config — created once and rarely changed.
+ * Caching avoids a DB query on every requestUploadUrl call. The bucket
+ * lookup in the plugin runs under RLS, but since AuthzEntityMembership
+ * grants all org members access to all org buckets, and the cached data
+ * is just config (mime types, size limits), bypassing RLS on cache hits
+ * is safe. The important RLS is on the files table (INSERT/UPDATE),
+ * which is never cached.
+ *
+ * Keys: `bucket:${databaseId}:${bucketKey}`
+ * TTL: same as storage module cache (5min dev / 1hr prod)
+ */
+const bucketCache = new LRUCache<string, BucketConfig>({
+  max: 500, // many buckets across many databases
+  ttl: process.env.NODE_ENV === 'development' ? FIVE_MINUTES_MS : ONE_HOUR_MS,
+  updateAgeOnGet: true,
+});
+
+/**
+ * Resolve bucket metadata for a given database + bucket key, using the LRU cache.
+ *
+ * On cache miss, queries the bucket table (RLS-enforced via pgSettings on
+ * the pgClient). On cache hit, returns the cached metadata directly.
+ *
+ * @param pgClient - A pg client from the Graphile context
+ * @param storageConfig - The resolved StorageModuleConfig for this database
+ * @param databaseId - The metaschema database UUID (used as cache key prefix)
+ * @param bucketKey - The bucket key (e.g., "public", "private")
+ * @returns BucketConfig or null if the bucket doesn't exist / isn't accessible
+ */
+export async function getBucketConfig(
+  pgClient: { query: (sql: string, params: unknown[]) => Promise<{ rows: unknown[] }> },
+  storageConfig: StorageModuleConfig,
+  databaseId: string,
+  bucketKey: string,
+): Promise<BucketConfig | null> {
+  const cacheKey = `bucket:${databaseId}:${bucketKey}`;
+  const cached = bucketCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  log.debug(`Bucket cache miss for ${databaseId}:${bucketKey}, querying DB...`);
+
+  const result = await pgClient.query(
+    `SELECT id, key, type, is_public, owner_id, allowed_mime_types, max_file_size
+     FROM ${storageConfig.bucketsQualifiedName}
+     WHERE key = $1
+     LIMIT 1`,
+    [bucketKey],
+  );
+
+  if (result.rows.length === 0) {
+    return null;
+  }
+
+  const row = result.rows[0] as {
+    id: string;
+    key: string;
+    type: string;
+    is_public: boolean;
+    owner_id: string;
+    allowed_mime_types: string[] | null;
+    max_file_size: number | null;
+  };
+
+  const config: BucketConfig = {
+    id: row.id,
+    key: row.key,
+    type: row.type as BucketConfig['type'],
+    is_public: row.is_public,
+    owner_id: row.owner_id,
+    allowed_mime_types: row.allowed_mime_types,
+    max_file_size: row.max_file_size,
+  };
+
+  bucketCache.set(cacheKey, config);
+  log.debug(`Cached bucket config for ${databaseId}:${bucketKey} (id=${config.id})`);
+
+  return config;
+}
+
+/**
+ * Clear the storage module cache AND bucket cache.
+ * Useful for testing or schema changes.
  */
 export function clearStorageModuleCache(): void {
   storageModuleCache.clear();
+  bucketCache.clear();
+}
+
+/**
+ * Clear cached bucket entries for a specific database.
+ * Useful when bucket config changes are detected.
+ */
+export function clearBucketCache(databaseId?: string): void {
+  if (!databaseId) {
+    bucketCache.clear();
+    return;
+  }
+  // Evict all entries for this database
+  const prefix = `bucket:${databaseId}:`;
+  for (const key of bucketCache.keys()) {
+    if (key.startsWith(prefix)) {
+      bucketCache.delete(key);
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Adds an LRU cache for bucket metadata in the presigned-url-plugin. Previously, every `requestUploadUrl` call queried the `buckets` table even though bucket config (type, allowed_mime_types, max_file_size, etc.) is essentially static. Now the first request per `databaseId:bucketKey` pair hits the DB, and subsequent requests are served from cache.

**Cache details:**
- Composite key: `bucket:${databaseId}:${bucketKey}`
- Same TTL as the existing storage module cache (5min dev / 1hr prod)
- `max: 500` entries (vs 50 for storage module cache, since there are many more buckets)
- `clearStorageModuleCache()` now clears both caches (coordinated eviction)
- `clearBucketCache(databaseId?)` added for targeted per-database eviction

**Files changed:**
- `storage-module-cache.ts` — new `bucketCache` LRU, `getBucketConfig()`, `clearBucketCache()`
- `plugin.ts` — `requestUploadUrl` now calls `getBucketConfig()` instead of inline SQL
- `index.ts` — exports `getBucketConfig` and `clearBucketCache`

## Review & Testing Checklist for Human

- [ ] **RLS bypass on cache hits**: On cache miss the bucket query runs under the calling user's pgSettings (RLS-enforced). On cache hits, the cached result is returned to any user. Verify that all org members should always have identical bucket visibility (via AuthzEntityMembership) and that no bucket-level RLS restricts access to specific users within an org.
- [ ] **Stale cache on bucket mutation**: If a bucket's `allowed_mime_types` or `max_file_size` is updated, or a bucket is deleted, the cache will serve stale data for up to TTL (1hr prod). Confirm this is acceptable, or whether a cache-bust hook is needed on bucket DDL/DML.
- [ ] **No test coverage**: There are no unit or integration tests for the cache hit/miss behavior, TTL expiry, or `clearBucketCache` prefix-scan eviction. Consider whether tests should be added before merge.

**Suggested manual test:** Call `requestUploadUrl` twice with the same bucket key and verify the second call doesn't produce a `Bucket cache miss` debug log line.

### Notes
- The `bucketsQualifiedName` interpolation in the SQL query is carried over from the previous inline query — not a new pattern.
- `clearBucketCache` iterates `bucketCache.keys()` while deleting; this is safe with `lru-cache` v10's iterator implementation, but worth being aware of.

Link to Devin session: https://app.devin.ai/sessions/4c882ba2dfbf4045adf85fb83cde6f77
Requested by: @pyramation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/constructive-io/constructive/pull/946" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
