### PR TITLE
fix(codegen): collect input types referenced by table field arguments

### DIFF
--- a/graphql/codegen/src/__tests__/codegen/input-types-generator.test.ts
+++ b/graphql/codegen/src/__tests__/codegen/input-types-generator.test.ts
@@ -1003,3 +1003,95 @@ describe('edge cases', () => {
     );
   });
 });
+
+// ============================================================================
+// Tests - Table Field Argument Input Types (Bucket-style computed fields)
+// ============================================================================
+
+describe('table field argument input types', () => {
+  it('emits Input types referenced only by table-field args', () => {
+    const bucketTable = createTable({
+      name: 'FooBucket',
+      fields: [
+        { name: 'id', type: fieldTypes.uuid },
+        {
+          name: 'requestBulkUploadUrls',
+          type: { gqlType: 'String', isArray: true } as FieldType,
+          args: [
+            {
+              name: 'files',
+              type: createNonNull(
+                createList(
+                  createNonNull(
+                    createTypeRef('INPUT_OBJECT', 'FooBulkUploadFileInput'),
+                  ),
+                ),
+              ),
+              isRequired: true,
+            },
+          ],
+        },
+      ],
+    });
+
+    const registry = createTypeRegistry({
+      FooBulkUploadFileInput: {
+        kind: 'INPUT_OBJECT',
+        name: 'FooBulkUploadFileInput',
+        inputFields: [
+          {
+            name: 'fileName',
+            type: createNonNull(createTypeRef('SCALAR', 'String')),
+          },
+          {
+            name: 'contentType',
+            type: createTypeRef('SCALAR', 'String'),
+          },
+          {
+            name: 'sizeBytes',
+            type: createNonNull(createTypeRef('SCALAR', 'Int')),
+          },
+        ],
+      },
+    });
+
+    const result = generateInputTypesFile(registry, new Set(), [bucketTable]);
+
+    expect(result.content).toContain(
+      'export interface FooBulkUploadFileInput {',
+    );
+    expect(result.content).toContain('fileName: string;');
+    expect(result.content).toContain('contentType?: string;');
+    expect(result.content).toContain('sizeBytes: number;');
+  });
+
+  it('collectInputTypeNames discovers field-arg types when tables provided', () => {
+    const bucketTable = createTable({
+      name: 'FooBucket',
+      fields: [
+        { name: 'id', type: fieldTypes.uuid },
+        {
+          name: 'requestBulkUploadUrls',
+          type: { gqlType: 'String', isArray: true } as FieldType,
+          args: [
+            {
+              name: 'files',
+              type: createNonNull(
+                createTypeRef('INPUT_OBJECT', 'FooBulkUploadFileInput'),
+              ),
+              isRequired: true,
+            },
+          ],
+        },
+      ],
+    });
+
+    // Without tables: only collects from operations
+    const withoutTables = collectInputTypeNames([]);
+    expect(withoutTables.has('FooBulkUploadFileInput')).toBe(false);
+
+    // With tables: also collects from field args
+    const withTables = collectInputTypeNames([], [bucketTable]);
+    expect(withTables.has('FooBulkUploadFileInput')).toBe(true);
+  });
+});

--- a/graphql/codegen/src/core/codegen/orm/index.ts
+++ b/graphql/codegen/src/core/codegen/orm/index.ts
@@ -117,7 +117,7 @@ export function generateOrm(options: GenerateOrmOptions): GenerateOrmResult {
       ...(customOperations?.queries ?? []),
       ...(customOperations?.mutations ?? []),
     ];
-    const usedInputTypes = collectInputTypeNames(allOps);
+    const usedInputTypes = collectInputTypeNames(allOps, tables);
     const usedPayloadTypes = collectPayloadTypeNames(allOps);
 
     // Also include payload types for table CRUD mutations (they reference Edge types)

