### PR TITLE
feat: add deleteFile GraphQL mutation with sync S3 delete + async fallback

### DIFF
--- a/graphile/graphile-presigned-url-plugin/src/plugin.ts
+++ b/graphile/graphile-presigned-url-plugin/src/plugin.ts
@@ -678,13 +678,17 @@ async function processSingleFile(
 // --- Delete logic ---
 
 /**
- * Process a file deletion: remove the DB record, then attempt S3 cleanup.
+ * Process a file deletion: remove the DB record, then attempt sync S3 cleanup.
+ *
+ * The AFTER DELETE trigger on the files table always enqueues an async
+ * delete_s3_object job as a safety net. This function attempts the S3 delete
+ * inline for immediate cleanup — if it fails, the async job handles it.
  *
  * 1. Resolve the file row (key, bucket_id) and storage config
  * 2. DELETE the file row (RLS enforced — only owner/admin can delete)
+ *    → AFTER DELETE trigger enqueues async GC job (SECURITY DEFINER)
  * 3. Check refcount: any other file with same key in the same bucket?
- * 4. If orphaned: try S3 DeleteObject inline (sync)
- *    - On S3 failure: enqueue delete_s3_object job (async fallback)
+ * 4. If orphaned: try S3 DeleteObject inline (sync, best-effort)
  * 5. Return result
  */
 async function processDelete(
@@ -706,7 +710,7 @@ async function processDelete(
         throw new Error('DATABASE_NOT_FOUND');
       }
 
-      // 1. Resolve storage config + file across all storage modules (app-level + entity-scoped)
+      // 1. Resolve storage config + file across all storage modules
       const resolved = await resolveStorageModuleByFileId(txClient, databaseId, fileId);
       if (!resolved) {
         throw new Error('FILE_NOT_FOUND: file does not exist or access denied');
@@ -715,7 +719,7 @@ async function processDelete(
       const { storageConfig, file } = resolved;
       const { key, bucket_id } = file;
 
-      // 2. DELETE the file row (RLS enforced — will fail if user lacks permission)
+      // 2. DELETE the file row (RLS enforced)
       const deleteResult = await txClient.query({
         text: `DELETE FROM ${storageConfig.filesQualifiedName}
          WHERE id = $1
@@ -739,7 +743,6 @@ async function processDelete(
       const refCount = refcountResult.rows[0]?.ref_count ?? 0;
 
       if (refCount > 0) {
-        // Other files reference this S3 key — do not delete from S3
         log.info(`File ${fileId} deleted from DB; S3 key ${key} still referenced by ${refCount} file(s)`);
         return {
           success: true,
@@ -748,7 +751,7 @@ async function processDelete(
         };
       }
 
-      // 4. Attempt sync S3 delete
+      // 4. Attempt sync S3 delete (best-effort; async GC job is the fallback)
       try {
         const s3ForDb = resolveS3ForDatabase(options, storageConfig, databaseId);
         await deleteS3Object(s3ForDb, key);
@@ -759,39 +762,7 @@ async function processDelete(
           key,
         };
       } catch (s3Error: any) {
-        // S3 delete failed — enqueue async job as fallback
-        log.warn(`S3 delete failed for key=${key}, falling back to async job: ${s3Error.message}`);
-
-        try {
-          await txClient.query({
-            text: `SELECT app_jobs.add_job(
-              $1::text,
-              $2::json,
-              job_key := $3::text,
-              queue_name := $4::text,
-              priority := $5::int,
-              run_at := NOW() + interval '5 seconds'
-            )`,
-            values: [
-              'delete_s3_object',
-              JSON.stringify({
-                key,
-                bucket_id,
-                database_id: databaseId,
-                schema_name: storageConfig.schemaName,
-                table_name: storageConfig.filesTableName,
-              }),
-              `gc:${bucket_id}:${key}`,
-              'storage_gc',
-              100,
-            ],
-          });
-          log.info(`Enqueued delete_s3_object job for key=${key}`);
-        } catch (jobError: any) {
-          // app_jobs might not be installed — log but don't fail the delete
-          log.warn(`Failed to enqueue delete_s3_object job: ${jobError.message}`);
-        }
-
+        log.warn(`Sync S3 delete failed for key=${key}; async GC job will retry: ${s3Error.message}`);
         return {
           success: true,
           deletedFromS3: false,

--- a/graphile/graphile-presigned-url-plugin/src/plugin.ts
+++ b/graphile/graphile-presigned-url-plugin/src/plugin.ts
@@ -19,8 +19,8 @@ import { extendSchema, gql } from 'graphile-utils';
 import { Logger } from '@pgpmjs/logger';
 
 import type { PresignedUrlPluginOptions, S3Config, StorageModuleConfig, BucketConfig } from './types';
-import { getStorageModuleConfig, getStorageModuleConfigForOwner, getBucketConfig, isS3BucketProvisioned, markS3BucketProvisioned } from './storage-module-cache';
-import { generatePresignedPutUrl } from './s3-signer';
+import { getStorageModuleConfig, getStorageModuleConfigForOwner, getBucketConfig, resolveStorageModuleByFileId, isS3BucketProvisioned, markS3BucketProvisioned } from './storage-module-cache';
+import { generatePresignedPutUrl, deleteS3Object } from './s3-signer';
 
 const log = new Logger('graphile-presigned-url:plugin');
 
@@ -264,6 +264,20 @@ export function createPresignedUrlPlugin(
         files: [BulkUploadFilePayload!]!
       }
 
+      input DeleteFileInput {
+        """File ID to delete"""
+        fileId: UUID!
+      }
+
+      type DeleteFilePayload {
+        """Whether the file record was deleted from the database"""
+        success: Boolean!
+        """Whether the S3 object was deleted (false if other files reference the same key)"""
+        deletedFromS3: Boolean!
+        """The S3 key that was (or would have been) deleted"""
+        key: String
+      }
+
       extend type Mutation {
         """
         Request a presigned URL for uploading a file directly to S3.
@@ -283,6 +297,17 @@ export function createPresignedUrlPlugin(
         requestBulkUploadUrls(
           input: RequestBulkUploadUrlsInput!
         ): RequestBulkUploadUrlsPayload
+
+        """
+        Delete a file record and its S3 object.
+        The DB record is always deleted (subject to RLS). The S3 object is
+        deleted only if no other file records reference the same key in the
+        same bucket (content-addressed dedup safety). If the inline S3
+        delete fails, cleanup falls back to the async delete_s3_object job.
+        """
+        deleteFile(
+          input: DeleteFileInput!
+        ): DeleteFilePayload
       }
     `,
     plans: {
@@ -299,6 +324,21 @@ export function createPresignedUrlPlugin(
 
           return lambda($combined, async ({ input, withPgClient, pgSettings }: any) => {
             const result = await processUpload(options, input, withPgClient, pgSettings);
+            return result;
+          });
+        },
+        deleteFile(_$mutation: any, fieldArgs: any) {
+          const $input = fieldArgs.getRaw('input');
+          const $withPgClient = (grafastContext() as any).get('withPgClient');
+          const $pgSettings = (grafastContext() as any).get('pgSettings');
+          const $combined = object({
+            input: $input,
+            withPgClient: $withPgClient,
+            pgSettings: $pgSettings,
+          });
+
+          return lambda($combined, async ({ input, withPgClient, pgSettings }: any) => {
+            const result = await processDelete(options, input, withPgClient, pgSettings);
             return result;
           });
         },
@@ -633,6 +673,133 @@ async function processSingleFile(
     expiresAt,
     previousVersionId,
   };
+}
+
+// --- Delete logic ---
+
+/**
+ * Process a file deletion: remove the DB record, then attempt S3 cleanup.
+ *
+ * 1. Resolve the file row (key, bucket_id) and storage config
+ * 2. DELETE the file row (RLS enforced — only owner/admin can delete)
+ * 3. Check refcount: any other file with same key in the same bucket?
+ * 4. If orphaned: try S3 DeleteObject inline (sync)
+ *    - On S3 failure: enqueue delete_s3_object job (async fallback)
+ * 5. Return result
+ */
+async function processDelete(
+  options: PresignedUrlPluginOptions,
+  input: any,
+  withPgClient: any,
+  pgSettings: any,
+) {
+  const { fileId } = input;
+
+  if (!fileId || typeof fileId !== 'string') {
+    throw new Error('INVALID_FILE_ID');
+  }
+
+  return withPgClient(pgSettings, async (pgClient: any) => {
+    return pgClient.withTransaction(async (txClient: any) => {
+      const databaseId = await resolveDatabaseId(txClient);
+      if (!databaseId) {
+        throw new Error('DATABASE_NOT_FOUND');
+      }
+
+      // 1. Resolve storage config + file across all storage modules (app-level + entity-scoped)
+      const resolved = await resolveStorageModuleByFileId(txClient, databaseId, fileId);
+      if (!resolved) {
+        throw new Error('FILE_NOT_FOUND: file does not exist or access denied');
+      }
+
+      const { storageConfig, file } = resolved;
+      const { key, bucket_id } = file;
+
+      // 2. DELETE the file row (RLS enforced — will fail if user lacks permission)
+      const deleteResult = await txClient.query({
+        text: `DELETE FROM ${storageConfig.filesQualifiedName}
+         WHERE id = $1
+         RETURNING id`,
+        values: [fileId],
+      });
+
+      if (deleteResult.rows.length === 0) {
+        throw new Error('DELETE_DENIED: insufficient permissions to delete this file');
+      }
+
+      // 3. Check refcount: any other file with same key in this bucket?
+      const refcountResult = await txClient.query({
+        text: `SELECT COUNT(*)::int AS ref_count
+         FROM ${storageConfig.filesQualifiedName}
+         WHERE key = $1
+           AND bucket_id = $2`,
+        values: [key, bucket_id],
+      });
+
+      const refCount = refcountResult.rows[0]?.ref_count ?? 0;
+
+      if (refCount > 0) {
+        // Other files reference this S3 key — do not delete from S3
+        log.info(`File ${fileId} deleted from DB; S3 key ${key} still referenced by ${refCount} file(s)`);
+        return {
+          success: true,
+          deletedFromS3: false,
+          key,
+        };
+      }
+
+      // 4. Attempt sync S3 delete
+      try {
+        const s3ForDb = resolveS3ForDatabase(options, storageConfig, databaseId);
+        await deleteS3Object(s3ForDb, key);
+        log.info(`File ${fileId} deleted from DB and S3 (key=${key})`);
+        return {
+          success: true,
+          deletedFromS3: true,
+          key,
+        };
+      } catch (s3Error: any) {
+        // S3 delete failed — enqueue async job as fallback
+        log.warn(`S3 delete failed for key=${key}, falling back to async job: ${s3Error.message}`);
+
+        try {
+          await txClient.query({
+            text: `SELECT app_jobs.add_job(
+              $1::text,
+              $2::json,
+              job_key := $3::text,
+              queue_name := $4::text,
+              priority := $5::int,
+              run_at := NOW() + interval '5 seconds'
+            )`,
+            values: [
+              'delete_s3_object',
+              JSON.stringify({
+                key,
+                bucket_id,
+                database_id: databaseId,
+                schema_name: storageConfig.schemaName,
+                table_name: storageConfig.filesTableName,
+              }),
+              `gc:${bucket_id}:${key}`,
+              'storage_gc',
+              100,
+            ],
+          });
+          log.info(`Enqueued delete_s3_object job for key=${key}`);
+        } catch (jobError: any) {
+          // app_jobs might not be installed — log but don't fail the delete
+          log.warn(`Failed to enqueue delete_s3_object job: ${jobError.message}`);
+        }
+
+        return {
+          success: true,
+          deletedFromS3: false,
+          key,
+        };
+      }
+    });
+  });
 }
 
 export const PresignedUrlPlugin = createPresignedUrlPlugin;

--- a/graphile/graphile-presigned-url-plugin/src/s3-signer.ts
+++ b/graphile/graphile-presigned-url-plugin/src/s3-signer.ts
@@ -1,5 +1,6 @@
 import {
   S3Client,
+  DeleteObjectCommand,
   PutObjectCommand,
   GetObjectCommand,
   HeadObjectCommand,
@@ -116,4 +117,28 @@ export async function headObject(
     }
     throw e;
   }
+}
+
+/**
+ * Delete an object from S3.
+ *
+ * Returns true if the object was deleted (or didn't exist — S3 DeleteObject
+ * is idempotent). Throws on unexpected errors (permissions, network).
+ *
+ * @param s3Config - S3 client and bucket configuration
+ * @param key - S3 object key to delete
+ * @returns true if deletion succeeded
+ */
+export async function deleteS3Object(
+  s3Config: S3Config,
+  key: string,
+): Promise<boolean> {
+  await s3Config.client.send(
+    new DeleteObjectCommand({
+      Bucket: s3Config.bucket,
+      Key: key,
+    }),
+  );
+  log.debug(`Deleted S3 object: key=${key}, bucket=${s3Config.bucket}`);
+  return true;
 }

--- a/uploads/s3-utils/src/utils.ts
+++ b/uploads/s3-utils/src/utils.ts
@@ -1,4 +1,5 @@
 import {
+  DeleteObjectCommand,
   GetObjectCommand,
   HeadObjectCommand, 
   S3Client} from '@aws-sdk/client-s3';
@@ -26,6 +27,16 @@ export const fileExists = async ({ client, bucket, key }: FileOperationArgs): Pr
     return true;
   } catch (e: any) {
     if (e.name === 'NotFound' || e.$metadata?.httpStatusCode === 404) return false;
+    throw e;
+  }
+};
+
+export const deleteObject = async ({ client, bucket, key }: FileOperationArgs): Promise<boolean> => {
+  try {
+    await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }));
+    return true;
+  } catch (e: any) {
+    if (e.name === 'NoSuchKey' || e.$metadata?.httpStatusCode === 404) return false;
     throw e;
   }
 };


