### PR TITLE
feat(pgpm): add --minio flag to pgpm env for CDN/S3 environment variables

### DIFF
--- a/pgpm/cli/src/commands/env.ts
+++ b/pgpm/cli/src/commands/env.ts
@@ -7,11 +7,14 @@ Environment Command:
 
   pgpm env [OPTIONS] [COMMAND...]
 
-  Manage PostgreSQL environment variables with profile support.
+  Manage environment variables for local development with profile support.
 
-Profiles:
+Database Profiles:
   (default)          Use local Postgres development profile
   --supabase         Use Supabase local development profile
+
+Additional Services:
+  --minio            Include MinIO/S3 environment variables
 
 Modes:
   No command         Print export statements for shell evaluation
@@ -20,16 +23,18 @@ Modes:
 Options:
   --help, -h         Show this help message
   --supabase         Use Supabase profile instead of default Postgres
+  --minio            Include CDN_ENDPOINT, AWS_ACCESS_KEY, AWS_SECRET_KEY, AWS_REGION
 
 Examples:
   pgpm env                                    Print default Postgres env exports
   pgpm env --supabase                         Print Supabase env exports
+  pgpm env --minio                            Print Postgres + MinIO env exports
+  pgpm env --supabase --minio                 Print Supabase + MinIO env exports
   eval "$(pgpm env)"                          Load default Postgres env into shell
-  eval "$(pgpm env --supabase)"               Load Supabase env into shell
+  eval "$(pgpm env --minio)"                  Load Postgres + MinIO env into shell
+  eval "$(pgpm env --supabase --minio)"       Load Supabase + MinIO env into shell
   pgpm env pgpm deploy --database db1         Run command with default Postgres env
-  pgpm env createdb mydb                      Run command with default Postgres env
-  pgpm env --supabase pgpm deploy --database db1 Run command with Supabase env
-  pgpm env --supabase createdb mydb           Run command with Supabase env
+  pgpm env --minio pgpm deploy --database db1 Run command with Postgres + MinIO env
 `;
 
 const SUPABASE_PROFILE: PgConfig = {
@@ -44,26 +49,49 @@ const DEFAULT_PROFILE: PgConfig = {
   ...defaultPgConfig
 };
 
-function configToEnvVars(config: PgConfig): Record<string, string> {
-  return {
+interface MinioConfig {
+  endpoint: string;
+  accessKey: string;
+  secretKey: string;
+  region: string;
+}
+
+const MINIO_PROFILE: MinioConfig = {
+  endpoint: 'http://localhost:9000',
+  accessKey: 'minioadmin',
+  secretKey: 'minioadmin',
+  region: 'us-east-1',
+};
+
+function configToEnvVars(config: PgConfig, minio?: MinioConfig): Record<string, string> {
+  const vars: Record<string, string> = {
     PGHOST: config.host,
     PGPORT: String(config.port),
     PGUSER: config.user,
     PGPASSWORD: config.password,
     PGDATABASE: config.database
   };
+
+  if (minio) {
+    vars.CDN_ENDPOINT = minio.endpoint;
+    vars.AWS_ACCESS_KEY = minio.accessKey;
+    vars.AWS_SECRET_KEY = minio.secretKey;
+    vars.AWS_REGION = minio.region;
+  }
+
+  return vars;
 }
 
-function printExports(config: PgConfig): void {
-  const envVars = configToEnvVars(config);
+function printExports(config: PgConfig, minio?: MinioConfig): void {
+  const envVars = configToEnvVars(config, minio);
   for (const [key, value] of Object.entries(envVars)) {
     console.log(`export ${key}=${value}`);
   }
 }
 
-function executeCommand(config: PgConfig, command: string, args: string[]): Promise<number> {
+function executeCommand(config: PgConfig, command: string, args: string[], minio?: MinioConfig): Promise<number> {
   return new Promise((resolve, reject) => {
-    const envVars = configToEnvVars(config);
+    const envVars = configToEnvVars(config, minio);
     const env = {
       ...process.env,
       ...envVars
@@ -95,7 +123,11 @@ export default async (
   }
 
   const useSupabase = argv.supabase === true || typeof argv.supabase === 'string';
+  const useMinio = argv.minio === true || typeof argv.minio === 'string';
   const profile = useSupabase ? SUPABASE_PROFILE : DEFAULT_PROFILE;
+  const minioProfile = useMinio ? MINIO_PROFILE : undefined;
+
+  const knownFlags = ['--supabase', '--minio'];
 
   const rawArgs = process.argv.slice(2);
   
@@ -106,14 +138,7 @@ export default async (
   
   const argsAfterEnv = rawArgs.slice(envIndex + 1);
   
-  const supabaseIndex = argsAfterEnv.findIndex(arg => arg === '--supabase');
-  
-  let commandArgs: string[];
-  if (supabaseIndex !== -1) {
-    commandArgs = argsAfterEnv.slice(supabaseIndex + 1);
-  } else {
-    commandArgs = argsAfterEnv;
-  }
+  let commandArgs = argsAfterEnv.filter(arg => !knownFlags.includes(arg));
   
   commandArgs = commandArgs.filter(arg => arg !== '--cwd' && !arg.startsWith('--cwd='));
   
@@ -123,14 +148,14 @@ export default async (
   }
 
   if (commandArgs.length === 0) {
-    printExports(profile);
+    printExports(profile, minioProfile);
     return;
   }
 
   const [command, ...args] = commandArgs;
   
   try {
-    const exitCode = await executeCommand(profile, command, args);
+    const exitCode = await executeCommand(profile, command, args, minioProfile);
     process.exit(exitCode);
   } catch (error) {
     if (error instanceof Error) {

--- a/pgpm/cli/src/utils/display.ts
+++ b/pgpm/cli/src/utils/display.ts
@@ -40,7 +40,7 @@ export const usageText = `
   
   Development Tools:
     docker             Manage Docker containers (start/stop/ls, --include for additional services)
