### PR TITLE
feat(presets): add devices_module to auth:hardened, b2b, and b2b:storage presets

### DIFF
--- a/packages/node-type-registry/src/module-presets/auth-hardened.ts
+++ b/packages/node-type-registry/src/module-presets/auth-hardened.ts
@@ -49,7 +49,8 @@ export const PresetAuthHardened: ModulePreset = {
     'identity_providers_module',
     'webauthn_credentials_module',
     'webauthn_auth_module',
-    'phone_numbers_module'
+    'phone_numbers_module',
+    'devices_module'
   ],
   includes_notes: {
     rate_limits_module: 'Throttling for sign-in, password reset, sign-up, and IP-based gates.',
@@ -58,7 +59,8 @@ export const PresetAuthHardened: ModulePreset = {
     webauthn_credentials_module: 'Per-user passkey storage.',
     webauthn_auth_module: 'Passkey challenge + assertion runtime.',
     session_secrets_module: 'Nonces for magic links, email OTP, and WebAuthn challenges.',
-    phone_numbers_module: 'SMS sign-in / MFA support.'
+    phone_numbers_module: 'SMS sign-in / MFA support.',
+    devices_module: 'Device tracking and trusted-device MFA bypass.'
   },
   omits_notes: {
     'memberships_module:org': 'No orgs / teams — use `b2b` when you need multi-tenancy.',

--- a/packages/node-type-registry/src/module-presets/b2b-storage.ts
+++ b/packages/node-type-registry/src/module-presets/b2b-storage.ts
@@ -61,10 +61,12 @@ export const PresetB2bStorage: ModulePreset = {
     'hierarchy_module:org',
     'invites_module:app',
     'invites_module:org',
-    'storage_module'
+    'storage_module',
+    'devices_module'
   ],
   includes_notes: {
-    storage_module: 'File upload infrastructure: app_buckets + app_files tables with RLS. Entity-type storage scopes layered on top via `has_storage=true`.'
+    storage_module: 'File upload infrastructure: app_buckets + app_files tables with RLS. Entity-type storage scopes layered on top via `has_storage=true`.',
+    devices_module: 'Device tracking and trusted-device MFA bypass.'
   },
   omits_notes: {
     crypto_addresses_module: 'Not a web3 preset.'

--- a/packages/node-type-registry/src/module-presets/b2b.ts
+++ b/packages/node-type-registry/src/module-presets/b2b.ts
@@ -62,7 +62,8 @@ export const PresetB2b: ModulePreset = {
     'profiles_module:org',
     'hierarchy_module:org',
     'invites_module:app',
-    'invites_module:org'
+    'invites_module:org',
+    'devices_module'
   ],
   includes_notes: {
     'memberships_module:org': 'Org-scoped membership rows — every user in an org gets one.',
@@ -76,7 +77,8 @@ export const PresetB2b: ModulePreset = {
     'profiles_module:org': 'Org-scoped user profile (per org a user belongs to).',
     'hierarchy_module:org': 'Nested org structures (parent / child orgs).',
     'invites_module:app': 'App-level invites (rare — usually platform admin adds another admin).',
-    'invites_module:org': 'Org-level invites (the common case — invite a teammate into a workspace).'
+    'invites_module:org': 'Org-level invites (the common case — invite a teammate into a workspace).',
+    devices_module: 'Device tracking and trusted-device MFA bypass.'
   },
   omits_notes: {
     storage_module: 'Add separately if you need file uploads tied to orgs.',


### PR DESCRIPTION
## Summary

Adds `devices_module` to the three production-grade module presets: `auth:hardened`, `b2b`, and `b2b:storage`.

The `user_auth_module` insert trigger in constructive-db already looks up `devices_module` and threads `user_devices_table_id` / `device_settings_table_id` through to the `sign_in` and `sign_in_identity` generators. However, no preset actually included `devices_module` in its modules list — so device tracking (trusted-device MFA bypass, device token cookies) was never provisioned.

**What changed:**
- `auth:hardened` — added `devices_module` (production consumer auth with full surfaces)
- `b2b` — added `devices_module` (multi-tenant B2B)
- `b2b:storage` — added `devices_module` (B2B + file uploads)

**Not changed:**
- `full` — uses `modules: ['all']`, already picks up everything implicitly
- `minimal`, `auth:email`, `auth:email+magic`, `auth:sso`, `auth:passkey` — lighter presets where device tracking adds unnecessary overhead

Triggered by review feedback on [#1141 (OAuth identity sign-in)](https://github.com/constructive-io/constructive/pull/1141#issuecomment-4435519285), item #7.

## Review & Testing Checklist for Human
- [ ] Verify `devices_module` is correctly positioned in each preset's dependency order (after `sessions_module`, `user_auth_module`)
- [ ] After merging, re-provision a test database with `b2b:storage` preset and confirm `user_devices` + `device_settings` tables are created
- [ ] Confirm `sign_in_identity` generated function now includes `device_token` IN param and `out_device_token` OUT param when provisioned with this preset

### Notes
There are two related constructive-db follow-ups identified from the same review:
1. **`sign_up_identity` missing device support** — the body generator has no device params, so new OAuth signups won't get device tracking even after this preset change
2. **`sign_in_identity` missing `remember_me`** — always uses `default_session_duration`; the regular `sign_in` already supports `remember_me` for extended sessions

Link to Devin session: https://app.devin.ai/sessions/dd0bdd01d4cd47e1a432390593fd68d8
Requested by: @pyramation