### PR TITLE
feat(node-type-registry): add module presets

### DIFF
--- a/graphql/node-type-registry/src/index.ts
+++ b/graphql/node-type-registry/src/index.ts
@@ -4,6 +4,7 @@ export * from './data';
 export * from './relation';
 export * from './view';
 export * from './blueprint-types.generated';
+export * from './module-presets';
 
 import type { NodeTypeDefinition } from './types';
 import * as authz from './authz';

--- a/graphql/node-type-registry/src/module-presets/auth-email-magic.ts
+++ b/graphql/node-type-registry/src/module-presets/auth-email-magic.ts
@@ -1,0 +1,58 @@
+import type { ModulePreset } from './types';
+
+/**
+ * `auth:email+magic` — `auth:email` plus passwordless email flows.
+ *
+ * Adds `session_secrets_module`, which is where one-time nonces for magic
+ * links and email OTPs are stored. Once installed, the `user_auth_module`
+ * emits `sign_up_magic_link`, `sign_in_magic_link`, and `sign_in_email_otp`
+ * procedures (gated on the equivalent `allow_*` toggles in
+ * `app_settings_auth`).
+ *
+ * Choose this over `auth:email` when you want users to be able to log in
+ * without ever setting a password — but still only over email (no SMS, no
+ * SSO).
+ */
+export const PresetAuthEmailMagic: ModulePreset = {
+  name: 'auth:email+magic',
+  display_name: 'Email + Magic Link / OTP',
+  summary: 'Everything in `auth:email` plus magic-link and email-OTP passwordless flows.',
+  description:
+    'Same password-based auth as `auth:email`, with `session_secrets_module` added so the ' +
+    'generator emits the passwordless procedures: `sign_up_magic_link`, `sign_in_magic_link`, ' +
+    '`sign_in_email_otp`. Password flows still exist — you opt into passwordless-only by ' +
+    'flipping the `allow_password_sign_*` toggles off in `app_settings_auth` after install. ' +
+    "This is the right step up from `auth:email` when you want to ship magic links without yet " +
+    "taking on SSO or passkeys.",
+  good_for: [
+    'Consumer apps that want passwordless from day one',
+    'Apps targeting users who forget passwords (newsletters, one-off tools)',
+    'Hardening path from `auth:email` without jumping all the way to `auth:hardened`'
+  ],
+  not_for: [
+    'Apps that need SSO or passkeys — use `auth:sso` or `auth:passkey`',
+    'Production at scale — use `auth:hardened` for rate limiting'
+  ],
+  modules: [
+    'users_module',
+    'membership_types_module',
+    'memberships_module:app',
+    'sessions_module',
+    'secrets_module',
+    'encrypted_secrets_module',
+    'emails_module',
+    'rls_module',
+    'user_auth_module',
+    'session_secrets_module'
+  ],
+  includes_notes: {
+    session_secrets_module: 'Stores nonces for magic-link and email-OTP flows. Without it those procedures are not emitted.'
+  },
+  omits_notes: {
+    rate_limits_module: 'Same reasoning as `auth:email` — add later via `auth:hardened`.',
+    connected_accounts_module: 'No OAuth / SSO in this preset.',
+    webauthn_credentials_module: 'No passkeys — add `auth:passkey`.',
+    phone_numbers_module: 'No SMS — add `auth:hardened`.'
+  },
+  extends: ['auth:email']
+};

