### PR TITLE
ci: build-once-test-many + Blacksmith runners + pnpm caching

### DIFF
--- a/.github/workflows/docker-constructive.yaml
+++ b/.github/workflows/docker-constructive.yaml
@@ -26,10 +26,10 @@ jobs:
         include:
           - platform: linux/amd64
             arch: amd64
-            runner: ubuntu-latest      # x86_64
+            runner: blacksmith-4vcpu-ubuntu-2404      # x86_64
           - platform: linux/arm64
             arch: arm64
-            runner: ubuntu-24.04-arm   # native arm
+            runner: blacksmith-4vcpu-ubuntu-2404-arm  # native arm
     runs-on: ${{ matrix.runner }}
 
     permissions:
@@ -118,7 +118,7 @@ jobs:
   # multi-arch manifest for each tag.
   publish-constructive-manifest:
     if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: build-push-constructive
 
     permissions:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -41,7 +41,7 @@ concurrency:
 jobs:
   build-push:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     permissions:
       contents: read

--- a/.github/workflows/examples-integration.yaml
+++ b/.github/workflows/examples-integration.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   examples-types:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/notify-e2e.yml
+++ b/.github/workflows/notify-e2e.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   trigger-tests:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Trigger submodule update in constructive-hub
         uses: actions/github-script@v7

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -15,87 +15,74 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-tests
   cancel-in-progress: true
 
-jobs:
-  constructive-tests:
-    runs-on: ubuntu-latest
+# ---------------------------------------------------------------------------
+# Build-once, test-many architecture with tiered service containers.
+#
+# Phase 1 – build: single job installs deps + builds the monorepo once.
+# Phase 2 – fan-out: test jobs download the build artifact and run tests.
+#
+# Service tiers (avoids spinning up unneeded containers):
+#   unit-tests        → no services (pure JS/TS)
+#   pg-tests          → PostgreSQL only
+#   integration-tests → PostgreSQL + MinIO
+# ---------------------------------------------------------------------------
 
+jobs:
+  # =========================================================================
+  # BUILD (single job – runs once, shared by all test jobs)
+  # =========================================================================
+  build:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Configure Git (for tests)
+        run: |
+          git config --global user.name "CI Test User"
+          git config --global user.email "ci@example.com"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Upload workspace
+        uses: actions/upload-artifact@v4
+        with:
+          name: workspace-build
+          path: |
+            .
+            !.git
+          retention-days: 1
+
+  # =========================================================================
+  # TIER 1 – Unit tests (no services needed)
+  # =========================================================================
+  unit-tests:
+    needs: build
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     strategy:
       fail-fast: false
       matrix:
         include:
           - package: uploads/mime-bytes
             env: {}
-          - package: pgpm/core
-            env: {}
-          - package: pgpm/env
-            env: {}
-          - package: pgpm/cli
-            env: {}
-          - package: packages/cli
-            env: {}
-          - package: jobs/knative-job-service
-            env: {}
-          - package: packages/client
-            env:
-              TEST_DATABASE_URL: postgres://postgres:password@localhost:5432/postgres
-          - package: postgres/pgsql-client
-            env: {}
-          - package: postgres/pgsql-test
-            env: {}
-          - package: packages/orm
-            env: {}
-          - package: packages/url-domains
-            env: {}
           - package: uploads/uuid-hash
             env: {}
           - package: uploads/uuid-stream
-            env: {}
-          - package: postgres/introspectron
-            env: {}
-          - package: packages/query-builder
-            env: {}
-          - package: graphql/query
-            env: {}
-          - package: graphql/codegen
-            env: {}
-          - package: postgres/pg-ast
-            env: {}
-          - package: postgres/pg-codegen
-            env: {}
-          - package: uploads/content-type-stream
-            env: {}
-          - package: uploads/s3-streamer
-            env:
-              BUCKET_NAME: test-bucket
-          - package: uploads/upload-names
-            env: {}
-          - package: graphile/graphile-test
-            env: {}
-          - package: graphile/graphile-connection-filter
-            env: {}
-          - package: graphile/graphile-postgis
-            env: {}
-          - package: graphql/orm-test
-            env: {}
-          - package: graphql/server-test
-            env: {}
-          - package: graphql/env
-            env: {}
-          - package: graphql/server
-            env: {}
-          - package: graphql/test
-            env: {}
-          - package: graphql/playwright-test
-            env: {}
-          - package: packages/safegres
-            env: {}
-          # - package: jobs/knative-job-worker
-          #   env: {}
-          - package: packages/csv-to-pg
-            env: {}
-          - package: packages/smtppostmaster
-            env: {}
-          - package: postgres/drizzle-orm-test
             env: {}
           - package: uploads/etag-hash
             env: {}
