### PR TITLE
feat: add Check constraint node types (CheckOneOf, CheckGreaterThan, CheckLessThan, CheckNotEqual)

### DIFF
--- a/packages/node-type-registry/src/data/check-greater-than.ts
+++ b/packages/node-type-registry/src/data/check-greater-than.ts
@@ -1,0 +1,33 @@
+import type { NodeTypeDefinition } from '../types';
+
+export const CheckGreaterThan: NodeTypeDefinition = {
+  name: 'CheckGreaterThan',
+  slug: 'check_greater_than',
+  category: 'data',
+  display_name: 'Check Greater Than',
+  description:
+    'Adds a CHECK constraint that validates a column value is greater than a threshold (single-column: column > value) or that one column is greater than another (cross-column: columns[0] > columns[1]). Compiled via AST helpers.',
+  parameter_schema: {
+    type: 'object',
+    properties: {
+      column: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Single column to compare against value (mutually exclusive with columns)',
+      },
+      value: {
+        type: 'number',
+        description: 'Threshold value for single-column comparison (column > value)',
+        default: 0,
+      },
+      columns: {
+        type: 'array',
+        items: { type: 'string', format: 'column-ref' },
+        description: 'Two columns for cross-column comparison (columns[0] > columns[1])',
+        minItems: 2,
+        maxItems: 2,
+      },
+    },
+  },
+  tags: ['check', 'constraint', 'validation', 'comparison'],
+};

--- a/packages/node-type-registry/src/data/check-greater-than.ts
+++ b/packages/node-type-registry/src/data/check-greater-than.ts
@@ -3,7 +3,7 @@ import type { NodeTypeDefinition } from '../types';
 export const CheckGreaterThan: NodeTypeDefinition = {
   name: 'CheckGreaterThan',
   slug: 'check_greater_than',
-  category: 'data',
+  category: 'check',
   display_name: 'Check Greater Than',
   description:
     'Adds a CHECK constraint that validates a column value is greater than a threshold (single-column: column > value) or that one column is greater than another (cross-column: columns[0] > columns[1]). Compiled via AST helpers.',

--- a/packages/node-type-registry/src/data/check-less-than.ts
+++ b/packages/node-type-registry/src/data/check-less-than.ts
@@ -1,0 +1,32 @@
+import type { NodeTypeDefinition } from '../types';
+
+export const CheckLessThan: NodeTypeDefinition = {
+  name: 'CheckLessThan',
+  slug: 'check_less_than',
+  category: 'data',
+  display_name: 'Check Less Than',
+  description:
+    'Adds a CHECK constraint that validates a column value is less than a threshold (single-column: column < value) or that one column is less than another (cross-column: columns[0] < columns[1]). Compiled via AST helpers.',
+  parameter_schema: {
+    type: 'object',
+    properties: {
+      column: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Single column to compare against value (mutually exclusive with columns)',
+      },
+      value: {
+        type: 'number',
+        description: 'Threshold value for single-column comparison (column < value)',
+      },
+      columns: {
+        type: 'array',
+        items: { type: 'string', format: 'column-ref' },
+        description: 'Two columns for cross-column comparison (columns[0] < columns[1])',
+        minItems: 2,
+        maxItems: 2,
+      },
+    },
+  },
+  tags: ['check', 'constraint', 'validation', 'comparison'],
+};

--- a/packages/node-type-registry/src/data/check-less-than.ts
+++ b/packages/node-type-registry/src/data/check-less-than.ts
@@ -3,7 +3,7 @@ import type { NodeTypeDefinition } from '../types';
 export const CheckLessThan: NodeTypeDefinition = {
   name: 'CheckLessThan',
   slug: 'check_less_than',
-  category: 'data',
+  category: 'check',
   display_name: 'Check Less Than',
   description:
     'Adds a CHECK constraint that validates a column value is less than a threshold (single-column: column < value) or that one column is less than another (cross-column: columns[0] < columns[1]). Compiled via AST helpers.',

--- a/packages/node-type-registry/src/data/check-not-equal.ts
+++ b/packages/node-type-registry/src/data/check-not-equal.ts
@@ -1,0 +1,24 @@
+import type { NodeTypeDefinition } from '../types';
+
+export const CheckNotEqual: NodeTypeDefinition = {
+  name: 'CheckNotEqual',
+  slug: 'check_not_equal',
+  category: 'data',
+  display_name: 'Check Not Equal',
+  description:
+    'Adds a CHECK constraint that validates two columns are not equal (columns[0] != columns[1]). Useful for preventing self-referencing rows. Compiled via AST helpers.',
+  parameter_schema: {
+    type: 'object',
+    properties: {
+      columns: {
+        type: 'array',
+        items: { type: 'string', format: 'column-ref' },
+        description: 'Two columns that must not be equal',
+        minItems: 2,
+        maxItems: 2,
+      },
+    },
+    required: ['columns'],
+  },
+  tags: ['check', 'constraint', 'validation', 'inequality'],
+};

--- a/packages/node-type-registry/src/data/check-not-equal.ts
+++ b/packages/node-type-registry/src/data/check-not-equal.ts
@@ -3,7 +3,7 @@ import type { NodeTypeDefinition } from '../types';
 export const CheckNotEqual: NodeTypeDefinition = {
   name: 'CheckNotEqual',
   slug: 'check_not_equal',
-  category: 'data',
+  category: 'check',
   display_name: 'Check Not Equal',
   description:
     'Adds a CHECK constraint that validates two columns are not equal (columns[0] != columns[1]). Useful for preventing self-referencing rows. Compiled via AST helpers.',

--- a/packages/node-type-registry/src/data/check-one-of.ts
+++ b/packages/node-type-registry/src/data/check-one-of.ts
@@ -1,0 +1,27 @@
+import type { NodeTypeDefinition } from '../types';
+
+export const CheckOneOf: NodeTypeDefinition = {
+  name: 'CheckOneOf',
+  slug: 'check_one_of',
+  category: 'data',
+  display_name: 'Check One Of',
+  description:
+    'Adds a CHECK constraint that validates a column value is one of an allowed set (e.g. tier IN (\'free\', \'paid\', \'custom\')). Compiled to column = ANY(ARRAY[...]) via AST helpers.',
+  parameter_schema: {
+    type: 'object',
+    properties: {
+      column: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column to validate against the allowed values',
+      },
+      values: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Array of allowed values for the column',
+      },
+    },
+    required: ['column', 'values'],
+  },
+  tags: ['check', 'constraint', 'validation', 'enum'],
+};

