### PR TITLE
feat!: rename BlueprintMembershipType to BlueprintEntityType + add storage to BlueprintDefinition

### DIFF
--- a/graphql/node-type-registry/src/blueprint-types.generated.ts
+++ b/graphql/node-type-registry/src/blueprint-types.generated.ts
@@ -874,7 +874,7 @@ export interface BlueprintStorageConfig {
   /** CORS allowed origins for the storage module. */
   allowed_origins?: string[];
 }
-/** Override object for the entity table created by a BlueprintMembershipType. Shape mirrors BlueprintTable / secure_table_provision vocabulary. When supplied, policies[] replaces the default entity-table policies entirely. */
+/** Override object for the entity table created by a BlueprintEntityType. Shape mirrors BlueprintTable / secure_table_provision vocabulary. When supplied, policies[] replaces the default entity-table policies entirely. */
 export interface BlueprintEntityTableProvision {
   /** Whether to enable RLS on the entity table. Forwarded to secure_table_provision. Defaults to true. */
   use_rls?: boolean;
@@ -890,8 +890,8 @@ export interface BlueprintEntityTableProvision {
   /** RLS policies for the entity table. When present, these policies fully replace the five default entity-table policies (is_visible becomes a no-op). */
   policies?: BlueprintPolicy[];
 }
-/** A membership type entry for Phase 0 of construct_blueprint(). Provisions a full entity type with its own entity table, membership modules, and security policies via entity_type_provision. */
-export interface BlueprintMembershipType {
+/** An entity type entry for Phase 0 of construct_blueprint(). Provisions a full entity type with its own entity table, membership modules, and security policies via entity_type_provision. */
+export interface BlueprintEntityType {
   /** Entity type name (e.g., "data_room", "channel", "department"). Must be unique per database. */
   name: string;
   /** Short prefix for generated objects (e.g., "dr", "ch", "dept"). Used in table/trigger naming. */
@@ -1151,5 +1151,7 @@ export interface BlueprintDefinition {
   /** Unique constraints on table columns. */
   unique_constraints?: BlueprintUniqueConstraint[];
   /** Entity types to provision in Phase 0 (before tables). Each entry creates an entity table with membership modules and security. */
-  membership_types?: BlueprintMembershipType[];
+  entity_types?: BlueprintEntityType[];
+  /** App-level storage configuration. Creates a storage_module (membership_type = NULL) with the specified policies, seeds initial buckets, and overrides module-level settings (expiry times, file size limits, CORS). For entity-scoped storage, use entity_types[].has_storage + entity_types[].storage instead. */
+  storage?: BlueprintStorageConfig;
 }

--- a/graphql/node-type-registry/src/codegen/generate-types.ts
+++ b/graphql/node-type-registry/src/codegen/generate-types.ts
@@ -796,13 +796,13 @@ function buildBlueprintEntityTableProvision(): t.ExportNamedDeclaration {
         'RLS policies for the entity table. When present, these policies fully replace the five default entity-table policies (is_visible becomes a no-op).'
       )
     ]),
-    'Override object for the entity table created by a BlueprintMembershipType. Shape mirrors BlueprintTable / secure_table_provision vocabulary. When supplied, policies[] replaces the default entity-table policies entirely.'
+    'Override object for the entity table created by a BlueprintEntityType. Shape mirrors BlueprintTable / secure_table_provision vocabulary. When supplied, policies[] replaces the default entity-table policies entirely.'
   );
 }
 
-function buildBlueprintMembershipType(): t.ExportNamedDeclaration {
+function buildBlueprintEntityType(): t.ExportNamedDeclaration {
   return addJSDoc(
-    exportInterface('BlueprintMembershipType', [
+    exportInterface('BlueprintEntityType', [
       addJSDoc(
         requiredProp('name', t.tsStringKeyword()),
         'Entity type name (e.g., "data_room", "channel", "department"). Must be unique per database.'
@@ -862,7 +862,7 @@ function buildBlueprintMembershipType(): t.ExportNamedDeclaration {
         'Storage configuration. Only used when has_storage is true. Controls RLS policies on storage tables, seeds initial buckets, and overrides module-level settings (expiry times, file size limits, CORS).'
       )
     ]),
-    'A membership type entry for Phase 0 of construct_blueprint(). Provisions a full entity type with its own entity table, membership modules, and security policies via entity_type_provision.'
+    'An entity type entry for Phase 0 of construct_blueprint(). Provisions a full entity type with its own entity table, membership modules, and security policies via entity_type_provision.'
   );
 }
 
@@ -984,12 +984,19 @@ function buildBlueprintDefinition(): t.ExportNamedDeclaration {
       ),
       addJSDoc(
         optionalProp(
-          'membership_types',
+          'entity_types',
           t.tsArrayType(
-            t.tsTypeReference(t.identifier('BlueprintMembershipType'))
+            t.tsTypeReference(t.identifier('BlueprintEntityType'))
           )
         ),
         'Entity types to provision in Phase 0 (before tables). Each entry creates an entity table with membership modules and security.'
+      ),
+      addJSDoc(
+        optionalProp(
+          'storage',
+          t.tsTypeReference(t.identifier('BlueprintStorageConfig'))
+        ),
+        'App-level storage configuration. Creates a storage_module (membership_type = NULL) with the specified policies, seeds initial buckets, and overrides module-level settings (expiry times, file size limits, CORS). For entity-scoped storage, use entity_types[].has_storage + entity_types[].storage instead.'
       )
     ]),
     'The complete blueprint definition -- the JSONB shape accepted by construct_blueprint().'
@@ -1066,7 +1073,7 @@ function buildProgram(meta?: MetaTableInfo[]): string {
   statements.push(buildBlueprintBucketSeed());
   statements.push(buildBlueprintStorageConfig());
   statements.push(buildBlueprintEntityTableProvision());
-  statements.push(buildBlueprintMembershipType());
+  statements.push(buildBlueprintEntityType());
 
   // -- Node types discriminated union --
   statements.push(


### PR DESCRIPTION
## Summary

TypeScript type updates matching the SQL-level rename in constructive-db #956.

### Changes

1. **`BlueprintMembershipType` → `BlueprintEntityType`** — interface renamed in codegen source and regenerated output
2. **`membership_types` → `entity_types`** — the property on `BlueprintDefinition` now matches the SQL key
3. **`storage?: BlueprintStorageConfig`** — new optional property on `BlueprintDefinition` for app-level storage configuration (bucket seeds, policies, expiry overrides, CORS)
4. **JSDoc fix** — `BlueprintEntityTableProvision` doc now references `BlueprintEntityType` instead of `BlueprintMembershipType`

### Files changed

- `graphql/node-type-registry/src/codegen/generate-types.ts` — codegen source
- `graphql/node-type-registry/src/blueprint-types.generated.ts` — regenerated output

## Review & Testing Checklist for Human

- [ ] Verify `BlueprintEntityType` interface has all the same properties as the old `BlueprintMembershipType`
- [ ] Verify `BlueprintDefinition.entity_types` autocomplete works in IDE
- [ ] Verify `BlueprintDefinition.storage` shows `BlueprintStorageConfig` shape in autocomplete

### Notes

- Companion PR: constructive-db #956 (renames the SQL key and adds Phase 0.5 storage logic)
- No runtime code changes — these are purely type-level (codegen source + generated types)

Link to Devin session: https://app.devin.ai/sessions/58b40b3f63804c20b86643cc873ba844
Requested by: @pyramation