@@ -103,27 +90,165 @@ jobs:
             env: {}
           - package: uploads/stream-to-etag
             env: {}
-          - package: packages/oauth
+          - package: uploads/content-type-stream
+            env: {}
+          - package: uploads/upload-names
+            env: {}
+          - package: packages/url-domains
+            env: {}
+          - package: packages/query-builder
             env: {}
           - package: packages/csrf
             env: {}
+          - package: packages/oauth
+            env: {}
           - package: packages/12factor-env
+            env: {}
+          - package: packages/orm
             env: {}
           - package: packages/postmaster
             env: {}
+          - package: packages/smtppostmaster
+            env: {}
+          - package: packages/csv-to-pg
+            env: {}
+          - package: postgres/pgsql-client
+            env: {}
+          - package: postgres/pg-ast
+            env: {}
+          - package: graphql/query
+            env: {}
+          - package: graphql/codegen
+            env: {}
+          - package: packages/cli
+            env: {}
+
+    steps:
+      - name: Download workspace
+        uses: actions/download-artifact@v4
+        with:
+          name: workspace-build
+
+      - name: Test ${{ matrix.package }}
+        run: cd ./${{ matrix.package }} && pnpm test
+        env: ${{ matrix.env }}
+
+  # =========================================================================
+  # TIER 2 – PostgreSQL-only tests
+  # =========================================================================
+  pg-tests:
+    needs: build
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: pgpm/core
+            env: {}
+          - package: pgpm/cli
+            env: {}
+          - package: packages/client
+            env:
+              TEST_DATABASE_URL: postgres://postgres:password@localhost:5432/postgres
+          - package: packages/safegres
+            env: {}
+          - package: postgres/pg-codegen
+            env: {}
+          - package: postgres/pgsql-test
+            env: {}
+          - package: postgres/drizzle-orm-test
+            env: {}
+          - package: postgres/introspectron
+            env: {}
+          - package: graphile/graphile-test
+            env: {}
+          - package: graphile/graphile-connection-filter
+            env: {}
+          - package: graphile/graphile-postgis
+            env: {}
           - package: graphile/graphile-search
+            env: {}
+          - package: graphile/graphile-ltree
+            env: {}
+          - package: graphql/orm-test
+            env: {}
+          - package: graphql/test
+            env: {}
+          - package: graphql/playwright-test
+            env: {}
+          - package: jobs/knative-job-service
+            env: {}
+
+    env:
+      PGHOST: localhost
+      PGPORT: 5432
+      PGUSER: postgres
+      PGPASSWORD: password
+
+    services:
+      pg_db:
+        image: ghcr.io/constructive-io/docker/postgres-plus:18
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - name: Configure Git (for tests)
+        run: |
+          git config --global user.name "CI Test User"
+          git config --global user.email "ci@example.com"
+
+      - name: Download workspace
+        uses: actions/download-artifact@v4
+        with:
+          name: workspace-build
+
+      - name: Seed app_user
+        run: |
+          pnpm --filter pgpm exec node dist/index.js admin-users bootstrap --yes
+          pnpm --filter pgpm exec node dist/index.js admin-users add --test --yes
+
+      - name: Test ${{ matrix.package }}
+        run: cd ./${{ matrix.package }} && pnpm test
+        env: ${{ matrix.env }}
+
+  # =========================================================================
+  # TIER 3 – Integration tests (PostgreSQL + MinIO)
+  # =========================================================================
+  integration-tests:
+    needs: build
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: pgpm/env
+            env: {}
+          - package: uploads/s3-streamer
+            env:
+              BUCKET_NAME: test-bucket
+          - package: packages/upload-client
+            env: {}
+          - package: packages/bucket-provisioner
             env: {}
           - package: graphile/graphile-settings
             env: {}
           - package: graphile/graphile-presigned-url-plugin
             env: {}
-          - package: packages/bucket-provisioner
-            env: {}
-          - package: packages/upload-client
-            env: {}
           - package: graphile/graphile-bucket-provisioner-plugin
             env: {}
-          - package: graphile/graphile-ltree
+          - package: graphql/server-test
+            env: {}
+          - package: graphql/env
+            env: {}
+          - package: graphql/server
             env: {}
 
     env:
@@ -170,26 +295,12 @@ jobs:
           git config --global user.name "CI Test User"
           git config --global user.email "ci@example.com"
 
