### PR TITLE
fix(graphile-postgis): camelCase @spatialRelation field + PascalCase filter type

### DIFF
--- a/graphile/graphile-connection-filter/src/index.ts
+++ b/graphile/graphile-connection-filter/src/index.ts
@@ -49,6 +49,13 @@
  * ```
  */
 
+// Load the global type augmentations (inflection methods, build/scope
+// properties) so that downstream satellite plugins which `import
+// 'graphile-connection-filter'` pick up the `filterType`/`filterManyType`/
+// etc. type extensions without having to reach into the package's internal
+// file layout.
+import './augmentations';
+
 export { ConnectionFilterPreset } from './preset';
 
 // Re-export all plugins for granular use

--- a/graphile/graphile-postgis/__tests__/spatial-relations.test.ts
+++ b/graphile/graphile-postgis/__tests__/spatial-relations.test.ts
@@ -67,8 +67,16 @@ function buildMockRegistry(
 }
 
 function makeBuild(registry: any): any {
+  // Minimal inflection double — only `camelCase` is consulted by
+  // `collectSpatialRelations` (to normalize the parametric arg name).
+  const inflection = {
+    camelCase(str: string): string {
+      return str.replace(/[-_](.)/g, (_, c: string) => c.toUpperCase());
+    },
+  };
   return {
     input: { pgRegistry: registry },
+    inflection,
   };
 }
 
