### PR TITLE
feat: shared condition infrastructure + EventTracker node type

### DIFF
--- a/packages/node-type-registry/src/conditions/index.ts
+++ b/packages/node-type-registry/src/conditions/index.ts
@@ -1,0 +1,6 @@
+export {
+  conditionDefs,
+  conditionProperties,
+  triggerConditionSchema,
+  triggerConditionsProperty
+} from './trigger-condition';

--- a/packages/node-type-registry/src/conditions/trigger-condition.ts
+++ b/packages/node-type-registry/src/conditions/trigger-condition.ts
@@ -1,0 +1,100 @@
+import type { JSONSchema } from '../types';
+
+/**
+ * Shared trigger condition schema used by any node type that creates
+ * PostgreSQL triggers with conditional WHEN clauses.
+ *
+ * Consumed by: JobTrigger, EventTracker, ProcessExtraction,
+ * ProcessImageVersions, ProcessFileEmbedding, ProcessImageEmbedding.
+ *
+ * On the SQL side, these conditions are compiled to AST via
+ * metaschema_generators.build_condition_ast().
+ */
+export const triggerConditionSchema: JSONSchema = {
+  type: 'object',
+  description: 'A leaf condition ({field, op, value?, row?, ref?}) or a combinator ({AND, OR, NOT}).',
+  properties: {
+    field: { type: 'string', format: 'column-ref', description: 'Column name (validated against the table).' },
+    op: {
+      type: 'string',
+      enum: ['=', '!=', '>', '<', '>=', '<=', 'LIKE', 'NOT LIKE', 'IS NULL', 'IS NOT NULL', 'IS DISTINCT FROM'],
+      description: 'Comparison operator.'
+    },
+    value: { description: 'Comparison value. Type is resolved from the column definition. Omit for IS NULL, IS NOT NULL, IS DISTINCT FROM.' },
+    row: { type: 'string', enum: ['NEW', 'OLD'], default: 'NEW', description: 'Row reference (default: NEW).' },
+    ref: {
+      type: 'object',
+      description: 'Column reference for field-to-field comparison (alternative to value).',
+      properties: {
+        field: { type: 'string', format: 'column-ref' },
+        row: { type: 'string', enum: ['NEW', 'OLD'], default: 'NEW' }
+      }
+    },
+    AND: { type: 'array', description: 'Array of conditions combined with AND.', items: { $ref: '#/$defs/triggerCondition' } },
+    OR: { type: 'array', description: 'Array of conditions combined with OR.', items: { $ref: '#/$defs/triggerCondition' } },
+    NOT: { $ref: '#/$defs/triggerCondition', description: 'Negated condition.' }
+  }
+};
+
+/**
+ * $defs block for parameter_schema. Spread into any node that uses conditions.
+ *
+ * Usage:
+ *   parameter_schema: { type: 'object', $defs: conditionDefs, properties: { ... } }
+ */
+export const conditionDefs: Record<string, JSONSchema> = {
+  triggerCondition: triggerConditionSchema
+};
+
+/**
+ * Common condition-related properties for trigger-based nodes.
+ * Three mutually exclusive options for WHEN clause specification.
+ *
+ * Usage:
+ *   properties: { event_name: { ... }, ...conditionProperties }
+ */
+export const conditionProperties: Record<string, JSONSchema> = {
+  condition_field: {
+    type: 'string',
+    format: 'column-ref',
+    description: 'Column name for conditional WHEN clause (fires only when field equals condition_value)'
+  },
+  condition_value: {
+    type: 'string',
+    description: 'Value to compare against condition_field in WHEN clause'
+  },
+  conditions: {
+    description: 'Compound conditions for the trigger WHEN clause. Accepts a single leaf condition, an array of conditions (implicitly AND), or a nested combinator tree ({AND: [...], OR: [...], NOT: {...}}). Each leaf is {field, op, value?, row?, ref?}. Column types are resolved automatically from the table schema. Cannot be combined with condition_field or watch_fields.',
+    'x-codegen-type': 'TriggerCondition | TriggerCondition[]',
+    oneOf: [
+      { $ref: '#/$defs/triggerCondition' },
+      { type: 'array', items: { $ref: '#/$defs/triggerCondition' } }
+    ]
+  },
+  watch_fields: {
+    type: 'array',
+    items: {
+      type: 'string',
+      format: 'column-ref'
+    },
+    description: 'For UPDATE triggers, only fire when these fields change (uses DISTINCT FROM)'
+  }
+};
+
+/**
+ * Standalone trigger_conditions property for nodes that compose on top of
+ * JobTrigger (Process* nodes). These use trigger_conditions instead of
+ * the full condition_field/conditions/watch_fields trio because the
+ * underlying JobTrigger handles the WHEN clause; this property adds
+ * additional conditions merged via AND.
+ */
+export const triggerConditionsProperty: JSONSchema = {
+  description:
+    'Additional compound conditions beyond auto-generated filtering. ' +
+    'Merged with the auto-generated conditions via AND.',
+  'x-codegen-type': 'TriggerCondition | TriggerCondition[]',
+  oneOf: [
+    { $ref: '#/$defs/triggerCondition' },
+    { type: 'array', items: { $ref: '#/$defs/triggerCondition' } }
+  ]
+};

