### PR TITLE
docs: add logo and badges to agentic-server README

### DIFF
--- a/packages/agentic-server/README.md
+++ b/packages/agentic-server/README.md
@@ -1,5 +1,17 @@
 # agentic-server
 
+<p align="center" width="100%">
+  <img height="250" src="https://raw.githubusercontent.com/constructive-io/constructive/refs/heads/main/assets/outline-logo.svg" />
+</p>
+
+<p align="center" width="100%">
+  <a href="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml">
+    <img height="20" src="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml/badge.svg" />
+  </a>
+   <a href="https://github.com/constructive-io/constructive/blob/main/LICENSE"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
+   <a href="https://www.npmjs.com/package/agentic-server"><img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/constructive?filename=packages%2Fagentic-server%2Fpackage.json"/></a>
+</p>
+
 Standalone Express LLM service — agent threads, chat streaming, billing metering, and inference logging via `@constructive-io/express-context`.
 
 ## Overview


### PR DESCRIPTION
## Summary

Adds the centered Constructive logo, CI badge, license badge, and npm version badge to the `agentic-server` README — matching the style of other packages (`packages/cli`, `graphql/codegen`, etc.).

## Review & Testing Checklist for Human

- [ ] Verify the npm badge URL resolves correctly once the package is published (uses bare `agentic-server` package name)

### Notes

Cosmetic-only change — no code modifications.

Link to Devin session: https://app.devin.ai/sessions/2b5a29d83d3f478e8d3d972653b4879c
Requested by: @pyramation