### PR TITLE
feat(graphile-test): add setUserContext utility for RLS testing

### DIFF
--- a/graphile/graphile-test/src/context.ts
+++ b/graphile/graphile-test/src/context.ts
@@ -270,8 +270,28 @@ export const runGraphQLInContext = async <T = ExecutionResult>({
     _pgSettings: Record<string, string> | null,
     callback: (client: Client) => T | Promise<T>
   ): Promise<T> => {
-    // Simply use the test client - it's already in a transaction
-    // The pgSettings have already been applied above via setContextOnClient
+    // Augment the client with withTransaction if it doesn't already have it.
+    // In production, @dataplan/pg provides this method. In tests the raw pg
+    // Client lacks it, so we implement it via savepoints (which nest cleanly
+    // inside the test harness's outer transaction).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const client = pgClient as any;
+    if (typeof client.withTransaction !== 'function') {
+      client.withTransaction = async (
+        cb: (txClient: Client) => unknown | Promise<unknown>
+      ) => {
+        const sp = `wt_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+        await client.query(`SAVEPOINT ${sp}`);
+        try {
+          const result = await cb(client);
+          await client.query(`RELEASE SAVEPOINT ${sp}`);
+          return result;
+        } catch (err) {
+          await client.query(`ROLLBACK TO SAVEPOINT ${sp}`);
+          throw err;
+        }
+      };
+    }
     return callback(pgClient);
   };
 

--- a/graphile/graphile-test/src/index.ts
+++ b/graphile/graphile-test/src/index.ts
@@ -21,4 +21,5 @@ export type {
   GraphQLTestContext,
   Variables,
 } from './types';
+export { setUserContext } from './utils';
 export { seed, snapshot } from 'pgsql-test';

--- a/graphile/graphile-test/src/utils.ts
+++ b/graphile/graphile-test/src/utils.ts
@@ -1,1 +1,19 @@
+import type { PgTestClient } from 'pgsql-test/test-client';
+
 export * from 'pgsql-test/utils';
+
+/**
+ * Set authenticated user context for RLS testing.
+ * Convenience wrapper around db.setContext() with standard constructive JWT claims.
+ */
+export function setUserContext(
+  db: PgTestClient,
+  userId: string,
+  databaseId: string,
+): void {
+  db.setContext({
+    role: 'authenticated',
+    'jwt.claims.user_id': userId,
+    'jwt.claims.database_id': databaseId,
+  });
+}


### PR DESCRIPTION
## Summary

Two additions to `graphile-test`:

**1. `withTransaction` on test pg clients (`context.ts`)**

In production, `@dataplan/pg` provides `pgClient.withTransaction()`. The raw pg `Client` used in tests lacks it, which causes plugins that call `withTransaction` (e.g. the presigned-url plugin's upload mutations) to fail with `withTransaction is not a function`. This adds a savepoint-based polyfill that is injected once per client inside `withPgClient`, nesting cleanly inside the test harness's outer transaction.

**2. `setUserContext` utility (`utils.ts`)**

Every RLS integration test in constructive-db copies the same `db.setContext({ role: 'authenticated', 'jwt.claims.user_id': ..., 'jwt.claims.database_id': ... })` pattern. This adds a typed convenience function so tests can call `setUserContext(db, userId, databaseId)` instead.

## Review & Testing Checklist for Human

- [ ] **`withTransaction` savepoint semantics**: The polyfill uses `SAVEPOINT` / `RELEASE` / `ROLLBACK TO` instead of a real nested transaction. Verify this is sufficient for the plugins that depend on `withTransaction` — in particular, confirm the presigned-url plugin's usage doesn't rely on true transaction isolation (it shouldn't, since PG savepoints share the parent transaction's isolation).
- [ ] **`as any` cast and mutation of pgClient**: The polyfill monkey-patches the pg `Client` instance. The `typeof` guard prevents re-patching, but confirm this doesn't interfere with other test utilities that may also augment the client.
- [ ] **`setUserContext` claim names**: Hardcodes `jwt.claims.user_id` and `jwt.claims.database_id`. Confirm these are the canonical claim names across all constructive RLS policies and won't diverge.

Recommended test: run the storage integration tests in constructive-db (`app-integration-storage` CI job) after publishing this version — those tests exercise both `withTransaction` (via upload mutations) and the RLS context pattern that `setUserContext` standardizes.

### Notes

- The `withTransaction` polyfill was previously monkey-patched inline in `minio-multi-scope-graphql.integration.test.ts` in constructive-db. This moves it into the framework so all tests get it automatically and the monkey-patch can be removed.
- `setUserContext` is intentionally a standalone function (not a method on `PgTestClient`) because the claim names are constructive-specific, while `PgTestClient` lives in the generic `pgsql-test` package.

Link to Devin session: https://app.devin.ai/sessions/7903d2a3e7a34c6daa605e12d6b80d9e
Requested by: @pyramation