### PR TITLE
fix(presigned-url): codec table name matching + ownerId type resolution

### DIFF
--- a/graphile/graphile-presigned-url-plugin/src/plugin.ts
+++ b/graphile/graphile-presigned-url-plugin/src/plugin.ts
@@ -184,6 +184,12 @@ export function createPresignedUrlPlugin(
                 continue;
               }
 
+              // Resolve the GraphQL type for ownerId from the codec's attribute codec
+              // (e.g. UUID scalar instead of String) so Grafast's type matching works.
+              const ownerIdType = hasOwnerId
+                ? (build as any).getGraphQLTypeByPgCodec(codec.attributes.owner_id.codec, 'input')
+                : null;
+
               log.debug(`Adding mutation entry point "${fieldName}" for bucket type ${typeName} (entity-scoped=${hasOwnerId})`);
 
               newFields[fieldName] = context.fieldWithHooks(
@@ -194,7 +200,7 @@ export function createPresignedUrlPlugin(
                   args: {
                     key: { type: new GraphQLNonNull(GraphQLString), description: 'Bucket key (e.g., "public", "private")' },
                     ...(hasOwnerId
-                      ? { ownerId: { type: new GraphQLNonNull(GraphQLString), description: 'Owner entity ID (required for entity-scoped buckets)' } }
+                      ? { ownerId: { type: new GraphQLNonNull(ownerIdType || GraphQLString), description: 'Owner entity ID (required for entity-scoped buckets)' } }
                       : {}),
                   },
                   plan(_$mutation: any, fieldArgs: any) {

--- a/graphile/graphile-presigned-url-plugin/src/storage-module-cache.ts
+++ b/graphile/graphile-presigned-url-plugin/src/storage-module-cache.ts
@@ -367,11 +367,11 @@ export async function loadAllStorageModules(
  * @returns The matching StorageModuleConfig or null
  */
 export function resolveStorageConfigFromCodec(
-  pgCodec: { name: string; extensions?: { pg?: { schemaName?: string } }; sqlType?: string },
+  pgCodec: { name: string; extensions?: { pg?: { schemaName?: string; name?: string } }; sqlType?: string },
   allConfigs: StorageModuleConfig[],
 ): StorageModuleConfig | null {
   const schemaName = pgCodec.extensions?.pg?.schemaName;
-  const tableName = pgCodec.name;
+  const tableName = pgCodec.extensions?.pg?.name ?? pgCodec.name;
 
   if (!schemaName || !tableName) return null;
 


### PR DESCRIPTION
## Summary

Two fixes to the presigned-url plugin's mutation entry points (added in PR #1071 / #1072):

### 1. Use raw SQL table name for codec-to-storage-module lookup

`resolveStorageConfigFromCodec` was comparing `pgCodec.name` against metaschema table names (`bucketsTableName` / `filesTableName`). In PostGraphile v5, `pgCodec.name` is the **inflected** codec name (set via `inflection.classCodecName()`, e.g. `appBuckets`), while metaschema stores the **raw SQL table name** (e.g. `app_buckets`). The raw name is available at `pgCodec.extensions.pg.name` (set from `pgClass.relname` in `PgCodecsPlugin`).

This mismatch caused `STORAGE_MODULE_NOT_FOUND` errors whenever `requestUploadUrl` or `requestBulkUploadUrls` was called through the mutation entry points.

The fix reads from `extensions.pg.name` with a fallback to `pgCodec.name` for backward compatibility.

### 2. Resolve ownerId argument type from codec attribute

The `ownerId` mutation argument was hardcoded as `GraphQLString`. For codecs where `owner_id` is a UUID column, Grafast's type matching (referential equality via `===`) rejects `$ownerId: UUID!` variables because `GraphQLString !== UUID` scalar.

The fix uses `build.getGraphQLTypeByPgCodec(codec.attributes.owner_id.codec, 'input')` to resolve the correct GraphQL scalar type from the codec's attribute definition, with a fallback to `GraphQLString` if the lookup returns null.

**Related:** This unblocks constructive-db PR [#1054](https://github.com/constructive-io/constructive-db/pull/1054) which rewrites the minio-multi-scope integration tests to use the per-bucket mutation API.

## Review & Testing Checklist for Human

- [ ] **Verify `getGraphQLTypeByPgCodec` returns the expected UUID scalar** — the call uses `(build as any)` to bypass TypeScript; confirm at runtime that `ownerIdType` resolves to the UUID scalar (not null) for entity-scoped bucket codecs
- [ ] **Check `codec.attributes.owner_id.codec` access is safe** — it's guarded by `hasOwnerId = !!codec.attributes.owner_id`, but verify that the `.codec` sub-property is always present on attribute definitions
- [ ] **Confirm end-to-end** by publishing as a patch version and running constructive-db minio-multi-scope integration tests with `$ownerId: UUID!` (not `String!`) — this plugin has no local tests for either fix
- [ ] **Grep for other `pgCodec.name` usages** in `plugin.ts` and `storage-module-cache.ts` to check for similar raw-vs-inflected mismatches

### Notes

- The type signature on `resolveStorageConfigFromCodec` was updated to include `name?: string` in the `pg` extension type so TypeScript knows about the field.
- The `ownerIdType` fallback (`|| GraphQLString`) preserves the old behavior if `getGraphQLTypeByPgCodec` returns null for any reason.
- Both fixes are backward-compatible: the `extensions.pg.name` fallback uses `pgCodec.name`, and the `ownerIdType` fallback uses `GraphQLString`.

Link to Devin session: https://app.devin.ai/sessions/7903d2a3e7a34c6daa605e12d6b80d9e
Requested by: @pyramation