### PR TITLE
feat: typed table reads for CORS, pubkey, webauthn, database_settings + Graphile feature flag wiring

### DIFF
--- a/graphile/graphile-settings/src/index.ts
+++ b/graphile/graphile-settings/src/index.ts
@@ -44,6 +44,9 @@ import 'graphile-build';
 // Main preset
 export { ConstructivePreset } from './presets/constructive-preset';
 
+// Optional presets (not included in ConstructivePreset by default)
+export { PgAggregatesPreset } from 'graphile-pg-aggregates';
+
 // Re-export all plugins for convenience
 export * from './plugins/index';
 

--- a/graphql/server/src/middleware/api.ts
+++ b/graphql/server/src/middleware/api.ts
@@ -8,7 +8,7 @@ import { getPgPool } from 'pg-cache';
 
 import errorPage50x from '../errors/50x';
 import errorPage404Message from '../errors/404-message';
-import { ApiConfigResult, ApiError, ApiOptions, ApiStructure, AuthSettings, RlsModule } from '../types';
+import { ApiConfigResult, ApiError, ApiOptions, ApiStructure, AuthSettings, DatabaseSettings, PubkeyChallengeSettings, RlsModule, WebauthnSettings } from '../types';
 import './types';
 
 const log = new Logger('api');
@@ -139,6 +139,100 @@ const AUTH_SETTINGS_SQL = (schemaName: string, tableName: string) => `
   LIMIT 1
 `;
 
