### PR TITLE
feat(pgpm): add --ollama and --gpu flags to pgpm docker

### DIFF
--- a/pgpm/cli/src/commands/docker.ts
+++ b/pgpm/cli/src/commands/docker.ts
@@ -24,6 +24,8 @@ PostgreSQL Options:
 
 Additional Services:
   --minio            Include MinIO S3-compatible object storage (API: 9000, Console: 9001)
+  --ollama           Include Ollama LLM inference server (API: 11434)
+  --gpu              Enable NVIDIA GPU passthrough for Ollama (requires NVIDIA Container Toolkit)
 
 General Options:
   --help, -h         Show this help message
@@ -32,12 +34,15 @@ General Options:
 Examples:
   pgpm docker start                           Start PostgreSQL only
   pgpm docker start --minio                   Start PostgreSQL + MinIO
+  pgpm docker start --ollama                  Start PostgreSQL + Ollama (CPU)
+  pgpm docker start --ollama --gpu            Start PostgreSQL + Ollama (NVIDIA GPU)
   pgpm docker start --port 5433               Start on custom port
   pgpm docker start --shm-size 4g             Start with 4GB shared memory
   pgpm docker start --recreate                Remove and recreate containers
   pgpm docker start --recreate --minio        Recreate PostgreSQL + MinIO
   pgpm docker stop                            Stop PostgreSQL
   pgpm docker stop --minio                    Stop PostgreSQL + MinIO
+  pgpm docker stop --ollama                   Stop PostgreSQL + Ollama
   pgpm docker ls                              List services and status
 `;
 
@@ -68,6 +73,7 @@ interface ServiceDefinition {
   env: Record<string, string>;
   command?: string[];
   volumes?: VolumeMapping[];
+  gpuCapable?: boolean;
 }
 
 const ADDITIONAL_SERVICES: Record<string, ServiceDefinition> = {
@@ -84,6 +90,16 @@ const ADDITIONAL_SERVICES: Record<string, ServiceDefinition> = {
     },
     command: ['server', '/data', '--console-address', ':9001'],
     volumes: [{ name: 'minio-data', containerPath: '/data' }],
+  },
+  ollama: {
+    name: 'ollama',
+    image: 'ollama/ollama',
+    ports: [
+      { host: 11434, container: 11434 },
+    ],
+    env: {},
+    volumes: [{ name: 'ollama-data', containerPath: '/root/.ollama' }],
+    gpuCapable: true,
   },
 };
 
@@ -243,7 +259,7 @@ async function stopContainer(name: string): Promise<void> {
   }
 }
 
-async function startService(service: ServiceDefinition, recreate: boolean): Promise<void> {
+async function startService(service: ServiceDefinition, recreate: boolean, gpu: boolean = false): Promise<void> {
   const { name, image, ports, env: serviceEnv, command } = service;
 
   const exists = await containerExists(name);
@@ -293,6 +309,10 @@ async function startService(service: ServiceDefinition, recreate: boolean): Prom
     for (const vol of service.volumes) {
       runArgs.push('-v', `${vol.name}:${vol.containerPath}`);
     }
+  }
+
+  if (gpu && service.gpuCapable) {
+    runArgs.push('--gpus', 'all');
   }
 
   runArgs.push(image);
@@ -382,13 +402,14 @@ export default async (
   const password = (args.password as string) || 'password';
   const shmSize = (args['shm-size'] as string) || (args.shmSize as string) || '2g';
   const recreate = args.recreate === true;
+  const gpu = args.gpu === true;
   const includedServices = resolveServiceFlags(args);
 
   switch (subcommand) {
   case 'start':
     await startContainer({ name, image, port, user, password, shmSize, recreate });
     for (const service of includedServices) {
-      await startService(service, recreate);
+      await startService(service, recreate, gpu);
     }
     break;
 


### PR DESCRIPTION
## Summary

Adds Ollama as an additional service to `pgpm docker`, following the same pattern as the existing `--minio` flag. Also introduces a `--gpu` flag for NVIDIA GPU passthrough.

```bash
pgpm docker start --ollama           # PostgreSQL + Ollama (CPU)
pgpm docker start --ollama --gpu     # PostgreSQL + Ollama (NVIDIA GPU)
pgpm docker stop --ollama
```

**What's new:**
- `ollama` entry in `ADDITIONAL_SERVICES` — port 11434, persistent volume at `/root/.ollama` for model storage
- `gpuCapable` boolean on `ServiceDefinition` — when `--gpu` is passed and the service is gpu-capable, `--gpus all` is added to the `docker run` args
- Help text and examples updated

This enables `pgpm docker start --ollama` as a one-command alternative to a separate Docker Compose file for projects that need local LLM inference (e.g. embedding generation in agentic-db).

## Review & Testing Checklist for Human

- [ ] **`--gpus all` arg ordering** — verify that placing `--gpus all` just before the image name in the Docker run args is valid (Docker docs say runtime flags must come before the image). The diff inserts it after volumes but before `image`, which should be correct.
- [ ] **`--gpu` without `--ollama`** — currently silently no-ops since no service is resolved. Confirm this is acceptable behavior vs. warning the user.
- [ ] **Manual smoke test** — run `pgpm docker start --ollama` locally and verify the container starts on port 11434 with the `ollama-data` volume. If you have an NVIDIA GPU, also test `--ollama --gpu`.

### Notes
- `gpuCapable` is designed to be reusable — any future service that supports GPU can set this flag without changing the CLI arg parsing
- No new dependencies; this is purely additive to the existing service architecture
- Related: agentic-db PR #7 will update its READMEs to reference `pgpm docker start --ollama` once this lands

Link to Devin session: https://app.devin.ai/sessions/f70461c2d0a74993a271488c3aa077b1
Requested by: @pyramation