### PR TITLE
feat(node-type-registry): centralize missing defaults in registry

### DIFF
--- a/packages/node-type-registry/src/authz/authz-entity-membership.ts
+++ b/packages/node-type-registry/src/authz/authz-entity-membership.ts
@@ -14,6 +14,11 @@ export const AuthzEntityMembership: NodeTypeDefinition = {
         format: 'column-ref',
         description: 'Column name referencing the entity (e.g., entity_id, org_id)'
       },
+      sel_field: {
+        type: 'string',
+        description: 'SPRT column to select for the entity match',
+        default: 'entity_id'
+      },
       membership_type: {
         type: [
           'integer',

--- a/packages/node-type-registry/src/authz/authz-related-entity-membership.ts
+++ b/packages/node-type-registry/src/authz/authz-related-entity-membership.ts
@@ -14,6 +14,16 @@ export const AuthzRelatedEntityMembership: NodeTypeDefinition = {
         format: 'column-ref',
         description: 'Column name on protected table referencing the join table'
       },
+      sel_field: {
+        type: 'string',
+        description: 'SPRT column to select for the entity match',
+        default: 'entity_id'
+      },
+      sprt_join_field: {
+        type: 'string',
+        description: 'SPRT column to join on with the related table',
+        default: 'entity_id'
+      },
       membership_type: {
         type: [
           'integer',

--- a/packages/node-type-registry/src/authz/authz-related-peer-ownership.ts
+++ b/packages/node-type-registry/src/authz/authz-related-peer-ownership.ts
@@ -51,7 +51,8 @@ export const AuthzRelatedPeerOwnership: NodeTypeDefinition = {
       obj_ref_field: {
         type: 'string',
         format: 'column-ref',
-        description: 'Field on related table to select for matching entity_field (defaults to id)'
+        description: 'Field on related table to select for matching entity_field',
+        default: 'id'
       },
       permission: {
         type: 'string',


### PR DESCRIPTION
## Summary

Adds missing `default` values to three Authz* node type definitions so that ALL defaults live in the registry as the single source of truth. Previously these defaults were hardcoded in the `cpt_*` AST builder functions in constructive-db.

**Changes:**
- **AuthzRelatedPeerOwnership**: `obj_ref_field` — add `default: 'id'` (was hardcoded in `cpt_related_peer_ownership`)
- **AuthzEntityMembership**: add `sel_field` property with `default: 'entity_id'` (was hardcoded in `cpt_membership_by_field`)
- **AuthzRelatedEntityMembership**: add `sel_field` (`default: 'entity_id'`) and `sprt_join_field` (`default: 'entity_id'`) (were hardcoded in `cpt_membership_by_join`)

This is part of centralizing all defaults — after this publishes, the corresponding COALESCE fallbacks in the constructive-db `cpt_*` functions will be removed.

## Review & Testing Checklist for Human
- [ ] Verify the default values match the existing COALESCE fallbacks in `policy_ast_builders.sql`
- [ ] After publishing, regenerate the SQL seed in constructive-db and confirm the defaults appear in the seed

### Notes
Companion to constructive-db PRs #967 and #970 which implement the node_type_registry table and generic column cloning for issue #767.

Link to Devin session: https://app.devin.ai/sessions/20dbaaa0e6e74599842fbefe33efbc26
Requested by: @pyramation