### PR TITLE
feat(pgpm): replace --include with --minio flag for docker command

### DIFF
--- a/pgpm/cli/src/commands/docker.ts
+++ b/pgpm/cli/src/commands/docker.ts
@@ -7,8 +7,7 @@ Docker Command:
   pgpm docker <subcommand> [OPTIONS]
 
   Manage Docker containers for local development.
-  PostgreSQL is always started by default. Additional services can be
-  included with the --include flag.
+  PostgreSQL is always started by default.
 
 Subcommands:
   start              Start containers
@@ -23,23 +22,22 @@ PostgreSQL Options:
   --password <pass>  PostgreSQL password (default: password)
   --shm-size <size>  Shared memory size for container (default: 2g)
 
+Additional Services:
+  --minio            Include MinIO S3-compatible object storage (port 9000)
+
 General Options:
   --help, -h         Show this help message
   --recreate         Remove and recreate containers on start
-  --include <svc>    Include additional service (can be repeated)
-
-Available Additional Services:
-  minio              MinIO S3-compatible object storage (port 9000)
 
 Examples:
   pgpm docker start                           Start PostgreSQL only
-  pgpm docker start --include minio           Start PostgreSQL + MinIO
+  pgpm docker start --minio                   Start PostgreSQL + MinIO
   pgpm docker start --port 5433               Start on custom port
   pgpm docker start --shm-size 4g             Start with 4GB shared memory
   pgpm docker start --recreate                Remove and recreate containers
-  pgpm docker start --recreate --include minio Recreate PostgreSQL + MinIO
+  pgpm docker start --recreate --minio        Recreate PostgreSQL + MinIO
   pgpm docker stop                            Stop PostgreSQL
-  pgpm docker stop --include minio            Stop PostgreSQL + MinIO
+  pgpm docker stop --minio                    Stop PostgreSQL + MinIO
   pgpm docker ls                              List services and status
 `;
 
@@ -315,21 +313,10 @@ async function stopService(service: ServiceDefinition): Promise<void> {
   await stopContainer(service.name);
 }
 
-function parseInclude(args: Partial<Record<string, any>>): string[] {
-  const include = args.include;
-  if (!include) return [];
-  if (Array.isArray(include)) return include as string[];
-  if (typeof include === 'string') return [include];
-  return [];
-}
-
-function resolveIncludedServices(includeNames: string[]): ServiceDefinition[] {
+function resolveServiceFlags(args: Partial<Record<string, any>>): ServiceDefinition[] {
   const services: ServiceDefinition[] = [];
-  for (const name of includeNames) {
-    const service = ADDITIONAL_SERVICES[name];
-    if (!service) {
-      console.warn(`⚠️  Unknown service: "${name}". Available: ${Object.keys(ADDITIONAL_SERVICES).join(', ')}`);
-    } else {
+  for (const [key, service] of Object.entries(ADDITIONAL_SERVICES)) {
+    if (args[key] === true || typeof args[key] === 'string') {
       services.push(service);
     }
   }
@@ -350,7 +337,7 @@ async function listServices(): Promise<void> {
     console.log('    postgres    constructiveio/postgres-plus:18    \x1b[90m(docker not available)\x1b[0m');
   }
 
-  console.log('\n  Additional (use --include <name>):');
+  console.log('\n  Additional (use --<name> flag):');
 
   for (const [key, service] of Object.entries(ADDITIONAL_SERVICES)) {
     if (dockerAvailable) {
@@ -392,8 +379,7 @@ export default async (
   const password = (args.password as string) || 'password';
   const shmSize = (args['shm-size'] as string) || (args.shmSize as string) || '2g';
   const recreate = args.recreate === true;
-  const includeNames = parseInclude(args);
-  const includedServices = resolveIncludedServices(includeNames);
+  const includedServices = resolveServiceFlags(args);
 
   switch (subcommand) {
   case 'start':

--- a/pgpm/cli/src/utils/display.ts
+++ b/pgpm/cli/src/utils/display.ts
@@ -39,7 +39,7 @@ export const usageText = `
       deps             Show change dependencies
   
   Development Tools:
-    docker             Manage Docker containers (start/stop/ls, --include for additional services)
+    docker             Manage Docker containers (start/stop/ls, --minio)
     env                Manage environment variables (--supabase, --minio)
     test-packages      Run integration tests on workspace packages
   


### PR DESCRIPTION
## Summary

Replaces `pgpm docker start --include minio` with the simpler `pgpm docker start --minio`, matching the `--minio` flag pattern already used in `pgpm env` (PR #976).

- Removes `parseInclude()` and `resolveIncludedServices()` (which parsed `--include <name>` args and did name lookups with warnings for unknown services)
- Adds `resolveServiceFlags()` which checks CLI args directly against `ADDITIONAL_SERVICES` keys — if `args.minio` is truthy, the minio service is included
- Updates help text: moves minio from "Available Additional Services" list to an "Additional Services" section with `--minio` flag syntax
- Updates `pgpm docker ls` hint from `--include <name>` to `--<name> flag`
- Updates `display.ts` top-level help to show `--minio` instead of `--include for additional services`

**Breaking**: `--include minio` no longer works. Since #975 was merged very recently, adoption is near-zero.

## Review & Testing Checklist for Human

- [ ] **Verify `--minio` flag parsing**: Run `pgpm docker start --minio` and confirm `inquirerer` parses it as `{ minio: true }` so `resolveServiceFlags` picks it up. The old `--include` approach explicitly handled string/array parsing; the new approach assumes the arg parser sets a boolean — confirm this works with the actual CLI arg parser
- [ ] **End-to-end test**: `pgpm docker start --minio` (both containers up), `pgpm docker ls` (shows minio status), `pgpm docker stop --minio` (both stop)
- [ ] **Verify `--minio` doesn't collide with other args**: The new `resolveServiceFlags` iterates all `ADDITIONAL_SERVICES` keys and checks `args[key]` — confirm no existing arg names clash with service names (currently only `minio`, so low risk)

### Notes
- The extensibility model now requires that each service in `ADDITIONAL_SERVICES` has a key that works as a CLI flag name (e.g., no spaces, hyphens are fine). This is a reasonable constraint.
- No automated tests — this is Docker orchestration code that requires a running Docker daemon to test meaningfully.

Link to Devin session: https://app.devin.ai/sessions/44eca4b3fe5a46aaaf5c4907f0a0b600
Requested by: @pyramation