### PR TITLE
feat: add DataRealtime node type definition

### DIFF
--- a/packages/node-type-registry/src/data/data-realtime.ts
+++ b/packages/node-type-registry/src/data/data-realtime.ts
@@ -1,0 +1,33 @@
+import type { NodeTypeDefinition } from '../types';
+
+export const DataRealtime: NodeTypeDefinition = {
+  name: 'DataRealtime',
+  slug: 'data_realtime',
+  category: 'data',
+  display_name: 'Realtime Subscriptions',
+  description:
+    'Creates per-table subscriber tables in subscriptions_public with ' +
+    'RLS policies derived from source table SELECT policies. Attaches ' +
+    'statement-level triggers to emit changes to subscribers.',
+  parameter_schema: {
+    type: 'object',
+    properties: {
+      operations: {
+        type: 'array',
+        items: {
+          type: 'string',
+          enum: ['INSERT', 'UPDATE', 'DELETE']
+        },
+        description:
+          'Which DML operations to track with emit_change triggers',
+        default: ['INSERT', 'UPDATE', 'DELETE']
+      },
+      subscriber_table_name: {
+        type: 'string',
+        description:
+          'Custom name for the subscriber table (defaults to {source_table}_subscriber)'
+      }
+    }
+  },
+  tags: ['realtime', 'subscriptions', 'triggers']
+};

--- a/packages/node-type-registry/src/data/index.ts
+++ b/packages/node-type-registry/src/data/index.ts
@@ -17,6 +17,7 @@ export { DataOwnedFields } from './data-owned-fields';
 export { DataOwnershipInEntity } from './data-ownership-in-entity';
 export { DataPeoplestamps } from './data-peoplestamps';
 export { DataPublishable } from './data-publishable';
+export { DataRealtime } from './data-realtime';
 export { DataSlug } from './data-slug';
 export { DataSoftDelete } from './data-soft-delete';
 export { DataStatusField } from './data-status-field';


### PR DESCRIPTION
## Summary

Adds the `DataRealtime` node type definition to the node-type-registry, corresponding to the `data_realtime.sql` generator that was added in constructive-db (PRs #1082/#1085/#1086). This registers the type so it appears in `metaschema_public.node_type_registry` at deploy time.

**What it defines:**
- `DataRealtime` — category `data`, slug `data_realtime`
- `parameter_schema` with two properties:
  - `operations`: which DML operations to track (default: all three)
  - `subscriber_table_name`: optional override for the subscriber table name (no static default — the SQL generator computes `{source_table}_subscriber` at runtime)

**Notable design choice:** Unlike most other Data\* types, `DataRealtime` has **no `column-ref` properties**. This is intentional — the SQL generator dynamically introspects source table SELECT policies from the registry to discover which columns to create on the subscriber table, rather than declaring them statically here.

## Review & Testing Checklist for Human

- [ ] Verify `parameter_schema` matches what `data_realtime.sql` actually reads from the `data` jsonb — specifically that `operations` and `subscriber_table_name` are the correct keys and types
- [ ] After merging, regenerate the SQL seed in constructive-db (`pnpm generate` in `packages/node-type-registry`, then `pgpm package` in `pgpm-modules/metaschema-schema`) to populate the registry row

### Notes

Related PRs across other repos in this batch:
- constructive-db: skills updates (node-type-registry + data-modules installed copies)
- constructive-private-skills: DataRealtime section added to data-modules skill
- constructive-skills: Realtime Subscriptions section added to features catalog

Link to Devin session: https://app.devin.ai/sessions/19485cf5cc58416a9f86068563d512f5
Requested by: @pyramation