### PR TITLE
fix: expose MinIO console UI on port 9001

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,13 +16,15 @@ services:
     container_name: minio
     image: minio/minio
     environment:
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadmin
+      - MINIO_ROOT_USER=minioadmin
+      - MINIO_ROOT_PASSWORD=minioadmin
     ports:
       - "9000:9000"
+      - "9001:9001"
     expose:
       - "9000"
-    command: server /data
+      - "9001"
+    command: server /data --console-address ":9001"
     networks:
       - constructive-net
 

--- a/pgpm/cli/src/commands/docker.ts
+++ b/pgpm/cli/src/commands/docker.ts
@@ -23,7 +23,7 @@ PostgreSQL Options:
   --shm-size <size>  Shared memory size for container (default: 2g)
 
 Additional Services:
-  --minio            Include MinIO S3-compatible object storage (port 9000)
+  --minio            Include MinIO S3-compatible object storage (API: 9000, Console: 9001)
 
 General Options:
   --help, -h         Show this help message
@@ -74,12 +74,15 @@ const ADDITIONAL_SERVICES: Record<string, ServiceDefinition> = {
   minio: {
     name: 'minio',
     image: 'minio/minio',
-    ports: [{ host: 9000, container: 9000 }],
+    ports: [
+      { host: 9000, container: 9000 },
+      { host: 9001, container: 9001 },
+    ],
     env: {
-      MINIO_ACCESS_KEY: 'minioadmin',
-      MINIO_SECRET_KEY: 'minioadmin',
+      MINIO_ROOT_USER: 'minioadmin',
+      MINIO_ROOT_PASSWORD: 'minioadmin',
     },
-    command: ['server', '/data'],
+    command: ['server', '/data', '--console-address', ':9001'],
     volumes: [{ name: 'minio-data', containerPath: '/data' }],
   },
 };


### PR DESCRIPTION
## Summary

Fixes MinIO console UI being unreachable by pinning it to port 9001. Without `--console-address`, modern MinIO assigns a **random dynamic port** for the console, so accessing `:9000` in a browser redirects to an unmapped random port (e.g., `:43589`).

Changes in both `docker-compose.yml` and `pgpm docker start --minio`:
- Add `--console-address ":9001"` to the MinIO server command
- Map port `9001` from the container to the host
- Update deprecated `MINIO_ACCESS_KEY`/`MINIO_SECRET_KEY` env vars → `MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD`

Aligns with the existing `constructive-hub/docker-compose.yml` which already has these settings.

## Review & Testing Checklist for Human

- [ ] Verify `pgpm docker start --minio` creates a container with both ports 9000 and 9001 mapped and the console is accessible at `http://localhost:9001`
- [ ] Confirm the MinIO API still works on port 9000 (e.g., `curl http://localhost:9000/minio/health/live`)

### Notes
- The `docker-compose.yml` still uses `minio/minio` (untagged latest) while CI uses `minio/minio:edge-cicd` — this is pre-existing and not changed here.
- `MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD` have been the canonical env vars since MinIO `RELEASE.2021-04-22`. The old names still work as fallbacks in most versions but log deprecation warnings.

Link to Devin session: https://app.devin.ai/sessions/2095d9c144df4cd98da2d760016693a3
Requested by: @pyramation