### PR TITLE
fix: make conditions type a clean recursive TriggerCondition interface

### DIFF
--- a/packages/node-type-registry/src/blueprint-types.generated.ts
+++ b/packages/node-type-registry/src/blueprint-types.generated.ts
@@ -9,6 +9,34 @@
 
 /**
  * ===========================================================================
+ * Shared recursive types
+ * ===========================================================================
+ */
+;
+/** Recursive condition type for compound trigger WHEN clauses. Leaf conditions specify {field, op, value?, row?, ref?}. Combinators nest via AND, OR, NOT. */
+export interface TriggerCondition {
+  /** Column name (validated against the table). */
+  field?: string;
+  /** Comparison operator. */
+  op?: '=' | '!=' | '>' | '<' | '>=' | '<=' | 'LIKE' | 'NOT LIKE' | 'IS NULL' | 'IS NOT NULL' | 'IS DISTINCT FROM';
+  /** Comparison value. Type is resolved from the column definition. */
+  value?: any;
+  /** Row reference (default: NEW). */
+  row?: 'NEW' | 'OLD';
+  /** Column reference for field-to-field comparison (alternative to value). */
+  ref?: {
+    field?: string;
+    row?: 'NEW' | 'OLD';
+  };
+  /** Array of conditions combined with AND. */
+  AND?: TriggerCondition[];
+  /** Array of conditions combined with OR. */
+  OR?: TriggerCondition[];
+  /** Negated condition. */
+  NOT?: TriggerCondition;
+}
+/**
+ * ===========================================================================
  * Data node type parameters
  * ===========================================================================
  */
