### PR TITLE
fix: rename EventTracker slug from data_event_tracker to event_tracker

### DIFF
--- a/packages/node-type-registry/src/data/event-tracker.ts
+++ b/packages/node-type-registry/src/data/event-tracker.ts
@@ -3,7 +3,7 @@ import type { NodeTypeDefinition } from '../types';
 
 export const EventTracker: NodeTypeDefinition = {
   name: 'EventTracker',
-  slug: 'data_event_tracker',
+  slug: 'event_tracker',
   category: 'event',
   display_name: 'Event Tracker',
   description:


### PR DESCRIPTION
## Summary

Renames `EventTracker.slug` from `data_event_tracker` to `event_tracker` to match the node name. The `data_` prefix is for `Data*` category nodes — `EventTracker` is in the `event` category.

## Review & Testing Checklist for Human

Risk: 🟢 (single-line change)

- [ ] Verify slug `event_tracker` matches the SQL generator function name in constructive-db

### Notes
- Companion PR in constructive-db renames the SQL function and migration files to match

Link to Devin session: https://app.devin.ai/sessions/e0a3f1cfea6e4e809160c9d0cd755b90
Requested by: @pyramation