### PR TITLE
docs(graphile-postgis): lead spatial-relation examples with ORM `where:` shape

### DIFF
--- a/graphile/graphile-postgis/README.md
+++ b/graphile/graphile-postgis/README.md
@@ -81,23 +81,50 @@ COMMENT ON COLUMN <owner_table>.<owner_col> IS
 
 ### Filter shapes
 
-2-arg operators use the familiar `some` / `every` / `none` shape:
+2-arg operators use the familiar `some` / `every` / `none` shape.
+
+Through the generated ORM (`where:`):
+
+```ts
+await orm.telemedicineClinic
+  .findMany({
+    select: { id: true, name: true },
+    where: { county: { some: { name: { equalTo: 'California County' } } } },
+  })
+  .execute();
+```
+
+Or equivalently at the GraphQL layer (`filter:`):
 
 ```graphql
 telemedicineClinics(
-  filter: { county: { some: { name: { eq: "California County" } } } }
+  filter: { county: { some: { name: { equalTo: "California County" } } } }
 ) { nodes { id name } }
 ```
 
 `st_dwithin` takes its distance at the relation level (it parametrises
 the join, not the joined row):
 
+```ts
+await orm.telemedicineClinic
+  .findMany({
+    select: { id: true, name: true },
+    where: {
+      nearbyClinic: {
+        distance: 5000,
+        some: { specialty: { equalTo: 'pediatrics' } },
+      },
+    },
+  })
+  .execute();
+```
+
 ```graphql
 telemedicineClinics(
   filter: {
     nearbyClinic: {
       distance: 5000
-      some: { specialty: { eq: "pediatrics" } }
+      some: { specialty: { equalTo: "pediatrics" } }
     }
   }
 ) { nodes { id name } }


### PR DESCRIPTION
## Summary

Docs-only follow-up to #993. The README for `@spatialRelation` previously only showed GraphQL `filter:` examples, but most consumers use the generated ORM (`where:`). This adds ORM-shaped examples above each GraphQL example so readers can copy the form that matches their layer.

Also fixes a stale `eq` → `equalTo` in the GraphQL examples (the graphile-connection-filter idiom is `equalTo`; this is the same fix applied to the test suite in #993).

## Review & Testing Checklist for Human

- [ ] Confirm the ORM snippets (`orm.telemedicineClinic.findMany({ where: { … } }).execute()`) match your preferred documentation style — they mirror the shape used in the E2E test at `graphql/orm-test/__tests__/postgis-spatial-relations.test.ts` but the README isn't executed, so typos would go unnoticed.
- [ ] Skim-render the README on the PR page to check the two layers (`where:` ORM block → `filter:` GraphQL block) read cleanly in sequence.

### Notes

No code changes, no new tests; CI will just run the existing suite. Zero expected behaviour change.

Link to Devin session: https://app.devin.ai/sessions/c5eeee65a3c546c4ac6753bb05fa03e0
Requested by: @pyramation