### PR TITLE
feat(presigned-url): add uploadFile mutations (file-centric upload API)

### DIFF
--- a/graphile/graphile-presigned-url-plugin/src/plugin.ts
+++ b/graphile/graphile-presigned-url-plugin/src/plugin.ts
@@ -13,7 +13,12 @@
  *    type (e.g., `appBucket(key: "public"): AppBucket`), so upload operations
  *    can be accessed as proper GraphQL mutations instead of queries.
  *
- * 4. downloadUrl — handled by download-url-field.ts (separate plugin).
+ * 4. File creation mutations — adds `create<FileType>(input: {...})` mutations
+ *    on root Mutation for each @storageFiles/@storageBuckets pair. These combine
+ *    bucket resolution + file INSERT + presigned URL generation in one step.
+ *    E.g., `createAppFile(input: { bucketKey: "public", contentHash: "...", ... })`
+ *
+ * 5. downloadUrl — handled by download-url-field.ts (separate plugin).
  *
  * Scope resolution uses the codec's schema/table name matched against
  * cached storage module configs.
@@ -151,10 +156,18 @@ export function createPresignedUrlPlugin(
             scope: { pgCodec, isPgClassType, isRootMutation },
           } = context as any;
 
-          // --- Path 1: Add per-bucket mutation entry points on root Mutation ---
+          // --- Path 1: Add per-bucket mutation entry points + file creation mutations on root Mutation ---
           if (isRootMutation) {
             const {
-              graphql: { GraphQLString, GraphQLNonNull },
+              graphql: {
+                GraphQLString,
+                GraphQLNonNull,
+                GraphQLInt,
+                GraphQLBoolean,
+                GraphQLObjectType,
+                GraphQLInputObjectType,
+                GraphQLList,
+              },
             } = build;
 
             const bucketCodecs = Object.values((build.input as any).pgRegistry.pgCodecs).filter(
@@ -164,6 +177,8 @@ export function createPresignedUrlPlugin(
             if (bucketCodecs.length === 0) return fields;
 
             const newFields: Record<string, any> = {};
+
+            // --- 1a: Per-bucket entry points (appBucket, dataRoomBucket, etc.) ---
             for (const codec of bucketCodecs as any[]) {
               const typeName = (build.inflection as any).tableType(codec);
               const bucketType = build.getTypeByName(typeName);
@@ -175,7 +190,6 @@ export function createPresignedUrlPlugin(
               const fieldName = typeName.charAt(0).toLowerCase() + typeName.slice(1);
               const hasOwnerId = !!codec.attributes.owner_id;
 
-              // Find the PgResource for this codec so we can return a proper PgSelectSingleStep
               const bucketResource = Object.values((build.input as any).pgRegistry.pgResources).find(
                 (r: any) => r.codec === codec && !r.isUnique && !r.isVirtual && !r.parameters,
               ) as any;
@@ -184,8 +198,6 @@ export function createPresignedUrlPlugin(
                 continue;
               }
 
-              // Resolve the GraphQL type for ownerId from the codec's attribute codec
-              // (e.g. UUID scalar instead of String) so Grafast's type matching works.
               const ownerIdType = hasOwnerId
                 ? (build as any).getGraphQLTypeByPgCodec(codec.attributes.owner_id.codec, 'input')
                 : null;
@@ -216,10 +228,238 @@ export function createPresignedUrlPlugin(
               );
             }
 
+            // --- 1b: File creation mutations (createAppFile, createDataRoomFile, etc.) ---
+            const fileCodecs = Object.values((build.input as any).pgRegistry.pgCodecs).filter(
+              (codec: any) => codec.attributes && (codec.extensions as any)?.tags?.storageFiles,
+            );
+
+            for (const filesCodec of fileCodecs as any[]) {
+              const filesTypeName = (build.inflection as any).tableType(filesCodec);
+              const filesSchemaName = filesCodec.extensions?.pg?.schemaName;
+
+              // Find the matching bucket codec by schema name
+              const matchingBucketCodec = (bucketCodecs as any[]).find(
+                (bc: any) => bc.extensions?.pg?.schemaName === filesSchemaName,
+              );
+              if (!matchingBucketCodec) {
+                log.debug(`Skipping create mutation for ${filesCodec.name}: no matching bucket codec in schema ${filesSchemaName}`);
+                continue;
+              }
+
+              const hasOwnerId = !!matchingBucketCodec.attributes.owner_id;
+              const mutationName = `create${filesTypeName}`;
+
+              const ownerIdGqlType = hasOwnerId
+                ? (build as any).getGraphQLTypeByPgCodec(matchingBucketCodec.attributes.owner_id.codec, 'input')
+                : null;
+
+              const InputType = new GraphQLInputObjectType({
+                name: `Create${filesTypeName}Input`,
+                fields: {
+                  bucketKey: { type: new GraphQLNonNull(GraphQLString), description: 'Bucket key (e.g., "public", "private")' },
+                  ...(hasOwnerId
+                    ? { ownerId: { type: new GraphQLNonNull(ownerIdGqlType || GraphQLString), description: 'Owner entity ID (required for entity-scoped buckets)' } }
+                    : {}),
+                  contentHash: { type: new GraphQLNonNull(GraphQLString), description: 'SHA-256 content hash (hex-encoded, 64 chars)' },
+                  contentType: { type: new GraphQLNonNull(GraphQLString), description: 'MIME type of the file' },
+                  size: { type: new GraphQLNonNull(GraphQLInt), description: 'File size in bytes' },
+                  filename: { type: GraphQLString, description: 'Original filename (optional)' },
+                  key: { type: GraphQLString, description: 'Custom S3 key (only when bucket has allow_custom_keys=true)' },
+                },
+              });
+
+              const PayloadType = new GraphQLObjectType({
+                name: `Create${filesTypeName}Payload`,
+                fields: {
+                  uploadUrl: { type: GraphQLString, description: 'Presigned PUT URL (null if deduplicated)' },
+                  fileId: { type: new GraphQLNonNull(GraphQLString), description: 'The file ID (UUID)' },
+                  key: { type: new GraphQLNonNull(GraphQLString), description: 'The S3 object key' },
+                  deduplicated: { type: new GraphQLNonNull(GraphQLBoolean), description: 'Whether this file was deduplicated (content already exists)' },
+                  expiresAt: { type: GraphQLString, description: 'Presigned URL expiry time (null if deduplicated)' },
+                  previousVersionId: { type: GraphQLString, description: 'ID of the previous version (when using custom keys)' },
+                },
+              });
+
+              const capturedFilesCodec = filesCodec;
+
+              log.debug(`Adding file creation mutation "${mutationName}" for ${filesTypeName} (entity-scoped=${hasOwnerId})`);
+
+              newFields[mutationName] = context.fieldWithHooks(
+                { fieldName: mutationName } as any,
+                {
+                  description: `Create a file record and return a presigned upload URL. Resolves the bucket by key, validates the upload, creates the file row, and generates a presigned PUT URL.`,
+                  type: PayloadType,
+                  args: {
+                    input: { type: new GraphQLNonNull(InputType) },
+                  },
+                  plan(_$mutation: any, fieldArgs: any) {
+                    const $input = fieldArgs.getRaw('input');
+                    const $bucketKey = access($input, 'bucketKey');
+                    const $contentHash = access($input, 'contentHash');
+                    const $contentType = access($input, 'contentType');
+                    const $size = access($input, 'size');
+                    const $filename = access($input, 'filename');
+                    const $customKey = access($input, 'key');
+                    const $ownerId = hasOwnerId ? access($input, 'ownerId') : lambda(null, (): null => null);
+                    const $withPgClient = (grafastContext() as any).get('withPgClient');
+                    const $pgSettings = (grafastContext() as any).get('pgSettings');
+
+                    const $combined = object({
+                      bucketKey: $bucketKey,
+                      ownerId: $ownerId,
+                      contentHash: $contentHash,
+                      contentType: $contentType,
+                      size: $size,
+                      filename: $filename,
+                      customKey: $customKey,
+                      withPgClient: $withPgClient,
+                      pgSettings: $pgSettings,
+                    });
+
+                    return lambda($combined, async (vals: any) => {
+                      return vals.withPgClient(vals.pgSettings, async (pgClient: any) => {
+                        return pgClient.withTransaction(async (txClient: any) => {
+                          const databaseId = await resolveDatabaseId(txClient);
+                          if (!databaseId) throw new Error('DATABASE_NOT_FOUND');
+
+                          const allConfigs = await loadAllStorageModules(txClient, databaseId);
+                          const storageConfig = resolveStorageConfigFromCodec(capturedFilesCodec, allConfigs);
+                          if (!storageConfig) throw new Error('STORAGE_MODULE_NOT_FOUND');
+
+                          const bucket = await getBucketConfig(
+                            txClient, storageConfig, databaseId, vals.bucketKey, vals.ownerId || undefined,
+                          );
+                          if (!bucket) throw new Error('BUCKET_NOT_FOUND');
+
+                          const s3ForDb = resolveS3ForDatabase(options, storageConfig, databaseId);
+                          await ensureS3BucketExists(options, s3ForDb.bucket, bucket, databaseId, storageConfig.allowedOrigins);
+
+                          return processSingleFile(options, txClient, storageConfig, databaseId, bucket, s3ForDb, {
+                            contentHash: vals.contentHash,
+                            contentType: vals.contentType,
+                            size: vals.size,
+                            filename: vals.filename,
+                            key: vals.customKey,
+                          });
+                        });
+                      });
+                    });
+                  },
+                },
+              );
+
+              // --- Bulk file creation mutation ---
+              const BulkFileInputType = new GraphQLInputObjectType({
+                name: `Create${filesTypeName}BulkFileInput`,
+                fields: {
+                  contentHash: { type: new GraphQLNonNull(GraphQLString), description: 'SHA-256 content hash (hex-encoded, 64 chars)' },
+                  contentType: { type: new GraphQLNonNull(GraphQLString), description: 'MIME type of the file' },
+                  size: { type: new GraphQLNonNull(GraphQLInt), description: 'File size in bytes' },
+                  filename: { type: GraphQLString, description: 'Original filename (optional)' },
+                  key: { type: GraphQLString, description: 'Custom S3 key (only when bucket has allow_custom_keys=true)' },
+                },
+              });
+
+              const BulkFilePayloadType = new GraphQLObjectType({
+                name: `Create${filesTypeName}BulkFilePayload`,
+                fields: {
+                  uploadUrl: { type: GraphQLString },
+                  fileId: { type: new GraphQLNonNull(GraphQLString) },
+                  key: { type: new GraphQLNonNull(GraphQLString) },
+                  deduplicated: { type: new GraphQLNonNull(GraphQLBoolean) },
+                  expiresAt: { type: GraphQLString },
+                  previousVersionId: { type: GraphQLString },
+                },
+              });
+
+              const BulkInputType = new GraphQLInputObjectType({
+                name: `Create${filesTypeName}BulkInput`,
+                fields: {
+                  bucketKey: { type: new GraphQLNonNull(GraphQLString), description: 'Bucket key (e.g., "public", "private")' },
+                  ...(hasOwnerId
+                    ? { ownerId: { type: new GraphQLNonNull(ownerIdGqlType || GraphQLString), description: 'Owner entity ID (required for entity-scoped buckets)' } }
+                    : {}),
+                  files: { type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(BulkFileInputType))), description: 'Array of files to upload' },
+                },
+              });
+
+              const BulkPayloadType = new GraphQLObjectType({
+                name: `Create${filesTypeName}BulkPayload`,
+                fields: {
+                  files: { type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(BulkFilePayloadType))) },
+                },
+              });
+
+              const bulkMutationName = `create${filesTypeName}s`;
+              log.debug(`Adding bulk file creation mutation "${bulkMutationName}" for ${filesTypeName}`);
+
+              newFields[bulkMutationName] = context.fieldWithHooks(
+                { fieldName: bulkMutationName } as any,
+                {
+                  description: `Create multiple file records and return presigned upload URLs for each.`,
+                  type: BulkPayloadType,
+                  args: {
+                    input: { type: new GraphQLNonNull(BulkInputType) },
+                  },
+                  plan(_$mutation: any, fieldArgs: any) {
+                    const $input = fieldArgs.getRaw('input');
+                    const $bucketKey = access($input, 'bucketKey');
+                    const $ownerId = hasOwnerId ? access($input, 'ownerId') : lambda(null, (): null => null);
+                    const $files = access($input, 'files');
+                    const $withPgClient = (grafastContext() as any).get('withPgClient');
+                    const $pgSettings = (grafastContext() as any).get('pgSettings');
+
+                    const $combined = object({
+                      bucketKey: $bucketKey,
+                      ownerId: $ownerId,
+                      files: $files,
+                      withPgClient: $withPgClient,
+                      pgSettings: $pgSettings,
+                    });
+
+                    return lambda($combined, async (vals: any) => {
+                      return vals.withPgClient(vals.pgSettings, async (pgClient: any) => {
+                        return pgClient.withTransaction(async (txClient: any) => {
+                          const databaseId = await resolveDatabaseId(txClient);
+                          if (!databaseId) throw new Error('DATABASE_NOT_FOUND');
+
+                          const allConfigs = await loadAllStorageModules(txClient, databaseId);
+                          const storageConfig = resolveStorageConfigFromCodec(capturedFilesCodec, allConfigs);
+                          if (!storageConfig) throw new Error('STORAGE_MODULE_NOT_FOUND');
+
+                          const bucket = await getBucketConfig(
+                            txClient, storageConfig, databaseId, vals.bucketKey, vals.ownerId || undefined,
+                          );
+                          if (!bucket) throw new Error('BUCKET_NOT_FOUND');
+
+                          const s3ForDb = resolveS3ForDatabase(options, storageConfig, databaseId);
+                          await ensureS3BucketExists(options, s3ForDb.bucket, bucket, databaseId, storageConfig.allowedOrigins);
+
+                          const results = [];
+                          for (const file of vals.files) {
+                            results.push(
+                              await processSingleFile(options, txClient, storageConfig, databaseId, bucket, s3ForDb, {
+                                contentHash: file.contentHash,
+                                contentType: file.contentType,
+                                size: file.size,
+                                filename: file.filename,
+                                key: file.key,
+                              }),
+                            );
+                          }
+                          return { files: results };
+                        });
+                      });
+                    });
+                  },
+                },
+              );
+            }
+
             return build.extend(
               fields,
               newFields,
-              'PresignedUrlPlugin adding per-bucket mutation entry points',
+              'PresignedUrlPlugin adding per-bucket mutation entry points and file creation mutations',
             );
           }
 

