### PR TITLE
refactor: clean up upload integration test — expectRlsDenied, expectSuccess, DRY SQL

### DIFF
--- a/graphql/server-test/__fixtures__/seed/simple-seed-storage/schema.sql
+++ b/graphql/server-test/__fixtures__/seed/simple-seed-storage/schema.sql
@@ -1,135 +1,96 @@
 -- Schema creation for simple-seed-storage test scenario
--- Creates the app schema with storage tables (buckets, files)
-
--- Create app schemas
-CREATE SCHEMA IF NOT EXISTS "simple-storage-public";
-
--- Grant schema usage
-GRANT USAGE ON SCHEMA "simple-storage-public" TO administrator, authenticated, anonymous;
-
--- Set default privileges
-ALTER DEFAULT PRIVILEGES IN SCHEMA "simple-storage-public"
-  GRANT ALL ON TABLES TO administrator;
-ALTER DEFAULT PRIVILEGES IN SCHEMA "simple-storage-public"
-  GRANT USAGE ON SEQUENCES TO administrator, authenticated;
-ALTER DEFAULT PRIVILEGES IN SCHEMA "simple-storage-public"
-  GRANT ALL ON FUNCTIONS TO administrator, authenticated, anonymous;
+-- Creates storage schemas (buckets + files) for three tenants:
+--   Alice  (no RLS), Bob (moderate RLS), Mallory (strictest RLS)
 
 -- =====================================================
--- STORAGE TABLES (mirroring what the storage module generator creates)
+-- Helper: create a storage schema with buckets + files tables
 -- =====================================================
 
--- Buckets table
-CREATE TABLE IF NOT EXISTS "simple-storage-public".app_buckets (
-  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
-  key text NOT NULL,
-  type text NOT NULL DEFAULT 'private',
-  is_public boolean NOT NULL DEFAULT false,
-  allowed_mime_types text[] NULL,
-  max_file_size bigint NULL,
-  allow_custom_keys boolean NOT NULL DEFAULT false,
-  created_at timestamptz DEFAULT now(),
-  updated_at timestamptz DEFAULT now(),
-  UNIQUE (key)
-);
+CREATE FUNCTION _test_create_storage_schema(schema_name text) RETURNS void
+LANGUAGE plpgsql AS $$
+BEGIN
+  EXECUTE format('CREATE SCHEMA IF NOT EXISTS %I', schema_name);
 
-COMMENT ON TABLE "simple-storage-public".app_buckets IS E'@storageBuckets\nStorage buckets table';
+  EXECUTE format('GRANT USAGE ON SCHEMA %I TO administrator, authenticated, anonymous', schema_name);
 
--- Files table
-CREATE TABLE IF NOT EXISTS "simple-storage-public".app_files (
-  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
-  bucket_id uuid NOT NULL REFERENCES "simple-storage-public".app_buckets(id),
-  key text NOT NULL,
-  content_hash text NOT NULL,
-  mime_type text NOT NULL,
-  size bigint,
-  filename text,
-  owner_id uuid,
-  is_public boolean NOT NULL DEFAULT false,
-  previous_version_id uuid REFERENCES "simple-storage-public".app_files(id),
-  created_at timestamptz DEFAULT now(),
-  updated_at timestamptz DEFAULT now(),
-  UNIQUE (bucket_id, key)
-);
+  EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON TABLES TO administrator', schema_name);
+  EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT USAGE ON SEQUENCES TO administrator, authenticated', schema_name);
+  EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON FUNCTIONS TO administrator, authenticated, anonymous', schema_name);
 
-COMMENT ON TABLE "simple-storage-public".app_files IS E'@storageFiles\nStorage files table';
+  -- Buckets table
+  EXECUTE format(
+    'CREATE TABLE IF NOT EXISTS %I.app_buckets (
+       id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+       key text NOT NULL,
+       type text NOT NULL DEFAULT ''private'',
+       is_public boolean NOT NULL DEFAULT false,
+       allowed_mime_types text[] NULL,
+       max_file_size bigint NULL,
+       allow_custom_keys boolean NOT NULL DEFAULT false,
+       created_at timestamptz DEFAULT now(),
+       updated_at timestamptz DEFAULT now(),
+       UNIQUE (key)
+     )', schema_name);
 