-      - name: checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Download workspace
+        uses: actions/download-artifact@v4
         with:
-          node-version: '22'
+          name: workspace-build
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10
-
-      - name: install
-        run: pnpm install
-
-      - name: build
-        run: pnpm run build
-
-      - name: seed app_user
+      - name: Seed app_user
         run: |
           pnpm --filter pgpm exec node dist/index.js admin-users bootstrap --yes
           pnpm --filter pgpm exec node dist/index.js admin-users add --test --yes

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -21,6 +21,9 @@ concurrency:
 # Phase 1 – build: single job installs deps + builds the monorepo once.
 # Phase 2 – fan-out: test jobs download the build artifact and run tests.
 #
+# The build artifact is a tar archive to preserve symlinks and all files.
+# Test jobs extract the tar and run pnpm install to restore node_modules.
+#
 # Service tiers (avoids spinning up unneeded containers):
 #   unit-tests        → no services (pure JS/TS)
 #   pg-tests          → PostgreSQL only
@@ -59,13 +62,14 @@ jobs:
       - name: Build
         run: pnpm run build
 
+      - name: Create build archive
+        run: tar -czf /tmp/workspace.tar.gz --exclude='.git' --exclude='node_modules' .
+
       - name: Upload workspace
         uses: actions/upload-artifact@v4
         with:
           name: workspace-build
-          path: |
-            .
-            !.git
+          path: /tmp/workspace.tar.gz
           retention-days: 1
 
   # =========================================================================
@@ -133,13 +137,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+          cache: 'pnpm'
 
       - name: Download workspace
         uses: actions/download-artifact@v4
         with:
           name: workspace-build
 
-      - name: Restore symlinks
+      - name: Extract workspace
+        run: tar -xzf workspace.tar.gz && rm workspace.tar.gz
+
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Test ${{ matrix.package }}
@@ -227,13 +235,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+          cache: 'pnpm'
 
       - name: Download workspace
         uses: actions/download-artifact@v4
         with:
           name: workspace-build
 
-      - name: Restore symlinks
+      - name: Extract workspace
+        run: tar -xzf workspace.tar.gz && rm workspace.tar.gz
+
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Seed app_user
@@ -330,13 +342,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+          cache: 'pnpm'
 
       - name: Download workspace
         uses: actions/download-artifact@v4
         with:
           name: workspace-build
 
-      - name: Restore symlinks
+      - name: Extract workspace
+        run: tar -xzf workspace.tar.gz && rm workspace.tar.gz
+
+      - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Seed app_user

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -128,6 +128,14 @@ jobs:
             env: {}
 
     steps:
+      - name: Download workspace
+        uses: actions/download-artifact@v4
+        with:
+          name: workspace-build
+
+      - name: Extract workspace
+        run: tar -xzf workspace.tar.gz && rm workspace.tar.gz
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
@@ -138,14 +146,6 @@ jobs:
         with:
           node-version: '22'
           cache: 'pnpm'
-
-      - name: Download workspace
-        uses: actions/download-artifact@v4
-        with:
-          name: workspace-build
-
-      - name: Extract workspace
-        run: tar -xzf workspace.tar.gz && rm workspace.tar.gz
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -221,6 +221,14 @@ jobs:
           - 5432:5432
 
     steps:
+      - name: Download workspace
+        uses: actions/download-artifact@v4
+        with:
+          name: workspace-build
+
+      - name: Extract workspace
+        run: tar -xzf workspace.tar.gz && rm workspace.tar.gz
+
       - name: Configure Git (for tests)
         run: |
           git config --global user.name "CI Test User"
@@ -236,14 +244,6 @@ jobs:
         with:
           node-version: '22'
           cache: 'pnpm'
-
-      - name: Download workspace
-        uses: actions/download-artifact@v4
-        with:
-          name: workspace-build
-
-      - name: Extract workspace
-        run: tar -xzf workspace.tar.gz && rm workspace.tar.gz
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -328,6 +328,14 @@ jobs:
           --health-retries 5
 
     steps:
+      - name: Download workspace
+        uses: actions/download-artifact@v4
+        with:
+          name: workspace-build
+
+      - name: Extract workspace
+        run: tar -xzf workspace.tar.gz && rm workspace.tar.gz
+
       - name: Configure Git (for tests)
         run: |
           git config --global user.name "CI Test User"
@@ -343,14 +351,6 @@ jobs:
         with:
           node-version: '22'
           cache: 'pnpm'