### PR DESCRIPTION
## Summary

Adds a `deleteFile` GraphQL mutation to the presigned-url plugin. The mutation deletes a file record from the database (RLS enforced) and attempts to clean up the S3 object synchronously. If the sync S3 delete fails, the AFTER DELETE trigger on the files table (added in constructive-db [PR #1033](https://github.com/constructive-io/constructive-db/pull/1033)) enqueues an async `delete_s3_object` job as fallback.

**How it works:**

1. **Resolve** the file row and storage module config across all scopes (app-level + entity-scoped)
2. **DELETE** the file row — RLS enforced, only owner/admin can delete. The AFTER DELETE trigger fires and enqueues the async GC job.
3. **Refcount check** — if other files reference the same S3 key (content-addressed dedup), skip S3 delete
4. **Sync S3 delete** — best-effort inline `DeleteObject`. If it fails, the async job handles it.

**Changes:**

- `graphile-presigned-url-plugin/src/plugin.ts` — `DeleteFileInput`, `DeleteFilePayload` types + `deleteFile` mutation plan + `processDelete` function
- `graphile-presigned-url-plugin/src/s3-signer.ts` — `deleteS3Object()` helper
- `uploads/s3-utils/src/utils.ts` — `deleteObject()` utility (low-level S3 `DeleteObjectCommand`)

**Companion PR:** [constructive-db #1033](https://github.com/constructive-io/constructive-db/pull/1033) — AFTER DELETE GC trigger on files table

**Tracking:** [#789](https://github.com/constructive-io/constructive-planning/issues/789)

## Review & Testing Checklist for Human

- [ ] Verify the `deleteFile` mutation appears in the GraphQL schema when the presigned-url plugin is loaded
- [ ] Test that deleting a file you own returns `{ success: true, deletedFromS3: true }` and the S3 object is removed
- [ ] Test that deleting a file when content-addressed dedup is active (multiple files share the same key) returns `{ success: true, deletedFromS3: false }` — S3 object preserved
- [ ] Test that an unauthorized user gets `DELETE_DENIED` error (RLS blocks the DELETE)
- [ ] Verify the async GC job fires when S3 is unavailable (DB trigger fallback)

### Notes

- The `deleteObject` in `s3-utils` catches `NoSuchKey`/404 and returns `false` (idempotent). The `deleteS3Object` in `s3-signer` does not — it lets unexpected errors propagate up to `processDelete` which catches them and returns `{ deletedFromS3: false }`.
- The sync S3 delete is a performance optimization. The AFTER DELETE trigger is the reliable path. When sync succeeds, the async job worker will find the S3 object already gone — this is a no-op since `DeleteObject` is idempotent.
- No new dependencies added. Uses existing `@aws-sdk/client-s3` `DeleteObjectCommand`.


Link to Devin session: https://app.devin.ai/sessions/ffa3ed8652fc412f976accbdc229c88d
Requested by: @pyramation