### PR TITLE
feat: make name optional on BlueprintEntityType for extend path

### DIFF
--- a/packages/node-type-registry/src/blueprint-types.generated.ts
+++ b/packages/node-type-registry/src/blueprint-types.generated.ts
@@ -1284,10 +1284,10 @@ export interface BlueprintEntityTableProvision {
   /** RLS policies for the entity table. When present, these policies fully replace the five default entity-table policies (is_visible becomes a no-op). */
   policies?: BlueprintPolicy[];
 }
-/** An entity type entry for Phase 0 of construct_blueprint(). Provisions a full entity type with its own entity table, membership modules, and security policies via entity_type_provision. */
+/** An entity type entry for Phase 0 of construct_blueprint(). When name is provided, provisions a new entity type with its own entity table, membership modules, and security policies via entity_type_provision. When name is omitted and only prefix is given, extends an existing entity type (e.g., the built-in "org") with additional capabilities like storage — without creating a new entity type. */
 export interface BlueprintEntityType {
-  /** Entity type name (e.g., "data_room", "channel", "department"). Must be unique per database. */
-  name: string;
+  /** Entity type name (e.g., "data_room", "channel", "department"). Required when creating a new entity type. Omit when extending an existing entity type (e.g., prefix: "org") — the entry will add storage/config to the existing type without creating a new one. */
+  name?: string;
   /** Short prefix for generated objects (e.g., "dr", "ch", "dept"). Used in table/trigger naming. */
   prefix: string;
   /** Human-readable description of this entity type. */

--- a/packages/node-type-registry/src/codegen/generate-types.ts
+++ b/packages/node-type-registry/src/codegen/generate-types.ts
@@ -1003,8 +1003,8 @@ function buildBlueprintEntityType(): t.ExportNamedDeclaration {
   return addJSDoc(
     exportInterface('BlueprintEntityType', [
       addJSDoc(
-        requiredProp('name', t.tsStringKeyword()),
-        'Entity type name (e.g., "data_room", "channel", "department"). Must be unique per database.'
+        optionalProp('name', t.tsStringKeyword()),
+        'Entity type name (e.g., "data_room", "channel", "department"). Required when creating a new entity type. Omit when extending an existing entity type (e.g., prefix: "org") — the entry will add storage/config to the existing type without creating a new one.'
       ),
       addJSDoc(
         requiredProp('prefix', t.tsStringKeyword()),
@@ -1068,7 +1068,7 @@ function buildBlueprintEntityType(): t.ExportNamedDeclaration {
         'Storage module configuration array. Each entry provisions a separate storage module with its own tables, RLS, and settings. When non-empty, has_storage is derived as true. Each entry may specify a storage_key for multi-module support (defaults to "default").'
       )
     ]),
-    'An entity type entry for Phase 0 of construct_blueprint(). Provisions a full entity type with its own entity table, membership modules, and security policies via entity_type_provision.'
+    'An entity type entry for Phase 0 of construct_blueprint(). When name is provided, provisions a new entity type with its own entity table, membership modules, and security policies via entity_type_provision. When name is omitted and only prefix is given, extends an existing entity type (e.g., the built-in "org") with additional capabilities like storage — without creating a new entity type.'
   );
 }
 


### PR DESCRIPTION
## Summary

Makes `name` optional on `BlueprintEntityType`. When an `entity_types[]` entry has `prefix` but no `name`, it extends an existing entity type (e.g., the built-in org) with storage instead of creating a new entity type.

Changes:
- `generate-types.ts`: `requiredProp('name')` → `optionalProp('name')`, updated JSDoc
- `blueprint-types.generated.ts`: `name: string` → `name?: string`, updated interface/field docs

Companion to constructive-db#1250.

## Review & Testing Checklist for Human

- [ ] Verify that existing code creating new entity types (with `name` + `prefix`) still type-checks correctly
- [ ] Confirm the generated file change matches the generator source change (only `name` optionality + JSDoc)

### Notes

Low risk — types-only change. The SQL implementation (constructive-db#1250) is already merged.

Link to Devin session: https://app.devin.ai/sessions/c0494871633d4beb91f1e16e53c776d1
Requested by: @pyramation