### PR TITLE
feat!: unify grants[] and policies[] in node type registry and export config

### DIFF
--- a/graphql/node-type-registry/src/blueprint-types.generated.ts
+++ b/graphql/node-type-registry/src/blueprint-types.generated.ts
@@ -610,22 +610,22 @@ export interface RelationManyToManyParams {
   nodes?: {
     [key: string]: unknown;
   }[];
-  /* Database roles to grant privileges to. Forwarded to secure_table_provision as-is. Default: [authenticated] */
-  grant_roles?: string[];
-  /* Privilege grants for the junction table as [verb, columns] tuples (e.g. [['select','*'],['insert','*']]). Forwarded to secure_table_provision as-is. Default: select/insert/delete for all columns */
-  grant_privileges?: string[][];
-  /* RLS policy type for the junction table. Forwarded to secure_table_provision as-is. NULL means no policy. */
-  policy_type?: string;
-  /* Privileges the policy applies to. Forwarded to secure_table_provision as-is. NULL means derived from grant_privileges verbs. */
-  policy_privileges?: string[];
-  /* Database role the policy targets. Forwarded to secure_table_provision as-is. NULL means falls back to first grant_role. */
-  policy_role?: string;
-  /* Whether the policy is PERMISSIVE (true) or RESTRICTIVE (false). Forwarded to secure_table_provision as-is. */
-  policy_permissive?: boolean;
-  /* Policy configuration forwarded to secure_table_provision as-is. Structure varies by policy_type. */
-  policy_data?: {
-    [key: string]: unknown;
-  };
+  /* Unified grant objects for the junction table. Each entry is { roles: string[], privileges: string[][] }. Forwarded to secure_table_provision as-is. Default: [] */
+  grants?: {
+    roles: string[];
+    privileges: string[][];
+  }[];
+  /* RLS policy objects for the junction table. Each entry has $type (Authz* generator), optional data, privileges, policy_role, permissive, policy_name. Forwarded to secure_table_provision as-is. Default: [] */
+  policies?: {
+    $type: string;
+    data?: {
+      [key: string]: unknown;
+    };
+    privileges?: string[];
+    policy_role?: string;
+    permissive?: boolean;
+    policy_name?: string;
+  }[];
 }
 /** Declares a spatial predicate between two existing geometry/geography columns. Inserts a metaschema_public.spatial_relation row; the sync_spatial_relation_tags trigger then projects a @spatialRelation smart tag onto the owner column so graphile-postgis' PostgisSpatialRelationsPlugin can expose it as a cross-table filter in GraphQL. Metadata-only: both source_field and target_field must already exist on their tables. Idempotent on (source_table_id, name). One direction per tag — author two RelationSpatial entries if symmetry is desired. */
 export interface RelationSpatialParams {
@@ -838,10 +838,11 @@ export interface BlueprintEntityTableProvision {
   nodes?: BlueprintNode[];
   /** Custom fields (columns) to add to the entity table. Forwarded to secure_table_provision as-is. */
   fields?: BlueprintField[];
-  /** Privilege grants for the entity table as [verb, columns] tuples (e.g. [["select","*"],["insert","*"]]). Forwarded to secure_table_provision as-is. */
-  grant_privileges?: unknown[];
-  /** Database roles to grant privileges to. Forwarded to secure_table_provision as-is. Defaults to ["authenticated"]. */
-  grant_roles?: string[];
+  /** Unified grant objects for the entity table. Each entry is { roles: string[], privileges: unknown[] } where privileges are [verb, columns] tuples. Forwarded to secure_table_provision as-is. Defaults to []. */
+  grants?: {
+    roles: string[];
+    privileges: unknown[];
+  }[];
   /** RLS policies for the entity table. When present, these policies fully replace the five default entity-table policies (is_visible becomes a no-op). */
   policies?: BlueprintPolicy[];
 }
@@ -1075,10 +1076,11 @@ export interface BlueprintTable {
   fields?: BlueprintField[];
   /** RLS policies for this table. */
   policies?: BlueprintPolicy[];
-  /** Database roles to grant privileges to. Defaults to ["authenticated"]. */
-  grant_roles?: string[];
-  /** Privilege grants as [verb, column] tuples or objects. Defaults to empty (no grants — callers must explicitly specify). */
-  grants?: unknown[];
+  /** Unified grant objects. Each entry is { roles: string[], privileges: unknown[] } where privileges are [verb, columns] tuples (e.g. [["select","*"]]). Enables per-role targeting. Defaults to []. */
+  grants?: {
+    roles: string[];
+    privileges: unknown[];
+  }[];
   /** Whether to enable RLS on this table. Defaults to true. */
   use_rls?: boolean;
   /** Table-level indexes (table_name inherited from parent). */

--- a/graphql/node-type-registry/src/codegen/generate-types.ts
+++ b/graphql/node-type-registry/src/codegen/generate-types.ts
@@ -642,12 +642,16 @@ function buildBlueprintEntityTableProvision(): t.ExportNamedDeclaration {
         'Custom fields (columns) to add to the entity table. Forwarded to secure_table_provision as-is.'
       ),
       addJSDoc(
-        optionalProp('grant_privileges', t.tsArrayType(t.tsUnknownKeyword())),
-        'Privilege grants for the entity table as [verb, columns] tuples (e.g. [["select","*"],["insert","*"]]). Forwarded to secure_table_provision as-is.'
-      ),
-      addJSDoc(
-        optionalProp('grant_roles', t.tsArrayType(t.tsStringKeyword())),
-        'Database roles to grant privileges to. Forwarded to secure_table_provision as-is. Defaults to ["authenticated"].'
+        optionalProp(
+          'grants',
+          t.tsArrayType(
+            t.tsTypeLiteral([
+              requiredProp('roles', t.tsArrayType(t.tsStringKeyword())),
+              requiredProp('privileges', t.tsArrayType(t.tsUnknownKeyword())),
+            ])
+          )
+        ),
+        'Unified grant objects for the entity table. Each entry is { roles: string[], privileges: unknown[] } where privileges are [verb, columns] tuples. Forwarded to secure_table_provision as-is. Defaults to [].'
       ),
       addJSDoc(
         optionalProp(
@@ -749,12 +753,16 @@ function buildBlueprintTable(): t.ExportNamedDeclaration {
         'RLS policies for this table.'
       ),
       addJSDoc(
-        optionalProp('grant_roles', t.tsArrayType(t.tsStringKeyword())),
-        'Database roles to grant privileges to. Defaults to ["authenticated"].'
-      ),
-      addJSDoc(
-        optionalProp('grants', t.tsArrayType(t.tsUnknownKeyword())),
-        'Privilege grants as [verb, column] tuples or objects. Defaults to empty (no grants — callers must explicitly specify).'
+        optionalProp(
+          'grants',
+          t.tsArrayType(
+            t.tsTypeLiteral([
+              requiredProp('roles', t.tsArrayType(t.tsStringKeyword())),
+              requiredProp('privileges', t.tsArrayType(t.tsUnknownKeyword())),
+            ])
+          )
+        ),
+        'Unified grant objects. Each entry is { roles: string[], privileges: unknown[] } where privileges are [verb, columns] tuples (e.g. [["select","*"]]). Enables per-role targeting. Defaults to [].'
       ),
       addJSDoc(
         optionalProp('use_rls', t.tsBooleanKeyword()),

--- a/graphql/node-type-registry/src/relation/relation-many-to-many.ts
+++ b/graphql/node-type-registry/src/relation/relation-many-to-many.ts
@@ -48,46 +48,33 @@ export const RelationManyToMany: NodeTypeDefinition = {
         },
         "description": "Array of node objects for field creation on junction table. Each object has a $type key (e.g. DataId, DataEntityMembership) and optional data keys. Forwarded to secure_table_provision as-is. Empty array means no additional fields."
       },
-      "grant_roles": {
+      "grants": {
         "type": "array",
         "items": {
-          "type": "string"
+          "type": "object",
+          "properties": {
+            "roles": { "type": "array", "items": { "type": "string" } },
+            "privileges": { "type": "array", "items": { "type": "array", "items": { "type": "string" } } }
+          },
+          "required": ["roles", "privileges"]
         },
-        "description": "Database roles to grant privileges to. Forwarded to secure_table_provision as-is. Default: [authenticated]"
+        "description": "Unified grant objects for the junction table. Each entry is { roles: string[], privileges: string[][] }. Forwarded to secure_table_provision as-is. Default: []"
       },
-      "grant_privileges": {
+      "policies": {
         "type": "array",
         "items": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "type": "object",
+          "properties": {
+            "$type": { "type": "string" },
+            "data": { "type": "object" },
+            "privileges": { "type": "array", "items": { "type": "string" } },
+            "policy_role": { "type": "string" },
+            "permissive": { "type": "boolean" },
+            "policy_name": { "type": "string" }
+          },
+          "required": ["$type"]
         },
-        "description": "Privilege grants for the junction table as [verb, columns] tuples (e.g. [['select','*'],['insert','*']]). Forwarded to secure_table_provision as-is. Default: select/insert/delete for all columns"
-      },
-      "policy_type": {
-        "type": "string",
-        "description": "RLS policy type for the junction table. Forwarded to secure_table_provision as-is. NULL means no policy."
-      },
-      "policy_privileges": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "description": "Privileges the policy applies to. Forwarded to secure_table_provision as-is. NULL means derived from grant_privileges verbs."
-      },
-      "policy_role": {
-        "type": "string",
-        "description": "Database role the policy targets. Forwarded to secure_table_provision as-is. NULL means falls back to first grant_role."
-      },
-      "policy_permissive": {
-        "type": "boolean",
-        "description": "Whether the policy is PERMISSIVE (true) or RESTRICTIVE (false). Forwarded to secure_table_provision as-is.",
-        "default": true
-      },
-      "policy_data": {
-        "type": "object",
-        "description": "Policy configuration forwarded to secure_table_provision as-is. Structure varies by policy_type."
+        "description": "RLS policy objects for the junction table. Each entry has $type (Authz* generator), optional data, privileges, policy_role, permissive, policy_name. Forwarded to secure_table_provision as-is. Default: []"
       }
     },
     "required": [

--- a/packages/csv-to-pg/__tests__/__snapshots__/export.test.ts.snap
+++ b/packages/csv-to-pg/__tests__/__snapshots__/export.test.ts.snap
@@ -13,7 +13,7 @@ exports[`test case empty array fields emit empty array literal 1`] = `
   id,
   node_type,
   fields,
-  grant_roles
+  out_fields
 ) VALUES
   ('450e3b3b-b68d-4abc-990c-65cb8a1dcdb4', 'DataTimestamps', '{}', '{}');"
 `;
@@ -76,10 +76,9 @@ exports[`test case null array fields emit empty array literal instead of NULL 1`
   id,
   node_type,
   fields,
-  grant_privileges,
   out_fields
 ) VALUES
-  ('450e3b3b-b68d-4abc-990c-65cb8a1dcdb4', 'DataTimestamps', '{}', '{}', '{}');"
+  ('450e3b3b-b68d-4abc-990c-65cb8a1dcdb4', 'DataTimestamps', '{}', '{}');"
 `;
 
 exports[`test case test case 1`] = `Promise {}`;

--- a/packages/csv-to-pg/__tests__/export.test.ts
+++ b/packages/csv-to-pg/__tests__/export.test.ts
@@ -229,7 +229,6 @@ it('null array fields emit empty array literal instead of NULL', async () => {
       id: 'uuid',
       node_type: 'text',
       fields: 'jsonb[]',
-      grant_privileges: 'jsonb[]',
       out_fields: 'uuid[]'
     }
   });
@@ -239,7 +238,6 @@ it('null array fields emit empty array literal instead of NULL', async () => {
       id: '450e3b3b-b68d-4abc-990c-65cb8a1dcdb4',
       node_type: 'DataTimestamps',
       fields: null,
-      grant_privileges: null,
       out_fields: null
     }
   ]);
@@ -259,7 +257,7 @@ it('empty array fields emit empty array literal', async () => {
       id: 'uuid',
       node_type: 'text',
       fields: 'jsonb[]',
-      grant_roles: 'text[]'
+      out_fields: 'uuid[]'
     }
   });
 
@@ -268,7 +266,7 @@ it('empty array fields emit empty array literal', async () => {
       id: '450e3b3b-b68d-4abc-990c-65cb8a1dcdb4',
       node_type: 'DataTimestamps',
       fields: [],
-      grant_roles: []
+      out_fields: []
     }
   ]);
 

--- a/pgpm/export/src/export-utils.ts
+++ b/pgpm/export/src/export-utils.ts
@@ -985,14 +985,9 @@ export const META_TABLE_CONFIG: Record<string, TableConfig> = {
       node_type: 'text',
       use_rls: 'boolean',
       node_data: 'jsonb',
-      grant_roles: 'text[]',
       fields: 'jsonb[]',
-      grant_privileges: 'jsonb[]',
-      policy_type: 'text',
-      policy_privileges: 'text[]',
-      policy_role: 'text',
-      policy_permissive: 'boolean',
-      policy_data: 'jsonb',
+      grants: 'jsonb',
+      policies: 'jsonb',
       out_fields: 'uuid[]'
     }
   },


### PR DESCRIPTION
## Summary

Aligns the constructive plugin layer with the unified `grants[]` and `policies[]` DB schema introduced in constructive-db PR #929 (grants) and #924 (policies).

**Before:** Grants and policies were spread across many separate fields:
- `grant_roles`, `grant_privileges` (grants)
- `policy_type`, `policy_privileges`, `policy_role`, `policy_permissive`, `policy_data` (policies)

**After:** Two structured arrays:
- `grants: { roles: string[], privileges: unknown[] }[]`
- `policies: { $type: string, data?, privileges?, policy_role?, permissive?, policy_name? }[]`

### Files changed

| File | What changed |
|---|---|
| `generate-types.ts` | Codegen for `BlueprintEntityTableProvision` and `BlueprintTable` — replaces `grant_roles`/`grant_privileges` with unified `grants[]` |
| `relation-many-to-many.ts` | JSON schema for RelationManyToMany node — 7 separate fields → 2 structured arrays |
| `blueprint-types.generated.ts` | Regenerated from codegen |
| `export-utils.ts` | `secure_table_provision` table config: 8 columns → `fields`, `grants`, `policies` |
| `export.test.ts` + snapshots | Removed old column names from tests; null-array tests now use actual array columns (`out_fields`) instead of `grants`/`policies` (which are plain `jsonb`, not `jsonb[]`) |

## Review & Testing Checklist for Human

- [ ] **Deployment ordering**: Verify constructive-db PRs #929 and #924 are merged and the `secure_table_provision` table has the new `grants jsonb` / `policies jsonb` columns before deploying this. The `export-utils.ts` column list must match the live DB schema exactly.
- [ ] **`BlueprintTable.grants` consolidation**: Previously had *two* fields (`grant_roles: string[]` + `grants: unknown[]`); now a single `grants: { roles, privileges }[]`. Confirm no plugin code is still referencing the old `grant_roles` property on `BlueprintTable`.
- [ ] **RelationManyToMany schema**: Verify that consumers of this JSON schema (blueprint processors, UI editors) handle the new `grants[]`/`policies[]` shape and don't expect the old flat fields.

### Notes
- `grants` and `policies` in `export-utils.ts` are typed `'jsonb'` (not `'jsonb[]'`) — this matches the DB schema where they're JSONB columns containing arrays, not PostgreSQL array-of-JSONB.
- The csv-to-pg test changes are purely about keeping the null-array test focused on actual array-typed columns. Plain `jsonb` NULL → `NULL` is correct standard behavior.

Link to Devin session: https://app.devin.ai/sessions/18879be982854a40abe5c9b915aa4a84
Requested by: @pyramation