### PR TITLE
feat: expose embedding/extraction model config in node-type registry

### DIFF
--- a/packages/node-type-registry/src/data/data-chunks.ts
+++ b/packages/node-type-registry/src/data/data-chunks.ts
@@ -70,6 +70,20 @@ export const ProcessChunks: NodeTypeDefinition = {
         default: 'cosine'
       },
 
+      // ── Model config (optional — flows into job payload) ──────────
+      embedding_model: {
+        type: 'string',
+        description:
+          'Embedding model identifier for per-chunk embeddings. ' +
+          'When null, the worker falls back to runtime config (llm_module / env vars).'
+      },
+      embedding_provider: {
+        type: 'string',
+        description:
+          'Embedding provider name (e.g. "ollama", "openai"). ' +
+          'When null, the worker falls back to runtime config.'
+      },
+
       // ── Table naming ───────────────────────────────────────────────
       chunks_table_name: {
         type: 'string',

--- a/packages/node-type-registry/src/data/data-file-embedding.ts
+++ b/packages/node-type-registry/src/data/data-file-embedding.ts
@@ -47,6 +47,21 @@ export const ProcessFileEmbedding: NodeTypeDefinition = {
         default: {}
       },
 
+      // ── Model config (optional — flows into job payload) ──────────
+      embedding_model: {
+        type: 'string',
+        description:
+          'Embedding model identifier (e.g. "nomic-embed-text", "text-embedding-3-small", ' +
+          '"clip-vit-base-patch32"). Included in the job payload so the worker knows which ' +
+          'model to use. When null, the worker falls back to runtime config (llm_module / env vars).'
+      },
+      embedding_provider: {
+        type: 'string',
+        description:
+          'Embedding provider name (e.g. "ollama", "openai"). ' +
+          'When null, the worker falls back to runtime config.'
+      },
+
       // ── MIME scoping ───────────────────────────────────────────────
       mime_patterns: {
         type: 'array',

--- a/packages/node-type-registry/src/data/data-image-embedding.ts
+++ b/packages/node-type-registry/src/data/data-image-embedding.ts
@@ -56,6 +56,21 @@ export const ProcessImageEmbedding: NodeTypeDefinition = {
         default: {}
       },
 
+      // ── Model config (optional — flows into job payload) ──────────
+      embedding_model: {
+        type: 'string',
+        description:
+          'Embedding model identifier (e.g. "clip-vit-base-patch32"). ' +
+          'Included in the job payload so the worker knows which model to use. ' +
+          'When null, the worker falls back to runtime config (llm_module / env vars).'
+      },
+      embedding_provider: {
+        type: 'string',
+        description:
+          'Embedding provider name (e.g. "ollama", "openai"). ' +
+          'When null, the worker falls back to runtime config.'
+      },
+
       // ── MIME scoping ───────────────────────────────────────────────
       mime_patterns: {
         type: 'array',

--- a/packages/node-type-registry/src/data/process-extraction.ts
+++ b/packages/node-type-registry/src/data/process-extraction.ts
@@ -41,6 +41,21 @@ export const ProcessExtraction: NodeTypeDefinition = {
         default: 'extracted_metadata'
       },
 
+      // ── Model config (optional — flows into job payload) ──────────
+      extraction_model: {
+        type: 'string',
+        description:
+          'Extraction model identifier (e.g. a vision model for OCR, an LLM for ' +
+          'structured extraction). Included in the job payload so the worker knows ' +
+          'which model to use. When null, the worker falls back to runtime config.'
+      },
+      extraction_provider: {
+        type: 'string',
+        description:
+          'Extraction provider name (e.g. "ollama", "openai"). ' +
+          'When null, the worker falls back to runtime config.'
+      },
+
       // ── MIME scoping ──────────────────────────────────────────────
       mime_patterns: {
         type: 'array',

--- a/packages/node-type-registry/src/data/search-unified.ts
+++ b/packages/node-type-registry/src/data/search-unified.ts
@@ -110,6 +110,16 @@ export const SearchUnified: NodeTypeDefinition = {
               format: 'column-ref'
             }
           },
+          embedding_model: {
+            type: 'string',
+            description:
+              'Embedding model identifier. When null, the worker falls back to runtime config.'
+          },
+          embedding_provider: {
+            type: 'string',
+            description:
+              'Embedding provider name. When null, the worker falls back to runtime config.'
+          },
           search_score_weight: {
             type: 'number',
             default: 1

--- a/packages/node-type-registry/src/data/search-vector.ts
+++ b/packages/node-type-registry/src/data/search-vector.ts
@@ -52,6 +52,21 @@ export const SearchVector: NodeTypeDefinition = {
         },
         description: 'Column names that feed the embedding. Used by stale trigger to detect content changes.'
       },
+
+      // ── Model config (optional — flows into job payload) ──────────
+      embedding_model: {
+        type: 'string',
+        description:
+          'Embedding model identifier (e.g. "nomic-embed-text", "text-embedding-3-small"). ' +
+          'Included in the job payload so the worker knows which model to use. ' +
+          'When null, the worker falls back to runtime config (llm_module / env vars).'
+      },
+      embedding_provider: {
+        type: 'string',
+        description:
+          'Embedding provider name (e.g. "ollama", "openai"). ' +
+          'When null, the worker falls back to runtime config.'
+      },
       enqueue_job: {
         type: 'boolean',
         description: 'Auto-create trigger that enqueues embedding generation jobs',


### PR DESCRIPTION
## Summary

Adds optional `embedding_model` / `embedding_provider` parameters to 5 embedding-related node types, and `extraction_model` / `extraction_provider` to `ProcessExtraction`. This lets blueprint authors specify which model and provider to use per-node, rather than relying solely on runtime config.

All new parameters are optional strings with no defaults — when omitted (null), workers fall back to the existing resolution chain (llm_module → env vars).

**Node types updated:**
| Node Type | New Parameters |
|---|---|
| `SearchVector` | `embedding_model`, `embedding_provider` |
| `ProcessFileEmbedding` | `embedding_model`, `embedding_provider` |
| `ProcessImageEmbedding` | `embedding_model`, `embedding_provider` |
| `ProcessChunks` | `embedding_model`, `embedding_provider` |
| `SearchUnified` (embedding sub-config) | `embedding_model`, `embedding_provider` |
| `ProcessExtraction` | `extraction_model`, `extraction_provider` |

**Companion PR:** The SQL generator and seed changes that consume these parameters are in [constructive-db `feat/embedding-model-config`](https://github.com/constructive-io/constructive-db/compare/feat/embedding-model-config).

## Review & Testing Checklist for Human

- [ ] Verify the parameter names (`embedding_model`/`embedding_provider` vs `extraction_model`/`extraction_provider`) match what the constructive-db SQL generators extract from `data->>'...'`
- [ ] Confirm `SearchUnified.embedding` nesting is correct — the new params should be siblings of `field_name`, `dimensions`, `chunks`, etc. inside the `embedding` properties object, not at the top level
- [ ] Spot-check that no `base_url` parameter was accidentally included (intentionally excluded for billing bypass concerns)

### Notes
- This is a schema-only change (parameter definitions). No runtime behavior changes in this repo.
- `base_url` was intentionally excluded per discussion — exposing it would allow users to bypass the inference billing system.

Link to Devin session: https://app.devin.ai/sessions/64aab8157bae43e69f70f33c193dc903
Requested by: @pyramation