### PR TITLE
feat(node-type-registry): add max_depth parameter to EventReferral

### DIFF
--- a/packages/node-type-registry/src/event/referral.ts
+++ b/packages/node-type-registry/src/event/referral.ts
@@ -44,6 +44,17 @@ export const EventReferral: NodeTypeDefinition = {
         format: 'column-ref',
         description: 'Column containing the entity ID (org/group) for entity-scoped referral events. Omit for user-only events.'
       },
+      max_depth: {
+        type: 'integer',
+        description:
+          'Maximum depth to walk up the invite chain. ' +
+          'Default 1 (direct inviter only). Set 2–10 to enable ' +
+          'multi-level referral rewards. App-level only — must not ' +
+          'be combined with entity_field.',
+        default: 1,
+        minimum: 1,
+        maximum: 10,
+      },
       auto_register_type: {
         type: 'boolean',
         description: 'Automatically register the event_name in event_types during provisioning',


### PR DESCRIPTION
## Summary

Adds `max_depth` to `EventReferral`'s `parameter_schema` in the node-type-registry package. This enables the downstream generator in `constructive-db` to build multi-level referral chain walks.

**Change:** One new property in `packages/node-type-registry/src/event/referral.ts`:

```ts
max_depth: {
  type: 'integer',
  description: 'Maximum depth to walk up the invite chain. Default 1 (direct inviter only). Set 2–10 to enable multi-level referral rewards. App-level only — must not be combined with entity_field.',
  default: 1,
  minimum: 1,
  maximum: 10,
}
```

The generator implementation that consumes this is in [constructive-db PR #1261](https://github.com/constructive-io/constructive-db/pull/1261).

Closes constructive-io/constructive-planning#904

## Review & Testing Checklist for Human

- [ ] Verify the property position (before `auto_register_type`, after `entity_field`) is consistent with other node types
- [ ] Confirm the min/max/default values are reasonable (1–10, default 1)

### Notes

This is a purely additive schema change — no existing behavior changes since the default is 1 (today's single-hop behavior). The downstream `constructive-db` PR has the generator implementation + integration tests.

Link to Devin session: https://app.devin.ai/sessions/2ad5d38ab24e4d43ba283eb9ae8b5c81
Requested by: @pyramation