--- a/graphile/graphile-presigned-url-plugin/src/plugin.ts
+++ b/graphile/graphile-presigned-url-plugin/src/plugin.ts
@@ -13,10 +13,10 @@
  *    type (e.g., `appBucket(key: "public"): AppBucket`), so upload operations
  *    can be accessed as proper GraphQL mutations instead of queries.
  *
- * 4. File creation mutations — adds `create<FileType>(input: {...})` mutations
+ * 4. File upload mutations — adds `upload<FileType>(input: {...})` mutations
  *    on root Mutation for each @storageFiles/@storageBuckets pair. These combine
  *    bucket resolution + file INSERT + presigned URL generation in one step.
- *    E.g., `createAppFile(input: { bucketKey: "public", contentHash: "...", ... })`
+ *    E.g., `uploadAppFile(input: { bucketKey: "public", contentHash: "...", ... })`
  *
  * 5. downloadUrl — handled by download-url-field.ts (separate plugin).
  *
@@ -228,7 +228,7 @@ export function createPresignedUrlPlugin(
               );
             }
 
-            // --- 1b: File creation mutations (createAppFile, createDataRoomFile, etc.) ---
+            // --- 1b: File upload mutations (uploadAppFile, uploadDataRoomFile, etc.) ---
             const fileCodecs = Object.values((build.input as any).pgRegistry.pgCodecs).filter(
               (codec: any) => codec.attributes && (codec.extensions as any)?.tags?.storageFiles,
             );
