### PR TITLE
refactor(presigned-url): remove legacy upload fields and bucket entry points

### DIFF
--- a/graphile/graphile-presigned-url-plugin/src/plugin.ts
+++ b/graphile/graphile-presigned-url-plugin/src/plugin.ts
@@ -3,22 +3,15 @@
  *
  * Hooks into PostGraphile's auto-generated CRUD mutations to add S3 operations:
  *
- * 1. Delete middleware — wraps `delete*` mutations on `@storageFiles`-tagged tables
- *    with S3 object cleanup (sync + async GC fallback via AFTER DELETE trigger).
- *
- * 2. Upload fields — adds `requestUploadUrl` and `requestBulkUploadUrls` fields
- *    on `@storageBuckets`-tagged types, so clients upload via the typed bucket API.
- *
- * 3. Mutation entry points — adds per-bucket mutation fields on the root Mutation
- *    type (e.g., `appBucket(key: "public"): AppBucket`), so upload operations
- *    can be accessed as proper GraphQL mutations instead of queries.
- *
- * 4. File upload mutations — adds `upload<FileType>(input: {...})` mutations
+ * 1. File upload mutations — adds `upload<FileType>(input: {...})` mutations
  *    on root Mutation for each @storageFiles/@storageBuckets pair. These combine
  *    bucket resolution + file INSERT + presigned URL generation in one step.
  *    E.g., `uploadAppFile(input: { bucketKey: "public", contentHash: "...", ... })`
  *
- * 5. downloadUrl — handled by download-url-field.ts (separate plugin).
+ * 2. Delete middleware — wraps `delete*` mutations on `@storageFiles`-tagged tables
+ *    with S3 object cleanup (sync + async GC fallback via AFTER DELETE trigger).
+ *
+ * 3. downloadUrl — handled by download-url-field.ts (separate plugin).
  *
  * Scope resolution uses the codec's schema/table name matched against
  * cached storage module configs.
