### PR TITLE
feat: add missing modules to pgpm export flow

### DIFF
--- a/pgpm/core/src/modules/modules.ts
+++ b/pgpm/core/src/modules/modules.ts
@@ -21,7 +21,6 @@ export const PGPM_MODULE_MAP: Record<string, string> = {
   'pgpm-types': '@pgpm/types',
   'pgpm-utils': '@pgpm/utils',
   'pgpm-ltree-helpers': '@pgpm/ltree-helpers',
-  'pgpm-uuid': '@pgpm/uuid',
   'pgpm-partman': '@pgpm/partman'
 };
 

--- a/pgpm/core/src/modules/modules.ts
+++ b/pgpm/core/src/modules/modules.ts
@@ -20,7 +20,9 @@ export const PGPM_MODULE_MAP: Record<string, string> = {
   'pgpm-totp': '@pgpm/totp',
   'pgpm-types': '@pgpm/types',
   'pgpm-utils': '@pgpm/utils',
-  'pgpm-ltree-helpers': '@pgpm/ltree-helpers'
+  'pgpm-ltree-helpers': '@pgpm/ltree-helpers',
+  'pgpm-uuid': '@pgpm/uuid',
+  'pgpm-partman': '@pgpm/partman'
 };
 
 /**

--- a/pgpm/export/src/export-utils.ts
+++ b/pgpm/export/src/export-utils.ts
@@ -29,7 +29,6 @@ export const DB_REQUIRED_EXTENSIONS = [
   'ltree',
   'metaschema-schema',
   'pgpm-inflection',
-  'pgpm-uuid',
   'pgpm-utils',
   'pgpm-database-jobs',
   'pgpm-jwt-claims',

--- a/pgpm/export/src/export-utils.ts
+++ b/pgpm/export/src/export-utils.ts
@@ -37,7 +37,8 @@ export const DB_REQUIRED_EXTENSIONS = [
   'pgpm-base32',
   'pgpm-totp',
   'pgpm-types',
-  'pgpm-ltree-helpers'
+  'pgpm-ltree-helpers',
+  'pgpm-partman'
 ] as const;
 
 /**
@@ -162,7 +163,7 @@ export const META_TABLE_ORDER = [
   'memberships_module',
   'permissions_module',
   'limits_module',
-  'levels_module',
+  'events_module',
   'users_module',
   'hierarchy_module',
   'membership_types_module',
@@ -182,7 +183,8 @@ export const META_TABLE_ORDER = [
   'uuid_module',
   'default_ids_module',
   'denormalized_table_field',
-  'table_template_module',
+  // NOTE: blueprint_template, blueprint, and blueprint_construction are intentionally
+  // excluded from the export flow — they are runtime-only tables not exported as metadata.
   'relation_provision',
   'entity_type_provision',
   'rate_limits_module',
@@ -197,7 +199,9 @@ export const META_TABLE_ORDER = [
   'session_secrets_module',
   'config_secrets_org_module',
   'webauthn_auth_module',
-  'webauthn_credentials_module'
+  'webauthn_credentials_module',
+  'inference_log_module',
+  'rate_limit_meters_module'
 ] as const;
 
 // =============================================================================
@@ -822,32 +826,45 @@ export const META_TABLE_CONFIG: Record<string, TableConfig> = {
       actor_table_id: 'uuid'
     }
   },
-  levels_module: {
+  events_module: {
     schema: 'metaschema_modules_public',
-    table: 'levels_module',
+    table: 'events_module',
     fields: {
       id: 'uuid',
       database_id: 'uuid',
       schema_id: 'uuid',
       private_schema_id: 'uuid',
-      steps_table_id: 'uuid',
-      steps_table_name: 'text',
-      achievements_table_id: 'uuid',
-      achievements_table_name: 'text',
+      events_table_id: 'uuid',
+      events_table_name: 'text',
+      event_aggregates_table_id: 'uuid',
+      event_aggregates_table_name: 'text',
+      event_types_table_id: 'uuid',
+      event_types_table_name: 'text',
       levels_table_id: 'uuid',
       levels_table_name: 'text',
       level_requirements_table_id: 'uuid',
       level_requirements_table_name: 'text',
-      completed_step: 'text',
-      incompleted_step: 'text',
-      tg_achievement: 'text',
-      tg_achievement_toggle: 'text',
-      tg_achievement_toggle_boolean: 'text',
-      tg_achievement_boolean: 'text',
-      upsert_achievement: 'text',
-      tg_update_achievements: 'text',
+      level_grants_table_id: 'uuid',
+      level_grants_table_name: 'text',
+      achievement_rewards_table_id: 'uuid',
+      achievement_rewards_table_name: 'text',
+      record_event: 'text',
+      remove_event: 'text',
+      tg_event: 'text',
+      tg_event_toggle: 'text',
+      tg_event_toggle_bool: 'text',
+      tg_event_bool: 'text',
+      upsert_aggregate: 'text',
+      tg_update_aggregates: 'text',
+      prune_events: 'text',
       steps_required: 'text',
       level_achieved: 'text',
+      tg_check_achievements: 'text',
+      grant_achievement: 'text',
+      tg_achievement_reward: 'text',
+      interval: 'text',
+      retention: 'text',
+      premake: 'int',
       prefix: 'text',
       membership_type: 'int',
       entity_table_id: 'uuid',
@@ -1087,21 +1104,7 @@ export const META_TABLE_CONFIG: Record<string, TableConfig> = {
       fields: 'uuid[]'
     }
   },
-  table_template_module: {
-    schema: 'metaschema_modules_public',
-    table: 'table_template_module',
-    fields: {
-      id: 'uuid',
-      database_id: 'uuid',
-      schema_id: 'uuid',
-      private_schema_id: 'uuid',
-      table_id: 'uuid',
-      owner_table_id: 'uuid',
-      table_name: 'text',
-      node_type: 'text',
-      data: 'jsonb'
-    }
-  },
+  // NOTE: table_template_module has been removed from pgpm-modules (superseded by blueprints)
   secure_table_provision: {
     schema: 'metaschema_modules_public',
     table: 'secure_table_provision',
@@ -1454,6 +1457,42 @@ export const META_TABLE_CONFIG: Record<string, TableConfig> = {
       table_id: 'uuid',
       owner_table_id: 'uuid',
       table_name: 'text'
+    }
+  },
+  inference_log_module: {
+    schema: 'metaschema_modules_public',
+    table: 'inference_log_module',
+    fields: {
+      id: 'uuid',
+      database_id: 'uuid',
+      schema_id: 'uuid',
+      private_schema_id: 'uuid',
+      inference_log_table_id: 'uuid',
+      inference_log_table_name: 'text',
+      usage_daily_table_id: 'uuid',
+      usage_daily_table_name: 'text',
+      interval: 'text',
+      retention: 'text',
+      premake: 'int',
+      prefix: 'text'
+    }
+  },
+  rate_limit_meters_module: {
+    schema: 'metaschema_modules_public',
+    table: 'rate_limit_meters_module',
+    fields: {
+      id: 'uuid',
+      database_id: 'uuid',
+      schema_id: 'uuid',
+      private_schema_id: 'uuid',
+      rate_limit_state_table_id: 'uuid',
+      rate_limit_state_table_name: 'text',
+      rate_limit_overrides_table_id: 'uuid',
+      rate_limit_overrides_table_name: 'text',
+      rate_window_limits_table_id: 'uuid',
+      rate_window_limits_table_name: 'text',
+      check_rate_limit_function: 'text',
+      prefix: 'text'
     }
   },
   spatial_relation: {


### PR DESCRIPTION
## Summary

Syncs the export flow with the current state of `pgpm-modules/metaschema-modules`. Several modules were added, renamed, or removed in the upstream pgpm-modules repo but the export config here was stale.

**Changes:**

| File | Change |
|------|--------|
| `pgpm/export/src/export-utils.ts` | Add `pgpm-partman` to `DB_REQUIRED_EXTENSIONS` |
| | Remove `pgpm-uuid` from `DB_REQUIRED_EXTENSIONS` (vestigial — no SQL uses `uuids.*` functions, metaschema.control doesn't require it) |
| | Rename `levels_module` → `events_module` in `META_TABLE_ORDER` + `META_TABLE_CONFIG` (with new fields: events/aggregates/types tables, partition config, achievement rewards) |
| | Remove `table_template_module` (superseded by blueprints) |
| | Add `inference_log_module` config (partitioned inference log + usage_daily rollup) |
| | Add `rate_limit_meters_module` config (state, overrides, window_limits, check function) |
| | Add comment noting `blueprint_template`/`blueprint`/`blueprint_construction` are intentionally excluded |
| `pgpm/core/src/modules/modules.ts` | Add `'pgpm-partman': '@pgpm/partman'` to `PGPM_MODULE_MAP` |

## Review & Testing Checklist for Human
- [ ] Verify `events_module` fields match the actual `metaschema_modules_public.events_module` table DDL
- [ ] Verify `inference_log_module` and `rate_limit_meters_module` fields match their table DDLs
- [ ] Run `pgpm export` against a provisioned database to confirm the new modules are picked up correctly
- [ ] Confirm removing `pgpm-uuid` from required extensions doesn't break any existing export flows

### Notes
- Blueprint tables (`blueprint_template`, `blueprint`, `blueprint_construction`) are intentionally NOT in the export flow — they are runtime-only tables, not exported metadata
- `table_template_module` was removed from pgpm-modules (superseded by blueprints) — removed from config with a comment explaining why
- `pgpm-uuid` was removed because: no SQL references `uuids.*` functions, `metaschema.control` doesn't list it in `requires`, no pgpm-module depends on it. The `uuid_module` uses `metaschema.uuid_seed` GUC instead.
- Build passes cleanly (`pnpm build` at workspace root)

Link to Devin session: https://app.devin.ai/sessions/2cd4b3b9432a45acab518af28204ced2
Requested by: @pyramation