### PR TITLE
feat: add DataCompositeField to node-type-registry

### DIFF
--- a/graphql/node-type-registry/src/blueprint-types.generated.ts
+++ b/graphql/node-type-registry/src/blueprint-types.generated.ts
@@ -174,6 +174,15 @@ export interface DataImmutableFieldsParams {
   /* Field names that cannot be modified after INSERT (e.g. ["key", "bucket_id", "owner_id"]) */
   fields: string[];
 }
+/** Creates a derived text field that automatically concatenates multiple source fields via BEFORE INSERT/UPDATE triggers. Used to produce a unified text representation (e.g., embedding_text) from multiple columns on a table. The trigger fires with '_000' prefix to run before Search* triggers alphabetically. */
+export interface DataCompositeFieldParams {
+  /* Name of the derived text field to create (default: 'embedding_text') */
+  target?: string;
+  /* Array of source field names to concatenate into the target field */
+  source_fields: string[];
+  /* Output format: 'labeled' (field_name: value) or 'plain' (values only). Default: 'labeled' */
+  format?: "labeled" | "plain";
+}
 /** Creates a user profiles table with standard profile fields (profile_picture, bio, first_name, last_name, tags, desired). Uses AuthzDirectOwner for edit access and AuthzAllowAll for select. */
 export type TableUserProfilesParams = {};
 /** Creates an organization settings table with standard business fields (legal_name, address fields). Uses AuthzEntityMembership for access control. */
