### PR TITLE
fix(pgpm): use correct relative path in cd hint after init

### DIFF
--- a/pgpm/cli/src/commands/init/index.ts
+++ b/pgpm/cli/src/commands/init/index.ts
@@ -329,7 +329,8 @@ async function handleWorkspaceInit(
     process.stdout.write('\n');
   }
 
-  process.stdout.write(`\n✨ Enjoy!\n\ncd ./${dirName}\n`);
+  const relPath = path.relative(process.cwd(), targetPath);
+  process.stdout.write(`\n✨ Enjoy!\n\ncd ./${relPath}\n`);
 
   return { ...argv, ...answers, cwd: targetPath };
 }
@@ -619,7 +620,8 @@ async function handleModuleInit(
     process.stdout.write('\n');
   }
 
-  process.stdout.write(`\n✨ Enjoy!\n\ncd ./${modName}\n`);
+  const relPath = path.relative(process.cwd(), modulePath);
+  process.stdout.write(`\n✨ Enjoy!\n\ncd ./${relPath}\n`);
 
   return { ...argv, ...answers };
 }

--- a/pgpm/cli/src/commands/init/workspace.ts
+++ b/pgpm/cli/src/commands/init/workspace.ts
@@ -74,7 +74,8 @@ export default async function runWorkspaceSetup(
     process.stdout.write('\n');
   }
 
-  process.stdout.write(`\n✨ Enjoy!\n\ncd ./${dirName}\n`);
+  const relPath = path.relative(process.cwd(), targetPath);
+  process.stdout.write(`\n✨ Enjoy!\n\ncd ./${relPath}\n`);
 
   return { ...argv, ...answers, cwd: targetPath };
 }


### PR DESCRIPTION
## Summary

After `pgpm init` creates a module, it prints a `cd ./<name>` hint for the user. When the module is created inside a subdirectory (e.g. `packages/`), the hint was wrong — it only printed the bare module name (`cd ./cards`) instead of the actual relative path (`cd ./packages/cards`).

This fix uses `path.relative(process.cwd(), modulePath)` to compute the correct relative path from the user's current working directory to wherever the folder was actually created. Applied to all three `cd` hints:
- `handleWorkspaceInit` in `index.ts` (line 332)
- `handleModuleInit` in `index.ts` (line 622)
- `runWorkspaceSetup` in `workspace.ts` (line 77)

## Review & Testing Checklist for Human
- [ ] Run `pgpm init` from a workspace root and confirm the hint says `cd ./packages/<name>` 
- [ ] Run `pgpm init` from inside `packages/` and confirm it says `cd ./<name>`
- [ ] Run `pgpm init workspace` and confirm it says `cd ./<workspace-name>`

### Notes
The workspace cases were already correct in practice (workspace is always created directly in cwd), but updated for consistency and robustness when `--cwd` differs from `process.cwd()`.

Link to Devin session: https://app.devin.ai/sessions/95ae737fc0464b04b83a1cb7af4c65dc
Requested by: @pyramation