### PR TITLE
fix: export metaschema_public.function in services migration + defensive null fallback

### DIFF
--- a/graphql/server/src/middleware/api.ts
+++ b/graphql/server/src/middleware/api.ts
@@ -424,6 +424,10 @@ const toRlsModule = (row: RlsModuleRow | null): RlsModule | undefined => {
 
 const toRlsModuleFromSettings = (row: RlsModuleData | null): RlsModule | undefined => {
   if (!row) return undefined;
+  // If metaschema_public.function rows are missing (e.g. trigger was skipped
+  // during migration), the LEFT JOINs resolve NULL.  Return undefined so the
+  // caller falls back to the legacy api_modules lookup.
+  if (!row.authenticate || !row.authenticate_schema) return undefined;
   return {
     authenticate: row.authenticate,
     authenticateStrict: row.authenticate_strict,

--- a/pgpm/export/src/export-graphql-meta.ts
+++ b/pgpm/export/src/export-graphql-meta.ts
@@ -124,6 +124,7 @@ export const exportGraphQLMeta = async ({
     queryAndParse('database'),
     queryAndParse('database_extension'),
     queryAndParse('schema'),
+    queryAndParse('function'),
     queryAndParse('table'),
     queryAndParse('field'),
     queryAndParse('policy'),

--- a/pgpm/export/src/export-meta.ts
+++ b/pgpm/export/src/export-meta.ts
@@ -132,6 +132,7 @@ export const exportMeta = async ({ opts, dbname, database_id }: ExportMetaParams
   await queryAndParse('database', `SELECT * FROM metaschema_public.database WHERE id = $1 ORDER BY id`);
   await queryAndParse('database_extension', `SELECT * FROM metaschema_public.database_extension WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('schema', `SELECT * FROM metaschema_public.schema WHERE database_id = $1 ORDER BY id`);
+  await queryAndParse('function', `SELECT * FROM metaschema_public.function WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('table', `SELECT * FROM metaschema_public.table WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('field', `SELECT * FROM metaschema_public.field WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('policy', `SELECT * FROM metaschema_public.policy WHERE database_id = $1 ORDER BY id`);

--- a/pgpm/export/src/export-utils.ts
+++ b/pgpm/export/src/export-utils.ts
@@ -124,6 +124,7 @@ SET session_replication_role TO DEFAULT;`;
 export const META_TABLE_ORDER = [
   'database',
   'schema',
+  'function',
   'table',
   'field',
   'policy',
@@ -241,6 +242,16 @@ export const META_TABLE_CONFIG: Record<string, TableConfig> = {
       schema_name: 'text',
       description: 'text',
       is_public: 'boolean'
+    }
+  },
+  function: {
+    schema: 'metaschema_public',
+    table: 'function',
+    fields: {
+      id: 'uuid',
+      database_id: 'uuid',
+      schema_id: 'uuid',
+      name: 'text'
     }
   },
   table: {


### PR DESCRIPTION
## Summary

Two fixes for auth function discovery breaking in the GraphQL server:

### 1. Export pipeline: add `metaschema_public.function` to services migration export

`rls_settings` (6 FK columns) and `pubkey_settings` (4 FK columns) both reference `metaschema_public.function`, but the `@pgpmjs/export` pipeline was not including this table in the `constructive-services` migration output. Since all constructive-services migrations deploy with `session_replication_role=replica` (disabling triggers), the `insert_rls_module` trigger never fires to create the function rows. The result: dangling UUID references in `rls_settings`, the `RLS_SETTINGS_SQL` LEFT JOINs resolve NULL for every function name, the auth middleware sees `authenticate=none`, skips authentication, and all RLS policies deny access.

**Changes in `pgpm/export/src/`:**
- `export-utils.ts`: Add `function` to `META_TABLE_CONFIG` (schema + fields) and `META_TABLE_ORDER` (placed after `schema`, before `table` to satisfy FK deps)
- `export-meta.ts`: Add `queryAndParse` for `metaschema_public.function`
- `export-graphql-meta.ts`: Add `queryAndParse` for `function` in the parallel batch

After merging, re-running `pnpm run generate:constructive` in constructive-db will produce a `function.sql` migration in `constructive-services`.

### 2. Defensive fallback in `toRlsModuleFromSettings`

`toRlsModuleFromSettings` was returning a truthy `RlsModule` object with null fields when function rows were missing. This prevented `queryRlsModule` from falling back to the working legacy `api_modules` lookup. Added a guard: if `authenticate` or `authenticate_schema` are null, return `undefined` to trigger the fallback.

## Review & Testing Checklist for Human

- [ ] Verify `META_TABLE_ORDER` places `function` after `schema` (FK dep) and before `rls_settings`/`pubkey_settings` (FK refs)
- [ ] After merging, run `pnpm run generate:constructive` in constructive-db and confirm `services/constructive-services/deploy/migrate/function.sql` is generated with the 6 auth function rows
- [ ] Deploy to a fresh database and verify `SELECT count(*) FROM metaschema_public.function` shows the expected rows
- [ ] Verify the GraphQL server resolves non-NULL function names from `RLS_SETTINGS_SQL`
- [ ] Test end-to-end authentication (Bearer token → authenticate() → JWT claims → RLS access)

### Notes

`database_extension` is also queried in `export-meta.ts` but not in `META_TABLE_ORDER` — this may be another gap worth investigating separately."

Link to Devin session: https://app.devin.ai/sessions/45d6930943ec467496290581d22cb3a9
Requested by: @pyramation