### PR TITLE
fix: remove non-existent 'size' column from upload_requests INSERTs

### DIFF
--- a/graphile/graphile-presigned-url-plugin/src/plugin.ts
+++ b/graphile/graphile-presigned-url-plugin/src/plugin.ts
@@ -385,9 +385,9 @@ export function createPresignedUrlPlugin(
                 // --- Track the upload request ---
                 await txClient.query({
                   text: `INSERT INTO ${storageConfig.uploadRequestsQualifiedName}
-                   (file_id, bucket_id, key, content_type, content_hash, size, status, expires_at)
-                   VALUES ($1, $2, $3, $4, $5, $6, 'issued', $7)`,
-                  values: [fileId, bucket.id, s3Key, contentType, contentHash, size, expiresAt],
+                   (file_id, bucket_id, key, content_type, content_hash, status, expires_at)
+                   VALUES ($1, $2, $3, $4, $5, 'issued', $6)`,
+                  values: [fileId, bucket.id, s3Key, contentType, contentHash, expiresAt],
                 });
 
                 return {

--- a/graphile/graphile-presigned-url-plugin/src/plugin.ts
+++ b/graphile/graphile-presigned-url-plugin/src/plugin.ts
@@ -318,9 +318,9 @@ export function createPresignedUrlPlugin(
                   // Track the dedup request
                   await txClient.query({
                     text: `INSERT INTO ${storageConfig.uploadRequestsQualifiedName}
-                     (file_id, bucket_id, key, content_type, content_hash, size, status, expires_at)
-                     VALUES ($1, $2, $3, $4, $5, $6, 'confirmed', NOW())`,
-                    values: [existingFile.id, bucket.id, s3Key, contentType, contentHash, size],
+                     (file_id, bucket_id, key, content_type, content_hash, status, expires_at)
+                     VALUES ($1, $2, $3, $4, $5, 'confirmed', NOW())`,
+                    values: [existingFile.id, bucket.id, s3Key, contentType, contentHash],
                   });
 
                   return {

--- a/graphql/server-test/__fixtures__/seed/simple-seed-storage/schema.sql
+++ b/graphql/server-test/__fixtures__/seed/simple-seed-storage/schema.sql
@@ -56,14 +56,16 @@ COMMENT ON TABLE "simple-storage-public".files IS E'@storageFiles\nStorage files
 CREATE TABLE IF NOT EXISTS "simple-storage-public".upload_requests (
   id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
   file_id uuid NOT NULL REFERENCES "simple-storage-public".files(id),
+  actor_id uuid,
   bucket_id uuid NOT NULL REFERENCES "simple-storage-public".buckets(id),
   key text NOT NULL,
   content_type text NOT NULL,
   content_hash text,
-  size bigint,
   status text NOT NULL DEFAULT 'issued',
   expires_at timestamptz,
   confirmed_at timestamptz,
+  ip_address inet,
+  user_agent text,
   created_at timestamptz DEFAULT now(),
   updated_at timestamptz DEFAULT now()
 );


### PR DESCRIPTION
## Summary

The `upload_requests` table (generated by `storage_module.sql` in constructive-db) has no `size` column — `size` only exists on the `files` table. The plugin was including `size` in both upload_requests INSERT paths (normal upload and dedup), causing `column "size" of relation "app_upload_requests" does not exist` at runtime.

**Plugin fix:** Removes `size` from both INSERT statements and shifts the positional `$N` parameters accordingly.

**Test fixture fix:** Updates the `simple-seed-storage` upload_requests CREATE TABLE to match the actual generated schema — removes `size`, adds missing columns (`actor_id`, `ip_address`, `user_agent`).

Follow-up to PR #1012 which fixed `mime_type`/`content_hash` mismatches on the files table. Both bugs originated from the plugin SQL being written against assumed column names rather than the actual generated schema.

## Review & Testing Checklist for Human

- [ ] **Verify positional parameter alignment in both INSERTs**: Removing `size` shifted all `$N` params. Confirm the dedup path (5 columns → 5 values + 2 literals) and normal path (5 columns → 5 values + 1 literal + 1 param) are correctly aligned
- [ ] **Run the upload integration test** (`graphql/server-test`) end-to-end to confirm requestUploadUrl → PUT → confirmUpload still works with the corrected column list
- [ ] **Check for any test-data.sql that INSERTs into upload_requests** — the fixture schema changed column set, so any seed data INSERTs would need updating too

### Notes
- This is blocking the MinIO integration test in constructive-db PR #891 — that test hits this exact error at runtime
- After merge + publish, `graphile-presigned-url-plugin` needs a version bump so constructive-db can pick up the fix via lockfile update

Link to Devin session: https://app.devin.ai/sessions/18879be982854a40abe5c9b915aa4a84
Requested by: @pyramation