### PR TITLE
chore: scrub stale `filter` argument references in comments/errors

### DIFF
--- a/graphile/graphile-connection-filter/src/plugins/ConnectionFilterArgPlugin.ts
+++ b/graphile/graphile-connection-filter/src/plugins/ConnectionFilterArgPlugin.ts
@@ -7,9 +7,10 @@ const version = '1.0.0';
 /**
  * ConnectionFilterArgPlugin
  *
- * Adds the filter argument (configurable name, default 'where') to connection
- * and simple collection fields. Uses `applyPlan` to create a PgCondition that
- * child filter fields can add WHERE clauses to.
+ * Adds the `where` argument (name configurable via
+ * `connectionFilterArgumentName`, default `'where'`) to connection and
+ * simple collection fields. Uses `applyPlan` to create a PgCondition
+ * that child filter fields can add WHERE clauses to.
  *
  * This runs before PgConnectionArgOrderByPlugin so that filters are applied
  * before ordering (important for e.g. full-text search rank ordering).
@@ -17,7 +18,7 @@ const version = '1.0.0';
 export const ConnectionFilterArgPlugin: GraphileConfig.Plugin = {
   name: 'ConnectionFilterArgPlugin',
   version,
-  description: 'Adds the filter argument to connection and list fields',
+  description: 'Adds the `where` argument to connection and list fields',
   before: ['PgConnectionArgOrderByPlugin'],
 
   schema: {
@@ -100,7 +101,7 @@ export const ConnectionFilterArgPlugin: GraphileConfig.Plugin = {
                           fieldArg.apply(
                             $pgSelect,
                             (queryBuilder: any, value: any) => {
-                              // If filter is null/undefined or empty {}, treat as "no filter" — skip
+                              // If where is null/undefined or empty {}, treat as "no filter" — skip
                               if (value == null || isEmpty(value)) return;
                               const condition = new PgCondition(queryBuilder);
                               if (attributeCodec) {
@@ -126,7 +127,7 @@ export const ConnectionFilterArgPlugin: GraphileConfig.Plugin = {
                           fieldArg.apply(
                             $pgSelect,
                             (queryBuilder: any, value: any) => {
-                              // If filter is null/undefined or empty {}, treat as "no filter" — skip
+                              // If where is null/undefined or empty {}, treat as "no filter" — skip
                               if (value == null || isEmpty(value)) return;
                               const condition = new PgCondition(queryBuilder);
                               if (attributeCodec) {
@@ -143,7 +144,7 @@ export const ConnectionFilterArgPlugin: GraphileConfig.Plugin = {
                   }),
             },
           },
-          `Adding connection filter '${argName}' arg to field '${fieldName}' of '${Self.name}'`
+          `Adding connection where arg '${argName}' to field '${fieldName}' of '${Self.name}'`
         );
       },
     },

--- a/graphile/graphile-connection-filter/src/plugins/ConnectionFilterAttributesPlugin.ts
+++ b/graphile/graphile-connection-filter/src/plugins/ConnectionFilterAttributesPlugin.ts
@@ -96,7 +96,7 @@ export const ConnectionFilterAttributesPlugin: GraphileConfig.Plugin = {
                         if (isEmpty(value)) {
                           throw Object.assign(
                             new Error(
-                              'Empty objects are forbidden in filter argument input.'
+                              'Empty objects are forbidden in where argument input.'
                             ),
                             {}
                           );
@@ -107,7 +107,7 @@ export const ConnectionFilterAttributesPlugin: GraphileConfig.Plugin = {
                         ) {
                           throw Object.assign(
                             new Error(
-                              'Null literals are forbidden in filter argument input.'
+                              'Null literals are forbidden in where argument input.'
                             ),
                             {}
                           );

--- a/graphile/graphile-connection-filter/src/plugins/ConnectionFilterBackwardRelationsPlugin.ts
+++ b/graphile/graphile-connection-filter/src/plugins/ConnectionFilterBackwardRelationsPlugin.ts
@@ -15,7 +15,7 @@ const version = '1.0.0';
  *
  * For unique backward relations (one-to-one), a single filter field is added:
  * ```graphql
- * allClients(filter: {
+ * allClients(where: {
  *   profileByClientId: { bio: { includes: "engineer" } }
  * }) { ... }
  * ```
@@ -23,7 +23,7 @@ const version = '1.0.0';
  * For non-unique backward relations (one-to-many), a "many" filter type is added
  * with `some`, `every`, and `none` sub-fields:
  * ```graphql
- * allClients(filter: {
+ * allClients(where: {
  *   ordersByClientId: { some: { total: { greaterThan: 1000 } } }
  * }) { ... }
  * ```

--- a/graphile/graphile-connection-filter/src/plugins/ConnectionFilterComputedAttributesPlugin.ts
+++ b/graphile/graphile-connection-filter/src/plugins/ConnectionFilterComputedAttributesPlugin.ts
@@ -18,7 +18,7 @@ const version = '1.0.0';
  *
  * This plugin adds a `fullName` filter field to `PersonFilter`, typed as `StringFilter`,
  * allowing queries like:
- *   { people(filter: { fullName: { startsWith: "John" } }) { ... } }
+ *   { people(where: { fullName: { startsWith: "John" } }) { ... } }
  *
  * Controlled by the `connectionFilterComputedColumns` schema option (default: true).
  * Requires the `filterBy` behavior on the pgResource to be enabled.

--- a/graphile/graphile-connection-filter/src/plugins/ConnectionFilterForwardRelationsPlugin.ts
+++ b/graphile/graphile-connection-filter/src/plugins/ConnectionFilterForwardRelationsPlugin.ts
@@ -18,7 +18,7 @@ const version = '1.0.0';
  * allowing queries like:
  *
  * ```graphql
- * allOrders(filter: {
+ * allOrders(where: {
  *   clientByClientId: { name: { startsWith: "Acme" } }
  * }) { ... }
  * ```

--- a/graphile/graphile-connection-filter/src/plugins/operatorApply.ts
+++ b/graphile/graphile-connection-filter/src/plugins/operatorApply.ts
@@ -83,7 +83,7 @@ export function makeApplyFromOperatorSpec(
         }
         if (!connectionFilterAllowNullInput && value === null) {
           throw Object.assign(
-            new Error('Null literals are forbidden in filter argument input.'),
+            new Error('Null literals are forbidden in where argument input.'),
             {}
           );
         }

--- a/graphile/graphile-connection-filter/src/utils.ts
+++ b/graphile/graphile-connection-filter/src/utils.ts
@@ -116,11 +116,11 @@ export function makeAssertAllowed(build: any): (value: unknown, mode: 'object' |
       isEmpty: (o: unknown) => boolean
     ) =>
       function (value: unknown, mode: 'object' | 'list') {
-        // Reject empty objects in nested filter contexts (and/or/not, relation filters)
+        // Reject empty objects in nested where contexts (and/or/not, relation filters)
         if (mode === 'object' && isEmpty(value)) {
           throw Object.assign(
             new Error(
-              'Empty objects are forbidden in filter argument input.'
+              'Empty objects are forbidden in where argument input.'
             ),
             {}
           );
@@ -134,7 +134,7 @@ export function makeAssertAllowed(build: any): (value: unknown, mode: 'object' |
               if (isEmpty(arr[i])) {
                 throw Object.assign(
                   new Error(
-                    'Empty objects are forbidden in filter argument input.'
+                    'Empty objects are forbidden in where argument input.'
                   ),
                   {}
                 );
@@ -147,7 +147,7 @@ export function makeAssertAllowed(build: any): (value: unknown, mode: 'object' |
         if (!connectionFilterAllowNullInput && value === null) {
           throw Object.assign(
             new Error(
-              'Null literals are forbidden in filter argument input.'
+              'Null literals are forbidden in where argument input.'
             ),
             {}
           );

--- a/graphile/graphile-postgis/src/plugins/spatial-relations.ts
+++ b/graphile/graphile-postgis/src/plugins/spatial-relations.ts
@@ -46,7 +46,7 @@ import type { PostgisExtensionInfo } from './detect-extension';
  * Generated GraphQL (for the `st_dwithin` case):
  *
  * ```graphql
- * telemedicineClinics(filter: {
+ * telemedicineClinics(where: {
  *   nearbyClinic: {
  *     distance: 5000,
  *     some: { specialty: { eq: "pediatrics" } }

--- a/graphile/graphile-settings/__tests__/preset-integration.test.ts
+++ b/graphile/graphile-settings/__tests__/preset-integration.test.ts
@@ -131,7 +131,7 @@ describe('Schema introspection', () => {
     expect(fieldNames).toContain('embedding');
   });
 
-  it('locations connection exists and has filter argument but no condition', async () => {
+  it('locations connection exists and has where argument but no condition', async () => {
     const result = await query<{ __type: { fields: { name: string; args: { name: string }[] }[] } | null }>({
       query: `
         query {

--- a/graphile/graphile-settings/src/plugins/enable-all-filter-columns.ts
+++ b/graphile/graphile-settings/src/plugins/enable-all-filter-columns.ts
@@ -39,7 +39,7 @@ import type { GraphileConfig } from 'graphile-config';
  * and adds `+attribute:filterBy` and `+attribute:orderBy` back to ALL columns, regardless of index status.
  *
  * This means:
- * - All columns will appear in the connection filter's filter argument
+ * - All columns will appear in the connection filter's `where` argument
  * - All columns will appear in the connection's orderBy enum
  * - Developers can filter and sort by any column
  * - It's the developer's/DBA's responsibility to add indexes for frequently filtered/sorted columns

--- a/graphile/graphile-settings/src/presets/constructive-preset.ts
+++ b/graphile/graphile-settings/src/presets/constructive-preset.ts
@@ -54,8 +54,8 @@ import { getBucketProvisionerConnection } from '../bucket-provisioner-resolver';
  *
  * RELATION FILTERS:
  * - Enabled via connectionFilterRelations: true
- * - Forward: filter child by parent (e.g. allOrders(filter: { clientByClientId: { name: { startsWith: "Acme" } } }))
- * - Backward: filter parent by children (e.g. allClients(filter: { ordersByClientId: { some: { total: { greaterThan: 1000 } } } }))
+ * - Forward: filter child by parent (e.g. allOrders(where: { clientByClientId: { name: { startsWith: "Acme" } } }))
+ * - Backward: filter parent by children (e.g. allClients(where: { ordersByClientId: { some: { total: { greaterThan: 1000 } } } }))
  *
  * USAGE:
  * ```typescript
@@ -105,9 +105,11 @@ export const ConstructivePreset: GraphileConfig.Preset = {
   ],
   /**
    * Disable PostGraphile core's condition argument entirely.
-   * All filtering now lives under the `filter` argument via our v5-native
-   * graphile-connection-filter plugin. Search, BM25, pgvector, and PostGIS
-   * filter fields all hook into `isPgConnectionFilter` instead of `isPgCondition`.
+   * All filtering now lives under the `where` argument via our v5-native
+   * graphile-connection-filter plugin (which renames the default `filter`
+   * argument to `where` via `connectionFilterArgumentName: 'where'`).
+   * Search, BM25, pgvector, and PostGIS filter fields all hook into
+   * `isPgConnectionFilter` instead of `isPgCondition`.
    */
   disablePlugins: [
     'PgConditionArgumentPlugin',
@@ -116,7 +118,7 @@ export const ConstructivePreset: GraphileConfig.Preset = {
   /**
    * Connection Filter Plugin Configuration
    *
-   * These options control what fields appear in the `filter` argument on connections.
+   * These options control what fields appear in the `where` argument on connections.
    * Our v5-native graphile-connection-filter plugin controls relation filters via the
    * `connectionFilterRelations` option passed to ConnectionFilterPreset().
    *
@@ -144,14 +146,14 @@ export const ConstructivePreset: GraphileConfig.Preset = {
     /**
      * connectionFilterLogicalOperators: true (default)
      * Keeps `and`, `or`, `not` operators for combining filter conditions.
-     * Example: filter: { or: [{ name: { eq: "foo" } }, { name: { eq: "bar" } }] }
+     * Example: where: { or: [{ name: { eq: "foo" } }, { name: { eq: "bar" } }] }
      */
     connectionFilterLogicalOperators: true,
 
     /**
      * connectionFilterArrays: true (default)
      * Allows filtering on PostgreSQL array columns.
-     * Example: filter: { tags: { contains: ["important"] } }
+     * Example: where: { tags: { contains: ["important"] } }
      */
     connectionFilterArrays: true,
 


### PR DESCRIPTION
## Summary

Follow-up cleanup to #995. The GraphQL connection argument was renamed from `filter` to `where` in commit 10b4fc6 (via `connectionFilterArgumentName: 'where'` defaulted in `graphile-connection-filter`'s preset), but a number of JSDoc examples, plugin descriptions, error strings, and preset comments were not updated at the time. This PR scrubs them.

Changes are almost entirely in comments/docstrings. The only behavior-adjacent diffs are:

1. Two error message strings renamed:
   - `"Empty objects are forbidden in filter argument input."` → `"...in where argument input."`
   - `"Null literals are forbidden in filter argument input."` → `"...in where argument input."`
2. One test case title renamed to match what it actually asserts (`where` arg, not `filter`).
3. One internal `extend(...)` log string renamed (not user-visible, just debug output).

Specifically updated:

- `graphile-connection-filter`: JSDoc examples (`filter:` → `where:`) in `ConnectionFilter{Forward,Backward,ComputedAttributes}RelationsPlugin`, the `ConnectionFilterArgPlugin` top-level JSDoc + `description` string + inline comments, and the two error message strings in `utils.ts`, `ConnectionFilterAttributesPlugin.ts`, and `operatorApply.ts`.
- `graphile-postgis`: JSDoc example in `spatial-relations.ts`.
- `graphile-settings`: corrected the misleading preset comments in `constructive-preset.ts` (the ones that tripped me up in #995 and made me think the GraphQL arg was still `filter:`), updated an example comment in `enable-all-filter-columns.ts`, and renamed the preset-integration test case title.

## Review & Testing Checklist for Human

- [ ] Confirm you're OK with the two error message text changes — anyone downstream matching on the exact string `'... forbidden in filter argument input.'` (equality check, not substring) would need to update their match. I grepped the repo for these strings and the only call sites are the three source files in this diff; no test snapshots reference them.
- [ ] Skim the preset comments in `graphile/graphile-settings/src/presets/constructive-preset.ts` — the rewritten block about "filtering now lives under the `where` argument" should read accurately to you.

### Notes

- No runtime behavior change other than the two error message strings mentioned above.
- Ran the individual `graphile-connection-filter` and `graphile-postgis` package builds locally; both clean. The workspace-level build fails on unrelated missing cross-package type declarations in my environment, but CI will do the full build.
- CHANGELOG entries that reference the historical `filter` → `where` rename commit were deliberately left alone — they're historical and accurate.

Link to Devin session: https://app.devin.ai/sessions/059b0c2e4594474aa107e3f83f83fe0f
Requested by: @pyramation