### PR TITLE
fix: scope BucketNameResolver to (databaseId, bucketKey)

### DIFF
--- a/graphile/graphile-presigned-url-plugin/src/download-url-field.ts
+++ b/graphile/graphile-presigned-url-plugin/src/download-url-field.ts
@@ -60,10 +60,11 @@ function resolveS3ForDatabase(
   options: PresignedUrlPluginOptions,
   storageConfig: StorageModuleConfig,
   databaseId: string,
+  bucketKey: string,
 ): S3Config {
   const globalS3 = resolveS3(options);
   const bucket = options.resolveBucketName
-    ? options.resolveBucketName(databaseId)
+    ? options.resolveBucketName(databaseId, bucketKey)
     : globalS3.bucket;
   const publicUrlPrefix = storageConfig.publicUrlPrefix ?? globalS3.publicUrlPrefix;
 
@@ -127,6 +128,7 @@ export function createDownloadUrlPlugin(
                     const $key = $parent.get('key');
                     const $isPublic = $parent.get('is_public');
                     const $filename = $parent.get('filename');
+                    const $bucketId = $parent.get('bucket_id');
 
                     const $withPgClient = (grafastContext() as any).get('withPgClient');
                     const $pgSettings = (grafastContext() as any).get('pgSettings');
@@ -135,11 +137,12 @@ export function createDownloadUrlPlugin(
                       key: $key,
                       isPublic: $isPublic,
                       filename: $filename,
+                      bucketId: $bucketId,
                       withPgClient: $withPgClient,
                       pgSettings: $pgSettings,
                     });
 
-                    return lambda($combined, async ({ key, isPublic, filename, withPgClient, pgSettings }: any) => {
+                    return lambda($combined, async ({ key, isPublic, filename, bucketId, withPgClient, pgSettings }: any) => {
                       if (!key) return null;
 
                       let s3ForDb = resolveS3(options);
@@ -155,11 +158,24 @@ export function createDownloadUrlPlugin(
                             const allConfigs = await loadAllStorageModules(pgClient, databaseId);
                             const config = resolveStorageConfigFromCodec(capturedCodec, allConfigs);
                             if (!config) return null;
-                            return { config, databaseId };
+
+                            // Look up the bucket key for scoped S3 resolution
+                            let bucketKey = 'public';
+                            if (bucketId) {
+                              const bucketResult = await pgClient.query({
+                                text: `SELECT key FROM ${config.bucketsQualifiedName} WHERE id = $1 LIMIT 1`,
+                                values: [bucketId],
+                              });
+                              if (bucketResult.rows[0]?.key) {
+                                bucketKey = bucketResult.rows[0].key;
+                              }
+                            }
+
+                            return { config, databaseId, bucketKey };
                           });
                           if (resolved) {
                             downloadUrlExpirySeconds = resolved.config.downloadUrlExpirySeconds;
-                            s3ForDb = resolveS3ForDatabase(options, resolved.config, resolved.databaseId);
+                            s3ForDb = resolveS3ForDatabase(options, resolved.config, resolved.databaseId, resolved.bucketKey);
                           }
                         }
                       } catch {

--- a/graphile/graphile-presigned-url-plugin/src/plugin.ts
+++ b/graphile/graphile-presigned-url-plugin/src/plugin.ts
@@ -92,10 +92,11 @@ function resolveS3ForDatabase(
   options: PresignedUrlPluginOptions,
   storageConfig: StorageModuleConfig,
   databaseId: string,
+  bucketKey: string,
 ): S3Config {
   const globalS3 = resolveS3(options);
   const bucket = options.resolveBucketName
-    ? options.resolveBucketName(databaseId)
+    ? options.resolveBucketName(databaseId, bucketKey)
     : globalS3.bucket;
   const publicUrlPrefix = storageConfig.publicUrlPrefix ?? globalS3.publicUrlPrefix;
 
@@ -282,7 +283,7 @@ export function createPresignedUrlPlugin(
                           );
                           if (!bucket) throw new Error('BUCKET_NOT_FOUND');
 
-                          const s3ForDb = resolveS3ForDatabase(options, storageConfig, databaseId);
+                          const s3ForDb = resolveS3ForDatabase(options, storageConfig, databaseId, bucket.key);
                           await ensureS3BucketExists(options, s3ForDb.bucket, bucket, databaseId, storageConfig.allowedOrigins);
 
                           return processSingleFile(options, txClient, storageConfig, databaseId, bucket, s3ForDb, {
@@ -397,7 +398,7 @@ export function createPresignedUrlPlugin(
                             );
                           }
 
-                          const s3ForDb = resolveS3ForDatabase(options, storageConfig, databaseId);
+                          const s3ForDb = resolveS3ForDatabase(options, storageConfig, databaseId, bucket.key);
                           await ensureS3BucketExists(options, s3ForDb.bucket, bucket, databaseId, storageConfig.allowedOrigins);
 
                           const results = [];
@@ -533,7 +534,17 @@ export function createPresignedUrlPlugin(
                       }
 
                       // No other references — attempt sync S3 delete
-                      const s3ForDb = resolveS3ForDatabase(options, storageConfig, databaseId);
+                      // Look up the bucket key for scoped S3 resolution
+                      const bucketResult = await pgClient.query({
+                        text: `SELECT key FROM ${storageConfig.bucketsQualifiedName} WHERE id = $1 LIMIT 1`,
+                        values: [fileRow!.bucket_id],
+                      });
+                      const bucketKey = bucketResult.rows[0]?.key;
+                      if (!bucketKey) {
+                        log.warn(`Bucket not found for bucket_id=${fileRow!.bucket_id}; skipping S3 delete`);
+                        return;
+                      }
+                      const s3ForDb = resolveS3ForDatabase(options, storageConfig, databaseId, bucketKey);
                       await deleteS3Object(s3ForDb, fileRow!.key);
                       log.info(`Sync S3 delete succeeded for key=${fileRow!.key}`);
                     });

--- a/graphile/graphile-presigned-url-plugin/src/types.ts
+++ b/graphile/graphile-presigned-url-plugin/src/types.ts
@@ -149,16 +149,17 @@ export interface S3Config {
 export type S3ConfigOrGetter = S3Config | (() => S3Config);
 
 /**
- * Function to derive the actual S3 bucket name for a given database.
+ * Function to derive the actual S3 bucket name for a given database and bucket key.
  *
  * When provided, the presigned URL plugin calls this on every request
- * to determine which S3 bucket to use — enabling per-database bucket
+ * to determine which S3 bucket to use — enabling per-(database, bucketKey)
  * isolation. If not provided, falls back to `s3Config.bucket` (global).
  *
  * @param databaseId - The metaschema database UUID
- * @returns The S3 bucket name for this database
+ * @param bucketKey - The logical bucket key (e.g., "public", "private")
+ * @returns The S3 bucket name for this database + bucket key
  */
-export type BucketNameResolver = (databaseId: string) => string;
+export type BucketNameResolver = (databaseId: string, bucketKey: string) => string;
 
 /**
  * Callback to lazily provision an S3 bucket on first use.

--- a/graphile/graphile-settings/src/presigned-url-resolver.ts
+++ b/graphile/graphile-settings/src/presigned-url-resolver.ts
@@ -86,24 +86,21 @@ export function getPresignedUrlS3Config(): S3Config {
 }
 
 /**
- * Create a per-database bucket name resolver.
+ * Create a per-(database, bucketKey) bucket name resolver.
  *
- * Uses the BUCKET_NAME env var as a prefix. For each database, the S3 bucket
- * name becomes `{prefix}-{databaseId}` (e.g., "myapp-abc123def456").
+ * Uses the BUCKET_NAME env var as a prefix. For each (database, bucketKey)
+ * pair, the S3 bucket name becomes `{prefix}-{bucketKey}-{databaseId}`
+ * (e.g., "myapp-public-abc123def456").
  *
- * In local development with MinIO (default BUCKET_NAME="test-bucket"),
- * all databases share the same bucket for simplicity — the resolver
- * returns the prefix as-is when it looks like a local dev bucket.
- *
- * In production, set BUCKET_NAME to your org prefix (e.g., "myapp")
- * and each database gets its own isolated S3 bucket.
+ * This aligns with the bucket provisioner plugin which creates separate
+ * S3 buckets per logical bucket key.
  */
 export function createBucketNameResolver(): BucketNameResolver {
   const { cdn } = getEnvOptions();
   const prefix = cdn?.bucketName || 'test-bucket';
 
-  return (databaseId: string): string => {
-    return `${prefix}-${databaseId}`;
+  return (databaseId: string, bucketKey: string): string => {
+    return `${prefix}-${bucketKey}-${databaseId}`;
   };
 }
 


### PR DESCRIPTION
## Summary

The presigned URL plugin's `BucketNameResolver` only accepted `databaseId`, routing **all uploads for a database to a single S3 bucket** regardless of `bucketKey`. Meanwhile, the bucket provisioner plugin correctly creates per-`bucketKey` S3 buckets using `(bucketKey, databaseId)`.

This PR aligns the presigned URL plugin so every S3 operation (upload, download, delete) resolves the S3 bucket name per `(databaseId, bucketKey)` pair.

**Changes:**

| File | What changed |
|------|-------------|
| `graphile-presigned-url-plugin/src/types.ts` | `BucketNameResolver` signature: `(databaseId) → (databaseId, bucketKey)` |
| `graphile-presigned-url-plugin/src/plugin.ts` | `resolveS3ForDatabase()` accepts `bucketKey`; upload, bulk upload, and delete paths pass `bucket.key` through |
| `graphile-presigned-url-plugin/src/download-url-field.ts` | Fetches `bucket_id` from the file row, looks up the bucket's `key`, passes it to `resolveS3ForDatabase()` |
| `graphile-settings/src/presigned-url-resolver.ts` | `createBucketNameResolver()` returns `${prefix}-${bucketKey}-${databaseId}` instead of `${prefix}-${databaseId}` |

**Breaking change:** Custom `resolveBucketName` callbacks must now accept `(databaseId: string, bucketKey: string)` instead of `(databaseId: string)`.

## Review & Testing Checklist for Human

- [ ] Verify the new S3 bucket naming pattern `${prefix}-${bucketKey}-${databaseId}` works with your deployment's bucket naming conventions
- [ ] Verify existing data migrations: any files already uploaded to `${prefix}-${databaseId}` buckets will need to be migrated to the new `${prefix}-${bucketKey}-${databaseId}` buckets (or a custom `resolveBucketName` provided for backward compat)
- [ ] Run upload integration tests (`pnpm test -- --testPathPattern=upload.integration`) against MinIO to confirm lazy bucket provisioning still works
- [ ] After publishing, update constructive-db tests that may reference the old bucket naming

### Notes

- The bucket provisioner plugin (`graphile-bucket-provisioner-plugin`) is **not changed** — it already had the correct `(bucketKey, databaseId)` signature
- The `EnsureBucketProvisioned` callback signature is unchanged — it already receives the resolved bucket name
- Tests previously passed because the presigned URL plugin was self-consistent: it created and read from the same (incorrectly scoped) bucket, so the round-trip worked. The mismatch only surfaced when crossing plugin boundaries (provision vs upload)

Link to Devin session: https://app.devin.ai/sessions/2b5a29d83d3f478e8d3d972653b4879c
Requested by: @pyramation