--- a/graphql/node-type-registry/src/module-presets/auth-email.ts
+++ b/graphql/node-type-registry/src/module-presets/auth-email.ts
@@ -1,0 +1,72 @@
+import type { ModulePreset } from './types';
+
+/**
+ * `auth:email` — email + password sign_up/sign_in. No orgs, no SSO, no SMS,
+ * no passkeys, no rate limits.
+ *
+ * This is the "working consumer login in one step" preset. It installs the
+ * `user_auth_module` and all the tables its insert trigger hard-requires,
+ * giving you the standard procedures: `sign_up`, `sign_in`, `sign_out`,
+ * `set_password`, `reset_password`, `forgot_password`, `verify_email`,
+ * `delete_account`, `my_sessions`, API-key CRUD. Nothing more.
+ *
+ * It deliberately excludes rate limits, connected accounts / identity
+ * providers (OAuth), WebAuthn (passkeys), phone numbers (SMS), invites,
+ * permissions, and org-scoped memberships. Bolt those on by moving to a
+ * richer preset (`auth:hardened`, `b2b`) when you actually need them.
+ */
+export const PresetAuthEmail: ModulePreset = {
+  name: 'auth:email',
+  display_name: 'Email + Password',
+  summary: 'Standard email/password auth flow. No orgs, no SSO, no MFA, no rate limits.',
+  description:
+    "Installs `user_auth_module` with exactly the table dependencies its insert trigger " +
+    "hard-requires: users, app-scoped memberships, emails, secrets, encrypted secrets, " +
+    "sessions, plus RLS. You get the standard password-based auth procedures (sign_up, " +
+    "sign_in, reset_password, verify_email, delete_account, ...) and that's it. " +
+    "Everything else in the module catalog — SSO, passkeys, SMS, rate limits, orgs, " +
+    "invites, permissions — is deliberately omitted. This is the right shape for single-tenant " +
+    "consumer apps in the first weeks, internal tools that need a real login, or anything " +
+    "where you want the lightest possible working auth and will add complexity only when " +
+    "forced to.",
+  good_for: [
+    'Single-tenant consumer apps in the first week of development',
+    'Internal tools where one simple login is enough',
+    'Demos and hobby projects that need real password auth',
+    'B2C SaaS before org/team features are needed'
+  ],
+  not_for: [
+    'Apps with org/team/workspace structure — use `b2b`',
+    'Apps that need SSO or passkeys from day one — use `auth:sso` or `auth:passkey`',
+    'Production apps at scale — use `auth:hardened` (adds rate limits, SSO, passkeys, SMS)'
+  ],
+  modules: [
+    'users_module',
+    'membership_types_module',
+    'memberships_module:app',
+    'sessions_module',
+    'secrets_module',
+    'encrypted_secrets_module',
+    'emails_module',
+    'rls_module',
+    'user_auth_module'
+  ],
+  includes_notes: {
+    'memberships_module:app': 'Required by `user_auth_module`: every user gets an app-level membership row at sign-up.',
+    membership_types_module: "Required by `memberships_module:app`; defines the 'app' scope.",
+    emails_module: 'Required by the `user_auth_module` insert trigger (`RAISE EXCEPTION REQUIRES emails_module`).',
+    encrypted_secrets_module: 'Required for password hashing; referenced by `set_password`, `verify_password`, and reset flows.',
+    secrets_module: 'API-key storage (`create_api_key`, `revoke_api_key`, `my_api_keys`).'
+  },
+  omits_notes: {
+    rate_limits_module: 'Omitted intentionally; throttle_* helpers are null-safe and the auth procs compile without it. Add later via `auth:hardened`.',
+    connected_accounts_module: 'No OAuth / SSO in this preset — add `auth:sso`.',
+    identity_providers_module: 'No OAuth provider configs without connected_accounts.',
+    webauthn_credentials_module: 'No passkeys — add `auth:passkey`.',
+    phone_numbers_module: 'No SMS login — add `auth:hardened` or the SMS-only refactor path.',
+    'memberships_module:org': 'No org/team structure — move to `b2b` when you need one.',
+    'permissions_module:app': 'No fine-grained RBAC; the `is_admin` flag on users is the only gate.',
+    invites_module: 'Self-serve signup only.',
+    session_secrets_module: 'No magic-link / email-OTP nonces; add `auth:email+magic`.'
+  }
+};

