### PR TITLE
fix: correct mutation variable shapes and expand expectRlsDenied patterns

### DIFF
--- a/graphql/server-test/__tests__/upload.integration.test.ts
+++ b/graphql/server-test/__tests__/upload.integration.test.ts
@@ -240,7 +240,8 @@ function expectRlsDenied(
     expect(
       msg.includes('permission denied') ||
         msg.includes('new row violates row-level security') ||
-        msg.includes('insufficient_privilege'),
+        msg.includes('insufficient_privilege') ||
+        msg.includes('No values were'),
     ).toBe(true);
     return;
   }
@@ -607,7 +608,7 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
       const res = await postGraphQLViaApi(bobDatabaseId, 'bob-app', {
         query: UPDATE_APP_FILE,
         variables: {
-          input: { id: bobSeededPublicFileId, patch: { bucketId: bobPrivateBucketId } },
+          input: { id: bobSeededPublicFileId, appFilePatch: { bucketId: bobPrivateBucketId } },
         },
       });
       expectRlsDenied(res, 'updateAppFile');
@@ -617,7 +618,7 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
       const res = await postGraphQLViaApi(bobDatabaseId, 'bob-app', {
         query: UPDATE_APP_FILE,
         variables: {
-          input: { id: bobSeededPublicFileId, patch: { isPublic: false } },
+          input: { id: bobSeededPublicFileId, appFilePatch: { isPublic: false } },
         },
       });
       expectRlsDenied(res, 'updateAppFile');
@@ -654,7 +655,7 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
       const res = await postGraphQLViaApi(malloryDatabaseId, 'mallory-app', {
         query: UPDATE_APP_FILE,
         variables: {
-          input: { id: malloryPublicFileId, patch: { filename: 'hacked.txt' } },
+          input: { id: malloryPublicFileId, appFilePatch: { filename: 'hacked.txt' } },
         },
       });
       expectRlsDenied(res, 'updateAppFile');
@@ -695,7 +696,7 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
       const res = await postGraphQLViaApi(bobDatabaseId, 'bob-app', {
         query: UPDATE_APP_BUCKET,
         variables: {
-          input: { id: bobPublicBucketId, patch: { isPublic: false } },
+          input: { id: bobPublicBucketId, appBucketPatch: { isPublic: false } },
         },
       });
       expectRlsDenied(res, 'updateAppBucket');


### PR DESCRIPTION
## Summary

Fixes 10 failing tests in `upload.integration.test.ts` caused by two issues:

1. **Wrong update mutation variable field names** — All update mutations used `patch` (e.g. `{ id, patch: { ... } }`) but PostGraphile v5 generates table-specific field names: `appFilePatch` for `UpdateAppFileInput` and `appBucketPatch` for `UpdateAppBucketInput`. Previously the old `expectMutationDenied` helper silently accepted these as "denied" since the GraphQL schema validation error (`Field "patch" is not defined by type "UpdateAppFileInput"`) was treated as any error. After PR #1098 introduced the stricter `expectRlsDenied`, these schema validation errors are correctly rejected — the tests were never actually reaching the RLS layer.

2. **Missing RLS denial pattern for filtered deletes/updates** — When RLS `USING` clauses filter out all matching rows, PostGraphile returns `"No values were deleted in collection '...' because no values you can delete were found matching these criteria"`. This is a legitimate RLS denial not covered by the existing three patterns (`permission denied`, `new row violates row-level security`, `insufficient_privilege`). Added `'No values were'` as a fourth pattern.

## Review & Testing Checklist for Human

- [ ] **Verify `appFilePatch` / `appBucketPatch` match the actual generated input types** — These names depend on PostGraphile's inflector. If the table names or inflector config change, these field names would too. Confirm by introspecting the schema or checking a working mutation in GraphiQL.
- [ ] **Verify `'No values were'` pattern specificity** — This is a substring match. Confirm no non-RLS errors in PostGraphile contain this phrase that could cause a false pass. The full message is typically `"No values were deleted/updated in collection '...' because no values you can delete/update were found matching these criteria"`.
- [ ] **CI must pass** — The integration test suite (`integration-tests (graphql/server-test)`) runs against real PostgreSQL + MinIO and is the only way to verify these mutations now correctly reach the RLS layer and are denied there.

### Notes
- The 4 affected update tests (Bob: bucket_id move, Bob: is_public flip, Mallory: filename update, Bob: bucket public→private) were previously passing for the **wrong reason** — GraphQL schema validation, not RLS. After this fix they will actually exercise the RLS policies as intended.
- This targets the `feat/rls-alice-bob-integration-test` branch (PR #1095).

Link to Devin session: https://app.devin.ai/sessions/94a2728a9c414500bead29cbbc829c15
Requested by: @pyramation