@@ -287,6 +295,27 @@ describe('collectSpatialRelations', () => {
     expect(rel.operator.name).toBe('st_dwithin');
     expect(rel.operator.parametric).toBe(true);
     expect(rel.paramFieldName).toBe('distance');
+  });
+
+  it('camelCases snake_case parametric arg names', () => {
+    // The @spatialRelation tag grammar accepts any [A-Za-z_][A-Za-z0-9_]*
+    // identifier for the parametric arg; the GraphQL field we expose for
+    // it must follow the same camelCase convention as every other field.
+    const registry = buildMockRegistry({
+      clinics: {
+        pk: ['id'],
+        attributes: {
+          id: { base: 'int4' },
+          location: {
+            base: 'geometry',
+            spatialRelation:
+              'nearbyClinic clinics.location st_dwithin travel_distance',
+          },
+        },
+      },
+    });
+    const [rel] = collectSpatialRelations(makeBuild(registry));
+    expect(rel.paramFieldName).toBe('travelDistance');
   });
 
   it('supports multiple tags on the same column (string[] form)', () => {

--- a/graphile/graphile-postgis/src/plugins/spatial-relations.ts
+++ b/graphile/graphile-postgis/src/plugins/spatial-relations.ts
@@ -322,6 +322,13 @@ export function collectSpatialRelations(build: any): SpatialRelationInfo[] {
   const pgRegistry = build.input?.pgRegistry;
   if (!pgRegistry) return [];
 
+  // Inflection is used to normalize user-supplied identifiers (the
+  // parametric arg name, e.g. `travel_distance` → `travelDistance`) into the
+  // GraphQL casing conventions. Fall back to identity if not available
+  // (e.g. when invoked from unit tests with a stub build).
+  const camelCase: (s: string) => string =
+    build.inflection?.camelCase?.bind(build.inflection) ?? ((s: string) => s);
+
   const relations: SpatialRelationInfo[] = [];
 
   for (const resource of Object.values(pgRegistry.pgResources) as any[]) {
@@ -400,7 +407,7 @@ export function collectSpatialRelations(build: any): SpatialRelationInfo[] {
           targetResource: target.resource,
           targetAttributeName: target.attributeName,
           operator: OPERATOR_REGISTRY[parsed.operator],
-          paramFieldName: parsed.paramName,
+          paramFieldName: parsed.paramName ? camelCase(parsed.paramName) : null,
           isSelfRelation,
           ownerPkAttributes,
           targetPkAttributes,
@@ -431,7 +438,10 @@ export function collectSpatialRelations(build: any): SpatialRelationInfo[] {
 function spatialFilterTypeName(build: any, rel: SpatialRelationInfo): string {
   const { inflection } = build;
   const ownerTypeName = inflection.tableType(rel.ownerCodec);
-  const rel0 = rel.relationName.charAt(0).toUpperCase() + rel.relationName.slice(1);
+  // Normalize the user-supplied relation name (which may be snake_case,
+  // kebab-case, or mixed) into PascalCase so the type name is consistent
+  // with every other generated GraphQL type name.
+  const rel0 = inflection.upperCamelCase(rel.relationName);
   return `${ownerTypeName}Spatial${rel0}Filter`;
 }
 
@@ -638,7 +648,10 @@ export const PostgisSpatialRelationsPlugin: GraphileConfig.Plugin = {
             const FilterType = build.getTypeByName(filterTypeName);
             if (!FilterType) continue;
 
-            const fieldName = rel.relationName;
+            // Normalize the user-supplied relation name (which may be
+            // snake_case, kebab-case, or mixed) into camelCase so the GraphQL
+            // field name matches the casing of every other generated field.
+            const fieldName = inflection.camelCase(rel.relationName);
             // Avoid clobbering fields an upstream plugin may have registered
             // (e.g. an FK-derived relation with the same name).
             if (fields[fieldName]) {


### PR DESCRIPTION
## Summary

A `@spatialRelation` tag like

```sql
COMMENT ON COLUMN places.geom IS
  E'@spatialRelation inside_neighborhood neighborhoods.geom st_within';
```

used to generate a filter whose casing passed the raw tag identifier through verbatim:

```ts
export interface PlaceFilter {
  // …
  /** Filter by rows from `Neighborhood` related to this row via `st_within`. */
  inside_neighborhood?: PlaceSpatialInside_neighborhoodFilter;
}
```

The fix routes the relation name through the standard Graphile inflectors so spatial-relation identifiers follow the same conventions as every other generated GraphQL type/field:

```ts
  insideNeighborhood?: PlaceSpatialInsideNeighborhoodFilter;
```

Concretely:

- <ref_snippet file="/home/ubuntu/repos/constructive/graphile/graphile-postgis/src/plugins/spatial-relations.ts" lines="430-439" /> — filter type name now uses `inflection.upperCamelCase(rel.relationName)` instead of a raw `charAt(0).toUpperCase()` splice.
- <ref_snippet file="/home/ubuntu/repos/constructive/graphile/graphile-postgis/src/plugins/spatial-relations.ts" lines="644-650" /> — the field name on the owner filter type now uses `inflection.camelCase(rel.relationName)`.
- <ref_snippet file="/home/ubuntu/repos/constructive/graphile/graphile-postgis/src/plugins/spatial-relations.ts" lines="325-330" /> — the parametric arg field name (e.g. `travel_distance` → `travelDistance`) is normalized at collection time so both the GraphQL field and the `value[paramFieldName]` read inside `apply()` stay consistent.

Both inflectors are idempotent on already-camelCased input, so existing tags such as `nearbyClinic` / `intersectingCounty` keep producing the exact same identifiers they do today (the `TelemedicineClinicFilter.nearbyClinic` / `distance` assertions in `graphql/orm-test/__tests__/postgis-spatial-relations.test.ts` all still hold).

### Drive-by: connection-filter augmentation barrel

While adding the test, `jest` surfaced a pre-existing TS2339 in the same plugin:

```
src/plugins/spatial-relations.ts:703:29 - error TS2339: Property 'filterType' does not exist on type 'Inflection'.
```

`graphile-connection-filter/src/augmentations.ts` declares the `filterType` / `filterManyType` inflection augmentations, but the package barrel never imported it — so any satellite plugin that only did `import 'graphile-connection-filter';` (as this one does) couldn't see the augmentations. Every plugin inside the package imports `../augmentations` directly, but downstream consumers can't reach into that path.

Fixed by loading the augmentations from the public barrel: <ref_snippet file="/home/ubuntu/repos/constructive/graphile/graphile-connection-filter/src/index.ts" lines="52-59" />

## Review & Testing Checklist for Human

- [ ] Regenerate the public SDK against a DB with at least one `@spatialRelation` tag and confirm the emitted `*Filter` interface now uses `camelCase` field names and `PascalCase` filter-type names (including the `PlaceSpatial*Filter` that triggered this).
- [ ] Confirm any hand-written callers of `where: { inside_neighborhood: … }` (should be none, but worth a quick grep across downstream apps) — the field name changes from snake_case to camelCase. This is a breaking change on the generated schema if anyone was somehow writing snake_case relation tags in production.
- [ ] Spot-check that a tag with a snake_case parametric arg name (e.g. `st_dwithin travel_distance`) produces a GraphQL field named `travelDistance` and that the subfilter still propagates the numeric value correctly at runtime.

### Notes

- All 250 `graphile-postgis` unit tests still pass; a new `camelCases snake_case parametric arg names` test pins the parametric-arg fix.
- No changes to the tag grammar, operator registry, or SQL emit path.


Link to Devin session: https://app.devin.ai/sessions/51d10f7657484009ba4b4c303b9704e4
Requested by: @pyramation