### PR TITLE
refactor: DataImageEmbedding delegates to DataFileEmbedding

### DIFF
--- a/packages/node-type-registry/src/data/data-image-embedding.ts
+++ b/packages/node-type-registry/src/data/data-image-embedding.ts
@@ -1,14 +1,32 @@
 import type { NodeTypeDefinition } from '../types';
 
+/**
+ * Image-specific preset of DataFileEmbedding.
+ *
+ * At the SQL layer, data_image_embedding delegates entirely to
+ * data_file_embedding, merging image-specific defaults before forwarding.
+ * The parameter schema here is intentionally identical to DataFileEmbedding;
+ * only the defaults differ (dimensions: 512, task: process_image_embedding,
+ * mime_patterns: ['image/%']).
+ *
+ * Kept as a separate node type for backward compatibility — existing
+ * blueprints that reference DataImageEmbedding continue to work unchanged.
+ */
 export const DataImageEmbedding: NodeTypeDefinition = {
   name: 'DataImageEmbedding',
   slug: 'data_image_embedding',
   category: 'data',
   display_name: 'Image Embedding',
-  description: 'Composition wrapper that creates a vector embedding field with HNSW/IVFFlat index (via SearchVector) and a job trigger with compound conditions (via DataJobTrigger) that fires on INSERT for image files matching mime_type patterns. Designed for storage file tables.',
+  description:
+    'Image-specific preset of DataFileEmbedding. Delegates to DataFileEmbedding ' +
+    'with image-oriented defaults: dimensions=512 (CLIP), mime_patterns=[\'image/%\'], ' +
+    'task_identifier=\'process_image_embedding\', direct mode (no extraction). ' +
+    'Accepts all DataFileEmbedding parameters — any overrides are forwarded through.',
   parameter_schema: {
     type: 'object',
     properties: {
+
+      // ── Vector config (passed through to DataFileEmbedding) ──────────
       field_name: {
         type: 'string',
         format: 'column-ref',
@@ -17,47 +35,51 @@ export const DataImageEmbedding: NodeTypeDefinition = {
       },
       dimensions: {
         type: 'integer',
-        description: 'Vector dimensions',
+        description: 'Vector dimensions (default 512 for CLIP-style image embeddings)',
         default: 512
       },
       index_method: {
         type: 'string',
-        enum: [
-          'hnsw',
-          'ivfflat'
-        ],
+        enum: ['hnsw', 'ivfflat'],
         description: 'Index type for similarity search',
         default: 'hnsw'
       },
       metric: {
         type: 'string',
-        enum: [
-          'cosine',
-          'l2',
-          'ip'
-        ],
+        enum: ['cosine', 'l2', 'ip'],
         description: 'Distance metric',
         default: 'cosine'
       },
-      task_identifier: {
-        type: 'string',
-        description: 'Job task identifier for the embedding worker',
-        default: 'process_image_embedding'
+      index_options: {
+        type: 'object',
+        description: 'Index-specific options. HNSW: {m, ef_construction}. IVFFlat: {lists}.',
+        default: {}
       },
+
+      // ── MIME scoping ───────────────────────────────────────────────
       mime_patterns: {
         type: 'array',
-        items: {
-          type: 'string'
-        },
-        description: 'MIME type LIKE patterns to match (e.g., image/%, video/%). Multiple patterns are OR\'d together.',
+        items: { type: 'string' },
+        description:
+          'MIME type LIKE patterns to match. Multiple patterns are OR\'d together.',
         default: ['image/%']
+      },
+
+      // ── Job routing ────────────────────────────────────────────────
+      task_identifier: {
+        type: 'string',
+        description: 'Job task identifier for the image embedding worker',
+        default: 'process_image_embedding'
+      },
+      events: {
+        type: 'array',
+        items: { type: 'string', enum: ['INSERT', 'UPDATE'] },
+        description: 'Trigger events that fire the job',
+        default: ['INSERT']
       },
       payload_custom: {
         type: 'object',
-        additionalProperties: {
-          type: 'string',
-          format: 'column-ref'
-        },
+        additionalProperties: { type: 'string', format: 'column-ref' },
         description: 'Custom payload key-to-column mapping for the job trigger',
         default: {
           file_id: 'id',
@@ -65,6 +87,82 @@ export const DataImageEmbedding: NodeTypeDefinition = {
           mime_type: 'mime_type',
           bucket_id: 'bucket_id'
         }
+      },
+      trigger_conditions: {
+        description:
+          'Additional compound conditions beyond MIME filtering. ' +
+          'Merged with the auto-generated MIME conditions via AND.',
+        'x-codegen-type': 'TriggerCondition | TriggerCondition[]',
+        oneOf: [
+          { $ref: '#/$defs/triggerCondition' },
+          { type: 'array', items: { $ref: '#/$defs/triggerCondition' } }
+        ]
+      },
+
+      // ── Extraction config (optional — enables extract mode) ────────
+      extraction: {
+        type: 'object',
+        description:
+          'Text extraction configuration. Forwarded to DataFileEmbedding. ' +
+          'When present, enables extract mode (e.g., OCR for images).',
+        properties: {
+          text_field: {
+            type: 'string',
+            format: 'column-ref',
+            description: 'Field to store extracted text',
+            default: 'extracted_text'
+          },
+          metadata_field: {
+            type: 'string',
+            format: 'column-ref',
+            description: 'JSONB field for extraction metadata',
+            default: 'extracted_metadata'
+          },
+          status_field: {
+            type: 'string',
+            format: 'column-ref',
+            description: 'Extraction lifecycle status field',
+            default: 'extraction_status'
+          }
+        }
+      },
+
+      // ── Chunking config (optional — forwarded to DataFileEmbedding) ─
+      chunks: {
+        type: 'object',
+        description:
+          'Chunking configuration. Forwarded to DataFileEmbedding. ' +
+          'Only meaningful when extraction is also provided.',
+        properties: {
+          content_field_name: {
+            type: 'string',
+            format: 'column-ref',
+            default: 'content'
+          },
+          chunk_size: { type: 'integer', default: 1000 },
+          chunk_overlap: { type: 'integer', default: 200 },
+          chunk_strategy: {
+            type: 'string',
+            enum: ['fixed', 'sentence', 'paragraph', 'semantic'],
+            default: 'paragraph'
+          },
+          metadata_fields: { type: 'object' },
+          enqueue_chunking_job: { type: 'boolean', default: true },
+          chunking_task_name: { type: 'string', default: 'generate_chunks' }
+        }
+      },
+
+      // ── Stale tracking (forwarded to DataFileEmbedding) ────────────
+      stale_strategy: {
+        type: 'string',
+        enum: ['column', 'null', 'hash'],
+        description: 'Strategy for tracking embedding staleness in extract mode',
+        default: 'column'
+      },
+      include_stale_field: {
+        type: 'boolean',
+        description: 'Whether to include the embedding_stale boolean field',
+        default: true
       }
     }
   },


### PR DESCRIPTION
## Summary

Rewrites the `DataImageEmbedding` node type definition to be a thin preset of `DataFileEmbedding`. The parameter schema is now intentionally identical to `DataFileEmbedding` — only the **defaults** differ:

| Parameter | Default |
|---|---|
| `dimensions` | `512` (CLIP-style) |
| `mime_patterns` | `['image/%']` |
| `task_identifier` | `'process_image_embedding'` |

New parameters forwarded through: `index_options`, `events`, `trigger_conditions`, `extraction`, `chunks`, `stale_strategy`, `include_stale_field`. All are optional and override-able by the caller.

The actual delegation happens at the SQL layer in the companion PR: [constructive-db PR](https://github.com/constructive-io/constructive-db/pull/new/feat/image-embedding-delegates-to-file-embedding) — `data_image_embedding()` merges image defaults over caller data and calls `data_file_embedding()`.

## Review & Testing Checklist for Human

- [ ] **Verify `$defs/triggerCondition` resolves correctly** — `trigger_conditions` uses `$ref: '#/$defs/triggerCondition'` but no `$defs` block is visible in this file. Confirm this ref is defined (e.g. in a shared schema resolver or in DataFileEmbedding) and works at runtime.
- [ ] **Compare parameter schema against `data-file-embedding.ts`** — the intent is these are identical (same properties, same types). Spot-check that no property was missed or has a type mismatch.
- [ ] **Review the companion constructive-db PR** — this TS definition is inert without the SQL-side delegation. Ensure both PRs land together.

### Notes

- Existing blueprints referencing `DataImageEmbedding` are unaffected — all new parameters are optional with sensible defaults matching previous behavior.
- The description string changed, which may affect any tooling that parses it verbatim.

Link to Devin session: https://app.devin.ai/sessions/3722a7a0782a4f3190a04a41f74d1bf4
Requested by: @pyramation