### PR TITLE
feat: remove confirmUpload from upload-client, simplify to 3-step flow

### DIFF
--- a/graphile/graphile-settings/src/presets/constructive-preset.ts
+++ b/graphile/graphile-settings/src/presets/constructive-preset.ts
@@ -40,7 +40,7 @@ import { getBucketProvisionerConnection } from '../bucket-provisioner-resolver';
  * - PostGIS support (geometry/geography types, GeoJSON scalar — auto-detects PostGIS extension)
  * - PostGIS connection filter operators (spatial filtering on geometry/geography columns)
  * - Upload plugin (file upload to S3/MinIO for image, upload, attachment domain columns)
- * - Presigned URL plugin (requestUploadUrl, confirmUpload mutations + downloadUrl computed field)
+ * - Presigned URL plugin (requestUploadUrl mutation + downloadUrl computed field)
  * - Bucket provisioner plugin (auto-provisions S3 buckets on @storageBuckets table mutations,
  *   CORS management, provisionBucket mutation for manual/retry)
  * - SQL expression validator (validates @sqlExpression columns in mutations)

--- a/packages/bucket-provisioner/src/cors.ts
+++ b/packages/bucket-provisioner/src/cors.ts
@@ -14,7 +14,7 @@ import type { CorsRule } from './types';
  * This allows:
  * - PUT: for presigned uploads from the browser
  * - GET: for presigned downloads and public file access
- * - HEAD: for confirmUpload verification and cache headers
+ * - HEAD: for cache headers and object existence checks
  *
  * @param allowedOrigins - Domains allowed to make cross-origin requests.
  *                          Use specific domains in production (e.g., ["https://app.example.com"]).

--- a/packages/upload-client/__tests__/upload.test.ts
+++ b/packages/upload-client/__tests__/upload.test.ts
@@ -1,6 +1,6 @@
 import { uploadFile } from '../src/upload';
 import { UploadError } from '../src/types';
