### PR TITLE
feat(graphile-realtime-test): add WebSocket test helpers and server factory

### DIFF
--- a/graphile/graphile-realtime-test/__tests__/realtime-websocket.integration.test.ts
+++ b/graphile/graphile-realtime-test/__tests__/realtime-websocket.integration.test.ts
@@ -15,10 +15,8 @@
  *   6. Fire pg_notify and verify events arrive over the WebSocket
  */
 
-import { createServer, type Server as HttpServer } from 'node:http';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
-import type { AddressInfo } from 'node:net';
 
 import { subscribe as grafastSubscribe } from 'grafast';
 import { makeSchema } from 'graphile-build';
@@ -30,78 +28,18 @@ import type { GraphQLSchema, ExecutionResult } from 'graphql';
 import type { GraphileConfig } from 'graphile-config';
 import { seed, getConnections } from 'pgsql-test';
 import type { GetConnectionResult } from 'pgsql-test';
-import { createClient, type Client as GqlWsClient } from 'graphql-ws';
-import { WebSocketServer, WebSocket } from 'ws';
-import { useServer } from 'graphql-ws/use/ws';
+import type { Client as GqlWsClient } from 'graphql-ws';
 
 import { makeRealtimeSmartTagsPlugin } from '../src/smart-tags';
 import { createRealtimeSubscriptionsPlugin } from 'graphile-realtime-subscriptions';
-import { notify, notifyChange, notifyInvalidate } from '../src/notify';
+import { notifyChange, notifyInvalidate, notify } from '../src/notify';
+import { nextWsEvent, collectWsEvents } from '../src/ws-helpers';
+import { createWsTestServer } from '../src/ws-server';
+import type { WsTestServer } from '../src/ws-server';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
 const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
