### PR TITLE
feat: add MeterRateLimit node type definition

### DIFF
--- a/packages/node-type-registry/src/data/data-meter-rate-limit.ts
+++ b/packages/node-type-registry/src/data/data-meter-rate-limit.ts
@@ -1,0 +1,46 @@
+import type { NodeTypeDefinition } from '../types';
+
+export const MeterRateLimit: NodeTypeDefinition = {
+  name: 'MeterRateLimit',
+  slug: 'meter_rate_limit',
+  category: 'rate_limit',
+  display_name: 'Meter Rate Limit',
+  description:
+    'Attaches a BEFORE trigger that calls check_rate_limit() to enforce sliding-window rate limits before allowing mutations. The function checks all three scopes (entity, actor-in-entity, actor) in a single call; which scopes are actually enforced is controlled by what rows exist in rate_window_limits (plan-based config). Requires a provisioned meter_rate_limits_module and billing_module for the target database.',
+  parameter_schema: {
+    type: 'object',
+    properties: {
+      meter_slug: {
+        type: 'string',
+        description:
+          'Slug of the billing meter to check rate limits against (must match a meters table entry, e.g. "messaging", "inference")',
+      },
+      entity_field: {
+        type: 'string',
+        format: 'column-ref',
+        description:
+          'Column on the target table that holds the entity id (org) for rate limiting',
+        default: 'entity_id',
+      },
+      actor_field: {
+        type: 'string',
+        format: 'column-ref',
+        description:
+          'Column on the target table that holds the actor id (user) for rate limiting',
+        default: 'owner_id',
+      },
+      events: {
+        type: 'array',
+        items: {
+          type: 'string',
+          enum: ['INSERT', 'UPDATE'],
+        },
+        description:
+          'Which DML events to enforce rate limits on (DELETE is excluded since it reduces load)',
+        default: ['INSERT'],
+      },
+    },
+    required: ['meter_slug'],
+  },
+  tags: ['rate-limits', 'triggers', 'billing', 'metering', 'abuse-protection'],
+};

--- a/packages/node-type-registry/src/data/index.ts
+++ b/packages/node-type-registry/src/data/index.ts
@@ -19,6 +19,7 @@ export { DataInflection } from './data-inflection';
 export { DataInheritFromParent } from './data-inherit-from-parent';
 export { JobTrigger } from './data-job-trigger';
 export { LimitCounter } from './data-limit-counter';
+export { MeterRateLimit } from './data-meter-rate-limit';
 export { DataJsonb } from './data-jsonb';
 export { DataOwnedFields } from './data-owned-fields';
 export { ProcessExtraction } from './process-extraction';


### PR DESCRIPTION
## Summary

Adds the `MeterRateLimit` node type definition to the node-type-registry. This is the TypeScript side of the MeterRateLimit blueprint node, which pairs with the SQL generator (`data_meter_rate_limit.sql`) and AST trigger builder (`proc_meter_rate_limit_trigger_body`) added in constructive-db [PR #1178](https://github.com/constructive-io/constructive-db/pull/1178).

**What it does:** Declares a `MeterRateLimit` node type (category: `rate_limit`) that attaches a BEFORE trigger calling `check_rate_limit()` to enforce sliding-window rate limits before allowing mutations. All three scopes (entity, actor-in-entity, actor) are checked in a single call.

**Parameter schema:**
- `meter_slug` (required) — which billing meter to check
- `entity_field` (default: `entity_id`) — column holding entity id
- `actor_field` (default: `owner_id`) — column holding actor id  
- `events` (default: `['INSERT']`) — which DML events to enforce

**Files changed:**
- `packages/node-type-registry/src/data/data-meter-rate-limit.ts` — new node type definition
- `packages/node-type-registry/src/data/index.ts` — export added

## Review & Testing Checklist for Human
- [ ] Verify `parameter_schema` matches the SQL generator's expected parameters in constructive-db
- [ ] Verify `category: 'rate_limit'` matches the dispatch case in `table_module.sql`

### Notes
Companion to constructive-db PR #1178 which adds the SQL generator, AST trigger builder, and `table_module` dispatch for `MeterRateLimit`.


Link to Devin session: https://app.devin.ai/sessions/c0494871633d4beb91f1e16e53c776d1
Requested by: @pyramation