--- a/graphql/node-type-registry/src/module-presets/auth-hardened.ts
+++ b/graphql/node-type-registry/src/module-presets/auth-hardened.ts
@@ -1,0 +1,68 @@
+import type { ModulePreset } from './types';
+
+/**
+ * `auth:hardened` — `auth:email` with rate limiting, SSO, passkeys, SMS,
+ * and magic-link / OTP infrastructure all installed. Production-ready
+ * consumer auth with the full identifier matrix.
+ *
+ * Still single-tenant (no orgs / teams / invites / permissions). For
+ * multi-tenant B2B, step up to `b2b`.
+ */
+export const PresetAuthHardened: ModulePreset = {
+  name: 'auth:hardened',
+  display_name: 'Hardened (all auth surfaces)',
+  summary: 'Rate limits + SSO + passkeys + SMS + magic links. Production-grade consumer auth.',
+  description:
+    'All of `auth:email`, plus every optional auth module that fits inside the single-tenant ' +
+    'model: `rate_limits_module` for throttling (protects sign-in, password reset, and ' +
+    'signup flows), `connected_accounts_module` + `identity_providers_module` for SSO, ' +
+    '`webauthn_credentials_module` + `webauthn_auth_module` for passkeys, ' +
+    '`session_secrets_module` for magic-link / email-OTP nonces, and ' +
+    '`phone_numbers_module` for SMS flows. Every login identifier is available; ' +
+    'toggle whichever ones you want off via `app_settings_auth.allow_*` columns. ' +
+    'Choose this for any production consumer app; step up to `b2b` once you need orgs.',
+  good_for: [
+    'Production consumer apps with a serious user base',
+    'Apps that need every identifier available (email, SSO, passkey, SMS) with throttling',
+    'Apps doing a progressive rollout of auth methods — everything is installed, you toggle per method'
+  ],
+  not_for: [
+    'Hobby projects / demos — way too much infrastructure; use `auth:email`',
+    'Multi-tenant B2B apps — use `b2b`, which layers orgs + invites + permissions on top'
+  ],
+  modules: [
+    'users_module',
+    'membership_types_module',
+    'memberships_module:app',
+    'sessions_module',
+    'secrets_module',
+    'encrypted_secrets_module',
+    'emails_module',
+    'rls_module',
+    'user_auth_module',
+    'session_secrets_module',
+    'rate_limits_module',
+    'connected_accounts_module',
+    'identity_providers_module',
+    'webauthn_credentials_module',
+    'webauthn_auth_module',
+    'phone_numbers_module'
+  ],
+  includes_notes: {
+    rate_limits_module: 'Throttling for sign-in, password reset, sign-up, and IP-based gates.',
+    connected_accounts_module: 'OAuth / SSO linkage.',
+    identity_providers_module: 'OAuth provider configs (required for `connected_accounts_module`).',
+    webauthn_credentials_module: 'Per-user passkey storage.',
+    webauthn_auth_module: 'Passkey challenge + assertion runtime.',
+    session_secrets_module: 'Nonces for magic links, email OTP, and WebAuthn challenges.',
+    phone_numbers_module: 'SMS sign-in / MFA support.'
+  },
+  omits_notes: {
+    'memberships_module:org': 'No orgs / teams — use `b2b` when you need multi-tenancy.',
+    'permissions_module:app': 'No RBAC beyond the `is_admin` flag — add via `b2b`.',
+    invites_module: 'No invite flow — add via `b2b`.',
+    storage_module: 'Add separately if you need file uploads.',
+    crypto_addresses_module: 'Not a web3 preset; omit unless doing wallet sign-in.'
+  },
+  extends: ['auth:email', 'auth:email+magic', 'auth:sso', 'auth:passkey']
+};

--- a/graphql/node-type-registry/src/module-presets/auth-passkey.ts
+++ b/graphql/node-type-registry/src/module-presets/auth-passkey.ts
@@ -1,0 +1,59 @@
+import type { ModulePreset } from './types';
+
+/**
+ * `auth:passkey` — `auth:email` plus WebAuthn / passkeys.
+ *
+ * Adds `webauthn_credentials_module` (stores each user's registered public
+ * keys and credential IDs), `webauthn_auth_module` (the auth-time challenge
+ * storage + flow), and `session_secrets_module` (where the one-time
+ * challenge nonces live). The generator then emits WebAuthn registration
+ * and assertion procedures.
+ *
+ * Password flows stay on by default as a recovery path; toggle them off in
+ * `app_settings_auth` if you want strictly-passkey.
+ */
+export const PresetAuthPasskey: ModulePreset = {
+  name: 'auth:passkey',
+  display_name: 'Passkeys (WebAuthn)',
+  summary: '`auth:email` plus WebAuthn passkey registration and assertion.',
+  description:
+    "Installs the three modules WebAuthn needs: `webauthn_credentials_module` for each user's " +
+    "registered public keys, `webauthn_auth_module` for the runtime challenge/assertion flow, " +
+    "and `session_secrets_module` for the one-time challenge nonces. With these installed, " +
+    "the generator emits WebAuthn registration/login procs. Keep password flows as a recovery " +
+    "path, or disable them in `app_settings_auth` for passkey-only deployments.",
+  good_for: [
+    'Apps where you want users to adopt phishing-resistant auth',
+    'Consumer apps with a tech-forward audience',
+    'Internal tools protecting sensitive data where FIDO2 is a requirement'
+  ],
+  not_for: [
+    'Apps that also need SSO or SMS — use `auth:hardened` for everything',
+    'Apps where the end-user device mix is heavy on old browsers that lack WebAuthn'
+  ],
+  modules: [
+    'users_module',
+    'membership_types_module',
+    'memberships_module:app',
+    'sessions_module',
+    'secrets_module',
+    'encrypted_secrets_module',
+    'emails_module',
+    'rls_module',
+    'user_auth_module',
+    'session_secrets_module',
+    'webauthn_credentials_module',
+    'webauthn_auth_module'
+  ],
+  includes_notes: {
+    webauthn_credentials_module: 'Per-user WebAuthn credential storage. Without it, passkey registration does not compile.',
+    webauthn_auth_module: 'Runtime challenge + assertion flow.',
+    session_secrets_module: 'Challenge nonces for registration and assertion.'
+  },
+  omits_notes: {
+    rate_limits_module: 'Add via `auth:hardened` for production.',
+    connected_accounts_module: 'No OAuth / SSO — add via `auth:hardened`.',
+    phone_numbers_module: 'No SMS.'
+  },
+  extends: ['auth:email']
+};

