### PR TITLE
feat: update authz descriptions + add BlueprintMembershipType for dynamic entity types

### DIFF
--- a/graphql/node-type-registry/src/authz/authz-entity-membership.ts
+++ b/graphql/node-type-registry/src/authz/authz-entity-membership.ts
@@ -18,7 +18,7 @@ export const AuthzEntityMembership: NodeTypeDefinition = {
           "integer",
           "string"
         ],
-        "description": "Scope: 1=app, 2=org, 3=group (or string name resolved via membership_types_module)"
+        "description": "Scope: 1=app, 2=org, 3+=dynamic entity types (or string name resolved via membership_types_module)"
       },
       "permission": {
         "type": "string",

--- a/graphql/node-type-registry/src/authz/authz-membership-check.ts
+++ b/graphql/node-type-registry/src/authz/authz-membership-check.ts
@@ -14,7 +14,7 @@ export const AuthzMembership: NodeTypeDefinition = {
           "integer",
           "string"
         ],
-        "description": "Scope: 1=app, 2=org, 3=group (or string name resolved via membership_types_module)"
+        "description": "Scope: 1=app, 2=org, 3+=dynamic entity types (or string name resolved via membership_types_module)"
       },
       "permission": {
         "type": "string",

--- a/graphql/node-type-registry/src/authz/authz-peer-ownership.ts
+++ b/graphql/node-type-registry/src/authz/authz-peer-ownership.ts
@@ -18,7 +18,7 @@ export const AuthzPeerOwnership: NodeTypeDefinition = {
           "integer",
           "string"
         ],
-        "description": "Scope: 1=app, 2=org, 3=group (or string name resolved via membership_types_module)"
+        "description": "Scope: 1=app, 2=org, 3+=dynamic entity types (or string name resolved via membership_types_module)"
       },
       "permission": {
         "type": "string",

--- a/graphql/node-type-registry/src/authz/authz-related-entity-membership.ts
+++ b/graphql/node-type-registry/src/authz/authz-related-entity-membership.ts
@@ -18,7 +18,7 @@ export const AuthzRelatedEntityMembership: NodeTypeDefinition = {
           "integer",
           "string"
         ],
-        "description": "Scope: 1=app, 2=org, 3=group (or string name resolved via membership_types_module)"
+        "description": "Scope: 1=app, 2=org, 3+=dynamic entity types (or string name resolved via membership_types_module)"
       },
       "obj_table_id": {
         "type": "string",

--- a/graphql/node-type-registry/src/authz/authz-related-peer-ownership.ts
+++ b/graphql/node-type-registry/src/authz/authz-related-peer-ownership.ts
@@ -18,7 +18,7 @@ export const AuthzRelatedPeerOwnership: NodeTypeDefinition = {
           "integer",
           "string"
         ],
-        "description": "Scope: 1=app, 2=org, 3=group (or string name resolved via membership_types_module)"
+        "description": "Scope: 1=app, 2=org, 3+=dynamic entity types (or string name resolved via membership_types_module)"
       },
       "obj_table_id": {
         "type": "string",

--- a/graphql/node-type-registry/src/blueprint-types.generated.ts
+++ b/graphql/node-type-registry/src/blueprint-types.generated.ts
@@ -372,7 +372,7 @@ export interface AuthzDirectOwnerAnyParams {
 }
 /** Membership check that verifies the user has membership (optionally with specific permission) without binding to any entity from the row. Uses EXISTS subquery against SPRT table. */
 export interface AuthzMembershipParams {
-  /* Scope: 1=app, 2=org, 3=group (or string name resolved via membership_types_module) */
+  /* Scope: 1=app, 2=org, 3+=dynamic entity types (or string name resolved via membership_types_module) */
   membership_type: number | string;
   /* Single permission name to check (resolved to bitstring mask) */
   permission?: string;
@@ -387,7 +387,7 @@ export interface AuthzMembershipParams {
 export interface AuthzEntityMembershipParams {
   /* Column name referencing the entity (e.g., entity_id, org_id) */
   entity_field: string;
-  /* Scope: 1=app, 2=org, 3=group (or string name resolved via membership_types_module) */
+  /* Scope: 1=app, 2=org, 3+=dynamic entity types (or string name resolved via membership_types_module) */
   membership_type?: number | string;
   /* Single permission name to check (resolved to bitstring mask) */
   permission?: string;
@@ -402,7 +402,7 @@ export interface AuthzEntityMembershipParams {
 export interface AuthzRelatedEntityMembershipParams {
   /* Column name on protected table referencing the join table */
   entity_field: string;
-  /* Scope: 1=app, 2=org, 3=group (or string name resolved via membership_types_module) */
+  /* Scope: 1=app, 2=org, 3+=dynamic entity types (or string name resolved via membership_types_module) */
   membership_type?: number | string;
   /* UUID of the join table (alternative to obj_schema/obj_table) */
   obj_table_id?: string;
@@ -490,7 +490,7 @@ export interface AuthzCompositeParams {
 export interface AuthzPeerOwnershipParams {
   /* Column name on protected table referencing the owning user (e.g., owner_id) */
   owner_field: string;
-  /* Scope: 1=app, 2=org, 3=group (or string name resolved via membership_types_module) */
+  /* Scope: 1=app, 2=org, 3+=dynamic entity types (or string name resolved via membership_types_module) */
   membership_type?: number | string;
   /* Single permission name to check on the current user membership (resolved to bitstring mask) */
   permission?: string;
@@ -505,7 +505,7 @@ export interface AuthzPeerOwnershipParams {
 export interface AuthzRelatedPeerOwnershipParams {
   /* Column name on protected table referencing the related table (e.g., message_id) */
   entity_field: string;
-  /* Scope: 1=app, 2=org, 3=group (or string name resolved via membership_types_module) */
+  /* Scope: 1=app, 2=org, 3+=dynamic entity types (or string name resolved via membership_types_module) */
   membership_type?: number | string;
   /* UUID of the related table (alternative to obj_schema/obj_table) */
   obj_table_id?: string;

--- a/graphql/node-type-registry/src/blueprint-types.generated.ts
+++ b/graphql/node-type-registry/src/blueprint-types.generated.ts
@@ -796,6 +796,29 @@ export interface BlueprintTableUniqueConstraint {
   /** Optional schema name override. */
   schema_name?: string;
 }
+/** A membership type entry for Phase 0 of construct_blueprint(). Provisions a full entity type with its own entity table, membership modules, and security policies via entity_type_provision. */
+export interface BlueprintMembershipType {
+  /** Entity type name (e.g., "data_room", "channel", "department"). Must be unique per database. */
+  name: string;
+  /** Short prefix for generated objects (e.g., "dr", "ch", "dept"). Used in table/trigger naming. */
+  prefix: string;
+  /** Human-readable description of this entity type. */
+  description?: string;
+  /** Parent entity type name. Defaults to "org". */
+  parent_entity?: string;
+  /** Custom table name for the entity table. Defaults to name-derived convention. */
+  table_name?: string;
+  /** Whether this entity type is visible in the API. Defaults to true. */
+  is_visible?: boolean;
+  /** Whether to provision a limits module for this entity type. Defaults to false. */
+  has_limits?: boolean;
+  /** Whether to provision a profiles module for this entity type. Defaults to false. */
+  has_profiles?: boolean;
+  /** Whether to provision a levels module for this entity type. Defaults to false. */
+  has_levels?: boolean;
+  /** Whether to skip creating default RLS policies on the entity table. Defaults to false. */
+  skip_entity_policies?: boolean;
+}
 /**
  * ===========================================================================
  * Node types -- discriminated union for nodes[] entries
@@ -1015,4 +1038,6 @@ export interface BlueprintDefinition {
   full_text_searches?: BlueprintFullTextSearch[];
   /** Unique constraints on table columns. */
   unique_constraints?: BlueprintUniqueConstraint[];
+  /** Entity types to provision in Phase 0 (before tables). Each entry creates an entity table with membership modules and security. */
+  membership_types?: BlueprintMembershipType[];
 }

--- a/graphql/node-type-registry/src/codegen/generate-types.ts
+++ b/graphql/node-type-registry/src/codegen/generate-types.ts
@@ -599,6 +599,54 @@ function buildBlueprintTableUniqueConstraint(): t.ExportNamedDeclaration {
   );
 }
 
+function buildBlueprintMembershipType(): t.ExportNamedDeclaration {
+  return addJSDoc(
+    exportInterface('BlueprintMembershipType', [
+      addJSDoc(
+        requiredProp('name', t.tsStringKeyword()),
+        'Entity type name (e.g., "data_room", "channel", "department"). Must be unique per database.'
+      ),
+      addJSDoc(
+        requiredProp('prefix', t.tsStringKeyword()),
+        'Short prefix for generated objects (e.g., "dr", "ch", "dept"). Used in table/trigger naming.'
+      ),
+      addJSDoc(
+        optionalProp('description', t.tsStringKeyword()),
+        'Human-readable description of this entity type.'
+      ),
+      addJSDoc(
+        optionalProp('parent_entity', t.tsStringKeyword()),
+        'Parent entity type name. Defaults to "org".'
+      ),
+      addJSDoc(
+        optionalProp('table_name', t.tsStringKeyword()),
+        'Custom table name for the entity table. Defaults to name-derived convention.'
+      ),
+      addJSDoc(
+        optionalProp('is_visible', t.tsBooleanKeyword()),
+        'Whether this entity type is visible in the API. Defaults to true.'
+      ),
+      addJSDoc(
+        optionalProp('has_limits', t.tsBooleanKeyword()),
+        'Whether to provision a limits module for this entity type. Defaults to false.'
+      ),
+      addJSDoc(
+        optionalProp('has_profiles', t.tsBooleanKeyword()),
+        'Whether to provision a profiles module for this entity type. Defaults to false.'
+      ),
+      addJSDoc(
+        optionalProp('has_levels', t.tsBooleanKeyword()),
+        'Whether to provision a levels module for this entity type. Defaults to false.'
+      ),
+      addJSDoc(
+        optionalProp('skip_entity_policies', t.tsBooleanKeyword()),
+        'Whether to skip creating default RLS policies on the entity table. Defaults to false.'
+      ),
+    ]),
+    'A membership type entry for Phase 0 of construct_blueprint(). Provisions a full entity type with its own entity table, membership modules, and security policies via entity_type_provision.'
+  );
+}
+
 function buildBlueprintTable(): t.ExportNamedDeclaration {
   return addJSDoc(
     exportInterface('BlueprintTable', [
@@ -711,6 +759,15 @@ function buildBlueprintDefinition(): t.ExportNamedDeclaration {
         ),
         'Unique constraints on table columns.'
       ),
+      addJSDoc(
+        optionalProp(
+          'membership_types',
+          t.tsArrayType(
+            t.tsTypeReference(t.identifier('BlueprintMembershipType'))
+          )
+        ),
+        'Entity types to provision in Phase 0 (before tables). Each entry creates an entity table with membership modules and security.'
+      ),
     ]),
     'The complete blueprint definition -- the JSONB shape accepted by construct_blueprint().'
   );
@@ -782,6 +839,7 @@ function buildProgram(meta?: MetaTableInfo[]): string {
   statements.push(buildBlueprintTableIndex());
   statements.push(buildBlueprintUniqueConstraint());
   statements.push(buildBlueprintTableUniqueConstraint());
+  statements.push(buildBlueprintMembershipType());
 
   // -- Node types discriminated union --
   statements.push(


### PR DESCRIPTION
## Summary

Two changes to the node type registry to support dynamic entity types:

**1. Authz description updates** — Updates the `membership_type` parameter description across all 5 authz node type definitions from `"3=group"` to `"3+=dynamic entity types"`. This reflects that membership types ≥3 are no longer hardcoded as "group" — they are now dynamically registered entity types (data rooms, channels, departments, etc.) provisioned via `membership_types_module`.

**2. New `BlueprintMembershipType` interface** — Adds the TypeScript type for the `membership_types[]` array in `BlueprintDefinition`, matching the JSONB shape that `construct_blueprint()` Phase 0 reads from `entity_type_provision`. This was missing — the SQL procedure already supported it but the TS types didn't expose it.

```ts
export interface BlueprintMembershipType {
  name: string;              // e.g., "data_room", "channel"
  prefix: string;            // e.g., "dr", "ch"
  description?: string;
  parent_entity?: string;    // DEFAULT 'org'
  table_name?: string;
  is_visible?: boolean;      // DEFAULT true
  has_limits?: boolean;      // DEFAULT false
  has_profiles?: boolean;    // DEFAULT false
  has_levels?: boolean;      // DEFAULT false
  skip_entity_policies?: boolean; // DEFAULT false
}
```

**Files changed (source):**
- `authz-membership-check.ts` — description update
- `authz-entity-membership.ts` — description update
- `authz-peer-ownership.ts` — description update
- `authz-related-entity-membership.ts` — description update
- `authz-related-peer-ownership.ts` — description update
- `codegen/generate-types.ts` — new `buildBlueprintMembershipType()` function + wired into `buildBlueprintDefinition()` and `buildProgram()`

**Regenerated:** `blueprint-types.generated.ts` via `pnpm generate:types`

Companion to [constructive-db PR #813](https://github.com/constructive-io/constructive-db/pull/813) which renames `create_group`/`admin_group`/`create_organizations` → `create_entity`/`admin_entity` in the SQL generators and test files.

## Review & Testing Checklist for Human

- [ ] **Verify `BlueprintMembershipType` fields match the SQL** — compare the interface fields against the `INSERT INTO entity_type_provision` in `construct_blueprint()` ([procedure.sql](https://github.com/constructive-io/constructive-db/blob/develop/packages/metaschema/deploy/schemas/metaschema_modules_public/procedures/construct_blueprint/procedure.sql)). Any mismatch means blueprints built with this type would produce invalid JSONB.
- [ ] **Regenerate and diff** — run `cd graphql/node-type-registry && pnpm generate:types` locally and confirm the output matches `blueprint-types.generated.ts` exactly (no manual edits crept in).
- [ ] **Grep for `3=group`** — confirm no other files in the repo still reference the old description.

### Notes
- No logic changes — the authz updates are purely documentation strings in JSON schemas and their generated TypeScript type comments.
- The `BlueprintMembershipType` is a static type definition (not introspection-driven) since `entity_type_provision` is a provisioning table, not a regular _meta-exposed table.
- After this merges, the `node_type_registry` seed SQL in `constructive-db` should be regenerated so the deployed DB seed reflects the updated descriptions and new type.

Link to Devin session: https://app.devin.ai/sessions/61be2d8e471048e294178e4a95d7e9dc
Requested by: @pyramation