### PR TITLE
refactor(codegen): accept WsClient via config instead of require('graphql-ws')

### DIFF
--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/client-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/client-generator.test.ts.snap
@@ -137,6 +137,7 @@ export type {
   SubscriptionFieldMeta,
   SubscriptionOperation,
   Unsubscribe,
+  WsClient,
 } from './realtime';
 export { RealtimeManager } from './realtime';
 

--- a/graphql/codegen/src/core/codegen/templates/orm-client.ts
+++ b/graphql/codegen/src/core/codegen/templates/orm-client.ts
@@ -41,6 +41,7 @@ export type {
   SubscriptionFieldMeta,
   SubscriptionOperation,
   Unsubscribe,
+  WsClient,
 } from './realtime';
 export { RealtimeManager } from './realtime';
 

--- a/graphql/codegen/src/core/codegen/templates/orm-realtime.ts
+++ b/graphql/codegen/src/core/codegen/templates/orm-realtime.ts
@@ -9,9 +9,51 @@
  * Any changes here will affect all generated ORM clients.
  */
 
-// graphql-ws is loaded lazily so that importing this module does not
-// throw when the package is absent (e.g. CLI-only consumers).
-type WsClient = import('graphql-ws').Client;
+// Minimal type shims for graphql-ws so that this module compiles
+// without requiring graphql-ws to be installed.  The actual library
+// is loaded lazily via require() inside the RealtimeManager
+// constructor — consumers that never use subscriptions never need
+// the package at all.
+
+interface WsGraphQLError {
+  readonly message: string;
+  readonly [key: string]: unknown;
+}
+
+interface WsExecutionResult<TData = Record<string, unknown>> {
+  data?: TData | null;
+  errors?: readonly WsGraphQLError[];
+  extensions?: Record<string, unknown>;
+}
+
+interface WsSink<T> {
+  next(value: T): void;
+  error(error: unknown): void;
+  complete(): void;
+}
+
+interface WsClient {
+  subscribe<TData = Record<string, unknown>>(
+    payload: { query: string; variables?: Record<string, unknown> },
+    sink: WsSink<WsExecutionResult<TData>>,
+  ): () => void;
+  dispose(): void;
+}
+
+interface WsClientOptions {
+  url: string;
+  lazy?: boolean;
+  retryAttempts?: number;
+  retryWait?: (retryCount: number) => Promise<void>;
+  connectionParams?:
+    | Record<string, unknown>
+    | (() => Promise<Record<string, unknown>> | Record<string, unknown>);
+  on?: {
+    connecting?: () => void;
+    connected?: () => void;
+    closed?: (event: unknown) => void;
+  };
+}
 
 // ============================================================================
 // Types
