### PR TITLE
chore(ci): batch unit tests, add timeouts, optimize Dockerfile

### DIFF
--- a/.github/workflows/examples-integration.yaml
+++ b/.github/workflows/examples-integration.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   examples-types:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -36,6 +36,7 @@ jobs:
   # =========================================================================
   build:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
     steps:
       - name: Configure Git (for tests)
         run: |
@@ -78,54 +79,19 @@ jobs:
   unit-tests:
     needs: build
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
         include:
-          - package: uploads/mime-bytes
-            env: {}
-          - package: uploads/uuid-hash
-            env: {}
-          - package: uploads/uuid-stream
-            env: {}
-          - package: uploads/etag-hash
-            env: {}
-          - package: uploads/etag-stream
-            env: {}
-          - package: uploads/stream-to-etag
-            env: {}
-          - package: uploads/content-type-stream
-            env: {}
-          - package: uploads/upload-names
-            env: {}
-          - package: packages/url-domains
-            env: {}
-          - package: packages/query-builder
-            env: {}
-          - package: packages/csrf
-            env: {}
-          - package: packages/oauth
-            env: {}
-          - package: packages/12factor-env
-            env: {}
-          - package: packages/orm
-            env: {}
-          - package: packages/postmaster
-            env: {}
-          - package: packages/smtppostmaster
-            env: {}
-          - package: packages/csv-to-pg
-            env: {}
-          - package: postgres/pgsql-client
-            env: {}
-          - package: postgres/pg-ast
-            env: {}
-          - package: graphql/query
-            env: {}
-          - package: graphql/codegen
-            env: {}
-          - package: packages/cli
-            env: {}
+          - batch: uploads
+            packages: 'uploads/mime-bytes uploads/uuid-hash uploads/uuid-stream uploads/etag-hash uploads/etag-stream uploads/stream-to-etag uploads/content-type-stream uploads/upload-names'
+          - batch: packages-core
+            packages: 'packages/url-domains packages/query-builder packages/csrf packages/oauth packages/12factor-env packages/orm'
+          - batch: packages-services
+            packages: 'packages/postmaster packages/smtppostmaster packages/csv-to-pg packages/cli postgres/pgsql-client postgres/pg-ast'
+          - batch: graphql
+            packages: 'graphql/query graphql/codegen'
 
     steps:
       - name: Download workspace
@@ -150,9 +116,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Test ${{ matrix.package }}
-        run: cd ./${{ matrix.package }} && pnpm test
-        env: ${{ matrix.env }}
+      - name: Test ${{ matrix.batch }}
+        run: |
+          for pkg in ${{ matrix.packages }}; do
+            echo "::group::Testing $pkg"
+            (cd ./$pkg && pnpm test)
+            echo "::endgroup::"
+          done
 
   # =========================================================================
   # TIER 2 – PostgreSQL-only tests
@@ -160,6 +130,7 @@ jobs:
   pg-tests:
     needs: build
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -263,6 +234,7 @@ jobs:
   integration-tests:
     needs: build
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,15 @@ RUN set -eux; \
     npm install -g pnpm@10.10.0; \
     rm -rf /var/lib/apt/lists/*
 
-# Copy full repo (build context must be repo root when building this image)
-COPY . .
+# Fetch all dependencies into the pnpm store (cached unless lockfile changes).
+# This layer avoids re-downloading packages when only source code changes.
+COPY pnpm-lock.yaml ./
+RUN pnpm fetch
 
-# Install and build all workspaces
+# Copy full repo and install from local store + build
+COPY . .
 RUN set -eux; \
-    CI=true pnpm install --frozen-lockfile; \
+    CI=true pnpm install --frozen-lockfile --offline; \
     pnpm run build
 
 ################################################################################


### PR DESCRIPTION
## Summary

Three optimizations to reduce CI costs and prevent waste:

### 1. Batch unit tests (22 jobs → 4 jobs)

Unit tests previously ran as 22 individual 2vcpu jobs, each with ~1 min of download/install overhead for tests that run in seconds. Due to per-minute billing rounding, this was billed as 44 2vcpu-minutes for ~5 min of actual test work.

Now grouped into 4 batched jobs:
| Batch | Packages |
|---|---|
| `uploads` | mime-bytes, uuid-hash, uuid-stream, etag-hash, etag-stream, stream-to-etag, content-type-stream, upload-names |
| `packages-core` | url-domains, query-builder, csrf, oauth, 12factor-env, orm |
| `packages-services` | postmaster, smtppostmaster, csv-to-pg, cli, pgsql-client, pg-ast |
| `graphql` | query, codegen |

Each batch runs tests sequentially using `::group::` markers for clear log separation. **Estimated savings: ~73% of unit test minutes** (44 → ~12 2vcpu-minutes).

### 2. Add timeout-minutes to all jobs

Prevents runaway jobs from burning money (default GitHub timeout is 6 hours):
- `build`: 10 min (usually ~2 min)
- `unit-tests`: 10 min (usually ~2 min)
- `pg-tests`: 15 min (usually ~5-8 min)
- `integration-tests`: 15 min (usually ~5-8 min)
- `examples-types`: 15 min

### 3. Dockerfile: pnpm fetch for layer caching

Adds a `pnpm fetch` layer that pre-populates the pnpm store using only `pnpm-lock.yaml`. This layer is cached and only invalidated when dependencies change — not when source code changes. Subsequent `pnpm install --frozen-lockfile --offline` links from the local store without network access.

## Review & Testing Checklist for Human

- [ ] **Verify all 4 unit test batches pass** — confirm no test relies on being in its own isolated runner (e.g., global state pollution between tests in different packages within the same batch)
- [ ] **Verify Dockerfile builds correctly** — the `pnpm fetch` + `--offline` pattern should work with pnpm 10, but confirm the Docker image builds and the CLI shims work
- [ ] **Spot-check timeout values** — if any job routinely takes longer than the set timeout, it will start failing. The values are set at ~3× typical runtime but edge cases may exist

### Notes

- pg-tests and integration-tests are left as individual matrix jobs since each has different env vars and test durations. Batching these would require more careful grouping.
- The `::group::` / `::endgroup::` markers in the batch test step provide collapsible sections in the GitHub Actions log so you can still see which specific test in a batch failed.

Link to Devin session: https://app.devin.ai/sessions/f42f42528fb0465684159227efbef017
Requested by: @pyramation