### PR TITLE
feat: propagate request_id through pgSettings and metering context

### DIFF
--- a/graphile/graphile-llm/src/metering.ts
+++ b/graphile/graphile-llm/src/metering.ts
@@ -41,6 +41,8 @@ export interface MeteringContext {
   billing: BillingConfig;
   /** Entity ID to meter against (from JWT claims) */
   entityId: string;
+  /** Per-request correlation ID (from request.id pgSetting) */
+  requestId: string | null;
 }
 
 export interface MeteringOptions {
@@ -185,6 +187,7 @@ export async function meteredEmbed(
   // Record actual usage (input_chars as the metered amount)
   ctx.withPgClient(ctx.pgSettings, async (pgClient) => {
     await recordUsage(pgClient, ctx.billing, ctx.entityId, meterSlug, text.length, {
+      request_id: ctx.requestId,
       input_chars: text.length,
       dims: result.length,
       latency_ms: latencyMs,
@@ -271,6 +274,7 @@ export async function meteredChat(
   const inputChars = messages.reduce((sum, m) => sum + m.content.length, 0);
   ctx.withPgClient(ctx.pgSettings, async (pgClient) => {
     await recordUsage(pgClient, ctx.billing, ctx.entityId, meterSlug, inputChars + result.length, {
+      request_id: ctx.requestId,
       input_chars: inputChars,
       output_chars: result.length,
       messages_count: messages.length,

--- a/graphile/graphile-llm/src/plugins/metering-plugin.ts
+++ b/graphile/graphile-llm/src/plugins/metering-plugin.ts
@@ -66,6 +66,7 @@ async function buildMeteringContext(
   const pgSettings: Record<string, string> = graphqlContext?.pgSettings ?? {};
   const entityId = resolveEntityId(pgSettings);
   const databaseId = pgSettings['jwt.claims.database_id'] ?? null;
+  const requestId = pgSettings['request.id'] ?? null;
   if (!entityId || !databaseId) return null;
 
   const withPgClient: WithPgClient | undefined = graphqlContext?.withPgClient;
@@ -88,6 +89,7 @@ async function buildMeteringContext(
     pgSettings,
     billing: billingConfig,
     entityId,
+    requestId,
   };
 }
 

--- a/graphql/server/src/middleware/graphile.ts
+++ b/graphql/server/src/middleware/graphile.ts
@@ -275,15 +275,24 @@ const buildPreset = (
             pgSettings['default_transaction_read_only'] = 'on';
           }
 
+          if (req.requestId) {
+            pgSettings['request.id'] = req.requestId;
+          }
+
           return { pgSettings };
         }
       }
 
+      const anonSettings: Record<string, string> = {
+        role: anonRole,
+        ...context,
+      };
+      if (req?.requestId) {
+        anonSettings['request.id'] = req.requestId;
+      }
+
       return {
-        pgSettings: {
-          role: anonRole,
-          ...context,
-        },
+        pgSettings: anonSettings,
       };
     },
   },

--- a/graphql/server/src/middleware/llm-api.ts
+++ b/graphql/server/src/middleware/llm-api.ts
@@ -114,6 +114,9 @@ function getPgSettings(req: Request): Record<string, string> {
   if (req.databaseId) {
     settings['jwt.claims.database_id'] = req.databaseId;
   }
+  if (req.requestId) {
+    settings['request.id'] = req.requestId;
+  }
 
   return settings;
 }


### PR DESCRIPTION
## Summary

Propagates the per-request `request_id` (already generated by `request-logger.ts` middleware via `X-Request-Id` header or `crypto.randomUUID()`) into PostgreSQL session settings and the LLM metering pipeline.

**Changes:**
- `graphile.ts`: adds `request.id` to pgSettings for both authenticated and anonymous GraphQL requests
- `llm-api.ts`: adds `request.id` to `getPgSettings()` for REST LLM endpoints
- `metering.ts`: adds `requestId` to `MeteringContext` interface; includes `request_id` in `record_usage()` billing metadata for both embed and chat operations
- `metering-plugin.ts`: extracts `request.id` from pgSettings into the metering context

After this change, `request.id` is available in SQL via `current_setting('request.id', true)` — enabling distributed tracing and correlation across Express → GraphQL → billing → inference log layers.

Companion PR: constructive-io/constructive-db#1276 (adds `request_id uuid` column to `inference_log_module`)

## Review & Testing Checklist for Human

- [ ] Verify `request.id` appears in pgSettings during a real GraphQL request (check via `current_setting('request.id', true)` in a PG function or trigger)
- [ ] Confirm billing `record_usage` metadata includes `request_id` — check the billing ledger jsonb after an LLM call

### Notes

No new dependencies. The `request_id` generation already existed in `request-logger.ts` — this PR just wires it through to pgSettings and metering. The `request.id` pgSetting is the standard Constructive convention (matching `jwt.claims.*` pattern).

Link to Devin session: https://app.devin.ai/sessions/2b5a29d83d3f478e8d3d972653b4879c
Requested by: @pyramation