### PR TITLE
feat(node-type-registry): strip membership_type from AuthzAppMembership

### DIFF
--- a/packages/node-type-registry/src/authz/authz-app-membership.ts
+++ b/packages/node-type-registry/src/authz/authz-app-membership.ts
@@ -6,20 +6,10 @@ export const AuthzAppMembership: NodeTypeDefinition = {
   category: 'authz',
   display_name: 'App Membership Check',
   description:
-    'App-level membership check (membership_type=1). Verifies the user has app membership (optionally with specific permission) without binding to any entity from the row. Uses EXISTS subquery against SPRT table. Replaces AuthzMembership for clarity.',
+    'App-level membership check (hardcoded membership_type=1). Verifies the user has app membership (optionally with specific permission) without binding to any entity from the row. Uses EXISTS subquery against SPRT table. For entity-scoped checks (org, channel, etc.), use AuthzEntityMembership instead.',
   parameter_schema: {
     type: 'object',
     properties: {
-      membership_type: {
-        type: ['integer', 'string'],
-        description:
-          'Scope: 1=app, 2=org, 3+=dynamic entity types (or string name resolved via membership_types_module)',
-      },
-      entity_type: {
-        type: 'string',
-        description:
-          "Entity type prefix (e.g. 'channel', 'department'). Resolved to membership_type integer via memberships_module lookup. Use instead of membership_type for readability.",
-      },
       permission: {
         type: 'string',
         description:

--- a/packages/node-type-registry/src/blueprint-types.generated.ts
+++ b/packages/node-type-registry/src/blueprint-types.generated.ts
@@ -452,12 +452,8 @@ export interface SearchVectorParams {
 ;
 /** Allows all access. Generates TRUE expression. */
 export type AuthzAllowAllParams = {};
-/** App-level membership check (membership_type=1). Verifies the user has app membership (optionally with specific permission) without binding to any entity from the row. Uses EXISTS subquery against SPRT table. Replaces AuthzMembership for clarity. */
+/** App-level membership check (hardcoded membership_type=1). Verifies the user has app membership (optionally with specific permission) without binding to any entity from the row. Uses EXISTS subquery against SPRT table. For entity-scoped checks (org, channel, etc.), use AuthzEntityMembership instead. */
 export interface AuthzAppMembershipParams {
-  /* Scope: 1=app, 2=org, 3+=dynamic entity types (or string name resolved via membership_types_module) */
-  membership_type?: number | string;
-  /* Entity type prefix (e.g. 'channel', 'department'). Resolved to membership_type integer via memberships_module lookup. Use instead of membership_type for readability. */
-  entity_type?: string;
   /* Single permission name to check (resolved to bitstring mask) */
   permission?: string;
   /* Multiple permission names to check (ORed together into mask) */


### PR DESCRIPTION
## Summary

`AuthzAppMembership` is hardcoded to `membership_type=1` — it's an app-level-only check. Remove `membership_type` and `entity_type` from its `parameter_schema` since they don't belong on this type.

- For entity-scoped membership checks (org, channel, etc.), use `AuthzEntityMembership` instead
- Remaining params: `permission`, `permissions`, `is_admin`, `is_owner`
- Blueprint types regenerated

This makes the distinction between `AuthzAppMembership` (app-level, no scope config) and `AuthzEntityMembership` (entity-scoped, takes entity_field + membership_type) unambiguous.

## Review & Testing Checklist for Human

- [ ] Verify no downstream code passes `membership_type` to `AuthzAppMembership` policies (constructive-db generators already hardcode type=1)

### Notes

Companion change needed in `constructive-db`: hardcode `membership_type=1` in the RLS parser/AST builder for `AuthzAppMembership` so it ignores any `membership_type` param even if passed.

Link to Devin session: https://app.devin.ai/sessions/b4ff120294f446d8a0407ac21e05f7bb
Requested by: @pyramation