### PR TITLE
feat: add AuthzFilePath to node_type_registry

### DIFF
--- a/packages/node-type-registry/src/authz/authz-file-path.ts
+++ b/packages/node-type-registry/src/authz/authz-file-path.ts
@@ -1,0 +1,57 @@
+import type { NodeTypeDefinition } from '../types';
+
+export const AuthzFilePath: NodeTypeDefinition = {
+  name: 'AuthzFilePath',
+  slug: 'authz_file_path',
+  category: 'authz',
+  display_name: 'File Path Share',
+  description: 'Path-scoped file sharing via ltree containment. Grants access when a path_shares row matches the current user, bucket, and an ancestor path with the required permission.',
+  parameter_schema: {
+    type: 'object',
+    properties: {
+      shares_schema: {
+        type: 'string',
+        description: 'Schema of the path_shares table'
+      },
+      shares_table: {
+        type: 'string',
+        description: 'Name of the path_shares table'
+      },
+      files_schema: {
+        type: 'string',
+        description: 'Schema of the files table (used to qualify column references inside the EXISTS subquery)'
+      },
+      files_table: {
+        type: 'string',
+        description: 'Name of the files table (used to qualify column references inside the EXISTS subquery)'
+      },
+      permission_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Boolean column on the path_shares table that grants the required permission (e.g. can_read, can_write)'
+      },
+      bucket_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column on the files table referencing the bucket',
+        default: 'bucket_id'
+      },
+      path_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Ltree column on the files table representing the file path',
+        default: 'path'
+      }
+    },
+    required: [
+      'shares_schema',
+      'shares_table',
+      'files_table',
+      'permission_field'
+    ]
+  },
+  tags: [
+    'storage',
+    'authz'
+  ]
+};

--- a/packages/node-type-registry/src/authz/index.ts
+++ b/packages/node-type-registry/src/authz/index.ts
@@ -2,6 +2,7 @@ export { AuthzAllowAll } from './authz-allow-all';
 export { AuthzAppMembership } from './authz-app-membership';
 export { AuthzComposite } from './authz-composite';
 export { AuthzDenyAll } from './authz-deny-all';
+export { AuthzFilePath } from './authz-file-path';
 export { AuthzDirectOwner } from './authz-direct-owner';
 export { AuthzDirectOwnerAny } from './authz-direct-owner-any';
 export { AuthzEntityMembership } from './authz-entity-membership';


### PR DESCRIPTION
## Summary

Adds the `AuthzFilePath` node type definition to the registry. This was the only `Authz*` policy type handled by `rls_parser.parse()` and `cpt_path_share()` in constructive-db that had no registry entry, meaning it was excluded from schema-driven default normalization and required-field validation.

The `parameter_schema` was derived from the SQL consumers in constructive-db:
- **`cpt_path_share()`** in `policy_ast_builders.sql` — reads `shares_schema`, `shares_table`, `files_schema`, `files_table`, `permission_field`, `bucket_field`, `path_field`
- **`rls_parser.parse()`** — validates `shares_schema`+`shares_table`, `permission_field`, and `files_table` as required

Two properties have defaults (`bucket_field: "bucket_id"`, `path_field: "path"`) — these currently live as `COALESCE` fallbacks in `cpt_path_share()` and should be removed in a follow-up constructive-db PR once this registry entry is deployed.

Related: constructive-io/constructive-db#1043 added schema-driven validation to `rls_parser.parse()` that emits a `RAISE WARNING` for policy types missing from the registry. This PR closes that gap for `AuthzFilePath`.

## Review & Testing Checklist for Human

- [ ] **Verify `parameter_schema` matches SQL consumers.** The schema was reverse-engineered from `cpt_path_share()` and `parse.sql`. Cross-check that every parameter `cpt_path_share()` reads from `data` is represented, and that no parameter is missing or misspelled.
- [ ] **Verify `format: "column-ref"` annotations.** `permission_field`, `bucket_field`, and `path_field` are marked `column-ref` (they name columns on the files/shares tables). `shares_schema`, `shares_table`, `files_schema`, `files_table` are NOT marked `column-ref` (they're schema/table identifiers, not column names). Confirm this distinction is correct — `embedding_chunks` uses `column-ref` to discover which columns to clone.
- [ ] **Verify `required` array.** `files_schema` is intentionally optional (`cpt_path_share` falls back to unqualified column refs when it's absent). Confirm this matches actual usage in storage provisioning.

### Notes
- Once this is published and the seed regenerated in constructive-db, the `COALESCE` fallbacks for `bucket_field` and `path_field` in `cpt_path_share()` should be removed (per the "no COALESCE in cpt_* functions" convention).
- The `allNodeTypes` array in `src/index.ts` picks this up automatically via `...Object.values(authz)`.

Link to Devin session: https://app.devin.ai/sessions/3c3b5331f50749ccb3156e000c039e47
Requested by: @pyramation