+const CORS_SETTINGS_SQL = `
+  SELECT allowed_origins
+  FROM services_public.cors_settings
+  WHERE database_id = $1 AND api_id = $2
+  LIMIT 1
+`;
+
+const CORS_SETTINGS_DB_DEFAULT_SQL = `
+  SELECT allowed_origins
+  FROM services_public.cors_settings
+  WHERE database_id = $1 AND api_id IS NULL
+  LIMIT 1
+`;
+
+const CORS_MODULE_SQL = `
+  SELECT data
+  FROM services_public.api_modules
+  WHERE api_id = $1 AND name = 'cors'
+  LIMIT 1
+`;
+
+const PUBKEY_SETTINGS_SQL = `
+  SELECT
+    s.schema_name AS schema,
+    ps.crypto_network,
+    sign_up_fn.name AS sign_up_with_key,
+    sign_in_req_fn.name AS sign_in_request_challenge,
+    sign_in_fail_fn.name AS sign_in_record_failure,
+    sign_in_fn.name AS sign_in_with_challenge
+  FROM services_public.pubkey_settings ps
+  LEFT JOIN metaschema_public.schema s ON ps.schema_id = s.id
+  LEFT JOIN metaschema_public.function sign_up_fn ON ps.sign_up_with_key_function_id = sign_up_fn.id
+  LEFT JOIN metaschema_public.function sign_in_req_fn ON ps.sign_in_request_challenge_function_id = sign_in_req_fn.id
+  LEFT JOIN metaschema_public.function sign_in_fail_fn ON ps.sign_in_record_failure_function_id = sign_in_fail_fn.id
+  LEFT JOIN metaschema_public.function sign_in_fn ON ps.sign_in_with_challenge_function_id = sign_in_fn.id
+  WHERE ps.database_id = $1
+  LIMIT 1
+`;
+
+const PUBKEY_MODULE_SQL = `
+  SELECT data
+  FROM services_public.api_modules
+  WHERE api_id = $1 AND name = 'pubkey_challenge'
+  LIMIT 1
+`;
+
+const WEBAUTHN_SETTINGS_SQL = `
+  SELECT
+    s.schema_name AS schema,
+    cred_s.schema_name AS credentials_schema,
+    sess_s.schema_name AS sessions_schema,
+    sec_s.schema_name AS session_secrets_schema,
+    ws.rp_id,
+    ws.rp_name,
+    ws.origin_allowlist,
+    ws.attestation_type,
+    ws.require_user_verification,
+    ws.resident_key,
+    ws.challenge_expiry_seconds
+  FROM services_public.webauthn_settings ws
+  LEFT JOIN metaschema_public.schema s ON ws.schema_id = s.id
+  LEFT JOIN metaschema_public.schema cred_s ON ws.credentials_schema_id = cred_s.id
+  LEFT JOIN metaschema_public.schema sess_s ON ws.sessions_schema_id = sess_s.id
+  LEFT JOIN metaschema_public.schema sec_s ON ws.session_secrets_schema_id = sec_s.id
+  WHERE ws.database_id = $1
+  LIMIT 1
+`;
+
+const DATABASE_SETTINGS_SQL = `
+  SELECT
+    ds.enable_aggregates,
+    ds.enable_postgis,
+    ds.enable_search,
+    ds.enable_direct_uploads,
+    ds.enable_presigned_uploads,
+    ds.enable_many_to_many,
+    ds.enable_connection_filter,
+    ds.enable_ltree,
+    ds.enable_llm,
+    COALESCE(aps.enable_aggregates, ds.enable_aggregates) AS resolved_enable_aggregates,
+    COALESCE(aps.enable_postgis, ds.enable_postgis) AS resolved_enable_postgis,
+    COALESCE(aps.enable_search, ds.enable_search) AS resolved_enable_search,
+    COALESCE(aps.enable_direct_uploads, ds.enable_direct_uploads) AS resolved_enable_direct_uploads,
+    COALESCE(aps.enable_presigned_uploads, ds.enable_presigned_uploads) AS resolved_enable_presigned_uploads,
+    COALESCE(aps.enable_many_to_many, ds.enable_many_to_many) AS resolved_enable_many_to_many,
+    COALESCE(aps.enable_connection_filter, ds.enable_connection_filter) AS resolved_enable_connection_filter,
+    COALESCE(aps.enable_ltree, ds.enable_ltree) AS resolved_enable_ltree,
+    COALESCE(aps.enable_llm, ds.enable_llm) AS resolved_enable_llm
+  FROM services_public.database_settings ds
+  LEFT JOIN services_public.api_settings aps ON ds.database_id = aps.database_id AND aps.api_id = $2
+  WHERE ds.database_id = $1
+  LIMIT 1
+`;
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -177,6 +271,60 @@ interface AuthSettingsRow {
 
 interface RlsModuleRow {
   data: RlsModuleData | null;
+}
+
+interface CorsSettingsRow {
+  allowed_origins: string[];
+}
+
+interface CorsModuleRow {
+  data: { urls: string[] } | null;
+}
+
+interface PubkeySettingsRow {
+  schema: string;
+  crypto_network: string;
+  sign_up_with_key: string;
+  sign_in_request_challenge: string;
+  sign_in_record_failure: string;
+  sign_in_with_challenge: string;
+}
+
+interface PubkeyModuleRow {
+  data: {
+    schema: string;
+    crypto_network: string;
+    sign_up_with_key: string;
+    sign_in_request_challenge: string;
+    sign_in_record_failure: string;
+    sign_in_with_challenge: string;
+  } | null;
+}
+
+interface WebauthnSettingsRow {
+  schema: string;
+  credentials_schema: string;
+  sessions_schema: string;
+  session_secrets_schema: string;
+  rp_id: string;
+  rp_name: string;
+  origin_allowlist: string[];
+  attestation_type: string;
+  require_user_verification: boolean;
+  resident_key: string;
+  challenge_expiry_seconds: number;
+}
+
+interface DatabaseSettingsRow {
+  resolved_enable_aggregates: boolean;
+  resolved_enable_postgis: boolean;
+  resolved_enable_search: boolean;
+  resolved_enable_direct_uploads: boolean;
+  resolved_enable_presigned_uploads: boolean;
+  resolved_enable_many_to_many: boolean;
+  resolved_enable_connection_filter: boolean;
+  resolved_enable_ltree: boolean;
+  resolved_enable_llm: boolean;
 }
 
 interface ApiListRow {
@@ -304,18 +452,31 @@ const toAuthSettings = (row: AuthSettingsRow | null): AuthSettings | undefined =
   };
 };
 