@@ -121,139 +149,7 @@ export interface DataJobTriggerParams {
   /* Value to compare against condition_field in WHEN clause */
   condition_value?: string;
   /* Compound conditions for the trigger WHEN clause. Accepts a single leaf condition, an array of conditions (implicitly AND), or a nested combinator tree ({AND: [...], OR: [...], NOT: {...}}). Each leaf is {field, op, value?, row?, ref?}. Column types are resolved automatically from the table schema. Cannot be combined with condition_field or watch_fields. */
-  conditions?: {
-    /* Column name (validated against the table) */field?: string;
-    /* Comparison operator */op?: '=' | '!=' | '>' | '<' | '>=' | '<=' | 'LIKE' | 'NOT LIKE' | 'IS NULL' | 'IS NOT NULL' | 'IS DISTINCT FROM';
-    /* Comparison value. Type is resolved from the column definition. Omit for IS NULL, IS NOT NULL, IS DISTINCT FROM. */value?: any;
-    /* Row reference (default: NEW) */row?: 'NEW' | 'OLD';
-    /* Column reference for field-to-field comparison (alternative to value) */ref?: {
-      field?: string;
-      row?: 'NEW' | 'OLD';
-    };
-    /* Array of conditions combined with AND */AND?: {
-      /* Column name (validated against the table) */field?: string;
-      /* Comparison operator */op?: '=' | '!=' | '>' | '<' | '>=' | '<=' | 'LIKE' | 'NOT LIKE' | 'IS NULL' | 'IS NOT NULL' | 'IS DISTINCT FROM';
-      /* Comparison value. Type is resolved from the column definition. Omit for IS NULL, IS NOT NULL, IS DISTINCT FROM. */value?: any;
-      /* Row reference (default: NEW) */row?: 'NEW' | 'OLD';
-      /* Column reference for field-to-field comparison (alternative to value) */ref?: {
-        field?: string;
-        row?: 'NEW' | 'OLD';
-      };
-      /* Nested AND */AND?: {
-        [key: string]: unknown;
-      }[];
-      /* Nested OR */OR?: {
-        [key: string]: unknown;
-      }[];
-      /* Nested NOT */NOT?: {
-        [key: string]: unknown;
-      };
-    }[];
-    /* Array of conditions combined with OR */OR?: {
-      /* Column name (validated against the table) */field?: string;
-      /* Comparison operator */op?: '=' | '!=' | '>' | '<' | '>=' | '<=' | 'LIKE' | 'NOT LIKE' | 'IS NULL' | 'IS NOT NULL' | 'IS DISTINCT FROM';
-      /* Comparison value. Type is resolved from the column definition. Omit for IS NULL, IS NOT NULL, IS DISTINCT FROM. */value?: any;
-      /* Row reference (default: NEW) */row?: 'NEW' | 'OLD';
-      /* Column reference for field-to-field comparison (alternative to value) */ref?: {
-        field?: string;
-        row?: 'NEW' | 'OLD';
-      };
-      /* Nested AND */AND?: {
-        [key: string]: unknown;
-      }[];
-      /* Nested OR */OR?: {
-        [key: string]: unknown;
-      }[];
-      /* Nested NOT */NOT?: {
-        [key: string]: unknown;
-      };
-    }[];
-    /* Negated condition */NOT?: {
-      /* Column name (validated against the table) */field?: string;
-      /* Comparison operator */op?: '=' | '!=' | '>' | '<' | '>=' | '<=' | 'LIKE' | 'NOT LIKE' | 'IS NULL' | 'IS NOT NULL' | 'IS DISTINCT FROM';
-      /* Comparison value. Type is resolved from the column definition. Omit for IS NULL, IS NOT NULL, IS DISTINCT FROM. */value?: any;
-      /* Row reference (default: NEW) */row?: 'NEW' | 'OLD';
-      /* Column reference for field-to-field comparison (alternative to value) */ref?: {
-        field?: string;
-        row?: 'NEW' | 'OLD';
-      };
-      /* Nested AND */AND?: {
-        [key: string]: unknown;
-      }[];
-      /* Nested OR */OR?: {
-        [key: string]: unknown;
-      }[];
-      /* Nested NOT */NOT?: {
-        [key: string]: unknown;
-      };
-    };
-  } | {
-    /* Column name (validated against the table) */field?: string;
-    /* Comparison operator */op?: '=' | '!=' | '>' | '<' | '>=' | '<=' | 'LIKE' | 'NOT LIKE' | 'IS NULL' | 'IS NOT NULL' | 'IS DISTINCT FROM';
-    /* Comparison value. Type is resolved from the column definition. Omit for IS NULL, IS NOT NULL, IS DISTINCT FROM. */value?: any;
-    /* Row reference (default: NEW) */row?: 'NEW' | 'OLD';
-    /* Column reference for field-to-field comparison (alternative to value) */ref?: {
-      field?: string;
-      row?: 'NEW' | 'OLD';
-    };
-    /* Array of conditions combined with AND */AND?: {
-      /* Column name (validated against the table) */field?: string;
-      /* Comparison operator */op?: '=' | '!=' | '>' | '<' | '>=' | '<=' | 'LIKE' | 'NOT LIKE' | 'IS NULL' | 'IS NOT NULL' | 'IS DISTINCT FROM';
-      /* Comparison value. Type is resolved from the column definition. Omit for IS NULL, IS NOT NULL, IS DISTINCT FROM. */value?: any;
-      /* Row reference (default: NEW) */row?: 'NEW' | 'OLD';
-      /* Column reference for field-to-field comparison (alternative to value) */ref?: {
-        field?: string;
-        row?: 'NEW' | 'OLD';
-      };
-      /* Nested AND */AND?: {
-        [key: string]: unknown;
-      }[];
-      /* Nested OR */OR?: {
-        [key: string]: unknown;
-      }[];
-      /* Nested NOT */NOT?: {
-        [key: string]: unknown;
-      };
-    }[];
-    /* Array of conditions combined with OR */OR?: {
-      /* Column name (validated against the table) */field?: string;
-      /* Comparison operator */op?: '=' | '!=' | '>' | '<' | '>=' | '<=' | 'LIKE' | 'NOT LIKE' | 'IS NULL' | 'IS NOT NULL' | 'IS DISTINCT FROM';
-      /* Comparison value. Type is resolved from the column definition. Omit for IS NULL, IS NOT NULL, IS DISTINCT FROM. */value?: any;
-      /* Row reference (default: NEW) */row?: 'NEW' | 'OLD';
-      /* Column reference for field-to-field comparison (alternative to value) */ref?: {
-        field?: string;
-        row?: 'NEW' | 'OLD';
-      };
-      /* Nested AND */AND?: {
-        [key: string]: unknown;
-      }[];
-      /* Nested OR */OR?: {
-        [key: string]: unknown;
-      }[];
-      /* Nested NOT */NOT?: {
-        [key: string]: unknown;
-      };
-    }[];
-    /* Negated condition */NOT?: {
-      /* Column name (validated against the table) */field?: string;
-      /* Comparison operator */op?: '=' | '!=' | '>' | '<' | '>=' | '<=' | 'LIKE' | 'NOT LIKE' | 'IS NULL' | 'IS NOT NULL' | 'IS DISTINCT FROM';
-      /* Comparison value. Type is resolved from the column definition. Omit for IS NULL, IS NOT NULL, IS DISTINCT FROM. */value?: any;
-      /* Row reference (default: NEW) */row?: 'NEW' | 'OLD';
-      /* Column reference for field-to-field comparison (alternative to value) */ref?: {
-        field?: string;
-        row?: 'NEW' | 'OLD';
-      };
-      /* Nested AND */AND?: {
-        [key: string]: unknown;
-      }[];
-      /* Nested OR */OR?: {
-        [key: string]: unknown;
-      }[];
-      /* Nested NOT */NOT?: {
-        [key: string]: unknown;
-      };
-    };
-  }[];
+  conditions?: TriggerCondition | TriggerCondition[];
   /* For UPDATE triggers, only fire when these fields change (uses DISTINCT FROM) */
   watch_fields?: string[];
   /* Static job key for upsert semantics (prevents duplicate jobs) */

--- a/packages/node-type-registry/src/blueprint-types.generated.ts
+++ b/packages/node-type-registry/src/blueprint-types.generated.ts
@@ -130,13 +130,129 @@ export interface DataJobTriggerParams {
       field?: string;
       row?: 'NEW' | 'OLD';
     };
-    /* Array of conditions combined with AND */AND?: string[];
-    /* Array of conditions combined with OR */OR?: string[];
+    /* Array of conditions combined with AND */AND?: {
+      /* Column name (validated against the table) */field?: string;
+      /* Comparison operator */op?: '=' | '!=' | '>' | '<' | '>=' | '<=' | 'LIKE' | 'NOT LIKE' | 'IS NULL' | 'IS NOT NULL' | 'IS DISTINCT FROM';
+      /* Comparison value. Type is resolved from the column definition. Omit for IS NULL, IS NOT NULL, IS DISTINCT FROM. */value?: any;
+      /* Row reference (default: NEW) */row?: 'NEW' | 'OLD';
+      /* Column reference for field-to-field comparison (alternative to value) */ref?: {
+        field?: string;
+        row?: 'NEW' | 'OLD';
+      };
+      /* Nested AND */AND?: {
+        [key: string]: unknown;
+      }[];
+      /* Nested OR */OR?: {
+        [key: string]: unknown;
+      }[];
+      /* Nested NOT */NOT?: {
+        [key: string]: unknown;
+      };
+    }[];
+    /* Array of conditions combined with OR */OR?: {
+      /* Column name (validated against the table) */field?: string;
+      /* Comparison operator */op?: '=' | '!=' | '>' | '<' | '>=' | '<=' | 'LIKE' | 'NOT LIKE' | 'IS NULL' | 'IS NOT NULL' | 'IS DISTINCT FROM';
+      /* Comparison value. Type is resolved from the column definition. Omit for IS NULL, IS NOT NULL, IS DISTINCT FROM. */value?: any;
+      /* Row reference (default: NEW) */row?: 'NEW' | 'OLD';
+      /* Column reference for field-to-field comparison (alternative to value) */ref?: {
+        field?: string;
+        row?: 'NEW' | 'OLD';
+      };
+      /* Nested AND */AND?: {
+        [key: string]: unknown;
+      }[];
+      /* Nested OR */OR?: {
+        [key: string]: unknown;
+      }[];
+      /* Nested NOT */NOT?: {
+        [key: string]: unknown;
+      };
+    }[];
     /* Negated condition */NOT?: {
-      [key: string]: unknown;
+      /* Column name (validated against the table) */field?: string;
+      /* Comparison operator */op?: '=' | '!=' | '>' | '<' | '>=' | '<=' | 'LIKE' | 'NOT LIKE' | 'IS NULL' | 'IS NOT NULL' | 'IS DISTINCT FROM';
+      /* Comparison value. Type is resolved from the column definition. Omit for IS NULL, IS NOT NULL, IS DISTINCT FROM. */value?: any;
+      /* Row reference (default: NEW) */row?: 'NEW' | 'OLD';
+      /* Column reference for field-to-field comparison (alternative to value) */ref?: {
+        field?: string;
+        row?: 'NEW' | 'OLD';
+      };
+      /* Nested AND */AND?: {
+        [key: string]: unknown;
+      }[];
+      /* Nested OR */OR?: {
+        [key: string]: unknown;
+      }[];
+      /* Nested NOT */NOT?: {
+        [key: string]: unknown;
+      };
     };
   } | {
-    [key: string]: unknown;
+    /* Column name (validated against the table) */field?: string;
+    /* Comparison operator */op?: '=' | '!=' | '>' | '<' | '>=' | '<=' | 'LIKE' | 'NOT LIKE' | 'IS NULL' | 'IS NOT NULL' | 'IS DISTINCT FROM';
+    /* Comparison value. Type is resolved from the column definition. Omit for IS NULL, IS NOT NULL, IS DISTINCT FROM. */value?: any;
+    /* Row reference (default: NEW) */row?: 'NEW' | 'OLD';
+    /* Column reference for field-to-field comparison (alternative to value) */ref?: {
+      field?: string;
+      row?: 'NEW' | 'OLD';
+    };
+    /* Array of conditions combined with AND */AND?: {
+      /* Column name (validated against the table) */field?: string;
+      /* Comparison operator */op?: '=' | '!=' | '>' | '<' | '>=' | '<=' | 'LIKE' | 'NOT LIKE' | 'IS NULL' | 'IS NOT NULL' | 'IS DISTINCT FROM';
+      /* Comparison value. Type is resolved from the column definition. Omit for IS NULL, IS NOT NULL, IS DISTINCT FROM. */value?: any;
+      /* Row reference (default: NEW) */row?: 'NEW' | 'OLD';
+      /* Column reference for field-to-field comparison (alternative to value) */ref?: {
+        field?: string;
+        row?: 'NEW' | 'OLD';
+      };
+      /* Nested AND */AND?: {
+        [key: string]: unknown;
+      }[];
+      /* Nested OR */OR?: {
+        [key: string]: unknown;
+      }[];
+      /* Nested NOT */NOT?: {
+        [key: string]: unknown;
+      };
+    }[];
+    /* Array of conditions combined with OR */OR?: {
+      /* Column name (validated against the table) */field?: string;
+      /* Comparison operator */op?: '=' | '!=' | '>' | '<' | '>=' | '<=' | 'LIKE' | 'NOT LIKE' | 'IS NULL' | 'IS NOT NULL' | 'IS DISTINCT FROM';
+      /* Comparison value. Type is resolved from the column definition. Omit for IS NULL, IS NOT NULL, IS DISTINCT FROM. */value?: any;
+      /* Row reference (default: NEW) */row?: 'NEW' | 'OLD';
+      /* Column reference for field-to-field comparison (alternative to value) */ref?: {
+        field?: string;
+        row?: 'NEW' | 'OLD';
+      };
+      /* Nested AND */AND?: {
+        [key: string]: unknown;
+      }[];
+      /* Nested OR */OR?: {
+        [key: string]: unknown;
+      }[];
+      /* Nested NOT */NOT?: {
+        [key: string]: unknown;
+      };
+    }[];
+    /* Negated condition */NOT?: {
+      /* Column name (validated against the table) */field?: string;
+      /* Comparison operator */op?: '=' | '!=' | '>' | '<' | '>=' | '<=' | 'LIKE' | 'NOT LIKE' | 'IS NULL' | 'IS NOT NULL' | 'IS DISTINCT FROM';
+      /* Comparison value. Type is resolved from the column definition. Omit for IS NULL, IS NOT NULL, IS DISTINCT FROM. */value?: any;
+      /* Row reference (default: NEW) */row?: 'NEW' | 'OLD';
+      /* Column reference for field-to-field comparison (alternative to value) */ref?: {
+        field?: string;
+        row?: 'NEW' | 'OLD';
+      };
+      /* Nested AND */AND?: {
+        [key: string]: unknown;
+      }[];
+      /* Nested OR */OR?: {
+        [key: string]: unknown;
+      }[];
+      /* Nested NOT */NOT?: {
+        [key: string]: unknown;
+      };
+    };
   }[];
   /* For UPDATE triggers, only fire when these fields change (uses DISTINCT FROM) */
   watch_fields?: string[];