-    env                Manage PostgreSQL environment variables
+    env                Manage environment variables (--supabase, --minio)
     test-packages      Run integration tests on workspace packages
   
   Global Options:


### PR DESCRIPTION
## Summary

Adds a `--minio` flag to `pgpm env` that exports CDN/S3 environment variables (`CDN_ENDPOINT`, `AWS_ACCESS_KEY`, `AWS_SECRET_KEY`, `AWS_REGION`) alongside the existing PostgreSQL variables. This follows the same opt-in pattern as `--supabase` — Minio vars are only included when explicitly requested.

```bash
pgpm env --minio                  # Postgres + MinIO vars
pgpm env --supabase --minio       # Supabase + MinIO vars
eval "$(pgpm env --minio)"        # Load both into shell
pgpm env --minio pgpm deploy ...  # Run command with both sets
```

Also fixes the arg-parsing logic: the old code used index-based slicing that only knew about `--supabase` (everything before `--supabase` in arg position would be silently dropped). Replaced with a `knownFlags` filter that cleanly strips recognized flags regardless of position, which also makes it trivial to add future flags.

Context: follows [PR #975](https://github.com/constructive-io/constructive/pull/975) which added `--include minio` to `pgpm docker`. This gives users a matching way to get the env vars those containers need.

## Review & Testing Checklist for Human

- [ ] **Verify env var naming**: This exports `CDN_ENDPOINT` but `CLAUDE.md` references `MINIO_ENDPOINT` for S3/MinIO tests. Confirm `CDN_ENDPOINT` is correct for the app's upload/streaming packages, or if it should be `MINIO_ENDPOINT` (or both)
- [ ] **Verify `AWS_ACCESS_KEY` vs `AWS_ACCESS_KEY_ID`**: Standard AWS SDK expects `AWS_ACCESS_KEY_ID` — confirm the codebase uses `AWS_ACCESS_KEY` (the non-standard name) everywhere
- [ ] **Test arg parsing edge cases**: Run `pgpm env --minio`, `pgpm env --supabase --minio`, `pgpm env --minio pgpm deploy --database db1` and verify the correct exports are printed and commands execute with the right env
- [ ] **Confirm defaults match docker command**: The Minio defaults here (endpoint `http://localhost:9000`, creds `minioadmin/minioadmin`) should match what `pgpm docker start --include minio` actually starts

### Notes
- The help text examples were trimmed to make room for `--minio` variants — a few `--supabase`-only examples were removed (the flag still works, just fewer examples shown).
- The arg parsing refactor changes behavior in one edge case: if `--supabase` appeared _after_ positional command args (e.g., `pgpm env createdb --supabase`), the old code would drop `createdb`. The new code preserves it. This is a bug fix.
- No automated tests — this is a CLI env-export command that would need integration testing with actual shell evaluation.

Link to Devin session: https://app.devin.ai/sessions/44eca4b3fe5a46aaaf5c4907f0a0b600
Requested by: @pyramation