### PR TITLE
test(cli): import inquirerer test utils directly from @inquirerer/test

### DIFF
--- a/packages/cli/__tests__/cli.test.ts
+++ b/packages/cli/__tests__/cli.test.ts
@@ -1,6 +1,5 @@
+import { KEY_SEQUENCES, setupTests, TestEnvironment } from '@inquirerer/test';
 import { Inquirerer, Question } from 'inquirerer';
-
-import { KEY_SEQUENCES, setupTests, TestEnvironment } from '../test-utils';
 
 const beforeEachSetup = setupTests();
 

--- a/packages/cli/test-utils/index.ts
+++ b/packages/cli/test-utils/index.ts
@@ -1,16 +1,4 @@
+// Local CLI fixture helpers. For inquirerer testing primitives
+// (KEY_SEQUENCES, setupTests, createTestEnvironment, snapshot utils, etc.),
+// import directly from `@inquirerer/test`.
 export * from './fixtures';
-
-// Re-export test utilities from @inquirerer/test
-export {
-  KEY_SEQUENCES,
-  setupTests,
-  createTestEnvironment,
-  normalizePackageJsonForSnapshot,
-  cleanAnsi
-} from '@inquirerer/test';
-
-export type {
-  TestEnvironment,
-  InputResponse,
-  NormalizeOptions
-} from '@inquirerer/test';


### PR DESCRIPTION
## Summary

The `packages/cli/test-utils/index.ts` barrel was a pure passthrough re-export of `@inquirerer/test`, which made it look like there was a custom test harness when there wasn't. This makes `cli.test.ts` import from `@inquirerer/test` directly so the source is obvious, and trims `test-utils/index.ts` down to the genuinely local fixture helpers.

```diff
- import { KEY_SEQUENCES, setupTests, TestEnvironment } from '../test-utils';
+ import { KEY_SEQUENCES, setupTests, TestEnvironment } from '@inquirerer/test';
```

No behavioural change — the symbols are identical (the local barrel was just `export { ... } from '@inquirerer/test'`). `test-utils/fixtures.ts` stays put because it's a genuinely local wrapper around `createTestFixture`.

## Review & Testing Checklist for Human

- [ ] `pnpm --filter @constructive-io/cli test` still passes locally (with `@constructive-io/graphql-codegen` built — both `cli.test.ts` and `codegen.test.ts` should be green).
- [ ] No other `packages/cli/test-utils` imports got broken — confirmed via grep, only `cli.test.ts` referenced this path.

### Notes

Companion PR: [`constructive-io/dev-utils#79`](https://github.com/constructive-io/dev-utils/pull/79) adds a `runCli` subprocess helper to `@inquirerer/test` and a Testing section to inquirerer's main README pointing at the package. This PR is independent of that one (it just uses the existing in-process `setupTests` API), but they're part of the same "make CLI testing easy and discoverable" thread.

A separate downstream PR will follow in `constructive-io/agentic-db` to swap the hand-rolled `runCli` in `cli-e2e-tests` for the new shared helper once dev-utils#79 lands.

Link to Devin session: https://app.devin.ai/sessions/81001448b7c54b8099437f706d44a30d
Requested by: @pyramation