### PR TITLE
feat: add search_indexes parameter to ProcessChunks and ProcessFileEmbedding (#856)

### DIFF
--- a/packages/node-type-registry/src/data/data-chunks.ts
+++ b/packages/node-type-registry/src/data/data-chunks.ts
@@ -85,6 +85,17 @@ export const ProcessChunks: NodeTypeDefinition = {
           'Field names from the parent table to copy into chunk metadata'
       },
 
+      // ── Search indexes ───────────────────────────────────────────────
+      search_indexes: {
+        type: 'array',
+        items: { type: 'string', enum: ['fulltext', 'bm25', 'trigram'] },
+        description:
+          'Text search indexes to create on the chunks content column. ' +
+          'Enables keyword-based retrieval alongside vector search for ' +
+          'hybrid RAG workflows.',
+        default: ['fulltext']
+      },
+
       // ── Job trigger ────────────────────────────────────────────────
       enqueue_chunking_job: {
         type: 'boolean',

--- a/packages/node-type-registry/src/data/data-file-embedding.ts
+++ b/packages/node-type-registry/src/data/data-file-embedding.ts
@@ -161,6 +161,14 @@ export const ProcessFileEmbedding: NodeTypeDefinition = {
             items: { type: 'string' },
             description: 'Field names from parent to copy into chunk metadata'
           },
+          search_indexes: {
+            type: 'array',
+            items: { type: 'string', enum: ['fulltext', 'bm25', 'trigram'] },
+            description:
+              'Text search indexes to create on the chunks content column. ' +
+              'Enables keyword-based retrieval alongside vector search.',
+            default: ['fulltext']
+          },
           enqueue_chunking_job: {
             type: 'boolean',
             description: 'Whether to auto-enqueue a chunking job on insert/update',


### PR DESCRIPTION
## Summary

Adds `search_indexes` parameter to the `ProcessChunks` node type definition and the `ProcessFileEmbedding` chunks sub-config in the node type registry.

```typescript
search_indexes: {
  type: 'array',
  items: { type: 'string', enum: ['fulltext', 'bm25', 'trigram'] },
  default: ['fulltext']
}
```

This enables hybrid RAG workflows — keyword search (tsvector/BM25/trigram) alongside vector similarity search on the chunks table's content column.

The default `[\"fulltext\"]` is centralized here in the `parameter_schema` and applied by `table_module` normalization before reaching the SQL generator.

## Review & Testing Checklist for Human

- [ ] Verify `search_indexes` property matches the SQL column type (jsonb array of strings)
- [ ] Confirm default `['fulltext']` aligns with the SQL column default `'[\"fulltext\"]'::jsonb`

### Notes

- Companion to constructive-io/constructive-db#1164 (SQL implementation)
- Closes constructive-io/constructive-planning#856 (together with the DB PR)

Link to Devin session: https://app.devin.ai/sessions/2b5a29d83d3f478e8d3d972653b4879c
Requested by: @pyramation