### PR TITLE
fix(codegen/cli): make autoEmbedWhere/autoEmbedInput generic in embedder template

### DIFF
--- a/graphql/codegen/src/core/codegen/templates/embedder.ts
+++ b/graphql/codegen/src/core/codegen/templates/embedder.ts
@@ -113,13 +113,14 @@ function buildEmbedder(config: EmbedderConfig): EmbedderFunction | null {
  * @param embedder - The resolved embedder function
  * @returns The modified where clause
  */
-export async function autoEmbedWhere(
-  where: Record<string, unknown>,
+export async function autoEmbedWhere<T extends object>(
+  where: T,
   vectorFieldNames: string[],
   embedder: EmbedderFunction,
-): Promise<Record<string, unknown>> {
+): Promise<T> {
+  const rec = where as unknown as Record<string, unknown>;
   for (const fieldName of vectorFieldNames) {
-    const fieldValue = where[fieldName];
+    const fieldValue = rec[fieldName];
     if (fieldValue && typeof fieldValue === 'object') {
       const input = fieldValue as Record<string, unknown>;
       // If 'vector' is a string, embed it
@@ -132,7 +133,7 @@ export async function autoEmbedWhere(
       // Shorthand: --where.vectorEmbedding "text" with --auto-embed
       // becomes { vector: [embedded], metric: 'COSINE' }
       const embedding = await embedder(fieldValue);
-      where[fieldName] = { vector: embedding };
+      rec[fieldName] = { vector: embedding };
     }
   }
   return where;
@@ -157,17 +158,18 @@ export async function autoEmbedWhere(
  * @param embedder - The resolved embedder function
  * @returns The modified data object with text values replaced by vectors
  */
-export async function autoEmbedInput(
-  data: Record<string, unknown>,
+export async function autoEmbedInput<T extends object>(
+  data: T,
   vectorFieldNames: string[],
   embedder: EmbedderFunction,
-): Promise<Record<string, unknown>> {
+): Promise<T> {
+  const rec = data as unknown as Record<string, unknown>;
   for (const fieldName of vectorFieldNames) {
-    const fieldValue = data[fieldName];
+    const fieldValue = rec[fieldName];
     if (typeof fieldValue === 'string') {
       // Text string → embed to vector array
       const embedding = await embedder(fieldValue);
-      data[fieldName] = embedding;
+      rec[fieldName] = embedding;
     }
     // If it's already an array (pre-computed vector), leave it as-is
   }


### PR DESCRIPTION
## Summary

The generated `embedder.ts` template at `graphql/codegen/src/core/codegen/templates/embedder.ts` currently types `autoEmbedWhere` and `autoEmbedInput` to accept `Record<string, unknown>` — but the CLI codegen emits call sites that pass concrete generated `*Filter` / `*Patch` types (no index signature). `ts-jest` is lenient enough that downstream test runs stay green, but the strict `tsc` pass on `lerna publish` fails with ~74 TS2345 errors per consumer ("… is not assignable to parameter of type 'Record<string, unknown>'").

This was already patched directly on the generated file in `constructive-io/agentic-db` as part of unblocking their `lerna publish` ([agentic-db#29](https://github.com/constructive-io/agentic-db/pull/29)). Without this upstream fix, the next `pnpm generate:all` in any consumer that uses the embedder helpers will regenerate the narrow signatures and re-break publish.

Fix: make both helpers generic, preserving the caller's concrete type and casting to `Record<string, unknown>` internally for field lookup. Runtime behavior is identical.

```ts
export async function autoEmbedWhere<T extends object>(
  where: T,
  vectorFieldNames: string[],
  embedder: EmbedderFunction,
): Promise<T> { /* unchanged body, typed through T */ }

export async function autoEmbedInput<T extends object>(
  data: T,
  vectorFieldNames: string[],
  embedder: EmbedderFunction,
): Promise<T> { /* unchanged body, typed through T */ }
```

## Review & Testing Checklist for Human

- [ ] Regenerate a consumer SDK (e.g. run `pnpm generate:all` in agentic-db against this branch) and confirm the regenerated `embedder.ts` matches the patch that landed in agentic-db PR #29.
- [ ] Confirm `lerna publish`'s strict tsc pass succeeds on a consumer that exercises `autoEmbedWhere` / `autoEmbedInput` call sites from CLI commands with concrete `*Filter` / `*Patch` types.

### Notes

- Template-only change; no runtime behavior difference and no change to `EmbedderFunction` or to the call-site codegen.
- The same generic signature is already live in `agentic-db` at `sdk/cli/generated/cli/embedder.ts`, so this upstream change just prevents the next regen from reverting it.

Link to Devin session: https://app.devin.ai/sessions/fabecb6a46504fc293feca22d9cc91d4
Requested by: @pyramation