### PR TITLE
feat: add BlueprintAchievement types to blueprint schema

### DIFF
--- a/packages/node-type-registry/src/blueprint-types.generated.ts
+++ b/packages/node-type-registry/src/blueprint-types.generated.ts
@@ -1229,6 +1229,41 @@ export interface BlueprintStorageConfig {
     buckets?: BlueprintEntityTableProvision;
   };
 }
+/** A requirement entry within a blueprint achievement. Defines what events must occur to earn the achievement. */
+export interface BlueprintAchievementRequirement {
+  /** Name identifier matching an event_type or step name. */
+  event_name: string;
+  /** Number of events needed to satisfy this requirement. */
+  count: number;
+  /** Human-readable description of what this requirement entails. */
+  description?: string;
+}
+/** A reward entry within a blueprint achievement. Defines credits granted when the achievement is earned. */
+export interface BlueprintAchievementReward {
+  /** Type of reward: limit_credit (grants limit credits) or meter_credit (grants meter credits). */
+  reward_type: 'limit_credit' | 'meter_credit';
+  /** Target limit name or meter slug for the credit grant. */
+  target_name: string;
+  /** Number of credits to grant. */
+  amount: number;
+  /** Credit type: permanent, expiring, etc. Defaults to "permanent". */
+  credit_type?: string;
+}
+/** An achievement entry for the blueprint achievements[] section. Creates a level with requirements and optional rewards in the events_module. Requires events_module to be provisioned (e.g., via entity_types[].has_levels = true or modules includes events_module). */
+export interface BlueprintAchievement {
+  /** Unique name for the achievement level. */
+  name: string;
+  /** Human-readable description of this achievement. */
+  description?: string;
+  /** Display ordering priority; lower values appear first. Defaults to 100. */
+  priority?: number;
+  /** Requirements that must be met to earn this achievement. */
+  requirements: BlueprintAchievementRequirement[];
+  /** Rewards granted when the achievement is earned. */
+  rewards?: BlueprintAchievementReward[];
+  /** Entity prefix to scope this achievement to (e.g., "org", "app"). Used to resolve the correct events_module. Defaults to "app". */
+  entity_prefix?: string;
+}
 /** Override object for the entity table created by a BlueprintEntityType. Shape mirrors BlueprintTable / secure_table_provision vocabulary. When supplied, policies[] replaces the default entity-table policies entirely. */
 export interface BlueprintEntityTableProvision {
   /** Whether to enable RLS on the entity table. Forwarded to secure_table_provision. Defaults to true. */
@@ -1559,4 +1594,6 @@ export interface BlueprintDefinition {
   entity_types?: BlueprintEntityType[];
   /** App-level storage configuration. Creates a storage_module (membership_type = NULL), seeds initial buckets, and overrides module-level settings (expiry times, file size limits, CORS). Use provisions for per-table policy overrides. For entity-scoped storage, use entity_types[].has_storage + entity_types[].storage instead. */
   storage?: BlueprintStorageConfig;
+  /** Achievement definitions. Each entry creates a level with requirements and optional rewards in the events_module. Requires events_module to be provisioned (e.g., via entity_types[].has_levels = true or modules includes events_module). */
+  achievements?: BlueprintAchievement[];
 }

--- a/packages/node-type-registry/src/codegen/generate-types.ts
+++ b/packages/node-type-registry/src/codegen/generate-types.ts
@@ -844,6 +844,102 @@ function buildBlueprintStorageConfig(): t.ExportNamedDeclaration {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Achievement types
+// ---------------------------------------------------------------------------
+
+function buildBlueprintAchievementRequirement(): t.ExportNamedDeclaration {
+  return addJSDoc(
+    exportInterface('BlueprintAchievementRequirement', [
+      addJSDoc(
+        requiredProp('event_name', t.tsStringKeyword()),
+        'Name identifier matching an event_type or step name.'
+      ),
+      addJSDoc(
+        requiredProp('count', t.tsNumberKeyword()),
+        'Number of events needed to satisfy this requirement.'
+      ),
+      addJSDoc(
+        optionalProp('description', t.tsStringKeyword()),
+        'Human-readable description of what this requirement entails.'
+      )
+    ]),
+    'A requirement entry within a blueprint achievement. Defines what events must occur to earn the achievement.'
+  );
+}
+
+function buildBlueprintAchievementReward(): t.ExportNamedDeclaration {
+  return addJSDoc(
+    exportInterface('BlueprintAchievementReward', [
+      addJSDoc(
+        requiredProp(
+          'reward_type',
+          t.tsUnionType([
+            t.tsLiteralType(t.stringLiteral('limit_credit')),
+            t.tsLiteralType(t.stringLiteral('meter_credit'))
+          ])
+        ),
+        'Type of reward: limit_credit (grants limit credits) or meter_credit (grants meter credits).'
+      ),
+      addJSDoc(
+        requiredProp('target_name', t.tsStringKeyword()),
+        'Target limit name or meter slug for the credit grant.'
+      ),
+      addJSDoc(
+        requiredProp('amount', t.tsNumberKeyword()),
+        'Number of credits to grant.'
+      ),
+      addJSDoc(
+        optionalProp('credit_type', t.tsStringKeyword()),
+        'Credit type: permanent, expiring, etc. Defaults to "permanent".'
+      )
+    ]),
+    'A reward entry within a blueprint achievement. Defines credits granted when the achievement is earned.'
+  );
+}
+
+function buildBlueprintAchievement(): t.ExportNamedDeclaration {
+  return addJSDoc(
+    exportInterface('BlueprintAchievement', [
+      addJSDoc(
+        requiredProp('name', t.tsStringKeyword()),
+        'Unique name for the achievement level.'
+      ),
+      addJSDoc(
+        optionalProp('description', t.tsStringKeyword()),
+        'Human-readable description of this achievement.'
+      ),
+      addJSDoc(
+        optionalProp('priority', t.tsNumberKeyword()),
+        'Display ordering priority; lower values appear first. Defaults to 100.'
+      ),
+      addJSDoc(
+        requiredProp(
+          'requirements',
+          t.tsArrayType(
+            t.tsTypeReference(t.identifier('BlueprintAchievementRequirement'))
+          )
+        ),
+        'Requirements that must be met to earn this achievement.'
+      ),
+      addJSDoc(
+        optionalProp(
+          'rewards',
+          t.tsArrayType(
+            t.tsTypeReference(t.identifier('BlueprintAchievementReward'))
+          )
+        ),
+        'Rewards granted when the achievement is earned.'
+      ),
+      addJSDoc(
+        optionalProp('entity_prefix', t.tsStringKeyword()),
+        'Entity prefix to scope this achievement to (e.g., "org", "app"). Used to resolve the correct events_module. Defaults to "app".'
+      )
+    ]),
+    'An achievement entry for the blueprint achievements[] section. Creates a level with requirements and optional rewards in the events_module. Requires events_module to be provisioned (e.g., via entity_types[].has_levels = true or modules includes events_module).'
+  );
+}
+
 function buildBlueprintEntityTableProvision(): t.ExportNamedDeclaration {
   return addJSDoc(
     exportInterface('BlueprintEntityTableProvision', [
@@ -1090,6 +1186,15 @@ function buildBlueprintDefinition(): t.ExportNamedDeclaration {
           t.tsTypeReference(t.identifier('BlueprintStorageConfig'))
         ),
         'App-level storage configuration. Creates a storage_module (membership_type = NULL), seeds initial buckets, and overrides module-level settings (expiry times, file size limits, CORS). Use provisions for per-table policy overrides. For entity-scoped storage, use entity_types[].has_storage + entity_types[].storage instead.'
+      ),
+      addJSDoc(
+        optionalProp(
+          'achievements',
+          t.tsArrayType(
+            t.tsTypeReference(t.identifier('BlueprintAchievement'))
+          )
+        ),
+        'Achievement definitions. Each entry creates a level with requirements and optional rewards in the events_module. Requires events_module to be provisioned (e.g., via entity_types[].has_levels = true or modules includes events_module).'
       )
     ]),
     'The complete blueprint definition -- the JSONB shape accepted by construct_blueprint().'
@@ -1168,6 +1273,9 @@ function buildProgram(meta?: MetaTableInfo[]): string {
   statements.push(buildBlueprintTableUniqueConstraint());
   statements.push(buildBlueprintBucketSeed());
   statements.push(buildBlueprintStorageConfig());
+  statements.push(buildBlueprintAchievementRequirement());
+  statements.push(buildBlueprintAchievementReward());
+  statements.push(buildBlueprintAchievement());
   statements.push(buildBlueprintEntityTableProvision());
   statements.push(buildBlueprintEntityType());
 


### PR DESCRIPTION
## Summary

Adds achievement types to the blueprint definition schema, enabling developers to declare achievements directly in blueprint JSON:

```typescript
{
  tables: [...],
  achievements: [{
    name: "getting_started",
    requirements: [
      { event_name: "avatar_uploaded", count: 1 },
      { event_name: "first_project_created", count: 1 }
    ],
    rewards: [
      { reward_type: "limit_credit", target_name: "projects", amount: 10 }
    ]
  }]
}
```

**New types:**
- `BlueprintAchievementRequirement` — event_name + count + optional description
- `BlueprintAchievementReward` — reward_type (limit_credit|meter_credit), target_name, amount, credit_type
- `BlueprintAchievement` — name, description, priority, requirements[], rewards[], entity_prefix

**Changes:**
- `generate-types.ts`: Added builder functions for all 3 achievement types
- `blueprint-types.generated.ts`: Added achievement interfaces + `achievements` field on `BlueprintDefinition`
- `BlueprintDefinition.achievements` field scoped by `entity_prefix` (defaults to "app")

Companion PR in constructive-db handles the SQL validation + provisioning logic.

## Review & Testing Checklist for Human

- [ ] Verify the generated types match the expected blueprint JSON shape for achievements
- [ ] Verify `entity_prefix` default of "app" aligns with `provision_database_modules` events_module prefix naming

### Notes

Part of the analytics/achievements system (Phase 3). Companion constructive-db PR adds `validate_blueprint_definition` validation and `construct_blueprint` Phase 7 seeding logic.

Link to Devin session: https://app.devin.ai/sessions/e0a3f1cfea6e4e809160c9d0cd755b90
Requested by: @pyramation