### PR TITLE
fix(presigned-url): return PgSelectSingleStep from mutation entry points

### DIFF
--- a/graphile/graphile-presigned-url-plugin/src/plugin.ts
+++ b/graphile/graphile-presigned-url-plugin/src/plugin.ts
@@ -174,7 +174,15 @@ export function createPresignedUrlPlugin(
 
               const fieldName = typeName.charAt(0).toLowerCase() + typeName.slice(1);
               const hasOwnerId = !!codec.attributes.owner_id;
-              const capturedCodec = codec;
+
+              // Find the PgResource for this codec so we can return a proper PgSelectSingleStep
+              const bucketResource = Object.values((build.input as any).pgRegistry.pgResources).find(
+                (r: any) => r.codec === codec && !r.isUnique && !r.isVirtual && !r.parameters,
+              ) as any;
+              if (!bucketResource) {
+                log.debug(`Skipping mutation entry point for ${codec.name}: no PgResource found`);
+                continue;
+              }
 
               log.debug(`Adding mutation entry point "${fieldName}" for bucket type ${typeName} (entity-scoped=${hasOwnerId})`);
 
@@ -190,41 +198,13 @@ export function createPresignedUrlPlugin(
                       : {}),
                   },
                   plan(_$mutation: any, fieldArgs: any) {
-                    const $key = fieldArgs.getRaw('key');
-                    const $ownerId = hasOwnerId ? fieldArgs.getRaw('ownerId') : lambda(null, (): null => null);
-                    const $withPgClient = (grafastContext() as any).get('withPgClient');
-                    const $pgSettings = (grafastContext() as any).get('pgSettings');
-
-                    const $combined = object({
-                      key: $key,
-                      ownerId: $ownerId,
-                      withPgClient: $withPgClient,
-                      pgSettings: $pgSettings,
-                    });
-
-                    const $row = lambda($combined, async (vals: any) => {
-                      return vals.withPgClient(vals.pgSettings, async (pgClient: any) => {
-                        const databaseId = await resolveDatabaseId(pgClient);
-                        if (!databaseId) throw new Error('DATABASE_NOT_FOUND');
-
-                        const allConfigs = await loadAllStorageModules(pgClient, databaseId);
-                        const storageConfig = resolveStorageConfigFromCodec(capturedCodec, allConfigs);
-                        if (!storageConfig) throw new Error('STORAGE_MODULE_NOT_FOUND');
-
-                        const bucket = await getBucketConfig(
-                          pgClient, storageConfig, databaseId, vals.key, vals.ownerId ?? undefined,
-                        );
-                        if (!bucket) throw new Error('BUCKET_NOT_FOUND');
-
-                        return bucket;
-                      });
-                    });
-
-                    const columnEntries: Record<string, any> = {};
-                    for (const col of Object.keys(capturedCodec.attributes)) {
-                      columnEntries[col] = access($row, col);
+                    const spec: Record<string, any> = {
+                      key: fieldArgs.getRaw('key'),
+                    };
+                    if (hasOwnerId) {
+                      spec.owner_id = fieldArgs.getRaw('ownerId');
                     }
-                    return object(columnEntries);
+                    return bucketResource.find(spec).single();
                   },
                 },
               );


### PR DESCRIPTION
## Summary

The per-bucket mutation entry points added in #1071 returned a generic Grafast `object()` step, which PostGraphile v5 rejects at runtime because sub-fields like `requestUploadUrl` call `$parent.get('column_name')` — a method only available on `PgSelectSingleStep` (and similar Pg step types).

**Before:** The plan function manually fetched bucket config via `lambda` + `withPgClient`, then wrapped individual columns in `access()` calls and returned `object(columnEntries)`. This produced an `ObjectStep` that PostGraphile couldn't use for sub-field resolution.

**After:** The plan function looks up the `PgResource` for the bucket codec at schema build time, then calls `bucketResource.find(spec).single()` in the plan. This returns a proper `PgSelectSingleStep`, which PostGraphile can use to resolve sub-fields via `.get()`.

## Review & Testing Checklist for Human

- [ ] **RLS / auth context**: The old code explicitly passed `pgSettings` via `withPgClient`. Verify that `resource.find()` goes through PostGraphile's normal auth pipeline (`selectAuth`) so that RLS policies are respected on the bucket lookup.
- [ ] **Resource lookup filter**: The filter `!r.isUnique && !r.isVirtual && !r.parameters` is intended to find the primary table resource for each codec. Confirm this won't accidentally match a view or function resource if one exists for a bucket codec.
- [ ] **End-to-end validation**: This plugin has no unit tests for the mutation entry points. The real proof is the `minio-multi-scope.integration.test.ts` in `constructive-db` (PR [#1054](https://github.com/constructive-io/constructive-db/pull/1054)). After publishing, run those integration tests to confirm the full `mutation { appBucket(key: "public") { requestUploadUrl(...) { ... } } }` flow works.

### Notes

- The `capturedCodec` variable was removed since it's no longer needed (the resource lookup replaces the manual column iteration).
- Entity-scoped buckets pass `owner_id` in the find spec using the SQL column name, while the GraphQL arg is `ownerId` — this is correct since `resource.find()` expects codec attribute names.

Link to Devin session: https://app.devin.ai/sessions/7903d2a3e7a34c6daa605e12d6b80d9e
Requested by: @pyramation