### PR TITLE
feat(node-type-registry): complete column-ref annotations for all column-creating types

### DIFF
--- a/packages/node-type-registry/src/blueprint-types.generated.ts
+++ b/packages/node-type-registry/src/blueprint-types.generated.ts
@@ -183,6 +183,10 @@ export interface DataOwnedFieldsParams {
 }
 /** Combines direct ownership with entity scoping. Adds both owner_id and entity_id columns. Enables AuthzDirectOwner, AuthzEntityMembership, and AuthzOrgHierarchy authorization. Particularly useful for OrgHierarchy where a user owns a row (owner_id) within an entity (entity_id), and managers above can see subordinate-owned records via the hierarchy closure table. */
 export interface DataOwnershipInEntityParams {
+  /* Column name for the owner reference */
+  owner_field_name?: string;
+  /* Column name for the entity reference */
+  entity_field_name?: string;
   /* If true, also adds a UUID primary key column with auto-generation */
   include_id?: boolean;
   /* If true, adds foreign key constraints from owner_id and entity_id to the users table */
@@ -190,6 +194,10 @@ export interface DataOwnershipInEntityParams {
 }
 /** Adds user tracking for creates/updates with created_by and updated_by columns. */
 export interface DataPeoplestampsParams {
+  /* Column name for the creating user reference */
+  created_by_field?: string;
+  /* Column name for the last-updating user reference */
+  updated_by_field?: string;
   /* If true, also adds a UUID primary key column with auto-generation */
   include_id?: boolean;
   /* If true, adds foreign key constraints from created_by and updated_by to the users table */
@@ -197,6 +205,10 @@ export interface DataPeoplestampsParams {
 }
 /** Adds publish state columns (is_published, published_at) for content visibility. Enables AuthzPublishable and AuthzTemporal authorization. */
 export interface DataPublishableParams {
+  /* Column name for the published boolean flag */
+  is_published_field?: string;
+  /* Column name for the publish timestamp */
+  published_at_field?: string;
   /* If true, also adds a UUID primary key column with auto-generation */
   include_id?: boolean;
 }
@@ -209,6 +221,10 @@ export interface DataSlugParams {
 }
 /** Adds soft delete support with deleted_at and is_deleted columns. */
 export interface DataSoftDeleteParams {
+  /* Column name for the soft-delete timestamp */
+  deleted_at_field?: string;
+  /* Column name for the soft-delete boolean flag */
+  is_deleted_field?: string;
   /* If true, also adds a UUID primary key column with auto-generation */
   include_id?: boolean;
 }
@@ -236,6 +252,10 @@ export interface DataTagsParams {
 }
 /** Adds automatic timestamp tracking with created_at and updated_at columns. */
 export interface DataTimestampsParams {
+  /* Column name for the creation timestamp */
+  created_at_field?: string;
+  /* Column name for the last-updated timestamp */
+  updated_at_field?: string;
   /* If true, also adds a UUID primary key column with auto-generation */
   include_id?: boolean;
 }

--- a/packages/node-type-registry/src/data/data-image-embedding.ts
+++ b/packages/node-type-registry/src/data/data-image-embedding.ts
@@ -71,7 +71,8 @@ export const DataImageEmbedding: NodeTypeDefinition = {
       payload_custom: {
         type: 'object',
         additionalProperties: {
-          type: 'string'
+          type: 'string',
+          format: 'column-ref'
         },
         description: 'Custom payload key-to-column mapping for the job trigger',
         default: {

--- a/packages/node-type-registry/src/data/data-job-trigger.ts
+++ b/packages/node-type-registry/src/data/data-job-trigger.ts
@@ -64,7 +64,8 @@ export const DataJobTrigger: NodeTypeDefinition = {
       payload_custom: {
         type: 'object',
         additionalProperties: {
-          type: 'string'
+          type: 'string',
+          format: 'column-ref'
         },
         description: 'Key-to-column mapping for custom payload (e.g., {"invoice_id": "id", "total": "amount"})'
       },

--- a/packages/node-type-registry/src/data/data-ownership-in-entity.ts
+++ b/packages/node-type-registry/src/data/data-ownership-in-entity.ts
@@ -9,6 +9,18 @@ export const DataOwnershipInEntity: NodeTypeDefinition = {
   parameter_schema: {
     type: 'object',
     properties: {
+      owner_field_name: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column name for the owner reference',
+        default: 'owner_id'
+      },
+      entity_field_name: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column name for the entity reference',
+        default: 'entity_id'
+      },
       include_id: {
         type: 'boolean',
         description: 'If true, also adds a UUID primary key column with auto-generation',

--- a/packages/node-type-registry/src/data/data-peoplestamps.ts
+++ b/packages/node-type-registry/src/data/data-peoplestamps.ts
@@ -9,6 +9,18 @@ export const DataPeoplestamps: NodeTypeDefinition = {
   parameter_schema: {
     type: 'object',
     properties: {
+      created_by_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column name for the creating user reference',
+        default: 'created_by'
+      },
+      updated_by_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column name for the last-updating user reference',
+        default: 'updated_by'
+      },
       include_id: {
         type: 'boolean',
         description: 'If true, also adds a UUID primary key column with auto-generation',

--- a/packages/node-type-registry/src/data/data-publishable.ts
+++ b/packages/node-type-registry/src/data/data-publishable.ts
@@ -9,6 +9,18 @@ export const DataPublishable: NodeTypeDefinition = {
   parameter_schema: {
     type: 'object',
     properties: {
+      is_published_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column name for the published boolean flag',
+        default: 'is_published'
+      },
+      published_at_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column name for the publish timestamp',
+        default: 'published_at'
+      },
       include_id: {
         type: 'boolean',
         description: 'If true, also adds a UUID primary key column with auto-generation',

--- a/packages/node-type-registry/src/data/data-soft-delete.ts
+++ b/packages/node-type-registry/src/data/data-soft-delete.ts
@@ -9,6 +9,18 @@ export const DataSoftDelete: NodeTypeDefinition = {
   parameter_schema: {
     type: 'object',
     properties: {
+      deleted_at_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column name for the soft-delete timestamp',
+        default: 'deleted_at'
+      },
+      is_deleted_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column name for the soft-delete boolean flag',
+        default: 'is_deleted'
+      },
       include_id: {
         type: 'boolean',
         description: 'If true, also adds a UUID primary key column with auto-generation',

--- a/packages/node-type-registry/src/data/data-timestamps.ts
+++ b/packages/node-type-registry/src/data/data-timestamps.ts
@@ -9,6 +9,18 @@ export const DataTimestamps: NodeTypeDefinition = {
   parameter_schema: {
     type: 'object',
     properties: {
+      created_at_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column name for the creation timestamp',
+        default: 'created_at'
+      },
+      updated_at_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column name for the last-updated timestamp',
+        default: 'updated_at'
+      },
       include_id: {
         type: 'boolean',
         description: 'If true, also adds a UUID primary key column with auto-generation',

--- a/packages/node-type-registry/src/view/view-aggregated.ts
+++ b/packages/node-type-registry/src/view/view-aggregated.ts
@@ -44,6 +44,7 @@ export const ViewAggregated: NodeTypeDefinition = {
             },
             alias: {
               type: 'string',
+              format: 'column-ref',
               description: 'Output column name'
             }
           },


### PR DESCRIPTION
## Summary

Completes the `format: "column-ref"` annotation work across the entire node-type-registry. Every node type that creates or references columns now has proper annotations.

**Types that previously hardcoded column names with no `parameter_schema` entry — now have `column-ref` properties with defaults:**
- `DataPublishable`: `is_published_field` (default `"is_published"`), `published_at_field` (default `"published_at"`)
- `DataTimestamps`: `created_at_field` (default `"created_at"`), `updated_at_field` (default `"updated_at"`)
- `DataPeoplestamps`: `created_by_field` (default `"created_by"`), `updated_by_field` (default `"updated_by"`)
- `DataSoftDelete`: `deleted_at_field` (default `"deleted_at"`), `is_deleted_field` (default `"is_deleted"`)
- `DataOwnershipInEntity`: `owner_field_name` (default `"owner_id"`), `entity_field_name` (default `"entity_id"`)

**Existing string properties that referenced columns but lacked annotation:**
- `DataJobTrigger.payload_custom.additionalProperties`: values are column names (e.g., `{"invoice_id": "id", "total": "amount"}`)
- `DataImageEmbedding.payload_custom.additionalProperties`: same pattern
- `ViewAggregated.aggregates[].alias`: output column name

Regenerated `blueprint-types.generated.ts` to include the new type definitions.

## Review & Testing Checklist for Human
- [ ] Verify the new default values match the hardcoded column names in the SQL generators (`table_module()` dispatch in constructive-db) — e.g., `DataTimestamps` SQL generator creates `created_at`/`updated_at`, so defaults must match
- [ ] After publishing, regenerate the SQL seed in constructive-db to confirm the registry table picks up the new annotations and defaults
- [ ] Verify no existing blueprint consumers break from the added properties (all new props have defaults, so existing blueprints with `{}` data remain valid)

### Notes
- All new properties have defaults matching the current hardcoded column names, so this is backward-compatible
- The Authz*, Search*, Relation*, and View* types were already fully annotated from PR #1043 — this PR completes the Data* types that were missing
- `blueprint-types.generated.ts` was regenerated via `npx ts-node src/codegen/generate-types.ts`

Link to Devin session: https://app.devin.ai/sessions/20dbaaa0e6e74599842fbefe33efbc26
Requested by: @pyramation