### PR TITLE
feat: add pgpm-ltree-helpers to system modules and PGPM_MODULE_MAP

### DIFF
--- a/pgpm/core/src/modules/modules.ts
+++ b/pgpm/core/src/modules/modules.ts
@@ -19,7 +19,8 @@ export const PGPM_MODULE_MAP: Record<string, string> = {
   'pgpm-stamps': '@pgpm/stamps',
   'pgpm-totp': '@pgpm/totp',
   'pgpm-types': '@pgpm/types',
-  'pgpm-utils': '@pgpm/utils'
+  'pgpm-utils': '@pgpm/utils',
+  'pgpm-ltree-helpers': '@pgpm/ltree-helpers'
 };
 
 /**

--- a/pgpm/export/src/export-utils.ts
+++ b/pgpm/export/src/export-utils.ts
@@ -26,6 +26,7 @@ export const DB_REQUIRED_EXTENSIONS = [
   'postgis',
   'hstore',
   'vector',
+  'ltree',
   'metaschema-schema',
   'pgpm-inflection',
   'pgpm-uuid',
@@ -35,7 +36,8 @@ export const DB_REQUIRED_EXTENSIONS = [
   'pgpm-stamps',
   'pgpm-base32',
   'pgpm-totp',
-  'pgpm-types'
+  'pgpm-types',
+  'pgpm-ltree-helpers'
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary

Registers the new `@pgpm/ltree-helpers` module in two places:

1. **`pgpm/export/src/export-utils.ts`** — Added `ltree` (native extension) and `pgpm-ltree-helpers` to `DB_REQUIRED_EXTENSIONS`. This ensures database exports include these as required extensions.

2. **`pgpm/core/src/modules/modules.ts`** — Added `'pgpm-ltree-helpers': '@pgpm/ltree-helpers'` to `PGPM_MODULE_MAP`. This enables `pgpm install` to resolve the control name to the npm package.

## Review & Testing Checklist for Human

- [ ] Verify `ltree` belongs in `DB_REQUIRED_EXTENSIONS` (it's already in `constructive.control` requires but was missing here)
- [ ] Confirm `pgpm-ltree-helpers` placement in the array ordering is acceptable

### Notes

Companion PRs:
- pgpm-modules [#64](https://github.com/constructive-io/pgpm-modules/pull/64): upstream module source
- constructive-db [#1007](https://github.com/constructive-io/constructive-db/pull/1007): downstream copy + `constructive.control` dependency

Link to Devin session: https://app.devin.ai/sessions/ffa3ed8652fc412f976accbdc229c88d
Requested by: @pyramation