--- a/graphql/node-type-registry/src/module-presets/auth-sso.ts
+++ b/graphql/node-type-registry/src/module-presets/auth-sso.ts
@@ -1,0 +1,68 @@
+import type { ModulePreset } from './types';
+
+/**
+ * `auth:sso` — `auth:email` plus OAuth / OpenID Connect sign-in.
+ *
+ * Adds `connected_accounts_module` (the junction table mapping a user to
+ * `(provider, external_id)`) and `identity_providers_module` (the provider
+ * config: URLs, client_id, encrypted client_secret, scopes, PKCE/nonce
+ * knobs). The generator then emits `sign_in_identity` / `sign_up_identity`
+ * procedures which rely on `encrypted_secrets_module` to decrypt the client
+ * secret at auth time.
+ *
+ * Password fallback stays on by default (break-glass for admins); flip the
+ * `allow_password_sign_*` toggles off in `app_settings_auth` for strictly
+ * SSO-only.
+ *
+ * Note: `emails_module` is still required — the `user_auth_module` insert
+ * trigger hard-requires it today. A pure SSO-only install without emails
+ * is a separate refactor (see `docs/architecture/module-presets.md` in
+ * constructive-db).
+ */
+export const PresetAuthSso: ModulePreset = {
+  name: 'auth:sso',
+  display_name: 'OAuth / OpenID Connect',
+  summary: '`auth:email` plus OAuth providers and connected-account linkage.',
+  description:
+    "Adds the two modules that make SSO work: `identity_providers_module` (where provider " +
+    "definitions live — Google, GitHub, Okta, etc., with their URLs, client IDs, and " +
+    "encrypted client secrets) and `connected_accounts_module` (the junction mapping a " +
+    "Constructive user to a `(provider, external_id)` pair). The generator emits " +
+    "`sign_in_identity` and `sign_up_identity` procedures which decrypt the client secret " +
+    "through `encrypted_secrets_module` at auth time. Keep password flows as break-glass, or " +
+    "disable them via `app_settings_auth` toggles for strictly-SSO deployments.",
+  good_for: [
+    'B2B apps where end users sign in via their employer IdP',
+    'Consumer apps that want "Sign in with Google / GitHub"',
+    'Apps that need to federate identity with a specific provider ecosystem'
+  ],
+  not_for: [
+    'Apps that also need passkeys and rate limits — use `auth:hardened`',
+    'Strictly-SSO apps that want NO email storage — needs the emails-optional refactor; not supported by a preset today'
+  ],
+  modules: [
+    'users_module',
+    'membership_types_module',
+    'memberships_module:app',
+    'sessions_module',
+    'secrets_module',
+    'encrypted_secrets_module',
+    'emails_module',
+    'rls_module',
+    'user_auth_module',
+    'connected_accounts_module',
+    'identity_providers_module'
+  ],
+  includes_notes: {
+    connected_accounts_module: 'Junction table for (user, provider, external_id). Without it, `sign_in_identity` does not compile.',
+    identity_providers_module: 'Provider config table (URLs, client_id, encrypted client_secret, scopes, PKCE knobs).',
+    encrypted_secrets_module: 'Required by `auth:email` already; also used by SSO to decrypt the provider client_secret at auth time.'
+  },
+  omits_notes: {
+    webauthn_credentials_module: 'No passkeys — add `auth:passkey` or move to `auth:hardened`.',
+    rate_limits_module: 'Omitted; add via `auth:hardened` for production.',
+    session_secrets_module: "Not required for authorization-code OAuth; add if you also want magic-link flows. PKCE doesn't require it for stateless OAuth flows today.",
+    phone_numbers_module: 'No SMS in this preset.'
+  },
+  extends: ['auth:email']
+};

