### PR TITLE
docs: document set_config transaction-local gotcha in pgsql-test

### DIFF
--- a/postgres/pgsql-test/AGENTS.md
+++ b/postgres/pgsql-test/AGENTS.md
@@ -29,6 +29,21 @@ beforeEach(() => db.beforeEach());
 afterEach(() => db.afterEach());
 ```
 
+## Transaction-Local Context
+
+`setContext()` uses `set_config('key', 'value', true)` — the `true` makes settings **transaction-local**. This means:
+
+- **In `it()` blocks:** Works automatically. `beforeEach()` starts a transaction, so context persists across queries.
+- **In `beforeAll()`:** No active transaction. Context is lost between queries. Wrap context-dependent operations in explicit `db.begin()` / `db.commit()`.
+
+```ts
+// In beforeAll — explicit transaction required
+await db.begin();
+db.setContext({ role: 'authenticated', 'jwt.claims.user_id': userId });
+await db.query('...'); // context persists
+await db.commit();
+```
+
 ## Seeding Notes
 
 - For raw SQL seeding, use `seed.sqlfile([...paths])`.

--- a/postgres/pgsql-test/README.md
+++ b/postgres/pgsql-test/README.md
@@ -191,7 +191,19 @@ db.setContext({
 });
 ```
 
-This applies the settings using `SET LOCAL` statements, ensuring they persist only for the current transaction and maintain proper isolation between tests.
+This applies the settings using `SET LOCAL` and `set_config(..., true)` statements, ensuring they persist only for the current transaction and maintain proper isolation between tests.
+
+> **⚠️ Important:** `set_config(..., true)` is **transaction-local**. Inside test bodies (`it()` blocks), `beforeEach()` has already started a transaction, so context persists across queries automatically. However, in `beforeAll()` there is no active transaction — each query runs in auto-commit mode and context is lost between calls. If you need context-aware operations in `beforeAll()`, wrap them in explicit `db.begin()` / `db.commit()`:
+>
+> ```ts
+> beforeAll(async () => {
+>   ({ db, teardown } = await getConnections());
+>   await db.begin();
+>   db.setContext({ role: 'authenticated', 'jwt.claims.user_id': '123' });
+>   await db.query('SELECT current_user_id()'); // context persists within transaction
+>   await db.commit();
+> });
+> ```
 
 #### Testing Role-Based Access
 


### PR DESCRIPTION
## Summary

Adds documentation about the transaction-local behavior of `set_config(..., true)` in two places:

**`postgres/pgsql-test/README.md`**
- Added a warning callout in the "Role-Based Context" section explaining that `setContext()` uses `set_config(..., true)` which is transaction-local
- Inside `it()` blocks this works automatically (transaction started by `beforeEach`)
- In `beforeAll()`, context is lost between queries — must wrap in explicit `db.begin()`/`db.commit()`
- Includes code example showing the correct pattern

**`postgres/pgsql-test/AGENTS.md`**
- Added a new "Transaction-Local Context" section with the same key information in concise format for AI agents

## Review & Testing Checklist for Human

- [ ] Verify the explanation matches the actual implementation in `pgsql-client/src/context-utils.ts` (`set_config` with `true` for `is_local`)

### Notes

Documentation-only change. Companion PRs going to `constructive-db` and `constructive-skills` repos.

Link to Devin session: https://app.devin.ai/sessions/ef4c0849684f44b4bb4dd83074c27d48
Requested by: @pyramation