### PR TITLE
refactor: update node type registry for per-field _updated_at timestamps

### DIFF
--- a/packages/node-type-registry/src/data/data-file-embedding.ts
+++ b/packages/node-type-registry/src/data/data-file-embedding.ts
@@ -177,24 +177,6 @@ export const DataFileEmbedding: NodeTypeDefinition = {
             default: 'generate_chunks'
           }
         }
-      },
-
-      // ── Stale tracking (meaningful in extract mode) ────────────────
-      stale_strategy: {
-        type: 'string',
-        enum: ['column', 'null', 'hash'],
-        description:
-          'Strategy for tracking embedding staleness when extraction is enabled. ' +
-          'column: {field_name}_updated_at timestamptz (NULL = needs computation). ' +
-          'null: set embedding to NULL. hash: {field_name}_source_hash md5.',
-        default: 'column'
-      },
-      include_updated_at_field: {
-        type: 'boolean',
-        description:
-          'Whether to include the {field_name}_updated_at timestamptz column ' +
-          '(read-only in GraphQL, set by worker on completion). Extract mode only.',
-        default: true
       }
     }
   },

--- a/packages/node-type-registry/src/data/data-file-embedding.ts
+++ b/packages/node-type-registry/src/data/data-file-embedding.ts
@@ -185,12 +185,15 @@ export const DataFileEmbedding: NodeTypeDefinition = {
         enum: ['column', 'null', 'hash'],
         description:
           'Strategy for tracking embedding staleness when extraction is enabled. ' +
-          'column: embedding_stale boolean. null: set embedding to NULL. hash: md5 hash.',
+          'column: {field_name}_updated_at timestamptz (NULL = needs computation). ' +
+          'null: set embedding to NULL. hash: {field_name}_source_hash md5.',
         default: 'column'
       },
-      include_stale_field: {
+      include_updated_at_field: {
         type: 'boolean',
-        description: 'Whether to include the embedding_stale boolean field (extract mode)',
+        description:
+          'Whether to include the {field_name}_updated_at timestamptz column ' +
+          '(read-only in GraphQL, set by worker on completion). Extract mode only.',
         default: true
       }
     }

--- a/packages/node-type-registry/src/data/data-image-embedding.ts
+++ b/packages/node-type-registry/src/data/data-image-embedding.ts
@@ -150,24 +150,6 @@ export const DataImageEmbedding: NodeTypeDefinition = {
           enqueue_chunking_job: { type: 'boolean', default: true },
           chunking_task_name: { type: 'string', default: 'generate_chunks' }
         }
-      },
-
-      // ── Stale tracking (forwarded to DataFileEmbedding) ────────────
-      stale_strategy: {
-        type: 'string',
-        enum: ['column', 'null', 'hash'],
-        description:
-          'Strategy for tracking embedding staleness in extract mode. ' +
-          'column: {field_name}_updated_at timestamptz. null: set embedding to NULL. ' +
-          'hash: {field_name}_source_hash md5.',
-        default: 'column'
-      },
-      include_updated_at_field: {
-        type: 'boolean',
-        description:
-          'Whether to include the {field_name}_updated_at timestamptz column ' +
-          '(read-only in GraphQL, set by worker on completion).',
-        default: true
       }
     }
   },