--- Grant table permissions (allow anonymous to do CRUD for tests — no RLS)
-GRANT SELECT, INSERT, UPDATE, DELETE ON "simple-storage-public".app_buckets TO administrator, authenticated, anonymous;
-GRANT SELECT, INSERT, UPDATE, DELETE ON "simple-storage-public".app_files TO administrator, authenticated, anonymous;
+  EXECUTE format(
+    'COMMENT ON TABLE %I.app_buckets IS E''@storageBuckets\nStorage buckets table''',
+    schema_name);
+
+  -- Files table
+  EXECUTE format(
+    'CREATE TABLE IF NOT EXISTS %I.app_files (
+       id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+       bucket_id uuid NOT NULL REFERENCES %I.app_buckets(id),
+       key text NOT NULL,
+       content_hash text NOT NULL,
+       mime_type text NOT NULL,
+       size bigint,
+       filename text,
+       owner_id uuid,
+       is_public boolean NOT NULL DEFAULT false,
+       previous_version_id uuid REFERENCES %I.app_files(id),
+       created_at timestamptz DEFAULT now(),
+       updated_at timestamptz DEFAULT now(),
+       UNIQUE (bucket_id, key)
+     )', schema_name, schema_name, schema_name);
+
+  EXECUTE format(
+    'COMMENT ON TABLE %I.app_files IS E''@storageFiles\nStorage files table''',
+    schema_name);
+
+  -- Grant CRUD to all roles
+  EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON %I.app_buckets TO administrator, authenticated, anonymous', schema_name);
+  EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON %I.app_files TO administrator, authenticated, anonymous', schema_name);
+END;
+$$;
 
 -- =====================================================
--- BOB'S STORAGE SCHEMA (separate tenant with RLS)
+-- ALICE (no RLS — wide open)
 -- =====================================================
 
-CREATE SCHEMA IF NOT EXISTS "bob-storage-public";
+SELECT _test_create_storage_schema('simple-storage-public');
 
-GRANT USAGE ON SCHEMA "bob-storage-public" TO administrator, authenticated, anonymous;
+-- =====================================================
+-- BOB (moderate RLS)
+--   Buckets: anonymous sees public only
+--   Files:   anonymous can SELECT public-bucket files + INSERT; no UPDATE/DELETE
+-- =====================================================
 
-ALTER DEFAULT PRIVILEGES IN SCHEMA "bob-storage-public"
-  GRANT ALL ON TABLES TO administrator;
-ALTER DEFAULT PRIVILEGES IN SCHEMA "bob-storage-public"
-  GRANT USAGE ON SEQUENCES TO administrator, authenticated;
-ALTER DEFAULT PRIVILEGES IN SCHEMA "bob-storage-public"
-  GRANT ALL ON FUNCTIONS TO administrator, authenticated, anonymous;
+SELECT _test_create_storage_schema('bob-storage-public');
 
--- Buckets table (same structure as Alice)
-CREATE TABLE IF NOT EXISTS "bob-storage-public".app_buckets (
-  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
-  key text NOT NULL,
-  type text NOT NULL DEFAULT 'private',
-  is_public boolean NOT NULL DEFAULT false,
-  allowed_mime_types text[] NULL,
-  max_file_size bigint NULL,
-  allow_custom_keys boolean NOT NULL DEFAULT false,
-  created_at timestamptz DEFAULT now(),
-  updated_at timestamptz DEFAULT now(),
-  UNIQUE (key)
-);
-
-COMMENT ON TABLE "bob-storage-public".app_buckets IS E'@storageBuckets\nStorage buckets table';
-
--- Files table (same structure as Alice)
-CREATE TABLE IF NOT EXISTS "bob-storage-public".app_files (
-  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
-  bucket_id uuid NOT NULL REFERENCES "bob-storage-public".app_buckets(id),
-  key text NOT NULL,
-  content_hash text NOT NULL,
-  mime_type text NOT NULL,
-  size bigint,
-  filename text,
-  owner_id uuid,
-  is_public boolean NOT NULL DEFAULT false,
-  previous_version_id uuid REFERENCES "bob-storage-public".app_files(id),
-  created_at timestamptz DEFAULT now(),
-  updated_at timestamptz DEFAULT now(),
-  UNIQUE (bucket_id, key)
-);
-
-COMMENT ON TABLE "bob-storage-public".app_files IS E'@storageFiles\nStorage files table';
-
--- Grant table permissions
-GRANT SELECT, INSERT, UPDATE, DELETE ON "bob-storage-public".app_buckets TO administrator, authenticated, anonymous;
-GRANT SELECT, INSERT, UPDATE, DELETE ON "bob-storage-public".app_files TO administrator, authenticated, anonymous;
-
--- Enable RLS on Bob's buckets table
 ALTER TABLE "bob-storage-public".app_buckets ENABLE ROW LEVEL SECURITY;
 
--- RLS: anonymous can only see public buckets (prevents bucket enumeration)
 CREATE POLICY anon_read_public_buckets ON "bob-storage-public".app_buckets
   FOR SELECT TO anonymous
   USING (is_public = true);
 
