### PR TITLE
fix(safegres): correct bin path so `safegres` CLI works after npm install

### DIFF
--- a/packages/safegres/package.json
+++ b/packages/safegres/package.json
@@ -2,7 +2,7 @@
   "name": "safegres",
   "version": "0.2.0",
   "author": "Constructive <developers@constructive.io>",
-  "description": "Pure-PostgreSQL RLS auditor: grants, RLS flags, policy coverage, and AST-level anti-pattern detection. Re-exports the Authz*/Data*/Relation*/View* type registry for downstream auditors.",
+  "description": "Pure-Postgres Row-Level Security auditor: grants, RLS enforcement, policy coverage, and risky SQL policy patterns. No app framework required.",
   "main": "index.js",
   "module": "esm/index.js",
   "types": "index.d.ts",
@@ -20,13 +20,13 @@
     "url": "https://github.com/constructive-io/constructive/issues"
   },
   "bin": {
-    "safegres": "dist/cli.js"
+    "safegres": "cli.js"
   },
   "scripts": {
     "clean": "makage clean",
     "prepack": "npm run build",
-    "build": "makage build",
-    "build:dev": "makage build --dev",
+    "build": "makage build && chmod +x dist/cli.js",
+    "build:dev": "makage build --dev && chmod +x dist/cli.js",
     "lint": "eslint . --fix",
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch"


### PR DESCRIPTION
## Summary

`safegres@0.2.0` (already on npm) ships with a broken `bin` path — `npm install -g safegres` does not create the `safegres` binary, and `safegres audit` is unrunnable.

### Root cause

The package publishes from `dist/` (via `publishConfig.directory: "dist"`), so `bin` paths must be **relative to the publish dir**, not the package root. We had:

```json
"bin": { "safegres": "dist/cli.js" }
```

When installed, npm looked for `node_modules/safegres/dist/cli.js`, but the file is actually at `node_modules/safegres/cli.js` (because the `dist/` contents are flattened to the package root on publish). npm silently skipped the bin link.

I confirmed locally:

```
$ npm install safegres@0.2.0
$ ls node_modules/.bin/safegres
ls: cannot access 'node_modules/.bin/safegres': No such file or directory
```

### Fix

Match the convention from `packages/cli` (which publishes the same way and works correctly):

- `bin: { safegres: "cli.js" }` — relative to publish dir
- `chmod +x dist/cli.js` in the build, so `pnpm` workspace symlinks during dev also have the executable bit (npm's auto-bin-chmod handles installs from registry, but the explicit chmod covers local dev too)

Also refreshed the package description to drop the stale "Re-exports the Authz*/Data*/Relation*/View* type registry" line — those re-exports were removed before publish but the description didn't get updated.

### After this lands

You'll need to publish a new patch (e.g. `safegres@0.2.1`) since `0.2.0` is already taken on npm. Cannot republish over an existing version.

Verified locally:
- `pnpm build` succeeds, `dist/cli.js` is `-rwxr-xr-x`
- `dist/package.json` (the published one) now has `bin: { safegres: "cli.js" }`
- Shebang `#!/usr/bin/env node` preserved through tsc

## Review & Testing Checklist for Human

- [ ] Confirm the fix matches `packages/cli/package.json`'s convention (`bin: { cnc: "index.js" }` alongside `publishConfig.directory: "dist"`)
- [ ] After merge, publish `safegres@0.2.1` from `packages/safegres/dist/` and verify `npm install -g safegres@0.2.1 && safegres --version` works
- [ ] Optional: deprecate `safegres@0.2.0` on npm (`npm deprecate safegres@0.2.0 "broken bin path; use 0.2.1+"`)

### Notes

This is a 4-line fix to one file. Zero impact on the package's runtime code or public API.


Link to Devin session: https://app.devin.ai/sessions/6ab67cb5b65b4d2ba498263198f43e46
Requested by: @pyramation