--- a/graphql/node-type-registry/src/module-presets/b2b.ts
+++ b/graphql/node-type-registry/src/module-presets/b2b.ts
@@ -1,0 +1,86 @@
+import type { ModulePreset } from './types';
+
+/**
+ * `b2b` — `auth:hardened` plus orgs, invites, permissions, levels,
+ * profiles, and hierarchy. The full multi-tenant / B2B SaaS shape.
+ *
+ * Installs both app-scoped AND org-scoped instances of the membership,
+ * permission, limit, level, profile, and invite modules. `hierarchy_module`
+ * at the org scope enables nested org/team structures.
+ *
+ * This is a large install — every B2B concept Constructive ships. Don't
+ * reach for it until you actually need orgs; moving from `auth:hardened`
+ * to `b2b` later is a provisioning step, not a schema rewrite.
+ */
+export const PresetB2b: ModulePreset = {
+  name: 'b2b',
+  display_name: 'B2B SaaS (orgs + invites + permissions)',
+  summary: '`auth:hardened` + orgs, invites, fine-grained permissions, levels, profiles, hierarchy.',
+  description:
+    'Everything in `auth:hardened`, plus the full org/team/permission stack at both app and ' +
+    'org membership scopes. You get: `memberships_module:org` for org-scoped memberships, ' +
+    '`permissions_module:app/:org` for fine-grained RBAC, `limits_module:app/:org` for per-scope ' +
+    'quota enforcement, `levels_module:app/:org` for role bundles, `profiles_module:app/:org` ' +
+    'for per-scope user display info, `hierarchy_module:org` for nested org structures, and ' +
+    '`invites_module:app/:org` for invite flows at either scope. Choose this when the app has ' +
+    'the concept of a "workspace" / "team" / "tenant" that users belong to and act within.',
+  good_for: [
+    'B2B SaaS with multi-tenant workspaces / teams',
+    'Apps where permissions scope to an organization, not globally',
+    'Apps with an invite-based onboarding flow (admins invite members)',
+    'Apps that need nested org hierarchies (parent org / sub-org / team)'
+  ],
+  not_for: [
+    'Single-tenant consumer apps — use `auth:hardened` or `auth:email`',
+    'Apps where all users see the same global dataset — orgs would add overhead with no benefit'
+  ],
+  modules: [
+    'users_module',
+    'membership_types_module',
+    'memberships_module:app',
+    'memberships_module:org',
+    'sessions_module',
+    'secrets_module',
+    'encrypted_secrets_module',
+    'emails_module',
+    'rls_module',
+    'user_auth_module',
+    'session_secrets_module',
+    'rate_limits_module',
+    'connected_accounts_module',
+    'identity_providers_module',
+    'webauthn_credentials_module',
+    'webauthn_auth_module',
+    'phone_numbers_module',
+    'permissions_module:app',
+    'permissions_module:org',
+    'limits_module:app',
+    'limits_module:org',
+    'levels_module:app',
+    'levels_module:org',
+    'profiles_module:app',
+    'profiles_module:org',
+    'hierarchy_module:org',
+    'invites_module:app',
+    'invites_module:org'
+  ],
+  includes_notes: {
+    'memberships_module:org': 'Org-scoped membership rows — every user in an org gets one.',
+    'permissions_module:app': 'App-wide permission grants (e.g. platform admins).',
+    'permissions_module:org': 'Org-scoped permission grants (per-workspace admins, members, viewers, ...).',
+    'limits_module:app': 'App-level quotas (e.g. max users per plan).',
+    'limits_module:org': 'Org-level quotas (e.g. per-workspace API call caps).',
+    'levels_module:app': 'Role/level bundles at the app scope.',
+    'levels_module:org': 'Role/level bundles at the org scope (admin / member / viewer, etc.).',
+    'profiles_module:app': 'App-scoped user profile (one per user).',
+    'profiles_module:org': 'Org-scoped user profile (per org a user belongs to).',
+    'hierarchy_module:org': 'Nested org structures (parent / child orgs).',
+    'invites_module:app': 'App-level invites (rare — usually platform admin adds another admin).',
+    'invites_module:org': 'Org-level invites (the common case — invite a teammate into a workspace).'
+  },
+  omits_notes: {
+    storage_module: 'Add separately if you need file uploads tied to orgs.',
+    crypto_addresses_module: 'Not a web3 preset.'
+  },
+  extends: ['auth:hardened']
+};