-import { REQUEST_UPLOAD_URL_MUTATION, CONFIRM_UPLOAD_MUTATION } from '../src/queries';
+import { REQUEST_UPLOAD_URL_MUTATION } from '../src/queries';
 import type { GraphQLExecutor, FileInput } from '../src/types';
 
 /**
@@ -44,7 +44,7 @@ afterAll(() => {
 
 describe('uploadFile', () => {
   describe('fresh upload (not deduplicated)', () => {
-    it('should hash, request URL, PUT to S3, and confirm', async () => {
+    it('should hash, request URL, and PUT to S3', async () => {
       const file = createMockFile('hello world');
       const executeCalls: Array<{ query: string; variables: Record<string, unknown> }> = [];
 
@@ -59,17 +59,7 @@ describe('uploadFile', () => {
               key: HELLO_WORLD_HASH,
               deduplicated: false,
               expiresAt: new Date(Date.now() + 900_000).toISOString(),
-              status: 'pending',
-            },
-          };
-        }
-
-        if (query === CONFIRM_UPLOAD_MUTATION) {
-          return {
-            confirmUpload: {
-              fileId: 'file-uuid-123',
-              status: 'ready',
-              success: true,
+              status: 'requested',
             },
           };
         }
@@ -94,7 +84,7 @@ describe('uploadFile', () => {
       expect(result.fileId).toBe('file-uuid-123');
       expect(result.key).toBe(HELLO_WORLD_HASH);
       expect(result.deduplicated).toBe(false);
-      expect(result.status).toBe('ready');
+      expect(result.status).toBe('requested');
 
       // Verify requestUploadUrl was called with correct input
       expect(executeCalls[0].query).toBe(REQUEST_UPLOAD_URL_MUTATION);
@@ -114,9 +104,8 @@ describe('uploadFile', () => {
         }),
       );
 
-      // Verify confirmUpload was called
-      expect(executeCalls[1].query).toBe(CONFIRM_UPLOAD_MUTATION);
-      expect(executeCalls[1].variables).toEqual({ input: { fileId: 'file-uuid-123' } });
+      // Only requestUploadUrl should have been called (no confirm step)
+      expect(executeCalls).toHaveLength(1);
     });
   });
 
@@ -156,7 +145,7 @@ describe('uploadFile', () => {
       expect(result.deduplicated).toBe(true);
       expect(result.status).toBe('ready');
 
-      // Only requestUploadUrl should have been called (no confirm, no PUT)
+      // Only requestUploadUrl should have been called (no PUT)
       expect(executeCalls).toHaveLength(1);
       expect(executeCalls[0].query).toBe(REQUEST_UPLOAD_URL_MUTATION);
       expect(global.fetch).not.toHaveBeenCalled();
@@ -201,7 +190,7 @@ describe('uploadFile', () => {
               key: 'hash',
               deduplicated: false,
               expiresAt: new Date().toISOString(),
-              status: 'pending',
+              status: 'requested',
             },
           };
         }
@@ -217,41 +206,6 @@ describe('uploadFile', () => {
       await expect(
         uploadFile({ file, bucketKey: 'test', execute }),
       ).rejects.toMatchObject({ code: 'PUT_UPLOAD_FAILED' });
-    });
-
-    it('should throw CONFIRM_UPLOAD_FAILED when confirm mutation fails', async () => {
-      const file = createMockFile('test');
-      let callCount = 0;
-
-      const execute: GraphQLExecutor = async (query) => {
-        callCount++;
-        if (query === REQUEST_UPLOAD_URL_MUTATION) {
-          return {
-            requestUploadUrl: {
-              uploadUrl: 'https://s3.example.com/put',
-              fileId: 'file-1',
-              key: 'hash',
-              deduplicated: false,
-              expiresAt: new Date().toISOString(),
-              status: 'pending',
-            },
-          };
-        }
-        if (query === CONFIRM_UPLOAD_MUTATION) {
-          throw new Error('Database error');
-        }
-        throw new Error('Unexpected');
-      };
-
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        text: async () => '',
-      });
-
-      await expect(
-        uploadFile({ file, bucketKey: 'test', execute }),
-      ).rejects.toMatchObject({ code: 'CONFIRM_UPLOAD_FAILED' });
     });
   });
 
@@ -283,12 +237,9 @@ describe('uploadFile', () => {
               key: 'hash',
               deduplicated: false,
               expiresAt: new Date().toISOString(),
-              status: 'pending',
+              status: 'requested',
             },
           };
-        }
-        if (query === CONFIRM_UPLOAD_MUTATION) {
-          return { confirmUpload: { fileId: 'file-1', status: 'ready', success: true } };
         }
         throw new Error('Unexpected');
       };

--- a/packages/upload-client/src/index.ts
+++ b/packages/upload-client/src/index.ts
@@ -6,7 +6,7 @@
  * Provides atomic functions for the presigned URL upload pipeline:
  * - `hashFile` — SHA-256 hash via Web Crypto API
  * - `hashFileChunked` — chunked SHA-256 for large files
- * - `uploadFile` — full upload orchestrator (hash → request → PUT → confirm)
+ * - `uploadFile` — full upload orchestrator (hash → request → PUT)
  *
  * Framework-agnostic, works in any browser or Node.js 18+ environment.
  *
@@ -33,7 +33,7 @@ export { hashFile, hashFileChunked } from './hash';
 export { uploadFile } from './upload';
 
 // GraphQL query strings (for custom integrations)
-export { REQUEST_UPLOAD_URL_MUTATION, CONFIRM_UPLOAD_MUTATION } from './queries';
+export { REQUEST_UPLOAD_URL_MUTATION } from './queries';
 
 // Types
 export type {
@@ -43,8 +43,6 @@ export type {
   UploadResult,
   RequestUploadUrlInput,
   RequestUploadUrlPayload,
-  ConfirmUploadInput,
-  ConfirmUploadPayload,
   UploadErrorCode,
 } from './types';
 

--- a/packages/upload-client/src/queries.ts
+++ b/packages/upload-client/src/queries.ts
@@ -17,13 +17,3 @@ export const REQUEST_UPLOAD_URL_MUTATION = `
     }
   }
 `;
-
-export const CONFIRM_UPLOAD_MUTATION = `
-  mutation ConfirmUpload($input: ConfirmUploadInput!) {
-    confirmUpload(input: $input) {
-      fileId
-      status
-      success
-    }
-  }
-`;

--- a/packages/upload-client/src/types.ts
+++ b/packages/upload-client/src/types.ts
@@ -32,22 +32,8 @@ export interface RequestUploadUrlPayload {
   deduplicated: boolean;
   /** Presigned URL expiry time (ISO string, null if deduplicated) */
   expiresAt: string | null;