@@ -794,7 +803,7 @@ export interface BlueprintTableUniqueConstraint {
  */
 ;
 /** String shorthand -- just the node type name. */
-export type BlueprintNodeShorthand = "AuthzDirectOwner" | "AuthzDirectOwnerAny" | "AuthzMembership" | "AuthzEntityMembership" | "AuthzRelatedEntityMembership" | "AuthzOrgHierarchy" | "AuthzTemporal" | "AuthzPublishable" | "AuthzMemberList" | "AuthzRelatedMemberList" | "AuthzAllowAll" | "AuthzDenyAll" | "AuthzComposite" | "AuthzPeerOwnership" | "AuthzRelatedPeerOwnership" | "DataId" | "DataDirectOwner" | "DataEntityMembership" | "DataOwnershipInEntity" | "DataTimestamps" | "DataPeoplestamps" | "DataPublishable" | "DataSoftDelete" | "SearchVector" | "SearchFullText" | "SearchBm25" | "SearchUnified" | "SearchSpatial" | "SearchSpatialAggregate" | "DataJobTrigger" | "DataTags" | "DataStatusField" | "DataJsonb" | "SearchTrgm" | "DataSlug" | "DataInflection" | "DataOwnedFields" | "DataInheritFromParent" | "DataForceCurrentUser" | "DataImmutableFields" | "TableUserProfiles" | "TableOrganizationSettings" | "TableUserSettings";
+export type BlueprintNodeShorthand = "AuthzDirectOwner" | "AuthzDirectOwnerAny" | "AuthzMembership" | "AuthzEntityMembership" | "AuthzRelatedEntityMembership" | "AuthzOrgHierarchy" | "AuthzTemporal" | "AuthzPublishable" | "AuthzMemberList" | "AuthzRelatedMemberList" | "AuthzAllowAll" | "AuthzDenyAll" | "AuthzComposite" | "AuthzPeerOwnership" | "AuthzRelatedPeerOwnership" | "DataId" | "DataDirectOwner" | "DataEntityMembership" | "DataOwnershipInEntity" | "DataTimestamps" | "DataPeoplestamps" | "DataPublishable" | "DataSoftDelete" | "SearchVector" | "SearchFullText" | "SearchBm25" | "SearchUnified" | "SearchSpatial" | "SearchSpatialAggregate" | "DataJobTrigger" | "DataTags" | "DataStatusField" | "DataJsonb" | "SearchTrgm" | "DataSlug" | "DataInflection" | "DataOwnedFields" | "DataInheritFromParent" | "DataForceCurrentUser" | "DataImmutableFields" | "DataCompositeField" | "TableUserProfiles" | "TableOrganizationSettings" | "TableUserSettings";
 /** Object form -- { $type, data } with typed parameters. */
 export type BlueprintNodeObject = {
   $type: "AuthzDirectOwner";
@@ -916,6 +925,9 @@ export type BlueprintNodeObject = {
 } | {
   $type: "DataImmutableFields";
   data: DataImmutableFieldsParams;
+} | {
+  $type: "DataCompositeField";
+  data: DataCompositeFieldParams;
 } | {
   $type: "TableUserProfiles";
   data?: Record<string, never>;

--- a/graphql/node-type-registry/src/data/data-composite-field.ts
+++ b/graphql/node-type-registry/src/data/data-composite-field.ts
@@ -1,0 +1,37 @@
+import type { NodeTypeDefinition } from '../types';
+
+export const DataCompositeField: NodeTypeDefinition = {
+  "name": "DataCompositeField",
+  "slug": "data_composite_field",
+  "category": "data",
+  "display_name": "Composite Field",
+  "description": "Creates a derived text field that automatically concatenates multiple source fields via BEFORE INSERT/UPDATE triggers. Used to produce a unified text representation (e.g., embedding_text) from multiple columns on a table. The trigger fires with '_000' prefix to run before Search* triggers alphabetically.",
+  "parameter_schema": {
+    "type": "object",
+    "properties": {
+      "target": {
+        "type": "string",
+        "description": "Name of the derived text field to create (default: 'embedding_text')"
+      },
+      "source_fields": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Array of source field names to concatenate into the target field"
+      },
+      "format": {
+        "type": "string",
+        "enum": ["labeled", "plain"],
+        "description": "Output format: 'labeled' (field_name: value) or 'plain' (values only). Default: 'labeled'"
+      }
+    },
+    "required": [
+      "source_fields"
+    ]
+  },
+  "tags": [
+    "transform",
+    "behavior"
+  ]
+};

--- a/graphql/node-type-registry/src/data/index.ts
+++ b/graphql/node-type-registry/src/data/index.ts
@@ -23,6 +23,7 @@ export { DataOwnedFields } from './data-owned-fields';
 export { DataInheritFromParent } from './data-inherit-from-parent';
 export { DataForceCurrentUser } from './data-force-current-user';
 export { DataImmutableFields } from './data-immutable-fields';
+export { DataCompositeField } from './data-composite-field';
 export { TableUserProfiles } from './table-user-profiles';
 export { TableOrganizationSettings } from './table-organization-settings';
 export { TableUserSettings } from './table-user-settings';


### PR DESCRIPTION
## Summary

Adds the `DataCompositeField` node type definition to the node-type-registry. This was the only node type dispatched by `table_module.sql` in constructive-db that was missing from the registry, meaning blueprints using it couldn't get typed params in `blueprint-types.generated.ts`.

The parameter schema (`target`, `source_fields`, `format`) was derived from the SQL source in `data_composite_field.sql`. The generated types file was regenerated via `pnpm generate:types`.

## Review & Testing Checklist for Human

- [ ] Verify the parameter schema matches the SQL function's `data jsonb` extraction in `constructive-db/packages/metaschema-generators/deploy/schemas/metaschema_generators/procedures/data_composite_field.sql` — specifically that `source_fields` is required, `target` defaults to `'embedding_text'`, and `format` enum is `['labeled', 'plain']`
- [ ] Confirm no other node types in `table_module.sql` are still missing from the registry

### Notes

- No runtime impact — this only adds a TypeScript type definition so blueprints get proper typing
- The `blueprint-types.generated.ts` diff is fully auto-generated; only `data-composite-field.ts` and `index.ts` are hand-written

Link to Devin session: https://app.devin.ai/sessions/f6dc079489ad4d7b835d5eb892bb616f
Requested by: @pyramation