### PR TITLE
chore: remove NodeTypeRegistryPreset and blueprint-types plugin

### DIFF
--- a/graphile/graphile-settings/src/plugins/index.ts
+++ b/graphile/graphile-settings/src/plugins/index.ts
@@ -110,14 +110,3 @@ export type {
   TrgmAdapterOptions,
   PgvectorAdapterOptions,
 } from 'graphile-search';
-
-// Node type registry — @oneOf typed input types for blueprint definitions
-// Gather-phase plugin queries node_type_registry through existing pgService
-export {
-  NodeTypeRegistryPlugin,
-  NodeTypeRegistryPreset,
-  // Legacy exports for backward compatibility
-  createBlueprintTypesPlugin,
-  BlueprintTypesPreset,
-} from './blueprint-types';
-export type { NodeTypeRegistryEntry } from './blueprint-types';

--- a/graphile/graphile-settings/src/presets/constructive-preset.ts
+++ b/graphile/graphile-settings/src/presets/constructive-preset.ts
@@ -11,7 +11,6 @@ import {
   MetaSchemaPreset,
   PgTypeMappingsPreset,
   RequiredInputPreset,
-  NodeTypeRegistryPreset,
 } from '../plugins';
 import { UnifiedSearchPreset, createMatchesOperatorFactory, createTrgmOperatorFactories } from 'graphile-search';
 import { GraphilePostgisPreset, createPostgisOperatorFactory } from 'graphile-postgis';
@@ -91,7 +90,6 @@ export const ConstructivePreset: GraphileConfig.Preset = {
     SqlExpressionValidatorPreset(),
     PgTypeMappingsPreset,
     RequiredInputPreset,
-    NodeTypeRegistryPreset,
   ],
   /**
    * Disable PostGraphile core's condition argument entirely.


### PR DESCRIPTION
## Summary

Removes the `node_type_registry` table entirely across three repos. Analysis showed nothing in the framework consumes this table at runtime — generators use hardcoded dispatch, tests only asserted rows exist without using them, and the blueprint-types GraphQL plugin generates typed inputs that nothing consumes (the blueprint executor passes plain JSON). The npm package (`graphql/node-type-registry`) remains the canonical source of truth.

**constructive-db** (this PR):
- Delete all deploy/revert/verify scripts for `node_type_registry` in `packages/metaschema` and `application/constructive`
- Remove entries from both `pgpm.plan` files
- Update `policy/table` dependency: `node_type_registry/table` → `index/table`
- Remove Phase 3b special-case from `apply_metaschema_rls.sql` (introspection RLS)
- Remove "should be registered in node_type_registry" smoke tests across 9 test files
- Update SQL comments and compiled SQL files
- Remove node_type_registry metadata rows from `services/constructive-services` migration data

**Companion PRs:**
- `constructive-io/constructive`: Remove `NodeTypeRegistryPreset` from `ConstructivePreset` and blueprint-types plugin exports
- `constructive-io/dashboard`: Replace `useNodeTypeRegistriesQuery` with UI-only `buildPolicyTypesFromUIConfig()` in policy-hooks

## Review & Testing Checklist for Human

- [ ] **Compiled SQL syntax integrity**: The compiled SQL files (`sql/*--0.0.1.sql`) and `services/constructive-services` migration data were edited via `sed` line-deletion on multi-line INSERT statements. Verify no dangling commas, mismatched parentheses, or wrong column counts were introduced. Consider running `pgpm` codegen to regenerate these files cleanly instead.
- [ ] **Services migration data consistency**: Rows were removed from `deploy/migrate/{table,field,policy,table_grant,primary_key_constraint,unique_constraint}.sql` — verify the resulting VALUES lists are syntactically valid and that no orphaned FK references remain (e.g., field rows referencing the deleted table UUID `a20545c4-...`).
- [ ] **Dependency chain**: `policy/table` now depends on `index/table` instead of `node_type_registry/table`. Verify no other entry in any `pgpm.plan` depended on `node_type_registry/table`.
- [ ] **Deploy to fresh database**: Provision `metaschema` and `constructive` packages to a fresh DB to verify the schema deploys correctly without node_type_registry.
- [ ] **Dashboard policy wizard**: Verify the policy wizard UI still renders correctly using the UI-only config path (no backend query).

### Notes
- Docs (`docs/spec/node-types.md`, `docs/unsafe.md`, etc.) and generated SDK files (`sdk/`) still contain `node_type_registry` references — these are downstream artifacts that will update on next SDK/doc regeneration.
- The blueprint-types plugin source files (`constructive/graphile/graphile-settings/src/plugins/blueprint-types/`) were not deleted — only their exports were removed from `index.ts`. A follow-up cleanup could delete those source files entirely.
- The `graphql/node-type-registry` npm package is intentionally kept as the source of truth for node type metadata.

Link to Devin session: https://app.devin.ai/sessions/f4da065c5a784261a4612ac64962e177
Requested by: @pyramation