-  /** File status — 'pending' for fresh uploads, 'ready' or 'processed' for deduplicated files */
+  /** File status — 'requested' for fresh uploads, 'uploaded'/'processed' for deduplicated files */
   status: string;
-}
-
-export interface ConfirmUploadInput {
-  /** The file ID returned by requestUploadUrl */
-  fileId: string;
-}
-
-export interface ConfirmUploadPayload {
-  /** The confirmed file ID */
-  fileId: string;
-  /** New file status (e.g., "ready") */
-  status: string;
-  /** Whether confirmation succeeded */
-  success: boolean;
 }
 
 // --- Client options ---
@@ -96,7 +82,7 @@ export interface UploadResult {
   key: string;
   /** Whether this file was deduplicated (no bytes uploaded) */
   deduplicated: boolean;
-  /** File status after upload ("ready" for fresh uploads, existing status for dedup) */
+  /** File status after upload ("requested" for fresh uploads, existing status for dedup) */
   status: string;
 }
 
@@ -127,7 +113,6 @@ export type UploadErrorCode =
   | 'GRAPHQL_ERROR'
   | 'REQUEST_UPLOAD_URL_FAILED'
   | 'PUT_UPLOAD_FAILED'
-  | 'CONFIRM_UPLOAD_FAILED'
   | 'ABORTED';
 
 export class UploadError extends Error {

--- a/packages/upload-client/src/upload.ts
+++ b/packages/upload-client/src/upload.ts
@@ -2,19 +2,18 @@
  * Core upload orchestrator.
  *
  * Coordinates the full presigned URL upload flow:
- *   hashFile → requestUploadUrl → PUT to S3 → confirmUpload
+ *   hashFile → requestUploadUrl → PUT to S3
  *
  * Each step is a pure function — this module just wires them together.
  */
 
 import { hashFile } from './hash';
-import { REQUEST_UPLOAD_URL_MUTATION, CONFIRM_UPLOAD_MUTATION } from './queries';
+import { REQUEST_UPLOAD_URL_MUTATION } from './queries';
 import { UploadError } from './types';
 import type {
   UploadFileOptions,
   UploadResult,
   RequestUploadUrlPayload,
-  ConfirmUploadPayload,
 } from './types';
 
 /**
@@ -23,7 +22,6 @@ import type {
  * 1. Computes SHA-256 hash of the file content
  * 2. Calls `requestUploadUrl` mutation to get a presigned PUT URL
  * 3. If not deduplicated, PUTs the file bytes directly to S3
- * 4. Calls `confirmUpload` mutation to verify and transition status
  *
  * @param options - Upload options (file, bucket, executor, etc.)
  * @returns Upload result with fileId, key, and status
@@ -98,16 +96,11 @@ export async function uploadFile(options: UploadFileOptions): Promise<UploadResu
     signal,
   );
 
-  checkAborted(signal);
-
-  // --- Step 4: Confirm ---
-  const confirmPayload = await confirmUpload(execute, requestPayload.fileId);
-
   return {
-    fileId: confirmPayload.fileId,
+    fileId: requestPayload.fileId,
     key: requestPayload.key,
     deduplicated: false,
-    status: confirmPayload.status,
+    status: requestPayload.status,
   };
 }
 
@@ -256,33 +249,6 @@ function putWithXHR(
       (err) => reject(new UploadError('PUT_UPLOAD_FAILED', 'Failed to read file', err)),
     );
   });
-}
-
-/**
- * Call the confirmUpload GraphQL mutation.
- */
-async function confirmUpload(
-  execute: UploadFileOptions['execute'],
-  fileId: string,
-): Promise<ConfirmUploadPayload> {
-  try {
-    const data = await execute(CONFIRM_UPLOAD_MUTATION, { input: { fileId } });
-    const payload = data.confirmUpload as ConfirmUploadPayload | undefined;
-    if (!payload) {
-      throw new UploadError('CONFIRM_UPLOAD_FAILED', 'No data returned from confirmUpload');
-    }
-    if (!payload.success) {
-      throw new UploadError('CONFIRM_UPLOAD_FAILED', `confirmUpload returned success=false`);
-    }
-    return payload;
-  } catch (err) {
-    if (err instanceof UploadError) throw err;
-    throw new UploadError(
-      'CONFIRM_UPLOAD_FAILED',
-      `confirmUpload mutation failed: ${err instanceof Error ? err.message : String(err)}`,
-      err,
-    );
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Removes the `confirmUpload` step from `@constructive-io/upload-client`. The upload flow is now 3 steps instead of 4:

```
Before: hashFile → requestUploadUrl → PUT to S3 → confirmUpload
After:  hashFile → requestUploadUrl → PUT to S3 (done)
```

The `confirmUpload` GraphQL mutation was removed from the server in [constructive-db#996](https://github.com/constructive-io/constructive-db/pull/996). The files row is now created directly on `requestUploadUrl` with `status = 'requested'`, and lifecycle transitions (`uploaded` → `processed`) are handled by server-side processing functions.

**Changes:**
- **`upload-client/src/upload.ts`** — Remove `confirmUpload()` helper and Step 4; return `requestPayload` status directly after S3 PUT
- **`upload-client/src/queries.ts`** — Remove `CONFIRM_UPLOAD_MUTATION` GraphQL query
- **`upload-client/src/types.ts`** — Remove `ConfirmUploadInput`, `ConfirmUploadPayload`, `CONFIRM_UPLOAD_FAILED` error code; update status docs to `'requested'`/`'uploaded'`/`'processed'`
- **`upload-client/src/index.ts`** — Remove `CONFIRM_UPLOAD_MUTATION` and `ConfirmUpload*` type exports
- **`upload-client/__tests__/upload.test.ts`** — Update all tests for 3-step flow, remove confirm assertions, update status values from `'pending'`/`'ready'` to `'requested'`
- **`bucket-provisioner/src/cors.ts`** — Update HEAD comment (no longer for confirmUpload verification)
- **`graphile-settings/constructive-preset.ts`** — Remove confirmUpload from plugin description comment

7 files changed, 19 insertions, 129 deletions. All `upload-client` tests pass (22/22).

## Review & Testing Checklist for Human

- [ ] Verify no other packages in the monorepo import `CONFIRM_UPLOAD_MUTATION` or `ConfirmUploadPayload` from `@constructive-io/upload-client` — the generated SDK files in `sdk/` still reference confirmUpload but they'll be regenerated by codegen
- [ ] Test an actual file upload end-to-end against a running Constructive instance to verify the 3-step flow works (hash → requestUploadUrl → PUT succeeds, file row created with `status = 'requested'`)

### Notes

Companion to [constructive-db#996](https://github.com/constructive-io/constructive-db/pull/996) (merged) which removed the server-side `confirmUpload` mutation and `upload_requests` table.

The generated SDK files in `sdk/` (constructive-sdk, constructive-cli, constructive-react) still contain `confirmUpload` references — these are codegen output and will be regenerated on the next codegen run against the updated database schema.

See [constructive-planning#789](https://github.com/constructive-io/constructive-planning/issues/789) for full context on the storage overhaul.

Link to Devin session: https://app.devin.ai/sessions/ffa3ed8652fc412f976accbdc229c88d
Requested by: @pyramation