### PR TITLE
fix(export): change field.type from text to jsonb in META_TABLE_CONFIG

### DIFF
--- a/pgpm/export/src/export-utils.ts
+++ b/pgpm/export/src/export-utils.ts
@@ -286,7 +286,7 @@ export const META_TABLE_CONFIG: Record<string, TableConfig> = {
       database_id: 'uuid',
       table_id: 'uuid',
       name: 'text',
-      type: 'text',
+      type: 'jsonb',
       description: 'text'
     }
   },


### PR DESCRIPTION
## Summary

`metaschema_public.field.type` is now a `jsonb` column (FieldType objects like `{"name":"uuid"}`). The `META_TABLE_CONFIG` in `@pgpmjs/export` still had `type: 'text'` for this column, which caused csv-to-pg's text coercion handler to call `String()` on JS objects — producing `[object Object]` in generated SQL INSERT statements.

One-line fix: `type: 'text'` → `type: 'jsonb'` in the field table config.

**Root cause:** The old patch (`patches/@pgpmjs__export@0.19.0.patch`) in constructive-db applied this fix, but it was never upstreamed into the source. When `@pgpmjs/export` was bumped to `0.19.1`, the patch became stale and was removed, exposing the bug.

## Review & Testing Checklist for Human

- [ ] After publishing, re-run the constructive-db dep update workflow — the `generate` CI job should produce valid JSON strings instead of `[object Object]` for field type values
- [ ] Verify the generated `migrate/field` SQL has proper JSON like `'{"name":"uuid"}'` instead of `'[object Object]'`

### Notes

Blocks [constructive-db#1405](https://github.com/constructive-io/constructive-db/pull/1405) — once this is published, that PR's CI should pass.

Link to Devin session: https://app.devin.ai/sessions/f9a05fd1f300470e8f6a398ebb59ecb4
Requested by: @pyramation