--- RLS: administrator bypasses bucket RLS
 CREATE POLICY admin_all_buckets ON "bob-storage-public".app_buckets
   FOR ALL TO administrator
   USING (true)
   WITH CHECK (true);
 
--- Enable RLS on Bob's files table
 ALTER TABLE "bob-storage-public".app_files ENABLE ROW LEVEL SECURITY;
 
--- RLS policy: anonymous can only see files in public buckets
 CREATE POLICY anon_read_public_files ON "bob-storage-public".app_files
   FOR SELECT TO anonymous
   USING (
@@ -138,7 +99,7 @@ CREATE POLICY anon_read_public_files ON "bob-storage-public".app_files
     )
   );
 
--- RLS policy: anonymous can insert into any bucket (for upload testing)
+-- Anonymous can insert into any bucket (for upload testing)
 CREATE POLICY anon_insert_files ON "bob-storage-public".app_files
   FOR INSERT TO anonymous
   WITH CHECK (true);
@@ -149,68 +110,17 @@ CREATE POLICY anon_insert_files ON "bob-storage-public".app_files
 --   - flip is_public flags
 --   - delete other users' files
 
--- RLS policy: administrator bypasses RLS
 CREATE POLICY admin_all_files ON "bob-storage-public".app_files
   FOR ALL TO administrator
   USING (true)
   WITH CHECK (true);
 
 -- =====================================================
--- MALLORY'S STORAGE SCHEMA (adversarial third tenant — strictest RLS)
--- anonymous can only SELECT, no INSERT/UPDATE/DELETE at all
+-- MALLORY (strictest RLS — anonymous can only SELECT)
 -- =====================================================
 
-CREATE SCHEMA IF NOT EXISTS "mallory-storage-public";
+SELECT _test_create_storage_schema('mallory-storage-public');
 
-GRANT USAGE ON SCHEMA "mallory-storage-public" TO administrator, authenticated, anonymous;
-
-ALTER DEFAULT PRIVILEGES IN SCHEMA "mallory-storage-public"
-  GRANT ALL ON TABLES TO administrator;
-ALTER DEFAULT PRIVILEGES IN SCHEMA "mallory-storage-public"
-  GRANT USAGE ON SEQUENCES TO administrator, authenticated;
-ALTER DEFAULT PRIVILEGES IN SCHEMA "mallory-storage-public"
-  GRANT ALL ON FUNCTIONS TO administrator, authenticated, anonymous;
-
--- Buckets table
-CREATE TABLE IF NOT EXISTS "mallory-storage-public".app_buckets (
-  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
-  key text NOT NULL,
-  type text NOT NULL DEFAULT 'private',
-  is_public boolean NOT NULL DEFAULT false,
-  allowed_mime_types text[] NULL,
-  max_file_size bigint NULL,
-  allow_custom_keys boolean NOT NULL DEFAULT false,
-  created_at timestamptz DEFAULT now(),
-  updated_at timestamptz DEFAULT now(),
-  UNIQUE (key)
-);
-
-COMMENT ON TABLE "mallory-storage-public".app_buckets IS E'@storageBuckets\nStorage buckets table';
-
--- Files table
-CREATE TABLE IF NOT EXISTS "mallory-storage-public".app_files (
-  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
-  bucket_id uuid NOT NULL REFERENCES "mallory-storage-public".app_buckets(id),
-  key text NOT NULL,
-  content_hash text NOT NULL,
-  mime_type text NOT NULL,
-  size bigint,
-  filename text,
-  owner_id uuid,
-  is_public boolean NOT NULL DEFAULT false,
-  previous_version_id uuid REFERENCES "mallory-storage-public".app_files(id),
-  created_at timestamptz DEFAULT now(),
-  updated_at timestamptz DEFAULT now(),
-  UNIQUE (bucket_id, key)
-);
-
-COMMENT ON TABLE "mallory-storage-public".app_files IS E'@storageFiles\nStorage files table';
-
--- Grant table permissions
-GRANT SELECT, INSERT, UPDATE, DELETE ON "mallory-storage-public".app_buckets TO administrator, authenticated, anonymous;
-GRANT SELECT, INSERT, UPDATE, DELETE ON "mallory-storage-public".app_files TO administrator, authenticated, anonymous;
-
--- Enable RLS on Mallory's buckets — anonymous can only read
 ALTER TABLE "mallory-storage-public".app_buckets ENABLE ROW LEVEL SECURITY;
 
 CREATE POLICY anon_read_buckets ON "mallory-storage-public".app_buckets
@@ -222,10 +132,9 @@ CREATE POLICY admin_all_buckets ON "mallory-storage-public".app_buckets
   USING (true)
   WITH CHECK (true);
 