-const toApiStructure = (row: ApiRow, opts: ApiOptions, rlsModule?: RlsModule, authSettingsRow?: AuthSettingsRow | null): ApiStructure => ({
+interface ResolvedSettings {
+  rlsModule?: RlsModule;
+  authSettingsRow?: AuthSettingsRow | null;
+  corsOrigins?: string[];
+  databaseSettings?: DatabaseSettings;
+  pubkeyChallengeSettings?: PubkeyChallengeSettings;
+  webauthnSettings?: WebauthnSettings;
+}
+
+const toApiStructure = (row: ApiRow, opts: ApiOptions, settings: ResolvedSettings = {}): ApiStructure => ({
   apiId: row.api_id,
   dbname: row.dbname || opts.pg?.database || '',
   anonRole: row.anon_role || 'anon',
   roleName: row.role_name || 'authenticated',
   schema: row.schemas || [],
   apiModules: [],
-  rlsModule,
+  rlsModule: settings.rlsModule,
   domains: [],
   databaseId: row.database_id,
   isPublic: row.is_public,
-  authSettings: toAuthSettings(authSettingsRow ?? null),
+  authSettings: toAuthSettings(settings.authSettingsRow ?? null),
+  corsOrigins: settings.corsOrigins,
+  databaseSettings: settings.databaseSettings,
+  pubkeyChallengeSettings: settings.pubkeyChallengeSettings,
+  webauthnSettings: settings.webauthnSettings,
 });
 
 const createAdminStructure = (
@@ -388,6 +549,135 @@ const queryRlsModule = async (pool: Pool, databaseId: string, apiId: string): Pr
   const fromSettings = await queryRlsSettings(pool, databaseId);
   if (fromSettings) return fromSettings;
   return queryRlsModuleLegacy(pool, apiId);
+};
+
+// -- CORS --
+
+const queryCorsSettings = async (pool: Pool, databaseId: string, apiId?: string): Promise<string[] | undefined> => {
+  try {
+    if (apiId) {
+      const perApi = await pool.query<CorsSettingsRow>(CORS_SETTINGS_SQL, [databaseId, apiId]);
+      if (perApi.rows[0]) return perApi.rows[0].allowed_origins;
+    }
+    const dbDefault = await pool.query<CorsSettingsRow>(CORS_SETTINGS_DB_DEFAULT_SQL, [databaseId]);
+    return dbDefault.rows[0]?.allowed_origins;
+  } catch {
+    return undefined;
+  }
+};
+
+const queryCorsModuleLegacy = async (pool: Pool, apiId: string): Promise<string[] | undefined> => {
+  const result = await pool.query<CorsModuleRow>(CORS_MODULE_SQL, [apiId]);
+  return result.rows[0]?.data?.urls;
+};
+
+const queryCorsOrigins = async (pool: Pool, databaseId: string, apiId?: string): Promise<string[] | undefined> => {
+  const fromSettings = await queryCorsSettings(pool, databaseId, apiId);
+  if (fromSettings) return fromSettings;
+  if (apiId) return queryCorsModuleLegacy(pool, apiId);
+  return undefined;
+};
+
+// -- Pubkey --
+
+const toPubkeyChallengeSettings = (row: PubkeySettingsRow | null): PubkeyChallengeSettings | undefined => {
+  if (!row?.schema || !row?.sign_up_with_key) return undefined;
+  return {
+    schema: row.schema,
+    cryptoNetwork: row.crypto_network,
+    signUpWithKey: row.sign_up_with_key,
+    signInRequestChallenge: row.sign_in_request_challenge,
+    signInRecordFailure: row.sign_in_record_failure,
+    signInWithChallenge: row.sign_in_with_challenge,
+  };
+};
+
+const toPubkeyChallengeFromModule = (row: PubkeyModuleRow | null): PubkeyChallengeSettings | undefined => {
+  if (!row?.data?.schema) return undefined;
+  const d = row.data;
+  return {
+    schema: d.schema,
+    cryptoNetwork: d.crypto_network,
+    signUpWithKey: d.sign_up_with_key,
+    signInRequestChallenge: d.sign_in_request_challenge,
+    signInRecordFailure: d.sign_in_record_failure,
+    signInWithChallenge: d.sign_in_with_challenge,
+  };
+};
+
+const queryPubkeySettings = async (pool: Pool, databaseId: string): Promise<PubkeyChallengeSettings | undefined> => {
+  try {
+    const result = await pool.query<PubkeySettingsRow>(PUBKEY_SETTINGS_SQL, [databaseId]);
+    return toPubkeyChallengeSettings(result.rows[0] ?? null);
+  } catch {
+    return undefined;
+  }
+};
+
+const queryPubkeyModuleLegacy = async (pool: Pool, apiId: string): Promise<PubkeyChallengeSettings | undefined> => {
+  const result = await pool.query<PubkeyModuleRow>(PUBKEY_MODULE_SQL, [apiId]);
+  return toPubkeyChallengeFromModule(result.rows[0] ?? null);
+};
+
+const queryPubkeyChallenge = async (pool: Pool, databaseId: string, apiId?: string): Promise<PubkeyChallengeSettings | undefined> => {
+  const fromSettings = await queryPubkeySettings(pool, databaseId);
+  if (fromSettings) return fromSettings;
+  if (apiId) return queryPubkeyModuleLegacy(pool, apiId);
+  return undefined;
+};
+
+// -- WebAuthn --
+
+const toWebauthnSettings = (row: WebauthnSettingsRow | null): WebauthnSettings | undefined => {
+  if (!row?.schema) return undefined;
+  return {
+    schema: row.schema,
+    credentialsSchema: row.credentials_schema,
+    sessionsSchema: row.sessions_schema,
+    sessionSecretsSchema: row.session_secrets_schema,
+    rpId: row.rp_id,
+    rpName: row.rp_name,
+    originAllowlist: row.origin_allowlist,
+    attestationType: row.attestation_type,
+    requireUserVerification: row.require_user_verification,
+    residentKey: row.resident_key,
+    challengeExpirySeconds: row.challenge_expiry_seconds,
+  };
+};
+
+const queryWebauthnSettings = async (pool: Pool, databaseId: string): Promise<WebauthnSettings | undefined> => {
+  try {
+    const result = await pool.query<WebauthnSettingsRow>(WEBAUTHN_SETTINGS_SQL, [databaseId]);
+    return toWebauthnSettings(result.rows[0] ?? null);
+  } catch {
+    return undefined;
+  }
+};
+
+// -- Database Settings (feature flags) --
+
+const toDatabaseSettings = (row: DatabaseSettingsRow | null): DatabaseSettings | undefined => {
+  if (!row) return undefined;
+  return {
+    enableAggregates: row.resolved_enable_aggregates,
+    enablePostgis: row.resolved_enable_postgis,
+    enableSearch: row.resolved_enable_search,
+    enableDirectUploads: row.resolved_enable_direct_uploads,
+    enablePresignedUploads: row.resolved_enable_presigned_uploads,
+    enableManyToMany: row.resolved_enable_many_to_many,
+    enableConnectionFilter: row.resolved_enable_connection_filter,
+    enableLtree: row.resolved_enable_ltree,
+    enableLlm: row.resolved_enable_llm,
+  };
+};
+
+const queryDatabaseSettings = async (pool: Pool, databaseId: string, apiId?: string): Promise<DatabaseSettings | undefined> => {
+  try {
+    const result = await pool.query<DatabaseSettingsRow>(DATABASE_SETTINGS_SQL, [databaseId, apiId ?? null]);
+    return toDatabaseSettings(result.rows[0] ?? null);
+  } catch {
+    return undefined;
+  }
 };
 
 /**
@@ -479,10 +769,16 @@ const resolveApiNameHeader = async (ctx: ResolveContext): Promise<ApiStructure |
     return null;
   }
 
-  const rlsModule = await queryRlsModule(pool, row.database_id, row.api_id);
-  const authSettings = await queryAuthSettings(opts, row.dbname);
-  log.debug(`[api-name-lookup] resolved schemas: [${row.schemas?.join(', ')}], rlsModule: ${rlsModule ? 'found' : 'none'}, authSettings: ${authSettings ? 'found' : 'none'}`);
-  return toApiStructure(row, opts, rlsModule, authSettings);
+  const [rlsModule, authSettingsRow, corsOrigins, databaseSettings, pubkeyChallengeSettings, webauthnSettings] = await Promise.all([
+    queryRlsModule(pool, row.database_id, row.api_id),
+    queryAuthSettings(opts, row.dbname),
+    queryCorsOrigins(pool, row.database_id, row.api_id),
+    queryDatabaseSettings(pool, row.database_id, row.api_id),
+    queryPubkeyChallenge(pool, row.database_id, row.api_id),
+    queryWebauthnSettings(pool, row.database_id),
+  ]);
+  log.debug(`[api-name-lookup] resolved schemas: [${row.schemas?.join(', ')}], rlsModule: ${rlsModule ? 'found' : 'none'}, authSettings: ${authSettingsRow ? 'found' : 'none'}`);
+  return toApiStructure(row, opts, { rlsModule, authSettingsRow, corsOrigins, databaseSettings, pubkeyChallengeSettings, webauthnSettings });
 };
 
 const resolveMetaSchemaHeader = (
@@ -505,10 +801,16 @@ const resolveDomainLookup = async (ctx: ResolveContext): Promise<ApiStructure | 
     return null;
   }
 
-  const rlsModule = await queryRlsModule(pool, row.database_id, row.api_id);
-  const authSettings = await queryAuthSettings(opts, row.dbname);
-  log.debug(`[domain-lookup] resolved schemas: [${row.schemas?.join(', ')}], rlsModule: ${rlsModule ? 'found' : 'none'}, authSettings: ${authSettings ? 'found' : 'none'}`);
-  return toApiStructure(row, opts, rlsModule, authSettings);
+  const [rlsModule, authSettingsRow, corsOrigins, databaseSettings, pubkeyChallengeSettings, webauthnSettings] = await Promise.all([
+    queryRlsModule(pool, row.database_id, row.api_id),
+    queryAuthSettings(opts, row.dbname),
+    queryCorsOrigins(pool, row.database_id, row.api_id),
+    queryDatabaseSettings(pool, row.database_id, row.api_id),
+    queryPubkeyChallenge(pool, row.database_id, row.api_id),
+    queryWebauthnSettings(pool, row.database_id),
+  ]);
+  log.debug(`[domain-lookup] resolved schemas: [${row.schemas?.join(', ')}], rlsModule: ${rlsModule ? 'found' : 'none'}, authSettings: ${authSettingsRow ? 'found' : 'none'}`);
+  return toApiStructure(row, opts, { rlsModule, authSettingsRow, corsOrigins, databaseSettings, pubkeyChallengeSettings, webauthnSettings });
 };
 
 const buildDevFallbackError = async (

--- a/graphql/server/src/middleware/cors.ts
+++ b/graphql/server/src/middleware/cors.ts
@@ -1,7 +1,7 @@
 import { parseUrl } from '@constructive-io/url-domains';
 import corsPlugin from 'cors';
 import type { Request, RequestHandler } from 'express';
-import { CorsModuleData } from '../types';
+import type { ApiStructure, CorsModuleData } from '../types';
 import './types'; // for Request type
 
 /**
@@ -9,7 +9,8 @@ import './types'; // for Request type
  *
  * Feature parity + compatibility:
  *  - Respects a global fallback origin (e.g. from env/CLI) for quick overrides.
- *  - Preserves multi-tenant, per-API CORS via meta schema ('cors' module + domains).
+ *  - Reads per-API CORS origins from typed cors_settings table (via req.api.corsOrigins).
+ *  - Falls back to legacy api_modules CORS data for backwards compatibility.
  *  - Always allows localhost to ease development.
  *
  * Usage:
@@ -33,11 +34,15 @@ export const cors = (fallbackOrigin?: string): RequestHandler => {
 
     // 2) Per-API allowlist sourced from req.api (if available)
     //    createApiMiddleware runs before this in server.ts, so req.api should be set
-    const api = (req as any).api as { apiModules?: any[]; domains?: string[] } | undefined;
+    const api = (req as any).api as ApiStructure | undefined;
     if (api) {
+      // Typed cors_settings origins (preferred)
+      const typedOrigins = api.corsOrigins || [];
+      // Legacy api_modules CORS data (fallback)
       const corsModules = (api.apiModules || []).filter((m: any) => m.name === 'cors') as { name: 'cors'; data: CorsModuleData }[];
+      const legacyOrigins = corsModules.reduce<string[]>((m, mod) => [...mod.data.urls, ...m], []);
       const siteUrls = api.domains || [];
-      const listOfDomains = corsModules.reduce<string[]>((m, mod) => [...mod.data.urls, ...m], siteUrls);
+      const listOfDomains = [...typedOrigins, ...legacyOrigins, ...siteUrls];
 
       if (origin && listOfDomains.includes(origin)) {
         return callback(null, true);

--- a/graphql/server/src/middleware/graphile.ts
+++ b/graphql/server/src/middleware/graphile.ts
@@ -6,13 +6,14 @@ import type { NextFunction, Request, RequestHandler, Response } from 'express';
 import type { GraphQLError, GraphQLFormattedError } from 'grafast/graphql';
 import { createGraphileInstance, type GraphileCacheEntry, graphileCache } from 'graphile-cache';
 import type { GraphileConfig } from 'graphile-config';
-import { ConstructivePreset, makePgService } from 'graphile-settings';
+import { ConstructivePreset, makePgService, PgAggregatesPreset } from 'graphile-settings';
 import { getPgPool } from 'pg-cache';
 import { getPgEnvOptions } from 'pg-env';
 import './types'; // for Request type
 import { isGraphqlObservabilityEnabled } from '../diagnostics/observability';
 import { HandlerCreationError } from '../errors/api-errors';
 import { observeGraphileBuild } from './observability/graphile-build-stats';
+import type { DatabaseSettings } from '../types';
 
 const maskErrorLog = new Logger('graphile:maskError');
 
@@ -194,15 +195,28 @@ const reqLabel = (req: Request): string => (req.requestId ? `[${req.requestId}]`
 
 /**
  * Build a PostGraphile v5 preset for a tenant.
+ *
+ * When `databaseSettings` are available, feature flags control which
+ * optional plugins are included.  Currently only `enable_aggregates`
+ * adds a preset (PgAggregatesPreset) — all other features are baked
+ * into ConstructivePreset and are always-on until per-plugin disable
+ * logic is implemented in a follow-up.
  */
 const buildPreset = (
   pool: import('pg').Pool,
   schemas: string[],
   anonRole: string,
   roleName: string,
+  databaseSettings?: DatabaseSettings,
 ): GraphileConfig.Preset => {
+  const presets: GraphileConfig.Preset[] = [ConstructivePreset];
+
+  if (databaseSettings?.enableAggregates) {
+    presets.push(PgAggregatesPreset);
+  }
+
   return {
-  extends: [ConstructivePreset],
+  extends: presets,
   pgServices: [
     makePgService({
       pool,
@@ -356,7 +370,7 @@ export const graphile = (opts: ConstructiveOptions): RequestHandler => {
       const pool = getPgPool(pgConfig);
 
       // Create promise and store in in-flight map BEFORE try block
-      const preset = buildPreset(pool, schema || [], anonRole, roleName);
+      const preset = buildPreset(pool, schema || [], anonRole, roleName, api.databaseSettings);
       const creationPromise = observeGraphileBuild(
         {
           cacheKey: key,

--- a/graphql/server/src/types.ts
+++ b/graphql/server/src/types.ts
@@ -18,6 +18,53 @@ export interface GenericModuleData {
   [key: string]: unknown;
 }
 
+/**
+ * Resolved feature flags from database_settings + api_settings cascade.
+ * api_settings values (when non-null) override database_settings defaults.
+ */
+export interface DatabaseSettings {
+  enableAggregates: boolean;
+  enablePostgis: boolean;
+  enableSearch: boolean;
+  enableDirectUploads: boolean;
+  enablePresignedUploads: boolean;
+  enableManyToMany: boolean;
+  enableConnectionFilter: boolean;
+  enableLtree: boolean;
+  enableLlm: boolean;
+}
+
+/**
+ * Resolved pubkey challenge config from pubkey_settings typed table.
+ * Matches the shape expected by the PublicKeySignature Graphile plugin.
+ */
+export interface PubkeyChallengeSettings {
+  schema: string;
+  cryptoNetwork: string;
+  signUpWithKey: string;
+  signInRequestChallenge: string;
+  signInRecordFailure: string;
+  signInWithChallenge: string;
+}
+
+/**
+ * Resolved WebAuthn config from webauthn_settings typed table.
+ * Stored on ApiStructure for future server-side WebAuthn wiring.
+ */
+export interface WebauthnSettings {
+  schema: string;
+  credentialsSchema: string;
+  sessionsSchema: string;
+  sessionSecretsSchema: string;
+  rpId: string;
+  rpName: string;
+  originAllowlist: string[];
+  attestationType: string;
+  requireUserVerification: boolean;
+  residentKey: string;
+  challengeExpirySeconds: number;
+}
+
 export type ApiModule =
   | { name: 'cors'; data: CorsModuleData }
   | { name: 'pubkey_challenge'; data: PublicKeyChallengeData }
@@ -68,6 +115,10 @@ export interface ApiStructure {
   databaseId?: string;
   isPublic?: boolean;
   authSettings?: AuthSettings;
+  corsOrigins?: string[];
+  databaseSettings?: DatabaseSettings;
+  pubkeyChallengeSettings?: PubkeyChallengeSettings;
+  webauthnSettings?: WebauthnSettings;
 }
 
 export type ApiError = { errorHtml: string };


### PR DESCRIPTION
## Summary

Continues the unified settings architecture (Phases 3–4, per [constructive-planning#812](https://github.com/constructive-io/constructive-planning/issues/812)). Builds on the RLS pattern from PR #1086 to read from **all remaining typed settings tables** with backwards-compatible fallback to `api_modules`.

**Server-side reads (Phase 3 continued):**
- **CORS** — queries `cors_settings` (per-API, then db-default), falls back to `api_modules` legacy `cors` module
- **Pubkey challenge** — queries `pubkey_settings` (with LEFT JOINs to `metaschema_public.schema` / `function`), falls back to `api_modules` legacy `pubkey_challenge` module
- **WebAuthn** — queries `webauthn_settings` (with LEFT JOINs to 4 schema FKs), no legacy fallback needed
- **Database settings** — queries `database_settings` with `api_settings` cascade via `COALESCE`

All queries use the same try/catch → `undefined` fallback pattern so deployments without the new tables continue working.

**Graphile feature flag wiring (Phase 4):**
- `buildPreset()` now accepts `databaseSettings` and conditionally includes `PgAggregatesPreset` when `enableAggregates` is true
- Other feature flags (postgis, search, uploads, etc.) are stored on `ApiStructure` but **do not yet disable** their corresponding plugins — deferred to a follow-up that maps each flag to specific `disablePlugins` entries

**Other changes:**
- Refactored `toApiStructure` from positional args to a `ResolvedSettings` object
- Both `resolveApiNameHeader` and `resolveDomainLookup` now run all 6 settings queries in parallel via `Promise.all`
- `cors.ts` reads `api.corsOrigins` (typed) and merges with legacy `api_modules` CORS data
- Re-exports `PgAggregatesPreset` from `graphile-settings` so the server doesn't need a direct dependency

## Review & Testing Checklist for Human

- [ ] **SQL column names match actual table schemas** — Verify the column names in `PUBKEY_SETTINGS_SQL`, `WEBAUTHN_SETTINGS_SQL`, `DATABASE_SETTINGS_SQL`, and `CORS_SETTINGS_SQL` match the table definitions from constructive-db PRs #1060/#1075. Mismatches would be silently swallowed by the try/catch.
- [ ] **CORS fallback asymmetry** — `queryCorsSettings` introduces a db-default cascade (api_id IS NULL) that `queryCorsModuleLegacy` does not have. Confirm this is desired new behavior, not an unintentional divergence.
- [ ] **`queryCorsModuleLegacy` lacks try/catch** — Unlike all other legacy fallback functions, the CORS legacy query will throw on DB errors rather than returning `undefined`. Verify this is acceptable or should be wrapped.
- [ ] **Feature flags are read but mostly not enforced** — Only `enableAggregates` actually gates a plugin. The other 8 flags are carried on `ApiStructure` but don't disable anything yet. Confirm this partial wiring is acceptable for now.
- [ ] **Deploy with `pgpm deploy`** — Test against a real database to verify the typed table queries return correct data and the `api_modules` fallback works when typed tables are empty.

### Notes
- No new tests are included — test coverage for typed settings reads is tracked in [constructive-planning#823](https://github.com/constructive-io/constructive-planning/issues/823).
- All pre-existing TS errors (`ConstructivePreset`, `makePgService`, `streamToStorage` not found) are confirmed present on main — they require building `graphile-settings` first.
- The `svcCache` LRU cache (1-year TTL) means the additional queries only fire on cold starts / cache misses.

Link to Devin session: https://app.devin.ai/sessions/94a2728a9c414500bead29cbbc829c15
Requested by: @pyramation