### PR TITLE
fix: update storage plugins to use scope instead of membershipType

### DIFF
--- a/graphile/graphile-bucket-provisioner-plugin/src/plugin.ts
+++ b/graphile/graphile-bucket-provisioner-plugin/src/plugin.ts
@@ -51,12 +51,12 @@ const log = new Logger('graphile-bucket-provisioner:plugin');
 // --- Storage module queries ---
 
 /**
- * Resolve the app-level storage module (membership_type IS NULL).
+ * Resolve the app-level storage module (scope = 'app').
  */
 const APP_STORAGE_MODULE_QUERY = `
   SELECT
     sm.id,
-    sm.membership_type,
+    sm.scope,
     sm.entity_table_id,
     bs.schema_name AS buckets_schema,
     bt.name AS buckets_table,
@@ -68,7 +68,7 @@ const APP_STORAGE_MODULE_QUERY = `
   JOIN metaschema_public.table bt ON bt.id = sm.buckets_table_id
   JOIN metaschema_public.schema bs ON bs.id = bt.schema_id
   WHERE sm.database_id = $1
-    AND sm.membership_type IS NULL
+    AND sm.scope = 'app'
   LIMIT 1
 `;
 
@@ -78,7 +78,7 @@ const APP_STORAGE_MODULE_QUERY = `
 const ALL_STORAGE_MODULES_QUERY = `
   SELECT
     sm.id,
-    sm.membership_type,
+    sm.scope,
     sm.entity_table_id,
     bs.schema_name AS buckets_schema,
     bt.name AS buckets_table,
@@ -98,7 +98,7 @@ const ALL_STORAGE_MODULES_QUERY = `
 
 interface StorageModuleRow {
   id: string;
-  membership_type: number | null;
+  scope: string;
   entity_table_id: string | null;
   buckets_schema: string;
   buckets_table: string;
@@ -426,7 +426,7 @@ export function createBucketProvisionerPlugin(
               }
 
               // Look up the bucket row (RLS enforced via pgSettings)
-              const hasOwner = ownerId && storageModule.membership_type !== null;
+              const hasOwner = ownerId && storageModule.scope !== 'app';
               const bucketsTable = QuoteUtils.quoteQualifiedIdentifier(storageModule.buckets_schema, storageModule.buckets_table);
               const bucketResult = await pgClient.query(
                 hasOwner

--- a/graphile/graphile-presigned-url-plugin/src/plugin.ts
+++ b/graphile/graphile-presigned-url-plugin/src/plugin.ts
@@ -692,7 +692,7 @@ async function processSingleFile(
   const derivedPath = isCustomKey && storageConfig.hasPathShares ? derivePathFromKey(s3Key) : null;
 
   // Create file record
-  const hasOwnerColumn = storageConfig.membershipType !== null;
+  const hasOwnerColumn = storageConfig.scope !== 'app';
   const columns = ['bucket_id', 'key', 'content_hash', 'mime_type', 'size', 'filename', 'is_public'];
   const values: any[] = [bucket.id, s3Key, contentHash, contentType, size, filename || null, bucket.is_public];
 

--- a/graphile/graphile-presigned-url-plugin/src/storage-module-cache.ts
+++ b/graphile/graphile-presigned-url-plugin/src/storage-module-cache.ts
@@ -149,7 +149,7 @@ function buildConfig(row: StorageModuleRow): StorageModuleConfig {
     schemaName: row.buckets_schema,
     bucketsTableName: row.buckets_table,
     filesTableName: row.files_table,
-    membershipType: row.scope === 'app' ? null : row.scope,
+    scope: row.scope,
     entityTableId: row.entity_table_id,
     entityQualifiedName: row.entity_schema && row.entity_table
       ? QuoteUtils.quoteQualifiedIdentifier(row.entity_schema, row.entity_table)
@@ -249,11 +249,9 @@ export async function getStorageModuleConfigForOwner(
     const result = await pgClient.query({ text: ALL_STORAGE_MODULES_QUERY, values: [databaseId] });
     allConfigs = (result.rows as StorageModuleRow[]).map(buildConfig);
 
-    // Cache each individual config by its membership type
+    // Cache each individual config by its scope
     for (const config of allConfigs) {
-      const key = config.membershipType === null
-        ? `storage:${databaseId}:app`
-        : `storage:${databaseId}:mt:${config.membershipType}`;
+      const key = `storage:${databaseId}:scope:${config.scope}`;
       storageModuleCache.set(key, config);
     }
   }
@@ -271,7 +269,7 @@ export async function getStorageModuleConfigForOwner(
       storageModuleCache.set(ownerCacheKey, mod);
       log.debug(
         `Resolved ownerId ${ownerId} to storage module ${mod.id} ` +
-        `(membershipType=${mod.membershipType}, table=${mod.bucketsQualifiedName})`,
+        `(scope=${mod.scope}, table=${mod.bucketsQualifiedName})`,
       );
       return mod;
     }
@@ -341,11 +339,9 @@ export async function loadAllStorageModules(
   const result = await pgClient.query({ text: ALL_STORAGE_MODULES_QUERY, values: [databaseId] });
   const configs = (result.rows as StorageModuleRow[]).map(buildConfig);
 
-  // Cache each individual config by its membership type
+  // Cache each individual config by its scope
   for (const config of configs) {
-    const key = config.membershipType === null
-      ? `storage:${databaseId}:app`
-      : `storage:${databaseId}:mt:${config.membershipType}`;
+    const key = `storage:${databaseId}:scope:${config.scope}`;
     storageModuleCache.set(key, config);
   }
 
@@ -433,14 +429,15 @@ export async function getBucketConfig(
 
   // Entity-scoped buckets use (owner_id, key) composite lookup;
   // app-level buckets just use key.
-  const hasOwner = ownerId && storageConfig.membershipType !== null;
+  const isEntityScoped = storageConfig.scope !== 'app';
+  const hasOwner = ownerId && isEntityScoped;
   const result = await pgClient.query({
     text: hasOwner
       ? `SELECT id, key, type, is_public, owner_id, allowed_mime_types, max_file_size, allow_custom_keys
          FROM ${storageConfig.bucketsQualifiedName}
          WHERE key = $1 AND owner_id = $2
          LIMIT 1`
-      : `SELECT id, key, type, is_public, ${storageConfig.membershipType !== null ? 'owner_id,' : ''} allowed_mime_types, max_file_size, allow_custom_keys
+      : `SELECT id, key, type, is_public, ${isEntityScoped ? 'owner_id,' : ''} allowed_mime_types, max_file_size, allow_custom_keys
          FROM ${storageConfig.bucketsQualifiedName}
          WHERE key = $1
          LIMIT 1`,
@@ -474,7 +471,7 @@ export async function getBucketConfig(
   };
 
   bucketCache.set(cacheKey, config);
-  log.debug(`Cached bucket config for ${databaseId}:${bucketKey} (id=${config.id}, scope=${storageConfig.membershipType ?? 'app'})`);
+  log.debug(`Cached bucket config for ${databaseId}:${bucketKey} (id=${config.id}, scope=${storageConfig.scope})`);
 
   return config;
 }

--- a/graphile/graphile-presigned-url-plugin/src/storage-module-cache.ts
+++ b/graphile/graphile-presigned-url-plugin/src/storage-module-cache.ts
@@ -37,14 +37,14 @@ const storageModuleCache = new LRUCache<string, StorageModuleConfig>({
  * SQL query to resolve the app-level storage module config for a database.
  *
  * Joins storage_module → table → schema to get fully-qualified table names.
- * Filters to app-level (membership_type IS NULL) by default.
+ * Filters to app-level (scope = 'app') by default.
  *
- * Requires the multi-scope schema (membership_type column on storage_module).
+ * Requires the multi-scope schema (scope column on storage_module).
  */
 const APP_STORAGE_MODULE_QUERY = `
   SELECT
     sm.id,
-    sm.membership_type,
+    sm.scope,
     sm.entity_table_id,
     bs.schema_name AS buckets_schema,
     bt.name AS buckets_table,
@@ -70,7 +70,7 @@ const APP_STORAGE_MODULE_QUERY = `
   JOIN metaschema_public.table ft ON ft.id = sm.files_table_id
   JOIN metaschema_public.schema fs ON fs.id = ft.schema_id
   WHERE sm.database_id = $1
-    AND sm.membership_type IS NULL
+    AND sm.scope = 'app'
   LIMIT 1
 `;
 
@@ -83,7 +83,7 @@ const APP_STORAGE_MODULE_QUERY = `
 const ALL_STORAGE_MODULES_QUERY = `
   SELECT
     sm.id,
-    sm.membership_type,
+    sm.scope,
     sm.entity_table_id,
     bs.schema_name AS buckets_schema,
     bt.name AS buckets_table,
@@ -115,7 +115,7 @@ const ALL_STORAGE_MODULES_QUERY = `
 
 interface StorageModuleRow {
   id: string;
-  membership_type: number | null;
+  scope: string;
   entity_table_id: string | null;
   buckets_schema: string;
   buckets_table: string;
@@ -149,7 +149,7 @@ function buildConfig(row: StorageModuleRow): StorageModuleConfig {
     schemaName: row.buckets_schema,
     bucketsTableName: row.buckets_table,
     filesTableName: row.files_table,
-    membershipType: row.membership_type,
+    membershipType: row.scope === 'app' ? null : row.scope,
     entityTableId: row.entity_table_id,
     entityQualifiedName: row.entity_schema && row.entity_table
       ? QuoteUtils.quoteQualifiedIdentifier(row.entity_schema, row.entity_table)
@@ -173,7 +173,7 @@ function buildConfig(row: StorageModuleRow): StorageModuleConfig {
  * Resolve the app-level storage module config for a database, using the LRU cache.
  *
  * This is the default path when no ownerId is provided. It returns the
- * storage module with membership_type IS NULL (app-level / database-wide).
+ * storage module with scope = 'app' (app-level / database-wide).
  *
  * @param pgClient - A pg client from the Graphile context (withPgClient or pgClient)
  * @param databaseId - The metaschema database UUID

--- a/graphile/graphile-presigned-url-plugin/src/types.ts
+++ b/graphile/graphile-presigned-url-plugin/src/types.ts
@@ -33,8 +33,8 @@ export interface StorageModuleConfig {
 
   // --- Scope identity ---
 
-  /** Membership type (NULL for app-level, non-NULL for entity-scoped) */
-  membershipType: number | null;
+  /** Scope (null for app-level, scope string for entity-scoped) */
+  membershipType: string | null;
   /** Entity table ID for entity-scoped storage (NULL for app-level) */
   entityTableId: string | null;
   /** Qualified entity table name for ownerId lookups (NULL for app-level) */

--- a/graphile/graphile-presigned-url-plugin/src/types.ts
+++ b/graphile/graphile-presigned-url-plugin/src/types.ts
@@ -33,8 +33,8 @@ export interface StorageModuleConfig {
 
   // --- Scope identity ---
 
-  /** Scope (null for app-level, scope string for entity-scoped) */
-  membershipType: string | null;
+  /** Scope name (e.g., 'app', 'org', 'team') */
+  scope: string;
   /** Entity table ID for entity-scoped storage (NULL for app-level) */
   entityTableId: string | null;
   /** Qualified entity table name for ownerId lookups (NULL for app-level) */

--- a/graphql/server-test/__fixtures__/seed/simple-seed-storage/setup.sql
+++ b/graphql/server-test/__fixtures__/seed/simple-seed-storage/setup.sql
@@ -49,6 +49,8 @@ CREATE TABLE IF NOT EXISTS metaschema_modules_public.storage_module (
   files_table_id uuid NOT NULL DEFAULT uuid_nil(),
   buckets_table_name text NOT NULL DEFAULT 'app_buckets',
   files_table_name text NOT NULL DEFAULT 'app_files',
+  scope text NOT NULL DEFAULT 'app',
+  prefix text NOT NULL DEFAULT 'app',
   membership_type int DEFAULT NULL,
   entity_table_id uuid NULL,
   endpoint text NULL,
@@ -72,6 +74,6 @@ CREATE INDEX IF NOT EXISTS storage_module_database_id_idx
   ON metaschema_modules_public.storage_module (database_id);
 
 CREATE UNIQUE INDEX IF NOT EXISTS storage_module_unique_scope
-  ON metaschema_modules_public.storage_module (database_id, COALESCE(membership_type, -1));
+  ON metaschema_modules_public.storage_module (database_id, scope);
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON metaschema_modules_public.storage_module TO administrator, authenticated, anonymous;


### PR DESCRIPTION
## Summary

Updates the graphile storage plugins (`graphile-presigned-url-plugin` and `graphile-bucket-provisioner-plugin`) to use the new `scope` column on `storage_module` instead of the removed `membership_type` column.

**Changes:**

- **`StorageModuleConfig.membershipType: string | null`** → **`scope: string`** — no more null, just the scope string (`'app'`, `'org'`, etc.)
- All SQL queries: `sm.membership_type` → `sm.scope`, `WHERE membership_type IS NULL` → `WHERE scope = 'app'`
- All entity-scoped checks: `membershipType !== null` → `scope !== 'app'`
- Cache keys: `storage:{db}:mt:{type}` → `storage:{db}:scope:{scope}`
- Bucket provisioner: same pattern — `membership_type` → `scope` in all queries

Companion PR: https://github.com/constructive-io/constructive-db/pull/1415

## Review & Testing Checklist for Human

- [ ] Verify `scope !== 'app'` correctly identifies entity-scoped storage (replaces `membershipType !== null`)
- [ ] Verify bucket queries include `owner_id` column only for entity-scoped storage

### Notes

This is a breaking change — requires the constructive-db scope+prefix migration to be deployed first (the `storage_module` table must have the `scope` column instead of `membership_type`).

Link to Devin session: https://app.devin.ai/sessions/f60e6c4d6c1941b497fae2b064722ff3
Requested by: @pyramation