--- a/graphql/codegen/src/core/codegen/orm/input-types-generator.ts
+++ b/graphql/codegen/src/core/codegen/orm/input-types-generator.ts
@@ -1559,19 +1559,21 @@ function generateAllCrudInputTypes(
 // ============================================================================
 
 /**
- * Collect all input type names used by operations
+ * Collect all input type names used by operations and table field arguments.
+ *
+ * Scans both custom operation args and computed-field args (e.g.
+ * `requestBulkUploadUrls(files: [FooBulkUploadFileInput!]!)` on bucket
+ * tables) so that referenced Input types are registered for generation.
  */
 export function collectInputTypeNames(
   operations: Array<{ args: Argument[] }>,
+  tables?: Table[],
 ): Set<string> {
   const inputTypes = new Set<string>();
 
   function collectFromTypeRef(typeRef: Argument['type']) {
     const baseName = getTypeBaseName(typeRef);
-    if (baseName && baseName.endsWith('Input')) {
-      inputTypes.add(baseName);
-    }
-    if (baseName && baseName.endsWith('Filter')) {
+    if (baseName && (baseName.endsWith('Input') || baseName.endsWith('Filter'))) {
       inputTypes.add(baseName);
     }
   }
@@ -1579,6 +1581,17 @@ export function collectInputTypeNames(
   for (const op of operations) {
     for (const arg of op.args) {
       collectFromTypeRef(arg.type);
+    }
+  }
+
+  if (tables) {
+    for (const table of tables) {
+      for (const field of table.fields) {
+        if (!field.args) continue;
+        for (const arg of field.args) {
+          collectFromTypeRef(arg.type);
+        }
+      }
     }
   }
 
@@ -2057,6 +2070,7 @@ export function generateInputTypesFile(
 
   // 7. Custom input types from TypeRegistry
   // Also include any extra types referenced by plugin-injected filter fields
+  // and by table field arguments (e.g. bucket computed-field args)
   const mergedUsedInputTypes = new Set(usedInputTypes);
   if (hasTables) {
     const filterExtraTypes = collectFilterExtraInputTypes(
@@ -2064,6 +2078,10 @@ export function generateInputTypesFile(
       typeRegistry,
     );
     for (const typeName of filterExtraTypes) {
+      mergedUsedInputTypes.add(typeName);
+    }
+    const fieldArgTypes = collectInputTypeNames([], tablesList);
+    for (const typeName of fieldArgTypes) {
       mergedUsedInputTypes.add(typeName);
     }
   }


### PR DESCRIPTION
## Summary

Split from #1200 (Issue 1 only), rewritten with an improved approach.

**Problem:** Input types referenced only by table-field arguments (e.g. `FooBulkUploadFileInput` on bucket computed fields like `requestBulkUploadUrls(files: [FooBulkUploadFileInput!]!)`) were inlined into `*Select` types via `typeRefToTs` but never registered for generation — leaving the referenced Input interfaces undefined in the output.

**Approach (differs from #1200):** Instead of adding a standalone `collectFieldArgInputTypes` function as a third parallel collector, this extends the existing `collectInputTypeNames()` to optionally accept `tables` and scan their computed-field args. This keeps one function and one code path for all input type collection from args.

The fix is applied at two levels for defense-in-depth:
1. **Orchestrator (`index.ts`):** passes `tables` to `collectInputTypeNames(allOps, tables)` so field-arg types flow through the normal pipeline
2. **`generateInputTypesFile`:** also merges field-arg types internally, so direct callers (including tests) get correct behavior without needing to pre-collect

**Files changed:**
- `graphql/codegen/src/core/codegen/orm/input-types-generator.ts` — extended `collectInputTypeNames` signature + defense-in-depth merge
- `graphql/codegen/src/core/codegen/orm/index.ts` — passes `tables` to `collectInputTypeNames`
- `graphql/codegen/src/__tests__/codegen/input-types-generator.test.ts` — 2 regression tests (end-to-end generation + unit test of `collectInputTypeNames`)

## Review & Testing Checklist for Human

- [ ] Run codegen against a schema with bucket tables and verify the `BulkUploadFileInput` types appear in generated output
- [ ] Verify no duplicate type declarations when a field-arg type is also referenced by a custom operation

### Notes

This replaces the original #1200 Issue 1 implementation. The key difference: no new standalone function — just extends the existing `collectInputTypeNames` with an optional `tables` parameter, following the principle of one collection path rather than parallel collectors.

Link to Devin session: https://app.devin.ai/sessions/11c358ec8678488eba3255c53f3e440f
Requested by: @pyramation