### PR TITLE
fix(codegen): merge condition into where filter instead of separate GraphQL argument

### DIFF
--- a/graphql/codegen/src/__tests__/codegen/query-builder.test.ts
+++ b/graphql/codegen/src/__tests__/codegen/query-builder.test.ts
@@ -123,6 +123,35 @@ function buildSelections(
   return fields;
 }
 
+function conditionToFilter(
+  condition: Record<string, unknown>,
+): Record<string, unknown> {
+  const filter: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(condition)) {
+    if (value === undefined) continue;
+    if (value === null) {
+      filter[key] = { isNull: true };
+    } else {
+      filter[key] = { equalTo: value };
+    }
+  }
+  return filter;
+}
+
+function mergeConditionIntoWhere(
+  where: Record<string, unknown> | undefined,
+  condition: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!condition || Object.keys(condition).length === 0) {
+    return where;
+  }
+  const converted = conditionToFilter(condition);
+  if (!where || Object.keys(where).length === 0) {
+    return converted;
+  }
+  return { ...where, ...converted };
+}
+
 function buildFindManyDocument<TSelect, TWhere, TCondition>(
   operationName: string,
   queryField: string,
@@ -144,21 +173,15 @@ function buildFindManyDocument<TSelect, TWhere, TCondition>(
   const queryArgs: ArgumentNode[] = [];
   const variables: Record<string, unknown> = {};
 
-  addVariable(
-    {
-      varName: 'condition',
-      typeName: conditionTypeName,
-      value: args.condition,
-    },
-    variableDefinitions,
-    queryArgs,
-    variables,
+  const mergedWhere = mergeConditionIntoWhere(
+    args.where as Record<string, unknown> | undefined,
+    args.condition as Record<string, unknown> | undefined,
   );
   addVariable(
     {
       varName: 'where',
       typeName: filterTypeName,
-      value: args.where,
+      value: mergedWhere,
     },
     variableDefinitions,
     queryArgs,
@@ -568,14 +591,41 @@ describe('query-builder', () => {
       });
     });
 
-    it('includes condition variable when conditionTypeName is provided', () => {
+    it('merges condition into where as equality filters', () => {
+      const { document, variables } = buildFindManyDocument(
+        'Documents',
+        'documents',
+        { id: true, title: true },
+        {
+          condition: { title: 'Financial', category: 'legal' },
+          first: 5,
+        },
+        'DocumentFilter',
+        'DocumentsOrderBy',
+        undefined,
+        'DocumentCondition',
+      );
+
+      // condition should NOT appear as a separate variable
+      expect(document).not.toContain('$condition');
+      expect(document).not.toContain('DocumentCondition');
+      // should be merged into where
+      expect(document).toContain('$where: DocumentFilter');
+      expect(document).toContain('where: $where');
+      expect(variables.where).toEqual({
+        title: { equalTo: 'Financial' },
+        category: { equalTo: 'legal' },
+      });
+    });
+
+    it('merges condition with existing where filters', () => {
       const { document, variables } = buildFindManyDocument(
         'Contacts',
         'contacts',
         { id: true, name: true },
         {
-          condition: { embeddingNearby: { vector: [0.1, 0.2], metric: 'COSINE' } },
-          where: { name: { equalTo: 'test' } },
+          condition: { status: 'active' },
+          where: { name: { startsWith: 'Acme' } },
           first: 5,
         },
         'ContactFilter',
@@ -584,17 +634,34 @@ describe('query-builder', () => {
         'ContactCondition',
       );
 
-      // condition variable should appear in the query
-      expect(document).toContain('$condition: ContactCondition');
-      expect(document).toContain('condition: $condition');
-      // where should still work alongside condition
+      // condition should NOT appear as a separate variable
+      expect(document).not.toContain('$condition');
+      expect(document).not.toContain('ContactCondition');
+      // merged where should contain both
       expect(document).toContain('$where: ContactFilter');
-      expect(document).toContain('where: $where');
-      // variables should include both
-      expect(variables.condition).toEqual({
-        embeddingNearby: { vector: [0.1, 0.2], metric: 'COSINE' },
+      expect(variables.where).toEqual({
+        name: { startsWith: 'Acme' },
+        status: { equalTo: 'active' },
       });
-      expect(variables.where).toEqual({ name: { equalTo: 'test' } });
+    });
+
+    it('converts null condition values to isNull filters', () => {
+      const { variables } = buildFindManyDocument(
+        'Users',
+        'users',
+        { id: true },
+        {
+          condition: { deletedAt: null },
+        },
+        'UserFilter',
+        'UsersOrderBy',
+        undefined,
+        'UserCondition',
+      );
+
+      expect(variables.where).toEqual({
+        deletedAt: { isNull: true },
+      });
     });
 
     it('omits condition variable when not provided', () => {
@@ -612,6 +679,8 @@ describe('query-builder', () => {
       // condition should NOT appear since no value was provided
       expect(document).not.toContain('$condition');
       expect(document).not.toContain('condition:');
+      // where should also not appear since no where was provided
+      expect(document).not.toContain('$where');
     });
   });
 

--- a/graphql/codegen/src/core/codegen/templates/query-builder.ts
+++ b/graphql/codegen/src/core/codegen/templates/query-builder.ts
@@ -232,21 +232,19 @@ export function buildFindManyDocument<TSelect, TWhere, TCondition = never>(
   const queryArgs: ArgumentNode[] = [];
   const variables: Record<string, unknown> = {};
 
-  addVariable(
-    {
-      varName: 'condition',
-      typeName: conditionTypeName,
-      value: args.condition,
-    },
-    variableDefinitions,
-    queryArgs,
-    variables,
+  // Merge condition values into where as equality filters.
+  // This avoids depending on PgConditionArgumentPlugin (which generates
+  // *Condition input types) and routes everything through the
+  // always-available connection-filter `where` argument instead.
+  const mergedWhere = mergeConditionIntoWhere(
+    args.where as Record<string, unknown> | undefined,
+    args.condition as Record<string, unknown> | undefined,
   );
   addVariable(
     {
       varName: 'where',
       typeName: filterTypeName,
-      value: args.where,
+      value: mergedWhere,
     },
     variableDefinitions,
     queryArgs,
@@ -347,21 +345,16 @@ export function buildFindFirstDocument<TSelect, TWhere, TCondition = never>(
     queryArgs,
     variables,
   );
-  addVariable(
-    {
-      varName: 'condition',
-      typeName: conditionTypeName,
-      value: args.condition,
-    },
-    variableDefinitions,
-    queryArgs,
-    variables,
+  // Merge condition values into where as equality filters
+  const mergedWhere = mergeConditionIntoWhere(
+    args.where as Record<string, unknown> | undefined,
+    args.condition as Record<string, unknown> | undefined,
   );
   addVariable(
     {
       varName: 'where',
       typeName: filterTypeName,
-      value: args.where,
+      value: mergedWhere,
     },
     variableDefinitions,
     queryArgs,
@@ -838,6 +831,53 @@ interface VariableSpec {
   argName?: string;
   typeName?: string;
   value: unknown;
+}
+
+/**
+ * Convert condition (exact equality) values to connection-filter format.
+ *
+ * The ORM exposes a simple `condition` API for equality matching:
+ *   condition: { title: "Financial", status: null }
+ *
+ * This converts each field to the filter operator format used by
+ * graphile-connection-filter's `where` argument:
+ *   { title: { equalTo: "Financial" }, status: { isNull: true } }
+ *
+ * This allows `condition` to work regardless of whether PostGraphile's
+ * PgConditionArgumentPlugin is enabled, since the values are routed
+ * through the always-available `where` (filter) argument instead.
+ */
+function conditionToFilter(
+  condition: Record<string, unknown>,
+): Record<string, unknown> {
+  const filter: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(condition)) {
+    if (value === undefined) continue;
+    if (value === null) {
+      filter[key] = { isNull: true };
+    } else {
+      filter[key] = { equalTo: value };
+    }
+  }
+  return filter;
+}
+
+/**
+ * Merge condition values (converted to filter equality format) into
+ * the existing where/filter object.
+ */
+function mergeConditionIntoWhere(
+  where: Record<string, unknown> | undefined,
+  condition: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!condition || Object.keys(condition).length === 0) {
+    return where;
+  }
+  const converted = conditionToFilter(condition);
+  if (!where || Object.keys(where).length === 0) {
+    return converted;
+  }
+  return { ...where, ...converted };
 }
 
 interface InputMutationConfig {


### PR DESCRIPTION
## Summary

The ORM query builder was emitting a separate `$condition` GraphQL variable referencing `*Condition` input types (e.g. `DocumentCondition`, `DiligenceRequestCondition`). These types don't exist in the schema because `PgConditionArgumentPlugin` is disabled in `ConstructivePreset` — all filtering goes through the `where` argument via `graphile-connection-filter`.

This PR converts the ORM's `condition` values into connection-filter equality format and merges them into the `where` variable instead:

```
condition: { title: "Financial", status: null }
→ where: { title: { equalTo: "Financial" }, status: { isNull: true } }
```

Both `buildFindManyDocument` and `buildFindFirstDocument` are updated. If both `condition` and `where` are provided, they are shallow-merged (condition fields spread on top of where).

## Review & Testing Checklist for Human

- [ ] **Verify `equalTo` / `isNull` are the correct operators** for graphile-connection-filter equality matching — these are hardcoded in `conditionToFilter` and must match the filter plugin's expected input shape
- [ ] **Check for field collisions**: when both `where` and `condition` specify the same field, `condition` silently wins via `{ ...where, ...converted }`. Confirm this is acceptable or if an `and` wrapper is needed
- [ ] **Run `diligence-room` integration tests** (`orm-search.test.ts`, `orm.test.ts`) against this change to confirm the original errors are resolved end-to-end
- [ ] **Audit downstream callers** that previously passed complex objects as condition values (e.g. `embeddingNearby` with vector/metric) — these would now be wrapped in `{ equalTo: ... }` which may not be correct for non-scalar fields

### Notes

- The test file maintains its own copy of the query builder helpers (existing pattern). The `conditionToFilter` and `mergeConditionIntoWhere` functions were duplicated there to match.
- The `conditionTypeName` parameter is still accepted by the function signatures but is now unused at runtime. It was left in place to avoid breaking the call sites in generated ORM code. A follow-up could clean this up.

Link to Devin session: https://app.devin.ai/sessions/136ba9e7789e4cf28c757e6740c21808
Requested by: @pyramation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/constructive-io/constructive/pull/971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
