### PR TITLE
feat(upload-client): replace Web Crypto with @noble/hashes for true incremental hashing

### DIFF
--- a/packages/upload-client/jest.config.js
+++ b/packages/upload-client/jest.config.js
@@ -1,8 +1,11 @@
 module.exports = {
   testEnvironment: 'node',
   transform: {
-    '^.+\\.tsx?$': ['ts-jest', { useESM: false }],
+    '^.+\\.[jt]sx?$': ['ts-jest', { useESM: false }],
   },
+  transformIgnorePatterns: [
+    'node_modules/(?!(\\.pnpm|@noble))',
+  ],
   testMatch: ['**/__tests__/**/*.test.ts'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   modulePathIgnorePatterns: ['<rootDir>/dist/'],

--- a/packages/upload-client/package.json
+++ b/packages/upload-client/package.json
@@ -29,7 +29,8 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@constructive-io/fetch": "^1.0.0"
+    "@constructive-io/fetch": "^1.0.0",
+    "@noble/hashes": "^2.2.0"
   },
   "devDependencies": {
     "makage": "^0.3.0"

--- a/packages/upload-client/src/hash-content.ts
+++ b/packages/upload-client/src/hash-content.ts
@@ -1,9 +1,9 @@
 /**
- * String content hashing using Web Crypto API.
+ * String content hashing using @noble/hashes.
  *
  * Complements `hashFile` (which accepts File/Blob) with a convenience
- * function for hashing plain strings. Uses the same Web Crypto API —
- * no Node.js-only dependencies.
+ * function for hashing plain strings. Uses @noble/hashes for incremental
+ * SHA-256 — works in browsers, Node.js, Deno, and Cloudflare Workers.
  *
  * @example
  * ```typescript
@@ -14,25 +14,20 @@
  * ```
  */
 
+import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex } from '@noble/hashes/utils.js';
 import { UploadError } from './types';
 
 /**
- * Compute the SHA-256 hex digest of a string using Web Crypto API.
+ * Compute the SHA-256 hex digest of a string.
  *
  * @param content - The string content to hash
  * @returns 64-character lowercase hex string
  */
 export async function hashContent(content: string): Promise<string> {
   try {
-    const encoder = new TextEncoder();
-    const data = encoder.encode(content);
-    const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-    const bytes = new Uint8Array(hashBuffer);
-    const hex = new Array<string>(bytes.length);
-    for (let i = 0; i < bytes.length; i++) {
-      hex[i] = bytes[i].toString(16).padStart(2, '0');
-    }
-    return hex.join('');
+    const data = new TextEncoder().encode(content);
+    return bytesToHex(sha256(data));
   } catch (err) {
     throw new UploadError('HASH_FAILED', 'Failed to compute SHA-256 hash', err);
   }

--- a/packages/upload-client/src/hash.ts
+++ b/packages/upload-client/src/hash.ts
@@ -1,13 +1,17 @@
 /**
- * File hashing utilities using Web Crypto API.
+ * File hashing utilities using @noble/hashes.
  *
  * Two strategies:
  * - `hashFile` — reads entire file into memory, fast for files up to ~200MB
- * - `hashFileChunked` — reads file in chunks via FileReader/Blob.slice,
- *   suitable for very large files where loading the full ArrayBuffer
- *   would exceed available memory
+ * - `hashFileChunked` — true incremental hashing via Blob.slice, suitable
+ *   for arbitrarily large files (GB+). Only one chunk is in memory at a time.
+ *
+ * Both use @noble/hashes (pure JS, audited, 0 dependencies) which supports
+ * incremental .update() — unlike Web Crypto API's one-shot digest().
  */
 
+import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex } from '@noble/hashes/utils.js';
 import { UploadError } from './types';
 import type { FileInput } from './types';
 
@@ -15,19 +19,7 @@ import type { FileInput } from './types';
 const DEFAULT_CHUNK_SIZE = 2 * 1024 * 1024;
 
 /**
- * Convert an ArrayBuffer to a lowercase hex string.
- */
-function bufferToHex(buffer: ArrayBuffer): string {
-  const bytes = new Uint8Array(buffer);
-  const hex = new Array<string>(bytes.length);
-  for (let i = 0; i < bytes.length; i++) {
-    hex[i] = bytes[i].toString(16).padStart(2, '0');
-  }
-  return hex.join('');
-}
-
-/**
- * Hash a file using SHA-256 (Web Crypto API).
+ * Hash a file using SHA-256.
  *
  * Reads the entire file into an ArrayBuffer, then computes the hash
  * in a single call. Fast and simple for files up to ~200MB.
@@ -48,29 +40,22 @@ export async function hashFile(file: FileInput): Promise<string> {
 
   try {
     const buffer = await file.arrayBuffer();
-    const hashBuffer = await crypto.subtle.digest('SHA-256', buffer);
-    return bufferToHex(hashBuffer);
+    return bytesToHex(sha256(new Uint8Array(buffer)));
   } catch (err) {
     throw new UploadError('HASH_FAILED', 'Failed to compute SHA-256 hash', err);
   }
 }
 
 /**
- * Hash a file using SHA-256 in chunks.
+ * Hash a file using SHA-256 in chunks (true incremental).
  *
  * Reads the file in fixed-size slices using `Blob.slice()`, feeding each
- * chunk into an incremental digest. This avoids loading the entire file
- * into memory at once, making it suitable for very large files (>200MB).
+ * chunk into @noble/hashes' incremental SHA-256 hasher. Only one chunk
+ * is held in memory at a time — O(chunkSize) memory for any file size.
  *
- * Uses the Web Crypto API's digest on each chunk via a streaming approach:
- * we manually accumulate chunks and hash the concatenated result.
- *
- * NOTE: Web Crypto API does not support incremental/streaming digest natively.
- * For true streaming on very large files (multi-GB), a WASM-based SHA-256
- * would be needed. This implementation reads chunks sequentially but still
- * needs to hold the full file data in memory for the final digest call.
- * The benefit is reduced *peak* memory by processing chunks incrementally
- * and giving the GC a chance to reclaim between reads.
+ * This is the same `.create().update().digest()` pattern used by
+ * uuid-hash and etag-hash in the uploads/ pipeline, but using SHA-256
+ * and working in both browsers and Node.js.
  *
  * @param file - File to hash
  * @param chunkSize - Size of each chunk in bytes (default: 2MB)
@@ -97,15 +82,15 @@ export async function hashFileChunked(
   }
 
   try {
+    const hasher = sha256.create();
     const totalSize = file.size;
-    const chunks: Uint8Array[] = [];
     let bytesRead = 0;
 
     while (bytesRead < totalSize) {
       const end = Math.min(bytesRead + chunkSize, totalSize);
       const slice = file.slice(bytesRead, end);
       const buffer = await slice.arrayBuffer();
-      chunks.push(new Uint8Array(buffer));
+      hasher.update(new Uint8Array(buffer));
       bytesRead = end;
 
       if (onProgress) {
@@ -113,17 +98,7 @@ export async function hashFileChunked(
       }
     }
 
-    // Concatenate all chunks for final digest
-    const totalLength = chunks.reduce((sum, c) => sum + c.length, 0);
-    const combined = new Uint8Array(totalLength);
-    let offset = 0;
-    for (const chunk of chunks) {
-      combined.set(chunk, offset);
-      offset += chunk.length;
-    }
-
-    const hashBuffer = await crypto.subtle.digest('SHA-256', combined);
-    return bufferToHex(hashBuffer);
+    return bytesToHex(hasher.digest());
   } catch (err) {
     if (err instanceof UploadError) throw err;
     throw new UploadError('HASH_FAILED', 'Failed to compute chunked SHA-256 hash', err);

--- a/packages/upload-client/src/index.ts
+++ b/packages/upload-client/src/index.ts
@@ -4,9 +4,9 @@
  * Client-side presigned URL upload utilities for Constructive.
  *
  * Provides atomic functions for the presigned URL upload pipeline:
- * - `hashFile` — SHA-256 hash via Web Crypto API (File/Blob)
- * - `hashFileChunked` — chunked SHA-256 for large files
- * - `hashContent` — SHA-256 hash for plain strings (Web Crypto)
+ * - `hashFile` — SHA-256 hash (File/Blob, one-shot)
+ * - `hashFileChunked` — true incremental SHA-256 for large files (GB+)
+ * - `hashContent` — SHA-256 hash for plain strings
  * - `putToPresignedUrl` — PUT bytes to a presigned S3 URL
  * - `fetchFromUrl` — GET from a presigned or CDN URL
  * - `uploadFile` — full upload orchestrator (hash → request → PUT)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,7 +219,7 @@ importers:
         version: 5.2.1
       grafserv:
         specifier: 1.0.0
-        version: 1.0.0(@types/node@25.6.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(grafast@1.0.0(graphql@16.13.0))(graphile-config@1.0.0)(graphql@16.13.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))(ws@8.19.0)
+        version: 1.0.0(@types/node@22.19.15)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(grafast@1.0.0(graphql@16.13.0))(graphile-config@1.0.0)(graphql@16.13.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))(ws@8.19.0)
       lru-cache:
         specifier: ^11.2.7
         version: 11.2.7
@@ -228,7 +228,7 @@ importers:
         version: link:../../postgres/pg-cache/dist
       postgraphile:
         specifier: 5.0.0
-        version: 5.0.0(b0c7f090e4779e091f8ad020f716afca)
+        version: 5.0.0(0c2cedda320a650bce7ee949e4b7e993)
     devDependencies:
       '@types/express':
         specifier: ^5.0.6
@@ -241,7 +241,7 @@ importers:
         version: 3.1.14
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@25.6.2)(typescript@5.9.3)
+        version: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
     publishDirectory: dist
 
   graphile/graphile-connection-filter:
@@ -628,7 +628,7 @@ importers:
         version: 0.3.0
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@25.6.2)(typescript@5.9.3)
+        version: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
     publishDirectory: dist
 
   graphile/graphile-search:
@@ -730,7 +730,7 @@ importers:
         version: 1.0.0(graphql@16.13.0)
       grafserv:
         specifier: 1.0.0
-        version: 1.0.0(@types/node@25.6.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(grafast@1.0.0(graphql@16.13.0))(graphile-config@1.0.0)(graphql@16.13.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))(ws@8.19.0)
+        version: 1.0.0(@types/node@22.19.15)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(grafast@1.0.0(graphql@16.13.0))(graphile-config@1.0.0)(graphql@16.13.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))(ws@8.19.0)
       graphile-bucket-provisioner-plugin:
         specifier: workspace:*
         version: link:../graphile-bucket-provisioner-plugin/dist
@@ -790,7 +790,7 @@ importers:
         version: 5.0.0
       postgraphile:
         specifier: 5.0.0
-        version: 5.0.0(b0c7f090e4779e091f8ad020f716afca)
+        version: 5.0.0(0c2cedda320a650bce7ee949e4b7e993)
       request-ip:
         specifier: ^3.3.0
         version: 3.3.0
@@ -821,7 +821,7 @@ importers:
         version: 3.1.14
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@25.6.2)(typescript@5.9.3)
+        version: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
     publishDirectory: dist
 
   graphile/graphile-sql-expression-validator:
@@ -1069,7 +1069,7 @@ importers:
         version: 5.2.1
       grafserv:
         specifier: 1.0.0
-        version: 1.0.0(@types/node@25.6.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(grafast@1.0.0(graphql@16.13.0))(graphile-config@1.0.0)(graphql@16.13.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))(ws@8.19.0)
+        version: 1.0.0(@types/node@22.19.15)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(grafast@1.0.0(graphql@16.13.0))(graphile-config@1.0.0)(graphql@16.13.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))(ws@8.19.0)
       graphile-cache:
         specifier: workspace:^
         version: link:../../graphile/graphile-cache/dist
@@ -1090,7 +1090,7 @@ importers:
         version: link:../../postgres/pg-env/dist
       postgraphile:
         specifier: 5.0.0
-        version: 5.0.0(b0c7f090e4779e091f8ad020f716afca)
+        version: 5.0.0(0c2cedda320a650bce7ee949e4b7e993)
     devDependencies:
       '@types/express':
         specifier: ^5.0.6
@@ -1103,7 +1103,7 @@ importers:
         version: 3.1.14
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@25.6.2)(typescript@5.9.3)
+        version: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
     publishDirectory: dist
 
   graphql/gql-ast:
@@ -1343,7 +1343,7 @@ importers:
         version: 1.0.0(graphql@16.13.0)
       grafserv:
         specifier: 1.0.0
-        version: 1.0.0(@types/node@25.6.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(grafast@1.0.0(graphql@16.13.0))(graphile-config@1.0.0)(graphql@16.13.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))(ws@8.19.0)
+        version: 1.0.0(@types/node@22.19.15)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(grafast@1.0.0(graphql@16.13.0))(graphile-config@1.0.0)(graphql@16.13.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))(ws@8.19.0)
       graphile-build:
         specifier: 5.0.0
         version: 5.0.0(grafast@1.0.0(graphql@16.13.0))(graphile-config@1.0.0)(graphql@16.13.0)
@@ -1391,7 +1391,7 @@ importers:
         version: 5.0.0
       postgraphile:
         specifier: 5.0.0
-        version: 5.0.0(b0c7f090e4779e091f8ad020f716afca)
+        version: 5.0.0(0c2cedda320a650bce7ee949e4b7e993)
       request-ip:
         specifier: ^3.3.0
         version: 3.3.0
@@ -1428,7 +1428,7 @@ importers:
         version: 3.1.14
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@25.6.2)(typescript@5.9.3)
+        version: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
     publishDirectory: dist
 
   graphql/server-test:
@@ -1853,7 +1853,7 @@ importers:
         version: 7.2.2
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@25.6.2)(typescript@5.9.3)
+        version: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
     publishDirectory: dist
 
   jobs/knative-job-worker:
@@ -2231,7 +2231,7 @@ importers:
         version: 0.3.0
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@25.6.2)(typescript@5.9.3)
+        version: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
     publishDirectory: dist
 
   packages/smtppostmaster:
@@ -2260,7 +2260,7 @@ importers:
         version: 3.18.1
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@25.6.2)(typescript@5.9.3)
+        version: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
     publishDirectory: dist
 
   packages/upload-client:
@@ -2268,6 +2268,9 @@ importers:
       '@constructive-io/fetch':
         specifier: ^1.0.0
         version: 1.0.0
+      '@noble/hashes':
+        specifier: ^2.2.0
+        version: 2.2.0
     devDependencies:
       makage:
         specifier: ^0.3.0
@@ -4241,6 +4244,10 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -11992,6 +11999,8 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
+  '@noble/hashes@2.2.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -13518,6 +13527,7 @@ snapshots:
   '@types/node@25.6.2':
     dependencies:
       undici-types: 7.19.2
+    optional: true
 
   '@types/nodemailer@7.0.11':
     dependencies:
@@ -18717,14 +18727,14 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@25.6.2)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 25.6.2
+      '@types/node': 22.19.15
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -18805,7 +18815,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici-types@7.19.2: {}
+  undici-types@7.19.2:
+    optional: true
 
   undici@7.24.6: {}
 


### PR DESCRIPTION
## Summary

Replaces `crypto.subtle.digest()` (Web Crypto API) with `@noble/hashes` for all SHA-256 hashing in `upload-client`. The key improvement is that **`hashFileChunked` now performs true incremental hashing** — only one chunk is held in memory at a time (O(chunkSize)), instead of the previous behavior which collected all chunks into an array and concatenated them before a single `digest()` call (O(fileSize)).

**Before:** `hashFileChunked` read chunks via `Blob.slice()`, pushed each into a `Uint8Array[]`, concatenated everything, then called `crypto.subtle.digest('SHA-256', combined)`. Despite the name, it still needed the full file in memory.

**After:** Uses `sha256.create()` → `.update(chunk)` per slice → `.digest()` at the end. This is the same incremental pattern used by `uuid-hash` and `etag-hash` in the `uploads/` pipeline.

`hashFile` and `hashContent` also switched to `@noble/hashes` for consistency. All three functions keep their `async` signatures for forward compatibility. `@noble/hashes` is pure JS, security-audited, 0 dependencies, ~2.4KB gzipped for SHA-256.

Jest config updated with `transformIgnorePatterns` since `@noble/hashes` v2.x is ESM-only — `tsc` handles it fine for the CJS/ESM dual build, but Jest needed the workaround.

## Review & Testing Checklist for Human

- [ ] **Hash output consistency**: Verify that `@noble/hashes` SHA-256 produces identical hex output to the previous Web Crypto implementation (same case, same encoding). This is critical because the presigned URL flow uses content hashes for deduplication. Tests pass (24/24) but worth a manual sanity check.
- [ ] **CJS consumers**: Confirm that packages which `require('@constructive-io/upload-client')` at runtime don't hit ESM resolution errors. The `tsc` build compiles noble's ESM imports into `require()` calls for the CJS output — verify this works in a real Node.js CJS context (not just Jest).
- [ ] **Lockfile noise**: `pnpm-lock.yaml` includes unrelated `@types/node` version resolution changes (25.6.2 → 22.19.15) caused by running `pnpm add`. Verify this doesn't affect other packages.

**Suggested test plan:** After publishing, update `@constructive-io/upload-client` in `constructive-db` and re-run the storage integration tests (`minio-multi-scope.integration.test.ts`) to confirm hashes still match and uploads succeed end-to-end.

### Notes
- `@noble/hashes` v2.x is ESM-only, which required `transformIgnorePatterns` in Jest config. The pattern `node_modules/(?!(\\.pnpm|@noble))` is slightly broader than necessary (allows all `@noble/*` and the `.pnpm` dir through) but is the standard approach for pnpm + Jest + ESM deps.
- The removed `bufferToHex` helper is replaced by `bytesToHex` from `@noble/hashes/utils.js`.

Link to Devin session: https://app.devin.ai/sessions/7903d2a3e7a34c6daa605e12d6b80d9e
Requested by: @pyramation