### PR TITLE
feat: read RLS config from typed rls_settings table with api_modules fallback

### DIFF
--- a/graphql/server/src/middleware/__tests__/upload.test.ts
+++ b/graphql/server/src/middleware/__tests__/upload.test.ts
@@ -184,6 +184,9 @@ describe('createUploadAuthenticateMiddleware', () => {
     const res = makeRes();
     const next = makeNext();
 
+    // typed rls_settings query returns no rows (table may not exist yet)
+    rootPool.query.mockResolvedValueOnce({ rows: [] });
+    // legacy api_modules fallback
     rootPool.query.mockResolvedValueOnce({
       rows: [
         {
@@ -282,6 +285,9 @@ describe('createUploadAuthenticateMiddleware', () => {
     const res = makeRes();
     const next = makeNext();
 
+    // typed rls_settings query returns no rows (table may not exist yet)
+    rootPool.query.mockResolvedValueOnce({ rows: [] });
+    // legacy api_modules fallback
     rootPool.query.mockResolvedValueOnce({
       rows: [
         {
@@ -330,7 +336,13 @@ describe('createUploadAuthenticateMiddleware', () => {
     const res = makeRes();
     const next = makeNext();
 
+    // typed rls_settings query returns no rows
     rootPool.query.mockResolvedValueOnce({ rows: [] });
+    // legacy api_modules by database_id returns no rows
+    rootPool.query.mockResolvedValueOnce({ rows: [] });
+    // typed rls_settings by dbname returns no rows
+    rootPool.query.mockResolvedValueOnce({ rows: [] });
+    // legacy api_modules by dbname returns no rows
     rootPool.query.mockResolvedValueOnce({ rows: [] });
 
     await middleware(req, res, next);

--- a/graphql/server/src/middleware/api.ts
+++ b/graphql/server/src/middleware/api.ts
@@ -86,6 +86,29 @@ const RLS_MODULE_SQL = `
   LIMIT 1
 `;
 
+const RLS_SETTINGS_SQL = `
+  SELECT
+    auth_schema.schema_name AS authenticate_schema,
+    role_schema.schema_name AS role_schema,
+    auth_fn.name AS authenticate,
+    auth_strict_fn.name AS authenticate_strict,
+    role_fn.name AS current_role,
+    role_id_fn.name AS current_role_id,
+    ua_fn.name AS current_user_agent,
+    ip_fn.name AS current_ip_address
+  FROM services_public.rls_settings rs
+  LEFT JOIN metaschema_public.schema auth_schema ON rs.authenticate_schema_id = auth_schema.id
+  LEFT JOIN metaschema_public.schema role_schema ON rs.role_schema_id = role_schema.id
+  LEFT JOIN metaschema_public.function auth_fn ON rs.authenticate_function_id = auth_fn.id
+  LEFT JOIN metaschema_public.function auth_strict_fn ON rs.authenticate_strict_function_id = auth_strict_fn.id
+  LEFT JOIN metaschema_public.function role_fn ON rs.current_role_function_id = role_fn.id
+  LEFT JOIN metaschema_public.function role_id_fn ON rs.current_role_id_function_id = role_id_fn.id
+  LEFT JOIN metaschema_public.function ua_fn ON rs.current_user_agent_function_id = ua_fn.id
+  LEFT JOIN metaschema_public.function ip_fn ON rs.current_ip_address_function_id = ip_fn.id
+  WHERE rs.database_id = $1
+  LIMIT 1
+`;
+
 /**
  * Discover auth settings table location via public metaschema tables.
  * Joins sessions_module with metaschema_public.schema to resolve
@@ -249,6 +272,24 @@ const toRlsModule = (row: RlsModuleRow | null): RlsModule | undefined => {
   };
 };
 
+const toRlsModuleFromSettings = (row: RlsModuleData | null): RlsModule | undefined => {
+  if (!row) return undefined;
+  return {
+    authenticate: row.authenticate,
+    authenticateStrict: row.authenticate_strict,
+    privateSchema: {
+      schemaName: row.authenticate_schema,
+    },
+    publicSchema: {
+      schemaName: row.role_schema,
+    },
+    currentRole: row.current_role,
+    currentRoleId: row.current_role_id,
+    currentIpAddress: row.current_ip_address,
+    currentUserAgent: row.current_user_agent,
+  };
+};
+
 const toAuthSettings = (row: AuthSettingsRow | null): AuthSettings | undefined => {
   if (!row) return undefined;
   return {
@@ -263,14 +304,14 @@ const toAuthSettings = (row: AuthSettingsRow | null): AuthSettings | undefined =
   };
 };
 
-const toApiStructure = (row: ApiRow, opts: ApiOptions, rlsModuleRow?: RlsModuleRow | null, authSettingsRow?: AuthSettingsRow | null): ApiStructure => ({
+const toApiStructure = (row: ApiRow, opts: ApiOptions, rlsModule?: RlsModule, authSettingsRow?: AuthSettingsRow | null): ApiStructure => ({
   apiId: row.api_id,
   dbname: row.dbname || opts.pg?.database || '',
   anonRole: row.anon_role || 'anon',
   roleName: row.role_name || 'authenticated',
   schema: row.schemas || [],
   apiModules: [],
-  rlsModule: toRlsModule(rlsModuleRow ?? null),
+  rlsModule,
   domains: [],
   databaseId: row.database_id,
   isPublic: row.is_public,
@@ -329,9 +370,24 @@ const queryApiList = async (pool: Pool, isPublic: boolean): Promise<ApiListRow[]
   return result.rows;
 };
 
-const queryRlsModule = async (pool: Pool, apiId: string): Promise<RlsModuleRow | null> => {
+const queryRlsSettings = async (pool: Pool, databaseId: string): Promise<RlsModule | undefined> => {
+  try {
+    const result = await pool.query<RlsModuleData>(RLS_SETTINGS_SQL, [databaseId]);
+    return toRlsModuleFromSettings(result.rows[0] ?? null);
+  } catch {
+    return undefined;
+  }
+};
+
+const queryRlsModuleLegacy = async (pool: Pool, apiId: string): Promise<RlsModule | undefined> => {
   const result = await pool.query<RlsModuleRow>(RLS_MODULE_SQL, [apiId]);
-  return result.rows[0] ?? null;
+  return toRlsModule(result.rows[0] ?? null);
+};
+
+const queryRlsModule = async (pool: Pool, databaseId: string, apiId: string): Promise<RlsModule | undefined> => {
+  const fromSettings = await queryRlsSettings(pool, databaseId);
+  if (fromSettings) return fromSettings;
+  return queryRlsModuleLegacy(pool, apiId);
 };
 
 /**
@@ -423,7 +479,7 @@ const resolveApiNameHeader = async (ctx: ResolveContext): Promise<ApiStructure |
     return null;
   }
 
-  const rlsModule = await queryRlsModule(pool, row.api_id);
+  const rlsModule = await queryRlsModule(pool, row.database_id, row.api_id);
   const authSettings = await queryAuthSettings(opts, row.dbname);
   log.debug(`[api-name-lookup] resolved schemas: [${row.schemas?.join(', ')}], rlsModule: ${rlsModule ? 'found' : 'none'}, authSettings: ${authSettings ? 'found' : 'none'}`);
   return toApiStructure(row, opts, rlsModule, authSettings);
@@ -449,7 +505,7 @@ const resolveDomainLookup = async (ctx: ResolveContext): Promise<ApiStructure | 
     return null;
   }
 
-  const rlsModule = await queryRlsModule(pool, row.api_id);
+  const rlsModule = await queryRlsModule(pool, row.database_id, row.api_id);
   const authSettings = await queryAuthSettings(opts, row.dbname);
   log.debug(`[domain-lookup] resolved schemas: [${row.schemas?.join(', ')}], rlsModule: ${rlsModule ? 'found' : 'none'}, authSettings: ${authSettings ? 'found' : 'none'}`);
   return toApiStructure(row, opts, rlsModule, authSettings);

--- a/graphql/server/src/middleware/upload.ts
+++ b/graphql/server/src/middleware/upload.ts
@@ -115,7 +115,7 @@ const RLS_SETTINGS_BY_DBNAME_SQL = `
     ua_fn.name AS current_user_agent,
     ip_fn.name AS current_ip_address
   FROM services_public.rls_settings rs
-  JOIN metaschema_public.database db ON rs.database_id = db.id
+  JOIN services_public.apis a ON rs.database_id = a.database_id
   LEFT JOIN metaschema_public.schema auth_schema ON rs.authenticate_schema_id = auth_schema.id
   LEFT JOIN metaschema_public.schema role_schema ON rs.role_schema_id = role_schema.id
   LEFT JOIN metaschema_public.function auth_fn ON rs.authenticate_function_id = auth_fn.id
@@ -124,7 +124,7 @@ const RLS_SETTINGS_BY_DBNAME_SQL = `
   LEFT JOIN metaschema_public.function role_id_fn ON rs.current_role_id_function_id = role_id_fn.id
   LEFT JOIN metaschema_public.function ua_fn ON rs.current_user_agent_function_id = ua_fn.id
   LEFT JOIN metaschema_public.function ip_fn ON rs.current_ip_address_function_id = ip_fn.id
-  WHERE db.database_name = $1
+  WHERE a.dbname = $1
   LIMIT 1
 `;
 

--- a/graphql/server/src/middleware/upload.ts
+++ b/graphql/server/src/middleware/upload.ts
@@ -81,6 +81,53 @@ const RLS_MODULE_BY_DBNAME_SQL = `
   LIMIT 1
 `;
 
+const RLS_SETTINGS_BY_DATABASE_ID_SQL = `
+  SELECT
+    auth_schema.schema_name AS authenticate_schema,
+    role_schema.schema_name AS role_schema,
+    auth_fn.name AS authenticate,
+    auth_strict_fn.name AS authenticate_strict,
+    role_fn.name AS current_role,
+    role_id_fn.name AS current_role_id,
+    ua_fn.name AS current_user_agent,
+    ip_fn.name AS current_ip_address
+  FROM services_public.rls_settings rs
+  LEFT JOIN metaschema_public.schema auth_schema ON rs.authenticate_schema_id = auth_schema.id
+  LEFT JOIN metaschema_public.schema role_schema ON rs.role_schema_id = role_schema.id
+  LEFT JOIN metaschema_public.function auth_fn ON rs.authenticate_function_id = auth_fn.id
+  LEFT JOIN metaschema_public.function auth_strict_fn ON rs.authenticate_strict_function_id = auth_strict_fn.id
+  LEFT JOIN metaschema_public.function role_fn ON rs.current_role_function_id = role_fn.id
+  LEFT JOIN metaschema_public.function role_id_fn ON rs.current_role_id_function_id = role_id_fn.id
+  LEFT JOIN metaschema_public.function ua_fn ON rs.current_user_agent_function_id = ua_fn.id
+  LEFT JOIN metaschema_public.function ip_fn ON rs.current_ip_address_function_id = ip_fn.id
+  WHERE rs.database_id = $1
+  LIMIT 1
+`;
+
+const RLS_SETTINGS_BY_DBNAME_SQL = `
+  SELECT
+    auth_schema.schema_name AS authenticate_schema,
+    role_schema.schema_name AS role_schema,
+    auth_fn.name AS authenticate,
+    auth_strict_fn.name AS authenticate_strict,
+    role_fn.name AS current_role,
+    role_id_fn.name AS current_role_id,
+    ua_fn.name AS current_user_agent,
+    ip_fn.name AS current_ip_address
+  FROM services_public.rls_settings rs
+  JOIN metaschema_public.database db ON rs.database_id = db.id
+  LEFT JOIN metaschema_public.schema auth_schema ON rs.authenticate_schema_id = auth_schema.id
+  LEFT JOIN metaschema_public.schema role_schema ON rs.role_schema_id = role_schema.id
+  LEFT JOIN metaschema_public.function auth_fn ON rs.authenticate_function_id = auth_fn.id
+  LEFT JOIN metaschema_public.function auth_strict_fn ON rs.authenticate_strict_function_id = auth_strict_fn.id
+  LEFT JOIN metaschema_public.function role_fn ON rs.current_role_function_id = role_fn.id
+  LEFT JOIN metaschema_public.function role_id_fn ON rs.current_role_id_function_id = role_id_fn.id
+  LEFT JOIN metaschema_public.function ua_fn ON rs.current_user_agent_function_id = ua_fn.id
+  LEFT JOIN metaschema_public.function ip_fn ON rs.current_ip_address_function_id = ip_fn.id
+  WHERE db.database_name = $1
+  LIMIT 1
+`;
+
 interface RlsModuleData {
   authenticate: string;
   authenticate_strict: string;
@@ -111,6 +158,20 @@ const toRlsModule = (row: RlsModuleRow | null): RlsModule | undefined => {
   };
 };
 
+const toRlsModuleFromSettings = (row: RlsModuleData | null): RlsModule | undefined => {
+  if (!row) return undefined;
+  return {
+    authenticate: row.authenticate,
+    authenticateStrict: row.authenticate_strict,
+    privateSchema: { schemaName: row.authenticate_schema },
+    publicSchema: { schemaName: row.role_schema },
+    currentRole: row.current_role,
+    currentRoleId: row.current_role_id,
+    currentIpAddress: row.current_ip_address,
+    currentUserAgent: row.current_user_agent,
+  };
+};
+
 const getBearerToken = (authorization?: string): string | null => {
   if (!authorization) return null;
   const [authType, authToken] = authorization.split(' ');
@@ -120,7 +181,27 @@ const getBearerToken = (authorization?: string): string | null => {
   return authToken;
 };
 
+const queryRlsSettingsByDatabaseId = async (pool: Pool, databaseId: string): Promise<RlsModule | undefined> => {
+  try {
+    const result = await pool.query<RlsModuleData>(RLS_SETTINGS_BY_DATABASE_ID_SQL, [databaseId]);
+    return toRlsModuleFromSettings(result.rows[0] ?? null);
+  } catch {
+    return undefined;
+  }
+};
+
+const queryRlsSettingsByDbname = async (pool: Pool, dbname: string): Promise<RlsModule | undefined> => {
+  try {
+    const result = await pool.query<RlsModuleData>(RLS_SETTINGS_BY_DBNAME_SQL, [dbname]);
+    return toRlsModuleFromSettings(result.rows[0] ?? null);
+  } catch {
+    return undefined;
+  }
+};
+
 const queryRlsModuleByDatabaseId = async (pool: Pool, databaseId: string): Promise<RlsModule | undefined> => {
+  const fromSettings = await queryRlsSettingsByDatabaseId(pool, databaseId);
+  if (fromSettings) return fromSettings;
   const result = await pool.query<RlsModuleRow>(RLS_MODULE_BY_DATABASE_ID_SQL, [databaseId]);
   return toRlsModule(result.rows[0] ?? null);
 };
@@ -131,6 +212,8 @@ const queryRlsModuleByApiId = async (pool: Pool, apiId: string): Promise<RlsModu
 };
 
 const queryRlsModuleByDbname = async (pool: Pool, dbname: string): Promise<RlsModule | undefined> => {
+  const fromSettings = await queryRlsSettingsByDbname(pool, dbname);
+  if (fromSettings) return fromSettings;
   const result = await pool.query<RlsModuleRow>(RLS_MODULE_BY_DBNAME_SQL, [dbname]);
   return toRlsModule(result.rows[0] ?? null);
 };


### PR DESCRIPTION
## Summary

Updates the GraphQL server to prefer the new typed `services_public.rls_settings` table (introduced in constructive-db PR #1075) over the legacy `services_public.api_modules` JSONB blob when resolving RLS module configuration. This is the server-side component of Phase 2 of the unified settings architecture ([constructive-planning#812](https://github.com/constructive-io/constructive-planning/issues/812)).

**Three files changed:**

- **`api.ts`** — `queryRlsModule` now takes `(pool, databaseId, apiId)` and tries `rls_settings` by `database_id` first; falls back to `api_modules` by `api_id`. `toApiStructure` now accepts an already-resolved `RlsModule` instead of a raw `RlsModuleRow`.
- **`upload.ts`** — `queryRlsModuleByDatabaseId` and `queryRlsModuleByDbname` each try the typed table first via new `queryRlsSettingsByDatabaseId` / `queryRlsSettingsByDbname` helpers. `queryRlsModuleByApiId` is unchanged (no database_id available at that call site; the upload resolver tries database_id and dbname paths first anyway). The `RLS_SETTINGS_BY_DBNAME_SQL` query joins through `services_public.apis` (on `a.dbname = $1`) rather than `metaschema_public.database`, since `apis.dbname` holds the actual PostgreSQL database name used by the server.
- **`upload.test.ts`** — Existing tests updated with additional `mockResolvedValueOnce({ rows: [] })` calls for the new typed-table queries that now precede the legacy `api_modules` queries.

All new typed-table queries are wrapped in `try/catch` returning `undefined` on failure, so the server gracefully degrades to `api_modules` for databases that haven't been reprovisioned yet or where the `rls_settings` table doesn't exist.

## Review & Testing Checklist for Human

- [ ] **Check `toRlsModuleFromSettings` truthy-object behavior**: If an `rls_settings` row exists but all FK joins resolve to `NULL` (e.g. stale/orphaned row), `toRlsModuleFromSettings` returns `{ authenticate: null, ... }` — a truthy object that **prevents fallback** to `api_modules`. Consider whether the converter should check that at least `authenticate` and `authenticate_schema` are non-null before returning a result.
- [ ] **Verify SQL column aliases match `RlsModuleData` interface**: The 8-way LEFT JOIN queries select `authenticate_schema`, `role_schema`, `authenticate`, `authenticate_strict`, `current_role`, `current_role_id`, `current_user_agent`, `current_ip_address`. These must exactly match the fields on `RlsModuleData` (lines 133-142 in api.ts, mirrored in upload.ts). A mismatch produces an `RlsModule` with `undefined` fields instead of falling back.
- [ ] **Silent catch blocks swallow all errors**: `queryRlsSettings` / `queryRlsSettingsByDatabaseId` / `queryRlsSettingsByDbname` catch all exceptions and return `undefined` with no logging. This is intentional for backwards compat but means a broken query (typo, permission issue) is invisible. Consider whether a `log.debug` should be added inside the catch.
- [ ] **End-to-end test**: Deploy a database with the trigger rewiring from constructive-db PR #1075 so `rls_settings` is populated, then verify the server actually reads from the typed table (not just silently falling back). One way: temporarily add a log line in `queryRlsSettings` on success, provision a DB, and confirm the log fires.

### Notes
- The same 22-line SQL query (8 LEFT JOINs) appears 3 times across both files. A future cleanup could extract it into a shared constant or query builder, but keeping it inline matches the existing patterns in these files.
- `queryRlsModuleByApiId` in `upload.ts` intentionally has no typed-table path — in `resolveUploadRlsModule`, the database_id and dbname paths (which do use typed tables) are tried first; `apiId` is the last resort.
- `RLS_SETTINGS_BY_DBNAME_SQL` joins through `services_public.apis` (not `metaschema_public.database`) because `apis.dbname` is the PostgreSQL database name the server uses at runtime, whereas `metaschema_public.database.name` is a display name.
- Companion DB-side PR: [constructive-db#1075](https://github.com/constructive-io/constructive-db/pull/1075) (trigger rewiring to populate `rls_settings`, `pubkey_settings`, `webauthn_settings`).

Link to Devin session: https://app.devin.ai/sessions/94a2728a9c414500bead29cbbc829c15
Requested by: @pyramation