### PR TITLE
fix(graphile-settings): empty belongsTo 

### DIFF
--- a/graphile/graphile-settings/src/plugins/meta-schema/constraint-meta-builders.ts
+++ b/graphile/graphile-settings/src/plugins/meta-schema/constraint-meta-builders.ts
@@ -94,7 +94,7 @@ export function buildForeignKeyConstraints(
   const constraints: ForeignKeyConstraintMeta[] = [];
 
   for (const [relationName, relation] of Object.entries(relations)) {
-    if (relation.isReferencee !== false) continue;
+    if (relation.isReferencee) continue;
 
     const remoteCodec = relation.remoteResource?.codec;
     const remoteAttributes = remoteCodec?.attributes || {};

--- a/graphile/graphile-settings/src/plugins/meta-schema/relation-meta-builders.ts
+++ b/graphile/graphile-settings/src/plugins/meta-schema/relation-meta-builders.ts
@@ -36,7 +36,9 @@ export function buildBelongsToRelations(
   const belongsTo: BelongsToRelation[] = [];
 
   for (const [relationName, relation] of Object.entries(relations)) {
-    if (relation.isReferencee !== false) continue;
+    // PostGraphile only sets isReferencee when true (reverse FK);
+    // forward relations have isReferencee undefined, not false.
+    if (relation.isReferencee) continue;
 
     const localAttributes = relation.localAttributes || [];
     const isUnique = uniques.some((unique) =>

--- a/graphile/graphile-settings/src/plugins/meta-schema/table-meta-builder.ts
+++ b/graphile/graphile-settings/src/plugins/meta-schema/table-meta-builder.ts
@@ -50,7 +50,7 @@ function buildTableMeta(
     }
   }
   for (const relation of Object.values(relations)) {
-    if (relation.isReferencee !== false) continue;
+    if (relation.isReferencee) continue;
     for (const attrName of relation.localAttributes || []) fkAttrNames.add(attrName);
   }
 


### PR DESCRIPTION
Use truthy check for isReferencee in _meta plugin

PostGraphile sets isReferencee only when true (reverse FK); forward relations have isReferencee undefined, not false. The !== false check was skipping all belongsTo relations.