### PR TITLE
chore(ci): switch non-hot-path workflows from Blacksmith to ubuntu-latest

### DIFF
--- a/.github/workflows/docker-constructive.yaml
+++ b/.github/workflows/docker-constructive.yaml
@@ -26,10 +26,10 @@ jobs:
         include:
           - platform: linux/amd64
             arch: amd64
-            runner: blacksmith-4vcpu-ubuntu-2404      # x86_64
+            runner: ubuntu-latest      # x86_64
           - platform: linux/arm64
             arch: arm64
-            runner: blacksmith-4vcpu-ubuntu-2404-arm  # native arm
+            runner: ubuntu-latest  # arm builds via QEMU
     runs-on: ${{ matrix.runner }}
 
     permissions:
@@ -118,7 +118,7 @@ jobs:
   # multi-arch manifest for each tag.
   publish-constructive-manifest:
     if: github.event_name != 'pull_request'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: build-push-constructive
 
     permissions:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -41,7 +41,7 @@ concurrency:
 jobs:
   build-push:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read

--- a/.github/workflows/notify-e2e.yml
+++ b/.github/workflows/notify-e2e.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   trigger-tests:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Trigger submodule update in constructive-hub
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary

Switch non-hot-path CI workflows from Blacksmith runners to `ubuntu-latest` to reduce Blacksmith usage. Only workflows that don't run on the PR critical path are affected:

| Workflow | Trigger | Before | After |
|---|---|---|---|
| `docker.yaml` | `workflow_dispatch` only | `blacksmith-4vcpu-ubuntu-2404` | `ubuntu-latest` |
| `docker-constructive.yaml` (build) | push to main | `blacksmith-4vcpu-ubuntu-2404` + arm | `ubuntu-latest` (arm via QEMU) |
| `docker-constructive.yaml` (manifest) | push to main | `blacksmith-2vcpu-ubuntu-2404` | `ubuntu-latest` |
| `notify-e2e.yml` | push to main | `blacksmith-2vcpu-ubuntu-2404` | `ubuntu-latest` |

**Hot-path jobs unchanged** — `build`, `unit-tests`, `pg-tests`, `integration-tests`, and `examples-integration` remain on Blacksmith for fast PR feedback.

## Review & Testing Checklist for Human

- [ ] Verify Docker builds still succeed on `ubuntu-latest` after next push to main (Docker + Buildx are pre-installed on GitHub runners)
- [ ] Confirm notify-e2e still triggers constructive-hub E2E tests on push to main

### Notes

- `docker-constructive.yaml` previously used a native ARM runner (`blacksmith-4vcpu-ubuntu-2404-arm`). With `ubuntu-latest`, ARM builds will use QEMU emulation which is slower but still functional. If ARM build speed matters, this can be revisited.
- All PR-blocking test workflows remain on Blacksmith — no impact on developer iteration speed.

Link to Devin session: https://app.devin.ai/sessions/f42f42528fb0465684159227efbef017
Requested by: @pyramation