### PR TITLE
feat: add DataBillingMeter and DataAggregateLimitCounter node types

### DIFF
--- a/packages/node-type-registry/src/data/data-aggregate-limit-counter.ts
+++ b/packages/node-type-registry/src/data/data-aggregate-limit-counter.ts
@@ -1,0 +1,38 @@
+import type { NodeTypeDefinition } from '../types';
+
+export const DataAggregateLimitCounter: NodeTypeDefinition = {
+  name: 'DataAggregateLimitCounter',
+  slug: 'data_aggregate_limit_counter',
+  category: 'data',
+  display_name: 'Aggregate Limit Counter',
+  description:
+    'Declaratively attaches aggregate limit-tracking triggers to a table. On INSERT the named limit is incremented per entity; on DELETE it is decremented. Uses org_limit_aggregates_inc/dec for per-entity (org-level) aggregate limits rather than per-user limits. Requires a provisioned limits_module for the target database.',
+  parameter_schema: {
+    type: 'object',
+    properties: {
+      limit_name: {
+        type: 'string',
+        description:
+          'Name of the aggregate limit to track (must match a default_limits entry, e.g. "databases", "members")',
+      },
+      entity_field: {
+        type: 'string',
+        format: 'column-ref',
+        description:
+          'Column on the target table that holds the entity id for aggregate limit lookup',
+        default: 'entity_id',
+      },
+      events: {
+        type: 'array',
+        items: {
+          type: 'string',
+          enum: ['INSERT', 'DELETE', 'UPDATE'],
+        },
+        description: 'Which DML events to attach triggers for',
+        default: ['INSERT', 'DELETE'],
+      },
+    },
+    required: ['limit_name'],
+  },
+  tags: ['limits', 'triggers', 'aggregates', 'billing'],
+};

--- a/packages/node-type-registry/src/data/data-billing-meter.ts
+++ b/packages/node-type-registry/src/data/data-billing-meter.ts
@@ -1,0 +1,43 @@
+import type { NodeTypeDefinition } from '../types';
+
+export const DataBillingMeter: NodeTypeDefinition = {
+  name: 'DataBillingMeter',
+  slug: 'data_billing_meter',
+  category: 'data',
+  display_name: 'Billing Meter',
+  description:
+    'Declaratively attaches billing usage-recording triggers to a table. On INSERT the named meter is incremented via record_usage; on DELETE it is decremented (reversal). On UPDATE, if the entity_field changes, the old entity is decremented and the new entity is incremented. Requires a provisioned billing_module for the target database.',
+  parameter_schema: {
+    type: 'object',
+    properties: {
+      meter_slug: {
+        type: 'string',
+        description:
+          'Slug of the billing meter to record usage against (must match a meters table entry, e.g. "databases", "seats")',
+      },
+      entity_field: {
+        type: 'string',
+        format: 'column-ref',
+        description:
+          'Column on the target table that holds the entity id for billing',
+        default: 'entity_id',
+      },
+      quantity: {
+        type: 'integer',
+        description: 'Units to record per event (default 1)',
+        default: 1,
+      },
+      events: {
+        type: 'array',
+        items: {
+          type: 'string',
+          enum: ['INSERT', 'DELETE', 'UPDATE'],
+        },
+        description: 'Which DML events to attach triggers for',
+        default: ['INSERT', 'DELETE'],
+      },
+    },
+    required: ['meter_slug'],
+  },
+  tags: ['billing', 'triggers', 'metering', 'usage'],
+};

--- a/packages/node-type-registry/src/data/index.ts
+++ b/packages/node-type-registry/src/data/index.ts
@@ -1,3 +1,5 @@
+export { DataAggregateLimitCounter } from './data-aggregate-limit-counter';
+export { DataBillingMeter } from './data-billing-meter';
 export { DataChunks } from './data-chunks';
 export { DataCompositeField } from './data-composite-field';
 export { DataDirectOwner } from './data-direct-owner';


### PR DESCRIPTION
## Summary

Adds two new node type definitions to `packages/node-type-registry` for billing and aggregate limit tracking:

- **`DataBillingMeter`** — Declares a billing usage-recording trigger on a table. Calls `record_usage` on INSERT (increment), DELETE (reversal), and optionally UPDATE (transfer when `entity_field` changes). Required param: `meter_slug`.

- **`DataAggregateLimitCounter`** — Declares per-entity (org-level) aggregate limit triggers via `org_limit_aggregates_inc/dec`, complementing the existing per-user `DataLimitCounter`. Required param: `limit_name`.

Both follow the existing `NodeTypeDefinition` pattern and are exported from `src/data/index.ts`.

The corresponding SQL generators live in `constructive-io/constructive-db`:
- `DataAggregateLimitCounter` generator — merged via PR #1071
- `DataBillingMeter` generator — in PR #1081 (billing metering phase 1)

## Review & Testing Checklist for Human

- [ ] Verify `DataBillingMeter.parameter_schema` matches the parameters consumed by the `data_billing_meter` generator in constructive-db (`meter_slug`, `entity_field`, `quantity`, `events`)
- [ ] Verify `DataAggregateLimitCounter.parameter_schema` matches the `data_aggregate_limit_counter` generator (`limit_name`, `entity_field`, `events`)
- [ ] Confirm the `description` text accurately reflects runtime behavior for both nodes

### Notes

- These are static type definitions only — no runtime code. The actual trigger generation logic lives in `metaschema-generators` in constructive-db.
- `DataBillingMeter` includes a `quantity` param (default 1) that `DataAggregateLimitCounter` does not, mirroring the difference between billing (variable units) and limits (always ±1). This matches the generator implementations.

Link to Devin session: https://app.devin.ai/sessions/6e29559e7a5d4074810f0bd0273dcfc3
Requested by: @pyramation