### PR TITLE
feat: rename user_secrets_module/org_secrets_module to config_secrets_user_module/config_secrets_org_module

### DIFF
--- a/packages/node-type-registry/src/module-presets/auth-email-magic.ts
+++ b/packages/node-type-registry/src/module-presets/auth-email-magic.ts
@@ -42,7 +42,7 @@ export const PresetAuthEmailMagic: ModulePreset = {
     'memberships_module:app',
     'sessions_module',
     'user_state_module',
-    'user_secrets_module',
+    'config_secrets_user_module',
     'emails_module',
     'rls_module',
     'user_auth_module',

--- a/packages/node-type-registry/src/module-presets/auth-email.ts
+++ b/packages/node-type-registry/src/module-presets/auth-email.ts
@@ -53,7 +53,7 @@ export const PresetAuthEmail: ModulePreset = {
     'memberships_module:app',
     'sessions_module',
     'user_state_module',
-    'user_secrets_module',
+    'config_secrets_user_module',
     'emails_module',
     'rls_module',
     'user_auth_module'
@@ -65,7 +65,7 @@ export const PresetAuthEmail: ModulePreset = {
     'limits_module:app': 'Required by `memberships_module:app`: NOT NULL FK to caps table.',
     'levels_module:app': 'Required by `memberships_module:app`: NOT NULL FK to levels table.',
     emails_module: 'Required by the `user_auth_module` insert trigger (`RAISE EXCEPTION REQUIRES emails_module`).',
-    user_secrets_module: 'Required for password hashing; referenced by `set_password`, `verify_password`, and reset flows.',
+    config_secrets_user_module: 'Required for password hashing; referenced by `set_password`, `verify_password`, and reset flows.',
     user_state_module: 'API-key storage (`create_api_key`, `revoke_api_key`, `my_api_keys`).'
   },
   omits_notes: {

--- a/packages/node-type-registry/src/module-presets/auth-hardened.ts
+++ b/packages/node-type-registry/src/module-presets/auth-hardened.ts
@@ -39,7 +39,7 @@ export const PresetAuthHardened: ModulePreset = {
     'memberships_module:app',
     'sessions_module',
     'user_state_module',
-    'user_secrets_module',
+    'config_secrets_user_module',
     'emails_module',
     'rls_module',
     'user_auth_module',

--- a/packages/node-type-registry/src/module-presets/auth-passkey.ts
+++ b/packages/node-type-registry/src/module-presets/auth-passkey.ts
@@ -40,7 +40,7 @@ export const PresetAuthPasskey: ModulePreset = {
     'memberships_module:app',
     'sessions_module',
     'user_state_module',
-    'user_secrets_module',
+    'config_secrets_user_module',
     'emails_module',
     'rls_module',
     'user_auth_module',

--- a/packages/node-type-registry/src/module-presets/auth-sso.ts
+++ b/packages/node-type-registry/src/module-presets/auth-sso.ts
@@ -7,7 +7,7 @@ import type { ModulePreset } from './types';
  * `(provider, external_id)`) and `identity_providers_module` (the provider
  * config: URLs, client_id, encrypted client_secret, scopes, PKCE/nonce
  * knobs). The generator then emits `sign_in_identity` / `sign_up_identity`
- * procedures which rely on `user_secrets_module` to decrypt the client
+ * procedures which rely on `config_secrets_user_module` to decrypt the client
  * secret at auth time.
  *
  * Password fallback stays on by default (break-glass for admins); flip the
@@ -29,7 +29,7 @@ export const PresetAuthSso: ModulePreset = {
     'encrypted client secrets) and `connected_accounts_module` (the junction mapping a ' +
     'Constructive user to a `(provider, external_id)` pair). The generator emits ' +
     '`sign_in_identity` and `sign_up_identity` procedures which decrypt the client secret ' +
-    'through `user_secrets_module` at auth time. Keep password flows as break-glass, or ' +
+    'through `config_secrets_user_module` at auth time. Keep password flows as break-glass, or ' +
     'disable them via `app_settings_auth` toggles for strictly-SSO deployments.',
   good_for: [
     'B2B apps where end users sign in via their employer IdP',
@@ -49,7 +49,7 @@ export const PresetAuthSso: ModulePreset = {
     'memberships_module:app',
     'sessions_module',
     'user_state_module',
-    'user_secrets_module',
+    'config_secrets_user_module',
     'emails_module',
     'rls_module',
     'user_auth_module',
@@ -59,7 +59,7 @@ export const PresetAuthSso: ModulePreset = {
   includes_notes: {
     connected_accounts_module: 'Junction table for (user, provider, external_id). Without it, `sign_in_identity` does not compile.',
     identity_providers_module: 'Provider config table (URLs, client_id, encrypted client_secret, scopes, PKCE knobs).',
-    user_secrets_module: 'Required by `auth:email` already; also used by SSO to decrypt the provider client_secret at auth time.'
+    config_secrets_user_module: 'Required by `auth:email` already; also used by SSO to decrypt the provider client_secret at auth time.'
   },
   omits_notes: {
     webauthn_credentials_module: 'No passkeys — add `auth:passkey` or move to `auth:hardened`.',

--- a/packages/node-type-registry/src/module-presets/b2b-storage.ts
+++ b/packages/node-type-registry/src/module-presets/b2b-storage.ts
@@ -45,7 +45,7 @@ export const PresetB2bStorage: ModulePreset = {
     'memberships_module:org',
     'sessions_module',
     'user_state_module',
-    'user_secrets_module',
+    'config_secrets_user_module',
     'emails_module',
     'rls_module',
     'user_auth_module',

--- a/packages/node-type-registry/src/module-presets/b2b.ts
+++ b/packages/node-type-registry/src/module-presets/b2b.ts
@@ -41,7 +41,7 @@ export const PresetB2b: ModulePreset = {
     'memberships_module:org',
     'sessions_module',
     'user_state_module',
-    'user_secrets_module',
+    'config_secrets_user_module',
     'emails_module',
     'rls_module',
     'user_auth_module',

--- a/pgpm/export/__tests__/export-meta.test.ts
+++ b/pgpm/export/__tests__/export-meta.test.ts
@@ -49,7 +49,7 @@ describe('Export Meta Config Validation', () => {
       'permissions_module', 'limits_module', 'levels_module',
       'users_module', 'hierarchy_module', 'membership_types_module',
       'invites_module', 'emails_module', 'sessions_module',
-      'user_state_module', 'profiles_module', 'user_secrets_module',
+      'user_state_module', 'profiles_module', 'config_secrets_user_module',
       'connected_accounts_module', 'phone_numbers_module',
       'crypto_addresses_module', 'crypto_auth_module',
       'field_module', 'table_module', 'table_template_module',

--- a/pgpm/export/__tests__/graphql-naming.test.ts
+++ b/pgpm/export/__tests__/graphql-naming.test.ts
@@ -65,7 +65,7 @@ describe('getGraphQLQueryName', () => {
     expect(getGraphQLQueryName('sessions_module')).toBe('sessionsModules');
     expect(getGraphQLQueryName('user_state_module')).toBe('userStateModules');
     expect(getGraphQLQueryName('profiles_module')).toBe('profilesModules');
-    expect(getGraphQLQueryName('user_secrets_module')).toBe('userSecretsModules');
+    expect(getGraphQLQueryName('config_secrets_user_module')).toBe('configSecretsUserModules');
     expect(getGraphQLQueryName('connected_accounts_module')).toBe('connectedAccountsModules');
     expect(getGraphQLQueryName('phone_numbers_module')).toBe('phoneNumbersModules');
     expect(getGraphQLQueryName('crypto_addresses_module')).toBe('cryptoAddressesModules');

--- a/pgpm/export/src/export-graphql-meta.ts
+++ b/pgpm/export/src/export-graphql-meta.ts
@@ -178,7 +178,7 @@ export const exportGraphQLMeta = async ({
     queryAndParse('sessions_module'),
     queryAndParse('user_state_module'),
     queryAndParse('profiles_module'),
-    queryAndParse('user_secrets_module'),
+    queryAndParse('config_secrets_user_module'),
     queryAndParse('connected_accounts_module'),
     queryAndParse('phone_numbers_module'),
     queryAndParse('crypto_addresses_module'),
@@ -202,7 +202,7 @@ export const exportGraphQLMeta = async ({
     queryAndParse('plans_module'),
     queryAndParse('realtime_module'),
     queryAndParse('session_secrets_module'),
-    queryAndParse('org_secrets_module'),
+    queryAndParse('config_secrets_org_module'),
     queryAndParse('webauthn_auth_module'),
     queryAndParse('webauthn_credentials_module')
   ]);

--- a/pgpm/export/src/export-meta.ts
+++ b/pgpm/export/src/export-meta.ts
@@ -186,7 +186,7 @@ export const exportMeta = async ({ opts, dbname, database_id }: ExportMetaParams
   await queryAndParse('sessions_module', `SELECT * FROM metaschema_modules_public.sessions_module WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('user_state_module', `SELECT * FROM metaschema_modules_public.user_state_module WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('profiles_module', `SELECT * FROM metaschema_modules_public.profiles_module WHERE database_id = $1 ORDER BY id`);
-  await queryAndParse('user_secrets_module', `SELECT * FROM metaschema_modules_public.user_secrets_module WHERE database_id = $1 ORDER BY id`);
+  await queryAndParse('config_secrets_user_module', `SELECT * FROM metaschema_modules_public.config_secrets_user_module WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('connected_accounts_module', `SELECT * FROM metaschema_modules_public.connected_accounts_module WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('phone_numbers_module', `SELECT * FROM metaschema_modules_public.phone_numbers_module WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('crypto_addresses_module', `SELECT * FROM metaschema_modules_public.crypto_addresses_module WHERE database_id = $1 ORDER BY id`);
@@ -210,7 +210,7 @@ export const exportMeta = async ({ opts, dbname, database_id }: ExportMetaParams
   await queryAndParse('plans_module', `SELECT * FROM metaschema_modules_public.plans_module WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('realtime_module', `SELECT * FROM metaschema_modules_public.realtime_module WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('session_secrets_module', `SELECT * FROM metaschema_modules_public.session_secrets_module WHERE database_id = $1 ORDER BY id`);
-  await queryAndParse('org_secrets_module', `SELECT * FROM metaschema_modules_public.org_secrets_module WHERE database_id = $1 ORDER BY id`);
+  await queryAndParse('config_secrets_org_module', `SELECT * FROM metaschema_modules_public.config_secrets_org_module WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('webauthn_auth_module', `SELECT * FROM metaschema_modules_public.webauthn_auth_module WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('webauthn_credentials_module', `SELECT * FROM metaschema_modules_public.webauthn_credentials_module WHERE database_id = $1 ORDER BY id`);
 

--- a/pgpm/export/src/export-utils.ts
+++ b/pgpm/export/src/export-utils.ts
@@ -171,7 +171,7 @@ export const META_TABLE_ORDER = [
   'sessions_module',
   'user_state_module',
   'profiles_module',
-  'user_secrets_module',
+  'config_secrets_user_module',
   'connected_accounts_module',
   'phone_numbers_module',
   'crypto_addresses_module',
@@ -195,7 +195,7 @@ export const META_TABLE_ORDER = [
   'plans_module',
   'realtime_module',
   'session_secrets_module',
-  'org_secrets_module',
+  'config_secrets_org_module',
   'webauthn_auth_module',
   'webauthn_credentials_module'
 ] as const;
@@ -988,9 +988,9 @@ export const META_TABLE_CONFIG: Record<string, TableConfig> = {
       prefix: 'text'
     }
   },
-  user_secrets_module: {
+  config_secrets_user_module: {
     schema: 'metaschema_modules_public',
-    table: 'user_secrets_module',
+    table: 'config_secrets_user_module',
     fields: {
       id: 'uuid',
       database_id: 'uuid',
@@ -1410,9 +1410,9 @@ export const META_TABLE_CONFIG: Record<string, TableConfig> = {
       sessions_table_id: 'uuid'
     }
   },
-  org_secrets_module: {
+  config_secrets_org_module: {
     schema: 'metaschema_modules_public',
-    table: 'org_secrets_module',
+    table: 'config_secrets_org_module',
     fields: {
       id: 'uuid',
       database_id: 'uuid',


### PR DESCRIPTION
## Summary

Renames module identifiers to match the upstream rename in [constructive-db #1219](https://github.com/constructive-io/constructive-db/pull/1219):

- `user_secrets_module` → `config_secrets_user_module`
- `org_secrets_module` → `config_secrets_org_module`

**Three areas updated:**

1. **Module presets** (7 files) — `modules` arrays and `includes_notes` in all auth/b2b presets
2. **Export pipeline** (3 files) — `META_TABLE_ORDER`, `META_TABLE_CONFIG` keys/table names, SQL queries in `export-meta.ts`, and GraphQL query keys in `export-graphql-meta.ts`
3. **Tests** (2 files) — expected module names in `export-meta.test.ts` and GraphQL naming assertions in `graphql-naming.test.ts`

No functionality changes — purely a naming alignment.

## Review & Testing Checklist for Human

- [ ] **Merge ordering**: constructive-db [#1219](https://github.com/constructive-io/constructive-db/pull/1219) must be merged first — this PR queries `metaschema_modules_public.config_secrets_user_module` / `config_secrets_org_module` tables that only exist after the DB rename lands
- [ ] **Completeness**: grep the repo for any remaining `\buser_secrets_module\b` or `\borg_secrets_module\b` references that may have been missed (note: `session_secrets_module` is a different module and should NOT be renamed)
- [ ] **GraphQL name derivation**: verify that PostGraphile will expose `config_secrets_user_module` as `configSecretsUserModules` (the `getGraphQLQueryName` function is generic camelCase+pluralize, so this should be automatic, but worth confirming against a live schema)

### Notes

- The `session_secrets_module` references in the export pipeline are intentionally unchanged — that is a separate module
- `auth-sso.ts` has documentation strings that also referenced the old name; those were updated too

Link to Devin session: https://app.devin.ai/sessions/af039a166f1c4df4a67704c842540835
Requested by: @pyramation