### PR TITLE
feat(presigned-url): add per-bucket mutation entry points on root Mutation type

### DIFF
--- a/graphile/graphile-presigned-url-plugin/src/plugin.ts
+++ b/graphile/graphile-presigned-url-plugin/src/plugin.ts
@@ -9,20 +9,23 @@
  * 2. Upload fields — adds `requestUploadUrl` and `requestBulkUploadUrls` fields
  *    on `@storageBuckets`-tagged types, so clients upload via the typed bucket API.
  *
- * 3. downloadUrl — handled by download-url-field.ts (separate plugin).
+ * 3. Mutation entry points — adds per-bucket mutation fields on the root Mutation
+ *    type (e.g., `appBucket(key: "public"): AppBucket`), so upload operations
+ *    can be accessed as proper GraphQL mutations instead of queries.
  *
- * No global mutations — all S3 operations are scoped to the per-table types that
- * PostGraphile already generates. Scope resolution uses the codec's schema/table
- * name matched against cached storage module configs.
+ * 4. downloadUrl — handled by download-url-field.ts (separate plugin).
+ *
+ * Scope resolution uses the codec's schema/table name matched against
+ * cached storage module configs.
  */
 
-import { context as grafastContext, lambda, object } from 'grafast';
+import { access, context as grafastContext, lambda, object } from 'grafast';
 import type { GraphileConfig } from 'graphile-config';
 import 'graphile-build';
 import { Logger } from '@pgpmjs/logger';
 
 import type { PresignedUrlPluginOptions, S3Config, StorageModuleConfig, BucketConfig } from './types';
-import { loadAllStorageModules, resolveStorageConfigFromCodec, isS3BucketProvisioned, markS3BucketProvisioned } from './storage-module-cache';
+import { loadAllStorageModules, resolveStorageConfigFromCodec, getBucketConfig, isS3BucketProvisioned, markS3BucketProvisioned } from './storage-module-cache';
 import { generatePresignedPutUrl, deleteS3Object } from './s3-signer';
 
 const log = new Logger('graphile-presigned-url:plugin');
