### PR TITLE
feat: add has_invite_achievements to BlueprintEntityType

### DIFF
--- a/packages/node-type-registry/src/blueprint-types.generated.ts
+++ b/packages/node-type-registry/src/blueprint-types.generated.ts
@@ -1304,6 +1304,8 @@ export interface BlueprintEntityType {
   has_storage?: boolean;
   /** Whether to provision entity-scoped invite tables ({prefix}_invites, {prefix}_claimed_invites) and a submit_{prefix}_invite_code() function. Defaults to false. */
   has_invites?: boolean;
+  /** Whether to auto-attach an EventTracker to the claimed_invites table for invite-based achievements. Requires has_invites=true AND has_levels=true. When true, records 'invite_claimed' events credited to the sender (inviter) on each claimed invite. Defaults to false. */
+  has_invite_achievements?: boolean;
   /** Escape hatch: when true AND table_provision is NULL, zero policies are provisioned on the entity table. Defaults to false. */
   skip_entity_policies?: boolean;
   /** Override for the entity table. Shape mirrors BlueprintTable / secure_table_provision vocabulary. When supplied, its policies[] replaces the five default entity-table policies; is_visible becomes a no-op. When NULL (default), the five default policies are applied (gated by is_visible). */

--- a/packages/node-type-registry/src/codegen/generate-types.ts
+++ b/packages/node-type-registry/src/codegen/generate-types.ts
@@ -1033,6 +1033,10 @@ function buildBlueprintEntityType(): t.ExportNamedDeclaration {
         'Whether to provision entity-scoped invite tables ({prefix}_invites, {prefix}_claimed_invites) and a submit_{prefix}_invite_code() function. Defaults to false.'
       ),
       addJSDoc(
+        optionalProp('has_invite_achievements', t.tsBooleanKeyword()),
+        "Whether to auto-attach an EventTracker to the claimed_invites table for invite-based achievements. Requires has_invites=true AND has_levels=true. When true, records 'invite_claimed' events credited to the sender (inviter) on each claimed invite. Defaults to false."
+      ),
+      addJSDoc(
         optionalProp('skip_entity_policies', t.tsBooleanKeyword()),
         'Escape hatch: when true AND table_provision is NULL, zero policies are provisioned on the entity table. Defaults to false.'
       ),


### PR DESCRIPTION
## Summary

Adds `has_invite_achievements` boolean property to `BlueprintEntityType`. When set to `true` (requires `has_invites` + `has_levels`), the entity_type_provision trigger auto-attaches an `EventTracker` to the `claimed_invites` table, recording `'invite_claimed'` events credited to the sender (inviter).

**Changes:**
- `blueprint-types.generated.ts`: Added `has_invite_achievements?: boolean` to `BlueprintEntityType`
- `generate-types.ts`: Added codegen definition for the new property

Companion PR on constructive-db handles the SQL provisioning logic.

## Review & Testing Checklist for Human

- [ ] Verify the JSDoc on `has_invite_achievements` accurately describes the cross-field requirements (has_invites + has_levels)
- [ ] Verify the generated types match the SQL column added in the companion constructive-db PR

### Notes

This is the TypeScript types half of Phase 4 (invite virality achievements). The SQL provisioning (entity_type_provision trigger, validation, construct_blueprint passthrough) is in a separate constructive-db PR.

Link to Devin session: https://app.devin.ai/sessions/e0a3f1cfea6e4e809160c9d0cd755b90
Requested by: @pyramation