### PR TITLE
feat: wire enable_realtime into DATABASE_SETTINGS_SQL COALESCE cascade

### DIFF
--- a/graphql/server-test/__fixtures__/seed/simple-seed-services/setup.sql
+++ b/graphql/server-test/__fixtures__/seed/simple-seed-services/setup.sql
@@ -302,6 +302,7 @@ CREATE TABLE IF NOT EXISTS services_public.database_settings (
   enable_connection_filter boolean NOT NULL DEFAULT true,
   enable_ltree boolean NOT NULL DEFAULT true,
   enable_llm boolean NOT NULL DEFAULT false,
+  enable_realtime boolean NOT NULL DEFAULT false,
   options jsonb NOT NULL DEFAULT '{}'::jsonb,
   CONSTRAINT ds_db_fkey FOREIGN KEY (database_id) REFERENCES metaschema_public.database (id) ON DELETE CASCADE
 );
@@ -320,6 +321,7 @@ CREATE TABLE IF NOT EXISTS services_public.api_settings (
   enable_connection_filter boolean,
   enable_ltree boolean,
   enable_llm boolean,
+  enable_realtime boolean,
   options jsonb NOT NULL DEFAULT '{}'::jsonb,
   CONSTRAINT as_db_fkey FOREIGN KEY (database_id) REFERENCES metaschema_public.database (id) ON DELETE CASCADE,
   CONSTRAINT as_api_fkey FOREIGN KEY (api_id) REFERENCES services_public.apis (id) ON DELETE CASCADE

--- a/graphql/server/src/middleware/api.ts
+++ b/graphql/server/src/middleware/api.ts
@@ -226,7 +226,8 @@ const DATABASE_SETTINGS_SQL = `
     COALESCE(aps.enable_many_to_many, ds.enable_many_to_many) AS resolved_enable_many_to_many,
     COALESCE(aps.enable_connection_filter, ds.enable_connection_filter) AS resolved_enable_connection_filter,
     COALESCE(aps.enable_ltree, ds.enable_ltree) AS resolved_enable_ltree,
-    COALESCE(aps.enable_llm, ds.enable_llm) AS resolved_enable_llm
+    COALESCE(aps.enable_llm, ds.enable_llm) AS resolved_enable_llm,
+    COALESCE(aps.enable_realtime, ds.enable_realtime) AS resolved_enable_realtime
   FROM services_public.database_settings ds
   LEFT JOIN services_public.api_settings aps ON ds.database_id = aps.database_id AND aps.api_id = $2
   WHERE ds.database_id = $1
@@ -325,6 +326,7 @@ interface DatabaseSettingsRow {
   resolved_enable_connection_filter: boolean;
   resolved_enable_ltree: boolean;
   resolved_enable_llm: boolean;
+  resolved_enable_realtime: boolean;
 }
 
 interface ApiListRow {
@@ -672,9 +674,7 @@ const toDatabaseSettings = (row: DatabaseSettingsRow | null): DatabaseSettings |
     enableConnectionFilter: row.resolved_enable_connection_filter,
     enableLtree: row.resolved_enable_ltree,
     enableLlm: row.resolved_enable_llm,
-    // Reads from the COALESCE cascade once constructive-db#1105 is merged and
-    // the enable_realtime column exists in database_settings / api_settings.
-    enableRealtime: false,
+    enableRealtime: row.resolved_enable_realtime,
   };
 };
 


### PR DESCRIPTION
## Summary

Removes the hardcoded `enableRealtime: false` placeholder and wires `enable_realtime` into the `DATABASE_SETTINGS_SQL` COALESCE cascade, following the same pattern as all other feature flags (`enable_llm`, `enable_ltree`, etc.).

This is a follow-up to constructive-db#1105 (which added the `enable_realtime` column to `database_settings` and `api_settings`) and #1119 (which integrated `RealtimeManager` into the preset but hardcoded the flag to `false` because the column didn't exist yet).

Three changes in `api.ts`:
1. SQL: added `COALESCE(aps.enable_realtime, ds.enable_realtime) AS resolved_enable_realtime` to the query
2. Type: added `resolved_enable_realtime: boolean` to `DatabaseSettingsRow`
3. Mapping: replaced `enableRealtime: false` with `enableRealtime: row.resolved_enable_realtime` in `toDatabaseSettings`

### Updates since last revision

Added `enable_realtime` column to the integration test seed DDL (`simple-seed-services/setup.sql`). Without this, the `DATABASE_SETTINGS_SQL` query fails against the test database (column doesn't exist), `queryDatabaseSettings` catches the error and returns `undefined`, and **all** feature flags fall back to defaults — causing the `Bob restricted API: uploadAppFile NOT exposed` test to fail because the `api_settings` override for `enable_presigned_uploads` was silently ignored.

## Review & Testing Checklist for Human

- [ ] **Deployment ordering**: This PR assumes `enable_realtime` already exists in both `services_public.database_settings` and `services_public.api_settings`. If constructive-db#1105 has not been deployed to an environment, the `DATABASE_SETTINGS_SQL` query will fail. The failure is caught by `queryDatabaseSettings`'s try/catch (returns `undefined` + logs a warning), but this means **all** database settings become undefined for that tenant — not just realtime. Verify #1105 is deployed before rolling this out.
- [ ] **Verify the COALESCE cascade resolves correctly**: `api_settings.enable_realtime` is nullable (NULL inherits from `database_settings`), while `database_settings.enable_realtime` is `NOT NULL DEFAULT false`. Confirm COALESCE produces the right result: api-level override wins when non-null, otherwise falls back to database-level default.
- [ ] **Test seed DDL stays in sync**: The test seed in `simple-seed-services/setup.sql` manually mirrors the production `database_settings` / `api_settings` schema. Any future column additions to these tables will need a corresponding update to the seed DDL, or the same silent-failure pattern will recur.

### Notes
- With this merged, setting `enable_realtime = true` in `database_settings` (or per-API in `api_settings`) will cause `RealtimeManager` to start and the `RealtimeSubscriptionsPreset` to be included for that tenant.
- The next step toward integration testing is deploying `realtime_module` to a test database and applying `DataRealtime` to a table (which automatically adds the `@realtime` smart tag).

Link to Devin session: https://app.devin.ai/sessions/19485cf5cc58416a9f86068563d512f5
Requested by: @pyramation