### PR TITLE
fix(upload-client): use Node crypto for CJS, @noble/hashes for ESM

### DIFF
--- a/packages/upload-client/package.json
+++ b/packages/upload-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@constructive-io/upload-client",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "author": "Constructive <developers@constructive.io>",
   "description": "Client-side presigned URL upload utilities for Constructive",
   "main": "index.js",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@constructive-io/fetch": "^1.0.0",
-    "@noble/hashes": "^2.2.0"
+    "@constructive-io/noble-hashes": "^0.1.0"
   },
   "devDependencies": {
     "makage": "^0.3.0"

--- a/packages/upload-client/package.json
+++ b/packages/upload-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@constructive-io/upload-client",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "author": "Constructive <developers@constructive.io>",
   "description": "Client-side presigned URL upload utilities for Constructive",
   "main": "index.js",

--- a/packages/upload-client/src/hash-content.ts
+++ b/packages/upload-client/src/hash-content.ts
@@ -1,9 +1,11 @@
 /**
- * String content hashing using @noble/hashes.
+ * String content hashing.
  *
  * Complements `hashFile` (which accepts File/Blob) with a convenience
- * function for hashing plain strings. Uses @noble/hashes for incremental
- * SHA-256 — works in browsers, Node.js, Deno, and Cloudflare Workers.
+ * function for hashing plain strings.
+ *
+ * Uses Node.js `crypto` when available (CJS/Node), falling back to
+ * @noble/hashes in browser/ESM environments. See hash.ts for details.
  *
  * @example
  * ```typescript
@@ -14,8 +16,6 @@
  * ```
  */
 
-import { sha256 } from '@noble/hashes/sha2.js';
-import { bytesToHex } from '@noble/hashes/utils.js';
 import { UploadError } from './types';
 
 /**
@@ -27,8 +27,18 @@ import { UploadError } from './types';
 export async function hashContent(content: string): Promise<string> {
   try {
     const data = new TextEncoder().encode(content);
-    return bytesToHex(sha256(data));
+    try {
+      // Node.js: use built-in crypto (works in CJS and ESM)
+      const crypto = require('crypto');
+      return crypto.createHash('sha256').update(data).digest('hex');
+    } catch {
+      // Browser/non-Node: use @noble/hashes (ESM import works here)
+      const { sha256 } = await import('@noble/hashes/sha2.js');
+      const { bytesToHex } = await import('@noble/hashes/utils.js');
+      return bytesToHex(sha256(data));
+    }
   } catch (err) {
+    if (err instanceof UploadError) throw err;
     throw new UploadError('HASH_FAILED', 'Failed to compute SHA-256 hash', err);
   }
 }

--- a/packages/upload-client/src/hash-content.ts
+++ b/packages/upload-client/src/hash-content.ts
@@ -4,9 +4,6 @@
  * Complements `hashFile` (which accepts File/Blob) with a convenience
  * function for hashing plain strings.
  *
- * Uses Node.js `crypto` when available (CJS/Node), falling back to
- * @noble/hashes in browser/ESM environments. See hash.ts for details.
- *
  * @example
  * ```typescript
  * import { hashContent } from '@constructive-io/upload-client';
@@ -16,6 +13,8 @@
  * ```
  */
 
+import { sha256 } from '@constructive-io/noble-hashes/sha2';
+import { bytesToHex } from '@constructive-io/noble-hashes/utils';
 import { UploadError } from './types';
 
 /**
@@ -27,16 +26,7 @@ import { UploadError } from './types';
 export async function hashContent(content: string): Promise<string> {
   try {
     const data = new TextEncoder().encode(content);
-    try {
-      // Node.js: use built-in crypto (works in CJS and ESM)
-      const crypto = require('crypto');
-      return crypto.createHash('sha256').update(data).digest('hex');
-    } catch {
-      // Browser/non-Node: use @noble/hashes (ESM import works here)
-      const { sha256 } = await import('@noble/hashes/sha2.js');
-      const { bytesToHex } = await import('@noble/hashes/utils.js');
-      return bytesToHex(sha256(data));
-    }
+    return bytesToHex(sha256(data));
   } catch (err) {
     if (err instanceof UploadError) throw err;
     throw new UploadError('HASH_FAILED', 'Failed to compute SHA-256 hash', err);

--- a/packages/upload-client/src/hash.ts
+++ b/packages/upload-client/src/hash.ts
@@ -1,64 +1,19 @@
 /**
- * File hashing utilities.
+ * File hashing utilities using @constructive-io/noble-hashes.
  *
  * Two strategies:
  * - `hashFile` — reads entire file into memory, fast for files up to ~200MB
  * - `hashFileChunked` — true incremental hashing via Blob.slice, suitable
  *   for arbitrarily large files (GB+). Only one chunk is in memory at a time.
  *
- * Uses Node.js `crypto` when available (CJS/Node), falling back to
- * @noble/hashes (pure JS, audited, 0 deps) in browser/ESM environments.
- * This avoids the "Must use import to load ES Module" error that occurs
- * when CJS code `require()`s the ESM-only @noble/hashes package.
+ * Both use @constructive-io/noble-hashes (pure JS, audited, 0 dependencies)
+ * which supports incremental .update() — unlike Web Crypto API's one-shot digest().
  */
 
+import { sha256 } from '@constructive-io/noble-hashes/sha2';
+import { bytesToHex } from '@constructive-io/noble-hashes/utils';
 import { UploadError } from './types';
 import type { FileInput } from './types';
-
-interface Sha256Hasher {
-  update(data: Uint8Array): Sha256Hasher;
-  digest(): Uint8Array;
-}
-
-interface HashImpl {
-  sha256(data: Uint8Array): Uint8Array;
-  sha256create(): Sha256Hasher;
-  bytesToHex(bytes: Uint8Array): string;
-}
-
-let _impl: HashImpl | undefined;
-
-async function getImpl(): Promise<HashImpl> {
-  if (_impl) return _impl;
-  try {
-    // Node.js: use built-in crypto (works in CJS and ESM)
-    const crypto = require('crypto');
-    _impl = {
-      sha256: (data: Uint8Array) => new Uint8Array(crypto.createHash('sha256').update(data).digest()),
-      sha256create: () => {
-        const h = crypto.createHash('sha256');
-        const wrapper: Sha256Hasher = {
-          update(data: Uint8Array) { h.update(data); return wrapper; },
-          digest() { return new Uint8Array(h.digest()); },
-        };
-        return wrapper;
-      },
-      bytesToHex: (bytes: Uint8Array) => Buffer.from(bytes).toString('hex'),
-    };
-  } catch {
-    // Browser/non-Node: use @noble/hashes (ESM import works here)
-    const [noble, utils] = await Promise.all([
-      import('@noble/hashes/sha2.js'),
-      import('@noble/hashes/utils.js'),
-    ]);
-    _impl = {
-      sha256: noble.sha256,
-      sha256create: () => noble.sha256.create(),
-      bytesToHex: utils.bytesToHex,
-    };
-  }
-  return _impl;
-}
 
 /** Default chunk size for chunked hashing: 2MB */
 const DEFAULT_CHUNK_SIZE = 2 * 1024 * 1024;
@@ -84,9 +39,8 @@ export async function hashFile(file: FileInput): Promise<string> {
   }
 
   try {
-    const impl = await getImpl();
     const buffer = await file.arrayBuffer();
-    return impl.bytesToHex(impl.sha256(new Uint8Array(buffer)));
+    return bytesToHex(sha256(new Uint8Array(buffer)));
   } catch (err) {
     if (err instanceof UploadError) throw err;
     throw new UploadError('HASH_FAILED', 'Failed to compute SHA-256 hash', err);
@@ -125,8 +79,7 @@ export async function hashFileChunked(
   }
 
   try {
-    const impl = await getImpl();
-    const hasher = impl.sha256create();
+    const hasher = sha256.create();
     const totalSize = file.size;
     let bytesRead = 0;
 
@@ -142,7 +95,7 @@ export async function hashFileChunked(
       }
     }
 
-    return impl.bytesToHex(hasher.digest());
+    return bytesToHex(hasher.digest());
   } catch (err) {
     if (err instanceof UploadError) throw err;
     throw new UploadError('HASH_FAILED', 'Failed to compute chunked SHA-256 hash', err);

--- a/packages/upload-client/src/hash.ts
+++ b/packages/upload-client/src/hash.ts
@@ -1,19 +1,64 @@
 /**
- * File hashing utilities using @noble/hashes.
+ * File hashing utilities.
  *
  * Two strategies:
  * - `hashFile` — reads entire file into memory, fast for files up to ~200MB
  * - `hashFileChunked` — true incremental hashing via Blob.slice, suitable
  *   for arbitrarily large files (GB+). Only one chunk is in memory at a time.
  *
- * Both use @noble/hashes (pure JS, audited, 0 dependencies) which supports
- * incremental .update() — unlike Web Crypto API's one-shot digest().
+ * Uses Node.js `crypto` when available (CJS/Node), falling back to
+ * @noble/hashes (pure JS, audited, 0 deps) in browser/ESM environments.
+ * This avoids the "Must use import to load ES Module" error that occurs
+ * when CJS code `require()`s the ESM-only @noble/hashes package.
  */
 
-import { sha256 } from '@noble/hashes/sha2.js';
-import { bytesToHex } from '@noble/hashes/utils.js';
 import { UploadError } from './types';
 import type { FileInput } from './types';
+
+interface Sha256Hasher {
+  update(data: Uint8Array): Sha256Hasher;
+  digest(): Uint8Array;
+}
+
+interface HashImpl {
+  sha256(data: Uint8Array): Uint8Array;
+  sha256create(): Sha256Hasher;
+  bytesToHex(bytes: Uint8Array): string;
+}
+
+let _impl: HashImpl | undefined;
+
+async function getImpl(): Promise<HashImpl> {
+  if (_impl) return _impl;
+  try {
+    // Node.js: use built-in crypto (works in CJS and ESM)
+    const crypto = require('crypto');
+    _impl = {
+      sha256: (data: Uint8Array) => new Uint8Array(crypto.createHash('sha256').update(data).digest()),
+      sha256create: () => {
+        const h = crypto.createHash('sha256');
+        const wrapper: Sha256Hasher = {
+          update(data: Uint8Array) { h.update(data); return wrapper; },
+          digest() { return new Uint8Array(h.digest()); },
+        };
+        return wrapper;
+      },
+      bytesToHex: (bytes: Uint8Array) => Buffer.from(bytes).toString('hex'),
+    };
+  } catch {
+    // Browser/non-Node: use @noble/hashes (ESM import works here)
+    const [noble, utils] = await Promise.all([
+      import('@noble/hashes/sha2.js'),
+      import('@noble/hashes/utils.js'),
+    ]);
+    _impl = {
+      sha256: noble.sha256,
+      sha256create: () => noble.sha256.create(),
+      bytesToHex: utils.bytesToHex,
+    };
+  }
+  return _impl;
+}
 
 /** Default chunk size for chunked hashing: 2MB */
 const DEFAULT_CHUNK_SIZE = 2 * 1024 * 1024;
@@ -39,9 +84,11 @@ export async function hashFile(file: FileInput): Promise<string> {
   }
 
   try {
+    const impl = await getImpl();
     const buffer = await file.arrayBuffer();
-    return bytesToHex(sha256(new Uint8Array(buffer)));
+    return impl.bytesToHex(impl.sha256(new Uint8Array(buffer)));
   } catch (err) {
+    if (err instanceof UploadError) throw err;
     throw new UploadError('HASH_FAILED', 'Failed to compute SHA-256 hash', err);
   }
 }
@@ -50,12 +97,8 @@ export async function hashFile(file: FileInput): Promise<string> {
  * Hash a file using SHA-256 in chunks (true incremental).
  *
  * Reads the file in fixed-size slices using `Blob.slice()`, feeding each
- * chunk into @noble/hashes' incremental SHA-256 hasher. Only one chunk
- * is held in memory at a time — O(chunkSize) memory for any file size.
- *
- * This is the same `.create().update().digest()` pattern used by
- * uuid-hash and etag-hash in the uploads/ pipeline, but using SHA-256
- * and working in both browsers and Node.js.
+ * chunk into an incremental SHA-256 hasher. Only one chunk is held in
+ * memory at a time — O(chunkSize) memory for any file size.
  *
  * @param file - File to hash
  * @param chunkSize - Size of each chunk in bytes (default: 2MB)
@@ -82,7 +125,8 @@ export async function hashFileChunked(
   }
 
   try {
-    const hasher = sha256.create();
+    const impl = await getImpl();
+    const hasher = impl.sha256create();
     const totalSize = file.size;
     let bytesRead = 0;
 
@@ -98,7 +142,7 @@ export async function hashFileChunked(
       }
     }
 
-    return bytesToHex(hasher.digest());
+    return impl.bytesToHex(hasher.digest());
   } catch (err) {
     if (err instanceof UploadError) throw err;
     throw new UploadError('HASH_FAILED', 'Failed to compute chunked SHA-256 hash', err);


### PR DESCRIPTION
## Summary

`@noble/hashes` v2.x is ESM-only (`"type": "module"`). The CJS build of upload-client compiled `import { sha256 } from '@noble/hashes/sha2.js'` to `require("@noble/hashes/sha2.js")`, which fails in Jest 30 and other CJS consumers with:

```
Must use import to load ES Module: .../@noble/hashes/sha2.js
```

This broke [constructive-db PR #1100](https://github.com/constructive-io/constructive-db/pull/1100) storage integration tests after bumping `upload-client` from `0.10.0` → `0.11.0`.

**Fix**: Use Node.js built-in `crypto` module as the primary SHA-256 implementation (always available in CJS/Node), with `@noble/hashes` as a dynamic `import()` fallback for browser/ESM environments where `crypto` is not available. This avoids the static `require()` on an ESM-only package entirely.

- `hash.ts`: Abstracted behind a `HashImpl` interface with lazy initialization
- `hash-content.ts`: Same Node crypto primary / @noble/hashes fallback pattern
- Version bumped to `0.12.0`

All 24 existing tests pass.

## Review & Testing Checklist for Human

- [ ] Verify the CJS output (`dist/hash.js`) does NOT contain a top-level `require('@noble/hashes/...')` — only inside the catch block
- [ ] Confirm `hashContent` and `hashFile` produce identical SHA-256 digests as before (the test suite covers this)
- [ ] After publishing `0.12.0`, update `constructive-db` to use `^0.12.0` and verify the storage integration tests pass

### Notes

- The `@noble/hashes` import in the catch block is still compiled to `require()` by TypeScript, but it's never reached in Node.js because `require('crypto')` always succeeds
- Browser bundlers (webpack, vite, esbuild) will tree-shake the `require('crypto')` path and use the `@noble/hashes` ESM imports from the `esm/` build instead
- `@noble/hashes` remains a runtime dependency for browser consumers

Link to Devin session: https://app.devin.ai/sessions/1a2b164e76c747dcb3f8f79ee76fa903
Requested by: @pyramation