### PR TITLE
refactor: remove extraction status_field from node type registry

### DIFF
--- a/packages/node-type-registry/src/data/data-file-embedding.ts
+++ b/packages/node-type-registry/src/data/data-file-embedding.ts
@@ -114,12 +114,6 @@ export const DataFileEmbedding: NodeTypeDefinition = {
             format: 'column-ref',
             description: 'JSONB field for extraction metadata (page count, language, etc.)',
             default: 'extracted_metadata'
-          },
-          status_field: {
-            type: 'string',
-            format: 'column-ref',
-            description: 'Extraction lifecycle status field',
-            default: 'extraction_status'
           }
         }
       },

--- a/packages/node-type-registry/src/data/data-image-embedding.ts
+++ b/packages/node-type-registry/src/data/data-image-embedding.ts
@@ -117,12 +117,6 @@ export const DataImageEmbedding: NodeTypeDefinition = {
             format: 'column-ref',
             description: 'JSONB field for extraction metadata',
             default: 'extracted_metadata'
-          },
-          status_field: {
-            type: 'string',
-            format: 'column-ref',
-            description: 'Extraction lifecycle status field',
-            default: 'extraction_status'
           }
         }
       },


### PR DESCRIPTION
## Summary

Removes the `status_field` parameter from the extraction config in DataFileEmbedding and DataImageEmbedding node type definitions. Extraction lifecycle is tracked via `_updated_at` timestamps and job queue status, making a separate status column redundant.

**Removed from both `data-file-embedding.ts` and `data-image-embedding.ts`:**
- `extraction.properties.status_field` parameter definition (was `default: 'extraction_status'`)

## Review & Testing Checklist for Human

Risk: **green** — TypeScript-only change, removes a parameter the SQL generator no longer reads.

- [ ] Confirm no existing blueprints use `extraction.status_field`

### Notes

- Companion PR: constructive-io/constructive-db#1149 (SQL generator)
- Follow-up to #1156 (per-field _updated_at timestamps)

Link to Devin session: https://app.devin.ai/sessions/2b5a29d83d3f478e8d3d972653b4879c
Requested by: @pyramation