### PR TITLE
fix: add defensive checks in storage resolvers instead of non-null assertions

### DIFF
--- a/graphile/graphile-settings/src/bucket-provisioner-resolver.ts
+++ b/graphile/graphile-settings/src/bucket-provisioner-resolver.ts
@@ -29,8 +29,22 @@ export function getBucketProvisionerConnection(): StorageConnectionConfig {
 
   const { cdn } = getEnvOptions();
 
-  // cdn is guaranteed populated — pgpmDefaults provides all CDN fields
-  const { provider, awsRegion, awsAccessKey, awsSecretKey, endpoint } = cdn!;
+  if (!cdn) {
+    throw new Error(
+      '[bucket-provisioner-resolver] CDN config not found. ' +
+      'Ensure CDN environment variables (AWS_ACCESS_KEY, AWS_SECRET_KEY, etc.) ' +
+      'are set or that pgpmDefaults provides CDN fields.',
+    );
+  }
+
+  const { provider, awsRegion, awsAccessKey, awsSecretKey, endpoint } = cdn;
+
+  if (!awsAccessKey || !awsSecretKey) {
+    throw new Error(
+      '[bucket-provisioner-resolver] Missing S3 credentials. ' +
+      'Set AWS_ACCESS_KEY and AWS_SECRET_KEY environment variables.',
+    );
+  }
 
   log.info(
     `[bucket-provisioner-resolver] Initializing: provider=${provider} endpoint=${endpoint}`,
@@ -39,8 +53,8 @@ export function getBucketProvisionerConnection(): StorageConnectionConfig {
   connectionConfig = {
     provider: (provider as StorageConnectionConfig['provider']) || 'minio',
     region: awsRegion || 'us-east-1',
-    accessKeyId: awsAccessKey!,
-    secretAccessKey: awsSecretKey!,
+    accessKeyId: awsAccessKey,
+    secretAccessKey: awsSecretKey,
     ...(endpoint ? { endpoint, forcePathStyle: true } : {}),
   };
 

--- a/graphile/graphile-settings/src/presigned-url-resolver.ts
+++ b/graphile/graphile-settings/src/presigned-url-resolver.ts
@@ -29,8 +29,29 @@ export function getPresignedUrlS3Config(): S3Config {
 
   const { cdn } = getEnvOptions();
 
-  // cdn is guaranteed populated — pgpmDefaults provides all CDN fields
-  const { bucketName, awsRegion, awsAccessKey, awsSecretKey, endpoint, publicUrlPrefix } = cdn!;
+  if (!cdn) {
+    throw new Error(
+      '[presigned-url-resolver] CDN config not found. ' +
+      'Ensure CDN environment variables (AWS_ACCESS_KEY, AWS_SECRET_KEY, etc.) ' +
+      'are set or that pgpmDefaults provides CDN fields.',
+    );
+  }
+
+  const { bucketName, awsRegion, awsAccessKey, awsSecretKey, endpoint, publicUrlPrefix } = cdn;
+
+  if (!awsAccessKey || !awsSecretKey) {
+    throw new Error(
+      '[presigned-url-resolver] Missing S3 credentials. ' +
+      'Set AWS_ACCESS_KEY and AWS_SECRET_KEY environment variables.',
+    );
+  }
+
+  if (!bucketName) {
+    throw new Error(
+      '[presigned-url-resolver] Missing CDN bucket name. ' +
+      'Set CDN_BUCKET_NAME environment variable.',
+    );
+  }
 
   log.info(
     `[presigned-url-resolver] Initializing: bucket=${bucketName} endpoint=${endpoint}`,
@@ -38,13 +59,13 @@ export function getPresignedUrlS3Config(): S3Config {
 
   const client = new S3Client({
     region: awsRegion,
-    credentials: { accessKeyId: awsAccessKey!, secretAccessKey: awsSecretKey! },
+    credentials: { accessKeyId: awsAccessKey, secretAccessKey: awsSecretKey },
     ...(endpoint ? { endpoint, forcePathStyle: true } : {}),
   });
 
   s3Config = {
     client,
-    bucket: bucketName!,
+    bucket: bucketName,
     region: awsRegion,
     publicUrlPrefix,
     ...(endpoint ? { endpoint, forcePathStyle: true } : {}),


### PR DESCRIPTION
## Summary

Replaces `cdn!` and credential `!` non-null assertions with explicit guard clauses and actionable error messages in both `bucket-provisioner-resolver.ts` and `presigned-url-resolver.ts`.

Previously, if CDN env vars were missing, these resolvers would silently pass `undefined` into the S3 client, producing cryptic errors deep in the AWS SDK. Now they throw early with messages that name the specific missing config.

Both resolvers are lazy (called on first storage operation, not at startup), so servers that don't use storage features are unaffected.

## Review & Testing Checklist for Human

- [ ] **Verify env var names in error messages match reality** — messages reference `AWS_ACCESS_KEY`, `AWS_SECRET_KEY`, `CDN_BUCKET_NAME`. Confirm these match the actual env var names that feed into `getEnvOptions().cdn`. If the real names differ (e.g. `CDN_AWS_ACCESS_KEY`), the error messages will be misleading.
- [ ] **Confirm lazy throw doesn't crash the server** — these resolvers are called from within mutation/resolver handlers. Verify that a thrown error here surfaces as a GraphQL error to the caller rather than crashing the process. The plugin code wraps provisioning calls in try/catch, but the presigned-url plugin path should be checked too.

### Notes
- `bucket-provisioner-resolver.ts` intentionally does not check for `bucketName` (it doesn't use one — bucket names are resolved per-row from the database).
- `presigned-url-resolver.ts` adds an additional `bucketName` check since it requires a default bucket for signing URLs.
- No logic changes — purely guard clauses replacing `!` assertions, so existing behavior is preserved when config is present.

Link to Devin session: https://app.devin.ai/sessions/4c882ba2dfbf4045adf85fb83cde6f77
Requested by: @pyramation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/constructive-io/constructive/pull/965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