@@ -247,14 +247,14 @@ export function createPresignedUrlPlugin(
               }
 
               const hasOwnerId = !!matchingBucketCodec.attributes.owner_id;
-              const mutationName = `create${filesTypeName}`;
+              const mutationName = `upload${filesTypeName}`;
 
               const ownerIdGqlType = hasOwnerId
                 ? (build as any).getGraphQLTypeByPgCodec(matchingBucketCodec.attributes.owner_id.codec, 'input')
                 : null;
 
               const InputType = new GraphQLInputObjectType({
-                name: `Create${filesTypeName}Input`,
+                name: `Upload${filesTypeName}Input`,
                 fields: {
                   bucketKey: { type: new GraphQLNonNull(GraphQLString), description: 'Bucket key (e.g., "public", "private")' },
                   ...(hasOwnerId
@@ -269,7 +269,7 @@ export function createPresignedUrlPlugin(
               });
 
               const PayloadType = new GraphQLObjectType({
-                name: `Create${filesTypeName}Payload`,
+                name: `Upload${filesTypeName}Payload`,
                 fields: {
                   uploadUrl: { type: GraphQLString, description: 'Presigned PUT URL (null if deduplicated)' },
                   fileId: { type: new GraphQLNonNull(GraphQLString), description: 'The file ID (UUID)' },
@@ -282,12 +282,12 @@ export function createPresignedUrlPlugin(
 
               const capturedFilesCodec = filesCodec;
 
-              log.debug(`Adding file creation mutation "${mutationName}" for ${filesTypeName} (entity-scoped=${hasOwnerId})`);
+              log.debug(`Adding file upload mutation "${mutationName}" for ${filesTypeName} (entity-scoped=${hasOwnerId})`);
 
               newFields[mutationName] = context.fieldWithHooks(
                 { fieldName: mutationName } as any,
                 {
-                  description: `Create a file record and return a presigned upload URL. Resolves the bucket by key, validates the upload, creates the file row, and generates a presigned PUT URL.`,
+                  description: `Upload a file: resolves the bucket by key, creates the file row, and returns a presigned PUT URL.`,
                   type: PayloadType,
                   args: {
                     input: { type: new GraphQLNonNull(InputType) },
@@ -348,9 +348,9 @@ export function createPresignedUrlPlugin(
                 },
               );
 
-              // --- Bulk file creation mutation ---
+              // --- Bulk file upload mutation ---
               const BulkFileInputType = new GraphQLInputObjectType({
-                name: `Create${filesTypeName}BulkFileInput`,
+                name: `Upload${filesTypeName}BulkFileInput`,
                 fields: {
                   contentHash: { type: new GraphQLNonNull(GraphQLString), description: 'SHA-256 content hash (hex-encoded, 64 chars)' },
                   contentType: { type: new GraphQLNonNull(GraphQLString), description: 'MIME type of the file' },
@@ -361,7 +361,7 @@ export function createPresignedUrlPlugin(
               });
 
               const BulkFilePayloadType = new GraphQLObjectType({
-                name: `Create${filesTypeName}BulkFilePayload`,
+                name: `Upload${filesTypeName}BulkFilePayload`,
                 fields: {
                   uploadUrl: { type: GraphQLString },
                   fileId: { type: new GraphQLNonNull(GraphQLString) },
@@ -373,7 +373,7 @@ export function createPresignedUrlPlugin(
               });
 
               const BulkInputType = new GraphQLInputObjectType({
-                name: `Create${filesTypeName}BulkInput`,
+                name: `Upload${filesTypeName}BulkInput`,
                 fields: {
                   bucketKey: { type: new GraphQLNonNull(GraphQLString), description: 'Bucket key (e.g., "public", "private")' },
                   ...(hasOwnerId
@@ -384,19 +384,19 @@ export function createPresignedUrlPlugin(
               });
 
               const BulkPayloadType = new GraphQLObjectType({
-                name: `Create${filesTypeName}BulkPayload`,
+                name: `Upload${filesTypeName}BulkPayload`,
                 fields: {
                   files: { type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(BulkFilePayloadType))) },
                 },
               });
 
-              const bulkMutationName = `create${filesTypeName}s`;
-              log.debug(`Adding bulk file creation mutation "${bulkMutationName}" for ${filesTypeName}`);
+              const bulkMutationName = `upload${filesTypeName}s`;
+              log.debug(`Adding bulk file upload mutation "${bulkMutationName}" for ${filesTypeName}`);
 
               newFields[bulkMutationName] = context.fieldWithHooks(
                 { fieldName: bulkMutationName } as any,
                 {
-                  description: `Create multiple file records and return presigned upload URLs for each.`,
+                  description: `Upload multiple files: resolves the bucket by key, creates file rows, and returns presigned PUT URLs for each.`,
                   type: BulkPayloadType,
                   args: {
                     input: { type: new GraphQLNonNull(BulkInputType) },
@@ -459,7 +459,7 @@ export function createPresignedUrlPlugin(
             return build.extend(
               fields,
               newFields,
-              'PresignedUrlPlugin adding per-bucket mutation entry points and file creation mutations',
+              'PresignedUrlPlugin adding per-bucket mutation entry points and file upload mutations',
             );
           }
 


### PR DESCRIPTION
## Summary

Adds `upload<FileType>(input: {...})` and `upload<FileType>s(input: {...})` mutations to root Mutation for each `@storageFiles`/`@storageBuckets` codec pair. These combine bucket resolution, file INSERT, and presigned URL generation into a single mutation step.

**Before** (two-level nesting via bucket entry point):
```graphql
mutation { appBucket(key: "public") { requestUploadUrl(contentHash: "...", ...) { uploadUrl, fileId } } }
```

**After** (single flat mutation):
```graphql
mutation { uploadAppFile(input: { bucketKey: "public", contentHash: "...", contentType: "image/png", size: 1024 }) {
  uploadUrl, fileId, key, deduplicated, expiresAt, previousVersionId
}}
```

Also adds bulk variant (`uploadAppFiles`) with the same pattern.

File codecs (`@storageFiles`) are matched to bucket codecs (`@storageBuckets`) by shared `extensions.pg.schemaName`. Entity-scoped codecs get an `ownerId` input field typed from the bucket codec's `owner_id` attribute (e.g. UUID).

The existing per-bucket entry points (`appBucket`, `dataRoomBucket`) are preserved for backward compatibility.

### Naming: `upload*` instead of `create*`

Originally named `create<Type>`, but PostGraphile's built-in CRUD plugin already auto-generates `createFile` / `createAppFile` mutations for these tables. Using `upload*` avoids the `build.extend()` naming conflict and is semantically more accurate — the mutation initiates an upload (creates a file row + presigned URL), not just a CRUD insert.

## Review & Testing Checklist for Human

- [ ] **Grafast `access()` on input object steps**: The plan uses `fieldArgs.getRaw('input')` → `access($input, 'bucketKey')` to destructure the `GraphQLInputObjectType`. This compiles but has not been validated at runtime. Verify that Grafast resolves input object fields correctly via `access()` (vs. e.g. needing `fieldArgs.getRaw(['input', 'bucketKey'])` or a different API).
- [ ] **Flat payload shape**: The payload returns flat fields (`fileId`, `key`, `uploadUrl`, etc.) without a nested `file` object backed by `PgSelectSingleStep`. This means computed columns like `downloadUrl` and `file_path` won't auto-resolve on the payload. Confirm this is acceptable as a first pass.
- [ ] **End-to-end test**: Run the constructive-db `minio-multi-scope.integration.test.ts` against a build with this plugin version to confirm the mutations appear in the schema and execute correctly.

### Notes
- TypeScript compiles cleanly (`tsc --noEmit` passes).
- CI: 51 pass, 0 fail (including `graphql/server-test` upload integration tests).
- No runtime tests exist in this repo for the presigned-url plugin — the real validation is the integration test in `constructive-db`.
- Follow-up: adding a nested `file` field (returning a `PgSelectSingleStep` so computed columns resolve) requires deeper Grafast integration — tracked separately.

Link to Devin session: https://app.devin.ai/sessions/7903d2a3e7a34c6daa605e12d6b80d9e
Requested by: @pyramation