### PR TITLE
chore(node-type-registry): remove includes_notes and omits_notes

### DIFF
--- a/packages/node-type-registry/src/module-presets/auth-email-magic.ts
+++ b/packages/node-type-registry/src/module-presets/auth-email-magic.ts
@@ -49,14 +49,5 @@ export const PresetAuthEmailMagic: ModulePreset = {
     'user_auth_module',
     'session_secrets_module'
   ],
-  includes_notes: {
-    session_secrets_module: 'Stores nonces for magic-link and email-OTP flows. Without it those procedures are not emitted.'
-  },
-  omits_notes: {
-    rate_limits_module: 'Same reasoning as `auth:email` — add later via `auth:hardened`.',
-    connected_accounts_module: 'No OAuth / SSO in this preset.',
-    webauthn_credentials_module: 'No passkeys — add `auth:passkey`.',
-    phone_numbers_module: 'No SMS — add `auth:hardened`.'
-  },
   extends: ['auth:email']
 };

--- a/packages/node-type-registry/src/module-presets/auth-email.ts
+++ b/packages/node-type-registry/src/module-presets/auth-email.ts
@@ -58,26 +58,5 @@ export const PresetAuthEmail: ModulePreset = {
     'emails_module',
     'rls_module',
     'user_auth_module'
-  ],
-  includes_notes: {
-    'memberships_module (app)': 'Required by `user_auth_module`: every user gets an app-level membership row at sign-up.',
-    membership_types_module: "Required by app-scoped memberships; defines the 'app' scope.",
-    'permissions_module (app)': 'Required by app-scoped memberships: NOT NULL FK to grants table.',
-    'limits_module (app)': 'Required by app-scoped memberships: NOT NULL FK to caps table.',
-    'levels_module (app)': 'Required by app-scoped memberships: NOT NULL FK to levels table.',
-    emails_module: 'Required by the `user_auth_module` insert trigger (`RAISE EXCEPTION REQUIRES emails_module`).',
-    user_credentials_module: 'Per-user bcrypt credential store for password hashing; referenced by `set_password`, `verify_password`, and reset flows.',
-    config_secrets_module: 'App-level PGP secrets + config; required for app_secrets_get.',
-    user_state_module: 'API-key storage (`create_api_key`, `revoke_api_key`, `my_api_keys`).'
-  },
-  omits_notes: {
-    rate_limits_module: 'Omitted intentionally; throttle_* helpers are null-safe and the auth procs compile without it. Add later via `auth:hardened`.',
-    connected_accounts_module: 'No OAuth / SSO in this preset — add `auth:sso`.',
-    identity_providers_module: 'No OAuth provider configs without connected_accounts.',
-    webauthn_credentials_module: 'No passkeys — add `auth:passkey`.',
-    phone_numbers_module: 'No SMS login — add `auth:hardened` or the SMS-only refactor path.',
-    'memberships_module (org)': 'No org/team structure — move to `b2b` when you need one.',
-    invites_module: 'Self-serve signup only.',
-    session_secrets_module: 'No magic-link / email-OTP nonces; add `auth:email+magic`.'
-  }
+  ]
 };

--- a/packages/node-type-registry/src/module-presets/auth-hardened.ts
+++ b/packages/node-type-registry/src/module-presets/auth-hardened.ts
@@ -53,21 +53,5 @@ export const PresetAuthHardened: ModulePreset = {
     'phone_numbers_module',
     'devices_module'
   ],
-  includes_notes: {
-    rate_limits_module: 'Throttling for sign-in, password reset, sign-up, and IP-based gates.',
-    connected_accounts_module: 'OAuth / SSO linkage.',
-    identity_providers_module: 'OAuth provider configs (required for `connected_accounts_module`).',
-    webauthn_credentials_module: 'Per-user passkey storage.',
-    webauthn_auth_module: 'Passkey challenge + assertion runtime.',
-    session_secrets_module: 'Nonces for magic links, email OTP, and WebAuthn challenges.',
-    phone_numbers_module: 'SMS sign-in / MFA support.',
-    devices_module: 'Device tracking and trusted-device MFA bypass.'
-  },
-  omits_notes: {
-    'memberships_module (org)': 'No orgs / teams — use `b2b` when you need multi-tenancy.',
-    invites_module: 'No invite flow — add via `b2b`.',
-    storage_module: 'Add separately if you need file uploads.',
-    crypto_addresses_module: 'Not a web3 preset; omit unless doing wallet sign-in.'
-  },
   extends: ['auth:email', 'auth:email+magic', 'auth:sso', 'auth:passkey']
 };