@@ -138,7 +180,9 @@ export class RealtimeManager {
 
   constructor(config: RealtimeConfig) {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { createClient: createWsClient } = require('graphql-ws') as typeof import('graphql-ws');
+    const { createClient: createWsClient } = require('graphql-ws') as {
+      createClient: (options: WsClientOptions) => WsClient;
+    };
 
     const retryWait = async (retryCount: number): Promise<void> => {
       if (typeof config.retryWait === 'function') {

--- a/graphql/codegen/src/core/codegen/templates/orm-realtime.ts
+++ b/graphql/codegen/src/core/codegen/templates/orm-realtime.ts
@@ -9,11 +9,9 @@
  * Any changes here will affect all generated ORM clients.
  */
 
-// Minimal type shims for graphql-ws so that this module compiles
-// without requiring graphql-ws to be installed.  The actual library
-// is loaded lazily via require() inside the RealtimeManager
-// constructor — consumers that never use subscriptions never need
-// the package at all.
+// Minimal type shims so this module compiles without graphql-ws
+// installed.  Consumers supply a WsClient via RealtimeConfig;
+// the SDK itself never imports or requires graphql-ws.
 
 interface WsGraphQLError {
   readonly message: string;
@@ -32,27 +30,16 @@ interface WsSink<T> {
   complete(): void;
 }
 
-interface WsClient {
+/**
+ * Minimal interface matching the graphql-ws Client.
+ * Consumers pass a concrete instance via RealtimeConfig.client.
+ */
+export interface WsClient {
   subscribe<TData = Record<string, unknown>>(
     payload: { query: string; variables?: Record<string, unknown> },
     sink: WsSink<WsExecutionResult<TData>>,
   ): () => void;
   dispose(): void;
-}
-
-interface WsClientOptions {
-  url: string;
-  lazy?: boolean;
-  retryAttempts?: number;
-  retryWait?: (retryCount: number) => Promise<void>;
-  connectionParams?:
-    | Record<string, unknown>
-    | (() => Promise<Record<string, unknown>> | Record<string, unknown>);
-  on?: {
-    connecting?: () => void;
-    connected?: () => void;
-    closed?: (event: unknown) => void;
-  };
 }
 
 // ============================================================================
@@ -127,40 +114,32 @@ export interface SubscriptionFieldMeta {
 /**
  * Configuration for the realtime (WebSocket) connection.
  * Pass this as the `realtime` option in OrmClientConfig.
+ *
+ * @example
+ * ```ts
+ * import { createClient } from 'graphql-ws';
+ *
+ * const client = createOrmClient({
+ *   endpoint: 'https://api.example.com/graphql',
+ *   realtime: {
+ *     client: createClient({ url: 'wss://api.example.com/graphql' }),
+ *   },
+ * });
+ * ```
  */
 export interface RealtimeConfig {
-  /** WebSocket endpoint URL (e.g., 'wss://api.example.com/graphql') */
-  url: string;
   /**
-   * Returns the current auth token. Called on connection init and
-   * on reconnection so the client always sends a fresh token.
+   * A graphql-ws Client instance (or any object satisfying WsClient).
+   * The consumer creates this themselves, giving full control over
+   * connection options, auth, and transport.
+   *
+   * @example
+   * ```ts
+   * import { createClient } from 'graphql-ws';
+   * const wsClient = createClient({ url: 'wss://...' });
+   * ```
    */
-  getToken?: () => string | Promise<string>;
-  /**
-   * Additional connection parameters sent during WebSocket handshake.
-   * Merged with the authorization header from getToken().
-   */
-  connectionParams?: Record<string, unknown>;
-  /**
-   * Whether to connect lazily (on first subscribe) or eagerly.
-   * @default true
-   */
-  lazy?: boolean;
-  /**
-   * Maximum number of reconnection attempts before giving up.
-   * @default 5
-   */
-  retryAttempts?: number;
-  /**
-   * Delay between reconnection attempts in milliseconds,
-   * or a function for custom backoff.
-   * @default 1000
-   */
-  retryWait?: number | ((retryCount: number) => number | Promise<number>);
-  /** Called when the WebSocket connection is established */
-  onConnected?: () => void;
-  /** Called when the WebSocket connection is closed */
-  onDisconnected?: (reason?: unknown) => void;
+  client: WsClient;
 }
 
 // ============================================================================
@@ -168,8 +147,8 @@ export interface RealtimeConfig {
 // ============================================================================
 
 /**
- * Manages a single graphql-ws WebSocket connection and multiplexes
- * subscriptions over it. Created lazily by OrmClient when `realtime`
+ * Manages a graphql-ws WebSocket client and multiplexes
+ * subscriptions over it. Created by OrmClient when `realtime`
  * config is provided.
  */
 export class RealtimeManager {
@@ -179,58 +158,7 @@ export class RealtimeManager {
   private activeSubscriptions = 0;
 
   constructor(config: RealtimeConfig) {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { createClient: createWsClient } = require('graphql-ws') as {
-      createClient: (options: WsClientOptions) => WsClient;
-    };
-
-    const retryWait = async (retryCount: number): Promise<void> => {
-      if (typeof config.retryWait === 'function') {
-        const result = config.retryWait(retryCount);
-        const ms = typeof result === 'number' ? result : await result;
-        await new Promise<void>((resolve) => setTimeout(resolve, ms));
-      } else {
-        const base =
-          typeof config.retryWait === 'number' ? config.retryWait : 1000;
-        await new Promise<void>((resolve) =>
-          setTimeout(resolve, base * Math.pow(2, retryCount)),
-        );
-      }
-    };
-
-    this.wsClient = createWsClient({
-      url: config.url,
-      lazy: config.lazy ?? true,
-      retryAttempts: config.retryAttempts ?? 5,
-      retryWait,
-      connectionParams: async () => {
-        const params: Record<string, unknown> = {
-          ...config.connectionParams,
-        };
-        if (config.getToken) {
-          const token = await config.getToken();
-          params['authorization'] = `Bearer ${token}`;
-        }
-        return params;
-      },
-      on: {
-        connecting: () => {
-          const newState =
-            this.connectionState === 'disconnected'
-              ? 'connecting'
-              : 'reconnecting';
-          this.setConnectionState(newState);
-        },
-        connected: () => {
-          this.setConnectionState('connected');
-          config.onConnected?.();
-        },
-        closed: (event) => {
-          this.setConnectionState('disconnected');
-          config.onDisconnected?.(event);
-        },
-      },
-    });
+    this.wsClient = config.client;
   }
 
   /**


### PR DESCRIPTION
## Summary

The `orm-realtime.ts` codegen template previously did `require('graphql-ws')` inside the `RealtimeManager` constructor, which:
- Fails in ESM environments
- Forces `graphql-ws` as a hidden dependency even when subscriptions aren't used

**New approach**: `RealtimeConfig` now accepts a `client: WsClient` property. The consumer creates and passes in their own `graphql-ws` client instance:

```ts
import { createClient } from 'graphql-ws';

const orm = createOrmClient({
  endpoint: 'https://api.example.com/graphql',
  realtime: {
    client: createClient({ url: 'wss://api.example.com/graphql' }),
  },
});
```

The SDK defines only a minimal `WsClient` interface — no `import`, no `require`, no dependency on `graphql-ws` at all. If the developer never uses subscriptions, they never need the package.

Changes:
- `RealtimeConfig` simplified to `{ client: WsClient }` — all WS connection options (url, auth, retry, etc.) are now the consumer's responsibility when creating the client
- `WsClient` exported as a public type so consumers can reference the interface
- `RealtimeManager` constructor reduced to `this.wsClient = config.client`
- Snapshot updated for the new `WsClient` export

## Review & Testing Checklist for Human

- [ ] Verify the `WsClient` interface shape (`subscribe` + `dispose`) stays compatible with `graphql-ws`'s `Client` type
- [ ] After merging, run codegen in `constructive-db` to confirm the regenerated `realtime.ts` files match the new template
- [ ] Check that any existing subscription usage in downstream apps is updated to pass `client: createClient(...)` instead of the old `url`/`getToken`/etc. config

### Notes

Companion fix already pushed to constructive-db PR #1089 (`deps-update/20260510-105803`) with the same changes applied to all 13 generated `realtime.ts` files.

Link to Devin session: https://app.devin.ai/sessions/37cd48fd674844c8b6fa1be2b7995746
Requested by: @pyramation