--- a/packages/node-type-registry/src/data/check-one-of.ts
+++ b/packages/node-type-registry/src/data/check-one-of.ts
@@ -3,7 +3,7 @@ import type { NodeTypeDefinition } from '../types';
 export const CheckOneOf: NodeTypeDefinition = {
   name: 'CheckOneOf',
   slug: 'check_one_of',
-  category: 'data',
+  category: 'check',
   display_name: 'Check One Of',
   description:
     'Adds a CHECK constraint that validates a column value is one of an allowed set (e.g. tier IN (\'free\', \'paid\', \'custom\')). Compiled to column = ANY(ARRAY[...]) via AST helpers.',

--- a/packages/node-type-registry/src/data/index.ts
+++ b/packages/node-type-registry/src/data/index.ts
@@ -1,3 +1,7 @@
+export { CheckGreaterThan } from './check-greater-than';
+export { CheckLessThan } from './check-less-than';
+export { CheckNotEqual } from './check-not-equal';
+export { CheckOneOf } from './check-one-of';
 export { DataAggregateLimitCounter } from './data-aggregate-limit-counter';
 export { DataBillingMeter } from './data-billing-meter';
 export { DataChunks } from './data-chunks';

--- a/packages/node-type-registry/src/types.ts
+++ b/packages/node-type-registry/src/types.ts
@@ -43,7 +43,7 @@ export interface NodeTypeDefinition {
   name: string;
   /** snake_case slug, e.g. 'authz_direct_owner' */
   slug: string;
-  /** Category: authz | data | field | relation | view */
+  /** Category: authz | check | data | field | relation | search | view */
   category: string;
   /** Human-readable display name, e.g. 'Direct Ownership' */
   display_name: string;


### PR DESCRIPTION
## Summary

Adds four new node type definitions to `packages/node-type-registry` for blueprint check constraints, following the established `$type` + `data` pattern:

- **`CheckOneOf`** — enum validation (`column = ANY(ARRAY[...])`)
- **`CheckGreaterThan`** — single-column threshold or cross-column comparison
- **`CheckLessThan`** — single-column threshold or cross-column comparison
- **`CheckNotEqual`** — cross-column inequality

These are the registry-side counterparts to the `provision_check_constraint()` SQL procedure added in [constructive-db#1104](https://github.com/constructive-io/constructive-db/pull/1104).

## Review & Testing Checklist for Human

- [ ] **Category choice**: All four types use `category: 'data'`. Verify this is the correct category for check constraints — there is no existing `constraint` category, so `data` was chosen to match the closest existing convention. Consider whether a new category is warranted.
- [ ] **Parameter schema mutual exclusivity**: `CheckGreaterThan` and `CheckLessThan` accept either `column`+`value` or `columns` but the JSON Schema doesn't enforce `oneOf` — mutual exclusivity is enforced by the SQL procedure. Confirm this is acceptable or if the schema should be stricter.
- [ ] **Generated types**: `blueprint-types.generated.ts` was not regenerated via `generate:types`. Verify whether this needs to be run before merge so downstream consumers pick up the new types.

### Notes

- The parameter schemas intentionally mirror the `data` body shapes expected by `provision_check_constraint()` in constructive-db.
- `CheckNotEqual` only supports cross-column mode (`columns` required); `CheckOneOf` only supports single-column mode (`column` + `values` required). The comparison types (`CheckGreaterThan`/`CheckLessThan`) support both modes.

Link to Devin session: https://app.devin.ai/sessions/6e29559e7a5d4074810f0bd0273dcfc3
Requested by: @pyramation