### PR TITLE
fix(codegen): remove condition generation from ORM codegen

### DIFF
--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/cli-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/cli-generator.test.ts.snap
@@ -757,7 +757,7 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
       isElectric: true,
       createdAt: true
     };
-    const findManyArgs = parseFindManyArgs<FindManyArgs<CarSelect, CarFilter, never, CarsOrderBy> & {
+    const findManyArgs = parseFindManyArgs<FindManyArgs<CarSelect, CarFilter, CarsOrderBy> & {
       select: CarSelect;
     }>(argv, defaultSelect);
     const client = getClient();
@@ -781,7 +781,7 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
       isElectric: true,
       createdAt: true
     };
-    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<CarSelect, CarFilter, never> & {
+    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<CarSelect, CarFilter> & {
       select: CarSelect;
     }>(argv, defaultSelect);
     const client = getClient();
@@ -1219,7 +1219,7 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
       name: true,
       licenseNumber: true
     };
-    const findManyArgs = parseFindManyArgs<FindManyArgs<DriverSelect, DriverFilter, never, DriversOrderBy> & {
+    const findManyArgs = parseFindManyArgs<FindManyArgs<DriverSelect, DriverFilter, DriversOrderBy> & {
       select: DriverSelect;
     }>(argv, defaultSelect);
     const client = getClient();
@@ -1240,7 +1240,7 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
       name: true,
       licenseNumber: true
     };
-    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<DriverSelect, DriverFilter, never> & {
+    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<DriverSelect, DriverFilter> & {
       select: DriverSelect;
     }>(argv, defaultSelect);
     const client = getClient();
@@ -3255,7 +3255,7 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
       email: true,
       name: true
     };
-    const findManyArgs = parseFindManyArgs<FindManyArgs<UserSelect, UserFilter, never, UsersOrderBy> & {
+    const findManyArgs = parseFindManyArgs<FindManyArgs<UserSelect, UserFilter, UsersOrderBy> & {
       select: UserSelect;
     }>(argv, defaultSelect);
     const client = getClient("auth");
@@ -3276,7 +3276,7 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
       email: true,
       name: true
     };
-    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<UserSelect, UserFilter, never> & {
+    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<UserSelect, UserFilter> & {
       select: UserSelect;
     }>(argv, defaultSelect);
     const client = getClient("auth");
@@ -3487,7 +3487,7 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
       id: true,
       role: true
     };
-    const findManyArgs = parseFindManyArgs<FindManyArgs<MemberSelect, MemberFilter, never, MembersOrderBy> & {
+    const findManyArgs = parseFindManyArgs<FindManyArgs<MemberSelect, MemberFilter, MembersOrderBy> & {
       select: MemberSelect;
     }>(argv, defaultSelect);
     const client = getClient("members");
@@ -3507,7 +3507,7 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
       id: true,
       role: true
     };