--- a/packages/node-type-registry/src/module-presets/auth-passkey.ts
+++ b/packages/node-type-registry/src/module-presets/auth-passkey.ts
@@ -49,15 +49,5 @@ export const PresetAuthPasskey: ModulePreset = {
     'webauthn_credentials_module',
     'webauthn_auth_module'
   ],
-  includes_notes: {
-    webauthn_credentials_module: 'Per-user WebAuthn credential storage. Without it, passkey registration does not compile.',
-    webauthn_auth_module: 'Runtime challenge + assertion flow.',
-    session_secrets_module: 'Challenge nonces for registration and assertion.'
-  },
-  omits_notes: {
-    rate_limits_module: 'Add via `auth:hardened` for production.',
-    connected_accounts_module: 'No OAuth / SSO — add via `auth:hardened`.',
-    phone_numbers_module: 'No SMS.'
-  },
   extends: ['auth:email']
 };

--- a/packages/node-type-registry/src/module-presets/auth-sso.ts
+++ b/packages/node-type-registry/src/module-presets/auth-sso.ts
@@ -57,16 +57,5 @@ export const PresetAuthSso: ModulePreset = {
     'connected_accounts_module',
     'identity_providers_module'
   ],
-  includes_notes: {
-    connected_accounts_module: 'Junction table for (user, provider, external_id). Without it, `sign_in_identity` does not compile.',
-    identity_providers_module: 'Provider config table (URLs, client_id, encrypted client_secret, scopes, PKCE knobs).',
-    config_secrets_module: 'Required by `auth:email` already; also used by SSO to decrypt the provider client_secret at auth time.'
-  },
-  omits_notes: {
-    webauthn_credentials_module: 'No passkeys — add `auth:passkey` or move to `auth:hardened`.',
-    rate_limits_module: 'Omitted; add via `auth:hardened` for production.',
-    session_secrets_module: "Not required for authorization-code OAuth; add if you also want magic-link flows. PKCE doesn't require it for stateless OAuth flows today.",
-    phone_numbers_module: 'No SMS in this preset.'
-  },
   extends: ['auth:email']
 };

--- a/packages/node-type-registry/src/module-presets/b2b-storage.ts
+++ b/packages/node-type-registry/src/module-presets/b2b-storage.ts
@@ -65,12 +65,5 @@ export const PresetB2bStorage: ModulePreset = {
     'storage_module',
     'devices_module'
   ],
-  includes_notes: {
-    storage_module: 'File upload infrastructure: app_buckets + app_files tables with RLS. Entity-type storage scopes layered on top via the `storage` array (array-only format, supports multiple modules per entity via storage_key).',
-    devices_module: 'Device tracking and trusted-device MFA bypass.'
-  },
-  omits_notes: {
-    crypto_addresses_module: 'Not a web3 preset.'
-  },
   extends: ['b2b']
 };

--- a/packages/node-type-registry/src/module-presets/b2b.ts
+++ b/packages/node-type-registry/src/module-presets/b2b.ts
@@ -66,24 +66,5 @@ export const PresetB2b: ModulePreset = {
     ['invites_module', { scope: 'org' }],
     'devices_module'
   ],