@@ -149,16 +142,16 @@ export function createPresignedUrlPlugin(
     schema: {
       hooks: {
         /**
-         * Add requestUploadUrl and requestBulkUploadUrls fields on @storageBuckets types.
+         * Add file upload mutations (uploadAppFile, uploadDataRoomFile, etc.) on root Mutation.
          */
         GraphQLObjectType_fields(fields, build, context) {
           const {
-            scope: { pgCodec, isPgClassType, isRootMutation },
+            scope: { isRootMutation },
           } = context as any;
 
-          // --- Path 1: Add per-bucket mutation entry points + file creation mutations on root Mutation ---
-          if (isRootMutation) {
-            const {
+          if (!isRootMutation) return fields;
+
+          const {
               graphql: {
                 GraphQLString,
                 GraphQLNonNull,
@@ -178,64 +171,13 @@ export function createPresignedUrlPlugin(
 
             const newFields: Record<string, any> = {};
 
-            // --- 1a: Per-bucket entry points (appBucket, dataRoomBucket, etc.) ---
-            for (const codec of bucketCodecs as any[]) {
-              const typeName = (build.inflection as any).tableType(codec);
-              const bucketType = build.getTypeByName(typeName);
-              if (!bucketType) {
-                log.debug(`Skipping mutation entry point for ${codec.name}: type ${typeName} not found`);
-                continue;
-              }
-
-              const fieldName = typeName.charAt(0).toLowerCase() + typeName.slice(1);
-              const hasOwnerId = !!codec.attributes.owner_id;
-
-              const bucketResource = Object.values((build.input as any).pgRegistry.pgResources).find(
-                (r: any) => r.codec === codec && !r.isUnique && !r.isVirtual && !r.parameters,
-              ) as any;
-              if (!bucketResource) {
-                log.debug(`Skipping mutation entry point for ${codec.name}: no PgResource found`);
-                continue;
-              }
-
-              const ownerIdType = hasOwnerId
-                ? (build as any).getGraphQLTypeByPgCodec(codec.attributes.owner_id.codec, 'input')
-                : null;
-
-              log.debug(`Adding mutation entry point "${fieldName}" for bucket type ${typeName} (entity-scoped=${hasOwnerId})`);
-
-              newFields[fieldName] = context.fieldWithHooks(
-                { fieldName } as any,
-                {
-                  description: `Look up a ${typeName} by key for mutation operations (upload, etc.).`,
-                  type: bucketType,
-                  args: {
-                    key: { type: new GraphQLNonNull(GraphQLString), description: 'Bucket key (e.g., "public", "private")' },
-                    ...(hasOwnerId
-                      ? { ownerId: { type: new GraphQLNonNull(ownerIdType || GraphQLString), description: 'Owner entity ID (required for entity-scoped buckets)' } }
-                      : {}),
-                  },
-                  plan(_$mutation: any, fieldArgs: any) {
-                    const spec: Record<string, any> = {
-                      key: fieldArgs.getRaw('key'),
-                    };
-                    if (hasOwnerId) {
-                      spec.owner_id = fieldArgs.getRaw('ownerId');
-                    }
-                    return bucketResource.find(spec).single();
-                  },
-                },
-              );
-            }
-
-            // --- 1b: File upload mutations (uploadAppFile, uploadDataRoomFile, etc.) ---
+            // --- File upload mutations (uploadAppFile, uploadDataRoomFile, etc.) ---
             const fileCodecs = Object.values((build.input as any).pgRegistry.pgCodecs).filter(
               (codec: any) => codec.attributes && (codec.extensions as any)?.tags?.storageFiles,
             );
 
             for (const filesCodec of fileCodecs as any[]) {
               const filesTypeName = (build.inflection as any).tableType(filesCodec);
-              const filesSchemaName = filesCodec.extensions?.pg?.schemaName;
 
               // Find the matching bucket codec by table name prefix.
               // Schema-name matching is ambiguous when multiple storage modules share
@@ -465,269 +407,10 @@ export function createPresignedUrlPlugin(
               );
             }
 
-            return build.extend(
-              fields,
-              newFields,
-              'PresignedUrlPlugin adding per-bucket mutation entry points and file upload mutations',
-            );
-          }
-
-          // --- Path 2: Add upload fields on @storageBuckets types ---
-          if (!isPgClassType || !pgCodec || !pgCodec.attributes) {
-            return fields;
-          }
-
-          const tags = (pgCodec.extensions as any)?.tags;
-          if (!tags?.storageBuckets) {
-            return fields;
-          }
-
-          log.debug(`Adding upload fields to bucket type: ${pgCodec.name} (has @storageBuckets tag)`);
-
-          const {
-            graphql: {
-              GraphQLString,
-              GraphQLNonNull,
-              GraphQLInt,
-              GraphQLBoolean,
-              GraphQLObjectType,
-              GraphQLList,
-              GraphQLInputObjectType,
-            },
-          } = build;
-
-          // --- Shared output types ---
-
-          const UploadUrlPayloadType = new GraphQLObjectType({
-            name: `${build.inflection.upperCamelCase(pgCodec.name)}RequestUploadUrlPayload`,
-            fields: {
-              uploadUrl: { type: GraphQLString, description: 'Presigned PUT URL (null if deduplicated)' },
-              fileId: { type: new GraphQLNonNull(GraphQLString), description: 'The file ID' },
-              key: { type: new GraphQLNonNull(GraphQLString), description: 'The S3 object key' },
-              deduplicated: { type: new GraphQLNonNull(GraphQLBoolean), description: 'Whether this file was deduplicated' },
-              expiresAt: { type: GraphQLString, description: 'Presigned URL expiry time (null if deduplicated)' },
-              previousVersionId: { type: GraphQLString, description: 'ID of the previous version' },
-            },
-          });
-
-          const BulkUploadFilePayloadType = new GraphQLObjectType({
-            name: `${build.inflection.upperCamelCase(pgCodec.name)}BulkUploadFilePayload`,
-            fields: {
-              uploadUrl: { type: GraphQLString },
-              fileId: { type: new GraphQLNonNull(GraphQLString) },
-              key: { type: new GraphQLNonNull(GraphQLString) },
-              deduplicated: { type: new GraphQLNonNull(GraphQLBoolean) },
-              expiresAt: { type: GraphQLString },
-              previousVersionId: { type: GraphQLString },
-              index: { type: new GraphQLNonNull(GraphQLInt), description: 'Index in the input array' },
-            },
-          });
-
-          const BulkUploadUrlsPayloadType = new GraphQLObjectType({
-            name: `${build.inflection.upperCamelCase(pgCodec.name)}RequestBulkUploadUrlsPayload`,
-            fields: {
-              files: { type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(BulkUploadFilePayloadType))) },
-            },
-          });
-
-          const BulkUploadFileInputType = new GraphQLInputObjectType({
-            name: `${build.inflection.upperCamelCase(pgCodec.name)}BulkUploadFileInput`,
-            fields: {
-              contentHash: { type: new GraphQLNonNull(GraphQLString) },
-              contentType: { type: new GraphQLNonNull(GraphQLString) },
-              size: { type: new GraphQLNonNull(GraphQLInt) },
-              filename: { type: GraphQLString },
-              key: { type: GraphQLString },
-            },
-          });
-
-          // Capture codec for closure
-          const capturedCodec = pgCodec;
-
           return build.extend(
             fields,
-            {
-              requestUploadUrl: context.fieldWithHooks(
-                { fieldName: 'requestUploadUrl' } as any,
-                {
-                  description: 'Request a presigned URL for uploading a file to this bucket.',
-                  type: UploadUrlPayloadType,
-                  args: {
-                    contentHash: { type: new GraphQLNonNull(GraphQLString), description: 'SHA-256 content hash (hex-encoded, 64 chars)' },
-                    contentType: { type: new GraphQLNonNull(GraphQLString), description: 'MIME type of the file' },
-                    size: { type: new GraphQLNonNull(GraphQLInt), description: 'File size in bytes' },
-                    filename: { type: GraphQLString, description: 'Original filename (optional)' },
-                    key: { type: GraphQLString, description: 'Custom S3 key (only when bucket has allow_custom_keys=true)' },
-                  },
-                  plan($parent: any, fieldArgs: any) {
-                    const $bucketId = $parent.get('id');
-                    const $bucketKey = $parent.get('key');
-                    const $bucketType = $parent.get('type');
-                    const $bucketIsPublic = $parent.get('is_public');
-                    const $bucketAllowCustomKeys = $parent.get('allow_custom_keys');
-                    const $bucketAllowedMimeTypes = $parent.get('allowed_mime_types');
-                    const $bucketMaxFileSize = $parent.get('max_file_size');
-                    const $bucketOwnerId = capturedCodec.attributes.owner_id ? $parent.get('owner_id') : lambda(null, (): null => null);
-
-                    const $contentHash = fieldArgs.getRaw('contentHash');
-                    const $contentType = fieldArgs.getRaw('contentType');
-                    const $size = fieldArgs.getRaw('size');
-                    const $filename = fieldArgs.getRaw('filename');
-                    const $customKey = fieldArgs.getRaw('key');
-
-                    const $withPgClient = (grafastContext() as any).get('withPgClient');
-                    const $pgSettings = (grafastContext() as any).get('pgSettings');
-
-                    const $combined = object({
-                      bucketId: $bucketId,
-                      bucketKey: $bucketKey,
-                      bucketType: $bucketType,
-                      bucketIsPublic: $bucketIsPublic,
-                      bucketAllowCustomKeys: $bucketAllowCustomKeys,
-                      bucketAllowedMimeTypes: $bucketAllowedMimeTypes,
-                      bucketMaxFileSize: $bucketMaxFileSize,
-                      bucketOwnerId: $bucketOwnerId,
-                      contentHash: $contentHash,
-                      contentType: $contentType,
-                      size: $size,
-                      filename: $filename,
-                      customKey: $customKey,
-                      withPgClient: $withPgClient,
-                      pgSettings: $pgSettings,
-                    });
-
-                    return lambda($combined, async (vals: any) => {
-                      return vals.withPgClient(vals.pgSettings, async (pgClient: any) => {
-                        return pgClient.withTransaction(async (txClient: any) => {
-                          const databaseId = await resolveDatabaseId(txClient);
-                          if (!databaseId) throw new Error('DATABASE_NOT_FOUND');
-
-                          const allConfigs = await loadAllStorageModules(txClient, databaseId);
-                          const storageConfig = resolveStorageConfigFromCodec(capturedCodec, allConfigs);
-                          if (!storageConfig) throw new Error('STORAGE_MODULE_NOT_FOUND');
-
-                          const bucket: BucketConfig = {
-                            id: vals.bucketId,
-                            key: vals.bucketKey,
-                            type: vals.bucketType,
-                            is_public: vals.bucketIsPublic,
-                            owner_id: vals.bucketOwnerId,
-                            allowed_mime_types: vals.bucketAllowedMimeTypes,
-                            max_file_size: vals.bucketMaxFileSize,
-                            allow_custom_keys: vals.bucketAllowCustomKeys ?? false,
-                          };
-
-                          const s3ForDb = resolveS3ForDatabase(options, storageConfig, databaseId);
-                          await ensureS3BucketExists(options, s3ForDb.bucket, bucket, databaseId, storageConfig.allowedOrigins);
-
-                          return processSingleFile(
-                            options, txClient, storageConfig, databaseId, bucket, s3ForDb, {
-                              contentHash: vals.contentHash,
-                              contentType: vals.contentType,
-                              size: vals.size,
-                              filename: vals.filename,
-                              key: vals.customKey,
-                            },
-                          );
-                        });
-                      });
-                    });
-                  },
-                },
-              ),
-              requestBulkUploadUrls: context.fieldWithHooks(
-                { fieldName: 'requestBulkUploadUrls' } as any,
-                {
-                  description: 'Request presigned URLs for uploading multiple files to this bucket.',
-                  type: BulkUploadUrlsPayloadType,
-                  args: {
-                    files: {
-                      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(BulkUploadFileInputType))),
-                      description: 'Array of files to upload',
-                    },
-                  },
-                  plan($parent: any, fieldArgs: any) {
-                    const $bucketId = $parent.get('id');
-                    const $bucketKey = $parent.get('key');
-                    const $bucketType = $parent.get('type');
-                    const $bucketIsPublic = $parent.get('is_public');
-                    const $bucketAllowCustomKeys = $parent.get('allow_custom_keys');
-                    const $bucketAllowedMimeTypes = $parent.get('allowed_mime_types');
-                    const $bucketMaxFileSize = $parent.get('max_file_size');
-                    const $bucketOwnerId = capturedCodec.attributes.owner_id ? $parent.get('owner_id') : lambda(null, (): null => null);
-
-                    const $files = fieldArgs.getRaw('files');
-                    const $withPgClient = (grafastContext() as any).get('withPgClient');
-                    const $pgSettings = (grafastContext() as any).get('pgSettings');
-
-                    const $combined = object({
-                      bucketId: $bucketId,
-                      bucketKey: $bucketKey,
-                      bucketType: $bucketType,
-                      bucketIsPublic: $bucketIsPublic,
-                      bucketAllowCustomKeys: $bucketAllowCustomKeys,
-                      bucketAllowedMimeTypes: $bucketAllowedMimeTypes,
-                      bucketMaxFileSize: $bucketMaxFileSize,
-                      bucketOwnerId: $bucketOwnerId,
-                      files: $files,
-                      withPgClient: $withPgClient,
-                      pgSettings: $pgSettings,
-                    });
-
-                    return lambda($combined, async (vals: any) => {
-                      const { files } = vals;
-                      if (!Array.isArray(files) || files.length === 0) {
-                        throw new Error('INVALID_FILES: must provide at least one file');
-                      }
-
-                      return vals.withPgClient(vals.pgSettings, async (pgClient: any) => {
-                        return pgClient.withTransaction(async (txClient: any) => {
-                          const databaseId = await resolveDatabaseId(txClient);
-                          if (!databaseId) throw new Error('DATABASE_NOT_FOUND');
-
-                          const allConfigs = await loadAllStorageModules(txClient, databaseId);
-                          const storageConfig = resolveStorageConfigFromCodec(capturedCodec, allConfigs);
-                          if (!storageConfig) throw new Error('STORAGE_MODULE_NOT_FOUND');
-
-                          if (files.length > storageConfig.maxBulkFiles) {
-                            throw new Error(`BULK_LIMIT_EXCEEDED: max ${storageConfig.maxBulkFiles} files per batch`);
-                          }
-                          const totalSize = files.reduce((sum: number, f: any) => sum + (f.size || 0), 0);
-                          if (totalSize > storageConfig.maxBulkTotalSize) {
-                            throw new Error(`BULK_SIZE_EXCEEDED: total size ${totalSize} exceeds max ${storageConfig.maxBulkTotalSize} bytes`);
-                          }
-
-                          const bucket: BucketConfig = {
-                            id: vals.bucketId,
-                            key: vals.bucketKey,
-                            type: vals.bucketType,
-                            is_public: vals.bucketIsPublic,
-                            owner_id: vals.bucketOwnerId,
-                            allowed_mime_types: vals.bucketAllowedMimeTypes,
-                            max_file_size: vals.bucketMaxFileSize,
-                            allow_custom_keys: vals.bucketAllowCustomKeys ?? false,
-                          };
-
-                          const s3ForDb = resolveS3ForDatabase(options, storageConfig, databaseId);
-                          await ensureS3BucketExists(options, s3ForDb.bucket, bucket, databaseId, storageConfig.allowedOrigins);
-
-                          const results = [];
-                          for (let i = 0; i < files.length; i++) {
-                            const result = await processSingleFile(
-                              options, txClient, storageConfig, databaseId, bucket, s3ForDb, files[i],
-                            );
-                            results.push({ ...result, index: i });
-                          }
-
-                          return { files: results };
-                        });
-                      });
-                    });
-                  },
-                },
-              ),
-            },
-            `PresignedUrlPlugin adding upload fields to ${pgCodec.name}`,
+            newFields,
+            'PresignedUrlPlugin adding file upload mutations',
           );
         },
 

--- a/graphql/server-test/__fixtures__/seed/simple-seed-storage/schema.sql
+++ b/graphql/server-test/__fixtures__/seed/simple-seed-storage/schema.sql
@@ -20,12 +20,11 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA "simple-storage-public"
 -- =====================================================
 
 -- Buckets table
-CREATE TABLE IF NOT EXISTS "simple-storage-public".buckets (
+CREATE TABLE IF NOT EXISTS "simple-storage-public".app_buckets (
   id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
   key text NOT NULL,
   type text NOT NULL DEFAULT 'private',
   is_public boolean NOT NULL DEFAULT false,
-  owner_id uuid,
   allowed_mime_types text[] NULL,
   max_file_size bigint NULL,
   allow_custom_keys boolean NOT NULL DEFAULT false,
@@ -34,12 +33,12 @@ CREATE TABLE IF NOT EXISTS "simple-storage-public".buckets (
   UNIQUE (key)
 );
 
-COMMENT ON TABLE "simple-storage-public".buckets IS E'@storageBuckets\nStorage buckets table';
+COMMENT ON TABLE "simple-storage-public".app_buckets IS E'@storageBuckets\nStorage buckets table';
 
 -- Files table
-CREATE TABLE IF NOT EXISTS "simple-storage-public".files (
+CREATE TABLE IF NOT EXISTS "simple-storage-public".app_files (
   id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
-  bucket_id uuid NOT NULL REFERENCES "simple-storage-public".buckets(id),
+  bucket_id uuid NOT NULL REFERENCES "simple-storage-public".app_buckets(id),
   key text NOT NULL,
   content_hash text NOT NULL,
   mime_type text NOT NULL,
@@ -47,14 +46,14 @@ CREATE TABLE IF NOT EXISTS "simple-storage-public".files (
   filename text,
   owner_id uuid,
   is_public boolean NOT NULL DEFAULT false,
-  previous_version_id uuid REFERENCES "simple-storage-public".files(id),
+  previous_version_id uuid REFERENCES "simple-storage-public".app_files(id),
   created_at timestamptz DEFAULT now(),
   updated_at timestamptz DEFAULT now(),
   UNIQUE (bucket_id, key)
 );
 
-COMMENT ON TABLE "simple-storage-public".files IS E'@storageFiles\nStorage files table';
+COMMENT ON TABLE "simple-storage-public".app_files IS E'@storageFiles\nStorage files table';
 
 -- Grant table permissions (allow anonymous to do CRUD for tests — no RLS)
-GRANT SELECT, INSERT, UPDATE, DELETE ON "simple-storage-public".buckets TO administrator, authenticated, anonymous;
-GRANT SELECT, INSERT, UPDATE, DELETE ON "simple-storage-public".files TO administrator, authenticated, anonymous;
+GRANT SELECT, INSERT, UPDATE, DELETE ON "simple-storage-public".app_buckets TO administrator, authenticated, anonymous;
+GRANT SELECT, INSERT, UPDATE, DELETE ON "simple-storage-public".app_files TO administrator, authenticated, anonymous;

--- a/graphql/server-test/__fixtures__/seed/simple-seed-storage/test-data.sql
+++ b/graphql/server-test/__fixtures__/seed/simple-seed-storage/test-data.sql
@@ -29,7 +29,7 @@ VALUES (
   'b0000001-0000-0000-0000-000000000001',
   '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9',
   '6dbae92a-5450-401b-1ed5-d69e7754940d',
-  'buckets',
+  'app_buckets',
   NULL
 ) ON CONFLICT (id) DO NOTHING;
 
@@ -39,7 +39,7 @@ VALUES (
   'b0000001-0000-0000-0000-000000000002',
   '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9',
   '6dbae92a-5450-401b-1ed5-d69e7754940d',
-  'files',
+  'app_files',
   NULL
 ) ON CONFLICT (id) DO NOTHING;
 
@@ -88,10 +88,10 @@ VALUES (
 -- BUCKET SEED DATA
 -- =====================================================
 
-INSERT INTO "simple-storage-public".buckets (id, key, type, is_public, owner_id)
+INSERT INTO "simple-storage-public".app_buckets (id, key, type, is_public)
 VALUES
-  ('d0000001-0000-0000-0000-000000000001', 'public', 'public', true, NULL),
-  ('d0000001-0000-0000-0000-000000000002', 'private', 'private', false, NULL)
+  ('d0000001-0000-0000-0000-000000000001', 'public', 'public', true),
+  ('d0000001-0000-0000-0000-000000000002', 'private', 'private', false)
 ON CONFLICT (id) DO NOTHING;
 
 SET session_replication_role TO DEFAULT;

--- a/graphql/server-test/__tests__/upload.integration.test.ts
+++ b/graphql/server-test/__tests__/upload.integration.test.ts
@@ -1,8 +1,8 @@
 /**
  * Upload Integration Tests — end-to-end presigned URL flow
  *
- * Exercises the per-table upload pipeline:
- *   query bucket → requestUploadUrl field → PUT to presigned URL → downloadUrl
+ * Exercises the file-centric upload pipeline:
+ *   uploadAppFile mutation → presigned PUT URL → PUT to S3
  *
  * Uses real MinIO (available in CI as minio_cdn service) and lazy bucket
  * provisioning. No RLS — that will be tested in constructive-db.
@@ -41,24 +41,14 @@ const seedFiles = [
 
 // --- GraphQL operations ---
 
-const REQUEST_UPLOAD_URL = `
-  query RequestUploadUrl($key: String!, $contentHash: String!, $contentType: String!, $size: Int!, $filename: String) {
-    buckets(where: { key: { equalTo: $key } }) {
-      nodes {
-        id
-        requestUploadUrl(
-          contentHash: $contentHash
-          contentType: $contentType
-          size: $size
-          filename: $filename
-        ) {
-          uploadUrl
-          fileId
-          key
-          deduplicated
-          expiresAt
-        }
-      }
+const UPLOAD_APP_FILE = `
+  mutation UploadAppFile($input: UploadAppFileInput!) {
+    uploadAppFile(input: $input) {
+      uploadUrl
+      fileId
+      key
+      deduplicated
+      expiresAt
     }
   }
 `;
@@ -86,7 +76,7 @@ async function putToPresignedUrl(
 
 // --- Tests ---
 
-describe('Upload integration (per-table presigned URL flow)', () => {
+describe('Upload integration (file-centric upload mutations)', () => {
   let request: supertest.Agent;
   let teardown: () => Promise<void>;
 
@@ -122,33 +112,30 @@ describe('Upload integration (per-table presigned URL flow)', () => {
     if (teardown) await teardown();
   });
 
-  describe('Public file upload via bucket field', () => {
+  describe('Public file upload via uploadAppFile mutation', () => {
     const fileContent = 'Hello, public world!';
     const contentType = 'text/plain';
     const contentHash = sha256(fileContent);
     let uploadUrl: string;
-    let fileId: string;
 
-    it('should return a presigned PUT URL via bucket.requestUploadUrl', async () => {
+    it('should return a presigned PUT URL via uploadAppFile', async () => {
       const res = await postGraphQL({
-        query: REQUEST_UPLOAD_URL,
+        query: UPLOAD_APP_FILE,
         variables: {
-          key: 'public',
-          contentHash,
-          contentType,
-          size: Buffer.byteLength(fileContent),
-          filename: 'hello-public.txt',
+          input: {
+            bucketKey: 'public',
+            contentHash,
+            contentType,
+            size: Buffer.byteLength(fileContent),
+            filename: 'hello-public.txt',
+          },
         },
       });
 
       expect(res.status).toBe(200);
       expect(res.body.errors).toBeUndefined();
 
-      const bucket = res.body.data.buckets.nodes[0];
-      expect(bucket).toBeTruthy();
-      expect(bucket.id).toBeTruthy();
-
-      const payload = bucket.requestUploadUrl;
+      const payload = res.body.data.uploadAppFile;
       expect(payload.uploadUrl).toBeTruthy();
       expect(payload.fileId).toBeTruthy();
       expect(payload.key).toBe(contentHash);
@@ -156,7 +143,6 @@ describe('Upload integration (per-table presigned URL flow)', () => {
       expect(payload.expiresAt).toBeTruthy();
 
       uploadUrl = payload.uploadUrl;
-      fileId = payload.fileId;
     });
 
     it('should accept a PUT to the presigned URL', async () => {
@@ -165,32 +151,30 @@ describe('Upload integration (per-table presigned URL flow)', () => {
     });
   });
 
-  describe('Private file upload via bucket field', () => {
+  describe('Private file upload via uploadAppFile mutation', () => {
     const fileContent = 'Hello, private world!';
     const contentType = 'text/plain';
     const contentHash = sha256(fileContent);
     let uploadUrl: string;
-    let fileId: string;
 
-    it('should return a presigned PUT URL via bucket.requestUploadUrl', async () => {
+    it('should return a presigned PUT URL via uploadAppFile', async () => {
       const res = await postGraphQL({
-        query: REQUEST_UPLOAD_URL,
+        query: UPLOAD_APP_FILE,
         variables: {
-          key: 'private',
-          contentHash,
-          contentType,
-          size: Buffer.byteLength(fileContent),
-          filename: 'hello-private.txt',
+          input: {
+            bucketKey: 'private',
+            contentHash,
+            contentType,
+            size: Buffer.byteLength(fileContent),
+            filename: 'hello-private.txt',
+          },
         },
       });
 
       expect(res.status).toBe(200);
       expect(res.body.errors).toBeUndefined();
 
-      const bucket = res.body.data.buckets.nodes[0];
-      expect(bucket).toBeTruthy();
-
-      const payload = bucket.requestUploadUrl;
+      const payload = res.body.data.uploadAppFile;
       expect(payload.uploadUrl).toBeTruthy();
       expect(payload.fileId).toBeTruthy();
       expect(payload.key).toBe(contentHash);
@@ -198,7 +182,6 @@ describe('Upload integration (per-table presigned URL flow)', () => {
       expect(payload.expiresAt).toBeTruthy();
 
       uploadUrl = payload.uploadUrl;
-      fileId = payload.fileId;
     });
 
     it('should accept a PUT to the presigned URL', async () => {
@@ -213,20 +196,22 @@ describe('Upload integration (per-table presigned URL flow)', () => {
       const contentHash = sha256(fileContent);
 
       const res = await postGraphQL({
-        query: REQUEST_UPLOAD_URL,
+        query: UPLOAD_APP_FILE,
         variables: {
-          key: 'public',
-          contentHash,
-          contentType: 'text/plain',
-          size: Buffer.byteLength(fileContent),
-          filename: 'hello-public-copy.txt',
+          input: {
+            bucketKey: 'public',
+            contentHash,
+            contentType: 'text/plain',
+            size: Buffer.byteLength(fileContent),
+            filename: 'hello-public-copy.txt',
+          },
         },
       });
 
       expect(res.status).toBe(200);
       expect(res.body.errors).toBeUndefined();
 
-      const payload = res.body.data.buckets.nodes[0].requestUploadUrl;
+      const payload = res.body.data.uploadAppFile;
       expect(payload.deduplicated).toBe(true);
       expect(payload.uploadUrl).toBeNull();
       expect(payload.expiresAt).toBeNull();
@@ -234,3 +219,4 @@ describe('Upload integration (per-table presigned URL flow)', () => {
     });
   });
 });
+


### PR DESCRIPTION
## Summary

Removes the legacy upload API surface from the presigned-url plugin, leaving only the file-centric upload mutations (`uploadAppFile`, `uploadDataRoomFile`, etc.) as the single upload path. Also rewrites the in-repo integration tests to exercise the new API.

**Plugin changes (~330 lines deleted):**
- `requestUploadUrl` field on `@storageBuckets` types — side-effecting query field
- `requestBulkUploadUrls` field on `@storageBuckets` types
- Per-bucket mutation entry points on root Mutation (e.g., `appBucket(key, ownerId)`) — existed only to access the above fields as mutations
- Unused `filesSchemaName` variable, `pgCodec`/`isPgClassType` from scope destructuring
- The `GraphQLObjectType_fields` hook now early-returns for non-mutation types instead of checking `isRootMutation` inside a branch

**Test fixture updates:**
- Renamed seed tables from `buckets`/`files` to `app_buckets`/`app_files` so the plugin's prefix-based codec matching (`app_files` → prefix `app` → matches `app_buckets`) works correctly
- Removed `owner_id` column from `app_buckets` CREATE TABLE and seed INSERT (test buckets are non-entity-scoped; having `owner_id` causes the plugin to require `ownerId` in the mutation input)
- Updated metaschema table entries to reference new table names
- Rewrote `upload.integration.test.ts` to use `uploadAppFile` mutation instead of the removed `requestUploadUrl` query field

**Unchanged:**
- `uploadAppFile` / `uploadAppFiles` / `uploadDataRoomFile` / `uploadDataRoomFiles` mutations (file-centric API)
- Delete middleware with S3 cleanup
- `processSingleFile()` shared logic

## Review & Testing Checklist for Human

- [ ] **Breaking change for downstream consumers**: Any code calling `requestUploadUrl`, `requestBulkUploadUrls`, or the bucket entry points (`appBucket(...)`, `dataRoomBucket(...)`) will break. The `constructive-db` integration tests (`minio-multi-scope.integration.test.ts`) already use the file-centric mutations, but the generated SDK may still reference removed fields — regenerate after publishing.
- [ ] **Verify `uploadAppFile` mutation still registers on root Mutation**: The `GraphQLObjectType_fields` hook now early-returns with `if (!isRootMutation) return fields;`. Confirm the file upload mutations still appear in the schema and that bucket types no longer get any plugin-injected fields.
- [ ] **Verify test fixture table renaming is correct**: Seed tables renamed `buckets` → `app_buckets`, `files` → `app_files`. Confirm the plugin's prefix matching (`_files$` / `_buckets$` regex) produces the correct prefix `"app"` for both, and that `resolveStorageConfigFromCodec` matches the metaschema table names against the codec's `extensions.pg.name`.
- [ ] **Publish + regenerate SDK**: After merging, publish a new plugin version and regenerate the constructive-db SDK to remove the now-dead `request-upload-url` and `request-bulk-upload-urls` CLI commands / types.
- [ ] **Suggested test plan**: Run `pnpm test` in `graphql/server-test` locally (requires MinIO + Postgres) and confirm all 5 assertions in `upload.integration.test.ts` pass (public upload, private upload, deduplication, and the two PUT-to-presigned-URL checks).

### Notes
- `tsc --noEmit` and `pnpm build` both pass cleanly.

Link to Devin session: https://app.devin.ai/sessions/7903d2a3e7a34c6daa605e12d6b80d9e
Requested by: @pyramation