--- Enable RLS on Mallory's files — anonymous can only read (strictest policy)
--- No INSERT/UPDATE/DELETE for anonymous at all
 ALTER TABLE "mallory-storage-public".app_files ENABLE ROW LEVEL SECURITY;
 
+-- Anonymous can only read (no INSERT/UPDATE/DELETE at all)
 CREATE POLICY anon_read_files ON "mallory-storage-public".app_files
   FOR SELECT TO anonymous
   USING (true);
@@ -234,3 +143,6 @@ CREATE POLICY admin_all_files ON "mallory-storage-public".app_files
   FOR ALL TO administrator
   USING (true)
   WITH CHECK (true);
+
+-- Clean up helper
+DROP FUNCTION _test_create_storage_schema(text);

--- a/graphql/server-test/__tests__/upload.integration.test.ts
+++ b/graphql/server-test/__tests__/upload.integration.test.ts
@@ -31,6 +31,7 @@
 import crypto from 'crypto';
 import path from 'path';
 import { getConnections, seed } from '../src';
+import type { PgTestClient } from 'pgsql-test/test-client';
 import type supertest from 'supertest';
 
 jest.setTimeout(120000);
@@ -218,18 +219,46 @@ async function putToPresignedUrl(
   });
 }
 
-/** Expect a GraphQL response to indicate a denied mutation (error or null). */
-function expectMutationDenied(
+/**
+ * Assert that a mutation was denied specifically by RLS (not by some other error).
+ *
+ * PostgreSQL RLS denials surface in two ways through PostGraphile:
+ *   1. An explicit PG error — message contains "permission denied" or
+ *      "new row violates row-level security".
+ *   2. The mutation silently affects 0 rows and returns null (RLS USING
+ *      clause filtered out the target row).
+ *
+ * Any other shape (e.g. a GraphQL validation error, a 500, a typo in a
+ * field name) is treated as an unexpected failure so tests don't
+ * accidentally pass for the wrong reason.
+ */
+function expectRlsDenied(
   res: supertest.Response,
   mutationName: string,
 ): void {
-  if (res.body.errors) {
-    expect(res.body.errors.length).toBeGreaterThan(0);
-  } else if (res.body.data) {
-    expect(res.body.data[mutationName]).toBeNull();
-  } else {
-    expect(res.status).not.toBe(200);
+  if (res.body.errors?.length) {
+    const msg: string = res.body.errors[0].message;
+    expect(
+      msg.includes('permission denied') ||
+        msg.includes('new row violates row-level security') ||
+        msg.includes('insufficient_privilege'),
+    ).toBe(true);
+    return;
   }
+  if (res.body.data) {
+    expect(res.body.data[mutationName]).toBeNull();
+    return;
+  }
+  throw new Error(
+    `Expected RLS denial but got status=${res.status}, body=${JSON.stringify(res.body)}`,
+  );
+}
+
+/** Assert 200 + no GraphQL errors, return the data payload. */
+function expectSuccess(res: supertest.Response): Record<string, any> {
+  expect(res.status).toBe(200);
+  expect(res.body.errors).toBeUndefined();
+  return res.body.data;
 }
 
 // =========================================================================
@@ -237,6 +266,7 @@ function expectMutationDenied(
 // =========================================================================
 
 describe('Integration tests (uploads, tenant isolation, RLS)', () => {
+  let pg: PgTestClient;
   let request: supertest.Agent;
   let teardown: () => Promise<void>;
 
@@ -283,7 +313,7 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
 
   // Single setup: one server, one pool, all three schemas registered
   beforeAll(async () => {
-    ({ request, teardown } = await getConnections(
+    ({ pg, request, teardown } = await getConnections(
       {
         schemas: [...aliceSchemas, ...bobSchemas, ...mallorySchemas],
         authRole: 'anonymous',
@@ -328,10 +358,9 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
           },
         });
 
-        expect(res.status).toBe(200);
-        expect(res.body.errors).toBeUndefined();
+        const data = expectSuccess(res);
 
-        const payload = res.body.data.uploadAppFile;
+        const payload = data.uploadAppFile;
         expect(payload.uploadUrl).toBeTruthy();
         expect(payload.fileId).toBeTruthy();
         expect(payload.key).toBe(contentHash);
@@ -367,10 +396,9 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
           },
         });
 
-        expect(res.status).toBe(200);
-        expect(res.body.errors).toBeUndefined();
+        const data = expectSuccess(res);
 
-        const payload = res.body.data.uploadAppFile;
+        const payload = data.uploadAppFile;
         expect(payload.uploadUrl).toBeTruthy();
         expect(payload.fileId).toBeTruthy();
         expect(payload.key).toBe(contentHash);
@@ -404,10 +432,9 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
           },
         });
 
-        expect(res.status).toBe(200);
-        expect(res.body.errors).toBeUndefined();
+        const data = expectSuccess(res);
 
-        const payload = res.body.data.uploadAppFile;
+        const payload = data.uploadAppFile;
         expect(payload.deduplicated).toBe(true);
         expect(payload.uploadUrl).toBeNull();
         expect(payload.expiresAt).toBeNull();
@@ -425,9 +452,8 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
       const res = await postGraphQLViaApi(aliceDatabaseId, 'app', {
         query: INTROSPECT_UPLOAD_MUTATION,
       });
-      expect(res.status).toBe(200);
-      expect(res.body.errors).toBeUndefined();
-      const names = (res.body.data.__type?.fields ?? []).map(
+      const data = expectSuccess(res);
+      const names = (data.__type?.fields ?? []).map(
         (f: { name: string }) => f.name,
       );
       expect(names).toContain('uploadAppFile');
@@ -437,9 +463,8 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
       const res = await postGraphQLViaApi(bobDatabaseId, 'bob-app', {
         query: INTROSPECT_UPLOAD_MUTATION,
       });
-      expect(res.status).toBe(200);
-      expect(res.body.errors).toBeUndefined();
-      const names = (res.body.data.__type?.fields ?? []).map(
+      const data = expectSuccess(res);
+      const names = (data.__type?.fields ?? []).map(
         (f: { name: string }) => f.name,
       );
       expect(names).toContain('uploadAppFile');
@@ -449,9 +474,8 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
       const res = await postGraphQLViaApi(bobDatabaseId, 'bob-restricted', {
         query: INTROSPECT_UPLOAD_MUTATION,
       });
-      expect(res.status).toBe(200);
-      expect(res.body.errors).toBeUndefined();
-      const names = (res.body.data.__type?.fields ?? []).map(
+      const data = expectSuccess(res);
+      const names = (data.__type?.fields ?? []).map(
         (f: { name: string }) => f.name,
       );
       expect(names).not.toContain('uploadAppFile');
@@ -461,9 +485,8 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
       const res = await postGraphQLViaApi(malloryDatabaseId, 'mallory-app', {
         query: INTROSPECT_UPLOAD_MUTATION,
       });
-      expect(res.status).toBe(200);
-      expect(res.body.errors).toBeUndefined();
-      const names = (res.body.data.__type?.fields ?? []).map(
+      const data = expectSuccess(res);
+      const names = (data.__type?.fields ?? []).map(
         (f: { name: string }) => f.name,
       );
       expect(names).toContain('uploadAppFile');
@@ -492,9 +515,8 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
         },
       });
 
-      expect(res.status).toBe(200);
-      expect(res.body.errors).toBeUndefined();
-      const payload = res.body.data.uploadAppFile;
+      const data = expectSuccess(res);
+      const payload = data.uploadAppFile;
       expect(payload.fileId).toBeTruthy();
       expect(payload.uploadUrl).toBeTruthy();
 
@@ -504,27 +526,24 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
 
     it('Bob sees his own files', async () => {
       const res = await postGraphQLViaApi(bobDatabaseId, 'bob-app', { query: APP_FILES });
-      expect(res.status).toBe(200);
-      expect(res.body.errors).toBeUndefined();
-      const files = res.body.data.appFiles.nodes;
+      const data = expectSuccess(res);
+      const files = data.appFiles.nodes;
       expect(files.length).toBeGreaterThanOrEqual(1);
       expect(files.some((f: { filename: string }) => f.filename === 'bob-file.txt')).toBe(true);
     });
 
     it('Mallory sees her own pre-seeded files', async () => {
       const res = await postGraphQLViaApi(malloryDatabaseId, 'mallory-app', { query: APP_FILES });
-      expect(res.status).toBe(200);
-      expect(res.body.errors).toBeUndefined();
-      const files: { filename: string }[] = res.body.data.appFiles.nodes;
+      const data = expectSuccess(res);
+      const files: { filename: string }[] = data.appFiles.nodes;
       expect(files.some((f) => f.filename === 'mallory-public.txt')).toBe(true);
       expect(files.some((f) => f.filename === 'mallory-private.txt')).toBe(true);
     });
 
     it('Alice API does NOT leak Bob or Mallory files', async () => {
       const res = await postGraphQLViaApi(aliceDatabaseId, 'app', { query: APP_FILES });
-      expect(res.status).toBe(200);
-      expect(res.body.errors).toBeUndefined();
-      const names = res.body.data.appFiles.nodes.map((f: { filename: string }) => f.filename);
+      const data = expectSuccess(res);
+      const names = data.appFiles.nodes.map((f: { filename: string }) => f.filename);
       expect(names).not.toContain('bob-file.txt');
       expect(names).not.toContain('mallory-public.txt');
       expect(names).not.toContain('mallory-private.txt');
@@ -532,9 +551,8 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
 
     it('Bob API does NOT leak Alice or Mallory files', async () => {
       const res = await postGraphQLViaApi(bobDatabaseId, 'bob-app', { query: APP_FILES });
-      expect(res.status).toBe(200);
-      expect(res.body.errors).toBeUndefined();
-      const names = res.body.data.appFiles.nodes.map((f: { filename: string }) => f.filename);
+      const data = expectSuccess(res);
+      const names = data.appFiles.nodes.map((f: { filename: string }) => f.filename);
       expect(names).not.toContain('hello-public.txt');
       expect(names).not.toContain('hello-private.txt');
       expect(names).not.toContain('mallory-public.txt');
@@ -543,9 +561,8 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
 
     it('Mallory API does NOT leak Alice or Bob files', async () => {
       const res = await postGraphQLViaApi(malloryDatabaseId, 'mallory-app', { query: APP_FILES });
-      expect(res.status).toBe(200);
-      expect(res.body.errors).toBeUndefined();
-      const names = res.body.data.appFiles.nodes.map((f: { filename: string }) => f.filename);
+      const data = expectSuccess(res);
+      const names = data.appFiles.nodes.map((f: { filename: string }) => f.filename);
       expect(names).not.toContain('hello-public.txt');
       expect(names).not.toContain('hello-private.txt');
       expect(names).not.toContain('bob-file.txt');
@@ -560,27 +577,24 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
   describe('Bucket enumeration attacks', () => {
     it('Alice sees all buckets (no RLS on her schema)', async () => {
       const res = await postGraphQLViaApi(aliceDatabaseId, 'app', { query: APP_BUCKETS });
-      expect(res.status).toBe(200);
-      expect(res.body.errors).toBeUndefined();
-      const keys = res.body.data.appBuckets.nodes.map((b: { key: string }) => b.key);
+      const data = expectSuccess(res);
+      const keys = data.appBuckets.nodes.map((b: { key: string }) => b.key);
       expect(keys).toContain('public');
       expect(keys).toContain('private');
     });
 
     it('Bob anonymous only sees public buckets (RLS hides private)', async () => {
       const res = await postGraphQLViaApi(bobDatabaseId, 'bob-app', { query: APP_BUCKETS });
-      expect(res.status).toBe(200);
-      expect(res.body.errors).toBeUndefined();
-      const buckets: { isPublic: boolean }[] = res.body.data.appBuckets.nodes;
+      const data = expectSuccess(res);
+      const buckets: { isPublic: boolean }[] = data.appBuckets.nodes;
       expect(buckets.length).toBeGreaterThanOrEqual(1);
       expect(buckets.every((b) => b.isPublic)).toBe(true);
     });
 
     it('Mallory anonymous sees all buckets (her RLS policy allows all SELECT)', async () => {
       const res = await postGraphQLViaApi(malloryDatabaseId, 'mallory-app', { query: APP_BUCKETS });
-      expect(res.status).toBe(200);
-      expect(res.body.errors).toBeUndefined();
-      const keys = res.body.data.appBuckets.nodes.map((b: { key: string }) => b.key);
+      const data = expectSuccess(res);
+      const keys = data.appBuckets.nodes.map((b: { key: string }) => b.key);
       expect(keys).toContain('public');
       expect(keys).toContain('private');
     });
@@ -598,7 +612,7 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
           input: { id: bobSeededPublicFileId, patch: { bucketId: bobPrivateBucketId } },
         },
       });
-      expectMutationDenied(res, 'updateAppFile');
+      expectRlsDenied(res, 'updateAppFile');
     });
 
     it('Bob: anonymous cannot flip is_public flag on a file', async () => {
@@ -608,7 +622,7 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
           input: { id: bobSeededPublicFileId, patch: { isPublic: false } },
         },
       });
-      expectMutationDenied(res, 'updateAppFile');
+      expectRlsDenied(res, 'updateAppFile');
     });
 
     it('Bob: anonymous cannot delete a file', async () => {
@@ -616,7 +630,7 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
         query: DELETE_APP_FILE,
         variables: { input: { id: bobSeededPublicFileId } },
       });
-      expectMutationDenied(res, 'deleteAppFile');
+      expectRlsDenied(res, 'deleteAppFile');
     });
 
     it('Mallory: anonymous cannot create a file directly (bypassing presigned URL)', async () => {
@@ -635,7 +649,7 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
           },
         },
       });