@@ -145,9 +148,96 @@ export function createPresignedUrlPlugin(
          */
         GraphQLObjectType_fields(fields, build, context) {
           const {
-            scope: { pgCodec, isPgClassType },
+            scope: { pgCodec, isPgClassType, isRootMutation },
           } = context as any;
 
+          // --- Path 1: Add per-bucket mutation entry points on root Mutation ---
+          if (isRootMutation) {
+            const {
+              graphql: { GraphQLString, GraphQLNonNull },
+            } = build;
+
+            const bucketCodecs = Object.values((build.input as any).pgRegistry.pgCodecs).filter(
+              (codec: any) => codec.attributes && (codec.extensions as any)?.tags?.storageBuckets,
+            );
+
+            if (bucketCodecs.length === 0) return fields;
+
+            const newFields: Record<string, any> = {};
+            for (const codec of bucketCodecs as any[]) {
+              const typeName = (build.inflection as any).tableType(codec);
+              const bucketType = build.getTypeByName(typeName);
+              if (!bucketType) {
+                log.debug(`Skipping mutation entry point for ${codec.name}: type ${typeName} not found`);
+                continue;
+              }
+
+              const fieldName = typeName.charAt(0).toLowerCase() + typeName.slice(1);
+              const hasOwnerId = !!codec.attributes.owner_id;
+              const capturedCodec = codec;
+
+              log.debug(`Adding mutation entry point "${fieldName}" for bucket type ${typeName} (entity-scoped=${hasOwnerId})`);
+
+              newFields[fieldName] = context.fieldWithHooks(
+                { fieldName } as any,
+                {
+                  description: `Look up a ${typeName} by key for mutation operations (upload, etc.).`,
+                  type: bucketType,
+                  args: {
+                    key: { type: new GraphQLNonNull(GraphQLString), description: 'Bucket key (e.g., "public", "private")' },
+                    ...(hasOwnerId
+                      ? { ownerId: { type: new GraphQLNonNull(GraphQLString), description: 'Owner entity ID (required for entity-scoped buckets)' } }
+                      : {}),
+                  },
+                  plan(_$mutation: any, fieldArgs: any) {
+                    const $key = fieldArgs.getRaw('key');
+                    const $ownerId = hasOwnerId ? fieldArgs.getRaw('ownerId') : lambda(null, (): null => null);
+                    const $withPgClient = (grafastContext() as any).get('withPgClient');
+                    const $pgSettings = (grafastContext() as any).get('pgSettings');
+
+                    const $combined = object({
+                      key: $key,
+                      ownerId: $ownerId,
+                      withPgClient: $withPgClient,
+                      pgSettings: $pgSettings,
+                    });
+
+                    const $row = lambda($combined, async (vals: any) => {
+                      return vals.withPgClient(vals.pgSettings, async (pgClient: any) => {
+                        const databaseId = await resolveDatabaseId(pgClient);
+                        if (!databaseId) throw new Error('DATABASE_NOT_FOUND');
+
+                        const allConfigs = await loadAllStorageModules(pgClient, databaseId);
+                        const storageConfig = resolveStorageConfigFromCodec(capturedCodec, allConfigs);
+                        if (!storageConfig) throw new Error('STORAGE_MODULE_NOT_FOUND');
+
+                        const bucket = await getBucketConfig(
+                          pgClient, storageConfig, databaseId, vals.key, vals.ownerId ?? undefined,
+                        );
+                        if (!bucket) throw new Error('BUCKET_NOT_FOUND');
+
+                        return bucket;
+                      });
+                    });
+
+                    const columnEntries: Record<string, any> = {};
+                    for (const col of Object.keys(capturedCodec.attributes)) {
+                      columnEntries[col] = access($row, col);
+                    }
+                    return object(columnEntries);
+                  },
+                },
+              );
+            }
+
+            return build.extend(
+              fields,
+              newFields,
+              'PresignedUrlPlugin adding per-bucket mutation entry points',
+            );
+          }
+
+          // --- Path 2: Add upload fields on @storageBuckets types ---
           if (!isPgClassType || !pgCodec || !pgCodec.attributes) {
             return fields;
           }


### PR DESCRIPTION
## Summary

Adds per-bucket mutation fields on the root GraphQL Mutation type so that upload operations (`requestUploadUrl`, `requestBulkUploadUrls`) can be accessed as proper mutations instead of queries. Previously, these were only reachable via query fields on bucket types.

For each `@storageBuckets`-tagged codec, the plugin now adds a mutation field named after the bucket type (e.g., `appBucket`, `dataRoomBucket`):

```graphql
mutation {
  appBucket(key: "public") {
    requestUploadUrl(contentHash: "...", contentType: "...", size: 123) {
      uploadUrl fileId key deduplicated expiresAt
    }
  }
}
```

Entity-scoped buckets automatically include a required `ownerId` argument. The mutation resolves the bucket row via `getBucketConfig` and returns an `ObjectStep` with `access()` steps for each codec attribute, so existing sub-field plans (which call `$parent.get('column')`) continue to work.

## Review & Testing Checklist for Human

- [ ] **ObjectStep ↔ PgSelectSingleStep compatibility**: The mutation plan returns a Grafast `object()` step, NOT a `PgSelectSingleStep`. PostGraphile's generated attribute field plans call `$parent.get('column')` — verify that `ObjectStep.get()` behaves identically to `PgSelectSingleStep.get()` for sub-field resolution. This is the highest-risk area and has not been integration-tested.
- [ ] **Column coverage gap**: `getBucketConfig` returns only 8 fields (`id`, `key`, `type`, `is_public`, `owner_id`, `allowed_mime_types`, `max_file_size`, `allow_custom_keys`), but the `object()` step is built from `Object.keys(codec.attributes)` which may include additional columns (e.g., `created_at`). Selecting those columns through the mutation entry point will return `undefined`. Verify this is acceptable or if `SELECT *` should be used instead.
- [ ] **Integration test**: Run the `minio-multi-scope` integration test in constructive-db with a `mutation { appBucket(...) { requestUploadUrl(...) { ... } } }` query to confirm the full plan chain resolves correctly at runtime.

### Notes
- The `@pgpmjs/logger` type errors in the build output are pre-existing on `main` (verified by building before and after changes). The workspace-level `pnpm build` passes cleanly.
- `ownerId` uses `GraphQLString` rather than the PostGraphile `UUID` scalar — works but is less type-precise.
- Related: this unblocks updating the failing test in [constructive-db PR #1054](https://github.com/constructive-io/constructive-db/pull/1054) to use the mutation API.

Link to Devin session: https://app.devin.ai/sessions/7903d2a3e7a34c6daa605e12d6b80d9e
Requested by: @pyramation