### PR TITLE
docs: update graphile-i18n README + add constructive-skills to footer

### DIFF
--- a/FOOTER.md
+++ b/FOOTER.md
@@ -44,6 +44,10 @@ Common issues and solutions for pgpm, PostgreSQL, and testing.
 * [@pgsql/types](https://www.npmjs.com/package/@pgsql/types): **📝 Type definitions** for PostgreSQL AST nodes in TypeScript.
 * [@pgsql/utils](https://www.npmjs.com/package/@pgsql/utils): **🛠️ AST utilities** for constructing and transforming PostgreSQL syntax trees.
 
+### 📚 Documentation & Skills
+
+* [constructive-skills](https://github.com/constructive-io/constructive-skills): **📖 Platform documentation and AI agent skills** — feature catalog, blueprint reference, SDK guides (i18n, billing, limits, events, uploads, security, entities, search, AI), and deployment guides.
+
 ## Credits
 
 **🛠 Built by the [Constructive](https://constructive.io) team — creators of modular Postgres tooling for secure, composable backends. If you like our work, contribute on [GitHub](https://github.com/constructive-io).**

--- a/README.md
+++ b/README.md
@@ -294,6 +294,10 @@ This architecture eliminates the traditional ORM layer and API boilerplate, lett
 - **[@pgsql/enums](https://www.npmjs.com/package/@pgsql/enums)** - TypeScript enums for PostgreSQL AST for safe parsing logic
 - **[@pgsql/utils](https://www.npmjs.com/package/@pgsql/utils)** - AST manipulation utilities for constructing and transforming syntax trees
 
+### 📚 Documentation & Skills
+
+- **[constructive-skills](https://github.com/constructive-io/constructive-skills)** - Platform documentation and AI agent skills — feature catalog, blueprint reference, SDK guides (i18n, billing, limits, events, uploads, security, entities, search, AI), and deployment guides
+
 ## Disclaimer
 
 AS DESCRIBED IN THE LICENSES, THE SOFTWARE IS PROVIDED "AS IS", AT YOUR OWN RISK, AND WITHOUT WARRANTIES OF ANY KIND.

--- a/README.md
+++ b/README.md
@@ -294,10 +294,6 @@ This architecture eliminates the traditional ORM layer and API boilerplate, lett
 - **[@pgsql/enums](https://www.npmjs.com/package/@pgsql/enums)** - TypeScript enums for PostgreSQL AST for safe parsing logic
 - **[@pgsql/utils](https://www.npmjs.com/package/@pgsql/utils)** - AST manipulation utilities for constructing and transforming syntax trees
 
-### 📚 Documentation & Skills
-
-- **[constructive-skills](https://github.com/constructive-io/constructive-skills)** - Platform documentation and AI agent skills — feature catalog, blueprint reference, SDK guides (i18n, billing, limits, events, uploads, security, entities, search, AI), and deployment guides
-
 ## Disclaimer
 
 AS DESCRIBED IN THE LICENSES, THE SOFTWARE IS PROVIDED "AS IS", AT YOUR OWN RISK, AND WITHOUT WARRANTIES OF ANY KIND.

--- a/graphile/graphile-i18n/README.md
+++ b/graphile/graphile-i18n/README.md
@@ -145,17 +145,30 @@ When the requested language has no translation, the plugin falls back through th
 
 ## Constructive Integration
 
-When used with the Constructive framework, the `DataI18n` node type automates translation table creation:
+When used with the Constructive framework, the `DataI18n` node type automates translation table creation and optionally composes with `SearchFullText` for multilingual full-text search:
 
 ```json
 {
   "nodes": [
     {
       "$type": "DataI18n",
-      "data": { "fields": ["name", "description"] }
+      "data": {
+        "fields": ["name", "description"],
+        "search": {
+          "field_name": "search",
+          "source_fields": [
+            { "field": "name", "weight": "A" },
+            { "field": "description", "weight": "B" }
+          ]
+        }
+      }
     }
   ]
 }
 ```
 
+When `search` is provided, the tsvector is created on the **translations table** with dynamic per-row language stemming — each row is stemmed using its own `lang_code` value (e.g., `'spanish'` → Spanish stemmer, `'french'` → French stemmer). PostgreSQL ships with 30+ built-in text search configurations, so multilingual search works out of the box with no per-language configuration.
+
 The `i18n_module` provides app-level configuration via `app_settings_i18n` with supported languages, default language, and fallback chain — all manageable via GraphQL mutations.
+
+For the full i18n guide (blueprint patterns, ORM queries, SQL search examples), see the [constructive-sdk-i18n skill](https://github.com/constructive-io/constructive-skills/tree/main/.agents/skills/constructive-sdk-i18n).


### PR DESCRIPTION
## Summary

Two documentation updates:

1. **graphile-i18n README** — Updated the Constructive Integration section to show the `DataI18n` + `SearchFullText` composition pattern with `search` parameter. Explains dynamic per-row language stemming via `lang_code::regconfig` and notes 30+ built-in PostgreSQL languages. Links to `constructive-sdk-i18n` skill.

2. **FOOTER.md** — Added `constructive-skills` link to the "Related Constructive Tooling" section (under Documentation & Skills).

Link to Devin session: https://app.devin.ai/sessions/243ba35035a849eba6ebe463d00c04c4
Requested by: @pyramation