--- a/graphql/node-type-registry/src/module-presets/full.ts
+++ b/graphql/node-type-registry/src/module-presets/full.ts
@@ -1,0 +1,41 @@
+import type { ModulePreset } from './types';
+
+/**
+ * `full` — install everything. Equivalent to the default
+ * `provision_database_modules(v_modules => ARRAY['all'])` behavior.
+ *
+ * This is the maximalist preset: every module Constructive ships, including
+ * `storage_module` for file uploads and `crypto_addresses_module` for
+ * wallet-based sign-in. Use it for greenfield apps where you'd rather
+ * disable features via `app_settings_auth` toggles than uninstall modules,
+ * or for the "kitchen sink" example / demo databases.
+ *
+ * Prefer a more targeted preset for anything production-bound — installing
+ * a module you'll never use still costs tables, triggers, and grants.
+ */
+export const PresetFull: ModulePreset = {
+  name: 'full',
+  display_name: 'Full (every module)',
+  summary: "Install every Constructive module. Equivalent to v_modules => ARRAY['all'].",
+  description:
+    'Installs every module in the catalog: everything in `b2b` plus `storage_module` ' +
+    'for file uploads and `crypto_addresses_module` / `crypto_auth_module` for ' +
+    'wallet-based sign-in. This matches the current default when `provision_database_modules` ' +
+    "is called without an explicit `v_modules` argument. Use it for fully-featured " +
+    'demo/example databases, kitchen-sink reference deployments, or greenfield apps that ' +
+    'would rather feature-flag at the app_settings level than uninstall modules.',
+  good_for: [
+    'Reference / demo databases that showcase every Constructive feature',
+    'Greenfield apps where the product scope is still open-ended',
+    'Keeping the provisioning call identical to the pre-preset default'
+  ],
+  not_for: [
+    'Production apps with a defined feature set — pick the narrowest preset that fits',
+    'Resource-constrained environments — every module costs schema bloat, RLS policies, and grants'
+  ],
+  modules: ['all'],
+  includes_notes: {
+    all: "Sentinel — the provisioner installs every known module when `modules = ['all']`."
+  },
+  extends: ['b2b']
+};

--- a/graphql/node-type-registry/src/module-presets/index.ts
+++ b/graphql/node-type-registry/src/module-presets/index.ts
@@ -1,0 +1,43 @@
+export type { ModulePreset } from './types';
+
+import type { ModulePreset } from './types';
+
+import { PresetMinimal } from './minimal';
+import { PresetAuthEmail } from './auth-email';
+import { PresetAuthEmailMagic } from './auth-email-magic';
+import { PresetAuthSso } from './auth-sso';
+import { PresetAuthPasskey } from './auth-passkey';
+import { PresetAuthHardened } from './auth-hardened';
+import { PresetB2b } from './b2b';
+import { PresetFull } from './full';
+
+export {
+  PresetMinimal,
+  PresetAuthEmail,
+  PresetAuthEmailMagic,
+  PresetAuthSso,
+  PresetAuthPasskey,
+  PresetAuthHardened,
+  PresetB2b,
+  PresetFull
+};
+
+/**
+ * Ordered list of all shipped module presets, from smallest to largest
+ * module footprint. Stable ordering — CLIs / UIs can present this directly.
+ */
+export const allModulePresets: ModulePreset[] = [
+  PresetMinimal,
+  PresetAuthEmail,
+  PresetAuthEmailMagic,
+  PresetAuthSso,
+  PresetAuthPasskey,
+  PresetAuthHardened,
+  PresetB2b,
+  PresetFull
+];
+
+/** Look up a preset by name. Returns undefined if the name isn't known. */
+export function getModulePreset(name: string): ModulePreset | undefined {
+  return allModulePresets.find((p) => p.name === name);
+}

