### PR TITLE
feat(node-type-registry): add AuthzMemberOwner + DataMemberOwner types

### DIFF
--- a/packages/node-type-registry/src/authz/authz-member-owner.ts
+++ b/packages/node-type-registry/src/authz/authz-member-owner.ts
@@ -1,0 +1,50 @@
+import type { NodeTypeDefinition } from '../types';
+
+export const AuthzMemberOwner: NodeTypeDefinition = {
+  name: 'AuthzMemberOwner',
+  slug: 'authz_member_owner',
+  category: 'authz',
+  display_name: 'Member Owner',
+  description: 'Compound policy: the row must be owned by the current user (owner_field = current_user_id) AND the current user must be a member of the entity referenced by entity_field. Combines direct ownership with entity membership — the actor can only access rows they own within entities they belong to.',
+  parameter_schema: {
+    type: 'object',
+    properties: {
+      owner_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column name containing the owner user ID (e.g., owner_id)',
+        default: 'owner_id'
+      },
+      entity_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column name referencing the entity (e.g., entity_id)',
+        default: 'entity_id'
+      },
+      sel_field: {
+        type: 'string',
+        description: 'SPRT column to select for the entity match',
+        default: 'entity_id'
+      },
+      membership_type: {
+        type: ['integer', 'string'],
+        description: 'Scope: 1=app, 2=org, 3+=dynamic entity types (or string name resolved via membership_types_module)'
+      },
+      entity_type: {
+        type: 'string',
+        description: "Entity type prefix (e.g. 'channel', 'department'). Resolved to membership_type integer via memberships_module lookup."
+      },
+      permission: {
+        type: 'string',
+        description: 'Single permission name to check (resolved to bitstring mask)'
+      },
+      permissions: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Multiple permission names to check (ORed together into mask)'
+      }
+    },
+    required: ['owner_field', 'entity_field']
+  },
+  tags: ['ownership', 'membership', 'authz']
+};

--- a/packages/node-type-registry/src/authz/index.ts
+++ b/packages/node-type-registry/src/authz/index.ts
@@ -7,6 +7,7 @@ export { AuthzDirectOwner } from './authz-direct-owner';
 export { AuthzDirectOwnerAny } from './authz-direct-owner-any';
 export { AuthzEntityMembership } from './authz-entity-membership';
 export { AuthzMemberList } from './authz-member-list';
+export { AuthzMemberOwner } from './authz-member-owner';
 export { AuthzNotReadOnly } from './authz-not-read-only';
 export { AuthzOrgHierarchy } from './authz-org-hierarchy';
 export { AuthzPeerOwnership } from './authz-peer-ownership';

--- a/packages/node-type-registry/src/data/data-member-owner.ts
+++ b/packages/node-type-registry/src/data/data-member-owner.ts
@@ -1,0 +1,52 @@
+import type { NodeTypeDefinition } from '../types';
+
+export const DataMemberOwner: NodeTypeDefinition = {
+  name: 'DataMemberOwner',
+  slug: 'data_member_owner',
+  category: 'data',
+  display_name: 'Member Owner',
+  description: 'Adds owner_id and entity_id columns with a compound AuthzMemberOwner policy. The actor must own the row (owner_id = current_user_id()) AND be a member of the entity (entity_id in SPRT). Use for private data within an entity scope — e.g., personal chat threads that belong to the company but only the author can see.',
+  parameter_schema: {
+    type: 'object',
+    properties: {
+      owner_field_name: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column name for the owner reference',
+        default: 'owner_id'
+      },
+      entity_field_name: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Column name for the entity reference',
+        default: 'entity_id'
+      },
+      include_id: {
+        type: 'boolean',
+        description: 'If true, also adds a UUID primary key column with auto-generation',
+        default: true
+      },
+      include_user_fk: {
+        type: 'boolean',
+        description: 'If true, adds foreign key constraints from owner_id and entity_id to the users table',
+        default: true
+      },
+      create_index: {
+        type: 'boolean',
+        description: 'If true, creates B-tree indexes on the owner and entity columns',
+        default: true
+      },
+      membership_type: {
+        type: 'integer',
+        description: 'Membership type for SPRT resolution. Required for entity-scoped provisioning.',
+        default: null
+      }
+    }
+  },
+  tags: [
+    'ownership',
+    'membership',
+    'security',
+    'schema'
+  ]
+};

--- a/packages/node-type-registry/src/data/index.ts
+++ b/packages/node-type-registry/src/data/index.ts
@@ -12,6 +12,7 @@ export { DataImmutableFields } from './data-immutable-fields';
 export { DataInflection } from './data-inflection';
 export { DataInheritFromParent } from './data-inherit-from-parent';
 export { DataJsonb } from './data-jsonb';
+export { DataMemberOwner } from './data-member-owner';
 export { DataOwnedFields } from './data-owned-fields';
 export { DataOwnershipInEntity } from './data-ownership-in-entity';
 export { DataPeoplestamps } from './data-peoplestamps';


### PR DESCRIPTION
## Summary

Upstream two new node types from constructive-db PR #1327 into the shared `node-type-registry` package:

**`AuthzMemberOwner`** — Compound authorization policy requiring BOTH:
- Row ownership (`owner_field = current_user_id()`)
- Entity membership (`entity_field` in the user's SPRT for that entity)

Used for private data within an entity scope (e.g., personal chat threads that only the author can see, but scoped within an entity they belong to).

**`DataMemberOwner`** — Compound data node that creates:
- `owner_id` column (FK to users, auto-set to current_user_id)
- `entity_id` column (FK to entity table)
- B-tree indexes on both columns
- `AuthzMemberOwner` policy applied automatically

Blueprint usage becomes a one-liner:
```json
{ "nodeType": "DataMemberOwner", "data": { "membership_type": 3 } }
```

## Review & Testing Checklist for Human

- [ ] Verify the `parameter_schema` for both types matches what constructive-db expects (owner_field, entity_field, membership_type, etc.)
- [ ] Build passes: `cd packages/node-type-registry && pnpm build`

### Notes

- These types are already deployed and tested in constructive-db (PR #1327, merged, all 28 CI checks passing)
- The SQL-level implementation (AST builder `cpt_member_owner`, RLS parser dispatch, validator) lives in constructive-db's metaschema package
- This PR only adds the TypeScript type definitions to the shared registry

Link to Devin session: https://app.devin.ai/sessions/8820b639fbd94ac8bfae86cfb01cf827
Requested by: @pyramation