### PR TITLE
fix(codegen): sanitize */ in JSDoc comments to prevent syntax errors

### DIFF
--- a/graphql/codegen/src/__tests__/codegen/jsdoc-comment.test.ts
+++ b/graphql/codegen/src/__tests__/codegen/jsdoc-comment.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for JSDoc comment sanitization in babel-ast and hooks-ast
+ */
+import * as t from '@babel/types';
+
+import {
+  addJSDocComment,
+  generateCode,
+} from '../../core/codegen/babel-ast';
+import { addJSDocComment as addJSDocCommentHooks } from '../../core/codegen/hooks-ast';
+
+describe('addJSDocComment', () => {
+  describe('babel-ast', () => {
+    it('produces valid JSDoc for simple descriptions', () => {
+      const node = t.identifier('x');
+      addJSDocComment(node, ['A simple description']);
+      const code = generateCode([
+        t.variableDeclaration('const', [
+          t.variableDeclarator(node, t.numericLiteral(1)),
+        ]),
+      ]);
+      expect(code).toContain('/** A simple description */');
+      expect(code).not.toContain('*/\n');
+    });
+
+    it('sanitizes */ in single-line descriptions', () => {
+      const node = t.identifier('x');
+      addJSDocComment(node, [
+        'Reads and enables pagination through a set of */ values.',
+      ]);
+      const code = generateCode([
+        t.variableDeclaration('const', [
+          t.variableDeclarator(node, t.numericLiteral(1)),
+        ]),
+      ]);
+      expect(code).toContain('*\\/');
+      expect(code).not.toMatch(/\/\*.*\*\/.*\*\//);
+    });
+
+    it('sanitizes */ in multi-line descriptions', () => {
+      const node = t.identifier('x');
+      addJSDocComment(node, [
+        'First line with */ embedded',
+        'Second line is fine',
+        'Third line also has */ inside',
+      ]);
+      const code = generateCode([
+        t.variableDeclaration('const', [
+          t.variableDeclarator(node, t.numericLiteral(1)),
+        ]),
+      ]);
+      const commentMatch = code.match(/\/\*[\s\S]*?\*\//);
+      expect(commentMatch).not.toBeNull();
+      const comment = commentMatch![0];
+      const innerSlashes = comment.slice(2, -2);
+      expect(innerSlashes).not.toContain('*/');
+    });
+  });
+
+  describe('hooks-ast', () => {
+    it('produces valid JSDoc for simple descriptions', () => {
+      const node = t.identifier('y');
+      addJSDocCommentHooks(node, ['A simple description']);
+      expect(node.leadingComments).toHaveLength(1);
+      expect(node.leadingComments![0].value).toBe('* A simple description ');
+    });
+
+    it('sanitizes */ in single-line descriptions', () => {
+      const node = t.identifier('y');
+      addJSDocCommentHooks(node, [
+        'Reads and enables pagination through a set of */ values.',
+      ]);
+      expect(node.leadingComments![0].value).not.toContain('*/');
+      expect(node.leadingComments![0].value).toContain('*\\/');
+    });
+
+    it('sanitizes */ in multi-line descriptions', () => {
+      const node = t.identifier('y');
+      addJSDocCommentHooks(node, [
+        'Line with */ problem',
+        'Normal line',
+      ]);
+      const commentValue = node.leadingComments![0].value;
+      expect(commentValue).not.toContain('*/');
+      expect(commentValue).toContain('*\\/');
+    });
+  });
+});

--- a/graphql/codegen/src/core/codegen/babel-ast.ts
+++ b/graphql/codegen/src/core/codegen/babel-ast.ts
@@ -50,10 +50,11 @@ export const commentLine = (value: string): t.CommentLine => {
  * Add a leading JSDoc comment to a node
  */
 export function addJSDocComment<T extends t.Node>(node: T, lines: string[]): T {
+  const sanitized = lines.map((line) => line.replace(/\*\//g, '*\\/'));
   const commentText =
-    lines.length === 1
-      ? `* ${lines[0]} `
-      : `*\n${lines.map((line) => ` * ${line}`).join('\n')}\n `;
+    sanitized.length === 1
+      ? `* ${sanitized[0]} `
+      : `*\n${sanitized.map((line) => ` * ${line}`).join('\n')}\n `;
 
   if (!node.leadingComments) {
     node.leadingComments = [];

--- a/graphql/codegen/src/core/codegen/hooks-ast.ts
+++ b/graphql/codegen/src/core/codegen/hooks-ast.ts
@@ -570,10 +570,11 @@ export function destructureParamsWithSelectionAndScope(
 // ============================================================================
 
 export function addJSDocComment<T extends t.Node>(node: T, lines: string[]): T {
+  const sanitized = lines.map((line) => line.replace(/\*\//g, '*\\/'));
   const text =
-    lines.length === 1
-      ? `* ${lines[0]} `
-      : `*\n${lines.map((line) => ` * ${line}`).join('\n')}\n `;
+    sanitized.length === 1
+      ? `* ${sanitized[0]} `
+      : `*\n${sanitized.map((line) => ` * ${line}`).join('\n')}\n `;
   if (!node.leadingComments) {
     node.leadingComments = [];
   }


### PR DESCRIPTION
## Summary

When `codegen.comments: true` is enabled, `addJSDocComment()` in both `babel-ast.ts` and `hooks-ast.ts` embeds field descriptions directly into `/* ... */` block comments without sanitizing. If a description contains a literal `*/` sequence (common in PostGraphile-generated descriptions like "Reads and enables pagination through a set of ..."), it prematurely closes the JSDoc comment block and produces invalid JavaScript/TypeScript.

This PR applies `*/` → `*\/` sanitization to both `addJSDocComment` implementations and adds unit tests to prevent regression.

**Changes:**
- `babel-ast.ts`: sanitize `*/` in lines before building comment text
- `hooks-ast.ts`: same sanitization applied
- New test file `jsdoc-comment.test.ts`: 6 tests covering single-line, multi-line, and safe descriptions for both implementations

Closes constructive-io/constructive-planning#820

## Review & Testing Checklist for Human

- [ ] Verify generated JSDoc output looks correct when `codegen.comments: true` is used with a schema containing `*/` in field descriptions
- [ ] Confirm the `*\/` escape renders acceptably in IDE tooltips and documentation generators

### Notes

The downstream workaround (`comments: false` in constructive-db's codegen-helper.ts) can be reverted once this fix is merged.

Link to Devin session: https://app.devin.ai/sessions/2ddfbe8d8fc04675af6e2540decbafe1
Requested by: @pyramation