### PR TITLE
feat: unified file-path syntax for ltree — codec converts between slash paths and ltree

### DIFF
--- a/graphile/graphile-ltree/src/__tests__/ltree.test.ts
+++ b/graphile/graphile-ltree/src/__tests__/ltree.test.ts
@@ -4,17 +4,14 @@ import { getConnections, seed } from 'graphile-test';
 import { join } from 'path';
 import type { PgTestClient } from 'pgsql-test';
 
-import { createLtreeOperatorFactory } from '../plugins/connection-filter-operators';
-import { LtreeExtensionDetectionPlugin } from '../plugins/detect-ltree';
-import { LtreeFolderFieldPlugin } from '../plugins/folder-field';
 import { createFolderOperatorFactory } from '../plugins/folder-filter-operators';
+import { LtreeExtensionDetectionPlugin } from '../plugins/detect-ltree';
 import { LtreeCodecPlugin } from '../plugins/ltree-codec';
 
 interface FileNode {
   id: number;
   filename: string;
   path: string;
-  pathTree: string;
 }
 
 interface AllFilesResult {
@@ -27,7 +24,6 @@ interface CategoryNode {
   id: number;
   name: string;
   treePath: string;
-  treePathTree: string;
 }
 
 interface AllCategoriesResult {
@@ -53,12 +49,10 @@ describe('graphile-ltree', () => {
       ],
       plugins: [
         LtreeExtensionDetectionPlugin,
-        LtreeCodecPlugin,
-        LtreeFolderFieldPlugin
+        LtreeCodecPlugin
       ],
       schema: {
         connectionFilterOperatorFactories: [
-          createLtreeOperatorFactory(),
           createFolderOperatorFactory()
         ]
       }
@@ -101,13 +95,13 @@ describe('graphile-ltree', () => {
     await db.afterEach();
   });
 
-  // ─── Field naming ─────────────────────────────────────────────────────
+  // ─── File-path output ──────────────────────────────────────────────────
 
-  describe('field naming', () => {
-    it('renames ltree column to pathTree (dot-delimited)', async () => {
+  describe('file-path output', () => {
+    it('returns path as slash-delimited file path', async () => {
       const result = await query<AllFilesResult>(`{
         allFiles {
-          nodes { id filename pathTree }
+          nodes { id filename path }
         }
       }`);
       expect(result.errors).toBeUndefined();
@@ -115,21 +109,6 @@ describe('graphile-ltree', () => {
       expect(nodes.length).toBe(10);
       const docsFile = nodes.find(n => n.filename === 'contract.pdf');
       expect(docsFile).toBeDefined();
-      expect(docsFile!.pathTree).toBe('projects.alpha.docs');
-    });
-
-    it('exposes path as slash-delimited folder field', async () => {
-      const result = await query<AllFilesResult>(`{
-        allFiles {
-          nodes { filename path pathTree }
-        }
-      }`);
-      expect(result.errors).toBeUndefined();
-      const docsFile = result.data!.allFiles.nodes.find(
-        n => n.filename === 'contract.pdf'
-      );
-      expect(docsFile).toBeDefined();
-      expect(docsFile!.pathTree).toBe('projects.alpha.docs');
       expect(docsFile!.path).toBe('/projects/alpha/docs');
     });
 
@@ -150,7 +129,7 @@ describe('graphile-ltree', () => {
     it('works on other tables with ltree columns', async () => {
       const result = await query<AllCategoriesResult>(`{
         allCategories {
-          nodes { name treePath treePathTree }
+          nodes { name treePath }
         }
       }`);
       expect(result.errors).toBeUndefined();
@@ -158,18 +137,17 @@ describe('graphile-ltree', () => {
         n => n.name === 'Laptops'
       );
       expect(laptops).toBeDefined();
-      expect(laptops!.treePathTree).toBe('shop.electronics.laptops');
       expect(laptops!.treePath).toBe('/shop/electronics/laptops');
     });
   });
 
-  // ─── Raw ltree operators (on pathTree) ────────────────────────────────
+  // ─── Filter operators (slash-delimited input) ──────────────────────────
 
-  describe('isAncestorOf filter', () => {
-    it('finds files under a given path', async () => {
+  describe('within filter', () => {
+    it('finds files within a folder using slash paths', async () => {
       const result = await query<AllFilesResult>(`{
-        allFiles(where: { pathTree: { isAncestorOf: "projects.alpha" } }) {
-          nodes { filename }
+        allFiles(where: { path: { within: "/projects/alpha" } }) {
+          nodes { filename path }
         }
       }`);
       expect(result.errors).toBeUndefined();
@@ -184,100 +162,36 @@ describe('graphile-ltree', () => {
 
     it('includes the exact path itself', async () => {
       const result = await query<AllFilesResult>(`{
-        allFiles(where: { pathTree: { isAncestorOf: "projects.alpha" } }) {
-          nodes { filename pathTree }
-        }
-      }`);
-      expect(result.errors).toBeUndefined();
-      const paths = result.data!.allFiles.nodes.map(n => n.pathTree);
-      expect(paths).toContain('projects.alpha');
-    });
-  });
-
-  describe('isDescendantOf filter', () => {
-    it('finds ancestors of a given path', async () => {
-      const result = await query<AllFilesResult>(`{
-        allFiles(where: { pathTree: { isDescendantOf: "projects.alpha.docs.images" } }) {
-          nodes { filename pathTree }
-        }
-      }`);
-      expect(result.errors).toBeUndefined();
-      const paths = result.data!.allFiles.nodes.map(n => n.pathTree);
-      expect(paths).toContain('projects.alpha.docs.images');
-      expect(paths).toContain('projects.alpha.docs');
-      expect(paths).toContain('projects.alpha');
-      expect(paths).toContain('projects');
-    });
-  });
-
-  describe('matchesGlob filter', () => {
-    it('matches single-level wildcard', async () => {
-      const result = await query<AllFilesResult>(`{
-        allFiles(where: { pathTree: { matchesGlob: "projects.*" } }) {
-          nodes { filename pathTree }
-        }
-      }`);
-      expect(result.errors).toBeUndefined();
-      const filenames = result.data!.allFiles.nodes.map(n => n.filename);
-      expect(filenames).toContain('alpha-spec.pdf');
-      expect(filenames).toContain('beta-spec.pdf');
-      expect(filenames).not.toContain('contract.pdf');
-    });
-
-    it('matches multi-level wildcard', async () => {
-      const result = await query<AllFilesResult>(`{
-        allFiles(where: { pathTree: { matchesGlob: "projects.*.docs" } }) {
-          nodes { filename pathTree }
-        }
-      }`);
-      expect(result.errors).toBeUndefined();
-      const filenames = result.data!.allFiles.nodes.map(n => n.filename);
-      expect(filenames).toContain('contract.pdf');
-      expect(filenames).toContain('proposal.docx');
-      expect(filenames).not.toContain('design.png');
-    });
-  });
-
-  // ─── Folder operators (slash-path interface, on pathTree) ─────────────
-
-  describe('within filter (folder operator)', () => {
-    it('finds files within a folder using slash paths', async () => {
-      const result = await query<AllFilesResult>(`{
-        allFiles(where: { pathTree: { within: "/projects/alpha" } }) {
+        allFiles(where: { path: { within: "/projects/alpha" } }) {
           nodes { filename path }
         }
       }`);
       expect(result.errors).toBeUndefined();
-      const filenames = result.data!.allFiles.nodes.map(n => n.filename);
-      expect(filenames).toContain('alpha-spec.pdf');
-      expect(filenames).toContain('contract.pdf');
-      expect(filenames).toContain('design.png');
-      expect(filenames).toContain('budget.xlsx');
-      expect(filenames).not.toContain('beta-spec.pdf');
-      expect(filenames).not.toContain('root.txt');
+      const paths = result.data!.allFiles.nodes.map(n => n.path);
+      expect(paths).toContain('/projects/alpha');
     });
   });
 
-  describe('ancestorOf filter (folder operator)', () => {
+  describe('ancestorOf filter', () => {
     it('finds ancestor folders using slash paths', async () => {
       const result = await query<AllFilesResult>(`{
-        allFiles(where: { pathTree: { ancestorOf: "/projects/alpha/docs/images" } }) {
+        allFiles(where: { path: { ancestorOf: "/projects/alpha/docs/images" } }) {
           nodes { filename path }
         }
       }`);
       expect(result.errors).toBeUndefined();
-      const folders = result.data!.allFiles.nodes.map(n => n.path);
-      expect(folders).toContain('/projects/alpha/docs/images');
-      expect(folders).toContain('/projects/alpha/docs');
-      expect(folders).toContain('/projects/alpha');
-      expect(folders).toContain('/projects');
+      const paths = result.data!.allFiles.nodes.map(n => n.path);
+      expect(paths).toContain('/projects/alpha/docs/images');
+      expect(paths).toContain('/projects/alpha/docs');
+      expect(paths).toContain('/projects/alpha');
+      expect(paths).toContain('/projects');
     });
   });
 
-  describe('glob filter (folder operator)', () => {
+  describe('glob filter', () => {
     it('matches single-level wildcard with slash paths', async () => {
       const result = await query<AllFilesResult>(`{
-        allFiles(where: { pathTree: { glob: "/projects/*" } }) {
+        allFiles(where: { path: { glob: "/projects/*" } }) {
           nodes { filename path }
         }
       }`);
@@ -290,7 +204,7 @@ describe('graphile-ltree', () => {
 
     it('matches multi-level wildcard with slash paths', async () => {
       const result = await query<AllFilesResult>(`{
-        allFiles(where: { pathTree: { glob: "/projects/*/docs" } }) {
+        allFiles(where: { path: { glob: "/projects/*/docs" } }) {
           nodes { filename path }
         }
       }`);
@@ -299,6 +213,34 @@ describe('graphile-ltree', () => {
       expect(filenames).toContain('contract.pdf');
       expect(filenames).toContain('proposal.docx');
       expect(filenames).not.toContain('design.png');
+    });
+  });
+
+  // ─── Slash-to-ltree conversion (round-trip) ────────────────────────────
+
+  describe('slash-to-ltree conversion', () => {
+    it('accepts slash paths on input and stores as ltree', async () => {
+      const result = await query<AllFilesResult>(`{
+        allFiles(where: { path: { within: "/users" } }) {
+          nodes { filename path }
+        }
+      }`);
+      expect(result.errors).toBeUndefined();
+      const filenames = result.data!.allFiles.nodes.map(n => n.filename);
+      expect(filenames).toContain('avatar.jpg');
+      expect(filenames).toContain('notes.txt');
+    });
+
+    it('dot-delimited input still works (backward compat)', async () => {
+      const result = await query<AllFilesResult>(`{
+        allFiles(where: { path: { within: "projects.alpha" } }) {
+          nodes { filename path }
+        }
+      }`);
+      expect(result.errors).toBeUndefined();
+      const filenames = result.data!.allFiles.nodes.map(n => n.filename);
+      expect(filenames).toContain('alpha-spec.pdf');
+      expect(filenames).toContain('contract.pdf');
     });
   });
 });

--- a/graphile/graphile-ltree/src/index.ts
+++ b/graphile/graphile-ltree/src/index.ts
@@ -1,17 +1,12 @@
 /**
  * graphile-ltree — PostGraphile v5 ltree Plugin
  *
- * Two presets:
- *
- * - `GraphileLtreePreset` — base ltree operators (isAncestorOf, isDescendantOf, matchesGlob)
- * - `GraphileFolderPreset` — folder-oriented layer (within, ancestorOf, glob) + pathFolder fields
+ * File-path syntax for ltree columns. The LTree scalar auto-converts between
+ * slash-delimited file paths ("/projects/alpha/docs") in the GraphQL API and
+ * dot-delimited ltree ("projects.alpha.docs") in PostgreSQL.
  *
  * @example
  * ```typescript
- * // For folder-style interface (recommended):
- * import { GraphileFolderPreset } from 'graphile-ltree';
- *
- * // For raw ltree operators only:
  * import { GraphileLtreePreset } from 'graphile-ltree';
  * ```
  */
@@ -22,9 +17,12 @@ export { GraphileFolderPreset, GraphileLtreePreset } from './preset';
 // Individual plugins
 export type { LtreeExtensionInfo } from './plugins/detect-ltree';
 export { LtreeExtensionDetectionPlugin } from './plugins/detect-ltree';
-export { LtreeFolderFieldPlugin } from './plugins/folder-field';
-export { LTREE_SCALAR_NAME, LtreeCodecPlugin } from './plugins/ltree-codec';
+export { ltreeToSlash, LTREE_SCALAR_NAME, LtreeCodecPlugin, slashToLtree } from './plugins/ltree-codec';
 
 // Connection filter operator factories
-export { createLtreeOperatorFactory } from './plugins/connection-filter-operators';
 export { createFolderOperatorFactory } from './plugins/folder-filter-operators';
+
+// Deprecated — folder field plugin is no longer needed (scalar handles conversion)
+export { LtreeFolderFieldPlugin } from './plugins/folder-field';
+// Deprecated — use createFolderOperatorFactory instead (better operator names)
+export { createLtreeOperatorFactory } from './plugins/connection-filter-operators';

--- a/graphile/graphile-ltree/src/plugins/ltree-codec.ts
+++ b/graphile/graphile-ltree/src/plugins/ltree-codec.ts
@@ -7,6 +7,14 @@
  * This plugin:
  * 1. Falls back to registering codecs if PostGraphile's native handling misses them
  * 2. Re-enables ltree columns for select/filterBy (overrides rc.8 HIDE_BY_DEFAULT)
+ * 3. Converts between slash-delimited file paths (external API) and dot-delimited
+ *    ltree (internal storage) at the GraphQL boundary via the codec's fromPg/toPg.
+ *
+ * External API: "/projects/alpha/docs" (slash-delimited file paths)
+ * Internal DB:  "projects.alpha.docs" (ltree native format)
+ *
+ * The conversion happens at the codec level (fromPg/toPg) so it works regardless
+ * of whether PostGraphile registers its own LTree scalar or we register ours.
  *
  * The native scalar name is "LTree" (capital T). All operators and downstream
  * plugins should reference LTREE_SCALAR_NAME for consistency.
@@ -18,10 +26,32 @@ import sql from 'pg-sql2';
 
 export const LTREE_SCALAR_NAME = 'LTree';
 
+/**
+ * Convert a slash-delimited file path to ltree format.
+ * Idempotent on ltree values (no slashes → no change).
+ *
+ * "/projects/alpha/docs" → "projects.alpha.docs"
+ * "projects.alpha.docs"  → "projects.alpha.docs" (no-op)
+ */
+export function slashToLtree(value: string): string {
+  return value.replace(/^\//, '').replace(/\//g, '.');
+}
+
+/**
+ * Convert an ltree value to a slash-delimited file path.
+ *
+ * "projects.alpha.docs" → "/projects/alpha/docs"
+ * ""                     → "/"
+ */
+export function ltreeToSlash(value: string): string {
+  if (value === '') return '/';
+  return '/' + value.replace(/\./g, '/');
+}
+
 export const LtreeCodecPlugin: GraphileConfig.Plugin = {
   name: 'LtreeCodecPlugin',
-  version: '1.0.0',
-  description: 'Ensures ltree/lquery codecs are properly registered and enabled',
+  version: '2.0.0',
+  description: 'Ensures ltree/lquery codecs are registered; converts between file paths and ltree at the GraphQL boundary',
 
   gather: {
     hooks: {
@@ -64,6 +94,36 @@ export const LtreeCodecPlugin: GraphileConfig.Plugin = {
 
   schema: {
     hooks: {
+      /**
+       * Patch the ltree codec's fromPg/toPg to convert between file paths
+       * and ltree. This runs in the `build` hook (before type registration)
+       * so it works regardless of whether PostGraphile registers its own
+       * LTree scalar or we register ours.
+       *
+       * fromPg: "projects.alpha.docs" → "/projects/alpha/docs"
+       * toPg:   "/projects/alpha/docs" → "projects.alpha.docs"
+       */
+      build(build) {
+        for (const codec of Object.values(build.input.pgRegistry.pgCodecs)) {
+          if (codec.name === 'ltree') {
+            const c = codec as any;
+            const origFromPg = c.fromPg;
+            c.fromPg = (value: string) => {
+              const raw = origFromPg ? origFromPg(value) : value;
+              if (raw == null) return raw;
+              return ltreeToSlash(String(raw));
+            };
+            const origToPg = c.toPg;
+            c.toPg = (value: string) => {
+              if (value == null) return origToPg ? origToPg(value) : value;
+              const converted = slashToLtree(String(value));
+              return origToPg ? origToPg(converted) : converted;
+            };
+          }
+        }
+        return build;
+      },
+
       init: {
         before: ['PgCodecs', 'PgConnectionArgFilterPlugin'],
         callback(_, build) {
@@ -77,13 +137,17 @@ export const LtreeCodecPlugin: GraphileConfig.Plugin = {
                   {},
                   () => ({
                     description:
-                      'A PostgreSQL ltree hierarchical label path, represented as a dot-delimited string (e.g. "projects.alpha.docs").',
+                      'A hierarchical file path. Accepts slash-delimited paths (e.g. "/projects/alpha/docs"). ' +
+                      'Stored internally as PostgreSQL ltree.',
                     serialize(value: unknown) {
+                      if (value == null) return null;
                       return String(value);
                     },
                     parseValue(value: unknown) {
-                      if (typeof value === 'string') return value;
-                      throw new Error(`${LTREE_SCALAR_NAME} must be a string`);
+                      if (typeof value !== 'string') {
+                        throw new Error(`${LTREE_SCALAR_NAME} must be a string`);
+                      }
+                      return value;
                     },
                     parseLiteral(lit: any) {
                       if (lit.kind === 'NullValue') return null;

--- a/graphile/graphile-ltree/src/preset.ts
+++ b/graphile/graphile-ltree/src/preset.ts
@@ -1,18 +1,24 @@
 import type { GraphileConfig } from 'graphile-config';
 
-import { createLtreeOperatorFactory } from './plugins/connection-filter-operators';
 import { LtreeExtensionDetectionPlugin } from './plugins/detect-ltree';
-import { LtreeFolderFieldPlugin } from './plugins/folder-field';
 import { createFolderOperatorFactory } from './plugins/folder-filter-operators';
 import { LtreeCodecPlugin } from './plugins/ltree-codec';
 
 /**
  * GraphileLtreePreset
  *
- * Base preset: ltree codec, detection, and raw ltree operators.
+ * Full ltree support with file-path syntax.
  *
- * Operators on LTree fields: isAncestorOf, isDescendantOf, matchesGlob
- * (accept dot-delimited or slash-delimited paths)
+ * - LTree scalar auto-converts between slash-delimited file paths (API) and
+ *   dot-delimited ltree (DB). External API always uses "/projects/alpha/docs".
+ * - Filter operators: within, ancestorOf, glob (all accept slash-delimited paths)
+ *
+ * @example
+ * ```graphql
+ * allFiles(where: { path: { within: "/projects/alpha" } }) {
+ *   nodes { path filename }
+ * }
+ * ```
  */
 export const GraphileLtreePreset: GraphileConfig.Preset = {
   plugins: [
@@ -21,37 +27,15 @@ export const GraphileLtreePreset: GraphileConfig.Preset = {
   ],
   schema: {
     connectionFilterOperatorFactories: [
-      createLtreeOperatorFactory()
-    ]
-  } as GraphileConfig.Preset['schema'] & Record<string, unknown>
-};
-
-/**
- * GraphileFolderPreset
- *
- * Folder-oriented layer on top of the base ltree preset.
- *
- * Adds:
- * - Virtual `{column}Folder` fields with slash-delimited paths
- * - Folder operators: within, ancestorOf, glob (always slash-delimited)
- *
- * @example
- * ```graphql
- * allFiles(where: { path: { within: "/projects/alpha" } }) {
- *   nodes { pathFolder filename }
- * }
- * ```
- */
-export const GraphileFolderPreset: GraphileConfig.Preset = {
-  extends: [GraphileLtreePreset],
-  plugins: [
-    LtreeFolderFieldPlugin
-  ],
-  schema: {
-    connectionFilterOperatorFactories: [
       createFolderOperatorFactory()
     ]
   } as GraphileConfig.Preset['schema'] & Record<string, unknown>
 };
 
-export default GraphileFolderPreset;
+/**
+ * @deprecated Use GraphileLtreePreset instead. The folder field plugin is no
+ * longer needed — the LTree scalar now handles slash↔ltree conversion directly.
+ */
+export const GraphileFolderPreset: GraphileConfig.Preset = GraphileLtreePreset;
+
+export default GraphileLtreePreset;

--- a/graphile/graphile-settings/src/presets/constructive-preset.ts
+++ b/graphile/graphile-settings/src/presets/constructive-preset.ts
@@ -1,7 +1,7 @@
 import { BucketProvisionerPreset } from 'graphile-bucket-provisioner-plugin';
 import type { GraphileConfig } from 'graphile-config';
 import { ConnectionFilterPreset } from 'graphile-connection-filter';
-import { createFolderOperatorFactory,createLtreeOperatorFactory, GraphileFolderPreset } from 'graphile-ltree';
+import { createFolderOperatorFactory, GraphileLtreePreset } from 'graphile-ltree';
 import { createPostgisOperatorFactory,GraphilePostgisPreset } from 'graphile-postgis';
 import { PresignedUrlPreset } from 'graphile-presigned-url-plugin';
 import { createMatchesOperatorFactory, createTrgmOperatorFactories,UnifiedSearchPreset } from 'graphile-search';
@@ -53,8 +53,8 @@ import { constructiveUploadFieldDefinitions } from '../upload-resolver';
  *   orderBy score — zero config)
  * - pg_trgm fuzzy matching (similarTo/wordSimilarTo on text columns, similarity score fields,
  *   orderBy similarity — zero config, typo-tolerant)
- * - ltree support (auto-detects ltree columns, LTree scalar, folder fields, containment/glob filters)
- * - Folder operators (within, ancestorOf, glob — slash-delimited path interface)
+ * - ltree support (auto-detects ltree columns, LTree scalar with file-path syntax,
+ *   containment/glob filters — within, ancestorOf, glob)
  *
  * RELATION FILTERS:
  * - Enabled via connectionFilterRelations: true
@@ -90,7 +90,7 @@ export const ConstructivePreset: GraphileConfig.Preset = {
     MetaSchemaPreset,
     UnifiedSearchPreset({ fullTextScalarName: 'FullText', tsConfig: 'english' }),
     GraphilePostgisPreset,
-    GraphileFolderPreset,
+    GraphileLtreePreset,
     UploadPreset({
       uploadFieldDefinitions: constructiveUploadFieldDefinitions,
       maxFileSize: 10 * 1024 * 1024 // 10MB
@@ -172,7 +172,6 @@ export const ConstructivePreset: GraphileConfig.Preset = {
       createMatchesOperatorFactory('FullText', 'english'),
       createTrgmOperatorFactories(),
       createPostgisOperatorFactory(),
-      createLtreeOperatorFactory(),
       createFolderOperatorFactory()
     ]
     // NOTE: The UnifiedSearchPreset also registers matches + trgm operator factories.


### PR DESCRIPTION
## Summary

Implements the rule: **public-facing APIs use file paths (`/projects/alpha/docs`), internal storage uses ltree (`projects.alpha.docs`)**.

The conversion now happens at the codec level (`fromPg`/`toPg`) in the schema `build` hook, which reliably patches the ltree codec regardless of whether PostGraphile registers its own native LTree scalar or we register ours.

**Key changes:**

- **`ltree-codec.ts`**: Patches codec `fromPg` (ltree→slash on output) and `toPg` (slash→ltree on input) in the `build` hook. Adds exported `slashToLtree()`/`ltreeToSlash()` helpers. Fallback scalar registration kept for environments where PostGraphile doesn't natively detect ltree.

- **`preset.ts`**: Simplified to single `GraphileLtreePreset` (combines detection + codec + folder operators). `GraphileFolderPreset` deprecated as alias. `LtreeFolderFieldPlugin` removed from preset (no longer needed — codec handles conversion).

- **`index.ts`**: Exports conversion helpers. Marks `LtreeFolderFieldPlugin` and `createLtreeOperatorFactory` as deprecated.

- **`constructive-preset.ts`**: Uses `GraphileLtreePreset` (was `GraphileFolderPreset`). Removes deprecated `createLtreeOperatorFactory` from operator factories.

- **`ltree.test.ts`**: Rewritten — all tests verify slash-path output, slash-path filter input, and backward compat with dot-delimited input. 10/10 pass.

## Review & Testing Checklist for Human

- [ ] **Verify file-path output**: Query a table with ltree columns via GraphQL — paths should return as `/projects/alpha/docs` not `projects.alpha.docs`
- [ ] **Verify file-path input**: Create/update a row with an ltree column using slash paths — should store as ltree internally
- [ ] **Verify filter operators**: `within`, `ancestorOf`, `glob` all accept slash paths (e.g., `where: { path: { within: "/projects/alpha" } }`)
- [ ] **Check backward compat**: Dot-delimited input (`projects.alpha`) should still work (idempotent conversion)
- [ ] **Confirm no pathTree references remain**: The old `pathTree` virtual field from the folder field plugin is gone — all ltree columns use their original inflected names

### Notes
- The folder field plugin (`LtreeFolderFieldPlugin`) is kept in the package for backward compat but removed from the default preset and marked deprecated
- Raw ltree operators (`createLtreeOperatorFactory`) are kept for backward compat but deprecated — folder operators (`within`, `ancestorOf`, `glob`) are the primary API
- This is a breaking change for any code that relied on `pathTree` field names — but no code in the monorepo references `pathTree` outside of changelogs


Link to Devin session: https://app.devin.ai/sessions/ffa3ed8652fc412f976accbdc229c88d
Requested by: @pyramation