### PR TITLE
feat: add DataI18n node type definition

### DIFF
--- a/packages/node-type-registry/src/data/data-i18n.ts
+++ b/packages/node-type-registry/src/data/data-i18n.ts
@@ -1,0 +1,49 @@
+import type { NodeTypeDefinition } from '../types';
+
+export const DataI18n: NodeTypeDefinition = {
+  name: 'DataI18n',
+  slug: 'data_i18n',
+  category: 'data',
+  display_name: 'Internationalization',
+  description:
+    'Creates a companion _translations table with lang_code + translatable ' +
+    'fields. Copies SELECT policies and column-ref fields from the base ' +
+    'table. Adds @i18n smart comment so the Graphile i18n plugin discovers ' +
+    'it. Requires i18n_module to be provisioned for the database.',
+  parameter_schema: {
+    type: 'object',
+    properties: {
+      fields: {
+        type: 'array',
+        items: {
+          type: 'string',
+          format: 'column-ref'
+        },
+        description:
+          'Field names on the base table to make translatable. Each field ' +
+          'is duplicated on the translation table with the same type.'
+      },
+      table_suffix: {
+        type: 'string',
+        description: 'Suffix for the translation table name',
+        default: '_translations'
+      },
+      lang_code_type: {
+        type: 'string',
+        enum: ['citext', 'text'],
+        description: 'Type for the lang_code column',
+        default: 'citext'
+      },
+      copy_mutation_policies: {
+        type: 'boolean',
+        description:
+          'Whether to also copy INSERT/UPDATE/DELETE policies (not just ' +
+          'SELECT). Default true — translations should be editable by the ' +
+          'same users who can edit the base row.',
+        default: true
+      }
+    },
+    required: ['fields']
+  },
+  tags: ['i18n', 'translation', 'schema']
+};

--- a/packages/node-type-registry/src/data/index.ts
+++ b/packages/node-type-registry/src/data/index.ts
@@ -7,6 +7,7 @@ export { DataCompositeField } from './data-composite-field';
 export { DataDirectOwner } from './data-direct-owner';
 export { DataEntityMembership } from './data-entity-membership';
 export { DataForceCurrentUser } from './data-force-current-user';
+export { DataI18n } from './data-i18n';
 export { DataId } from './data-id';
 export { DataImmutableFields } from './data-immutable-fields';
 export { DataInflection } from './data-inflection';


### PR DESCRIPTION
## Summary

Adds `DataI18n` to the node-type-registry — a new blueprint node type that creates companion `_translations` tables for any blueprint table with inherited RLS policies.

**parameter_schema:**
```json
{
  "fields": ["name", "description"],       // column-ref[] — translatable fields
  "table_suffix": "_translations",          // default
  "lang_code_type": "citext",               // or "text"
  "copy_mutation_policies": true            // copy INSERT/UPDATE/DELETE policies from base table
}
```

This is the constructive repo half of the i18n module system. The companion PR in constructive-db implements the SQL generator (`data_i18n`), the `i18n_module` table/trigger/generator, and the `app_settings_i18n` singleton.

Relates to [constructive-planning#975](https://github.com/constructive-io/constructive-planning/issues/975).

Link to Devin session: https://app.devin.ai/sessions/243ba35035a849eba6ebe463d00c04c4
Requested by: @pyramation