-      expectMutationDenied(res, 'createAppFile');
+      expectRlsDenied(res, 'createAppFile');
     });
 
     it('Mallory: anonymous cannot update a file', async () => {
@@ -645,7 +659,7 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
           input: { id: malloryPublicFileId, patch: { filename: 'hacked.txt' } },
         },
       });
-      expectMutationDenied(res, 'updateAppFile');
+      expectRlsDenied(res, 'updateAppFile');
     });
 
     it('Mallory: anonymous cannot delete a file', async () => {
@@ -653,15 +667,18 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
         query: DELETE_APP_FILE,
         variables: { input: { id: malloryPublicFileId } },
       });
-      expectMutationDenied(res, 'deleteAppFile');
+      expectRlsDenied(res, 'deleteAppFile');
     });
 
     it('Bob seeded public file still exists after all attack attempts', async () => {
-      const res = await postGraphQLViaApi(bobDatabaseId, 'bob-app', { query: APP_FILES });
-      expect(res.status).toBe(200);
-      expect(res.body.errors).toBeUndefined();
-      const ids = res.body.data.appFiles.nodes.map((f: { id: string }) => f.id);
-      expect(ids).toContain(bobSeededPublicFileId);
+      // Verify via superuser: ground-truth check that RLS attacks didn't mutate data
+      const { rows } = await pg.query(
+        'SELECT id, bucket_id, is_public FROM "bob-storage-public".app_files WHERE id = $1',
+        [bobSeededPublicFileId],
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0].bucket_id).toBe(bobPublicBucketId);
+      expect(rows[0].is_public).toBe(true);
     });
   });
 
