### PR TITLE
feat: add entity_type field to all 5 authz policy types

### DIFF
--- a/graphql/node-type-registry/src/authz/authz-entity-membership.ts
+++ b/graphql/node-type-registry/src/authz/authz-entity-membership.ts
@@ -20,6 +20,10 @@ export const AuthzEntityMembership: NodeTypeDefinition = {
         ],
         "description": "Scope: 1=app, 2=org, 3+=dynamic entity types (or string name resolved via membership_types_module)"
       },
+      "entity_type": {
+        "type": "string",
+        "description": "Entity type prefix (e.g. 'channel', 'department'). Resolved to membership_type integer via memberships_module lookup. Use instead of membership_type for readability."
+      },
       "permission": {
         "type": "string",
         "description": "Single permission name to check (resolved to bitstring mask)"

--- a/graphql/node-type-registry/src/authz/authz-membership-check.ts
+++ b/graphql/node-type-registry/src/authz/authz-membership-check.ts
@@ -16,6 +16,10 @@ export const AuthzMembership: NodeTypeDefinition = {
         ],
         "description": "Scope: 1=app, 2=org, 3+=dynamic entity types (or string name resolved via membership_types_module)"
       },
+      "entity_type": {
+        "type": "string",
+        "description": "Entity type prefix (e.g. 'channel', 'department'). Resolved to membership_type integer via memberships_module lookup. Use instead of membership_type for readability."
+      },
       "permission": {
         "type": "string",
         "description": "Single permission name to check (resolved to bitstring mask)"
@@ -36,9 +40,7 @@ export const AuthzMembership: NodeTypeDefinition = {
         "description": "If true, require is_owner flag"
       }
     },
-    "required": [
-      "membership_type"
-    ]
+    "required": []
   },
   "tags": [
     "membership",

--- a/graphql/node-type-registry/src/authz/authz-peer-ownership.ts
+++ b/graphql/node-type-registry/src/authz/authz-peer-ownership.ts
@@ -20,6 +20,10 @@ export const AuthzPeerOwnership: NodeTypeDefinition = {
         ],
         "description": "Scope: 1=app, 2=org, 3+=dynamic entity types (or string name resolved via membership_types_module)"
       },
+      "entity_type": {
+        "type": "string",
+        "description": "Entity type prefix (e.g. 'channel', 'department'). Resolved to membership_type integer via memberships_module lookup. Use instead of membership_type for readability."
+      },
       "permission": {
         "type": "string",
         "description": "Single permission name to check on the current user membership (resolved to bitstring mask)"

--- a/graphql/node-type-registry/src/authz/authz-related-entity-membership.ts
+++ b/graphql/node-type-registry/src/authz/authz-related-entity-membership.ts
@@ -20,6 +20,10 @@ export const AuthzRelatedEntityMembership: NodeTypeDefinition = {
         ],
         "description": "Scope: 1=app, 2=org, 3+=dynamic entity types (or string name resolved via membership_types_module)"
       },
+      "entity_type": {
+        "type": "string",
+        "description": "Entity type prefix (e.g. 'channel', 'department'). Resolved to membership_type integer via memberships_module lookup. Use instead of membership_type for readability."
+      },
       "obj_table_id": {
         "type": "string",
         "format": "uuid",

--- a/graphql/node-type-registry/src/authz/authz-related-peer-ownership.ts
+++ b/graphql/node-type-registry/src/authz/authz-related-peer-ownership.ts
@@ -20,6 +20,10 @@ export const AuthzRelatedPeerOwnership: NodeTypeDefinition = {
         ],
         "description": "Scope: 1=app, 2=org, 3+=dynamic entity types (or string name resolved via membership_types_module)"
       },
+      "entity_type": {
+        "type": "string",
+        "description": "Entity type prefix (e.g. 'channel', 'department'). Resolved to membership_type integer via memberships_module lookup. Use instead of membership_type for readability."
+      },
       "obj_table_id": {
         "type": "string",
         "format": "uuid",


### PR DESCRIPTION
## Summary

Adds a new `entity_type` string property to the `parameter_schema` of all 5 authz node type definitions in the node-type-registry:

- `AuthzMembership`
- `AuthzEntityMembership`
- `AuthzRelatedEntityMembership`
- `AuthzPeerOwnership`
- `AuthzRelatedPeerOwnership`

This lets policy definitions use `entity_type: 'channel'` (the entity prefix string) instead of `membership_type: 3` (a hardcoded integer that depends on provisioning order). The RLS parser resolves the prefix to the correct `membership_type` integer via `memberships_module` lookup at parse time.

For `AuthzMembership`, the `required` array is changed from `["membership_type"]` to `[]` — either `membership_type` or `entity_type` must be provided, but this is now validated server-side in `parse.sql` rather than by the JSON schema.

Companion to [constructive-db PR #816](https://github.com/constructive-io/constructive-db/pull/816) which implements the actual `parse_policy_sprt_entity_type()` resolution function.

## Review & Testing Checklist for Human

- [ ] **`required: []` on AuthzMembership** — Previously `membership_type` was required by the schema. Now neither field is required at the schema level; validation is deferred to the server (`parse.sql` checks `IF membership_type IS NULL AND entity_type IS NULL`). Verify no client-side code relies on this schema validation to catch missing fields before they reach the server.
- [ ] **Merge ordering** — constructive-db PR #816 must be deployed before anyone uses `entity_type` in a policy node, otherwise the RLS parser won't recognize the field. Confirm the deployment sequence.
- [ ] **Generated code** — If the node-type-registry schemas feed into downstream codegen (e.g. `pnpm generate:types`), regenerated output may need updating in a follow-up. Check whether the seed SQL in constructive-db also needs regeneration to reflect these schema changes.

### Notes
- The 4 other authz types (`AuthzEntityMembership`, `AuthzRelatedEntityMembership`, `AuthzPeerOwnership`, `AuthzRelatedPeerOwnership`) already had `membership_type` as optional in their `required` arrays, so adding `entity_type` there is purely additive with no validation behavior change.
- No runtime logic changes — these are static JSON schema definitions only.

Link to Devin session: https://app.devin.ai/sessions/61be2d8e471048e294178e4a95d7e9dc
Requested by: @pyramation