### PR TITLE
feat: add has_invites and storage_table_provisions to blueprint types

### DIFF
--- a/graphql/node-type-registry/src/blueprint-types.generated.ts
+++ b/graphql/node-type-registry/src/blueprint-types.generated.ts
@@ -873,6 +873,12 @@ export interface BlueprintStorageConfig {
   default_max_file_size?: number;
   /** CORS allowed origins for the storage module. */
   allowed_origins?: string[];
+  /** Per-table overrides for storage tables. Each key targets a specific storage table (files, buckets, upload_requests) and uses the same shape as table_provision: { nodes, fields, grants, use_rls, policies }. Fanned out to secure_table_provision targeting the corresponding table. */
+  storage_table_provisions?: {
+    files?: BlueprintEntityTableProvision;
+    buckets?: BlueprintEntityTableProvision;
+    upload_requests?: BlueprintEntityTableProvision;
+  };
 }
 /** Override object for the entity table created by a BlueprintEntityType. Shape mirrors BlueprintTable / secure_table_provision vocabulary. When supplied, policies[] replaces the default entity-table policies entirely. */
 export interface BlueprintEntityTableProvision {
@@ -912,6 +918,8 @@ export interface BlueprintEntityType {
   has_levels?: boolean;
   /** Whether to provision a storage module (buckets, files, upload_requests tables) for this entity type. Defaults to false. */
   has_storage?: boolean;
+  /** Whether to provision entity-scoped invite tables ({prefix}_invites, {prefix}_claimed_invites) and a submit_{prefix}_invite_code() function. Defaults to false. */
+  has_invites?: boolean;
   /** Escape hatch: when true AND table_provision is NULL, zero policies are provisioned on the entity table. Defaults to false. */
   skip_entity_policies?: boolean;
   /** Override for the entity table. Shape mirrors BlueprintTable / secure_table_provision vocabulary. When supplied, its policies[] replaces the five default entity-table policies; is_visible becomes a no-op. When NULL (default), the five default policies are applied (gated by is_visible). */

--- a/graphql/node-type-registry/src/codegen/generate-types.ts
+++ b/graphql/node-type-registry/src/codegen/generate-types.ts
@@ -749,6 +749,26 @@ function buildBlueprintStorageConfig(): t.ExportNamedDeclaration {
           t.tsArrayType(t.tsStringKeyword())
         ),
         'CORS allowed origins for the storage module.'
+      ),
+      addJSDoc(
+        optionalProp(
+          'storage_table_provisions',
+          t.tsTypeLiteral([
+            optionalProp(
+              'files',
+              t.tsTypeReference(t.identifier('BlueprintEntityTableProvision'))
+            ),
+            optionalProp(
+              'buckets',
+              t.tsTypeReference(t.identifier('BlueprintEntityTableProvision'))
+            ),
+            optionalProp(
+              'upload_requests',
+              t.tsTypeReference(t.identifier('BlueprintEntityTableProvision'))
+            )
+          ])
+        ),
+        'Per-table overrides for storage tables. Each key targets a specific storage table (files, buckets, upload_requests) and uses the same shape as table_provision: { nodes, fields, grants, use_rls, policies }. Fanned out to secure_table_provision targeting the corresponding table.'
       )
     ]),
     'Storage configuration for an entity type. Controls RLS policies on storage tables, seeds initial buckets, and overrides module-level settings (expiry times, file size limits, CORS).'
@@ -842,6 +862,10 @@ function buildBlueprintEntityType(): t.ExportNamedDeclaration {
       addJSDoc(
         optionalProp('has_storage', t.tsBooleanKeyword()),
         'Whether to provision a storage module (buckets, files, upload_requests tables) for this entity type. Defaults to false.'
+      ),
+      addJSDoc(
+        optionalProp('has_invites', t.tsBooleanKeyword()),
+        'Whether to provision entity-scoped invite tables ({prefix}_invites, {prefix}_claimed_invites) and a submit_{prefix}_invite_code() function. Defaults to false.'
       ),
       addJSDoc(
         optionalProp('skip_entity_policies', t.tsBooleanKeyword()),


### PR DESCRIPTION
## Summary

Updates the `BlueprintEntityType` and `BlueprintStorageConfig` types in `node-type-registry` to match the constructive-db changes in [constructive-db#958](https://github.com/constructive-io/constructive-db/pull/958):

- **`BlueprintEntityType.has_invites`** — boolean for entity-scoped invite tables provisioning
- **`BlueprintStorageConfig.storage_table_provisions`** — per-table overrides keyed by `files`, `buckets`, `upload_requests`, each using `BlueprintEntityTableProvision` shape (replaces the old `files_table_provision` which only covered files)

Both the codegen source (`generate-types.ts`) and the generated output (`blueprint-types.generated.ts`) are updated.

## Review & Testing Checklist for Human

- [ ] Verify `has_invites` appears in the generated `BlueprintEntityType` interface with correct JSDoc
- [ ] Verify `storage_table_provisions` has the correct typed keys (`files`, `buckets`, `upload_requests`) reusing `BlueprintEntityTableProvision`

### Notes

- Companion PR: [constructive-db#958](https://github.com/constructive-io/constructive-db/pull/958)
- Skills docs PR: constructive-skills (feat/docs-has-invites-storage-table-provisions)

Link to Devin session: https://app.devin.ai/sessions/ff0b16d790a34cceb17740c9897a295e
Requested by: @pyramation