### PR TITLE
feat: add org_secrets_module to export pipeline

### DIFF
--- a/pgpm/export/src/export-graphql-meta.ts
+++ b/pgpm/export/src/export-graphql-meta.ts
@@ -202,6 +202,7 @@ export const exportGraphQLMeta = async ({
     queryAndParse('plans_module'),
     queryAndParse('realtime_module'),
     queryAndParse('session_secrets_module'),
+    queryAndParse('org_secrets_module'),
     queryAndParse('webauthn_auth_module'),
     queryAndParse('webauthn_credentials_module')
   ]);

--- a/pgpm/export/src/export-meta.ts
+++ b/pgpm/export/src/export-meta.ts
@@ -210,6 +210,7 @@ export const exportMeta = async ({ opts, dbname, database_id }: ExportMetaParams
   await queryAndParse('plans_module', `SELECT * FROM metaschema_modules_public.plans_module WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('realtime_module', `SELECT * FROM metaschema_modules_public.realtime_module WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('session_secrets_module', `SELECT * FROM metaschema_modules_public.session_secrets_module WHERE database_id = $1 ORDER BY id`);
+  await queryAndParse('org_secrets_module', `SELECT * FROM metaschema_modules_public.org_secrets_module WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('webauthn_auth_module', `SELECT * FROM metaschema_modules_public.webauthn_auth_module WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('webauthn_credentials_module', `SELECT * FROM metaschema_modules_public.webauthn_credentials_module WHERE database_id = $1 ORDER BY id`);
 

--- a/pgpm/export/src/export-utils.ts
+++ b/pgpm/export/src/export-utils.ts
@@ -195,6 +195,7 @@ export const META_TABLE_ORDER = [
   'plans_module',
   'realtime_module',
   'session_secrets_module',
+  'org_secrets_module',
   'webauthn_auth_module',
   'webauthn_credentials_module'
 ] as const;
@@ -1407,6 +1408,17 @@ export const META_TABLE_CONFIG: Record<string, TableConfig> = {
       table_id: 'uuid',
       table_name: 'text',
       sessions_table_id: 'uuid'
+    }
+  },
+  org_secrets_module: {
+    schema: 'metaschema_modules_public',
+    table: 'org_secrets_module',
+    fields: {
+      id: 'uuid',
+      database_id: 'uuid',
+      schema_id: 'uuid',
+      table_id: 'uuid',
+      table_name: 'text'
     }
   },
   webauthn_auth_module: {


### PR DESCRIPTION
## Summary

Adds `org_secrets_module` to the pgpm export pipeline so that the new organization-scoped encrypted secrets config table (added in [constructive-db#1209](https://github.com/constructive-io/constructive-db/pull/1209)) is included in database exports.

Three files updated, all following the existing pattern for other module exports:
- **`export-utils.ts`**: adds `org_secrets_module` to `META_TABLE_ORDER` and `META_TABLE_CONFIG` (fields: `id`, `database_id`, `schema_id`, `table_id`, `table_name`)
- **`export-meta.ts`**: adds the SQL `queryAndParse` call
- **`export-graphql-meta.ts`**: adds the GraphQL `queryAndParse` call

## Review & Testing Checklist for Human

- [ ] Verify the `META_TABLE_CONFIG` fields (`id`, `database_id`, `schema_id`, `table_id`, `table_name`) match the actual `metaschema_modules_public.org_secrets_module` table columns in constructive-db — cross-reference with the [table DDL](https://github.com/constructive-io/constructive-db/blob/main/pgpm-modules/metaschema-modules/deploy/schemas/metaschema_modules_public/tables/org_secrets_module/table.sql)
- [ ] Run an export against a database provisioned with `org_secrets_module` and verify the org_secrets_module config row appears in the output

### Notes
- This is purely additive. The `buildDynamicFields()` mechanism in the SQL export path gracefully skips the table if it doesn't exist, so this change is safe for databases that don't use `org_secrets_module`.
- Upstream dependency: requires constructive-db#1209 (already merged) which adds the `org_secrets_module` config table to `metaschema_modules_public`.

Link to Devin session: https://app.devin.ai/sessions/af039a166f1c4df4a67704c842540835
Requested by: @pyramation