--- a/graphql/node-type-registry/src/module-presets/minimal.ts
+++ b/graphql/node-type-registry/src/module-presets/minimal.ts
@@ -1,0 +1,51 @@
+import type { ModulePreset } from './types';
+
+/**
+ * `minimal` — users + sessions + RLS + API keys. No auth procedures, no
+ * memberships, no orgs, no emails, no passwords.
+ *
+ * This is the barest foundation: a `users` table, a `sessions` table so
+ * something upstream can mint tokens, `rls_module` so row-level security
+ * is enforceable, and `secrets_module` so you can issue API keys. Nothing
+ * else.
+ *
+ * You still write your own identity bridge on top (or rely on a header-based
+ * user-id coming from an upstream proxy / JWT verifier).
+ */
+export const PresetMinimal: ModulePreset = {
+  name: 'minimal',
+  display_name: 'Minimal (RLS only)',
+  summary: 'users + sessions + RLS + API keys. No auth procedures installed.',
+  description:
+    'The smallest coherent Constructive install. You get a users table, a sessions table, ' +
+    'RLS enforcement, and API-key infrastructure — but no server-side sign_up/sign_in flow. ' +
+    'Pick this when authentication lives outside the database (an upstream IdP, a header from ' +
+    'a proxy, an internal service-to-service JWT) and Constructive is just the RLS-aware data ' +
+    'layer underneath.',
+  good_for: [
+    'Internal tools where an upstream proxy supplies the user identity',
+    'Backend-of-backend services that only need RLS, not an auth surface',
+    'Prototypes that will bolt on a richer auth preset later'
+  ],
+  not_for: [
+    'Any app that needs `sign_up` / `sign_in` / `reset_password` out of the box — use `auth:email` instead',
+    'Multi-tenant / org-scoped apps — use `b2b`'
+  ],
+  modules: [
+    'users_module',
+    'sessions_module',
+    'rls_module',
+    'secrets_module'
+  ],
+  includes_notes: {
+    users_module: 'The canonical users table. Required by every preset.',
+    sessions_module: 'Session/token storage; needed so whatever upstream auth can mint a session row.',
+    rls_module: 'RLS policy infrastructure. Without it, row-level security is not enforced.',
+    secrets_module: 'API-key storage. Optional for this preset but almost always wanted alongside upstream auth.'
+  },
+  omits_notes: {
+    user_auth_module: 'No server-side sign_up/sign_in procedures in this preset.',
+    emails_module: 'Not needed without password/magic-link flows; upstream auth handles identity.',
+    memberships_module: 'No memberships without a user_auth_module wiring them up.'
+  }
+};

--- a/graphql/node-type-registry/src/module-presets/types.ts
+++ b/graphql/node-type-registry/src/module-presets/types.ts
@@ -1,0 +1,69 @@
+/**
+ * A preset is a named, curated bundle of Constructive modules intended for a
+ * recognizable app shape (internal tool, consumer email login, SSO-only B2B,
+ * etc.). Presets are metadata only — passing `preset.modules` to
+ * `provision_database_modules(v_modules => ...)` is what actually installs
+ * them.
+ *
+ * Presets are NOT node types. They are a sibling concept: node types are
+ * reusable building blocks used inside a blueprint; presets are starting
+ * points for which modules to install before any blueprint is authored.
+ *
+ * All module names match the `rls_module`, `user_auth_module`, ... names in
+ * `metaschema_generators.provision_database_modules` in constructive-db.
+ *
+ * Naming uses snake_case for module names to match the server-side SQL
+ * convention, and kebab-ish `auth:email` for preset names because they're
+ * user-facing labels, not identifiers.
+ */
+export interface ModulePreset {
+  /** Preset identifier, e.g. 'auth:email'. Stable, used as a key in CLI/codegen. */
+  name: string;
+
+  /** Human-readable label for UIs, e.g. 'Email + Password'. */
+  display_name: string;
+
+  /** One-line pitch — what this preset is in plain English. */
+  summary: string;
+
+  /**
+   * Longer narrative. Explain when you'd reach for this preset, what it
+   * implies architecturally, and what tradeoffs the user is accepting by
+   * choosing it. Keep to a few paragraphs max.
+   */
+  description: string;
+
+  /** Concrete scenarios this preset fits well. */
+  good_for: string[];
+
+  /** Scenarios where this preset is the wrong choice — point at alternatives. */
+  not_for: string[];
+
+  /**
+   * Flat list of module names to install. Module names must match the
+   * canonical list accepted by
+   * `metaschema_generators.provision_database_modules` in constructive-db.
+   * Order doesn't matter — provisioning resolves dependencies.
+   */
+  modules: string[];
+
+  /**
+   * Optional per-module justifications. Map from module name to a short
+   * "why this module is in this preset" note. Rendered in docs and CLI
+   * `--explain` output.
+   */
+  includes_notes?: Record<string, string>;
+
+  /**
+   * Optional per-module "why we deliberately leave this out" notes. Only
+   * list modules that a user might reasonably expect to be here; don't
+   * enumerate every omitted module.
+   */
+  omits_notes?: Record<string, string>;
+
+  /**
+   * Optional: name(s) of presets this one builds on. Purely documentary —
+   * not enforced at runtime, `modules` must still be the full flat list.
+   */
+  extends?: string[];
+}


