### PR TITLE
feat(node-type-registry): sync latest from constructive-db

### DIFF
--- a/packages/node-type-registry/src/blueprint-types.generated.ts
+++ b/packages/node-type-registry/src/blueprint-types.generated.ts
@@ -514,6 +514,17 @@ export interface JobTriggerParams {
   conditions?: TriggerCondition | TriggerCondition[];
   /* For UPDATE triggers, only fire when these fields change (uses DISTINCT FROM) */
   watch_fields?: string[];
+  /* Column on the trigger table that holds (or references) the entity_id for billing scope */
+  entity_field?: string;
+  /* FK lookup configuration for resolving entity_id through a related table */
+  entity_lookup?: {
+    /* Name of the related table to look up entity_id from */
+    obj_table: string;
+    /* Schema of the related table (optional — resolved by table name if omitted) */
+    obj_schema?: string;
+    /* Column on the related table that holds the entity_id */
+    obj_field: string;
+  };
   /* Static job key for upsert semantics (prevents duplicate jobs) */
   job_key?: string;
   /* Job queue name for routing to specific workers */
@@ -549,6 +560,16 @@ export interface ProcessChunksParams {
   chunks_table_name?: string;
   /* Field names from the parent table to copy into chunk metadata */
   metadata_fields?: string[];
+  /* Text search indexes to create on the chunks content column */
+  search_indexes?: ('fulltext' | 'bm25' | 'trigram')[];
+  /* Column on the parent table that holds (or references) the entity_id for billing scope */
+  entity_field?: string;
+  /* FK lookup configuration for resolving entity_id through a related table */
+  entity_lookup?: {
+    obj_table: string;
+    obj_schema?: string;
+    obj_field: string;
+  };
   /* Whether to create a job trigger that auto-enqueues chunking on parent INSERT/UPDATE */
   enqueue_chunking_job?: boolean;
   /* Task identifier for the chunking job queue */
@@ -580,6 +601,14 @@ export interface ProcessFileEmbeddingParams {
   };
   /* Additional compound conditions beyond MIME filtering. Merged with the auto-generated MIME conditions via AND. Use this to add status checks, field guards, etc. */
   trigger_conditions?: TriggerCondition | TriggerCondition[];
+  /* Column on the trigger table that holds (or references) the entity_id for billing scope */
+  entity_field?: string;
+  /* FK lookup configuration for resolving entity_id through a related table */
+  entity_lookup?: {
+    obj_table: string;
+    obj_schema?: string;
+    obj_field: string;
+  };
   /* Text extraction configuration. When present, the generator creates extraction output fields on the table and configures SearchVector with source_fields + stale tracking. When absent, the node operates in direct mode (single vector per file, no text extraction). */
   extraction?: {
     /* Field to store extracted text/markdown */text_field?: string;
@@ -624,6 +653,14 @@ export interface ProcessImageEmbeddingParams {
   };
   /* Additional compound conditions beyond MIME filtering. Merged with the auto-generated MIME conditions via AND. */
   trigger_conditions?: TriggerCondition | TriggerCondition[];
+  /* Column on the trigger table that holds (or references) the entity_id for billing scope */
+  entity_field?: string;
+  /* FK lookup configuration for resolving entity_id through a related table */
+  entity_lookup?: {
+    obj_table: string;
+    obj_schema?: string;
+    obj_field: string;
+  };
   /* Text extraction configuration. Forwarded to ProcessFileEmbedding. When present, enables extract mode (e.g., OCR for images). */
   extraction?: {
     /* Field to store extracted text */text_field?: string;
@@ -660,6 +697,14 @@ export interface ProcessExtractionParams {
   };
   /* Additional compound conditions beyond MIME filtering. Merged with the auto-generated MIME conditions via AND. Use this to add status checks (e.g., status = 'uploaded'). */
   trigger_conditions?: TriggerCondition | TriggerCondition[];
+  /* Column on the trigger table that holds (or references) the entity_id for billing scope */
+  entity_field?: string;
+  /* FK lookup configuration for resolving entity_id through a related table */
+  entity_lookup?: {
+    obj_table: string;
+    obj_schema?: string;
+    obj_field: string;
+  };
   /* Job queue name for extraction tasks */
   queue_name?: string;
   /* Maximum number of retry attempts */
@@ -690,6 +735,14 @@ export interface ProcessImageVersionsParams {
   };
   /* Additional compound conditions beyond MIME filtering. Merged with the auto-generated MIME conditions via AND. */
   trigger_conditions?: TriggerCondition | TriggerCondition[];
+  /* Column on the trigger table that holds (or references) the entity_id for billing scope */
+  entity_field?: string;
+  /* FK lookup configuration for resolving entity_id through a related table */
+  entity_lookup?: {
+    obj_table: string;
+    obj_schema?: string;
+    obj_field: string;
+  };
   /* Job queue name for image processing tasks */
   queue_name?: string;
   /* Maximum number of retry attempts */

--- a/packages/node-type-registry/src/job/trigger.ts
+++ b/packages/node-type-registry/src/job/trigger.ts
@@ -69,6 +69,34 @@ export const JobTrigger: NodeTypeDefinition = {
         default: false
       },
       ...conditionProperties,
+      entity_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column on the trigger table that holds (or references) the entity_id for billing scope. For direct entity_id columns, just set this field. For FK lookups (e.g., channel_id → channels.entity_id), combine with entity_lookup.'
+      },
+      entity_lookup: {
+        type: 'object',
+        description: 'FK lookup configuration for resolving entity_id through a related table. Used when entity_field is a FK (e.g., channel_id) rather than a direct entity_id. The generator validates all fields against metaschema within the same database_id.',
+        properties: {
+          obj_table: {
+            type: 'string',
+            description: 'Name of the related table to look up entity_id from (e.g., "channels"). Required.'
+          },
+          obj_schema: {
+            type: 'string',
+            description: 'Schema of the related table (user-facing name, e.g., "public"). Optional — if omitted, resolved by table name within the same database_id (raises error if ambiguous).'
+          },
+          obj_field: {
+            type: 'string',
+            format: 'column-ref',
+            description: 'Column on the related table that holds the entity_id (e.g., "entity_id"). Required.'
+          }
+        },
+        required: [
+          'obj_table',
+          'obj_field'
+        ]
+      },
       job_key: {
         type: 'string',
         description: 'Static job key for upsert semantics (prevents duplicate jobs)'

--- a/packages/node-type-registry/src/module-presets/full.ts
+++ b/packages/node-type-registry/src/module-presets/full.ts
@@ -1,14 +1,14 @@
 import type { ModulePreset } from './types';
 
 /**
- * `full` — install everything. Equivalent to the default
- * `provision_database_modules(v_modules => ARRAY['all'])` behavior.
+ * `full` — install every standard module.
  *
  * This is the maximalist preset: every module Constructive ships, including
- * `storage_module` for file uploads and `crypto_addresses_module` for
- * wallet-based sign-in. Use it for greenfield apps where you'd rather
- * disable features via `app_settings_auth` toggles than uninstall modules,
- * or for the "kitchen sink" example / demo databases.
+ * `storage_module:full` for file uploads with all feature flags and
+ * `crypto_addresses_module` for wallet-based sign-in.
+ *
+ * Usage logging modules (compute_log, inference_log, transfer_log,
+ * storage_log, db_usage) are NOT included — they are opt-in only.
  *
  * Prefer a more targeted preset for anything production-bound — installing
  * a module you'll never use still costs tables, triggers, and grants.
@@ -16,26 +16,81 @@ import type { ModulePreset } from './types';
 export const PresetFull: ModulePreset = {
   name: 'full',
   display_name: 'Full (every module)',
-  summary: "Install every Constructive module. Equivalent to v_modules => ARRAY['all'].",
+  summary: 'Install every standard Constructive module with explicit module list.',
   description:
-    'Installs every module in the catalog: everything in `b2b` plus `storage_module` ' +
-    'for file uploads and `crypto_addresses_module` / `crypto_auth_module` for ' +
-    'wallet-based sign-in. This matches the current default when `provision_database_modules` ' +
-    'is called without an explicit `v_modules` argument. Use it for fully-featured ' +
-    'demo/example databases, kitchen-sink reference deployments, or greenfield apps that ' +
-    'would rather feature-flag at the app_settings level than uninstall modules.',
+    'Installs every standard module in the catalog: everything in `b2b` plus ' +
+    '`storage_module:full` for file uploads (versioning, content hash, custom keys, audit log), ' +
+    '`crypto_addresses_module` for wallet-based sign-in, `plans_module` and `billing_module` ' +
+    'for subscription management, `notifications_module` for in-app notifications, and ' +
+    '`events_module` at both app and org scopes. Usage logging modules are opt-in only — ' +
+    'add them explicitly if needed.',
   good_for: [
     'Reference / demo databases that showcase every Constructive feature',
     'Greenfield apps where the product scope is still open-ended',
-    'Keeping the provisioning call identical to the pre-preset default'
+    'Integration tests that need the full module stack'
   ],
   not_for: [
     'Production apps with a defined feature set — pick the narrowest preset that fits',
     'Resource-constrained environments — every module costs schema bloat, RLS policies, and grants'
   ],
-  modules: ['all'],
+  modules: [
+    // Core
+    'users_module',
+    'membership_types_module',
+    // App-level (membership_type = 1)
+    'permissions_module:app',
+    'limits_module:app',
+    'memberships_module:app',
+    'events_module:app',
+    'profiles_module:app',
+    // Org-level (membership_type = 2)
+    'permissions_module:org',
+    'limits_module:org',
+    'memberships_module:org',
+    'events_module:org',
+    'profiles_module:org',
+    // Hierarchy
+    'hierarchy_module:org',
+    // Billing & Plans
+    'plans_module',
+    'billing_module',
+    'rate_limit_meters_module',
+    'billing_provider_module',
+    // Auth infrastructure
+    'user_state_module',
+    'sessions_module',
+    'session_secrets_module',
+    'rate_limits_module',
+    'devices_module',
+    'config_secrets_user_module',
+    'rls_module',
+    // Contact modules
+    'emails_module',
+    'phone_numbers_module',
+    'crypto_addresses_module',
+    'webauthn_credentials_module',
+    'notifications_module',
+    // Connected accounts
+    'connected_accounts_module',
+    'identity_providers_module',
+    // Invites & Auth
+    'invites_module:app',
+    'invites_module:org',
+    'user_auth_module',
+    'webauthn_auth_module',
+    // Storage (full features)
+    'storage_module:full',
+  ],
   includes_notes: {
-    all: "Sentinel — the provisioner installs every known module when `modules = ['all']`."
+    'storage_module:full': 'All storage feature flags enabled: versioning, content hash, custom keys, audit log.',
+    billing_module: 'Metered billing with credits waterfall and period reset.',
+    plans_module: 'Subscription plan management with plan-governed caps.',
+    notifications_module: 'In-app notification system with read/unread tracking.'
+  },
+  omits_notes: {
+    compute_log_module: 'Usage logging is opt-in. Add explicitly if needed.',
+    inference_log_module: 'Usage logging is opt-in. Add explicitly if needed.',
+    agent_chat_module: 'Agent infrastructure is opt-in.'
   },
   extends: ['b2b']
 };

--- a/packages/node-type-registry/src/process/chunks.ts
+++ b/packages/node-type-registry/src/process/chunks.ts
@@ -109,6 +109,23 @@ export const ProcessChunks: NodeTypeDefinition = {
           'Set explicitly to override (e.g. ["fulltext", "bm25"]).'
       },
 
+      // ── Entity billing scope ──────────────────────────────────────
+      entity_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column on the parent table that holds (or references) the entity_id for billing scope. Forwarded to the chunking job trigger.'
+      },
+      entity_lookup: {
+        type: 'object',
+        description: 'FK lookup configuration for resolving entity_id through a related table. Forwarded to the chunking job trigger.',
+        properties: {
+          obj_table: { type: 'string', description: 'Name of the related table to look up entity_id from' },
+          obj_schema: { type: 'string', description: 'Schema of the related table (user-facing name, optional)' },
+          obj_field: { type: 'string', format: 'column-ref', description: 'Column on the related table that holds the entity_id' }
+        },
+        required: ['obj_table', 'obj_field']
+      },
+
       // ── Job trigger ────────────────────────────────────────────────
       enqueue_chunking_job: {
         type: 'boolean',

--- a/packages/node-type-registry/src/process/extraction.ts
+++ b/packages/node-type-registry/src/process/extraction.ts
@@ -93,6 +93,23 @@ export const ProcessExtraction: NodeTypeDefinition = {
       },
       trigger_conditions: triggerConditionsProperty,
 
+      // ── Entity billing scope ──────────────────────────────────────
+      entity_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column on the trigger table that holds (or references) the entity_id for billing scope. Forwarded to the composed JobTrigger.'
+      },
+      entity_lookup: {
+        type: 'object',
+        description: 'FK lookup configuration for resolving entity_id through a related table. Forwarded to the composed JobTrigger.',
+        properties: {
+          obj_table: { type: 'string', description: 'Name of the related table to look up entity_id from' },
+          obj_schema: { type: 'string', description: 'Schema of the related table (user-facing name, optional)' },
+          obj_field: { type: 'string', format: 'column-ref', description: 'Column on the related table that holds the entity_id' }
+        },
+        required: ['obj_table', 'obj_field']
+      },
+
       // ── Job options ───────────────────────────────────────────────
       queue_name: {
         type: 'string',

--- a/packages/node-type-registry/src/process/file-embedding.ts
+++ b/packages/node-type-registry/src/process/file-embedding.ts
@@ -101,6 +101,23 @@ export const ProcessFileEmbedding: NodeTypeDefinition = {
       },
       trigger_conditions: triggerConditionsProperty,
 
+      // ── Entity billing scope ──────────────────────────────────────
+      entity_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column on the trigger table that holds (or references) the entity_id for billing scope. Forwarded to the composed JobTrigger.'
+      },
+      entity_lookup: {
+        type: 'object',
+        description: 'FK lookup configuration for resolving entity_id through a related table. Forwarded to the composed JobTrigger.',
+        properties: {
+          obj_table: { type: 'string', description: 'Name of the related table to look up entity_id from' },
+          obj_schema: { type: 'string', description: 'Schema of the related table (user-facing name, optional)' },
+          obj_field: { type: 'string', format: 'column-ref', description: 'Column on the related table that holds the entity_id' }
+        },
+        required: ['obj_table', 'obj_field']
+      },
+
       // ── Extraction config (optional — enables extract mode) ────────
       extraction: {
         type: 'object',

--- a/packages/node-type-registry/src/process/image-embedding.ts
+++ b/packages/node-type-registry/src/process/image-embedding.ts
@@ -107,6 +107,23 @@ export const ProcessImageEmbedding: NodeTypeDefinition = {
       },
       trigger_conditions: triggerConditionsProperty,
 
+      // ── Entity billing scope ──────────────────────────────────────
+      entity_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column on the trigger table that holds (or references) the entity_id for billing scope. Forwarded to the composed JobTrigger.'
+      },
+      entity_lookup: {
+        type: 'object',
+        description: 'FK lookup configuration for resolving entity_id through a related table. Forwarded to the composed JobTrigger.',
+        properties: {
+          obj_table: { type: 'string', description: 'Name of the related table to look up entity_id from' },
+          obj_schema: { type: 'string', description: 'Schema of the related table (user-facing name, optional)' },
+          obj_field: { type: 'string', format: 'column-ref', description: 'Column on the related table that holds the entity_id' }
+        },
+        required: ['obj_table', 'obj_field']
+      },
+
       // ── Extraction config (optional — enables extract mode) ────────
       extraction: {
         type: 'object',

--- a/packages/node-type-registry/src/process/image-versions.ts
+++ b/packages/node-type-registry/src/process/image-versions.ts
@@ -109,6 +109,23 @@ export const ProcessImageVersions: NodeTypeDefinition = {
       },
       trigger_conditions: triggerConditionsProperty,
 
+      // ── Entity billing scope ──────────────────────────────────────
+      entity_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column on the trigger table that holds (or references) the entity_id for billing scope. Forwarded to the composed JobTrigger.'
+      },
+      entity_lookup: {
+        type: 'object',
+        description: 'FK lookup configuration for resolving entity_id through a related table. Forwarded to the composed JobTrigger.',
+        properties: {
+          obj_table: { type: 'string', description: 'Name of the related table to look up entity_id from' },
+          obj_schema: { type: 'string', description: 'Schema of the related table (user-facing name, optional)' },
+          obj_field: { type: 'string', format: 'column-ref', description: 'Column on the related table that holds the entity_id' }
+        },
+        required: ['obj_table', 'obj_field']
+      },
+
       // ── Job options ───────────────────────────────────────────────
       queue_name: {
         type: 'string',


### PR DESCRIPTION
## Summary

Syncs the `node-type-registry` package from `constructive-db` (source of truth) to prepare for publish.

Changes from upstream:
- **JobTrigger**: Add `entity_field` + `entity_lookup` parameters for billing scope resolution (direct entity_id columns or FK lookups through related tables)
- **Process generators** (chunks, extraction, file-embedding, image-embedding, image-versions): Forward `entity_field` + `entity_lookup` to composed JobTrigger
- **Full module preset**: Refactored from `['all']` sentinel to explicit module list — documents exactly which modules are installed and adds notes about opt-in usage logging modules
- **blueprint-types.generated.ts**: Regenerated to include new fields

## Review & Testing Checklist for Human

- [ ] Verify the `full` module preset explicit list matches expectations (previously used `['all']` sentinel, now enumerates each module)
- [ ] Confirm `entity_field`/`entity_lookup` parameter schemas are consistent across all Process types and JobTrigger
- [ ] Run `pnpm build` in `packages/node-type-registry` to confirm TypeScript compilation

### Notes

The `generate.ts` file in constructive-db is intentionally not synced — it's a SQL fixture generator specific to constructive-db's deployment pipeline.

Link to Devin session: https://app.devin.ai/sessions/5d8e5719a4534178b43fe8351da30b91
Requested by: @pyramation