-    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<MemberSelect, MemberFilter, never> & {
+    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<MemberSelect, MemberFilter> & {
       select: MemberSelect;
     }>(argv, defaultSelect);
     const client = getClient("members");
@@ -3711,7 +3711,7 @@ async function handleList(argv: Partial<Record<string, unknown>>, _prompter: Inq
       isElectric: true,
       createdAt: true
     };
-    const findManyArgs = parseFindManyArgs<FindManyArgs<CarSelect, CarFilter, never, CarsOrderBy> & {
+    const findManyArgs = parseFindManyArgs<FindManyArgs<CarSelect, CarFilter, CarsOrderBy> & {
       select: CarSelect;
     }>(argv, defaultSelect);
     const client = getClient("app");
@@ -3735,7 +3735,7 @@ async function handleFindFirst(argv: Partial<Record<string, unknown>>, _prompter
       isElectric: true,
       createdAt: true
     };
-    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<CarSelect, CarFilter, never> & {
+    const findFirstArgs = parseFindFirstArgs<FindFirstArgs<CarSelect, CarFilter> & {
       select: CarSelect;
     }>(argv, defaultSelect);
     const client = getClient("app");

--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/client-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/client-generator.test.ts.snap
@@ -276,10 +276,9 @@ export interface PageInfo {
   endCursor?: string | null;
 }
 
-export interface FindManyArgs<TSelect, TWhere, TCondition = never, TOrderBy = never> {
+export interface FindManyArgs<TSelect, TWhere, TOrderBy = never> {
   select?: TSelect;
   where?: TWhere;
-  condition?: TCondition;
   orderBy?: TOrderBy[];
   first?: number;
   last?: number;
@@ -288,10 +287,9 @@ export interface FindManyArgs<TSelect, TWhere, TCondition = never, TOrderBy = ne
   offset?: number;
 }
 
-export interface FindFirstArgs<TSelect, TWhere, TCondition = never> {
+export interface FindFirstArgs<TSelect, TWhere> {
   select?: TSelect;
   where?: TWhere;
-  condition?: TCondition;
 }
 
 export interface CreateArgs<TSelect, TData> {

--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/model-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/model-generator.test.ts.snap
@@ -13,7 +13,7 @@ import type { User, UserWithRelations, UserSelect, UserFilter, UsersOrderBy, Cre
 import { connectionFieldsMap } from "../input-types";
 export class UserModel {
   constructor(private client: OrmClient) {}
-  findMany<S extends UserSelect>(args: FindManyArgs<S, UserFilter, never, UsersOrderBy> & {
+  findMany<S extends UserSelect>(args: FindManyArgs<S, UserFilter, UsersOrderBy> & {
     select: S;
   } & StrictSelect<S, UserSelect>): QueryBuilder<{
     users: ConnectionResult<InferSelectResult<UserWithRelations, S>>;
@@ -162,7 +162,7 @@ import type { AuditLog, AuditLogWithRelations, AuditLogSelect, AuditLogFilter, A
 import { connectionFieldsMap } from "../input-types";
 export class AuditLogModel {
   constructor(private client: OrmClient) {}
-  findMany<S extends AuditLogSelect>(args: FindManyArgs<S, AuditLogFilter, never, AuditLogsOrderBy> & {
+  findMany<S extends AuditLogSelect>(args: FindManyArgs<S, AuditLogFilter, AuditLogsOrderBy> & {
     select: S;
   } & StrictSelect<S, AuditLogSelect>): QueryBuilder<{
     auditLogs: ConnectionResult<InferSelectResult<AuditLogWithRelations, S>>;
@@ -265,7 +265,7 @@ import type { Organization, OrganizationWithRelations, OrganizationSelect, Organ
 import { connectionFieldsMap } from "../input-types";
 export class OrganizationModel {
   constructor(private client: OrmClient) {}
-  findMany<S extends OrganizationSelect>(args: FindManyArgs<S, OrganizationFilter, never, OrganizationsOrderBy> & {
+  findMany<S extends OrganizationSelect>(args: FindManyArgs<S, OrganizationFilter, OrganizationsOrderBy> & {
     select: S;
   } & StrictSelect<S, OrganizationSelect>): QueryBuilder<{
     allOrganizations: ConnectionResult<InferSelectResult<OrganizationWithRelations, S>>;

--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/react-query-hooks.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/react-query-hooks.test.ts.snap
@@ -1672,7 +1672,7 @@ import type { ListSelectionConfig } from "../selection";
 import type { UserSelect, UserWithRelations, UserFilter, UsersOrderBy } from "../../orm/input-types";
 import type { FindManyArgs, InferSelectResult, ConnectionResult, HookStrictSelect } from "../../orm/select-types";
 export type { UserSelect, UserWithRelations, UserFilter, UsersOrderBy } from "../../orm/input-types";
-export const usersQueryKey = (variables?: FindManyArgs<unknown, UserFilter, never, UsersOrderBy>) => ["user", "list", variables] as const;
+export const usersQueryKey = (variables?: FindManyArgs<unknown, UserFilter, UsersOrderBy>) => ["user", "list", variables] as const;
 /**
  * Query hook for fetching User list
  * 

--- a/graphql/codegen/src/__tests__/codegen/input-types-generator.test.ts
+++ b/graphql/codegen/src/__tests__/codegen/input-types-generator.test.ts
@@ -893,13 +893,7 @@ describe('collectPayloadTypeNames', () => {
 // Tests - Plugin-Injected Condition Fields (e.g., VectorSearchPlugin)
 // ============================================================================
 
-describe('plugin-injected condition fields', () => {
-  /**
-   * Simulates a table with a vector embedding column.
-   * The VectorSearchPlugin adds extra condition fields (e.g., embeddingNearby)
-   * that are NOT derived from the table's own columns, but are injected into
-   * the GraphQL schema's condition type via plugin hooks.
-   */
+describe('plugin-injected orderBy values', () => {
   const contactTable = createTable({
     name: 'Contact',
     fields: [
@@ -918,151 +912,6 @@ describe('plugin-injected condition fields', () => {
       update: 'updateContact',
       delete: 'deleteContact',
     },
-  });
-
-  it('includes plugin-injected condition fields from TypeRegistry', () => {
-    // Registry simulates what PostGraphile + VectorSearchPlugin produce:
-    // The ContactCondition type has the regular columns PLUS an extra
-    // "embeddingNearby" field of type VectorNearbyInput injected by the plugin.
-    const registry = createTypeRegistry({
-      ContactCondition: {
-        kind: 'INPUT_OBJECT',
-        name: 'ContactCondition',
-        inputFields: [
-          { name: 'id', type: createTypeRef('SCALAR', 'UUID') },
-          { name: 'name', type: createTypeRef('SCALAR', 'String') },
-          { name: 'email', type: createTypeRef('SCALAR', 'String') },
-          { name: 'embedding', type: createTypeRef('SCALAR', 'Vector') },
-          {
-            name: 'embeddingNearby',
-            type: createTypeRef('INPUT_OBJECT', 'VectorNearbyInput'),
-            description: 'Find contacts near a vector embedding',
-          },
-        ],
-      },
-      VectorNearbyInput: {
-        kind: 'INPUT_OBJECT',
-        name: 'VectorNearbyInput',
-        inputFields: [
-          {
-            name: 'vector',
-            type: createNonNull(createTypeRef('SCALAR', 'Vector')),
-          },
-          {
-            name: 'metric',
-            type: createTypeRef('ENUM', 'VectorMetric'),
-          },
-          {
-            name: 'threshold',
-            type: createTypeRef('SCALAR', 'Float'),
-          },
-        ],
-      },
-      VectorMetric: {
-        kind: 'ENUM',
-        name: 'VectorMetric',
-        enumValues: ['L2', 'INNER_PRODUCT', 'COSINE'],
-      },
-    });
-
-    const result = generateInputTypesFile(registry, new Set(), [contactTable], undefined, true, { condition: true });
-
-    // Regular table column fields should still be present
-    expect(result.content).toContain('export interface ContactCondition {');
-    expect(result.content).toContain('id?: string | null;');
-    expect(result.content).toContain('name?: string | null;');
-    expect(result.content).toContain('email?: string | null;');
-
-    // Plugin-injected field should also be present
-    expect(result.content).toContain('embeddingNearby?: VectorNearbyInput');
-
-    // The referenced VectorNearbyInput type should be generated as a custom input type
-    expect(result.content).toContain('export interface VectorNearbyInput {');
-
-    // Transitively referenced enum type (VectorMetric) should also be generated
-    expect(result.content).toContain('VectorMetric');
-    expect(result.content).toContain('"L2"');
-    expect(result.content).toContain('"INNER_PRODUCT"');
-    expect(result.content).toContain('"COSINE"');
-  });
-
-  it('generates transitively referenced enum types from input fields', () => {
-    // This specifically tests that enum types referenced by input object fields
-    // are followed and generated, not just types ending with "Input".
-    // VectorNearbyInput.metric references VectorMetric (an ENUM),
-    // which must be included in the output.
-    const registry = createTypeRegistry({
-      ContactCondition: {
-        kind: 'INPUT_OBJECT',
-        name: 'ContactCondition',
-        inputFields: [
-          { name: 'id', type: createTypeRef('SCALAR', 'UUID') },
-          { name: 'name', type: createTypeRef('SCALAR', 'String') },
-          {
-            name: 'embeddingNearby',
-            type: createTypeRef('INPUT_OBJECT', 'VectorNearbyInput'),
-          },
-        ],
-      },
-      VectorNearbyInput: {
-        kind: 'INPUT_OBJECT',
-        name: 'VectorNearbyInput',
-        inputFields: [
-          {
-            name: 'vector',
-            type: createNonNull(createTypeRef('SCALAR', 'Vector')),
-          },
-          {
-            name: 'metric',
-            type: createTypeRef('ENUM', 'VectorMetric'),
-          },
-        ],
-      },
-      VectorMetric: {
-        kind: 'ENUM',
-        name: 'VectorMetric',
-        enumValues: ['L2', 'INNER_PRODUCT', 'COSINE'],
-      },
-    });
-
-    const result = generateInputTypesFile(registry, new Set(), [contactTable], undefined, true, { condition: true });
-
-    // VectorNearbyInput should be generated (follows *Input pattern)
-    expect(result.content).toContain('export interface VectorNearbyInput {');
-
-    // VectorMetric enum should ALSO be generated (transitive enum resolution)
-    expect(result.content).toMatch(/export type VectorMetric\s*=/);
-    expect(result.content).toContain('"L2"');
-    expect(result.content).toContain('"INNER_PRODUCT"');
-    expect(result.content).toContain('"COSINE"');
-  });
-
-  it('does not duplicate fields already derived from table columns', () => {
-    const registry = createTypeRegistry({
-      ContactCondition: {
-        kind: 'INPUT_OBJECT',
-        name: 'ContactCondition',
-        inputFields: [
-          { name: 'id', type: createTypeRef('SCALAR', 'UUID') },
-          { name: 'name', type: createTypeRef('SCALAR', 'String') },
-          { name: 'email', type: createTypeRef('SCALAR', 'String') },
-          { name: 'embedding', type: createTypeRef('SCALAR', 'Vector') },
-        ],
-      },
-    });
-
-    const result = generateInputTypesFile(registry, new Set(), [contactTable], undefined, true, { condition: true });
-
-    // Count occurrences of 'id?' in the ContactCondition interface
-    const conditionMatch = result.content.match(
-      /export interface ContactCondition \{([^}]*)\}/s,
-    );
-    expect(conditionMatch).toBeTruthy();
-    const conditionBody = conditionMatch![1];
-
-    // Each field should appear only once
-    const idOccurrences = (conditionBody.match(/\bid\?/g) || []).length;
-    expect(idOccurrences).toBe(1);
   });
 
   it('includes plugin-injected orderBy values from TypeRegistry', () => {
@@ -1100,15 +949,11 @@ describe('plugin-injected condition fields', () => {
     expect(result.content).toContain('"EMBEDDING_DISTANCE_DESC"');
   });
 
-  it('works without typeRegistry (backwards compatible)', () => {
-    // When no typeRegistry has the condition type, only table columns are used
-    const result = generateInputTypesFile(new Map(), new Set(), [contactTable], undefined, true, { condition: true });
+  it('does not generate Condition types', () => {
+    const result = generateInputTypesFile(new Map(), new Set(), [contactTable]);
 
-    expect(result.content).toContain('export interface ContactCondition {');
-    expect(result.content).toContain('id?: string | null;');
-    expect(result.content).toContain('name?: string | null;');
-    // No plugin-injected fields
-    expect(result.content).not.toContain('embeddingNearby');
+    // Condition types should NOT be generated
+    expect(result.content).not.toContain('ContactCondition');
   });
 });
 

--- a/graphql/codegen/src/__tests__/codegen/model-generator.test.ts
+++ b/graphql/codegen/src/__tests__/codegen/model-generator.test.ts
@@ -233,7 +233,7 @@ describe('model-generator', () => {
     expect(result.content).toContain('ProductPatch');
   });
 
-  it('imports and wires Condition type for findMany and findFirst', () => {
+  it('does not include Condition type in findMany or findFirst', () => {
     const table = createTable({
       name: 'Contact',
       fields: [
@@ -249,25 +249,10 @@ describe('model-generator', () => {
       },
     });
 
-    const result = generateModelFile(table, false, { condition: true });
+    const result = generateModelFile(table, false);
 
-    // Condition type should be imported
-    expect(result.content).toContain('ContactCondition');
-
-    // findMany should include condition in its args type
-    expect(result.content).toContain(
-      'FindManyArgs<S, ContactFilter, ContactCondition, ContactsOrderBy>',
-    );
-
-    // findFirst should include condition in its args type
-    expect(result.content).toContain(
-      'FindFirstArgs<S, ContactFilter, ContactCondition>',
-    );
-
-    // condition should be forwarded in the body args object
-    expect(result.content).toContain('condition: args?.condition');
-
-    // conditionTypeName should be passed as a string literal to the document builder
-    expect(result.content).toContain('"ContactCondition"');
+    // Condition type should NOT be imported or referenced
+    expect(result.content).not.toContain('ContactCondition');
+    expect(result.content).not.toContain('condition');
   });
 });

--- a/graphql/codegen/src/__tests__/codegen/query-builder.test.ts
+++ b/graphql/codegen/src/__tests__/codegen/query-builder.test.ts
@@ -123,15 +123,14 @@ function buildSelections(
   return fields;
 }
 
-function buildFindManyDocument<TSelect, TWhere, TCondition>(
+function buildFindManyDocument<TSelect, TWhere>(
   operationName: string,
   queryField: string,
   select: TSelect,
-  args: { where?: TWhere; condition?: TCondition; first?: number; orderBy?: string[] },
+  args: { where?: TWhere; first?: number; orderBy?: string[] },
   filterTypeName: string,
   orderByTypeName: string,
   connectionFieldsMap?: Record<string, Record<string, string>>,
-  conditionTypeName?: string,
 ): { document: string; variables: Record<string, unknown> } {
   const selections = select
     ? buildSelections(
@@ -144,16 +143,6 @@ function buildFindManyDocument<TSelect, TWhere, TCondition>(
   const queryArgs: ArgumentNode[] = [];
   const variables: Record<string, unknown> = {};
 
-  addVariable(
-    {
-      varName: 'condition',
-      typeName: conditionTypeName,
-      value: args.condition,
-    },
-    variableDefinitions,
-    queryArgs,
-    variables,
-  );
   addVariable(
     {
       varName: 'where',
@@ -568,36 +557,7 @@ describe('query-builder', () => {
       });
     });
 
-    it('includes condition variable when conditionTypeName is provided', () => {
-      const { document, variables } = buildFindManyDocument(
-        'Contacts',
-        'contacts',
-        { id: true, name: true },
-        {
-          condition: { embeddingNearby: { vector: [0.1, 0.2], metric: 'COSINE' } },
-          where: { name: { equalTo: 'test' } },
-          first: 5,
-        },
-        'ContactFilter',
-        'ContactsOrderBy',
-        undefined,
-        'ContactCondition',
-      );
-
-      // condition variable should appear in the query
-      expect(document).toContain('$condition: ContactCondition');
-      expect(document).toContain('condition: $condition');
-      // where should still work alongside condition
-      expect(document).toContain('$where: ContactFilter');
-      expect(document).toContain('where: $where');
-      // variables should include both
-      expect(variables.condition).toEqual({
-        embeddingNearby: { vector: [0.1, 0.2], metric: 'COSINE' },
-      });
-      expect(variables.where).toEqual({ name: { equalTo: 'test' } });
-    });
-
-    it('omits condition variable when not provided', () => {
+    it('does not include condition variable in generated queries', () => {
       const { document } = buildFindManyDocument(
         'Users',
         'users',
@@ -605,11 +565,9 @@ describe('query-builder', () => {
         { first: 10 },
         'UserFilter',
         'UsersOrderBy',
-        undefined,
-        'UserCondition',
       );
 
-      // condition should NOT appear since no value was provided
+      // condition should NOT appear in generated queries
       expect(document).not.toContain('$condition');
       expect(document).not.toContain('condition:');
     });

--- a/graphql/codegen/src/__tests__/codegen/react-query-hooks.test.ts
+++ b/graphql/codegen/src/__tests__/codegen/react-query-hooks.test.ts
@@ -342,44 +342,14 @@ describe('Regression: FindManyArgs TCondition type arg', () => {
   // This caused TOrderBy to land in the TCondition slot, defaulting TOrderBy to `never`
   // and breaking all hook orderBy params.
 
-  it('includes Condition type in imports and re-exports when condition is enabled', () => {
+  it('does not include Condition type in generated hooks', () => {
     const result = generateListQueryHook(simpleUserTable, {
       reactQueryEnabled: true,
       useCentralizedKeys: true,
-      condition: true,
     });
-    expect(result.content).toContain('UserCondition');
-    expect(result.content).toMatch(
-      /import type \{[^}]*UserCondition[^}]*\} from "\.\.\/\.\.\/orm\/input-types"/,
-    );
-    expect(result.content).toMatch(
-      /export type \{[^}]*UserCondition[^}]*\} from "\.\.\/\.\.\/orm\/input-types"/,
-    );
-  });
-
-  it('includes Condition type in FindManyArgs type arguments', () => {
-    const result = generateListQueryHook(simpleUserTable, {
-      reactQueryEnabled: true,
-      useCentralizedKeys: false,
-      condition: true,
-    });
-    // FindManyArgs should have 4 type args: unknown, UserFilter, UserCondition, UsersOrderBy
-    expect(result.content).toMatch(
-      /FindManyArgs<unknown, UserFilter, UserCondition, UsersOrderBy>/,
-    );
-  });
-
-  it('omits Condition type when condition is disabled', () => {
-    const result = generateListQueryHook(simpleUserTable, {
-      reactQueryEnabled: true,
-      useCentralizedKeys: false,
-      condition: false,
-    });
-    // FindManyArgs should have 4 type args with never for TCondition: unknown, UserFilter, never, UsersOrderBy
-    expect(result.content).toMatch(
-      /FindManyArgs<unknown, UserFilter, never, UsersOrderBy>/,
-    );
+    // Condition types should NOT appear in generated hooks
     expect(result.content).not.toContain('UserCondition');
+    expect(result.content).not.toContain('condition');
   });
 });
 

--- a/graphql/codegen/src/core/codegen/cli/index.ts
+++ b/graphql/codegen/src/core/codegen/cli/index.ts
@@ -78,12 +78,9 @@ export function generateCli(options: GenerateCliOptions): GenerateCliResult {
   const authFile = generateAuthCommand(toolName);
   files.push(authFile);
 
-  const conditionEnabled = config.codegen?.condition === true;
-
   for (const table of tables) {
     const tableFile = generateTableCommand(table, {
       typeRegistry: options.typeRegistry,
-      condition: conditionEnabled,
     });
     files.push(tableFile);
   }
@@ -146,8 +143,6 @@ export interface GenerateMultiTargetCliOptions {
   nodeHttpAdapter?: boolean;
   /** Generate a runnable index.ts entry point */
   entryPoint?: boolean;
-  /** Whether PostGraphile condition types are enabled (default: true) */
-  condition?: boolean;
 }
 
 export function resolveBuiltinNames(
@@ -175,7 +170,6 @@ export function generateMultiTargetCli(
   options: GenerateMultiTargetCliOptions,
 ): GenerateCliResult {
   const { toolName, targets } = options;
-  const conditionEnabled = options.condition === true;
   const files: GeneratedFile[] = [];
 
   const targetNames = targets.map((t) => t.name);
@@ -250,7 +244,6 @@ export function generateMultiTargetCli(
         targetName: target.name,
         executorImportPath: '../../executor',
         typeRegistry: target.typeRegistry,
-        condition: conditionEnabled,
       });
       files.push(tableFile);
     }

--- a/graphql/codegen/src/core/codegen/cli/table-command-generator.ts
+++ b/graphql/codegen/src/core/codegen/cli/table-command-generator.ts
@@ -17,7 +17,6 @@ import {
   getPatchTypeName,
   getFilterTypeName,
   getOrderByTypeName,
-  getConditionTypeName,
 } from '../utils';
 import type { Table, TypeRegistry } from '../../../types/schema';
 import type { GeneratedFile } from './executor-generator';
@@ -485,26 +484,22 @@ function buildAutoEmbedInputBlock(
 
 /**
  * Build the FindManyArgs type instantiation for a table:
- * FindManyArgs<SelectType, FilterType, ConditionType, OrderByType> & { select: SelectType }
+ * FindManyArgs<SelectType, FilterType, OrderByType> & { select: SelectType }
  *
  * The intersection with { select: SelectType } makes select required,
  * matching what the ORM's findMany method expects. parseFindManyArgs
  * always sets select at runtime (from defaultSelect or --select flag).
  */
-function buildFindManyArgsType(table: Table, conditionEnabled: boolean): t.TSType {
+function buildFindManyArgsType(table: Table): t.TSType {
   const { typeName } = getTableNames(table);
   const selectTypeName = `${typeName}Select`;
   const whereTypeName = getFilterTypeName(table);
-  const conditionTypeName = conditionEnabled ? getConditionTypeName(table) : undefined;
   const orderByTypeName = getOrderByTypeName(table);
   const findManyType = t.tsTypeReference(
     t.identifier('FindManyArgs'),
     t.tsTypeParameterInstantiation([
       t.tsTypeReference(t.identifier(selectTypeName)),
       t.tsTypeReference(t.identifier(whereTypeName)),
-      conditionTypeName
-        ? t.tsTypeReference(t.identifier(conditionTypeName))
-        : t.tsNeverKeyword(),
       t.tsTypeReference(t.identifier(orderByTypeName)),
     ]),
   );
@@ -525,24 +520,20 @@ function buildFindManyArgsType(table: Table, conditionEnabled: boolean): t.TSTyp
 
 /**
  * Build the FindFirstArgs type instantiation for a table:
- * FindFirstArgs<SelectType, FilterType, ConditionType> & { select: SelectType }
+ * FindFirstArgs<SelectType, FilterType> & { select: SelectType }
  *
  * The intersection with { select: SelectType } makes select required,
  * matching what the ORM's findFirst method expects.
  */
-function buildFindFirstArgsType(table: Table, conditionEnabled: boolean): t.TSType {
+function buildFindFirstArgsType(table: Table): t.TSType {
   const { typeName } = getTableNames(table);
   const selectTypeName = `${typeName}Select`;
   const whereTypeName = getFilterTypeName(table);
-  const conditionTypeName = conditionEnabled ? getConditionTypeName(table) : undefined;
   const findFirstType = t.tsTypeReference(
     t.identifier('FindFirstArgs'),
     t.tsTypeParameterInstantiation([
       t.tsTypeReference(t.identifier(selectTypeName)),
       t.tsTypeReference(t.identifier(whereTypeName)),
-      conditionTypeName
-        ? t.tsTypeReference(t.identifier(conditionTypeName))
-        : t.tsNeverKeyword(),
     ]),
   );
   // Intersect with { select: SelectType } to make select required
@@ -560,7 +551,7 @@ function buildFindFirstArgsType(table: Table, conditionEnabled: boolean): t.TSTy
   ]);
 }
 
-function buildListHandler(table: Table, vectorFieldNames: string[], targetName?: string, typeRegistry?: TypeRegistry, conditionEnabled = false): t.FunctionDeclaration {
+function buildListHandler(table: Table, vectorFieldNames: string[], targetName?: string, typeRegistry?: TypeRegistry): t.FunctionDeclaration {
   const { singularName } = getTableNames(table);
   const defaultSelectObj = buildSelectObject(table, typeRegistry);
 
@@ -581,7 +572,7 @@ function buildListHandler(table: Table, vectorFieldNames: string[], targetName?:
       t.identifier('defaultSelect'),
     ]);
     callExpr.typeParameters = t.tsTypeParameterInstantiation([
-      buildFindManyArgsType(table, conditionEnabled),
+      buildFindManyArgsType(table),
     ]);
     tryBody.push(
       t.variableDeclaration('const', [
@@ -655,10 +646,10 @@ function buildListHandler(table: Table, vectorFieldNames: string[], targetName?:
 
 /**
  * Build a `handleFindFirst` function — CLI equivalent of the TS SDK's findFirst().
- * Accepts --select, --where.<field>.<op>, --condition.<field>.<op> flags.
+ * Accepts --select, --where.<field>.<op> flags.
  * Internally calls findMany with first:1 and returns a single record (or null).
  */
-function buildFindFirstHandler(table: Table, targetName?: string, typeRegistry?: TypeRegistry, conditionEnabled = false): t.FunctionDeclaration {
+function buildFindFirstHandler(table: Table, targetName?: string, typeRegistry?: TypeRegistry): t.FunctionDeclaration {
   const { singularName } = getTableNames(table);
   const defaultSelectObj = buildSelectObject(table, typeRegistry);
 
@@ -678,7 +669,7 @@ function buildFindFirstHandler(table: Table, targetName?: string, typeRegistry?:
       t.identifier('defaultSelect'),
     ]);
     callExpr.typeParameters = t.tsTypeParameterInstantiation([
-      buildFindFirstArgsType(table, conditionEnabled),
+      buildFindFirstArgsType(table),
     ]);
     tryBody.push(
       t.variableDeclaration('const', [
@@ -748,7 +739,6 @@ function buildSearchHandler(
   vectorFieldNames: string[],
   targetName?: string,
   typeRegistry?: TypeRegistry,
-  conditionEnabled = false,
 ): t.FunctionDeclaration {
   const { singularName } = getTableNames(table);
   const defaultSelectObj = buildSelectObject(table, typeRegistry);
@@ -903,7 +893,7 @@ function buildSearchHandler(
       t.identifier('searchWhere'),
     ]);
     callExpr.typeParameters = t.tsTypeParameterInstantiation([
-      buildFindManyArgsType(table, conditionEnabled),
+      buildFindManyArgsType(table),
     ]);
     tryBody.push(
       t.variableDeclaration('const', [
@@ -1337,8 +1327,6 @@ export interface TableCommandOptions {
   executorImportPath?: string;
   /** TypeRegistry from introspection, used to check field defaults */
   typeRegistry?: TypeRegistry;
-  /** Whether PostGraphile condition types are enabled (default: true) */
-  condition?: boolean;
 }
 
 export function generateTableCommand(table: Table, options?: TableCommandOptions): GeneratedFile {
@@ -1382,15 +1370,12 @@ export function generateTableCommand(table: Table, options?: TableCommandOptions
   const selectTypeName = `${typeName}Select`;
   const whereTypeName = getFilterTypeName(table);
   const orderByTypeName = getOrderByTypeName(table);
-  const conditionEnabled = options?.condition === true;
-  const conditionTypeName = conditionEnabled ? getConditionTypeName(table) : undefined;
   statements.push(
     createImportDeclaration(inputTypesPath, [
       createInputTypeName,
       patchTypeName,
       selectTypeName,
       whereTypeName,
-      ...(conditionTypeName ? [conditionTypeName] : []),
       orderByTypeName,
     ], true),
   );
@@ -1692,9 +1677,9 @@ export function generateTableCommand(table: Table, options?: TableCommandOptions
 
   const tn = options?.targetName;
   const ormTypes = { createInputTypeName, patchTypeName, innerFieldName };
-  statements.push(buildListHandler(table, vectorFieldNames, tn, options?.typeRegistry, conditionEnabled));
-  statements.push(buildFindFirstHandler(table, tn, options?.typeRegistry, conditionEnabled));
-  if (hasSearchFields) statements.push(buildSearchHandler(table, specialGroups, vectorFieldNames, tn, options?.typeRegistry, conditionEnabled));
+  statements.push(buildListHandler(table, vectorFieldNames, tn, options?.typeRegistry));
+  statements.push(buildFindFirstHandler(table, tn, options?.typeRegistry));
+  if (hasSearchFields) statements.push(buildSearchHandler(table, specialGroups, vectorFieldNames, tn, options?.typeRegistry));
   if (hasGet) statements.push(buildGetHandler(table, tn, options?.typeRegistry));
   statements.push(buildMutationHandler(table, 'create', vectorFieldNames, tn, options?.typeRegistry, ormTypes));
   if (hasUpdate) statements.push(buildMutationHandler(table, 'update', vectorFieldNames, tn, options?.typeRegistry, ormTypes));

--- a/graphql/codegen/src/core/codegen/index.ts
+++ b/graphql/codegen/src/core/codegen/index.ts
@@ -190,15 +190,11 @@ export function generate(options: GenerateOptions): GenerateResult {
     hasInvalidation = true;
   }
 
-  // Condition types (PostGraphile simple equality filters)
-  const conditionEnabled = config.codegen?.condition === true;
-
   // 4. Generate table-based query hooks (queries/*.ts)
   const queryHooks = generateAllQueryHooks(tables, {
     reactQueryEnabled,
     useCentralizedKeys,
     hasRelationships,
-    condition: conditionEnabled,
   });
   for (const hook of queryHooks) {
     files.push({

--- a/graphql/codegen/src/core/codegen/orm/index.ts
+++ b/graphql/codegen/src/core/codegen/orm/index.ts
@@ -66,7 +66,6 @@ export interface GenerateOrmResult {
 export function generateOrm(options: GenerateOrmOptions): GenerateOrmResult {
   const { tables, customOperations, sharedTypesPath } = options;
   const commentsEnabled = options.config.codegen?.comments !== false;
-  const conditionEnabled = options.config.codegen?.condition === true;
   const files: GeneratedFile[] = [];
 
   // Use shared types when a sharedTypesPath is provided (unified output mode)
@@ -92,7 +91,7 @@ export function generateOrm(options: GenerateOrmOptions): GenerateOrmResult {
   });
 
   // 2. Generate model files
-  const modelFiles = generateAllModelFiles(tables, useSharedTypes, { condition: conditionEnabled });
+  const modelFiles = generateAllModelFiles(tables, useSharedTypes);
   for (const modelFile of modelFiles) {
     files.push({
       path: `models/${modelFile.fileName}`,
@@ -141,7 +140,6 @@ export function generateOrm(options: GenerateOrmOptions): GenerateOrmResult {
       tables,
       usedPayloadTypes,
       commentsEnabled,
-      { condition: conditionEnabled },
     );
     files.push({
       path: inputTypesFile.fileName,

--- a/graphql/codegen/src/core/codegen/orm/input-types-generator.ts
+++ b/graphql/codegen/src/core/codegen/orm/input-types-generator.ts
@@ -23,7 +23,6 @@ import { BASE_FILTER_TYPE_NAMES, SCALAR_NAMES, scalarToFilterType, scalarToTsTyp
 import { getTypeBaseName } from '../type-resolver';
 import {
   getCreateInputTypeName,
-  getConditionTypeName,
   getFilterTypeName,
   getGeneratedFileHeader,
   getOrderByTypeName,
@@ -324,8 +323,7 @@ const SCALAR_FILTER_CONFIGS: ScalarFilterConfig[] = [
   },
   { name: 'FullTextFilter', tsType: 'string', operators: ['fulltext'] },
   // VectorFilter: equality/distinct operators for vector columns on Filter types.
-  // Similarity search uses condition types (embeddingNearby), not filters, but
-  // connection-filter may still generate a filter for vector columns. This ensures
+  // connection-filter may generate a filter for vector columns. This ensures
   // the generated type uses number[] rather than being silently omitted.
   { name: 'VectorFilter', tsType: 'number[]', operators: ['equality', 'distinct'] },
   // List filters (for array fields like string[], int[], uuid[])
@@ -1156,91 +1154,6 @@ function generateTableFilterTypes(
 }
 
 // ============================================================================
-// Condition Types Generator (AST-based)
-// ============================================================================
-
-/**
- * Build properties for a table condition interface
- * Condition types are simpler than Filter types - they use direct value equality.
- *
- * Also merges any extra fields from the GraphQL schema's condition type
- * (e.g., plugin-injected fields like vectorEmbedding from VectorSearchPlugin)
- * that are not derived from the table's own columns.
- */
-function buildTableConditionProperties(
-  table: Table,
-  typeRegistry?: TypeRegistry,
-): InterfaceProperty[] {
-  const properties: InterfaceProperty[] = [];
-  const generatedFieldNames = new Set<string>();
-
-  for (const field of table.fields) {
-    const fieldType =
-      typeof field.type === 'string' ? field.type : field.type.gqlType;
-    if (isRelationField(field.name, table)) continue;
-
-    // Condition types use the raw scalar type (nullable)
-    const tsType = scalarToTsType(fieldType, { unknownScalar: 'unknown' });
-    properties.push({
-      name: field.name,
-      type: `${tsType} | null`,
-      optional: true,
-    });
-    generatedFieldNames.add(field.name);
-  }
-
-  // Merge any additional fields from the schema's condition type
-  // (e.g., plugin-added fields like vectorEmbedding from VectorSearchPlugin)
-  if (typeRegistry) {
-    const conditionTypeName = getConditionTypeName(table);
-    const conditionType = typeRegistry.get(conditionTypeName);
-    if (
-      conditionType?.kind === 'INPUT_OBJECT' &&
-      conditionType.inputFields
-    ) {
-      for (const field of conditionType.inputFields) {
-        if (generatedFieldNames.has(field.name)) continue;
-
-        const tsType = typeRefToTs(field.type);
-        properties.push({
-          name: field.name,
-          type: tsType,
-          optional: true,
-          description: stripSmartComments(field.description, true),
-        });
-      }
-    }
-  }
-
-  return properties;
-}
-
-/**
- * Generate table condition type statements
- */
-function generateTableConditionTypes(
-  tables: Table[],
-  typeRegistry?: TypeRegistry,
-): t.Statement[] {
-  const statements: t.Statement[] = [];
-
-  for (const table of tables) {
-    const conditionName = getConditionTypeName(table);
-    statements.push(
-      createExportedInterface(
-        conditionName,
-        buildTableConditionProperties(table, typeRegistry),
-      ),
-    );
-  }
-
-  if (statements.length > 0) {
-    addSectionComment(statements, 'Table Condition Types');
-  }
-  return statements;
-}
-
-// ============================================================================
 // OrderBy Types Generator (AST-based)
 // ============================================================================
 
@@ -2033,51 +1946,6 @@ function collectFilterExtraInputTypes(
   return extraTypes;
 }
 
-/**
- * Collect extra input type names referenced by plugin-injected condition fields.
- *
- * When plugins (like VectorSearchPlugin) inject fields into condition types,
- * they reference types (like VectorNearbyInput, VectorMetric) that also need
- * to be generated. This function discovers those types by comparing the
- * schema's condition type fields against the table's own columns.
- */
-function collectConditionExtraInputTypes(
-  tables: Table[],
-  typeRegistry: TypeRegistry,
-): Set<string> {
-  const extraTypes = new Set<string>();
-
-  for (const table of tables) {
-    const conditionTypeName = getConditionTypeName(table);
-    const conditionType = typeRegistry.get(conditionTypeName);
-    if (
-      !conditionType ||
-      conditionType.kind !== 'INPUT_OBJECT' ||
-      !conditionType.inputFields
-    ) {
-      continue;
-    }
-
-    const tableFieldNames = new Set(
-      table.fields
-        .filter((f) => !isRelationField(f.name, table))
-        .map((f) => f.name),
-    );
-
-    for (const field of conditionType.inputFields) {
-      if (tableFieldNames.has(field.name)) continue;
-
-      // Collect the base type name of this extra field
-      const baseName = getTypeBaseName(field.type);
-      if (baseName && !SCALAR_NAMES.has(baseName)) {
-        extraTypes.add(baseName);
-      }
-    }
-  }
-
-  return extraTypes;
-}
-
 // ============================================================================
 // Main Generator (AST-based)
 // ============================================================================
@@ -2091,9 +1959,7 @@ export function generateInputTypesFile(
   tables?: Table[],
   usedPayloadTypes?: Set<string>,
   comments: boolean = true,
-  options?: { condition?: boolean },
 ): GeneratedInputTypesFile {
-  const conditionEnabled = options?.condition === true;
   const statements: t.Statement[] = [];
   const tablesList = tables ?? [];
   const hasTables = tablesList.length > 0;
@@ -2129,13 +1995,6 @@ export function generateInputTypesFile(
     // capturing plugin-injected filter fields (e.g., bm25, tsvector, trgm, vector, geom)
     statements.push(...generateTableFilterTypes(tablesList, typeRegistry));
 
-    // 4b. Table condition types (simple equality filter)
-    // Pass typeRegistry to merge plugin-injected condition fields
-    // (e.g., vectorEmbedding from VectorSearchPlugin)
-    if (conditionEnabled) {
-      statements.push(...generateTableConditionTypes(tablesList, typeRegistry));
-    }
-
     // 5. OrderBy types
     // Pass typeRegistry to merge plugin-injected orderBy values
     // (e.g., EMBEDDING_DISTANCE_ASC/DESC from VectorSearchPlugin)
@@ -2150,7 +2009,7 @@ export function generateInputTypesFile(
   statements.push(...generateConnectionFieldsMap(tablesList, tableByName));
 
   // 7. Custom input types from TypeRegistry
-  // Also include any extra types referenced by plugin-injected filter/condition fields
+  // Also include any extra types referenced by plugin-injected filter fields
   const mergedUsedInputTypes = new Set(usedInputTypes);
   if (hasTables) {
     const filterExtraTypes = collectFilterExtraInputTypes(
@@ -2158,15 +2017,6 @@ export function generateInputTypesFile(
       typeRegistry,
     );
     for (const typeName of filterExtraTypes) {
-      mergedUsedInputTypes.add(typeName);
-    }
-  }
-  if (hasTables && conditionEnabled) {
-    const conditionExtraTypes = collectConditionExtraInputTypes(
-      tablesList,
-      typeRegistry,
-    );
-    for (const typeName of conditionExtraTypes) {
       mergedUsedInputTypes.add(typeName);
     }
   }

--- a/graphql/codegen/src/core/codegen/orm/model-generator.ts
+++ b/graphql/codegen/src/core/codegen/orm/model-generator.ts
@@ -171,10 +171,9 @@ function strictSelectGuard(selectTypeName: string): t.TSType {
 export function generateModelFile(
   table: Table,
   _useSharedTypes: boolean,
-  options?: { condition?: boolean },
+  options?: Record<string, never>,
   allTables?: Table[],
 ): GeneratedModelFile {
-  const conditionEnabled = options?.condition === true;
   const { typeName, singularName, pluralName } = getTableNames(table);
   const modelName = `${typeName}Model`;
   const baseFileName = lcFirst(typeName);
@@ -185,7 +184,6 @@ export function generateModelFile(
   const selectTypeName = `${typeName}Select`;
   const relationTypeName = `${typeName}WithRelations`;
   const whereTypeName = getFilterTypeName(table);
-  const conditionTypeName = conditionEnabled ? `${typeName}Condition` : undefined;
   const orderByTypeName = getOrderByTypeName(table);
   const createInputTypeName = `Create${typeName}Input`;
   const updateInputTypeName = `Update${typeName}Input`;
@@ -248,7 +246,6 @@ export function generateModelFile(
     relationTypeName,
     selectTypeName,
     whereTypeName,
-    ...(conditionTypeName ? [conditionTypeName] : []),
     orderByTypeName,
     createInputTypeName,
     updateInputTypeName,
@@ -292,9 +289,6 @@ export function generateModelFile(
     const findManyTypeArgs: Array<(sel: t.TSType) => t.TSType> = [
       (sel: t.TSType) => sel,
       () => t.tsTypeReference(t.identifier(whereTypeName)),
-      conditionTypeName
-        ? () => t.tsTypeReference(t.identifier(conditionTypeName))
-        : () => t.tsNeverKeyword(),
       () => t.tsTypeReference(t.identifier(orderByTypeName)),
     ];
     const argsType = (sel: t.TSType) =>
@@ -354,19 +348,6 @@ export function generateModelFile(
           true,
         ),
       ),
-      ...(conditionTypeName
-        ? [
-            t.objectProperty(
-              t.identifier('condition'),
-              t.optionalMemberExpression(
-                t.identifier('args'),
-                t.identifier('condition'),
-                false,
-                true,
-              ),
-            ),
-          ]
-        : []),
       t.objectProperty(
         t.identifier('orderBy'),
           t.tsAsExpression(
@@ -436,9 +417,6 @@ export function generateModelFile(
       t.stringLiteral(whereTypeName),
       t.stringLiteral(orderByTypeName),
       t.identifier('connectionFieldsMap'),
-      ...(conditionTypeName
-        ? [t.stringLiteral(conditionTypeName)]
-        : []),
     ];
     classBody.push(
       createClassMethod(
@@ -462,9 +440,6 @@ export function generateModelFile(
     const findFirstTypeArgs: Array<(sel: t.TSType) => t.TSType> = [
       (sel: t.TSType) => sel,
       () => t.tsTypeReference(t.identifier(whereTypeName)),
-      ...(conditionTypeName
-        ? [() => t.tsTypeReference(t.identifier(conditionTypeName))]
-        : []),
     ];
     const argsType = (sel: t.TSType) =>
       t.tsTypeReference(
@@ -527,19 +502,6 @@ export function generateModelFile(
           true,
         ),
       ),
-      ...(conditionTypeName
-        ? [
-            t.objectProperty(
-              t.identifier('condition'),
-              t.optionalMemberExpression(
-                t.identifier('args'),
-                t.identifier('condition'),
-                false,
-                true,
-              ),
-            ),
-          ]
-        : []),
     ];
     const bodyArgs = [
       t.stringLiteral(typeName),
@@ -548,9 +510,6 @@ export function generateModelFile(
       t.objectExpression(findFirstObjProps),
       t.stringLiteral(whereTypeName),
       t.identifier('connectionFieldsMap'),
-      ...(conditionTypeName
-        ? [t.stringLiteral(conditionTypeName)]
-        : []),
     ];
     classBody.push(
       createClassMethod(
@@ -1203,7 +1162,6 @@ export function generateModelFile(
 export function generateAllModelFiles(
   tables: Table[],
   useSharedTypes: boolean,
-  options?: { condition?: boolean },
 ): GeneratedModelFile[] {
-  return tables.map((table) => generateModelFile(table, useSharedTypes, options, tables));
+  return tables.map((table) => generateModelFile(table, useSharedTypes, undefined, tables));
 }

--- a/graphql/codegen/src/core/codegen/orm/select-types.ts
+++ b/graphql/codegen/src/core/codegen/orm/select-types.ts
@@ -201,10 +201,9 @@ export interface PageInfo {
 /**
  * Arguments for findMany operations
  */
-export interface FindManyArgs<TSelect, TWhere, TCondition, TOrderBy> {
+export interface FindManyArgs<TSelect, TWhere, TOrderBy> {
   select?: TSelect;
   where?: TWhere;
-  condition?: TCondition;
   orderBy?: TOrderBy[];
   first?: number;
   last?: number;
@@ -216,10 +215,9 @@ export interface FindManyArgs<TSelect, TWhere, TCondition, TOrderBy> {
 /**
  * Arguments for findFirst/findUnique operations
  */
-export interface FindFirstArgs<TSelect, TWhere, TCondition> {
+export interface FindFirstArgs<TSelect, TWhere> {
   select?: TSelect;
   where?: TWhere;
-  condition?: TCondition;
 }
 
 /**

--- a/graphql/codegen/src/core/codegen/queries.ts
+++ b/graphql/codegen/src/core/codegen/queries.ts
@@ -52,7 +52,6 @@ import {
 } from './hooks-ast';
 import {
   getAllRowsQueryName,
-  getConditionTypeName,
   getFilterTypeName,
   getListQueryFileName,
   getListQueryHookName,
@@ -76,7 +75,6 @@ export interface QueryGeneratorOptions {
   reactQueryEnabled?: boolean;
   useCentralizedKeys?: boolean;
   hasRelationships?: boolean;
-  condition?: boolean;
 }
 
 export function generateListQueryHook(
@@ -87,14 +85,12 @@ export function generateListQueryHook(
     reactQueryEnabled = true,
     useCentralizedKeys = true,
     hasRelationships = false,
-    condition: conditionEnabled = false,
   } = options;
   const { typeName, pluralName, singularName } = getTableNames(table);
   const hookName = getListQueryHookName(table);
   const queryName = getAllRowsQueryName(table);
   const filterTypeName = getFilterTypeName(table);
   const orderByTypeName = getOrderByTypeName(table);
-  const conditionTypeName = conditionEnabled ? getConditionTypeName(table) : undefined;
   const keysName = `${lcFirst(typeName)}Keys`;
   const scopeTypeName = `${typeName}Scope`;
   const selectTypeName = `${typeName}Select`;
@@ -136,7 +132,6 @@ export function generateListQueryHook(
   }
 
   const inputTypeImports = [selectTypeName, relationTypeName, filterTypeName, orderByTypeName];
-  if (conditionTypeName) inputTypeImports.push(conditionTypeName);
   statements.push(
     createImportDeclaration(
       '../../orm/input-types',
@@ -159,7 +154,6 @@ export function generateListQueryHook(
 
   // Re-exports
   const reExportTypes = [selectTypeName, relationTypeName, filterTypeName, orderByTypeName];
-  if (conditionTypeName) reExportTypes.push(conditionTypeName);
   statements.push(
     createTypeReExport(
       reExportTypes,
@@ -185,7 +179,6 @@ export function generateListQueryHook(
     const findManyKeyTypeArgs: t.TSType[] = [
       t.tsUnknownKeyword(),
       typeRef(filterTypeName),
-      conditionTypeName ? typeRef(conditionTypeName) : t.tsNeverKeyword(),
       typeRef(orderByTypeName),
     ];
     const keyFn = t.arrowFunctionExpression(

--- a/graphql/codegen/src/core/codegen/templates/cli-utils.ts
+++ b/graphql/codegen/src/core/codegen/templates/cli-utils.ts
@@ -267,7 +267,6 @@ export function parseFindManyArgs<T = Record<string, unknown>>(
   const where = parsed.where ?? extraWhere
     ? { ...(extraWhere ?? {}), ...((parsed.where as Record<string, unknown>) ?? {}) }
     : undefined;
-  const condition = parsed.condition;
   const orderBy = parseOrderByFlag(argv);
 
   return {
@@ -278,14 +277,13 @@ export function parseFindManyArgs<T = Record<string, unknown>>(
     ...(before !== undefined ? { before } : {}),
     ...(offset !== undefined ? { offset } : {}),
     ...(where !== undefined ? { where } : {}),
-    ...(condition !== undefined ? { condition } : {}),
     ...(orderBy !== undefined ? { orderBy } : {}),
   } as unknown as T;
 }
 
 /**
  * Build findFirst args from CLI argv.
- * Like parseFindManyArgs but only includes select, where, and condition
+ * Like parseFindManyArgs but only includes select and where
  * (no pagination flags — findFirst returns the first matching record).
  */
 export function parseFindFirstArgs<T = Record<string, unknown>>(
@@ -295,12 +293,10 @@ export function parseFindFirstArgs<T = Record<string, unknown>>(
   const select = parseSelectFlag(argv, defaultSelect);
   const parsed = unflattenDotNotation(argv);
   const where = parsed.where;
-  const condition = parsed.condition;
 
   return {
     select,
     ...(where !== undefined ? { where } : {}),
-    ...(condition !== undefined ? { condition } : {}),
   } as unknown as T;
 }
 

--- a/graphql/codegen/src/core/codegen/templates/query-builder.ts
+++ b/graphql/codegen/src/core/codegen/templates/query-builder.ts
@@ -201,13 +201,12 @@ export function buildSelections(
 // Document Builders
 // ============================================================================
 
-export function buildFindManyDocument<TSelect, TWhere, TCondition = never>(
+export function buildFindManyDocument<TSelect, TWhere>(
   operationName: string,
   queryField: string,
   select: TSelect,
   args: {
     where?: TWhere;
-    condition?: TCondition;
     orderBy?: string[];
     first?: number;
     last?: number;
@@ -218,7 +217,6 @@ export function buildFindManyDocument<TSelect, TWhere, TCondition = never>(
   filterTypeName: string,
   orderByTypeName: string,
   connectionFieldsMap?: Record<string, Record<string, string>>,
-  conditionTypeName?: string,
 ): { document: string; variables: Record<string, unknown> } {
   const selections = select
     ? buildSelections(
@@ -232,16 +230,6 @@ export function buildFindManyDocument<TSelect, TWhere, TCondition = never>(
   const queryArgs: ArgumentNode[] = [];
   const variables: Record<string, unknown> = {};
 
-  addVariable(
-    {
-      varName: 'condition',
-      typeName: conditionTypeName,
-      value: args.condition,
-    },
-    variableDefinitions,
-    queryArgs,
-    variables,
-  );
   addVariable(
     {
       varName: 'where',
@@ -319,14 +307,13 @@ export function buildFindManyDocument<TSelect, TWhere, TCondition = never>(
   return { document: print(document), variables };
 }
 
-export function buildFindFirstDocument<TSelect, TWhere, TCondition = never>(
+export function buildFindFirstDocument<TSelect, TWhere>(
   operationName: string,
   queryField: string,
   select: TSelect,
-  args: { where?: TWhere; condition?: TCondition },
+  args: { where?: TWhere },
   filterTypeName: string,
   connectionFieldsMap?: Record<string, Record<string, string>>,
-  conditionTypeName?: string,
 ): { document: string; variables: Record<string, unknown> } {
   const selections = select
     ? buildSelections(
@@ -343,16 +330,6 @@ export function buildFindFirstDocument<TSelect, TWhere, TCondition = never>(
   // Always add first: 1 for findFirst
   addVariable(
     { varName: 'first', typeName: 'Int', value: 1 },
-    variableDefinitions,
-    queryArgs,
-    variables,
-  );
-  addVariable(
-    {
-      varName: 'condition',
-      typeName: conditionTypeName,
-      value: args.condition,
-    },
     variableDefinitions,
     queryArgs,
     variables,

--- a/graphql/codegen/src/core/codegen/templates/select-types.ts
+++ b/graphql/codegen/src/core/codegen/templates/select-types.ts
@@ -21,10 +21,9 @@ export interface PageInfo {
   endCursor?: string | null;
 }
 
-export interface FindManyArgs<TSelect, TWhere, TCondition = never, TOrderBy = never> {
+export interface FindManyArgs<TSelect, TWhere, TOrderBy = never> {
   select?: TSelect;
   where?: TWhere;
-  condition?: TCondition;
   orderBy?: TOrderBy[];
   first?: number;
   last?: number;
@@ -33,10 +32,9 @@ export interface FindManyArgs<TSelect, TWhere, TCondition = never, TOrderBy = ne
   offset?: number;
 }
 
-export interface FindFirstArgs<TSelect, TWhere, TCondition = never> {
+export interface FindFirstArgs<TSelect, TWhere> {
   select?: TSelect;
   where?: TWhere;
-  condition?: TCondition;
 }
 
 export interface CreateArgs<TSelect, TData> {

--- a/graphql/codegen/src/core/generate.ts
+++ b/graphql/codegen/src/core/generate.ts
@@ -714,14 +714,12 @@ export async function generateMulti(
       firstTargetConfig?.nodeHttpAdapter === true ||
       (firstTargetConfig?.nodeHttpAdapter !== false);
 
-    const multiConditionEnabled = firstTargetConfig?.codegen?.condition === true;
     const { files } = generateMultiTargetCli({
       toolName,
       builtinNames: cliConfig.builtinNames,
       targets: cliTargets,
       nodeHttpAdapter: multiNodeHttpAdapter,
       entryPoint: cliConfig.entryPoint,
-      condition: multiConditionEnabled,
     });
 
     const cliFilesToWrite = files.map((file) => ({


### PR DESCRIPTION
## Summary

`ConstructivePreset` disables `PgConditionArgumentPlugin` and `PgConditionCustomFieldsPlugin`, so `*Condition` input types (e.g. `DocumentCondition`, `DiligenceRequestCondition`) do not exist in the GraphQL schema. However, the ORM codegen was still emitting `$condition` variables in generated GraphQL queries, causing runtime errors:

```
Variable "$condition" expected value of type "DocumentCondition" which cannot be used as an input type.
```

This PR removes condition generation entirely from the codegen pipeline:

- **Type interfaces**: Removed `TCondition` type parameter and `condition` property from `FindManyArgs` and `FindFirstArgs` (both template and ORM copies in `select-types.ts`)
- **Query builders**: Removed `$condition` variable emission from `buildFindManyDocument` and `buildFindFirstDocument` in `query-builder.ts`
- **CLI utilities**: Removed condition parsing from `parseFindManyArgs` and `parseFindFirstArgs` in `cli-utils.ts`
- **Model generator**: Removed condition type args, imports, property forwarding, and `conditionTypeName` string literal from generated model classes
- **CLI/codegen generators**: Removed `conditionEnabled` flags and `condition` option plumbing from `cli/index.ts`, `cli/table-command-generator.ts`, `codegen/index.ts`, `codegen/queries.ts`, and `generate.ts`
- **Input types generator**: Removed dead `buildTableConditionProperties`, `generateTableConditionTypes`, and `collectConditionExtraInputTypes` functions
- **Tests**: Removed condition-specific test cases, updated 10 snapshots

## Review & Testing Checklist for Human

- [ ] **Verify no downstream consumers rely on `condition`**: Any generated code or manually written code passing `condition` to `FindManyArgs`/`FindFirstArgs` will break at compile time. Check that SDK packages (`constructive-sdk`, `constructive-react`, `constructive-node`, `constructive-cli`) still build correctly after regeneration.
- [ ] **Test against diligence-room**: Run `orm-search.test.ts` in `pyramation-studio/diligence-room` against this branch to confirm the `$condition` runtime error is resolved.
- [ ] **Dead code in `utils.ts`**: `getConditionTypeName()` is still defined in `utils.ts` but no longer imported anywhere — consider whether to remove it or keep it for potential future use.
- [ ] **`generateAllModelFiles` signature**: Third param `options` was effectively removed (always `undefined` now). Verify all callers in `orm/index.ts` and tests are compatible.

### Notes
- This is a **breaking change** for any code that was using the `condition` property on `FindManyArgs`/`FindFirstArgs`. This is intentional since the schema has no condition types.
- All filtering should go through the `where` argument provided by `graphile-connection-filter`.

Link to Devin session: https://app.devin.ai/sessions/136ba9e7789e4cf28c757e6740c21808
Requested by: @pyramation