### PR TITLE
fix(types): remove = never default from FindManyArgs TOrderBy param

### DIFF
--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/client-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/client-generator.test.ts.snap
@@ -386,7 +386,7 @@ export interface PageInfo {
   endCursor?: string | null;
 }
 
-export interface FindManyArgs<TSelect, TWhere, TOrderBy = never> {
+export interface FindManyArgs<TSelect, TWhere, TOrderBy> {
   select?: TSelect;
   where?: TWhere;
   orderBy?: TOrderBy[];

--- a/graphql/codegen/src/__tests__/codegen/react-query-hooks.test.ts
+++ b/graphql/codegen/src/__tests__/codegen/react-query-hooks.test.ts
@@ -337,10 +337,8 @@ describe('Query Hook Generators', () => {
 });
 
 describe('Regression: FindManyArgs TCondition type arg', () => {
-  // Bug: queries.ts passed 3 type args to FindManyArgs (TSelect, TWhere, TOrderBy),
-  // but the template defines 4 params: FindManyArgs<TSelect, TWhere, TCondition = never, TOrderBy = never>.
-  // This caused TOrderBy to land in the TCondition slot, defaulting TOrderBy to `never`
-  // and breaking all hook orderBy params.
+  // Regression guard: queries.ts passes 3 type args to FindManyArgs (TSelect, TWhere, TOrderBy).
+  // A prior bug had 4 params with defaults, causing TOrderBy to land in the wrong slot.
 
   it('does not include Condition type in generated hooks', () => {
     const result = generateListQueryHook(simpleUserTable, {

--- a/graphql/codegen/src/core/codegen/templates/select-types.ts
+++ b/graphql/codegen/src/core/codegen/templates/select-types.ts
@@ -21,7 +21,7 @@ export interface PageInfo {
   endCursor?: string | null;
 }
 
-export interface FindManyArgs<TSelect, TWhere, TOrderBy = never> {
+export interface FindManyArgs<TSelect, TWhere, TOrderBy> {
   select?: TSelect;
   where?: TWhere;
   orderBy?: TOrderBy[];

--- a/sdk/constructive-cli/src/admin/orm/select-types.ts
+++ b/sdk/constructive-cli/src/admin/orm/select-types.ts
@@ -16,7 +16,7 @@ export interface PageInfo {
   endCursor?: string | null;
 }
 
-export interface FindManyArgs<TSelect, TWhere, TOrderBy = never> {
+export interface FindManyArgs<TSelect, TWhere, TOrderBy> {
   select?: TSelect;
   where?: TWhere;
   orderBy?: TOrderBy[];

--- a/sdk/constructive-cli/src/auth/orm/select-types.ts
+++ b/sdk/constructive-cli/src/auth/orm/select-types.ts
@@ -16,7 +16,7 @@ export interface PageInfo {
   endCursor?: string | null;
 }
 
-export interface FindManyArgs<TSelect, TWhere, TOrderBy = never> {
+export interface FindManyArgs<TSelect, TWhere, TOrderBy> {
   select?: TSelect;
   where?: TWhere;
   orderBy?: TOrderBy[];

--- a/sdk/constructive-cli/src/objects/orm/select-types.ts
+++ b/sdk/constructive-cli/src/objects/orm/select-types.ts
@@ -16,7 +16,7 @@ export interface PageInfo {
   endCursor?: string | null;
 }
 
-export interface FindManyArgs<TSelect, TWhere, TOrderBy = never> {
+export interface FindManyArgs<TSelect, TWhere, TOrderBy> {
   select?: TSelect;
   where?: TWhere;
   orderBy?: TOrderBy[];

--- a/sdk/constructive-cli/src/public/orm/select-types.ts
+++ b/sdk/constructive-cli/src/public/orm/select-types.ts
@@ -16,7 +16,7 @@ export interface PageInfo {
   endCursor?: string | null;
 }
 
-export interface FindManyArgs<TSelect, TWhere, TOrderBy = never> {
+export interface FindManyArgs<TSelect, TWhere, TOrderBy> {
   select?: TSelect;
   where?: TWhere;
   orderBy?: TOrderBy[];

--- a/sdk/constructive-react/src/admin/orm/select-types.ts
+++ b/sdk/constructive-react/src/admin/orm/select-types.ts
@@ -16,7 +16,7 @@ export interface PageInfo {
   endCursor?: string | null;
 }
 
-export interface FindManyArgs<TSelect, TWhere, TOrderBy = never> {
+export interface FindManyArgs<TSelect, TWhere, TOrderBy> {
   select?: TSelect;
   where?: TWhere;
   orderBy?: TOrderBy[];

--- a/sdk/constructive-react/src/auth/orm/select-types.ts
+++ b/sdk/constructive-react/src/auth/orm/select-types.ts
@@ -16,7 +16,7 @@ export interface PageInfo {
   endCursor?: string | null;
 }
 
-export interface FindManyArgs<TSelect, TWhere, TOrderBy = never> {
+export interface FindManyArgs<TSelect, TWhere, TOrderBy> {
   select?: TSelect;
   where?: TWhere;
   orderBy?: TOrderBy[];

--- a/sdk/constructive-react/src/objects/orm/select-types.ts
+++ b/sdk/constructive-react/src/objects/orm/select-types.ts
@@ -16,7 +16,7 @@ export interface PageInfo {
   endCursor?: string | null;
 }
 
-export interface FindManyArgs<TSelect, TWhere, TOrderBy = never> {
+export interface FindManyArgs<TSelect, TWhere, TOrderBy> {
   select?: TSelect;
   where?: TWhere;
   orderBy?: TOrderBy[];

--- a/sdk/constructive-react/src/public/orm/select-types.ts
+++ b/sdk/constructive-react/src/public/orm/select-types.ts
@@ -16,7 +16,7 @@ export interface PageInfo {
   endCursor?: string | null;
 }
 
-export interface FindManyArgs<TSelect, TWhere, TOrderBy = never> {
+export interface FindManyArgs<TSelect, TWhere, TOrderBy> {
   select?: TSelect;
   where?: TWhere;
   orderBy?: TOrderBy[];

--- a/sdk/constructive-sdk/src/admin/orm/select-types.ts
+++ b/sdk/constructive-sdk/src/admin/orm/select-types.ts
@@ -16,7 +16,7 @@ export interface PageInfo {
   endCursor?: string | null;
 }
 
-export interface FindManyArgs<TSelect, TWhere, TOrderBy = never> {
+export interface FindManyArgs<TSelect, TWhere, TOrderBy> {
   select?: TSelect;
   where?: TWhere;
   orderBy?: TOrderBy[];

--- a/sdk/constructive-sdk/src/auth/orm/select-types.ts
+++ b/sdk/constructive-sdk/src/auth/orm/select-types.ts
@@ -16,7 +16,7 @@ export interface PageInfo {
   endCursor?: string | null;
 }
 
-export interface FindManyArgs<TSelect, TWhere, TOrderBy = never> {
+export interface FindManyArgs<TSelect, TWhere, TOrderBy> {
   select?: TSelect;
   where?: TWhere;
   orderBy?: TOrderBy[];

--- a/sdk/constructive-sdk/src/objects/orm/select-types.ts
+++ b/sdk/constructive-sdk/src/objects/orm/select-types.ts
@@ -16,7 +16,7 @@ export interface PageInfo {
   endCursor?: string | null;
 }
 
-export interface FindManyArgs<TSelect, TWhere, TOrderBy = never> {
+export interface FindManyArgs<TSelect, TWhere, TOrderBy> {
   select?: TSelect;
   where?: TWhere;
   orderBy?: TOrderBy[];

--- a/sdk/constructive-sdk/src/public/orm/select-types.ts
+++ b/sdk/constructive-sdk/src/public/orm/select-types.ts
@@ -16,7 +16,7 @@ export interface PageInfo {
   endCursor?: string | null;
 }
 
-export interface FindManyArgs<TSelect, TWhere, TOrderBy = never> {
+export interface FindManyArgs<TSelect, TWhere, TOrderBy> {
   select?: TSelect;
   where?: TWhere;
   orderBy?: TOrderBy[];

--- a/sdk/migrate-client/src/migrate/orm/select-types.ts
+++ b/sdk/migrate-client/src/migrate/orm/select-types.ts
@@ -16,7 +16,7 @@ export interface PageInfo {
   endCursor?: string | null;
 }
 
-export interface FindManyArgs<TSelect, TWhere, TOrderBy = never> {
+export interface FindManyArgs<TSelect, TWhere, TOrderBy> {
   select?: TSelect;
   where?: TWhere;
   orderBy?: TOrderBy[];


### PR DESCRIPTION
## Summary

Same fix as `FindFirstArgs` (PR #1026) — remove the `= never` default from `FindManyArgs<TSelect, TWhere, TOrderBy>`.

Codegen always supplies a concrete `TOrderBy` type, so the default never fires. Removing it avoids a confusing API surface where `orderBy` appears available but silently rejects all values (since `never[]` accepts nothing).

**Files:** 1 template + 13 generated SDKs + 1 snapshot + 1 test comment update

## Review & Testing Checklist for Human

- [ ] Verify generated SDK `select-types.ts` files no longer have `= never` on `FindManyArgs`

### Notes

- Companion to PR #1026 (`FindFirstArgs`) and PR #1152 (`NodeHttpAdapter` removal)

Link to Devin session: https://app.devin.ai/sessions/7d04ac62fc67430aba0aaa40e044eb14
Requested by: @pyramation