### PR DESCRIPTION
## Summary

Ships eight curated Constructive module presets as TypeScript metadata in the `node-type-registry` package. Presets are documented shapes for `provision_database_modules(v_modules => ...)` — they tell a user which modules to install for a recognizable app shape (internal tool, consumer email login, SSO, B2B SaaS, …) and why each module is or isn't included.

**New package export:** `graphql/node-type-registry/src/module-presets/`

```ts
import { allModulePresets, getModulePreset, PresetAuthEmail } from '@constructive-io/node-type-registry';

getModulePreset('auth:email').modules;
// ['users_module', 'membership_types_module', 'memberships_module:app',
//  'sessions_module', 'secrets_module', 'encrypted_secrets_module',
//  'emails_module', 'rls_module', 'user_auth_module']
```

### Presets

| Name | Shape |
|---|---|
| `minimal` | users + sessions + rls + secrets. No auth procs. Upstream handles identity. |
| `auth:email` | Email + password. Single tenant. No SSO / passkey / SMS / rate limits. |
| `auth:email+magic` | `auth:email` + magic-link / email-OTP nonces. |
| `auth:sso` | `auth:email` + OAuth providers and connected accounts. |
| `auth:passkey` | `auth:email` + WebAuthn. |
| `auth:hardened` | Rate limits + SSO + passkeys + SMS + magic links. Single tenant. |
| `b2b` | `auth:hardened` + orgs + invites + permissions + levels + profiles + hierarchy. |
| `full` | Equivalent to the current default `['all']`. |

### Shape

```ts
interface ModulePreset {
  name: string;
  display_name: string;
  summary: string;
  description: string;
  good_for: string[];
  not_for: string[];
  modules: string[];
  includes_notes?: Record<string, string>;
  omits_notes?: Record<string, string>;
  extends?: string[];
}
```

Each preset file has a top-level JSDoc narrative plus per-module `includes_notes` / `omits_notes` rationale, so CLIs / docs / `--explain` output all have a single source of truth.

Presets live alongside node types (`authz/`, `data/`, `relation/`, `view/`) in the registry package, but are a sibling concept — not `NodeTypeDefinition`s. Node types are reusable blueprint building blocks; presets are starting points for which modules to install before any blueprint is authored.

Follow-up scope explicitly **not** in this PR: feature-flag / toggle-inside-preset syntax (e.g. `settings?: { app_settings_auth: { allow_password_sign_up: false } }`). The `ModulePreset` shape leaves room to add that later non-breakingly. Source doc with the preset rationale lives in [constructive-db docs/architecture/module-presets.md](https://github.com/constructive-io/constructive-db/pull/921).

## Review & Testing Checklist for Human

- [ ] Confirm preset names and contents match what you want published (`minimal`, `auth:email`, `auth:email+magic`, `auth:sso`, `auth:passkey`, `auth:hardened`, `b2b`, `full`).
- [ ] Sanity-check the per-preset `includes_notes` / `omits_notes` narratives — they're the user-facing reasoning and should match your mental model.
- [ ] Verify placement under `graphql/node-type-registry/src/module-presets/` is the right home. Alternative: a new package (`@constructive-io/module-presets`) or `pgpm/export/src/`. Easy to move if you'd prefer.

### Notes

Known caveat: every auth preset currently includes `emails_module` because the `user_auth_module` insert trigger in constructive-db hard-raises `REQUIRES (emails_module)`. Pure SSO-only / SMS-only / passkey-only (no emails) needs that trigger loosened — called out as a refactor target in the constructive-db docs. For now, presets reflect what provisioning will actually accept today.

Link to Devin session: https://app.devin.ai/sessions/649649b6aa824471adc8a84b563cf58a
Requested by: @pyramation