### PR TITLE
feat: add EventReferral node type definition

### DIFF
--- a/packages/node-type-registry/src/data/event-referral.ts
+++ b/packages/node-type-registry/src/data/event-referral.ts
@@ -1,0 +1,65 @@
+import { conditionDefs, conditionProperties } from '../conditions';
+import type { NodeTypeDefinition } from '../types';
+
+export const EventReferral: NodeTypeDefinition = {
+  name: 'EventReferral',
+  slug: 'event_referral',
+  category: 'event',
+  display_name: 'Event Referral',
+  description:
+    'Creates triggers that record events for the referrer (inviter) when their ' +
+    'invitees perform actions on a watched table. Resolves the referrer automatically ' +
+    'via the invites module\'s claimed_invites table using the membership_type context. ' +
+    'Supports the same compound condition system as EventTracker. Use with achievements ' +
+    'to unlock levels and grant credits based on invitee activity.',
+  parameter_schema: {
+    type: 'object',
+    $defs: conditionDefs,
+    properties: {
+      event_name: {
+        type: 'string',
+        description: 'Event type name to record for the referrer (e.g., "invitee_uploaded_avatar", "invitee_completed_onboarding")'
+      },
+      events: {
+        type: 'array',
+        items: {
+          type: 'string',
+          enum: [
+            'INSERT',
+            'UPDATE',
+            'DELETE'
+          ]
+        },
+        description: 'DML events that trigger recording',
+        default: ['INSERT']
+      },
+      actor_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column containing the invitee (actor) ID on the source table — used to look up the referrer via claimed_invites.receiver_id',
+        default: 'owner_id'
+      },
+      entity_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column containing the entity ID (org/group) for entity-scoped referral events. Omit for user-only events.'
+      },
+      auto_register_type: {
+        type: 'boolean',
+        description: 'Automatically register the event_name in event_types during provisioning',
+        default: true
+      },
+      ...conditionProperties
+    },
+    required: [
+      'event_name'
+    ]
+  },
+  tags: [
+    'events',
+    'referral',
+    'invites',
+    'analytics',
+    'tracking'
+  ]
+};

--- a/packages/node-type-registry/src/data/index.ts
+++ b/packages/node-type-registry/src/data/index.ts
@@ -9,6 +9,7 @@ export { ProcessChunks } from './data-chunks';
 export { DataCompositeField } from './data-composite-field';
 export { DataDirectOwner } from './data-direct-owner';
 export { DataEntityMembership } from './data-entity-membership';
+export { EventReferral } from './event-referral';
 export { EventTracker } from './event-tracker';
 export { ProcessFileEmbedding } from './data-file-embedding';
 export { LimitEnforceFeature } from './data-feature-flag';


### PR DESCRIPTION
## Summary

Adds the `EventReferral` node type definition to the node-type-registry. EventReferral is a sibling to `EventTracker` — it watches any table for DML events and records events attributed to the **referrer** (inviter) by automatically looking up `claimed_invites` from the membership_type context.

**Parameter schema:**
- `event_name` (required) — event type name to record for the referrer
- `events` — DML events to watch (default: `['INSERT']`)
- `actor_field` — column containing the invitee ID (default: `owner_id`)
- `entity_field` — optional column for entity-scoped referral events
- `auto_register_type` — auto-register in event_types (default: `true`)
- `conditions` / `condition_field` / `watch_fields` — same compound condition support as EventTracker

Companion PR in constructive-db implements the SQL generator and wiring.

Refs #877

## Review & Testing Checklist for Human

Risk: 🟢 Low — additive change, new file + one export line

- [ ] Verify `EventReferral` parameter schema matches what the SQL generator in constructive-db expects
- [ ] Confirm `conditionProperties` spread correctly includes condition_field, condition_value, conditions, watch_fields

### Notes
- No runtime behavior change — this is purely a TypeScript definition consumed by the seed generator
- The `conditionDefs`/`conditionProperties` are shared with EventTracker and JobTrigger

Link to Devin session: https://app.devin.ai/sessions/e0a3f1cfea6e4e809160c9d0cd755b90
Requested by: @pyramation