### PR TITLE
chore: update schemas from constructive-db

### DIFF
--- a/sdk/constructive-cli/src/auth/cli/README.md
+++ b/sdk/constructive-cli/src/auth/cli/README.md
@@ -306,14 +306,14 @@ csdk user list --where.searchTsv "search query" --select title,tsvRank
 csdk user list --where.trgmDisplayName.value "approximate query" --where.trgmDisplayName.threshold 0.3 --select title,displayNameTrgmSimilarity
 ```
 
-*Composite search (fullTextSearch dispatches to all text adapters):*
+*Composite search (unifiedSearch dispatches to all text adapters):*
 ```bash
-csdk user list --where.fullTextSearch "search query" --select title,tsvRank,displayNameTrgmSimilarity,searchScore
+csdk user list --where.unifiedSearch "search query" --select title,tsvRank,displayNameTrgmSimilarity,searchScore
 ```
 
 *Search with pagination and field projection:*
 ```bash
-csdk user list --where.fullTextSearch "query" --limit 10 --select id,title,searchScore
+csdk user list --where.unifiedSearch "query" --limit 10 --select id,title,searchScore
 csdk user search "query" --limit 10 --select id,title,searchScore
 ```
 

--- a/sdk/constructive-cli/src/auth/orm/input-types.ts
+++ b/sdk/constructive-cli/src/auth/orm/input-types.ts
@@ -679,12 +679,12 @@ export interface UserFilter {
   /** TRGM search on the `display_name` column. */
   trgmDisplayName?: TrgmSearchInput;
   /**
-   * Composite full-text search. Provide a search string and it will be dispatched
-   * to all text-compatible search algorithms (tsvector, BM25, pg_trgm)
+   * Composite unified search. Provide a search string and it will be dispatched to
+   * all text-compatible search algorithms (tsvector, BM25, pg_trgm)
    * simultaneously. Rows matching ANY algorithm are returned. All matching score
    * fields are populated.
    */
-  fullTextSearch?: string;
+  unifiedSearch?: string;
 }
 // ============ OrderBy Types ============
 export type EmailOrderBy =
@@ -1679,12 +1679,12 @@ export interface UserFilter {
   /** TRGM search on the `display_name` column. */
   trgmDisplayName?: TrgmSearchInput;
   /**
-   * Composite full-text search. Provide a search string and it will be dispatched
-   * to all text-compatible search algorithms (tsvector, BM25, pg_trgm)
+   * Composite unified search. Provide a search string and it will be dispatched to
+   * all text-compatible search algorithms (tsvector, BM25, pg_trgm)
    * simultaneously. Rows matching ANY algorithm are returned. All matching score
    * fields are populated.
    */
-  fullTextSearch?: string;
+  unifiedSearch?: string;
 }
 /** A filter to be used against String fields. All fields are combined with a logical ‘and.’ */
 export interface StringFilter {

--- a/sdk/constructive-cli/src/public/cli/README.md
+++ b/sdk/constructive-cli/src/public/cli/README.md
@@ -3471,14 +3471,14 @@ csdk user list --where.searchTsv "search query" --select title,tsvRank
 csdk user list --where.trgmDisplayName.value "approximate query" --where.trgmDisplayName.threshold 0.3 --select title,displayNameTrgmSimilarity
 ```
 
-*Composite search (fullTextSearch dispatches to all text adapters):*
+*Composite search (unifiedSearch dispatches to all text adapters):*
 ```bash
-csdk user list --where.fullTextSearch "search query" --select title,tsvRank,displayNameTrgmSimilarity,searchScore
+csdk user list --where.unifiedSearch "search query" --select title,tsvRank,displayNameTrgmSimilarity,searchScore
 ```
 
 *Search with pagination and field projection:*
 ```bash
-csdk user list --where.fullTextSearch "query" --limit 10 --select id,title,searchScore
+csdk user list --where.unifiedSearch "query" --limit 10 --select id,title,searchScore
 csdk user search "query" --limit 10 --select id,title,searchScore
 ```
 