--- a/packages/node-type-registry/src/data/data-image-embedding.ts
+++ b/packages/node-type-registry/src/data/data-image-embedding.ts
@@ -156,12 +156,17 @@ export const DataImageEmbedding: NodeTypeDefinition = {
       stale_strategy: {
         type: 'string',
         enum: ['column', 'null', 'hash'],
-        description: 'Strategy for tracking embedding staleness in extract mode',
+        description:
+          'Strategy for tracking embedding staleness in extract mode. ' +
+          'column: {field_name}_updated_at timestamptz. null: set embedding to NULL. ' +
+          'hash: {field_name}_source_hash md5.',
         default: 'column'
       },
-      include_stale_field: {
+      include_updated_at_field: {
         type: 'boolean',
-        description: 'Whether to include the embedding_stale boolean field',
+        description:
+          'Whether to include the {field_name}_updated_at timestamptz column ' +
+          '(read-only in GraphQL, set by worker on completion).',
         default: true
       }
     }

--- a/packages/node-type-registry/src/data/search-vector.ts
+++ b/packages/node-type-registry/src/data/search-vector.ts
@@ -5,7 +5,7 @@ export const SearchVector: NodeTypeDefinition = {
   slug: 'search_vector',
   category: 'search',
   display_name: 'Vector Search',
-  description: 'Adds a vector embedding column with HNSW or IVFFlat index for similarity search. Supports configurable dimensions, distance metrics (cosine, l2, ip), stale tracking strategies (column, null, hash), and automatic job enqueue triggers for embedding generation.',
+  description: 'Adds a vector embedding column with HNSW or IVFFlat index for similarity search. Supports configurable dimensions, distance metrics (cosine, l2, ip), per-field {field_name}_updated_at timestamp tracking (read-only in GraphQL), and automatic job enqueue triggers for embedding generation.',
   parameter_schema: {
     type: 'object',
     properties: {
@@ -44,11 +44,6 @@ export const SearchVector: NodeTypeDefinition = {
         description: 'Index-specific options. HNSW: {m, ef_construction}. IVFFlat: {lists}.',
         default: {}
       },
-      include_updated_at_field: {
-        type: 'boolean',
-        description: 'When stale_strategy is column, adds a per-field {field_name}_updated_at timestamptz column (read-only in GraphQL). NULL means needs computation; set by the worker on completion.',
-        default: true
-      },
       source_fields: {
         type: 'array',
         items: {
@@ -66,16 +61,6 @@ export const SearchVector: NodeTypeDefinition = {
         type: 'string',
         description: 'Task identifier for the job queue',
         default: 'generate_embedding'
-      },
-      stale_strategy: {
-        type: 'string',
-        enum: [
-          'column',
-          'null',
-          'hash'
-        ],
-        description: 'Strategy for tracking embedding staleness. column: {field_name}_updated_at timestamptz (NULL = needs computation). null: set embedding to NULL. hash: {field_name}_source_hash md5 of source fields.',
-        default: 'column'
       },
       chunks: {
         type: 'object',

--- a/packages/node-type-registry/src/data/search-vector.ts
+++ b/packages/node-type-registry/src/data/search-vector.ts
@@ -44,9 +44,9 @@ export const SearchVector: NodeTypeDefinition = {
         description: 'Index-specific options. HNSW: {m, ef_construction}. IVFFlat: {lists}.',
         default: {}
       },
-      include_stale_field: {
+      include_updated_at_field: {
         type: 'boolean',
-        description: 'When stale_strategy is column, adds an embedding_stale boolean field',
+        description: 'When stale_strategy is column, adds a per-field {field_name}_updated_at timestamptz column (read-only in GraphQL). NULL means needs computation; set by the worker on completion.',
         default: true
       },
       source_fields: {
@@ -74,7 +74,7 @@ export const SearchVector: NodeTypeDefinition = {
           'null',
           'hash'
         ],
-        description: 'Strategy for tracking embedding staleness. column: embedding_stale boolean. null: set embedding to NULL. hash: md5 hash of source fields.',
+        description: 'Strategy for tracking embedding staleness. column: {field_name}_updated_at timestamptz (NULL = needs computation). null: set embedding to NULL. hash: {field_name}_source_hash md5 of source fields.',
         default: 'column'
       },
       chunks: {


### PR DESCRIPTION
## Summary

Removes `stale_strategy` and `include_updated_at_field` parameters from the node type registry for SearchVector, DataFileEmbedding, and DataImageEmbedding. The SQL generators now always create `{field_name}_updated_at` with no configuration needed.

**What changed:**
- `SearchVector`: removed `stale_strategy` (was column/null/hash) and `include_updated_at_field` params, updated description
- `DataFileEmbedding`: removed `stale_strategy` and `include_updated_at_field` params
- `DataImageEmbedding`: removed `stale_strategy` and `include_updated_at_field` params

## Review & Testing Checklist for Human

Risk: **green** — TypeScript-only changes, removing parameters that the SQL generators no longer accept.

- [ ] Verify no existing blueprints in production use `stale_strategy` or `include_updated_at_field` (if any do, they'll be silently ignored by the SQL generator since it no longer reads those keys)

### Notes

- Companion PR: constructive-io/constructive-db#1148 (SQL generators)
- Closes constructive-io/constructive-planning#849

Link to Devin session: https://app.devin.ai/sessions/2b5a29d83d3f478e8d3d972653b4879c
Requested by: @pyramation