@@ -677,7 +694,7 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
           input: { appBucket: { key: 'evil-bucket', type: 'public', isPublic: true } },
         },
       });
-      expectMutationDenied(res, 'createAppBucket');
+      expectRlsDenied(res, 'createAppBucket');
     });
 
     it('Bob: anonymous cannot update a bucket (flip public to private)', async () => {
@@ -687,7 +704,7 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
           input: { id: bobPublicBucketId, patch: { isPublic: false } },
         },
       });
-      expectMutationDenied(res, 'updateAppBucket');
+      expectRlsDenied(res, 'updateAppBucket');
     });
 
     it('Bob: anonymous cannot delete a bucket', async () => {
@@ -695,7 +712,7 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
         query: DELETE_APP_BUCKET,
         variables: { input: { id: bobPublicBucketId } },
       });
-      expectMutationDenied(res, 'deleteAppBucket');
+      expectRlsDenied(res, 'deleteAppBucket');
     });
 
     it('Mallory: anonymous cannot create a bucket', async () => {
@@ -705,7 +722,7 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
           input: { appBucket: { key: 'evil-bucket', type: 'public', isPublic: true } },
         },
       });
-      expectMutationDenied(res, 'createAppBucket');
+      expectRlsDenied(res, 'createAppBucket');
     });
   });
 