--- a/sdk/constructive-cli/src/public/orm/input-types.ts
+++ b/sdk/constructive-cli/src/public/orm/input-types.ts
@@ -9744,12 +9744,12 @@ export interface UserFilter {
   /** TRGM search on the `display_name` column. */
   trgmDisplayName?: TrgmSearchInput;
   /**
-   * Composite full-text search. Provide a search string and it will be dispatched
-   * to all text-compatible search algorithms (tsvector, BM25, pg_trgm)
+   * Composite unified search. Provide a search string and it will be dispatched to
+   * all text-compatible search algorithms (tsvector, BM25, pg_trgm)
    * simultaneously. Rows matching ANY algorithm are returned. All matching score
    * fields are populated.
    */
-  fullTextSearch?: string;
+  unifiedSearch?: string;
 }
 export interface AstMigrationFilter {
   /** Filter by the object’s `id` field. */
@@ -22141,12 +22141,12 @@ export interface UserFilter {
   /** TRGM search on the `display_name` column. */
   trgmDisplayName?: TrgmSearchInput;
   /**
-   * Composite full-text search. Provide a search string and it will be dispatched
-   * to all text-compatible search algorithms (tsvector, BM25, pg_trgm)
+   * Composite unified search. Provide a search string and it will be dispatched to
+   * all text-compatible search algorithms (tsvector, BM25, pg_trgm)
    * simultaneously. Rows matching ANY algorithm are returned. All matching score
    * fields are populated.
    */
-  fullTextSearch?: string;
+  unifiedSearch?: string;
 }
 /** A filter to be used against `RlsModule` object types. All fields are combined with a logical ‘and.’ */
 export interface RlsModuleFilter {

--- a/sdk/constructive-react/src/auth/orm/input-types.ts
+++ b/sdk/constructive-react/src/auth/orm/input-types.ts
@@ -679,12 +679,12 @@ export interface UserFilter {
   /** TRGM search on the `display_name` column. */
   trgmDisplayName?: TrgmSearchInput;
   /**
-   * Composite full-text search. Provide a search string and it will be dispatched
-   * to all text-compatible search algorithms (tsvector, BM25, pg_trgm)
+   * Composite unified search. Provide a search string and it will be dispatched to
+   * all text-compatible search algorithms (tsvector, BM25, pg_trgm)
    * simultaneously. Rows matching ANY algorithm are returned. All matching score
    * fields are populated.
    */
-  fullTextSearch?: string;
+  unifiedSearch?: string;
 }
 // ============ OrderBy Types ============
 export type EmailOrderBy =
@@ -1679,12 +1679,12 @@ export interface UserFilter {
   /** TRGM search on the `display_name` column. */
   trgmDisplayName?: TrgmSearchInput;
   /**
-   * Composite full-text search. Provide a search string and it will be dispatched
-   * to all text-compatible search algorithms (tsvector, BM25, pg_trgm)
+   * Composite unified search. Provide a search string and it will be dispatched to
+   * all text-compatible search algorithms (tsvector, BM25, pg_trgm)
    * simultaneously. Rows matching ANY algorithm are returned. All matching score
    * fields are populated.
    */
-  fullTextSearch?: string;
+  unifiedSearch?: string;
 }
 /** A filter to be used against String fields. All fields are combined with a logical ‘and.’ */
 export interface StringFilter {

--- a/sdk/constructive-react/src/auth/schema-types.ts
+++ b/sdk/constructive-react/src/auth/schema-types.ts
@@ -323,12 +323,12 @@ export interface UserFilter {
   /** TRGM search on the `display_name` column. */
   trgmDisplayName?: TrgmSearchInput;
   /**
-   * Composite full-text search. Provide a search string and it will be dispatched
-   * to all text-compatible search algorithms (tsvector, BM25, pg_trgm)
+   * Composite unified search. Provide a search string and it will be dispatched to
+   * all text-compatible search algorithms (tsvector, BM25, pg_trgm)
    * simultaneously. Rows matching ANY algorithm are returned. All matching score
    * fields are populated.
    */
-  fullTextSearch?: string;
+  unifiedSearch?: string;
 }
 /** A filter to be used against String fields with pg_trgm support. All fields are combined with a logical ‘and.’ */
 export interface StringTrgmFilter {

--- a/sdk/constructive-react/src/public/orm/input-types.ts
+++ b/sdk/constructive-react/src/public/orm/input-types.ts
@@ -9744,12 +9744,12 @@ export interface UserFilter {
   /** TRGM search on the `display_name` column. */
   trgmDisplayName?: TrgmSearchInput;
   /**
-   * Composite full-text search. Provide a search string and it will be dispatched
-   * to all text-compatible search algorithms (tsvector, BM25, pg_trgm)
+   * Composite unified search. Provide a search string and it will be dispatched to
+   * all text-compatible search algorithms (tsvector, BM25, pg_trgm)
    * simultaneously. Rows matching ANY algorithm are returned. All matching score
    * fields are populated.
    */
-  fullTextSearch?: string;
+  unifiedSearch?: string;
 }
 export interface AstMigrationFilter {
   /** Filter by the object’s `id` field. */
@@ -22141,12 +22141,12 @@ export interface UserFilter {
   /** TRGM search on the `display_name` column. */
   trgmDisplayName?: TrgmSearchInput;
   /**
-   * Composite full-text search. Provide a search string and it will be dispatched
-   * to all text-compatible search algorithms (tsvector, BM25, pg_trgm)
+   * Composite unified search. Provide a search string and it will be dispatched to
+   * all text-compatible search algorithms (tsvector, BM25, pg_trgm)
    * simultaneously. Rows matching ANY algorithm are returned. All matching score
    * fields are populated.
    */
-  fullTextSearch?: string;
+  unifiedSearch?: string;
 }
 /** A filter to be used against `RlsModule` object types. All fields are combined with a logical ‘and.’ */
 export interface RlsModuleFilter {

--- a/sdk/constructive-react/src/public/schema-types.ts
+++ b/sdk/constructive-react/src/public/schema-types.ts
@@ -3336,12 +3336,12 @@ export interface UserFilter {
   /** TRGM search on the `display_name` column. */
   trgmDisplayName?: TrgmSearchInput;
   /**
-   * Composite full-text search. Provide a search string and it will be dispatched
-   * to all text-compatible search algorithms (tsvector, BM25, pg_trgm)
+   * Composite unified search. Provide a search string and it will be dispatched to
+   * all text-compatible search algorithms (tsvector, BM25, pg_trgm)
    * simultaneously. Rows matching ANY algorithm are returned. All matching score
    * fields are populated.
    */
-  fullTextSearch?: string;
+  unifiedSearch?: string;
 }
 /** A filter to be used against String fields with pg_trgm support. All fields are combined with a logical ‘and.’ */
 export interface StringTrgmFilter {

--- a/sdk/constructive-sdk/schemas/auth.graphql
+++ b/sdk/constructive-sdk/schemas/auth.graphql
@@ -854,12 +854,12 @@ input UserFilter {
   trgmDisplayName: TrgmSearchInput
 
   """
-  Composite full-text search. Provide a search string and it will be dispatched
-  to all text-compatible search algorithms (tsvector, BM25, pg_trgm)
+  Composite unified search. Provide a search string and it will be dispatched to
+  all text-compatible search algorithms (tsvector, BM25, pg_trgm)
   simultaneously. Rows matching ANY algorithm are returned. All matching score
   fields are populated.
   """
-  fullTextSearch: String
+  unifiedSearch: String
 }
 
 """

--- a/sdk/constructive-sdk/schemas/public.graphql
+++ b/sdk/constructive-sdk/schemas/public.graphql
@@ -8867,12 +8867,12 @@ input UserFilter {
   trgmDisplayName: TrgmSearchInput
 
   """
-  Composite full-text search. Provide a search string and it will be dispatched
-  to all text-compatible search algorithms (tsvector, BM25, pg_trgm)
+  Composite unified search. Provide a search string and it will be dispatched to
+  all text-compatible search algorithms (tsvector, BM25, pg_trgm)
   simultaneously. Rows matching ANY algorithm are returned. All matching score
   fields are populated.
   """
-  fullTextSearch: String
+  unifiedSearch: String
 }
 
 """

--- a/sdk/constructive-sdk/src/auth/orm/input-types.ts
+++ b/sdk/constructive-sdk/src/auth/orm/input-types.ts
@@ -679,12 +679,12 @@ export interface UserFilter {
   /** TRGM search on the `display_name` column. */
   trgmDisplayName?: TrgmSearchInput;
   /**
-   * Composite full-text search. Provide a search string and it will be dispatched
-   * to all text-compatible search algorithms (tsvector, BM25, pg_trgm)
+   * Composite unified search. Provide a search string and it will be dispatched to
+   * all text-compatible search algorithms (tsvector, BM25, pg_trgm)
    * simultaneously. Rows matching ANY algorithm are returned. All matching score
    * fields are populated.
    */
-  fullTextSearch?: string;
+  unifiedSearch?: string;
 }
 // ============ OrderBy Types ============
 export type EmailOrderBy =
@@ -1679,12 +1679,12 @@ export interface UserFilter {
   /** TRGM search on the `display_name` column. */
   trgmDisplayName?: TrgmSearchInput;
   /**
-   * Composite full-text search. Provide a search string and it will be dispatched
-   * to all text-compatible search algorithms (tsvector, BM25, pg_trgm)
+   * Composite unified search. Provide a search string and it will be dispatched to
+   * all text-compatible search algorithms (tsvector, BM25, pg_trgm)
    * simultaneously. Rows matching ANY algorithm are returned. All matching score
    * fields are populated.
    */
-  fullTextSearch?: string;
+  unifiedSearch?: string;
 }
 /** A filter to be used against String fields. All fields are combined with a logical ‘and.’ */
 export interface StringFilter {

--- a/sdk/constructive-sdk/src/public/orm/input-types.ts
+++ b/sdk/constructive-sdk/src/public/orm/input-types.ts
@@ -9744,12 +9744,12 @@ export interface UserFilter {
   /** TRGM search on the `display_name` column. */
   trgmDisplayName?: TrgmSearchInput;
   /**
-   * Composite full-text search. Provide a search string and it will be dispatched
-   * to all text-compatible search algorithms (tsvector, BM25, pg_trgm)
+   * Composite unified search. Provide a search string and it will be dispatched to
+   * all text-compatible search algorithms (tsvector, BM25, pg_trgm)
    * simultaneously. Rows matching ANY algorithm are returned. All matching score
    * fields are populated.
    */
-  fullTextSearch?: string;
+  unifiedSearch?: string;
 }
 export interface AstMigrationFilter {
   /** Filter by the object’s `id` field. */
@@ -22141,12 +22141,12 @@ export interface UserFilter {
   /** TRGM search on the `display_name` column. */
   trgmDisplayName?: TrgmSearchInput;
   /**
-   * Composite full-text search. Provide a search string and it will be dispatched
-   * to all text-compatible search algorithms (tsvector, BM25, pg_trgm)
+   * Composite unified search. Provide a search string and it will be dispatched to
+   * all text-compatible search algorithms (tsvector, BM25, pg_trgm)
    * simultaneously. Rows matching ANY algorithm are returned. All matching score
    * fields are populated.
    */
-  fullTextSearch?: string;
+  unifiedSearch?: string;
 }
 /** A filter to be used against `RlsModule` object types. All fields are combined with a logical ‘and.’ */
 export interface RlsModuleFilter {


### PR DESCRIPTION
## Automated Schema + SDK Update

This PR was created by the [schema-propagation workflow](https://github.com/constructive-io/constructive-hub/actions/workflows/schema-propagation.yml).

### What changed
Updated schema files from constructive-db and regenerated ALL SDK clients.

Source: `constructive-db@1920531e5e`

### Schemas updated
- `sdk/constructive-sdk/schemas/` — admin, app, auth, objects, public
- `sdk/migrate-client/schemas/` — migrate

### Clients regenerated
- `sdk/constructive-sdk/src/` — ORM client
- `sdk/constructive-cli/src/` — CLI client
- `sdk/constructive-react/src/` — React hooks
- `sdk/migrate-client/src/` — Migrate client

### Skill references updated
- `.agents/skills/` — Generated skill documentation

---
*Auto-generated by constructive-hub schema-propagation*