### PR TITLE
chore(node-type-registry): sync presets with constructive-db

### DIFF
--- a/packages/node-type-registry/src/module-presets/b2b-storage.ts
+++ b/packages/node-type-registry/src/module-presets/b2b-storage.ts
@@ -21,7 +21,7 @@ export const PresetB2bStorage: ModulePreset = {
     '`app_buckets` and `app_files` tables with full RLS: AuthzPublishable for public reads, ' +
     'AuthzAppMembership for member access, AuthzDirectOwner for uploader-only modify/delete. ' +
     'Entity-type provisioning with a non-empty `storage` array adds per-scope storage tables ' +
-    'automatically (multiple modules per entity via storage_key). Choose this when your B2B ' +
+    'automatically (multiple modules per entity via key). Choose this when your B2B ' +
     'app needs file uploads, avatars, attachments, or any object storage tied to workspaces.',
   good_for: [
     'B2B SaaS with file uploads (documents, avatars, attachments)',

--- a/packages/node-type-registry/src/module-presets/full.ts
+++ b/packages/node-type-registry/src/module-presets/full.ts
@@ -80,7 +80,10 @@ export const PresetFull: ModulePreset = {
     'user_auth_module',
     'webauthn_auth_module',
     // Storage (full features)
-    ['storage_module', { has_versioning: true, has_content_hash: true, has_custom_keys: true, has_audit_log: true }]
+    ['storage_module', { has_versioning: true, has_content_hash: true, has_custom_keys: true, has_audit_log: true }],
+    // Infrastructure (functions, namespaces)
+    'namespace_module',
+    'function_module',
   ],
   extends: ['b2b']
 };


### PR DESCRIPTION
## Summary

Syncs `b2b-storage.ts` and `full.ts` module presets to match constructive-db's latest versions:

- `b2b-storage.ts`: `storage_key` → `key` in description text
- `full.ts`: adds `namespace_module` and `function_module` to the modules array (present in constructive-db since the jsonb refactor)

Link to Devin session: https://app.devin.ai/sessions/e3d47c4b7872465d8f5e2b7813a7c48b
Requested by: @pyramation