@@ -774,10 +791,9 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
   describe('RLS enforcement on Bob schema', () => {
     it('anonymous only sees public-bucket files', async () => {
       const res = await postGraphQLViaApi(bobDatabaseId, 'bob-app', { query: APP_FILES });
-      expect(res.status).toBe(200);
-      expect(res.body.errors).toBeUndefined();
+      const data = expectSuccess(res);
 
-      const files: { bucketId: string }[] = res.body.data.appFiles.nodes;
+      const files: { bucketId: string }[] = data.appFiles.nodes;
       const publicFiles = files.filter((f) => f.bucketId === bobPublicBucketId);
       const privateFiles = files.filter((f) => f.bucketId === bobPrivateBucketId);
 
@@ -787,15 +803,15 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
 
     it('pre-seeded private file is NOT visible to anonymous', async () => {
       const res = await postGraphQLViaApi(bobDatabaseId, 'bob-app', { query: APP_FILES });
-      expect(res.status).toBe(200);
-      const names = res.body.data.appFiles.nodes.map((f: { filename: string }) => f.filename);
+      const data = expectSuccess(res);
+      const names = data.appFiles.nodes.map((f: { filename: string }) => f.filename);
       expect(names).not.toContain('bob-seeded-private.txt');
     });
 
     it('pre-seeded public file IS visible to anonymous', async () => {
       const res = await postGraphQLViaApi(bobDatabaseId, 'bob-app', { query: APP_FILES });
-      expect(res.status).toBe(200);
-      const names = res.body.data.appFiles.nodes.map((f: { filename: string }) => f.filename);
+      const data = expectSuccess(res);
+      const names = data.appFiles.nodes.map((f: { filename: string }) => f.filename);
       expect(names).toContain('bob-seeded-public.txt');
     });
   });

--- a/graphql/server-test/__tests__/upload.integration.test.ts
+++ b/graphql/server-test/__tests__/upload.integration.test.ts
@@ -31,7 +31,6 @@
 import crypto from 'crypto';
 import path from 'path';
 import { getConnections, seed } from '../src';
-import type { PgTestClient } from 'pgsql-test/test-client';
 import type supertest from 'supertest';
 
 jest.setTimeout(120000);
@@ -266,7 +265,6 @@ function expectSuccess(res: supertest.Response): Record<string, any> {
 // =========================================================================
 
 describe('Integration tests (uploads, tenant isolation, RLS)', () => {
-  let pg: PgTestClient;
   let request: supertest.Agent;
   let teardown: () => Promise<void>;
 
@@ -313,7 +311,7 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
 
   // Single setup: one server, one pool, all three schemas registered
   beforeAll(async () => {
-    ({ pg, request, teardown } = await getConnections(
+    ({ request, teardown } = await getConnections(
       {
         schemas: [...aliceSchemas, ...bobSchemas, ...mallorySchemas],
         authRole: 'anonymous',
@@ -671,14 +669,10 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
     });
 
     it('Bob seeded public file still exists after all attack attempts', async () => {
-      // Verify via superuser: ground-truth check that RLS attacks didn't mutate data
-      const { rows } = await pg.query(
-        'SELECT id, bucket_id, is_public FROM "bob-storage-public".app_files WHERE id = $1',
-        [bobSeededPublicFileId],
-      );
-      expect(rows).toHaveLength(1);
-      expect(rows[0].bucket_id).toBe(bobPublicBucketId);
-      expect(rows[0].is_public).toBe(true);
+      const res = await postGraphQLViaApi(bobDatabaseId, 'bob-app', { query: APP_FILES });
+      const data = expectSuccess(res);
+      const ids = data.appFiles.nodes.map((f: { id: string }) => f.id);
+      expect(ids).toContain(bobSeededPublicFileId);
     });
   });
 


### PR DESCRIPTION
## Summary

Test-only refactor of `upload.integration.test.ts` and its SQL seed fixture, following code review on the prior PR. No test logic or coverage changes — all 34 tests still exercise the same scenarios.

**Three changes:**

1. **`expectMutationDenied` → `expectRlsDenied`** — The old helper accepted *any* error as "denied" (including validation errors, 500s, typos). The new helper validates that the denial is specifically from RLS: checks for `permission denied`, `new row violates row-level security`, or `insufficient_privilege` in the error message, or a null mutation result (0-row RLS USING filter). Any other failure shape now throws, preventing tests from passing for the wrong reason.

2. **`expectSuccess` helper** — Extracts the repeated `expect(res.status).toBe(200); expect(res.body.errors).toBeUndefined()` pattern (~20 instances) into a single function that returns `res.body.data` for chaining.

3. **DRY SQL schema** — Extracted a `_test_create_storage_schema(schema_name)` PL/pgSQL function to eliminate ~110 lines of duplicated table definitions across Alice/Bob/Mallory. RLS policies remain inline since they differ per tenant. Function is dropped at the end of the seed file.

### Updates since last revision

- **Reverted superuser verification** — The initial version added a `pg.query()` superuser check for post-attack data integrity. This was reverted after review feedback: using a separate PG connection introduces a transaction isolation concern. The verification now uses the same HTTP → server → pool path (`postGraphQLViaApi` + `expectSuccess`) as the mutations themselves, ensuring we read from the same transactional context.
- Removed unused `pg` destructuring and `PgTestClient` import.

## Review & Testing Checklist for Human

- [ ] **Verify `expectRlsDenied` string matching is complete** — Are there other PG error messages for RLS denial that aren't covered by the three patterns (`permission denied`, `new row violates row-level security`, `insufficient_privilege`)? If any current test's denial uses a different message, it will now fail instead of silently passing.
- [ ] **Verify the DRY SQL function produces identical tables** — The `_test_create_storage_schema` uses `EXECUTE format(...)` with dynamic SQL. Confirm the generated table structure matches the original static DDL (column types, constraints, comments, grants).
- [ ] **Run the integration test suite** to confirm all 34 tests pass with the refactored helpers and DRY schema: `pnpm test -- upload.integration`

### Notes
- The `_test_create_storage_schema` function uses `CREATE FUNCTION` (not `CREATE OR REPLACE`) since this is a fresh test database — appropriate for a test fixture.
- This PR targets `feat/rls-alice-bob-integration-test`, so only Socket Security checks run in CI. The full 52-check suite will run once merged toward `main`.
- Net line reduction: ~80 lines removed across both files.

Link to Devin session: https://app.devin.ai/sessions/94a2728a9c414500bead29cbbc829c15
Requested by: @pyramation