-
-/**
- * Collect the next event from a graphql-ws subscription.
- * Returns a promise that resolves with the first `next` payload,
- * or rejects on error / timeout.
- */
-function nextEvent<T = Record<string, unknown>>(
-  client: GqlWsClient,
-  query: string,
-  variables?: Record<string, unknown>,
-  timeoutMs = 10000,
-): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => {
-      unsubscribe();
-      reject(new Error(`nextEvent timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-
-    const unsubscribe = client.subscribe(
-      { query, variables },
-      {
-        next(value) {
-          clearTimeout(timer);
-          unsubscribe();
-          resolve(value.data as T);
-        },
-        error(err) {
-          clearTimeout(timer);
-          unsubscribe();
-          reject(Array.isArray(err) ? err[0] : err);
-        },
-        complete() {
-          clearTimeout(timer);
-          reject(new Error('Subscription completed without yielding a value'));
-        },
-      },
-    );
-  });
-}
-
-/**
- * Subscribe and collect events into an array until unsubscribe is called.
- */
-function collectWsEvents<T = Record<string, unknown>>(
-  client: GqlWsClient,
-  query: string,
-  variables?: Record<string, unknown>,
-): { events: T[]; unsubscribe: () => void } {
-  const events: T[] = [];
-  const unsubscribe = client.subscribe(
-    { query, variables },
-    {
-      next(value) {
-        events.push(value.data as T);
-      },
-      error() { /* swallow */ },
-      complete() { /* done */ },
-    },
-  );
-  return { events, unsubscribe };
-}
 
 // ─── Test Suite ─────────────────────────────────────────────────────────────
 
@@ -113,9 +51,7 @@ describe('realtime WebSocket E2E (real graphql-ws over ws)', () => {
   let pgSubscriberKey: string;
   let pgServiceRef: any;
 
-  let httpServer: HttpServer;
-  let wss: WebSocketServer;
-  let serverCleanup: { dispose: () => Promise<void> };
+  let wsServer: WsTestServer;
   let wsClient: GqlWsClient;
 
   beforeAll(async () => {
@@ -158,71 +94,24 @@ describe('realtime WebSocket E2E (real graphql-ws over ws)', () => {
     pgSubscriber = (pgService as any).pgSubscriber;
     pgSubscriberKey = (pgService as any).pgSubscriberKey ?? 'pgSubscriber';
 
-    // 3. Start HTTP server + WebSocket server
-    httpServer = createServer();
-    wss = new WebSocketServer({ server: httpServer, path: '/graphql' });
-
-    // Wire graphql-ws server to the ws WebSocketServer
-    serverCleanup = useServer(
-      {
-        schema,
-        subscribe: async (args) => {
-          // Thread the pgSubscriber into the grafast context
-          const contextValue = {
-            [pgSubscriberKey]: pgSubscriber,
-            ...(typeof args.contextValue === 'object' && args.contextValue !== null
-              ? args.contextValue as Record<string, unknown>
-              : {}),
-          };
-
-          try {
-            const result = await grafastSubscribe({
-              schema: args.schema,
-              document: args.document,
-              variableValues: args.variableValues as Record<string, unknown> | undefined,
-              contextValue,
-              resolvedPreset,
-            });
-            return result as AsyncIterableIterator<ExecutionResult> | ExecutionResult;
-          } catch (err: unknown) {
-            console.error('[WS subscribe] grafastSubscribe threw:', err);
-            throw err;
-          }
-        },
-      },
-      wss,
-    );
-
-    await new Promise<void>((resolve) => {
-      httpServer.listen(0, '127.0.0.1', () => resolve());
+    // 3. Start WebSocket test server
+    wsServer = await createWsTestServer({
+      schema,
+      resolvedPreset,
+      pgSubscriber,
+      pgSubscriberKey,
     });
-
-    const addr = httpServer.address() as AddressInfo;
-    const serverUrl = `ws://127.0.0.1:${addr.port}/graphql`;
 
     // 4. Create graphql-ws client over a real WebSocket
-    wsClient = createClient({
-      url: serverUrl,
-      webSocketImpl: WebSocket,
-      retryAttempts: 0,
-    });
+    wsClient = wsServer.createClient();
 
     // Give the pgSubscriber time to establish LISTEN
     await delay(300);
   }, 30000);
 
   afterAll(async () => {
-    if (wsClient) {
-      await wsClient.dispose();
-    }
-    if (serverCleanup) {
-      await serverCleanup.dispose();
-    }
-    if (wss) {
-      wss.close();
-    }
-    if (httpServer?.listening) {
-      await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+    if (wsServer) {
+      await wsServer.dispose();
     }
     if (pgSubscriber && typeof pgSubscriber.release === 'function') {
       await pgSubscriber.release();
@@ -261,7 +150,7 @@ describe('realtime WebSocket E2E (real graphql-ws over ws)', () => {
   it('establishes a WebSocket connection and receives INSERT events', async () => {
     const testId = randomUUID();
 
-    const eventPromise = nextEvent<{
+    const eventPromise = nextWsEvent<{
       onItemChanged: { event: string; rowId: string; overflow: boolean };
     }>(
       wsClient,
@@ -290,7 +179,7 @@ describe('realtime WebSocket E2E (real graphql-ws over ws)', () => {
   it('delivers UPDATE and DELETE events over WebSocket', async () => {
     // UPDATE
     const updateId = randomUUID();
-    const updatePromise = nextEvent<{
+    const updatePromise = nextWsEvent<{
       onItemChanged: { event: string; overflow: boolean };
     }>(
       wsClient,
@@ -304,7 +193,7 @@ describe('realtime WebSocket E2E (real graphql-ws over ws)', () => {
 
     // DELETE
     const deleteId = randomUUID();
-    const deletePromise = nextEvent<{
+    const deletePromise = nextWsEvent<{
       onItemChanged: { event: string; overflow: boolean };
     }>(
       wsClient,
@@ -320,7 +209,7 @@ describe('realtime WebSocket E2E (real graphql-ws over ws)', () => {
   // ─── INVALIDATE (overflow) ────────────────────────────────────────────
 
   it('delivers INVALIDATE (overflow) events via WebSocket', async () => {
-    const eventPromise = nextEvent<{
+    const eventPromise = nextWsEvent<{
       onItemChanged: { event: string; overflow: boolean };
     }>(
       wsClient,
@@ -358,8 +247,6 @@ describe('realtime WebSocket E2E (real graphql-ws over ws)', () => {
     await delay(300);
 
     // Fire for unwatched ID — the event still arrives but with parsed=null
-    // (grafast subscriptions don't support event-level inhibition, so the
-    // plugin returns null parsed data which surfaces as event='UNKNOWN')
     await notifyChange(conn.pg.client, 'realtime_test', 'items', 'UPDATE', [unwatchedId]);
     await delay(200);
 
@@ -369,14 +256,11 @@ describe('realtime WebSocket E2E (real graphql-ws over ws)', () => {
 
     unsubscribe();
 
-    // Both NOTIFY events arrive, but the plugin marks non-matching ones
-    // with event='UNKNOWN' and rowId=null so clients can filter them out
     const relevant = events.filter(e => e.onItemChanged.event !== 'UNKNOWN');
     expect(relevant.length).toBe(1);
     expect(relevant[0].onItemChanged.event).toBe('INSERT');
     expect(relevant[0].onItemChanged.rowId).toBe(watchedId);
 
-    // The unwatched event should have been marked as UNKNOWN
     const filtered = events.filter(e => e.onItemChanged.event === 'UNKNOWN');
     expect(filtered.length).toBe(1);
     expect(filtered[0].onItemChanged.rowId).toBeNull();
@@ -388,7 +272,7 @@ describe('realtime WebSocket E2E (real graphql-ws over ws)', () => {
     const testId = randomUUID();
 
     // Subscriber 1 on the existing client
-    const promise1 = nextEvent<{
+    const promise1 = nextWsEvent<{
       onItemChanged: { event: string };
     }>(
       wsClient,
@@ -396,14 +280,9 @@ describe('realtime WebSocket E2E (real graphql-ws over ws)', () => {
     );
 
     // Subscriber 2 on a separate WebSocket client
-    const addr = httpServer.address() as AddressInfo;
-    const wsClient2 = createClient({
-      url: `ws://127.0.0.1:${addr.port}/graphql`,
-      webSocketImpl: WebSocket,
-      retryAttempts: 0,
-    });
+    const wsClient2 = wsServer.createClient();
 
-    const promise2 = nextEvent<{
+    const promise2 = nextWsEvent<{
       onItemChanged: { event: string };
     }>(
       wsClient2,
@@ -426,7 +305,7 @@ describe('realtime WebSocket E2E (real graphql-ws over ws)', () => {
   it('handles raw NOTIFY payloads via WebSocket', async () => {
     const testId = randomUUID();
 
-    const eventPromise = nextEvent<{
+    const eventPromise = nextWsEvent<{
       onItemChanged: { event: string; rowId: string; overflow: boolean };
     }>(
       wsClient,

--- a/graphile/graphile-realtime-test/package.json
+++ b/graphile/graphile-realtime-test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graphile-realtime-test",
-  "version": "0.2.0",
-  "description": "Subscription testing utilities for graphile-realtime-subscriptions — smart tag injection, grafast.subscribe() helpers, and pg_notify simulation",
+  "version": "0.3.0",
+  "description": "Subscription testing utilities for graphile-realtime-subscriptions — smart tag injection, grafast.subscribe() helpers, pg_notify simulation, and WebSocket test server",
   "author": "Constructive <developers@constructive.io>",
   "homepage": "https://github.com/constructive-io/constructive",
   "license": "MIT",
@@ -33,7 +33,8 @@
     "subscriptions",
     "realtime",
     "notify",
-    "test"
+    "test",
+    "websocket"
   ],
   "bugs": {
     "url": "https://github.com/constructive-io/constructive/issues"
@@ -48,8 +49,18 @@
     "graphile-build-pg": "5.0.0",
     "graphile-config": "1.0.0",
     "graphql": "16.13.0",
+    "graphql-ws": "^6.0.8",
     "pg": "^8.20.0",
-    "postgraphile": "5.0.0"
+    "postgraphile": "5.0.0",
+    "ws": "^8.20.1"
+  },
+  "peerDependenciesMeta": {
+    "graphql-ws": {
+      "optional": true
+    },
+    "ws": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/express": "^5.0.6",

--- a/graphile/graphile-realtime-test/src/index.ts
+++ b/graphile/graphile-realtime-test/src/index.ts
@@ -17,3 +17,8 @@ export {
   buildPayload,
   buildInvalidatePayload,
 } from './notify.js';
+
+export { nextWsEvent, collectWsEvents } from './ws-helpers.js';
+
+export { createWsTestServer } from './ws-server.js';
+export type { WsTestServerInput, WsTestServer } from './ws-server.js';

--- a/graphile/graphile-realtime-test/src/ws-helpers.ts
+++ b/graphile/graphile-realtime-test/src/ws-helpers.ts
@@ -1,0 +1,77 @@
+import type { Client as GqlWsClient } from 'graphql-ws';
+
+/**
+ * Subscribe via a graphql-ws WebSocket client and wait for the first event.
+ *
+ * Creates a subscription, resolves with the first `next` payload's `data`,
+ * then automatically unsubscribes. Rejects on error or timeout.
+ *
+ * @param client - A graphql-ws Client instance
+ * @param query - The GraphQL subscription query string
+ * @param variables - Optional variables for the subscription
+ * @param timeoutMs - Maximum time to wait (default: 15000ms)
+ * @returns The `data` field of the first subscription event
+ */
+export function nextWsEvent<T = Record<string, unknown>>(
+  client: GqlWsClient,
+  query: string,
+  variables?: Record<string, unknown>,
+  timeoutMs = 15000,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      unsubscribe();
+      reject(new Error(`nextWsEvent timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    const unsubscribe = client.subscribe(
+      { query, variables },
+      {
+        next(value) {
+          clearTimeout(timer);
+          unsubscribe();
+          resolve(value.data as T);
+        },
+        error(err) {
+          clearTimeout(timer);
+          unsubscribe();
+          reject(Array.isArray(err) ? err[0] : err);
+        },
+        complete() {
+          clearTimeout(timer);
+          reject(new Error('Subscription completed without yielding a value'));
+        },
+      },
+    );
+  });
+}
+
+/**
+ * Subscribe via a graphql-ws WebSocket client and collect events into an array.
+ *
+ * Events are pushed into the returned `events` array as they arrive.
+ * Call `unsubscribe()` when done collecting.
+ *
+ * @param client - A graphql-ws Client instance
+ * @param query - The GraphQL subscription query string
+ * @param variables - Optional variables for the subscription
+ * @returns An object with `events` array and `unsubscribe` function
+ */
+export function collectWsEvents<T = Record<string, unknown>>(
+  client: GqlWsClient,
+  query: string,
+  variables?: Record<string, unknown>,
+): { events: T[]; unsubscribe: () => void } {
+  const events: T[] = [];
+  const unsubscribe = client.subscribe(
+    { query, variables },
+    {
+      next(value) {
+        events.push(value.data as T);
+      },
+      error() { /* swallow */ },
+      complete() { /* done */ },
+    },
+  );
+  return { events, unsubscribe };
+}

--- a/graphile/graphile-realtime-test/src/ws-server.ts
+++ b/graphile/graphile-realtime-test/src/ws-server.ts
@@ -1,0 +1,167 @@
+import { createServer, type Server as HttpServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { subscribe as grafastSubscribe } from 'grafast';
+import type { GraphQLSchema, ExecutionResult } from 'graphql';
+import type { GraphileConfig } from 'graphile-config';
+import { createClient, type Client as GqlWsClient } from 'graphql-ws';
+import { useServer } from 'graphql-ws/use/ws';
+import { WebSocketServer, WebSocket } from 'ws';
+
+/**
+ * Input for creating a WebSocket test server.
+ */
+export interface WsTestServerInput {
+  schema: GraphQLSchema;
+  resolvedPreset: GraphileConfig.ResolvedPreset;
+  pgSubscriber: unknown;
+  pgSubscriberKey?: string;
+
+  /**
+   * Optional hook to build pgSettings from the WebSocket connectionParams.
+   * Return a pgSettings object to inject into the grafast context,
+   * or undefined to skip pgSettings injection.
+   *
+   * Example (constructive auth):
+   * ```ts
+   * buildPgSettings: (params) => ({
+   *   role: 'authenticated',
+   *   'jwt.claims.user_id': params.userId,
+   * })
+   * ```
+   */
+  buildPgSettings?: (
+    connectionParams: Record<string, string>,
+  ) => Record<string, string> | undefined;
+}
+
+/**
+ * A running WebSocket test server with helpers.
+ */
+export interface WsTestServer {
+  /** The ws:// URL clients can connect to */
+  serverUrl: string;
+
+  /** The underlying HTTP server */
+  httpServer: HttpServer;
+
+  /** The underlying WebSocketServer */
+  wss: WebSocketServer;
+
+  /**
+   * Create a graphql-ws client connected to this server.
+   *
+   * @param connectionParams - Optional params passed to the server on connect
+   * @returns A graphql-ws Client instance
+   */
+  createClient(connectionParams?: Record<string, unknown>): GqlWsClient;
+
+  /**
+   * Dispose the server: close all WebSocket connections, stop listening,
+   * and clean up the graphql-ws server transport.
+   */
+  dispose(): Promise<void>;
+}
+
+/**
+ * Create a WebSocket test server backed by graphql-ws + grafast.
+ *
+ * Bundles the HTTP server, WebSocketServer, and graphql-ws `useServer` wiring
+ * into a single helper. The server listens on a random port on 127.0.0.1.
+ *
+ * @param input - Server configuration
+ * @returns A `WsTestServer` with `serverUrl`, `createClient()`, and `dispose()`
+ */
+export async function createWsTestServer(
+  input: WsTestServerInput,
+): Promise<WsTestServer> {
+  const {
+    schema,
+    resolvedPreset,
+    pgSubscriber,
+    pgSubscriberKey = 'pgSubscriber',
+    buildPgSettings,
+  } = input;
+
+  const httpServer = createServer();
+  const wss = new WebSocketServer({ server: httpServer, path: '/graphql' });
+
+  const serverCleanup = useServer(
+    {
+      schema,
+      context: async (ctx) => ({
+        connectionParams: ctx.connectionParams,
+      }),
+      subscribe: async (args) => {
+        const params = (
+          args.contextValue as Record<string, unknown>
+        )?.connectionParams as Record<string, string> | undefined;
+
+        const contextValue: Record<string, unknown> = {
+          [pgSubscriberKey]: pgSubscriber,
+          ...(typeof args.contextValue === 'object' && args.contextValue !== null
+            ? (args.contextValue as Record<string, unknown>)
+            : {}),
+        };
+
+        if (buildPgSettings && params) {
+          const pgSettings = buildPgSettings(params);
+          if (pgSettings) {
+            contextValue['pgSettings'] = pgSettings;
+          }
+        }
+
+        const result = await grafastSubscribe({
+          schema: args.schema,
+          document: args.document,
+          variableValues: args.variableValues as
+            | Record<string, unknown>
+            | undefined,
+          contextValue,
+          resolvedPreset,
+        });
+        return result as AsyncIterableIterator<ExecutionResult> | ExecutionResult;
+      },
+    },
+    wss,
+  );
+
+  await new Promise<void>((resolve) => {
+    httpServer.listen(0, '127.0.0.1', () => resolve());
+  });
+
+  const addr = httpServer.address() as AddressInfo;
+  const serverUrl = `ws://127.0.0.1:${addr.port}/graphql`;
+
+  const clients: GqlWsClient[] = [];
+
+  return {
+    serverUrl,
+    httpServer,
+    wss,
+
+    createClient(connectionParams?: Record<string, unknown>): GqlWsClient {
+      const client = createClient({
+        url: serverUrl,
+        webSocketImpl: WebSocket,
+        retryAttempts: 0,
+        connectionParams,
+      });
+      clients.push(client);
+      return client;
+    },
+
+    async dispose() {
+      for (const client of clients) {
+        try {
+          await client.dispose();
+        } catch { /* ignore */ }
+      }
+      await serverCleanup.dispose();
+      wss.close();
+      if (httpServer.listening) {
+        await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Extracts the WebSocket subscription helpers and server setup/teardown boilerplate that was duplicated in integration tests into reusable exports from `graphile-realtime-test`.

**New modules:**
- **`ws-helpers.ts`** — `nextWsEvent<T>()` (subscribe, wait for first event, auto-unsubscribe) and `collectWsEvents<T>()` (subscribe, accumulate events into an array)
- **`ws-server.ts`** — `createWsTestServer()` factory that bundles HTTP server + `WebSocketServer` + `graphql-ws` `useServer` wiring, with a `buildPgSettings` hook for auth injection from connectionParams. Returns `{ serverUrl, createClient(), dispose() }`.

The existing WS integration test is updated to use these helpers, removing ~70 lines of inline setup code. The `afterAll` teardown is reduced from 5 manual cleanup steps to `wsServer.dispose()`.

`graphql-ws` and `ws` are added as **optional** peer dependencies so consumers that don't need WS support aren't forced to install them.

Version bump: 0.2.0 → 0.3.0.

## Review & Testing Checklist for Human

- [ ] **`createWsTestServer` context callback**: The factory adds a `context` callback (`{ connectionParams: ctx.connectionParams }`) that the original inline test didn't have. Verify this doesn't alter subscription behavior when `buildPgSettings` is not provided — the connectionParams object will be spread into the grafast contextValue alongside pgSubscriber.
- [ ] **Client tracking in `dispose()`**: `createClient()` tracks all created clients for bulk cleanup, but tests that manually call `client.dispose()` will cause a double-dispose attempt (swallowed by try/catch). Confirm this is acceptable vs. using a `WeakRef` or deregistering on manual dispose.
- [ ] **Run the WS integration test** (`cd graphile/graphile-realtime-test && npx jest realtime-websocket`) to verify all 7 tests pass after the refactor.

### Notes
- The default timeout for `nextWsEvent` is 15000ms vs. the previous inline `nextEvent` which used 10000ms. This is intentional to match Jest's per-test timeout.
- The companion PR [constructive-db#1155](https://github.com/constructive-io/constructive-db/pull/1155) will consume these helpers to similarly clean up its WS test.

Link to Devin session: https://app.devin.ai/sessions/19485cf5cc58416a9f86068563d512f5
Requested by: @pyramation