-  includes_notes: {
-    'memberships_module (org)': 'Org-scoped membership rows — every user in an org gets one.',
-    'permissions_module (app)': 'App-wide permission grants (e.g. platform admins).',
-    'permissions_module (org)': 'Org-scoped permission grants (per-workspace admins, members, viewers, ...).',
-    'limits_module (app)': 'App-level quotas (e.g. max users per plan).',
-    'limits_module (org)': 'Org-level quotas (e.g. per-workspace API call caps).',
-    'levels_module (app)': 'Role/level bundles at the app scope.',
-    'levels_module (org)': 'Role/level bundles at the org scope (admin / member / viewer, etc.).',
-    'profiles_module (app)': 'App-scoped user profile (one per user).',
-    'profiles_module (org)': 'Org-scoped user profile (per org a user belongs to).',
-    'hierarchy_module (org)': 'Nested org structures (parent / child orgs).',
-    'invites_module (app)': 'App-level invites (rare — usually platform admin adds another admin).',
-    'invites_module (org)': 'Org-level invites (the common case — invite a teammate into a workspace).',
-    devices_module: 'Device tracking and trusted-device MFA bypass.'
-  },
-  omits_notes: {
-    storage_module: 'Add separately if you need file uploads tied to orgs.',
-    crypto_addresses_module: 'Not a web3 preset.'
-  },
   extends: ['auth:hardened']
 };

--- a/packages/node-type-registry/src/module-presets/full.ts
+++ b/packages/node-type-registry/src/module-presets/full.ts
@@ -82,16 +82,5 @@ export const PresetFull: ModulePreset = {
     // Storage (full features)
     ['storage_module', { has_versioning: true, has_content_hash: true, has_custom_keys: true, has_audit_log: true }]
   ],
-  includes_notes: {
-    storage_module: 'All storage feature flags enabled: versioning, content hash, custom keys, audit log.',
-    billing_module: 'Metered billing with credits waterfall and period reset.',
-    plans_module: 'Subscription plan management with plan-governed caps.',
-    notifications_module: 'In-app notification system with read/unread tracking.'
-  },
-  omits_notes: {
-    compute_log_module: 'Usage logging is opt-in. Add explicitly if needed.',
-    inference_log_module: 'Usage logging is opt-in. Add explicitly if needed.',
-    agent_module: 'Agent infrastructure is opt-in.'
-  },
   extends: ['b2b']
 };

--- a/packages/node-type-registry/src/module-presets/minimal.ts
+++ b/packages/node-type-registry/src/module-presets/minimal.ts
@@ -36,16 +36,5 @@ export const PresetMinimal: ModulePreset = {
     'sessions_module',
     'rls_module',
     'user_state_module'
-  ],
-  includes_notes: {
-    users_module: 'The canonical users table. Required by every preset.',
-    sessions_module: 'Session/token storage; needed so whatever upstream auth can mint a session row.',
-    rls_module: 'RLS policy infrastructure. Without it, row-level security is not enforced.',
-    user_state_module: 'API-key storage. Optional for this preset but almost always wanted alongside upstream auth.'
-  },
-  omits_notes: {
-    user_auth_module: 'No server-side sign_up/sign_in procedures in this preset.',
-    emails_module: 'Not needed without password/magic-link flows; upstream auth handles identity.',
-    memberships_module: 'No memberships without a user_auth_module wiring them up.'
-  }
+  ]
 };

--- a/packages/node-type-registry/src/module-presets/types.ts
+++ b/packages/node-type-registry/src/module-presets/types.ts
@@ -53,19 +53,6 @@ export interface ModulePreset {
    */
   modules: (string | [string, Record<string, unknown>])[];
 
-  /**
-   * Optional per-module justifications. Map from module name to a short
-   * "why this module is in this preset" note. Rendered in docs and CLI
-   * `--explain` output.
-   */
-  includes_notes?: Record<string, string>;
-
-  /**
-   * Optional per-module "why we deliberately leave this out" notes. Only
-   * list modules that a user might reasonably expect to be here; don't
-   * enumerate every omitted module.
-   */
-  omits_notes?: Record<string, string>;
 
   /**
    * Optional: name(s) of presets this one builds on. Purely documentary —


### PR DESCRIPTION
## Summary

Removes `includes_notes` and `omits_notes` from the `ModulePreset` interface and all 9 preset files. These fields were unused documentation-only metadata — nothing consumed them at runtime or in codegen. They added clutter to the preset objects without providing value.

- Deletes `includes_notes?: Record<string, string>` and `omits_notes?: Record<string, string>` from `types.ts`
- Strips all `includes_notes` / `omits_notes` blocks from every preset file

Link to Devin session: https://app.devin.ai/sessions/e3d47c4b7872465d8f5e2b7813a7c48b
Requested by: @pyramation