--- a/packages/node-type-registry/src/data/data-file-embedding.ts
+++ b/packages/node-type-registry/src/data/data-file-embedding.ts
@@ -1,3 +1,4 @@
+import { conditionDefs, triggerConditionsProperty } from '../conditions';
 import type { NodeTypeDefinition } from '../types';
 
 export const ProcessFileEmbedding: NodeTypeDefinition = {
@@ -15,6 +16,7 @@ export const ProcessFileEmbedding: NodeTypeDefinition = {
     'names, and embedding strategies.',
   parameter_schema: {
     type: 'object',
+    $defs: conditionDefs,
     properties: {
 
       // ── Vector config (passed through to SearchVector) ─────────────
@@ -97,17 +99,7 @@ export const ProcessFileEmbedding: NodeTypeDefinition = {
           bucket_id: 'bucket_id'
         }
       },
-      trigger_conditions: {
-        description:
-          'Additional compound conditions beyond MIME filtering. ' +
-          'Merged with the auto-generated MIME conditions via AND. ' +
-          'Use this to add status checks, field guards, etc.',
-        'x-codegen-type': 'TriggerCondition | TriggerCondition[]',
-        oneOf: [
-          { $ref: '#/$defs/triggerCondition' },
-          { type: 'array', items: { $ref: '#/$defs/triggerCondition' } }
-        ]
-      },
+      trigger_conditions: triggerConditionsProperty,
 
       // ── Extraction config (optional — enables extract mode) ────────
       extraction: {

--- a/packages/node-type-registry/src/data/data-image-embedding.ts
+++ b/packages/node-type-registry/src/data/data-image-embedding.ts
@@ -1,3 +1,4 @@
+import { conditionDefs, triggerConditionsProperty } from '../conditions';
 import type { NodeTypeDefinition } from '../types';
 
 /**
@@ -24,6 +25,7 @@ export const ProcessImageEmbedding: NodeTypeDefinition = {
     'Accepts all ProcessFileEmbedding parameters — any overrides are forwarded through.',
   parameter_schema: {
     type: 'object',
+    $defs: conditionDefs,
     properties: {
 
       // ── Vector config (passed through to ProcessFileEmbedding) ──────────
@@ -103,16 +105,7 @@ export const ProcessImageEmbedding: NodeTypeDefinition = {
           bucket_id: 'bucket_id'
         }
       },
-      trigger_conditions: {
-        description:
-          'Additional compound conditions beyond MIME filtering. ' +
-          'Merged with the auto-generated MIME conditions via AND.',
-        'x-codegen-type': 'TriggerCondition | TriggerCondition[]',
-        oneOf: [
-          { $ref: '#/$defs/triggerCondition' },
-          { type: 'array', items: { $ref: '#/$defs/triggerCondition' } }
-        ]
-      },
+      trigger_conditions: triggerConditionsProperty,
 
       // ── Extraction config (optional — enables extract mode) ────────
       extraction: {

--- a/packages/node-type-registry/src/data/data-job-trigger.ts
+++ b/packages/node-type-registry/src/data/data-job-trigger.ts
@@ -1,30 +1,5 @@
+import { conditionDefs, conditionProperties } from '../conditions';
 import type { NodeTypeDefinition } from '../types';
-
-const triggerConditionSchema = {
-  type: 'object',
-  description: 'A leaf condition ({field, op, value?, row?, ref?}) or a combinator ({AND, OR, NOT}).',
-  properties: {
-    field: { type: 'string', format: 'column-ref', description: 'Column name (validated against the table).' },
-    op: {
-      type: 'string',
-      enum: ['=', '!=', '>', '<', '>=', '<=', 'LIKE', 'NOT LIKE', 'IS NULL', 'IS NOT NULL', 'IS DISTINCT FROM'],
-      description: 'Comparison operator.'
-    },
-    value: { description: 'Comparison value. Type is resolved from the column definition. Omit for IS NULL, IS NOT NULL, IS DISTINCT FROM.' },
-    row: { type: 'string', enum: ['NEW', 'OLD'], default: 'NEW', description: 'Row reference (default: NEW).' },
-    ref: {
-      type: 'object',
-      description: 'Column reference for field-to-field comparison (alternative to value).',
-      properties: {
-        field: { type: 'string', format: 'column-ref' },
-        row: { type: 'string', enum: ['NEW', 'OLD'], default: 'NEW' }
-      }
-    },
-    AND: { type: 'array', description: 'Array of conditions combined with AND.', items: { $ref: '#/$defs/triggerCondition' } },
-    OR: { type: 'array', description: 'Array of conditions combined with OR.', items: { $ref: '#/$defs/triggerCondition' } },
-    NOT: { $ref: '#/$defs/triggerCondition', description: 'Negated condition.' }
-  }
-};
 
 export const JobTrigger: NodeTypeDefinition = {
   name: 'JobTrigger',
@@ -34,9 +9,7 @@ export const JobTrigger: NodeTypeDefinition = {
   description: 'Dynamically creates PostgreSQL triggers that enqueue jobs via app_jobs.add_job() when table rows are inserted, updated, or deleted. Supports configurable payload strategies (full row, row ID, selected fields, or custom mapping), conditional firing via WHEN clauses, watched field changes, and extended job options (queue, priority, delay, max attempts).',
   parameter_schema: {
     type: 'object',
-    $defs: {
-      triggerCondition: triggerConditionSchema
-    },
+    $defs: conditionDefs,
     properties: {
       task_identifier: {
         type: 'string',
@@ -95,31 +68,7 @@ export const JobTrigger: NodeTypeDefinition = {
         description: 'Include table/schema metadata in payload',
         default: false
       },
-      condition_field: {
-        type: 'string',
-        format: 'column-ref',
-        description: 'Column name for conditional WHEN clause (fires only when field equals condition_value)'
-      },
-      condition_value: {
-        type: 'string',
-        description: 'Value to compare against condition_field in WHEN clause'
-      },
-      conditions: {
-        description: 'Compound conditions for the trigger WHEN clause. Accepts a single leaf condition, an array of conditions (implicitly AND), or a nested combinator tree ({AND: [...], OR: [...], NOT: {...}}). Each leaf is {field, op, value?, row?, ref?}. Column types are resolved automatically from the table schema. Cannot be combined with condition_field or watch_fields.',
-        'x-codegen-type': 'TriggerCondition | TriggerCondition[]',
-        oneOf: [
-          { $ref: '#/$defs/triggerCondition' },
-          { type: 'array', items: { $ref: '#/$defs/triggerCondition' } }
-        ]
-      },
-      watch_fields: {
-        type: 'array',
-        items: {
-          type: 'string',
-          format: 'column-ref'
-        },
-        description: 'For UPDATE triggers, only fire when these fields change (uses DISTINCT FROM)'
-      },
+      ...conditionProperties,
       job_key: {
         type: 'string',
         description: 'Static job key for upsert semantics (prevents duplicate jobs)'

--- a/packages/node-type-registry/src/data/event-tracker.ts
+++ b/packages/node-type-registry/src/data/event-tracker.ts
@@ -1,0 +1,74 @@
+import { conditionDefs, conditionProperties } from '../conditions';
+import type { NodeTypeDefinition } from '../types';
+
+export const EventTracker: NodeTypeDefinition = {
+  name: 'EventTracker',
+  slug: 'data_event_tracker',
+  category: 'event',
+  display_name: 'Event Tracker',
+  description:
+    'Creates triggers that record events via the events module when table rows change. ' +
+    'Supports the same compound condition system as JobTrigger (condition_field, watch_fields, ' +
+    'or full AND/OR/NOT conditions). Events are recorded to app_events and aggregated ' +
+    'automatically. Use with achievements (blueprint-level) to unlock levels and grant ' +
+    'credits based on event accumulation.',
+  parameter_schema: {
+    type: 'object',
+    $defs: conditionDefs,
+    properties: {
+      event_name: {
+        type: 'string',
+        description: 'Event type name to record (e.g., "avatar_uploaded", "order_completed")'
+      },
+      events: {
+        type: 'array',
+        items: {
+          type: 'string',
+          enum: [
+            'INSERT',
+            'UPDATE',
+            'DELETE'
+          ]
+        },
+        description: 'DML events that trigger recording',
+        default: ['INSERT']
+      },
+      count: {
+        type: 'integer',
+        description: 'Number of events to record per trigger fire',
+        default: 1
+      },
+      toggle: {
+        type: 'boolean',
+        description: 'Toggle mode: records event when condition is met, removes when condition is unmet',
+        default: false
+      },
+      actor_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column containing the actor (user) ID to attribute the event to',
+        default: 'owner_id'
+      },
+      entity_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column containing the entity ID (org/group) for entity-scoped events. Omit for user-only events.'
+      },
+      auto_register_type: {
+        type: 'boolean',
+        description: 'Automatically register the event_name in event_types during provisioning',
+        default: true
+      },
+      ...conditionProperties
+    },
+    required: [
+      'event_name'
+    ]
+  },
+  tags: [
+    'events',
+    'triggers',
+    'analytics',
+    'tracking'
+  ]
+};

--- a/packages/node-type-registry/src/data/index.ts
+++ b/packages/node-type-registry/src/data/index.ts
@@ -9,6 +9,7 @@ export { ProcessChunks } from './data-chunks';
 export { DataCompositeField } from './data-composite-field';
 export { DataDirectOwner } from './data-direct-owner';
 export { DataEntityMembership } from './data-entity-membership';
+export { EventTracker } from './event-tracker';
 export { ProcessFileEmbedding } from './data-file-embedding';
 export { LimitEnforceFeature } from './data-feature-flag';
 export { DataForceCurrentUser } from './data-force-current-user';

--- a/packages/node-type-registry/src/data/process-extraction.ts
+++ b/packages/node-type-registry/src/data/process-extraction.ts
@@ -1,3 +1,4 @@
+import { conditionDefs, triggerConditionsProperty } from '../conditions';
 import type { NodeTypeDefinition } from '../types';
 
 /**
@@ -25,6 +26,7 @@ export const ProcessExtraction: NodeTypeDefinition = {
     'Typically used upstream of ProcessFileEmbedding or ProcessChunks.',
   parameter_schema: {
     type: 'object',
+    $defs: conditionDefs,
     properties: {
 
       // ── Output fields ─────────────────────────────────────────────
@@ -89,17 +91,7 @@ export const ProcessExtraction: NodeTypeDefinition = {
           bucket_id: 'bucket_id'
         }
       },
-      trigger_conditions: {
-        description:
-          'Additional compound conditions beyond MIME filtering. ' +
-          'Merged with the auto-generated MIME conditions via AND. ' +
-          'Use this to add status checks (e.g., status = \'uploaded\').',
-        'x-codegen-type': 'TriggerCondition | TriggerCondition[]',
-        oneOf: [
-          { $ref: '#/$defs/triggerCondition' },
-          { type: 'array', items: { $ref: '#/$defs/triggerCondition' } }
-        ]
-      },
+      trigger_conditions: triggerConditionsProperty,
 
       // ── Job options ───────────────────────────────────────────────
       queue_name: {

--- a/packages/node-type-registry/src/data/process-image-versions.ts
+++ b/packages/node-type-registry/src/data/process-image-versions.ts
@@ -1,3 +1,4 @@
+import { conditionDefs, triggerConditionsProperty } from '../conditions';
 import type { NodeTypeDefinition } from '../types';
 
 /**
@@ -26,6 +27,7 @@ export const ProcessImageVersions: NodeTypeDefinition = {
     'file records linked to the source image.',
   parameter_schema: {
     type: 'object',
+    $defs: conditionDefs,
     required: ['versions'],
     properties: {
 
@@ -105,16 +107,7 @@ export const ProcessImageVersions: NodeTypeDefinition = {
           bucket_id: 'bucket_id'
         }
       },
-      trigger_conditions: {
-        description:
-          'Additional compound conditions beyond MIME filtering. ' +
-          'Merged with the auto-generated MIME conditions via AND.',
-        'x-codegen-type': 'TriggerCondition | TriggerCondition[]',
-        oneOf: [
-          { $ref: '#/$defs/triggerCondition' },
-          { type: 'array', items: { $ref: '#/$defs/triggerCondition' } }
-        ]
-      },
+      trigger_conditions: triggerConditionsProperty,
 
       // ── Job options ───────────────────────────────────────────────
       queue_name: {

--- a/packages/node-type-registry/src/index.ts
+++ b/packages/node-type-registry/src/index.ts
@@ -1,5 +1,6 @@
 export * from './authz';
 export * from './blueprint-types.generated';
+export * from './conditions';
 export * from './data';
 export * from './module-presets';
 export * from './relation';


### PR DESCRIPTION
## Summary

Implements Phase 0 and Phase 1 (TypeScript side) of the analytics/events/achievements system from the [v4 proposal](https://github.com/constructive-io/constructive-planning/pull/869).

**Phase 0: Shared Condition Infrastructure**
- Extracts `triggerConditionSchema`, `conditionDefs`, `conditionProperties`, and `triggerConditionsProperty` from `data-job-trigger.ts` into a new shared module at `src/conditions/trigger-condition.ts`
- Updates `JobTrigger` to import from `../conditions` instead of defining conditions inline
- Updates all 4 Process* nodes (`ProcessImageVersions`, `ProcessExtraction`, `DataFileEmbedding`, `DataImageEmbedding`) to import `conditionDefs` from shared conditions
- Exports the conditions module from the package index

**Phase 1: EventTracker Node Type**
- New `EventTracker` node type definition with category `event` (new `Event*` prefix)
- Parameters: `event_name` (required), `events` (default `['INSERT']`), `count`, `toggle`, `actor_field` (default `owner_id`), `entity_field`, `auto_register_type`
- Uses full compound conditions via shared `conditionProperties`

Companion PR: constructive-io/constructive-db (SQL generators for `build_condition_ast` extraction + `data_event_tracker` generator)

## Review & Testing Checklist for Human

Risk: 🟡 (refactoring shared code across multiple nodes)

- [ ] Verify `conditionProperties` and `conditionDefs` are correctly imported across all 6 consumer nodes (JobTrigger, EventTracker, 4 Process* nodes) — a typo would silently break condition support
- [ ] Check `EventTracker` parameter_schema matches the SQL generator's expectations (parameter names, types, defaults must align)
- [ ] Run `pnpm build` in `packages/node-type-registry` — should produce clean output

### Notes
- No behavioral changes to existing nodes — purely an extraction refactor for Phase 0
- The `EventTracker.slug` is `data_event_tracker`, matching the SQL generator function name in constructive-db
- ESLint has a pre-existing v9 migration config issue on main; not introduced by this PR

Link to Devin session: https://app.devin.ai/sessions/e0a3f1cfea6e4e809160c9d0cd755b90
Requested by: @pyramation