### PR TITLE
feat: add DataChunks node type, update DataFileEmbedding to compose it

### DIFF
--- a/packages/node-type-registry/src/data/data-chunks.ts
+++ b/packages/node-type-registry/src/data/data-chunks.ts
@@ -1,0 +1,110 @@
+import type { NodeTypeDefinition } from '../types';
+
+/**
+ * Standalone chunking node type.
+ *
+ * Creates an embedding_chunks record that provisions a chunks table with:
+ * - FK to parent table (CASCADE delete)
+ * - content text field
+ * - chunk_index integer field
+ * - embedding vector(N) field with HNSW index
+ * - metadata jsonb field
+ * - RLS policies inherited from parent
+ * - Optional job trigger for automatic chunking on INSERT/UPDATE
+ *
+ * This node is also composed internally by DataFileEmbedding (enabled by
+ * default in extract mode). Use it standalone when you want a chunks table
+ * without the full file-embedding pipeline.
+ */
+export const DataChunks: NodeTypeDefinition = {
+  name: 'DataChunks',
+  slug: 'data_chunks',
+  category: 'data',
+  display_name: 'Chunks',
+  description:
+    'Creates a chunked-embedding child table for any parent table. ' +
+    'Provisions the chunks table with content, chunk_index, embedding vector, ' +
+    'metadata, HNSW index, inherited RLS, and optional job trigger for ' +
+    'automatic text splitting. Composed internally by DataFileEmbedding ' +
+    '(enabled by default in extract mode) but can also be used standalone.',
+  parameter_schema: {
+    type: 'object',
+    properties: {
+
+      // ── Content config ─────────────────────────────────────────────
+      content_field_name: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Name of the text content column in the chunks table',
+        default: 'content'
+      },
+
+      // ── Chunking strategy ──────────────────────────────────────────
+      chunk_size: {
+        type: 'integer',
+        description: 'Maximum number of characters per chunk',
+        default: 1000
+      },
+      chunk_overlap: {
+        type: 'integer',
+        description: 'Number of overlapping characters between consecutive chunks',
+        default: 200
+      },
+      chunk_strategy: {
+        type: 'string',
+        enum: ['fixed', 'sentence', 'paragraph', 'semantic'],
+        description: 'Strategy for splitting text into chunks',
+        default: 'paragraph'
+      },
+
+      // ── Embedding config ───────────────────────────────────────────
+      dimensions: {
+        type: 'integer',
+        description: 'Vector dimensions for per-chunk embeddings',
+        default: 768
+      },
+      metric: {
+        type: 'string',
+        enum: ['cosine', 'l2', 'ip'],
+        description: 'Distance metric for the HNSW index on chunk embeddings',
+        default: 'cosine'
+      },
+
+      // ── Table naming ───────────────────────────────────────────────
+      chunks_table_name: {
+        type: 'string',
+        description:
+          'Override the chunks table name. Defaults to {parent_table}_chunks.',
+      },
+
+      // ── Metadata ───────────────────────────────────────────────────
+      metadata_fields: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'Field names from the parent table to copy into chunk metadata'
+      },
+
+      // ── Job trigger ────────────────────────────────────────────────
+      enqueue_chunking_job: {
+        type: 'boolean',
+        description:
+          'Whether to create a job trigger that auto-enqueues chunking ' +
+          'on parent INSERT/UPDATE',
+        default: true
+      },
+      chunking_task_name: {
+        type: 'string',
+        description: 'Task identifier for the chunking job queue',
+        default: 'generate_chunks'
+      }
+    }
+  },
+  tags: [
+    'embedding',
+    'chunks',
+    'vector',
+    'ai',
+    'rag'
+  ]
+};

