### PR TITLE
feat(presigned-url): enforce bulk upload limits (maxBulkFiles + maxBulkTotalSize)

### DIFF
--- a/graphile/graphile-presigned-url-plugin/src/plugin.ts
+++ b/graphile/graphile-presigned-url-plugin/src/plugin.ts
@@ -383,11 +383,25 @@ export function createPresignedUrlPlugin(
                           );
                           if (!bucket) throw new Error('BUCKET_NOT_FOUND');
 
+                          // Enforce bulk upload limits
+                          const filesArray = vals.files as any[];
+                          if (filesArray.length > storageConfig.maxBulkFiles) {
+                            throw new Error(
+                              `BULK_UPLOAD_FILES_EXCEEDED: ${filesArray.length} files exceeds maximum of ${storageConfig.maxBulkFiles} per batch`,
+                            );
+                          }
+                          const totalSize = filesArray.reduce((sum: number, f: any) => sum + (f.size || 0), 0);
+                          if (totalSize > storageConfig.maxBulkTotalSize) {
+                            throw new Error(
+                              `BULK_UPLOAD_SIZE_EXCEEDED: ${totalSize} bytes exceeds maximum of ${storageConfig.maxBulkTotalSize} bytes per batch`,
+                            );
+                          }
+
                           const s3ForDb = resolveS3ForDatabase(options, storageConfig, databaseId);
                           await ensureS3BucketExists(options, s3ForDb.bucket, bucket, databaseId, storageConfig.allowedOrigins);
 
                           const results = [];
-                          for (const file of vals.files) {
+                          for (const file of filesArray) {
                             results.push(
                               await processSingleFile(options, txClient, storageConfig, databaseId, bucket, s3ForDb, {
                                 contentHash: file.contentHash,


### PR DESCRIPTION
## Summary

Adds enforcement of `maxBulkFiles` and `maxBulkTotalSize` limits to the bulk file upload mutation (`uploadAppFiles`, `uploadDataRoomFiles`, etc.). Previously, these config values were loaded from `storage_module` (with defaults of 100 files / 1GB) but **never actually checked** — the bulk mutation would process any number of files unconditionally.

Now, before the file processing loop, the mutation validates:
1. **File count** against `storageConfig.maxBulkFiles` → throws `BULK_UPLOAD_FILES_EXCEEDED`
2. **Total batch size** against `storageConfig.maxBulkTotalSize` → throws `BULK_UPLOAD_SIZE_EXCEEDED`

This is Step 1 of the bulk upload limits plan (#794). Step 2 will wire in `resolve_cap()` from the limits module for per-org overrides.

## Review & Testing Checklist for Human

- [ ] **Verify `f.size || 0` fallback is acceptable**: If a file entry has `size: 0` or `size: undefined`, it contributes 0 bytes to the total. Individual files will still fail in `processSingleFile` (which requires `size > 0`), but the batch-level size check would pass. Confirm this fail-later behavior is fine, or if the batch check should also reject files with missing/zero size.
- [ ] **No unit or integration tests added**: Consider whether a test should be added to the `s3-signing.test.ts` suite or the `minio-multi-scope.integration.test.ts` in constructive-db to verify rejection at the limit boundary.
- [ ] **Test manually with a bulk upload exceeding the default limits** (100 files or 1GB total) to confirm the error messages surface correctly through GraphQL.

### Notes
- The `maxBulkFiles` and `maxBulkTotalSize` values are already configurable per-database via the `storage_module` table columns `max_bulk_files` and `max_bulk_total_size`, with plugin defaults of 100 and 1GB respectively.
- This is a pre-request validation (fails fast before any S3 or DB work), so it won't leave partial state.

Link to Devin session: https://app.devin.ai/sessions/7903d2a3e7a34c6daa605e12d6b80d9e
Requested by: @pyramation