--- a/packages/node-type-registry/src/codegen/generate-types.ts
+++ b/packages/node-type-registry/src/codegen/generate-types.ts
@@ -145,6 +145,17 @@ function partialOf(inner: t.TSType): t.TSTypeReference {
 function ensureArrayItems(schema: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = { ...schema };
 
+  // Strip $defs — they exist for JSON Schema validators but schema-typescript
+  // doesn't understand them and the TS types are emitted separately.
+  delete out.$defs;
+
+  // Properties with x-codegen-type get their TS type replaced post-generation,
+  // so collapse them to a simple {type:'object'} to avoid confusing
+  // schema-typescript with $ref or oneOf it can't resolve.
+  if (out['x-codegen-type']) {
+    return { type: 'object', description: out.description, 'x-codegen-type': out['x-codegen-type'] };
+  }
+
   // Ensure arrays have an items spec (schema-typescript throws without one)
   if (out.type === 'array' && !out.items) {
     out.items = { type: 'string' };

--- a/packages/node-type-registry/src/codegen/generate-types.ts
+++ b/packages/node-type-registry/src/codegen/generate-types.ts
@@ -177,6 +177,107 @@ function ensureArrayItems(schema: Record<string, unknown>): Record<string, unkno
 }
 
 // ---------------------------------------------------------------------------
+// TriggerCondition — recursive type for compound WHEN clause conditions.
+// Hand-written because JSON Schema / schema-typescript cannot express
+// self-referencing types.
+// ---------------------------------------------------------------------------
+
+function buildTriggerConditionInterface(): t.ExportNamedDeclaration {
+  const opType = t.tsUnionType(
+    ['=', '!=', '>', '<', '>=', '<=', 'LIKE', 'NOT LIKE', 'IS NULL', 'IS NOT NULL', 'IS DISTINCT FROM']
+      .map((op) => t.tsLiteralType(t.stringLiteral(op)))
+  );
+  const rowType = t.tsUnionType([
+    t.tsLiteralType(t.stringLiteral('NEW')),
+    t.tsLiteralType(t.stringLiteral('OLD'))
+  ]);
+  const condRef = t.tsTypeReference(t.identifier('TriggerCondition'));
+
+  return addJSDoc(
+    exportInterface('TriggerCondition', [
+      addJSDoc(optionalProp('field', t.tsStringKeyword()), 'Column name (validated against the table).'),
+      addJSDoc(optionalProp('op', opType), 'Comparison operator.'),
+      addJSDoc(optionalProp('value', t.tsAnyKeyword()), 'Comparison value. Type is resolved from the column definition.'),
+      addJSDoc(optionalProp('row', rowType), 'Row reference (default: NEW).'),
+      addJSDoc(
+        optionalProp('ref', t.tsTypeLiteral([
+          optionalProp('field', t.tsStringKeyword()),
+          optionalProp('row', rowType)
+        ])),
+        'Column reference for field-to-field comparison (alternative to value).'
+      ),
+      addJSDoc(optionalProp('AND', t.tsArrayType(condRef)), 'Array of conditions combined with AND.'),
+      addJSDoc(optionalProp('OR', t.tsArrayType(condRef)), 'Array of conditions combined with OR.'),
+      addJSDoc(optionalProp('NOT', condRef), 'Negated condition.')
+    ]),
+    'Recursive condition type for compound trigger WHEN clauses. Leaf conditions specify {field, op, value?, row?, ref?}. Combinators nest via AND, OR, NOT.'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// x-codegen-type post-processing — replaces properties that have an
+// 'x-codegen-type' marker in their JSON Schema with a hand-written TS type
+// reference.  This lets node type definitions delegate complex types
+// (like recursive TriggerCondition) to the codegen instead of trying to
+// express them in JSON Schema.
+// ---------------------------------------------------------------------------
+
+function applyCodegenTypeOverrides(
+  statements: t.ExportNamedDeclaration[],
+  nodeTypes: NodeTypeDefinition[]
+): void {
+  // Build a map of typeName -> { propName -> typeString }
+  const overrides = new Map<string, Map<string, string>>();
+  for (const nt of nodeTypes) {
+    const props = nt.parameter_schema?.properties;
+    if (!props) continue;
+    for (const [propName, propSchema] of Object.entries(props)) {
+      const schema = propSchema as Record<string, unknown>;
+      if (schema['x-codegen-type']) {
+        const typeName = `${nt.name}Params`;
+        if (!overrides.has(typeName)) overrides.set(typeName, new Map());
+        overrides.get(typeName)!.set(propName, schema['x-codegen-type'] as string);
+      }
+    }
+  }
+
+  if (overrides.size === 0) return;
+
+  for (const stmt of statements) {
+    const decl = stmt.declaration;
+    if (!t.isTSInterfaceDeclaration(decl)) continue;
+    const ifaceName = decl.id.name;
+    const propOverrides = overrides.get(ifaceName);
+    if (!propOverrides) continue;
+
+    for (const member of decl.body.body) {
+      if (!t.isTSPropertySignature(member)) continue;
+      const key = t.isIdentifier(member.key)
+        ? member.key.name
+        : t.isStringLiteral(member.key)
+          ? member.key.value
+          : null;
+      if (!key || !propOverrides.has(key)) continue;
+
+      const typeStr = propOverrides.get(key)!;
+      // Parse "TypeA | TypeB[]" into a TS union of type references
+      const parts = typeStr.split('|').map((s) => s.trim());
+      const tsTypes = parts.map((part) => {
+        const isArray = part.endsWith('[]');
+        const name = isArray ? part.slice(0, -2) : part;
+        const ref = t.tsTypeReference(t.identifier(name));
+        return isArray ? t.tsArrayType(ref) : ref;
+      });
+      const annotation = tsTypes.length === 1
+        ? tsTypes[0]
+        : t.tsUnionType(tsTypes);
+
+      member.typeAnnotation = t.tsTypeAnnotation(annotation);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Generate per-node-type parameter interfaces via schema-typescript
 // ---------------------------------------------------------------------------
 
@@ -209,6 +310,10 @@ function generateParamsInterfaces(
       results.push(addJSDoc(exportInterface(typeName, []), nt.description));
     }
   }
+
+  // Apply x-codegen-type overrides to replace schema-generated types with
+  // hand-written recursive types (e.g. TriggerCondition)
+  applyCodegenTypeOverrides(results, nodeTypes);
 
   return results;
 }
@@ -1013,6 +1118,10 @@ function buildProgram(meta?: MetaTableInfo[]): string {
     (nt) => nt.category === 'relation'
   );
   const authzNodes = allNodeTypes.filter((nt) => nt.category === 'authz');
+
+  // -- Shared recursive types (emitted before parameter interfaces) --
+  statements.push(sectionComment('Shared recursive types'));
+  statements.push(buildTriggerConditionInterface());
 
   // -- Parameter interfaces grouped by category --
   const categoryOrder = ['data', 'search', 'authz', 'relation', 'view'];

--- a/packages/node-type-registry/src/data/data-job-trigger.ts
+++ b/packages/node-type-registry/src/data/data-job-trigger.ts
@@ -1,81 +1,5 @@
 import type { NodeTypeDefinition } from '../types';
 
-const CONDITION_OPS: string[] = ['=', '!=', '>', '<', '>=', '<=', 'LIKE', 'NOT LIKE', 'IS NULL', 'IS NOT NULL', 'IS DISTINCT FROM'];
-
-const leafConditionProperties = {
-  field: {
-    type: 'string',
-    format: 'column-ref',
-    description: 'Column name (validated against the table)'
-  },
-  op: {
-    type: 'string',
-    enum: [...CONDITION_OPS],
-    description: 'Comparison operator'
-  },
-  value: {
-    description: 'Comparison value. Type is resolved from the column definition. Omit for IS NULL, IS NOT NULL, IS DISTINCT FROM.'
-  },
-  row: {
-    type: 'string',
-    enum: ['NEW', 'OLD'],
-    description: 'Row reference (default: NEW)',
-    default: 'NEW'
-  },
-  ref: {
-    type: 'object',
-    description: 'Column reference for field-to-field comparison (alternative to value)',
-    properties: {
-      field: { type: 'string', format: 'column-ref' },
-      row: { type: 'string', enum: ['NEW', 'OLD'], default: 'NEW' }
-    }
-  }
-};
-
-const conditionObjectSchema = {
-  type: 'object',
-  description: 'A leaf condition or combinator (AND/OR/NOT)',
-  properties: {
-    ...leafConditionProperties,
-    AND: {
-      type: 'array',
-      description: 'Array of conditions combined with AND',
-      items: {
-        type: 'object',
-        properties: {
-          ...leafConditionProperties,
-          AND: { type: 'array', description: 'Nested AND', items: { type: 'object' } },
-          OR: { type: 'array', description: 'Nested OR', items: { type: 'object' } },
-          NOT: { type: 'object', description: 'Nested NOT' }
-        }
-      }
-    },
-    OR: {
-      type: 'array',
-      description: 'Array of conditions combined with OR',
-      items: {
-        type: 'object',
-        properties: {
-          ...leafConditionProperties,
-          AND: { type: 'array', description: 'Nested AND', items: { type: 'object' } },
-          OR: { type: 'array', description: 'Nested OR', items: { type: 'object' } },
-          NOT: { type: 'object', description: 'Nested NOT' }
-        }
-      }
-    },
-    NOT: {
-      type: 'object',
-      description: 'Negated condition',
-      properties: {
-        ...leafConditionProperties,
-        AND: { type: 'array', description: 'Nested AND', items: { type: 'object' } },
-        OR: { type: 'array', description: 'Nested OR', items: { type: 'object' } },
-        NOT: { type: 'object', description: 'Nested NOT' }
-      }
-    }
-  }
-};
-
 export const DataJobTrigger: NodeTypeDefinition = {
   name: 'DataJobTrigger',
   slug: 'data_job_trigger',
@@ -152,14 +76,8 @@ export const DataJobTrigger: NodeTypeDefinition = {
       },
       conditions: {
         description: 'Compound conditions for the trigger WHEN clause. Accepts a single leaf condition, an array of conditions (implicitly AND), or a nested combinator tree ({AND: [...], OR: [...], NOT: {...}}). Each leaf is {field, op, value?, row?, ref?}. Column types are resolved automatically from the table schema. Cannot be combined with condition_field or watch_fields.',
-        oneOf: [
-          conditionObjectSchema,
-          {
-            type: 'array',
-            description: 'Array of conditions (implicitly AND)',
-            items: conditionObjectSchema
-          }
-        ]
+        type: 'object',
+        'x-codegen-type': 'TriggerCondition | TriggerCondition[]'
       },
       watch_fields: {
         type: 'array',

--- a/packages/node-type-registry/src/data/data-job-trigger.ts
+++ b/packages/node-type-registry/src/data/data-job-trigger.ts
@@ -1,5 +1,81 @@
 import type { NodeTypeDefinition } from '../types';
 
+const CONDITION_OPS: string[] = ['=', '!=', '>', '<', '>=', '<=', 'LIKE', 'NOT LIKE', 'IS NULL', 'IS NOT NULL', 'IS DISTINCT FROM'];
+
+const leafConditionProperties = {
+  field: {
+    type: 'string',
+    format: 'column-ref',
+    description: 'Column name (validated against the table)'
+  },
+  op: {
+    type: 'string',
+    enum: [...CONDITION_OPS],
+    description: 'Comparison operator'
+  },
+  value: {
+    description: 'Comparison value. Type is resolved from the column definition. Omit for IS NULL, IS NOT NULL, IS DISTINCT FROM.'
+  },
+  row: {
+    type: 'string',
+    enum: ['NEW', 'OLD'],
+    description: 'Row reference (default: NEW)',
+    default: 'NEW'
+  },
+  ref: {
+    type: 'object',
+    description: 'Column reference for field-to-field comparison (alternative to value)',
+    properties: {
+      field: { type: 'string', format: 'column-ref' },
+      row: { type: 'string', enum: ['NEW', 'OLD'], default: 'NEW' }
+    }
+  }
+};
+
+const conditionObjectSchema = {
+  type: 'object',
+  description: 'A leaf condition or combinator (AND/OR/NOT)',
+  properties: {
+    ...leafConditionProperties,
+    AND: {
+      type: 'array',
+      description: 'Array of conditions combined with AND',
+      items: {
+        type: 'object',
+        properties: {
+          ...leafConditionProperties,
+          AND: { type: 'array', description: 'Nested AND', items: { type: 'object' } },
+          OR: { type: 'array', description: 'Nested OR', items: { type: 'object' } },
+          NOT: { type: 'object', description: 'Nested NOT' }
+        }
+      }
+    },
+    OR: {
+      type: 'array',
+      description: 'Array of conditions combined with OR',
+      items: {
+        type: 'object',
+        properties: {
+          ...leafConditionProperties,
+          AND: { type: 'array', description: 'Nested AND', items: { type: 'object' } },
+          OR: { type: 'array', description: 'Nested OR', items: { type: 'object' } },
+          NOT: { type: 'object', description: 'Nested NOT' }
+        }
+      }
+    },
+    NOT: {
+      type: 'object',
+      description: 'Negated condition',
+      properties: {
+        ...leafConditionProperties,
+        AND: { type: 'array', description: 'Nested AND', items: { type: 'object' } },
+        OR: { type: 'array', description: 'Nested OR', items: { type: 'object' } },
+        NOT: { type: 'object', description: 'Nested NOT' }
+      }
+    }
+  }
+};
+
 export const DataJobTrigger: NodeTypeDefinition = {
   name: 'DataJobTrigger',
   slug: 'data_job_trigger',
@@ -77,57 +153,11 @@ export const DataJobTrigger: NodeTypeDefinition = {
       conditions: {
         description: 'Compound conditions for the trigger WHEN clause. Accepts a single leaf condition, an array of conditions (implicitly AND), or a nested combinator tree ({AND: [...], OR: [...], NOT: {...}}). Each leaf is {field, op, value?, row?, ref?}. Column types are resolved automatically from the table schema. Cannot be combined with condition_field or watch_fields.',
         oneOf: [
-          {
-            type: 'object',
-            description: 'A single leaf condition or a combinator (AND/OR/NOT)',
-            properties: {
-              field: {
-                type: 'string',
-                format: 'column-ref',
-                description: 'Column name (validated against the table)'
-              },
-              op: {
-                type: 'string',
-                enum: ['=', '!=', '>', '<', '>=', '<=', 'LIKE', 'NOT LIKE', 'IS NULL', 'IS NOT NULL', 'IS DISTINCT FROM'],
-                description: 'Comparison operator'
-              },
-              value: {
-                description: 'Comparison value. Type is resolved from the column definition. Omit for IS NULL, IS NOT NULL, IS DISTINCT FROM.'
-              },
-              row: {
-                type: 'string',
-                enum: ['NEW', 'OLD'],
-                description: 'Row reference (default: NEW)',
-                default: 'NEW'
-              },
-              ref: {
-                type: 'object',
-                description: 'Column reference for field-to-field comparison (alternative to value)',
-                properties: {
-                  field: { type: 'string', format: 'column-ref' },
-                  row: { type: 'string', enum: ['NEW', 'OLD'], default: 'NEW' }
-                }
-              },
-              AND: {
-                type: 'array',
-                description: 'Array of conditions combined with AND'
-              },
-              OR: {
-                type: 'array',
-                description: 'Array of conditions combined with OR'
-              },
-              NOT: {
-                type: 'object',
-                description: 'Negated condition'
-              }
-            }
-          },
+          conditionObjectSchema,
           {
             type: 'array',
             description: 'Array of conditions (implicitly AND)',
-            items: {
-              type: 'object'
-            }
+            items: conditionObjectSchema
           }
         ]
       },

--- a/packages/node-type-registry/src/data/data-job-trigger.ts
+++ b/packages/node-type-registry/src/data/data-job-trigger.ts
@@ -1,5 +1,31 @@
 import type { NodeTypeDefinition } from '../types';
 
+const triggerConditionSchema = {
+  type: 'object',
+  description: 'A leaf condition ({field, op, value?, row?, ref?}) or a combinator ({AND, OR, NOT}).',
+  properties: {
+    field: { type: 'string', format: 'column-ref', description: 'Column name (validated against the table).' },
+    op: {
+      type: 'string',
+      enum: ['=', '!=', '>', '<', '>=', '<=', 'LIKE', 'NOT LIKE', 'IS NULL', 'IS NOT NULL', 'IS DISTINCT FROM'],
+      description: 'Comparison operator.'
+    },
+    value: { description: 'Comparison value. Type is resolved from the column definition. Omit for IS NULL, IS NOT NULL, IS DISTINCT FROM.' },
+    row: { type: 'string', enum: ['NEW', 'OLD'], default: 'NEW', description: 'Row reference (default: NEW).' },
+    ref: {
+      type: 'object',
+      description: 'Column reference for field-to-field comparison (alternative to value).',
+      properties: {
+        field: { type: 'string', format: 'column-ref' },
+        row: { type: 'string', enum: ['NEW', 'OLD'], default: 'NEW' }
+      }
+    },
+    AND: { type: 'array', description: 'Array of conditions combined with AND.', items: { $ref: '#/$defs/triggerCondition' } },
+    OR: { type: 'array', description: 'Array of conditions combined with OR.', items: { $ref: '#/$defs/triggerCondition' } },
+    NOT: { $ref: '#/$defs/triggerCondition', description: 'Negated condition.' }
+  }
+};
+
 export const DataJobTrigger: NodeTypeDefinition = {
   name: 'DataJobTrigger',
   slug: 'data_job_trigger',
@@ -8,6 +34,9 @@ export const DataJobTrigger: NodeTypeDefinition = {
   description: 'Dynamically creates PostgreSQL triggers that enqueue jobs via app_jobs.add_job() when table rows are inserted, updated, or deleted. Supports configurable payload strategies (full row, row ID, selected fields, or custom mapping), conditional firing via WHEN clauses, watched field changes, and extended job options (queue, priority, delay, max attempts).',
   parameter_schema: {
     type: 'object',
+    $defs: {
+      triggerCondition: triggerConditionSchema
+    },
     properties: {
       task_identifier: {
         type: 'string',
@@ -76,8 +105,11 @@ export const DataJobTrigger: NodeTypeDefinition = {
       },
       conditions: {
         description: 'Compound conditions for the trigger WHEN clause. Accepts a single leaf condition, an array of conditions (implicitly AND), or a nested combinator tree ({AND: [...], OR: [...], NOT: {...}}). Each leaf is {field, op, value?, row?, ref?}. Column types are resolved automatically from the table schema. Cannot be combined with condition_field or watch_fields.',
-        type: 'object',
-        'x-codegen-type': 'TriggerCondition | TriggerCondition[]'
+        'x-codegen-type': 'TriggerCondition | TriggerCondition[]',
+        oneOf: [
+          { $ref: '#/$defs/triggerCondition' },
+          { type: 'array', items: { $ref: '#/$defs/triggerCondition' } }
+        ]
       },
       watch_fields: {
         type: 'array',


### PR DESCRIPTION
## Summary

The `conditions` type in `DataJobTriggerParams` was generated by `schema-typescript` as multi-level inline nested objects — `AND?: string[]`, `"Nested AND/OR"` comments, etc. JSON Schema's `schema-typescript` library can't handle recursive types.

**Fix: two complementary representations of the same structure.**

### TypeScript (generated output)
A clean, truly recursive `TriggerCondition` interface emitted directly by the codegen:

```typescript
export interface TriggerCondition {
  field?: string;
  op?: '=' | '!=' | '>' | '<' | '>=' | '<=' | 'LIKE' | 'NOT LIKE' | 'IS NULL' | 'IS NOT NULL' | 'IS DISTINCT FROM';
  value?: any;
  row?: 'NEW' | 'OLD';
  ref?: { field?: string; row?: 'NEW' | 'OLD' };
  AND?: TriggerCondition[];
  OR?: TriggerCondition[];
  NOT?: TriggerCondition;
}
```

`DataJobTriggerParams.conditions` becomes `TriggerCondition | TriggerCondition[]`.

### JSON Schema (source of truth for validation)
Full recursive schema using standard `$defs`/`$ref`:

```json
{
  "$defs": {
    "triggerCondition": {
      "type": "object",
      "properties": {
        "field": { "type": "string", "format": "column-ref" },
        "op": { "type": "string", "enum": ["=", "!=", ...] },
        "value": {},
        "row": { "type": "string", "enum": ["NEW", "OLD"] },
        "ref": { "type": "object", "properties": { "field": {}, "row": {} } },
        "AND": { "type": "array", "items": { "$ref": "#/$defs/triggerCondition" } },
        "OR":  { "type": "array", "items": { "$ref": "#/$defs/triggerCondition" } },
        "NOT": { "$ref": "#/$defs/triggerCondition" }
      }
    }
  }
}
```

### How `x-codegen-type` works

The `conditions` property carries both:
- Standard JSON Schema (`oneOf` with `$ref`) for validation
- `"x-codegen-type": "TriggerCondition | TriggerCondition[]"` for codegen

The `ensureArrayItems` sanitizer strips `$defs` and collapses `x-codegen-type` properties before `schema-typescript` sees them. Then `applyCodegenTypeOverrides` replaces the generated type annotation with the proper reference. This mechanism is generic — any future node type can use it.

## Review & Testing Checklist for Human

- [ ] Verify IDE autocomplete works at arbitrary nesting: `conditions: { AND: [{ OR: [{ field: ... }] }] }`
- [ ] Confirm JSON Schema validates correctly (e.g. via `ajv` or similar)

### Notes

Follow-up to PR #1045.


Link to Devin session: https://app.devin.ai/sessions/ffa3ed8652fc412f976accbdc229c88d
Requested by: @pyramation