### PR TITLE
refactor: replace smart tag discovery with module config query

### DIFF
--- a/graphile/graphile-llm/src/__tests__/graphile-llm.test.ts
+++ b/graphile/graphile-llm/src/__tests__/graphile-llm.test.ts
@@ -846,7 +846,7 @@ describe('GraphileLlmPreset toggles', () => {
     expect(pluginNames).not.toContain('LlmTextMutationPlugin');
   });
 
-  it('all toggles false leaves only LlmModulePlugin and LlmAgentDiscoveryPlugin', async () => {
+  it('all toggles false leaves only LlmModulePlugin', async () => {
     const { GraphileLlmPreset } = await import('../../src/preset');
     const preset = GraphileLlmPreset({
       enableTextSearch: false,
@@ -855,7 +855,7 @@ describe('GraphileLlmPreset toggles', () => {
     });
 
     const pluginNames = preset.plugins!.map((p: any) => p.name);
-    expect(pluginNames).toEqual(['LlmModulePlugin', 'LlmAgentDiscoveryPlugin']);
+    expect(pluginNames).toEqual(['LlmModulePlugin']);
   });
 
   it('default options include text search and mutations but not RAG', async () => {
@@ -866,7 +866,6 @@ describe('GraphileLlmPreset toggles', () => {
     expect(pluginNames).toContain('LlmModulePlugin');
     expect(pluginNames).toContain('LlmTextSearchPlugin');
     expect(pluginNames).toContain('LlmTextMutationPlugin');
-    expect(pluginNames).toContain('LlmAgentDiscoveryPlugin');
     expect(pluginNames).not.toContain('LlmRagPlugin');
   });
 });

--- a/graphile/graphile-llm/src/index.ts
+++ b/graphile/graphile-llm/src/index.ts
@@ -46,8 +46,8 @@ export { createLlmRagPlugin } from './plugins/rag-plugin';
 // Metering plugin (opt-in billing integration)
 export { createLlmMeteringPlugin } from './plugins/metering-plugin';
 
-// Agent discovery plugin (smart tag based table discovery)
-export { LlmAgentDiscoveryPlugin, getAgentDiscovery, clearAgentDiscoveryCache } from './plugins/agent-discovery-plugin';
+// Agent discovery (queries agent_chat_module config table at runtime)
+export { getAgentDiscovery, clearAgentDiscoveryCache } from './plugins/agent-discovery-plugin';
 export type { AgentTableInfo, AgentDiscovery } from './plugins/agent-discovery-plugin';
 
 // Embedder utilities

--- a/graphile/graphile-llm/src/plugins/agent-discovery-plugin.ts
+++ b/graphile/graphile-llm/src/plugins/agent-discovery-plugin.ts
@@ -1,31 +1,23 @@
 /**
- * LlmAgentDiscoveryPlugin
+ * Agent Discovery
  *
- * Discovers agent tables at PostGraphile schema build time by scanning
- * the pgRegistry for tables tagged with @agentThread, @agentMessage,
- * and @agentTask smart tags.
+ * Discovers agent tables by querying the agent_chat_module config table
+ * at runtime. The module stores schema_id, table names, and table IDs
+ * when provisioned — no smart tags needed.
  *
- * Results are:
- *   1. Placed on the build context (for other plugins)
- *   2. Stored in a module-level cache keyed by cacheKey (for the REST API
- *      middleware to look up discovered table names without access to the
- *      PostGraphile build)
- *
- * Smart tags are set via construct_blueprint() when the agent blueprint
- * includes `"smart_tags": { "agentThread": true }` on a table entry.
+ * Results are cached per-database with a TTL so the REST middleware
+ * doesn't hit the database on every request.
  */
 
-import type { GraphileConfig } from 'graphile-config';
+import { Pool } from 'pg';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export interface AgentTableInfo {
-  /** The PostgreSQL schema name (e.g. 'constructive_agent_public') */
+  /** The PostgreSQL schema name (e.g. 'agent_public') */
   schemaName: string;
   /** The table name (e.g. 'agent_thread') */
   tableName: string;
-  /** The codec name from pgRegistry */
-  codecName: string;
 }
 
 export interface AgentDiscovery {
@@ -34,139 +26,74 @@ export interface AgentDiscovery {
   task: AgentTableInfo | null;
 }
 
-// ─── Module-level cache ─────────────────────────────────────────────────────
+// ─── Cache ──────────────────────────────────────────────────────────────────
 
-/** Cache of agent discovery results, keyed by graphile cache key (dbname-based) */
-const agentDiscoveryCache = new Map<string, AgentDiscovery>();
-
-/**
- * Look up cached agent discovery for a given database name.
- * Called by the REST API middleware at request time.
- *
- * The key should match the graphile cache key format used by
- * the server (typically the dbname or a composite key).
- * Falls back to scanning all entries if an exact match isn't found
- * (single-database deployments).
- */
-export function getAgentDiscovery(dbname: string): AgentDiscovery | null {
-  // Exact match
-  const exact = agentDiscoveryCache.get(dbname);
-  if (exact) return exact;
-
-  // If there's only one entry, return it (single-database deployment)
-  if (agentDiscoveryCache.size === 1) {
-    return agentDiscoveryCache.values().next().value ?? null;
-  }
-
-  // Scan for partial key match (key might contain dbname as a substring)
-  for (const [key, value] of agentDiscoveryCache) {
-    if (key.includes(dbname)) return value;
-  }
-
-  return null;
+interface CacheEntry {
+  discovery: AgentDiscovery | null;
+  expiresAt: number;
 }
+
+const CACHE_TTL_MS = 60_000;
+
+const agentDiscoveryCache = new Map<string, CacheEntry>();
 
 /** Clear all cached discovery results (for testing) */
 export function clearAgentDiscoveryCache(): void {
   agentDiscoveryCache.clear();
 }
 
-// ─── TypeScript Augmentation ────────────────────────────────────────────────
+// ─── Discovery Query ────────────────────────────────────────────────────────
 
-declare global {
-  namespace GraphileBuild {
-    interface Build {
-      /** Discovered agent tables from smart tags, or null if agent blueprint not provisioned */
-      agentDiscovery: AgentDiscovery | null;
+const DISCOVERY_SQL = `
+  SELECT
+    s.schema_name,
+    acm.thread_table_name,
+    acm.message_table_name,
+    acm.task_table_name
+  FROM metaschema_modules_public.agent_chat_module acm
+  JOIN metaschema_public.schema s ON s.id = acm.schema_id
+  LIMIT 1
+`;
+
+/**
+ * Look up agent table info for a database, querying the module config table.
+ * Results are cached per-database for CACHE_TTL_MS.
+ */
+export async function getAgentDiscovery(
+  pool: Pool,
+  dbname: string,
+): Promise<AgentDiscovery | null> {
+  const now = Date.now();
+  const cached = agentDiscoveryCache.get(dbname);
+  if (cached && cached.expiresAt > now) {
+    return cached.discovery;
+  }
+
+  let discovery: AgentDiscovery | null = null;
+
+  try {
+    const { rows } = await pool.query(DISCOVERY_SQL);
+
+    if (rows.length > 0) {
+      const row = rows[0];
+      const schemaName: string = row.schema_name;
+
+      discovery = {
+        thread: row.thread_table_name
+          ? { schemaName, tableName: row.thread_table_name }
+          : null,
+        message: row.message_table_name
+          ? { schemaName, tableName: row.message_table_name }
+          : null,
+        task: row.task_table_name
+          ? { schemaName, tableName: row.task_table_name }
+          : null,
+      };
     }
+  } catch {
+    // Module table doesn't exist in this database — not provisioned
   }
-  namespace GraphileConfig {
-    interface Plugins {
-      LlmAgentDiscoveryPlugin: true;
-    }
-  }
+
+  agentDiscoveryCache.set(dbname, { discovery, expiresAt: now + CACHE_TTL_MS });
+  return discovery;
 }
-
-// ─── Helpers ────────────────────────────────────────────────────────────────
-
-function findTaggedTable(
-  build: any,
-  tagName: string,
-): AgentTableInfo | null {
-  const pgRegistry = build.pgRegistry;
-  if (!pgRegistry) return null;
-
-  for (const source of Object.values(pgRegistry.pgResources || {})) {
-    const codec = (source as any)?.codec;
-    if (!codec?.attributes) continue;
-
-    const tags = codec.extensions?.tags;
-    if (!tags?.[tagName]) continue;
-
-    const schemaName = codec.extensions?.pg?.schemaName
-      ?? (source as any)?.extensions?.pg?.schemaName
-      ?? null;
-    const tableName = codec.extensions?.pg?.name
-      ?? codec.name
-      ?? null;
-
-    if (!schemaName || !tableName) continue;
-
-    return {
-      schemaName,
-      tableName,
-      codecName: codec.name || tableName,
-    };
-  }
-
-  return null;
-}
-
-// ─── Plugin ─────────────────────────────────────────────────────────────────
-
-export const LlmAgentDiscoveryPlugin: GraphileConfig.Plugin = {
-  name: 'LlmAgentDiscoveryPlugin',
-  version: '0.1.0',
-  description:
-    'Discovers agent tables by @agentThread/@agentMessage/@agentTask smart tags ' +
-    'and makes schema/table names available on the build context and module cache',
-
-  schema: {
-    hooks: {
-      build(build) {
-        const thread = findTaggedTable(build, 'agentThread');
-        const message = findTaggedTable(build, 'agentMessage');
-        const task = findTaggedTable(build, 'agentTask');
-
-        const discovery: AgentDiscovery | null =
-          thread || message || task
-            ? { thread, message, task }
-            : null;
-
-        if (discovery) {
-          const parts: string[] = [];
-          if (thread) parts.push(`thread=${thread.schemaName}.${thread.tableName}`);
-          if (message) parts.push(`message=${message.schemaName}.${message.tableName}`);
-          if (task) parts.push(`task=${task.schemaName}.${task.tableName}`);
-          console.log(`[graphile-llm] Agent tables discovered: ${parts.join(', ')}`);
-
-          // Store in module-level cache for the REST middleware.
-          // Use the first schema name as cache key (all agent tables share one schema).
-          const cacheKey = thread?.schemaName ?? message?.schemaName ?? 'agent';
-          agentDiscoveryCache.set(cacheKey, discovery);
-        } else {
-          console.log(
-            '[graphile-llm] No agent tables found (no @agentThread/@agentMessage/@agentTask tags). ' +
-            'Agent REST API will be disabled.',
-          );
-        }
-
-        return build.extend(
-          build,
-          { agentDiscovery: discovery },
-          'LlmAgentDiscoveryPlugin adding agentDiscovery to build',
-        );
-      },
-    },
-  },
-};

--- a/graphile/graphile-llm/src/preset.ts
+++ b/graphile/graphile-llm/src/preset.ts
@@ -70,7 +70,6 @@ import { createLlmTextSearchPlugin } from './plugins/text-search-plugin';
 import { createLlmTextMutationPlugin } from './plugins/text-mutation-plugin';
 import { createLlmRagPlugin } from './plugins/rag-plugin';
 import { createLlmMeteringPlugin } from './plugins/metering-plugin';
-import { LlmAgentDiscoveryPlugin } from './plugins/agent-discovery-plugin';
 import type { GraphileLlmOptions } from './types';
 
 /**
@@ -86,7 +85,6 @@ export function GraphileLlmPreset(
     enableTextSearch = true,
     enableTextMutations = true,
     enableRag = false,
-    enableAgentDiscovery = true,
     ragDefaults,
     metering,
   } = options;
@@ -112,10 +110,6 @@ export function GraphileLlmPreset(
 
   if (enableRag) {
     plugins.push(createLlmRagPlugin(ragDefaults));
-  }
-
-  if (enableAgentDiscovery) {
-    plugins.push(LlmAgentDiscoveryPlugin);
   }
 
   return {

--- a/graphile/graphile-llm/src/types.ts
+++ b/graphile/graphile-llm/src/types.ts
@@ -253,11 +253,4 @@ export interface GraphileLlmOptions {
    */
   metering?: boolean | MeteringConfig;
 
-  /**
-   * Whether to enable agent table discovery via smart tags.
-   * When enabled, scans for @agentThread/@agentMessage/@agentTask tagged tables
-   * and caches their schema/table names for the REST API middleware.
-   * @default true
-   */
-  enableAgentDiscovery?: boolean;
 }

--- a/graphql/server/src/middleware/llm-api.ts
+++ b/graphql/server/src/middleware/llm-api.ts
@@ -2,8 +2,8 @@
  * LLM API Router
  *
  * Express router providing a REST streaming endpoint for AI agent conversations.
- * Uses the agent tables (agent_thread, agent_message) discovered by
- * LlmAgentDiscoveryPlugin via smart tags.
+ * Uses the agent tables (agent_thread, agent_message) discovered from the
+ * agent_chat_module config table at runtime.
  *
  * Hybrid architecture:
  *   - GraphQL handles CRUD (threads, messages, tasks) via PostGraphile
@@ -22,8 +22,7 @@ import { Logger } from '@pgpmjs/logger';
 import { Pool } from 'pg';
 import { getPgPool } from 'pg-cache';
 import OllamaClient from '@agentic-kit/ollama';
-import { getLlmEnvOptions } from 'graphile-llm';
-import type { AgentDiscovery } from 'graphile-llm';
+import { getLlmEnvOptions, getAgentDiscovery } from 'graphile-llm';
 
 const log = new Logger('llm-api');
 
@@ -113,13 +112,9 @@ function resolveOllamaClient(): { client: OllamaClient; model: string } | null {
 
 /**
  * Creates the LLM API router.
- *
- * @param getDiscovery - Function to look up agent discovery by dbname.
- *                       Typically imported from graphile-llm's agent-discovery-plugin.
+ * Agent table discovery queries the agent_chat_module config table.
  */
-export function createLlmApiRouter(
-  getDiscovery: (dbname: string) => AgentDiscovery | null,
-): Router {
+export function createLlmApiRouter(): Router {
   const router = Router();
 
   // JSON body parsing scoped to this router
@@ -140,7 +135,8 @@ export function createLlmApiRouter(
         return;
       }
 
-      const discovery = getDiscovery(dbname);
+      const pool = getPgPool({ database: dbname });
+      const discovery = await getAgentDiscovery(pool, dbname);
       if (!discovery?.thread) {
         res.status(404).json({ error: 'Agent module not provisioned for this database' });
         return;
@@ -148,7 +144,6 @@ export function createLlmApiRouter(
 
       const body: CreateThreadBody = req.body || {};
       const { thread } = discovery;
-      const pool = getPgPool({ database: dbname });
       const pgSettings = getPgSettings(req);
       const entityId = req.params.entity_id;
 
@@ -201,7 +196,8 @@ export function createLlmApiRouter(
           return;
         }
 
-        const discovery = getDiscovery(dbname);
+        const pool = getPgPool({ database: dbname });
+        const discovery = await getAgentDiscovery(pool, dbname);
         if (!discovery?.thread || !discovery?.message) {
           res.status(404).json({ error: 'Agent module not provisioned for this database' });
           return;
@@ -214,7 +210,6 @@ export function createLlmApiRouter(
         }
 
         const { thread, message: msgTable } = discovery;
-        const pool = getPgPool({ database: dbname });
         const pgSettings = getPgSettings(req);
         const threadId = req.params.thread_id;
         const userId = req.token.user_id;

--- a/graphql/server/src/server.ts
+++ b/graphql/server/src/server.ts
@@ -39,7 +39,6 @@ import { createCaptchaMiddleware } from './middleware/captcha';
 import { parseCookieValue, SESSION_COOKIE_NAME } from './middleware/cookie';
 import { createUploadAuthenticateMiddleware, uploadRoute } from './middleware/upload';
 import { createLlmApiRouter } from './middleware/llm-api';
-import { getAgentDiscovery } from 'graphile-llm';
 import { startDebugSampler } from './diagnostics/debug-sampler';
 
 const log = new Logger('server');
@@ -199,7 +198,7 @@ class Server {
 
     // LLM Agent REST API — mounted before graphile so SSE streaming
     // routes are handled without going through PostGraphile
-    app.use(createLlmApiRouter(getAgentDiscovery));
+    app.use(createLlmApiRouter());
 
     app.use(graphile(effectiveOpts));
     app.use(flush);


### PR DESCRIPTION
## Summary

Replaces the `LlmAgentDiscoveryPlugin` (PostGraphile build-time smart tag scanning) with a runtime query against `metaschema_modules_public.agent_chat_module`. The module config table already stores schema + table names, so smart tags are no longer needed for discovery.

**Changes:**
- `agent-discovery-plugin.ts`: Removed the `GraphileConfig.Plugin` entirely. `getAgentDiscovery(pool, dbname)` now queries the module config table with a 60s TTL cache
- `llm-api.ts`: `createLlmApiRouter()` no longer takes a `getDiscovery` param — calls `getAgentDiscovery` directly with the per-request pool
- `server.ts`: Simplified `createLlmApiRouter()` call, removed `getAgentDiscovery` import
- `preset.ts`: Removed `LlmAgentDiscoveryPlugin` from plugin list
- `types.ts`: Removed `enableAgentDiscovery` option

Companion PR: constructive-io/constructive-db (removes smart tags from the module generator).

## Review & Testing Checklist for Human

- [ ] Verify the SQL query in `DISCOVERY_SQL` matches the actual `agent_chat_module` table shape
- [ ] Confirm the 60s TTL cache is acceptable for your deployment (config changes take up to 60s to propagate)
- [ ] Test with a provisioned database that has `agent_chat_module` enabled — the REST endpoints should discover tables correctly

### Notes

- Based on `feat/llm-billing-metering` since that's where the agent discovery plugin was originally added
- The 11 test failures in `graphile-llm.test.ts` are pre-existing (require running Postgres+pgvector and Ollama) — confirmed same failures on the base branch

Link to Devin session: https://app.devin.ai/sessions/2b5a29d83d3f478e8d3d972653b4879c
Requested by: @pyramation