### PR TITLE
feat(graphile-test): add withTransaction to pgClient in test context

### DIFF
--- a/graphile/graphile-test/src/context.ts
+++ b/graphile/graphile-test/src/context.ts
@@ -270,8 +270,28 @@ export const runGraphQLInContext = async <T = ExecutionResult>({
     _pgSettings: Record<string, string> | null,
     callback: (client: Client) => T | Promise<T>
   ): Promise<T> => {
-    // Simply use the test client - it's already in a transaction
-    // The pgSettings have already been applied above via setContextOnClient
+    // Augment the client with withTransaction if it doesn't already have it.
+    // In production, @dataplan/pg provides this method. In tests the raw pg
+    // Client lacks it, so we implement it via savepoints (which nest cleanly
+    // inside the test harness's outer transaction).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const client = pgClient as any;
+    if (typeof client.withTransaction !== 'function') {
+      client.withTransaction = async (
+        cb: (txClient: Client) => unknown | Promise<unknown>
+      ) => {
+        const sp = `wt_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+        await client.query(`SAVEPOINT ${sp}`);
+        try {
+          const result = await cb(client);
+          await client.query(`RELEASE SAVEPOINT ${sp}`);
+          return result;
+        } catch (err) {
+          await client.query(`ROLLBACK TO SAVEPOINT ${sp}`);
+          throw err;
+        }
+      };
+    }
     return callback(pgClient);
   };
 


### PR DESCRIPTION
## Summary

Adds a savepoint-based `withTransaction` implementation to the `pgClient` provided inside the `withPgClient` callback in `graphile-test`'s execution context.

In production, `@dataplan/pg` provides `withTransaction` on the pgClient. In tests, the raw `pg.Client` from `pgsql-test` lacks this method, causing any Graphile plugin that calls `pgClient.withTransaction()` (e.g. `graphile-presigned-url-plugin`) to crash at runtime unless each test file manually monkey-patches the method.

This fix augments the client lazily (guarded by `typeof` check) with a savepoint-based implementation that nests cleanly inside the test harness's outer transaction. Downstream tests in `constructive-db` can now remove their per-file monkey patches.

## Review & Testing Checklist for Human

- [ ] Verify the savepoint-based `withTransaction` behaves correctly when the callback throws (should `ROLLBACK TO SAVEPOINT` and re-throw, not leave the transaction in a broken state)
- [ ] Confirm that mutating `pgClient` (attaching `withTransaction` permanently) doesn't cause issues across multiple `withPgClient` calls in the same test — the `if` guard prevents re-assignment but the method stays attached
- [ ] After publishing, verify downstream: remove the monkey patch from `constructive-db`'s `minio-multi-scope-graphql.integration.test.ts` and confirm the storage upload tests still pass

### Notes

- No unit test added in this PR. The method is exercised by the presigned-url plugin's upload flow in `constructive-db`'s integration tests. A focused unit test could be added as a follow-up.
- The `eslint-disable` for `@typescript-eslint/no-explicit-any` is required because the raw `pg.Client` type doesn't declare `withTransaction`.

Link to Devin session: https://app.devin.ai/sessions/7903d2a3e7a34c6daa605e12d6b80d9e
Requested by: @pyramation