### PR TITLE
feat(export): add 6 new services_public settings tables to export

### DIFF
--- a/pgpm/export/src/export-graphql-meta.ts
+++ b/pgpm/export/src/export-graphql-meta.ts
@@ -152,7 +152,13 @@ export const exportGraphQLMeta = async ({
     queryAndParse('site_metadata'),
     queryAndParse('api_modules'),
     queryAndParse('api_extensions'),
-    queryAndParse('api_schemas')
+    queryAndParse('api_schemas'),
+    queryAndParse('database_settings'),
+    queryAndParse('api_settings'),
+    queryAndParse('rls_settings'),
+    queryAndParse('cors_settings'),
+    queryAndParse('pubkey_settings'),
+    queryAndParse('webauthn_settings')
   ]);
 
   // metaschema_modules_public tables

--- a/pgpm/export/src/export-meta.ts
+++ b/pgpm/export/src/export-meta.ts
@@ -161,6 +161,12 @@ export const exportMeta = async ({ opts, dbname, database_id }: ExportMetaParams
   await queryAndParse('api_modules', `SELECT * FROM services_public.api_modules WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('api_extensions', `SELECT * FROM services_public.api_extensions WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('api_schemas', `SELECT * FROM services_public.api_schemas WHERE database_id = $1 ORDER BY id`);
+  await queryAndParse('database_settings', `SELECT * FROM services_public.database_settings WHERE database_id = $1 ORDER BY id`);
+  await queryAndParse('api_settings', `SELECT * FROM services_public.api_settings WHERE database_id = $1 ORDER BY id`);
+  await queryAndParse('rls_settings', `SELECT * FROM services_public.rls_settings WHERE database_id = $1 ORDER BY id`);
+  await queryAndParse('cors_settings', `SELECT * FROM services_public.cors_settings WHERE database_id = $1 ORDER BY id`);
+  await queryAndParse('pubkey_settings', `SELECT * FROM services_public.pubkey_settings WHERE database_id = $1 ORDER BY id`);
+  await queryAndParse('webauthn_settings', `SELECT * FROM services_public.webauthn_settings WHERE database_id = $1 ORDER BY id`);
 
   // =============================================================================
   // metaschema_modules_public tables

--- a/pgpm/export/src/export-utils.ts
+++ b/pgpm/export/src/export-utils.ts
@@ -149,6 +149,12 @@ export const META_TABLE_ORDER = [
   'api_modules',
   'api_extensions',
   'api_schemas',
+  'database_settings',
+  'api_settings',
+  'rls_settings',
+  'cors_settings',
+  'pubkey_settings',
+  'webauthn_settings',
   'rls_module',
   'user_auth_module',
   'memberships_module',
@@ -557,6 +563,107 @@ export const META_TABLE_CONFIG: Record<string, TableConfig> = {
       database_id: 'uuid',
       schema_id: 'uuid',
       api_id: 'uuid'
+    }
+  },
+  database_settings: {
+    schema: 'services_public',
+    table: 'database_settings',
+    fields: {
+      id: 'uuid',
+      database_id: 'uuid',
+      enable_aggregates: 'boolean',
+      enable_postgis: 'boolean',
+      enable_search: 'boolean',
+      enable_direct_uploads: 'boolean',
+      enable_presigned_uploads: 'boolean',
+      enable_many_to_many: 'boolean',
+      enable_connection_filter: 'boolean',
+      enable_ltree: 'boolean',
+      enable_llm: 'boolean',
+      options: 'jsonb'
+    }
+  },
+  api_settings: {
+    schema: 'services_public',
+    table: 'api_settings',
+    fields: {
+      id: 'uuid',
+      database_id: 'uuid',
+      api_id: 'uuid',
+      enable_aggregates: 'boolean',
+      enable_postgis: 'boolean',
+      enable_search: 'boolean',
+      enable_direct_uploads: 'boolean',
+      enable_presigned_uploads: 'boolean',
+      enable_many_to_many: 'boolean',
+      enable_connection_filter: 'boolean',
+      enable_ltree: 'boolean',
+      enable_llm: 'boolean',
+      options: 'jsonb'
+    }
+  },
+  rls_settings: {
+    schema: 'services_public',
+    table: 'rls_settings',
+    fields: {
+      id: 'uuid',
+      database_id: 'uuid',
+      authenticate: 'text',
+      authenticate_strict: 'text',
+      authenticate_schema: 'text',
+      role_schema: 'text',
+      current_role_fn: 'text',
+      current_role_id_fn: 'text',
+      current_user_agent_fn: 'text',
+      current_ip_address_fn: 'text'
+    }
+  },
+  cors_settings: {
+    schema: 'services_public',
+    table: 'cors_settings',
+    fields: {
+      id: 'uuid',
+      database_id: 'uuid',
+      api_id: 'uuid',
+      allowed_origins: 'text[]'
+    }
+  },
+  pubkey_settings: {
+    schema: 'services_public',
+    table: 'pubkey_settings',
+    fields: {
+      id: 'uuid',
+      database_id: 'uuid',
+      schema: 'text',
+      crypto_network: 'text',
+      user_field: 'text',
+      sign_up_with_key: 'text',
+      sign_in_request_challenge: 'text',
+      sign_in_record_failure: 'text',
+      sign_in_with_challenge: 'text'
+    }
+  },
+  webauthn_settings: {
+    schema: 'services_public',
+    table: 'webauthn_settings',
+    fields: {
+      id: 'uuid',
+      database_id: 'uuid',
+      schema: 'text',
+      credentials_schema: 'text',
+      credentials_table: 'text',
+      sessions_schema: 'text',
+      sessions_table: 'text',
+      session_credentials_table: 'text',
+      session_secrets_schema: 'text',
+      session_secrets_table: 'text',
+      rp_id: 'text',
+      rp_name: 'text',
+      origin_allowlist: 'text[]',
+      attestation_type: 'text',
+      require_user_verification: 'boolean',
+      resident_key: 'text',
+      challenge_expiry_seconds: 'int'
     }
   },
   // =============================================================================

--- a/pgpm/export/src/export-utils.ts
+++ b/pgpm/export/src/export-utils.ts
@@ -608,14 +608,14 @@ export const META_TABLE_CONFIG: Record<string, TableConfig> = {
     fields: {
       id: 'uuid',
       database_id: 'uuid',
-      authenticate: 'text',
-      authenticate_strict: 'text',
-      authenticate_schema: 'text',
-      role_schema: 'text',
-      current_role_fn: 'text',
-      current_role_id_fn: 'text',
-      current_user_agent_fn: 'text',
-      current_ip_address_fn: 'text'
+      authenticate_schema_id: 'uuid',
+      role_schema_id: 'uuid',
+      authenticate_function_id: 'uuid',
+      authenticate_strict_function_id: 'uuid',
+      current_role_function_id: 'uuid',
+      current_role_id_function_id: 'uuid',
+      current_user_agent_function_id: 'uuid',
+      current_ip_address_function_id: 'uuid'
     }
   },
   cors_settings: {
@@ -634,13 +634,13 @@ export const META_TABLE_CONFIG: Record<string, TableConfig> = {
     fields: {
       id: 'uuid',
       database_id: 'uuid',
-      schema: 'text',
+      schema_id: 'uuid',
       crypto_network: 'text',
       user_field: 'text',
-      sign_up_with_key: 'text',
-      sign_in_request_challenge: 'text',
-      sign_in_record_failure: 'text',
-      sign_in_with_challenge: 'text'
+      sign_up_with_key_function_id: 'uuid',
+      sign_in_request_challenge_function_id: 'uuid',
+      sign_in_record_failure_function_id: 'uuid',
+      sign_in_with_challenge_function_id: 'uuid'
     }
   },
   webauthn_settings: {
@@ -649,14 +649,15 @@ export const META_TABLE_CONFIG: Record<string, TableConfig> = {
     fields: {
       id: 'uuid',
       database_id: 'uuid',
-      schema: 'text',
-      credentials_schema: 'text',
-      credentials_table: 'text',
-      sessions_schema: 'text',
-      sessions_table: 'text',
-      session_credentials_table: 'text',
-      session_secrets_schema: 'text',
-      session_secrets_table: 'text',
+      schema_id: 'uuid',
+      credentials_schema_id: 'uuid',
+      sessions_schema_id: 'uuid',
+      session_secrets_schema_id: 'uuid',
+      credentials_table_id: 'uuid',
+      sessions_table_id: 'uuid',
+      session_credentials_table_id: 'uuid',
+      session_secrets_table_id: 'uuid',
+      user_field_id: 'uuid',
       rp_id: 'text',
       rp_name: 'text',
       origin_allowlist: 'text[]',


### PR DESCRIPTION
## Summary

Registers the 6 new `services_public` settings tables (from [constructive-db#1060](https://github.com/constructive-io/constructive-db/pull/1060)) in the pgpm export system so they are included during database exports.

**Tables added:** `database_settings`, `api_settings`, `rls_settings`, `cors_settings`, `pubkey_settings`, `webauthn_settings`

**Files changed (all in `pgpm/export/src/`):**
- `export-utils.ts` — field configs in `META_TABLE_CONFIG` + entries in `META_TABLE_ORDER`
- `export-meta.ts` — `queryAndParse()` calls for SQL export flow
- `export-graphql-meta.ts` — `queryAndParse()` calls for GraphQL export flow

Both export flows already handle missing tables gracefully (`42P01` catch in SQL, field-not-found catch in GraphQL), so this is safe to merge before or after constructive-db#1060.

### Updates since last revision

The field configs for `rls_settings`, `pubkey_settings`, and `webauthn_settings` were updated to match the text→UUID FK conversion in constructive-db#1060 ([#816](https://github.com/constructive-io/constructive-planning/issues/816), [#817](https://github.com/constructive-io/constructive-planning/issues/817)):

- **`rls_settings`**: Schema/function text fields → UUID FK fields (e.g. `authenticate_schema` → `authenticate_schema_id`, `current_role_fn` → `current_role_function_id`)
- **`pubkey_settings`**: `schema` → `schema_id`, function text fields → `*_function_id` uuid fields
- **`webauthn_settings`**: Schema text fields → `*_schema_id`, table text fields → `*_table_id`, added `user_field_id` uuid FK

`database_settings`, `api_settings`, and `cors_settings` remain unchanged.

## Review & Testing Checklist for Human

- [ ] **Cross-reference field names with constructive-db#1060 deploy SQL** — The UUID FK field names in `META_TABLE_CONFIG` (e.g. `authenticate_function_id`, `sign_up_with_key_function_id`, `credentials_table_id`) must exactly match the column names in the corresponding deploy `.sql` files. A mismatch won't cause errors (the dynamic field builder silently skips missing columns) but will cause silent data omission during exports.
- [ ] **`api_settings` nullable booleans** — The DB columns are nullable (`boolean` without `NOT NULL`) for inheritance semantics, but the config types them as `'boolean'`. Confirm `buildDynamicFields()` / `mapPgTypeToFieldType()` handles nullable `bool` columns correctly (the PG `udt_name` is `bool` regardless of nullability, so this should be fine, but worth a sanity check).
- [ ] **Run a local export** against a database that has these tables deployed (after merging constructive-db#1060) to verify the full round-trip produces valid SQL INSERT statements, especially for the UUID FK columns.

### Notes
- Related: [constructive-planning#814](https://github.com/constructive-io/constructive-planning/issues/814) tracks genericizing the export to auto-discover tables, eliminating the need for these manual additions in the future.

Link to Devin session: https://app.devin.ai/sessions/94a2728a9c414500bead29cbbc829c15
Requested by: @pyramation