### PR TITLE
fix(csv-to-pg): add preserveEmptyStrings option, default true

### DIFF
--- a/packages/csv-to-pg/__tests__/__snapshots__/export.test.ts.snap
+++ b/packages/csv-to-pg/__tests__/__snapshots__/export.test.ts.snap
@@ -94,6 +94,26 @@ exports[`test case test case parser 1`] = `
   ('450e3b3b-b68d-4abc-990c-65cb8a1dcdb4', '450e3b3b-b68d-4abc-990c-65cb8a1dcdb4', '450e3b3b-b68d-4abc-990c-65cb8a1dcdb4', 'name here', 'description');"
 `;
 
+exports[`test case text fields preserve empty strings instead of converting to NULL 1`] = `
+"INSERT INTO services_public.webauthn_settings (
+  id,
+  database_id,
+  rp_id,
+  rp_name
+) VALUES
+  ('450e3b3b-b68d-4abc-990c-65cb8a1dcdb4', '550e8400-e29b-41d4-a716-446655440000', '', '');"
+`;
+
+exports[`test case text fields with null values produce NULL 1`] = `
+"INSERT INTO services_public.webauthn_settings (
+  id,
+  database_id,
+  rp_id,
+  rp_name
+) VALUES
+  ('450e3b3b-b68d-4abc-990c-65cb8a1dcdb4', '550e8400-e29b-41d4-a716-446655440000', NULL, NULL);"
+`;
+
 exports[`test case uuid[] arrays 1`] = `
 "INSERT INTO metaschema_public.primary_key_constraint (
   id,

--- a/packages/csv-to-pg/__tests__/__snapshots__/export.test.ts.snap
+++ b/packages/csv-to-pg/__tests__/__snapshots__/export.test.ts.snap
@@ -94,7 +94,7 @@ exports[`test case test case parser 1`] = `
   ('450e3b3b-b68d-4abc-990c-65cb8a1dcdb4', '450e3b3b-b68d-4abc-990c-65cb8a1dcdb4', '450e3b3b-b68d-4abc-990c-65cb8a1dcdb4', 'name here', 'description');"
 `;
 
-exports[`test case text fields convert empty strings to NULL by default 1`] = `
+exports[`test case text fields convert empty strings to NULL when preserveEmptyStrings is false 1`] = `
 "INSERT INTO services_public.webauthn_settings (
   id,
   database_id,
@@ -104,7 +104,7 @@ exports[`test case text fields convert empty strings to NULL by default 1`] = `
   ('450e3b3b-b68d-4abc-990c-65cb8a1dcdb4', '550e8400-e29b-41d4-a716-446655440000', NULL, NULL);"
 `;
 
-exports[`test case text fields preserve empty strings when preserveEmptyStrings is true 1`] = `
+exports[`test case text fields preserve empty strings by default 1`] = `
 "INSERT INTO services_public.webauthn_settings (
   id,
   database_id,
@@ -114,7 +114,7 @@ exports[`test case text fields preserve empty strings when preserveEmptyStrings 
   ('450e3b3b-b68d-4abc-990c-65cb8a1dcdb4', '550e8400-e29b-41d4-a716-446655440000', '', '');"
 `;
 
-exports[`test case text fields with null values produce NULL even with preserveEmptyStrings 1`] = `
+exports[`test case text fields with null values produce NULL 1`] = `
 "INSERT INTO services_public.webauthn_settings (
   id,
   database_id,

--- a/packages/csv-to-pg/__tests__/__snapshots__/export.test.ts.snap
+++ b/packages/csv-to-pg/__tests__/__snapshots__/export.test.ts.snap
@@ -94,7 +94,17 @@ exports[`test case test case parser 1`] = `
   ('450e3b3b-b68d-4abc-990c-65cb8a1dcdb4', '450e3b3b-b68d-4abc-990c-65cb8a1dcdb4', '450e3b3b-b68d-4abc-990c-65cb8a1dcdb4', 'name here', 'description');"
 `;
 
-exports[`test case text fields preserve empty strings instead of converting to NULL 1`] = `
+exports[`test case text fields convert empty strings to NULL by default 1`] = `
+"INSERT INTO services_public.webauthn_settings (
+  id,
+  database_id,
+  rp_id,
+  rp_name
+) VALUES
+  ('450e3b3b-b68d-4abc-990c-65cb8a1dcdb4', '550e8400-e29b-41d4-a716-446655440000', NULL, NULL);"
+`;
+
+exports[`test case text fields preserve empty strings when preserveEmptyStrings is true 1`] = `
 "INSERT INTO services_public.webauthn_settings (
   id,
   database_id,
@@ -104,7 +114,7 @@ exports[`test case text fields preserve empty strings instead of converting to N
   ('450e3b3b-b68d-4abc-990c-65cb8a1dcdb4', '550e8400-e29b-41d4-a716-446655440000', '', '');"
 `;
 
-exports[`test case text fields with null values produce NULL 1`] = `
+exports[`test case text fields with null values produce NULL even with preserveEmptyStrings 1`] = `
 "INSERT INTO services_public.webauthn_settings (
   id,
   database_id,

--- a/packages/csv-to-pg/__tests__/export.test.ts
+++ b/packages/csv-to-pg/__tests__/export.test.ts
@@ -276,7 +276,7 @@ it('empty array fields emit empty array literal', async () => {
   expect(sql).toMatchSnapshot();
 });
 
-it('text fields convert empty strings to NULL by default', async () => {
+it('text fields preserve empty strings by default', async () => {
   const parser = new Parser({
     schema: 'services_public',
     singleStmts: true,
@@ -298,45 +298,44 @@ it('text fields convert empty strings to NULL by default', async () => {
     }
   ]);
 
-  // Default behavior: empty strings are treated as NULL (CSV convention)
-  expect(sql).toContain('NULL');
-  expect(sql).toMatchSnapshot();
-});
-
-it('text fields preserve empty strings when preserveEmptyStrings is true', async () => {
-  const parser = new Parser({
-    schema: 'services_public',
-    singleStmts: true,
-    table: 'webauthn_settings',
-    preserveEmptyStrings: true,
-    fields: {
-      id: 'uuid',
-      database_id: 'uuid',
-      rp_id: 'text',
-      rp_name: 'text'
-    }
-  });
-
-  const sql = await parser.parse([
-    {
-      id: '450e3b3b-b68d-4abc-990c-65cb8a1dcdb4',
-      database_id: '550e8400-e29b-41d4-a716-446655440000',
-      rp_id: '',
-      rp_name: ''
-    }
-  ]);
-
-  // With preserveEmptyStrings, empty strings are kept as '' not NULL
+  // Default: empty strings are preserved as ''
   expect(sql).not.toContain('NULL');
   expect(sql).toMatchSnapshot();
 });
 
-it('text fields with null values produce NULL even with preserveEmptyStrings', async () => {
+it('text fields convert empty strings to NULL when preserveEmptyStrings is false', async () => {
   const parser = new Parser({
     schema: 'services_public',
     singleStmts: true,
     table: 'webauthn_settings',
-    preserveEmptyStrings: true,
+    preserveEmptyStrings: false,
+    fields: {
+      id: 'uuid',
+      database_id: 'uuid',
+      rp_id: 'text',
+      rp_name: 'text'
+    }
+  });
+
+  const sql = await parser.parse([
+    {
+      id: '450e3b3b-b68d-4abc-990c-65cb8a1dcdb4',
+      database_id: '550e8400-e29b-41d4-a716-446655440000',
+      rp_id: '',
+      rp_name: ''
+    }
+  ]);
+
+  // Opt-in: empty strings treated as NULL (CSV convention)
+  expect(sql).toContain('NULL');
+  expect(sql).toMatchSnapshot();
+});
+
+it('text fields with null values produce NULL', async () => {
+  const parser = new Parser({
+    schema: 'services_public',
+    singleStmts: true,
+    table: 'webauthn_settings',
     fields: {
       id: 'uuid',
       database_id: 'uuid',

--- a/packages/csv-to-pg/__tests__/export.test.ts
+++ b/packages/csv-to-pg/__tests__/export.test.ts
@@ -276,6 +276,60 @@ it('empty array fields emit empty array literal', async () => {
   expect(sql).toMatchSnapshot();
 });
 
+it('text fields preserve empty strings instead of converting to NULL', async () => {
+  const parser = new Parser({
+    schema: 'services_public',
+    singleStmts: true,
+    table: 'webauthn_settings',
+    fields: {
+      id: 'uuid',
+      database_id: 'uuid',
+      rp_id: 'text',
+      rp_name: 'text'
+    }
+  });
+
+  const sql = await parser.parse([
+    {
+      id: '450e3b3b-b68d-4abc-990c-65cb8a1dcdb4',
+      database_id: '550e8400-e29b-41d4-a716-446655440000',
+      rp_id: '',
+      rp_name: ''
+    }
+  ]);
+
+  // Empty strings should be preserved as '' not converted to NULL
+  expect(sql).not.toContain('NULL');
+  expect(sql).toMatchSnapshot();
+});
+
+it('text fields with null values produce NULL', async () => {
+  const parser = new Parser({
+    schema: 'services_public',
+    singleStmts: true,
+    table: 'webauthn_settings',
+    fields: {
+      id: 'uuid',
+      database_id: 'uuid',
+      rp_id: 'text',
+      rp_name: 'text'
+    }
+  });
+
+  const sql = await parser.parse([
+    {
+      id: '450e3b3b-b68d-4abc-990c-65cb8a1dcdb4',
+      database_id: '550e8400-e29b-41d4-a716-446655440000',
+      rp_id: null,
+      rp_name: null
+    }
+  ]);
+
+  // Actual null values should still produce NULL
+  expect(sql).toContain('NULL');
+  expect(sql).toMatchSnapshot();
+});
+
 it('interval type with string value', async () => {
   const parser = new Parser({
     schema: 'metaschema_modules_public',

--- a/packages/csv-to-pg/__tests__/export.test.ts
+++ b/packages/csv-to-pg/__tests__/export.test.ts
@@ -276,7 +276,7 @@ it('empty array fields emit empty array literal', async () => {
   expect(sql).toMatchSnapshot();
 });
 
-it('text fields preserve empty strings instead of converting to NULL', async () => {
+it('text fields convert empty strings to NULL by default', async () => {
   const parser = new Parser({
     schema: 'services_public',
     singleStmts: true,
@@ -298,16 +298,45 @@ it('text fields preserve empty strings instead of converting to NULL', async () 
     }
   ]);
 
-  // Empty strings should be preserved as '' not converted to NULL
-  expect(sql).not.toContain('NULL');
+  // Default behavior: empty strings are treated as NULL (CSV convention)
+  expect(sql).toContain('NULL');
   expect(sql).toMatchSnapshot();
 });
 
-it('text fields with null values produce NULL', async () => {
+it('text fields preserve empty strings when preserveEmptyStrings is true', async () => {
   const parser = new Parser({
     schema: 'services_public',
     singleStmts: true,
     table: 'webauthn_settings',
+    preserveEmptyStrings: true,
+    fields: {
+      id: 'uuid',
+      database_id: 'uuid',
+      rp_id: 'text',
+      rp_name: 'text'
+    }
+  });
+
+  const sql = await parser.parse([
+    {
+      id: '450e3b3b-b68d-4abc-990c-65cb8a1dcdb4',
+      database_id: '550e8400-e29b-41d4-a716-446655440000',
+      rp_id: '',
+      rp_name: ''
+    }
+  ]);
+
+  // With preserveEmptyStrings, empty strings are kept as '' not NULL
+  expect(sql).not.toContain('NULL');
+  expect(sql).toMatchSnapshot();
+});
+
+it('text fields with null values produce NULL even with preserveEmptyStrings', async () => {
+  const parser = new Parser({
+    schema: 'services_public',
+    singleStmts: true,
+    table: 'webauthn_settings',
+    preserveEmptyStrings: true,
     fields: {
       id: 'uuid',
       database_id: 'uuid',

--- a/packages/csv-to-pg/src/parse.ts
+++ b/packages/csv-to-pg/src/parse.ts
@@ -239,7 +239,7 @@ const makeNullOrThrow = (fieldName: string, rawValue: unknown, type: string, req
 
 // type (int, text, etc)
 // from Array of keys that map to records found (e.g., ['lon', 'lat'])
-const getCoercionFunc = (type: string, from: string[], opts: FieldOptions, fieldName: string): CoercionFunc => {
+const getCoercionFunc = (type: string, from: string[], opts: FieldOptions, fieldName: string, globalOpts?: GlobalParseOptions): CoercionFunc => {
   const parseFn = opts.parse || identity;
   const required = opts.required || false;
 
@@ -436,12 +436,10 @@ const getCoercionFunc = (type: string, from: string[], opts: FieldOptions, field
     case 'text':
       return (record: Record<string, unknown>): Node => {
         const rawValue = record[from[0]];
-        if (rawValue === null || rawValue === undefined) {
-          return makeNullOrThrow(fieldName, rawValue, type, required, 'value is null');
-        }
-        const value = parseFn(rawValue);
-        if (value === null || value === undefined) {
-          return makeNullOrThrow(fieldName, rawValue, type, required, 'value is null');
+        const cleansed = globalOpts?.preserveEmptyStrings ? rawValue : cleanseEmptyStrings(rawValue);
+        const value = parseFn(cleansed);
+        if (isEmpty(value)) {
+          return makeNullOrThrow(fieldName, rawValue, type, required, 'value is empty or null');
         }
         const val = nodes.aConst({
           sval: ast.string({ sval: String(value) })
@@ -528,8 +526,13 @@ interface ConfigFields {
   [key: string]: string | FieldOptions;
 }
 
+export interface GlobalParseOptions {
+  preserveEmptyStrings?: boolean;
+}
+
 interface Config {
   fields: ConfigFields;
+  preserveEmptyStrings?: boolean;
 }
 
 interface TypesMap {
@@ -537,6 +540,9 @@ interface TypesMap {
 }
 
 export const parseTypes = (config: Config): TypesMap => {
+  const globalOpts: GlobalParseOptions = {
+    preserveEmptyStrings: config.preserveEmptyStrings
+  };
   return Object.entries(config.fields).reduce<TypesMap>((m, v) => {
     let [key, value] = v;
     let type: string;
@@ -555,7 +561,7 @@ export const parseTypes = (config: Config): TypesMap => {
       type = value.type!;
       from = getFromValue(value.from || key);
     }
-    m[key] = getCoercionFunc(type, from, value, key);
+    m[key] = getCoercionFunc(type, from, value, key, globalOpts);
     return m;
   }, {});
 };

--- a/packages/csv-to-pg/src/parse.ts
+++ b/packages/csv-to-pg/src/parse.ts
@@ -436,9 +436,12 @@ const getCoercionFunc = (type: string, from: string[], opts: FieldOptions, field
     case 'text':
       return (record: Record<string, unknown>): Node => {
         const rawValue = record[from[0]];
-        const value = parseFn(cleanseEmptyStrings(rawValue));
-        if (isEmpty(value)) {
-          return makeNullOrThrow(fieldName, rawValue, type, required, 'value is empty or null');
+        if (rawValue === null || rawValue === undefined) {
+          return makeNullOrThrow(fieldName, rawValue, type, required, 'value is null');
+        }
+        const value = parseFn(rawValue);
+        if (value === null || value === undefined) {
+          return makeNullOrThrow(fieldName, rawValue, type, required, 'value is null');
         }
         const val = nodes.aConst({
           sval: ast.string({ sval: String(value) })

--- a/packages/csv-to-pg/src/parse.ts
+++ b/packages/csv-to-pg/src/parse.ts
@@ -436,7 +436,8 @@ const getCoercionFunc = (type: string, from: string[], opts: FieldOptions, field
     case 'text':
       return (record: Record<string, unknown>): Node => {
         const rawValue = record[from[0]];
-        const cleansed = globalOpts?.preserveEmptyStrings ? rawValue : cleanseEmptyStrings(rawValue);
+        const preserve = globalOpts?.preserveEmptyStrings !== false;
+        const cleansed = preserve ? rawValue : cleanseEmptyStrings(rawValue);
         const value = parseFn(cleansed);
         if (isEmpty(value)) {
           return makeNullOrThrow(fieldName, rawValue, type, required, 'value is empty or null');

--- a/packages/csv-to-pg/src/parser.ts
+++ b/packages/csv-to-pg/src/parser.ts
@@ -15,6 +15,7 @@ interface ParserConfig {
   input?: string;
   debug?: boolean;
   fields: Record<string, unknown>;
+  preserveEmptyStrings?: boolean;
 }
 
 interface CsvOptions {

--- a/pgpm/export/src/export-meta.ts
+++ b/pgpm/export/src/export-meta.ts
@@ -96,8 +96,7 @@ export const exportMeta = async ({ opts, dbname, database_id }: ExportMetaParams
       schema: tableConfig.schema,
       table: tableConfig.table,
       conflictDoNothing: tableConfig.conflictDoNothing,
-      fields: dynamicFields,
-      preserveEmptyStrings: true
+      fields: dynamicFields
     });
 
     parsers[key] = parser;

--- a/pgpm/export/src/export-meta.ts
+++ b/pgpm/export/src/export-meta.ts
@@ -96,7 +96,8 @@ export const exportMeta = async ({ opts, dbname, database_id }: ExportMetaParams
       schema: tableConfig.schema,
       table: tableConfig.table,
       conflictDoNothing: tableConfig.conflictDoNothing,
-      fields: dynamicFields
+      fields: dynamicFields,
+      preserveEmptyStrings: true
     });
 
     parsers[key] = parser;


### PR DESCRIPTION
## Summary

The `text` type coercion in `csv-to-pg` called `cleanseEmptyStrings()` which treats `''` as a NULL token. This is wrong for PostgreSQL where `''` and `NULL` are distinct values.

**Root cause**: When the `webauthn_settings` trigger inserts `rp_id = ''` (the NOT NULL default), the export converts `''` → `NULL`. The subsequent migration fails with:

```
null value in column "rp_id" of relation "webauthn_settings" violates not-null constraint
```

**Fix**: Add a `preserveEmptyStrings` option to the Parser:
- **Default (`true`)**: Empty strings preserved as `''` — correct for PostgreSQL
- **`false`**: Empty strings → NULL (CSV convention, opt-in)

This unblocks [constructive-db PR #1078](https://github.com/constructive-io/constructive-db/pull/1078).

## Review & Testing Checklist for Human
- [ ] After publishing, re-run constructive-db PR #1078 CI to confirm the webauthn_settings migration passes

### Notes
- 3 new tests: default preserves empty strings, opt-out converts to NULL, null values still produce NULL


Link to Devin session: https://app.devin.ai/sessions/18d6c72085dc4b06b1428e2baddbf430
Requested by: @pyramation