### PR TITLE
feat: re-export getDbConnections and types for two-phase test patterns

### DIFF
--- a/graphql/test/src/index.ts
+++ b/graphql/test/src/index.ts
@@ -15,5 +15,11 @@ export { GraphQLTest } from './graphile-test';
 export * from './get-connections';
 export { seed, snapshot } from 'pgsql-test';
 
+// Re-export low-level DB connection utilities for advanced two-phase patterns
+// (e.g. provision first, then build GraphQL schema over dynamic tables).
+export { getConnections as getDbConnections } from 'pgsql-test';
+export type { GetConnectionResult, GetConnectionOpts } from 'pgsql-test';
+export type { PgTestClient } from 'pgsql-test/test-client';
+
 // Export GraphQL test adapter for SDK integration
 export { GraphQLTestAdapter } from './adapter';


### PR DESCRIPTION
## Summary

Re-exports low-level DB connection utilities from `pgsql-test` through `@constructive-io/graphql-test` so that tests needing a **two-phase pattern** can import everything from the framework without reaching down to `pgsql-test` directly.

New exports:
- `getDbConnections` — alias for `pgsql-test`'s `getConnections` (raw DB connections without GraphQL schema build)
- `GetConnectionResult`, `GetConnectionOpts` types from `pgsql-test`
- `PgTestClient` type from `pgsql-test/test-client`

**Why:** Some integration tests (e.g. presigned-url download tests in constructive-db PR #934) need to provision a database first (which creates dynamic schemas/tables via DDL), then build a GraphQL schema over those tables in a second phase. The existing `getConnections()` bundles both steps atomically — schemas must be known upfront before seeds run. These re-exports let tests call `getDbConnections()` for phase 1 and `GraphQLTest()` for phase 2, all from framework imports.

This follows the existing pattern where `seed` and `snapshot` are already re-exported from `pgsql-test` (line 16).

## Review & Testing Checklist for Human
- [ ] Verify `getDbConnections` doesn't conflict with the existing `getConnections` export from `./get-connections` (different names, but worth confirming no ambiguity for consumers)
- [ ] Confirm the `pgsql-test/test-client` subpath export resolves correctly at the consumer side (it's already used internally in `get-connections.ts`, so should be fine)

### Notes
- This is a pure re-export change — no logic modified
- The consuming PR is constructive-db#934 which will switch its `pgsql-test` direct import to use `getDbConnections` from this package instead

Link to Devin session: https://app.devin.ai/sessions/18879be982854a40abe5c9b915aa4a84
Requested by: @pyramation