--- a/packages/node-type-registry/src/data/data-file-embedding.ts
+++ b/packages/node-type-registry/src/data/data-file-embedding.ts
@@ -9,9 +9,10 @@ export const DataFileEmbedding: NodeTypeDefinition = {
     'Generic, MIME-scoped embedding node for file tables. Supports two modes: ' +
     'direct (whole-file to single vector, e.g. CLIP for images) when extraction ' +
     'is omitted, or extract (file to text to chunks to per-chunk vectors) when ' +
-    'extraction config is provided. Composes SearchVector + DataJobTrigger ' +
-    'internally. Multiple instances can coexist on the same table with different ' +
-    'MIME scopes, field names, and embedding strategies.',
+    'extraction config is provided. Composes SearchVector + DataJobTrigger + ' +
+    'DataChunks (enabled by default in extract mode) internally. Multiple ' +
+    'instances can coexist on the same table with different MIME scopes, field ' +
+    'names, and embedding strategies.',
   parameter_schema: {
     type: 'object',
     properties: {
@@ -123,13 +124,20 @@ export const DataFileEmbedding: NodeTypeDefinition = {
         }
       },
 
-      // ── Chunking config (optional — creates embedding_chunks) ──────
+      // ── Chunking (enabled by default in extract mode) ──────────────
+      include_chunks: {
+        type: 'boolean',
+        description:
+          'Whether to create a chunks table via DataChunks. Defaults to true ' +
+          'when extraction is provided, false in direct mode. Set explicitly ' +
+          'to override.',
+      },
       chunks: {
         type: 'object',
         description:
-          'Chunking configuration. Creates an embedding_chunks record that drives ' +
-          'automatic text splitting and per-chunk embedding. Only meaningful when ' +
-          'extraction is also provided.',
+          'Chunking configuration passed through to DataChunks. When ' +
+          'include_chunks is true (or defaults to true in extract mode), these ' +
+          'params configure the chunks table, embedding dimensions, strategy, etc.',
         properties: {
           content_field_name: {
             type: 'string',
@@ -154,8 +162,9 @@ export const DataFileEmbedding: NodeTypeDefinition = {
             default: 'paragraph'
           },
           metadata_fields: {
-            type: 'object',
-            description: 'Metadata fields from parent to copy into chunks'
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Field names from parent to copy into chunk metadata'
           },
           enqueue_chunking_job: {
             type: 'boolean',

--- a/packages/node-type-registry/src/data/index.ts
+++ b/packages/node-type-registry/src/data/index.ts
@@ -1,3 +1,4 @@
+export { DataChunks } from './data-chunks';
 export { DataCompositeField } from './data-composite-field';
 export { DataDirectOwner } from './data-direct-owner';
 export { DataEntityMembership } from './data-entity-membership';


### PR DESCRIPTION
## Summary

Adds a new standalone `DataChunks` node type and updates `DataFileEmbedding` to compose it by default in extract mode.

**DataChunks** (`data-chunks.ts`) is a standalone node that provisions a chunked-embedding child table via the existing `embedding_chunks` infrastructure. Parameters include chunking strategy (fixed/sentence/paragraph/semantic), chunk size/overlap, embedding dimensions/metric, table naming override, metadata field passthrough, and job trigger config.

**DataFileEmbedding** changes:
- New `include_chunks` boolean param — defaults to `true` when `extraction` is provided, `false` in direct mode
- Updated `chunks` description to reflect it's now passed through to DataChunks
- Changed `metadata_fields` type from `object` to `array` of strings (aligns with DataChunks definition)
- Updated description to mention DataChunks composition

Companion PR: constructive-io/constructive-db (SQL generator + seed regeneration with patched registry).

## Review & Testing Checklist for Human

- [ ] **`metadata_fields` type change** — changed from `{ type: 'object' }` to `{ type: 'array', items: { type: 'string' } }` in the `chunks` config. Verify no existing blueprints rely on the old object shape.
- [ ] **`include_chunks` has no explicit `default`** in the schema — the defaulting is context-dependent (SQL generator defaults based on whether `extraction` is present). Confirm this is acceptable for the registry's schema validation/UI generation.
- [ ] **Parameter alignment** — verify DataChunks params (`dimensions`, `metric`, `chunk_size`, etc.) match what the SQL generator in constructive-db expects to receive.

### Notes

- This is a TypeScript-only change (node type definitions). The actual SQL execution logic lives in the companion constructive-db PR.
- Once both PRs are merged, the user will publish a new `node-type-registry` version so constructive-db can remove its local patch.

Link to Devin session: https://app.devin.ai/sessions/3722a7a0782a4f3190a04a41f74d1bf4
Requested by: @pyramation