### PR TITLE
fix: handle nested node_modules in pgpm installModules

### DIFF
--- a/pgpm/core/src/core/class/pgpm.ts
+++ b/pgpm/core/src/core/class/pgpm.ts
@@ -1023,11 +1023,16 @@ ${dependencies.length > 0 ? dependencies.map(dep => `-- requires: ${dep}`).join(
         const installs = matches.map((conf) => {
           const fullConf = resolve(conf);
           const extDir = dirname(fullConf);
-          const relativeDir = extDir.split('node_modules/')[1];
+          const parts = extDir.split('node_modules/');
+          const relativeDir = parts[parts.length - 1];
           const dstDir = path.join(skitchExtDir, relativeDir);
           return { src: extDir, dst: dstDir, pkg: relativeDir };
         });
-  
+
+        // Sort deepest paths first so nested node_modules deps are
+        // extracted before their parent directories are moved.
+        installs.sort((a, b) => b.src.split('/').length - a.src.split('/').length);
+
         for (const { src, dst, pkg } of installs) {
           if (fs.existsSync(dst)) {
             fs.rmSync(dst, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Fixes `pgpm install` failing when a package has dependencies placed in nested `node_modules` (not hoisted by npm). Reported when running `pgpm install agentic-db`, which has `@pgpm/services` as a dependency, which in turn has `@pgpm/metaschema-schema` in a nested `node_modules`.

Two bugs in `installModules`:

1. **Wrong path segment selected:** `extDir.split('node_modules/')[1]` picks the first segment after the first `node_modules/` delimiter. For a path like `.../node_modules/@pgpm/services/node_modules/@pgpm/metaschema-schema`, `split('node_modules/')` produces `['...', '@pgpm/services/', '@pgpm/metaschema-schema']` and `[1]` yields `'@pgpm/services/'` — the wrong package. Fixed by using `parts[parts.length - 1]` to always select the leaf package name.

2. **Move order causes missing source:** When the parent (`@pgpm/services`) is moved first via `mv`, its nested `node_modules/@pgpm/metaschema-schema` goes with it, so subsequent `mv` for the nested dep fails with "No such file or directory". Fixed by sorting installs deepest-first so nested deps are extracted before their parents are moved.

## Review & Testing Checklist for Human

- [ ] **Verify the nested `node_modules` path is correctly resolved:** Confirm that `parts[parts.length - 1]` produces the right `relativeDir` for both flat (`node_modules/@pgpm/foo`) and nested (`node_modules/@pgpm/bar/node_modules/@pgpm/foo`) layouts.
- [ ] **Test with `agentic-db` end-to-end:** Run `pgpm install agentic-db` in a workspace to confirm the original error is resolved — the existing test suite uses `@pgpm-testing/totp` which may have its deps hoisted flat by npm, so it may not exercise the nested `node_modules` code path.
- [ ] **Check for duplicate leaf names:** If two different parent packages each have a nested dep with the same name, they'd map to the same destination and overwrite. Confirm this isn't a realistic scenario for pgpm modules.

### Notes

- Existing `module-installation` tests (15 tests) all pass with this change.
- The `parts[parts.length - 1]` expression is equivalent to `parts[1]` when there's only one `node_modules/` in the path (the common flat case), so there's no behavioral change for non-nested dependencies.

Link to Devin session: https://app.devin.ai/sessions/bfa8f73e1593425780eeae5fc60b759a
Requested by: @pyramation