### PR TITLE
fix(mime-bytes): detect HEIC/HEIF instead of misidentifying as MP4

### DIFF
--- a/uploads/mime-bytes/__tests__/file-type-detector.test.ts
+++ b/uploads/mime-bytes/__tests__/file-type-detector.test.ts
@@ -65,6 +65,7 @@ describe('FileTypeDetector', () => {
     });
 
     it('should detect MP4 files with offset', async () => {
+      // ftyp + "isom" brand = generic MP4
       const mp4Buffer = Buffer.from([
         0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70,
         0x69, 0x73, 0x6F, 0x6D, 0x00, 0x00, 0x02, 0x00
@@ -75,6 +76,34 @@ describe('FileTypeDetector', () => {
       expect(result?.name).toBe('mp4');
       expect(result?.mimeType).toBe('video/mp4');
       expect(result?.extensions).toContain('mp4');
+    });
+
+    it('should detect HEIC files (not misidentify as MP4)', async () => {
+      // ftyp + "heic" brand = HEIC image
+      const heicBuffer = Buffer.from([
+        0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70,
+        0x68, 0x65, 0x69, 0x63, 0x00, 0x00, 0x00, 0x00
+      ]);
+
+      const result = await detector.detectFromBuffer(heicBuffer);
+      expect(result).toBeDefined();
+      expect(result?.name).toBe('heic');
+      expect(result?.mimeType).toBe('image/heic');
+      expect(result?.extensions).toContain('heic');
+    });
+
+    it('should detect HEIF files (not misidentify as MP4)', async () => {
+      // ftyp + "mif1" brand = HEIF image
+      const heifBuffer = Buffer.from([
+        0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70,
+        0x6D, 0x69, 0x66, 0x31, 0x00, 0x00, 0x00, 0x00
+      ]);
+
+      const result = await detector.detectFromBuffer(heifBuffer);
+      expect(result).toBeDefined();
+      expect(result?.name).toBe('heif');
+      expect(result?.mimeType).toBe('image/heif');
+      expect(result?.extensions).toContain('heif');
     });
 
     it('should detect UTF-8 BOM', async () => {

--- a/uploads/mime-bytes/src/file-type-detector.ts
+++ b/uploads/mime-bytes/src/file-type-detector.ts
@@ -29,8 +29,14 @@ export class FileTypeDetector {
   private extensionCache: Map<string, FileTypeDefinition[]>;
 
   constructor(options: FileTypeDetectorOptions = {}) {
-    // Create a copy of FILE_TYPES to avoid modifying the global registry
-    this.fileTypes = [...FILE_TYPES];
+    // Create a copy of FILE_TYPES sorted so that longer magic byte sequences
+    // are checked before shorter ones. This ensures that specific formats
+    // (e.g. HEIC with 8-byte signature "ftypheic") are matched before generic
+    // container formats (e.g. MP4 with 4-byte signature "ftyp") that share
+    // the same prefix.
+    this.fileTypes = [...FILE_TYPES].sort(
+      (a, b) => b.magicBytes.length - a.magicBytes.length
+    );
     this.options = {
       peekBytes: options.peekBytes || 32,
       checkMultipleOffsets: options.checkMultipleOffsets !== false,


### PR DESCRIPTION
## Summary

Fixes #967. HEIC and HEIF images were misidentified as `video/mp4` because all three formats share the ISO Base Media File Format `ftyp` container prefix. The `mp4` entry (4 magic bytes) appeared before `heic`/`heif` (8 magic bytes) in the registry, so the shorter prefix matched first.

The fix sorts `this.fileTypes` by `magicBytes.length` descending in the `FileTypeDetector` constructor, ensuring longer (more specific) signatures are checked before shorter prefix patterns.

## Review & Testing Checklist for Human

- [ ] Verify with a real `.heic` photo from an iPhone that detection returns `image/heic` instead of `video/mp4`
- [ ] Confirm that actual MP4 video files (e.g. with `isom` brand) still detect correctly as `video/mp4`

### Notes

- The sort is stable (JS spec), so entries with identical `magicBytes.length` retain their original order.
- Tests added for both HEIC (`ftypheic` brand) and HEIF (`ftypmif1` brand) buffers, plus the existing MP4 (`ftypisom`) test continues to pass.

Link to Devin session: https://app.devin.ai/sessions/1db29f3c8a46434c99001ddcb701cc12
Requested by: @pyramation