-
-      - name: Download workspace
-        uses: actions/download-artifact@v4
-        with:
-          name: workspace-build
-
-      - name: Extract workspace
-        run: tar -xzf workspace.tar.gz && rm workspace.tar.gz
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -124,6 +124,16 @@ jobs:
             env: {}
 
     steps:
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Download workspace
         uses: actions/download-artifact@v4
         with:
@@ -204,6 +214,16 @@ jobs:
         run: |
           git config --global user.name "CI Test User"
           git config --global user.email "ci@example.com"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
 
       - name: Download workspace
         uses: actions/download-artifact@v4
@@ -294,6 +314,16 @@ jobs:
         run: |
           git config --global user.name "CI Test User"
           git config --global user.email "ci@example.com"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
 
       - name: Download workspace
         uses: actions/download-artifact@v4

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -139,6 +139,9 @@ jobs:
         with:
           name: workspace-build
 
+      - name: Restore symlinks
+        run: pnpm install --frozen-lockfile
+
       - name: Test ${{ matrix.package }}
         run: cd ./${{ matrix.package }} && pnpm test
         env: ${{ matrix.env }}
@@ -229,6 +232,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: workspace-build
+
+      - name: Restore symlinks
+        run: pnpm install --frozen-lockfile
 
       - name: Seed app_user
         run: |
@@ -329,6 +335,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: workspace-build
+
+      - name: Restore symlinks
+        run: pnpm install --frozen-lockfile
 
       - name: Seed app_user
         run: |


### PR DESCRIPTION
## Summary

Restructures the CI test pipeline from a flat 49-job matrix (each repeating the full `pnpm install` + `pnpm build` cycle) into a **build-once, test-many** architecture with **tiered service containers**, and migrates all workflows to **Blacksmith runners**.

**Before:** Every matrix job ran on `ubuntu-latest` (2 vCPU), installed deps, built the entire monorepo (~3.5 min), then ran tests (8–24s). 49 jobs × 3.5 min = ~170 min of redundant build compute.

**After:**
- **Build job** (1×, `blacksmith-4vcpu`): installs, builds, creates a tar.gz archive (excluding `.git` and `node_modules`), uploads as artifact.
- **Unit tests** (22 jobs, `blacksmith-2vcpu`): no services — pure JS/TS packages.
- **PG tests** (17 jobs, `blacksmith-4vcpu`): PostgreSQL only.
- **Integration tests** (10 jobs, `blacksmith-4vcpu`): PostgreSQL + MinIO.

Each test tier downloads the tar archive, extracts it, then runs `pnpm install --frozen-lockfile` to restore `node_modules` (with `cache: 'pnpm'` for fast cache hits on subsequent runs).

Also migrates all other workflows to Blacksmith runners:
- `docker-constructive.yaml` → `blacksmith-4vcpu` (x86 + arm) / `blacksmith-2vcpu` (manifest)
- `docker.yaml` → `blacksmith-4vcpu`
- `examples-integration.yaml` → `blacksmith-4vcpu`
- `notify-e2e.yml` → `blacksmith-2vcpu`

## Review & Testing Checklist for Human

- [ ] **Package tier classification correctness:** Packages were classified into tiers via static analysis of test imports. All 49 jobs passed on this PR, but verify over a few runs that no unit-test-tier package intermittently needs PG/MinIO at runtime (e.g., through transitive imports or conditional test setup). Key packages to spot-check: `packages/cli`, `graphql/codegen`, `packages/orm`.
- [ ] **Artifact overhead vs. build savings:** The tar archive + `pnpm install --frozen-lockfile` per test job adds ~30-60s per job. Compare total wall-clock time of this PR's CI run against a recent `main` run to confirm the net speedup is meaningful.
- [ ] **Blacksmith runner availability:** Confirm the Blacksmith GitHub App has access to `constructive-io/constructive`. If access is ever revoked, all workflows will queue indefinitely — there is no fallback to `ubuntu-latest`.

### Notes
- The `constructive-db` repo already uses `blacksmith-8vcpu-ubuntu-2404` with pnpm caching and test sharding. This PR brings similar patterns to the main `constructive` repo.
- Tar-based artifacts are used instead of zip to reliably preserve symlinks and directory structure. The artifact is extracted *before* `setup-node` runs, so `pnpm-lock.yaml` is available for cache key generation.
- The `env: {}` fields on matrix entries are carried over from the original workflow for forward compatibility, though most are empty.
- The commented-out `jobs/knative-job-worker` entry from the original workflow was intentionally dropped (it was already disabled).

Link to Devin session: https://app.devin.ai/sessions/d58eacc3839349848a2f544e227ea241
Requested by: @pyramation