### PR TITLE
fix: use Grafast plan() instead of resolve() for downloadUrl field

### DIFF
--- a/graphile/graphile-presigned-url-plugin/src/download-url-field.ts
+++ b/graphile/graphile-presigned-url-plugin/src/download-url-field.ts
@@ -11,9 +11,16 @@
  *   COMMENT ON TABLE files IS E'@storageFiles\nStorage files table';
  *
  * This is explicit and reliable — no duck-typing on column names.
+ *
+ * IMPORTANT: Uses Grafast plan() instead of traditional resolve().
+ * In PostGraphile V5, Grafast's planning system does not invoke traditional
+ * resolve functions on PG table type fields — it plans them as column
+ * lookups. Since downloadUrl is a computed field (not a real column),
+ * the plan() function is required for Grafast to execute the S3 signing.
  */
 
 import type { GraphileConfig } from 'graphile-config';
+import { context as grafastContext, lambda, object } from 'grafast';
 import { Logger } from '@pgpmjs/logger';
 
 import type { PresignedUrlPluginOptions, S3Config, StorageModuleConfig } from './types';
@@ -76,7 +83,7 @@ export function createDownloadUrlPlugin(
 
   return {
     name: 'PresignedUrlDownloadPlugin',
-    version: '0.1.0',
+    version: '0.2.0',
     description: 'Adds downloadUrl computed field to File types tagged with @storageFiles',
 
     schema: {
@@ -113,58 +120,71 @@ export function createDownloadUrlPlugin(
                     'URL to download this file. For public files, returns the public URL. ' +
                     'For private files, returns a time-limited presigned URL.',
                   type: GraphQLString,
-                  async resolve(parent: any, _args: any, context: any) {
-                    const key = parent.key || parent.get?.('key');
-                    const isPublic = parent.is_public ?? parent.get?.('is_public');
-                    const filename = parent.filename || parent.get?.('filename');
-                    const status = parent.status || parent.get?.('status');
+                  plan($parent: any) {
+                    // Access file attributes from the parent PgSelectSingleStep
+                    const $key = $parent.get('key');
+                    const $isPublic = $parent.get('is_public');
+                    const $filename = $parent.get('filename');
+                    const $status = $parent.get('status');
 
-                    if (!key) return null;
+                    // Access GraphQL context for per-database config resolution
+                    const $withPgClient = (grafastContext() as any).get('withPgClient');
+                    const $pgSettings = (grafastContext() as any).get('pgSettings');
 
-                    // Only provide download URLs for ready/processed files
-                    if (status !== 'ready' && status !== 'processed') {
-                      return null;
-                    }
+                    const $combined = object({
+                      key: $key,
+                      isPublic: $isPublic,
+                      filename: $filename,
+                      status: $status,
+                      withPgClient: $withPgClient,
+                      pgSettings: $pgSettings,
+                    });
 
-                    // Resolve per-database config (bucket, publicUrlPrefix, expiry)
-                    let s3ForDb = resolveS3(options); // fallback to global
-                    let downloadUrlExpirySeconds = 3600; // fallback default
-                    try {
-                      const withPgClient = context.pgSettings
-                        ? context.withPgClient
-                        : null;
-                      if (withPgClient) {
-                        const resolved = await withPgClient(null, async (pgClient: any) => {
-                          const dbResult = await pgClient.query({
-                            text: `SELECT jwt_private.current_database_id() AS id`,
-                          });
-                          const databaseId = dbResult.rows[0]?.id;
-                          if (!databaseId) return null;
-                          const config = await getStorageModuleConfig(pgClient, databaseId);
-                          if (!config) return null;
-                          return { config, databaseId };
-                        });
-                        if (resolved) {
-                          downloadUrlExpirySeconds = resolved.config.downloadUrlExpirySeconds;
-                          s3ForDb = resolveS3ForDatabase(options, resolved.config, resolved.databaseId);
-                        }
+                    return lambda($combined, async ({ key, isPublic, filename, status, withPgClient, pgSettings }: any) => {
+                      if (!key) return null;
+
+                      // Only provide download URLs for ready/processed files
+                      if (status !== 'ready' && status !== 'processed') {
+                        return null;
                       }
-                    } catch {
-                      // Fall back to global config if lookup fails
-                    }
 
-                    if (isPublic && s3ForDb.publicUrlPrefix) {
-                      // Public file: return direct CDN URL (per-database prefix)
-                      return `${s3ForDb.publicUrlPrefix}/${key}`;
-                    }
+                      // Resolve per-database config (bucket, publicUrlPrefix, expiry)
+                      let s3ForDb = resolveS3(options); // fallback to global
+                      let downloadUrlExpirySeconds = 3600; // fallback default
+                      try {
+                        if (withPgClient && pgSettings) {
+                          const resolved = await withPgClient(null, async (pgClient: any) => {
+                            const dbResult = await pgClient.query({
+                              text: `SELECT jwt_private.current_database_id() AS id`,
+                            });
+                            const databaseId = dbResult.rows[0]?.id;
+                            if (!databaseId) return null;
+                            const config = await getStorageModuleConfig(pgClient, databaseId);
+                            if (!config) return null;
+                            return { config, databaseId };
+                          });
+                          if (resolved) {
+                            downloadUrlExpirySeconds = resolved.config.downloadUrlExpirySeconds;
+                            s3ForDb = resolveS3ForDatabase(options, resolved.config, resolved.databaseId);
+                          }
+                        }
+                      } catch {
+                        // Fall back to global config if lookup fails
+                      }
 
-                    // Private file: generate presigned GET URL (per-database bucket)
-                    return generatePresignedGetUrl(
-                      s3ForDb,
-                      key,
-                      downloadUrlExpirySeconds,
-                      filename || undefined,
-                    );
+                      if (isPublic && s3ForDb.publicUrlPrefix) {
+                        // Public file: return direct CDN URL (per-database prefix)
+                        return `${s3ForDb.publicUrlPrefix}/${key}`;
+                      }
+
+                      // Private file: generate presigned GET URL (per-database bucket)
+                      return generatePresignedGetUrl(
+                        s3ForDb,
+                        key,
+                        downloadUrlExpirySeconds,
+                        filename || undefined,
+                      );
+                    });
                   },
                 },
               ),


### PR DESCRIPTION
## Summary

The `downloadUrl` computed field on `@storageFiles`-tagged file types was always returning `null` because it used a traditional GraphQL `resolve()` function. In PostGraphile V5, Grafast's planning system **does not invoke** traditional `resolve()` on PG table type fields — it only plans them as column lookups. Since `downloadUrl` is a computed field (not a real DB column), the resolver was silently never called.

This replaces `resolve()` with a Grafast `plan()` function using `lambda()`, `object()`, and `grafastContext()` — the same pattern already used by `requestUploadUrl` and `confirmUpload` mutations in this plugin. The underlying business logic (status check → per-database config resolution → public CDN URL or presigned GET URL) is unchanged.

Plugin version bumped from `0.1.0` → `0.2.0`.

## Review & Testing Checklist for Human

- [ ] **Verify the Grafast plan pattern matches the mutation pattern in `plugin.ts`** (~lines 217-403). The `$parent.get('column')` → `object()` → `lambda()` chain should mirror how `requestUploadUrl` accesses its input. This is the core correctness question.
- [ ] **Verify context key names**: the old code accessed `context.withPgClient` and `context.pgSettings` directly. The new code uses `grafastContext().get('withPgClient')` and `grafastContext().get('pgSettings')`. Confirm these keys exist in the Grafast context object (they should — the mutations use the same pattern).
- [ ] **Confirm the conditional change is equivalent**: old code used `context.pgSettings ? context.withPgClient : null`, new code uses `if (withPgClient && pgSettings)`. Both guard against missing context, but the shape is slightly different.
- [ ] **Test end-to-end with the companion test PR** ([constructive-db#934](https://github.com/constructive-io/constructive-db/pull/934)). That PR has 3 download tests that exercise this field via GraphQL: private file presigned URL, entity-member download, and public CDN URL. All 32 tests pass locally with MinIO. This repo's CI does not directly exercise the download path.

### Notes
- There are no tests for the download URL field in this repo — coverage comes from the integration tests in constructive-db.
- All types in the plan function are `any`, consistent with the existing mutation patterns in this plugin. Proper typing would require importing Grafast step types.
- The silent `catch {}` fallback to global S3 config is preserved from the original code.

Link to Devin session: https://app.devin.ai/sessions/18879be982854a40abe5c9b915aa4a84
Requested by: @pyramation