### PR TITLE
docs: update upload-client README to reflect 3-step flow

### DIFF
--- a/packages/upload-client/README.md
+++ b/packages/upload-client/README.md
@@ -35,7 +35,7 @@ const hash = await hashFile(myFile);
 
 ### `uploadFile(options)`
 
-Orchestrates the full presigned URL upload flow: hash → requestUploadUrl → PUT → confirmUpload.
+Orchestrates the full presigned URL upload flow: hash → requestUploadUrl → PUT to S3.
 
 ### `hashFile(file)`
 


### PR DESCRIPTION
## Summary

Updates the `upload-client` README to reflect the simplified 3-step upload flow after `confirmUpload` was removed in PR #1052.

**Changed:** Line 38 — "hash → requestUploadUrl → PUT → confirmUpload" → "hash → requestUploadUrl → PUT to S3"

## Review & Testing Checklist for Human

- [ ] Verify the README accurately describes the current `uploadFile` behavior

### Notes

One-line documentation fix. No code changes.

Link to Devin session: https://app.devin.ai/sessions/ffa3ed8652fc412f976accbdc229c88d
Requested by: @pyramation