### PR TITLE
Fix global fetch this issue

### DIFF
--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/client-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/client-generator.test.ts.snap
@@ -159,7 +159,7 @@ export class FetchAdapter implements GraphQLAdapter {
     fetchFn?: typeof globalThis.fetch,
   ) {
     this.headers = headers ?? {};
-    this.fetchFn = fetchFn ?? createFetch();
+    this.fetchFn = (fetchFn ?? createFetch()).bind(globalThis);
   }
 
   async execute<T>(

--- a/graphql/codegen/src/__tests__/codegen/client-generator.test.ts
+++ b/graphql/codegen/src/__tests__/codegen/client-generator.test.ts
@@ -76,6 +76,34 @@ describe('client-generator', () => {
       );
       expect(result.content).toContain('createFetch()');
     });
+
+    it('binds fetchFn to globalThis to avoid Illegal invocation in browsers', () => {
+      const result = generateOrmClientFile();
+
+      // The generated FetchAdapter must .bind(globalThis) to prevent
+      // "Illegal invocation" when native window.fetch is stored as
+      // an instance property (which detaches it from its original this).
+      expect(result.content).toContain('.bind(globalThis)');
+    });
+
+    it('bind(globalThis) prevents Illegal invocation for this-sensitive fetch', () => {
+      // Simulate a native browser fetch that requires this === globalThis
+      // (calling window.fetch with any other this throws TypeError)
+      function thisSensitiveFetch(this: unknown): Promise<Response> {
+        if (this !== globalThis) {
+          throw new TypeError('Illegal invocation');
+        }
+        return Promise.resolve(new Response(JSON.stringify({ data: null })));
+      }
+
+      // Without bind: storing on an object and calling detaches this
+      const broken = { fetchFn: thisSensitiveFetch };
+      expect(() => broken.fetchFn()).toThrow('Illegal invocation');
+
+      // With bind: the pattern used in FetchAdapter keeps correct this
+      const fixed = { fetchFn: thisSensitiveFetch.bind(globalThis) };
+      expect(() => fixed.fetchFn()).not.toThrow();
+    });
   });
 
   describe('generateQueryBuilderFile', () => {

--- a/graphql/codegen/src/core/codegen/templates/orm-client.ts
+++ b/graphql/codegen/src/core/codegen/templates/orm-client.ts
@@ -63,7 +63,7 @@ export class FetchAdapter implements GraphQLAdapter {
     fetchFn?: typeof globalThis.fetch,
   ) {
     this.headers = headers ?? {};
-    this.fetchFn = fetchFn ?? createFetch();
+    this.fetchFn = (fetchFn ?? createFetch()).bind(globalThis);
   }
 
   async execute<T>(


### PR DESCRIPTION
The Bug
In FetchAdapter, the generated code does this:
ts
this.fetchFn = fetchFn ?? createFetch();   // step 1: store fetch as property
// ...
const response = await this.fetchFn(url, opts);  // step 2: call it
When createFetch() runs in the browser, it returns globalThis.fetch — which is window.fetch. The problem is step 2: calling this.fetchFn(...) invokes fetch with this === the FetchAdapter instance, but native window.fetch requires this === window. That's what "Illegal invocation" means — the browser rejects the call because this is wrong.In plain terms: storing a native function as an object property and then calling it detaches it from its original owner. Same reason "hello".trim works but const fn = "hello".trim; fn() throws.