### PR TITLE
fix(codegen): lazy-load @agentic-kit/ollama in embedder template

### DIFF
--- a/graphql/codegen/src/core/codegen/templates/embedder.ts
+++ b/graphql/codegen/src/core/codegen/templates/embedder.ts
@@ -17,8 +17,6 @@
  * Any changes here will affect all generated CLI embedder modules.
  */
 
-import OllamaClient from '@agentic-kit/ollama';
-
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 export type EmbedderFunction = (text: string) => Promise<number[]>;
@@ -38,8 +36,18 @@ function createOllamaEmbedder(
   baseUrl: string = 'http://localhost:11434',
   model: string = 'nomic-embed-text'
 ): EmbedderFunction {
-  const client = new OllamaClient(baseUrl);
+  let clientP: Promise<{ generateEmbedding: (text: string, model: string) => Promise<{ embedding: number[] }> }> | undefined;
   return async (text: string): Promise<number[]> => {
+    if (!clientP) {
+      clientP = import('@agentic-kit/ollama')
+        .then((m) => new m.default(baseUrl))
+        .catch(() => {
+          throw new Error(
+            'The ollama embedder requires @agentic-kit/ollama. Install it: npm i @agentic-kit/ollama'
+          );
+        });
+    }
+    const client = await clientP;
     const result = await client.generateEmbedding(text, model);
     return result.embedding;
   };


### PR DESCRIPTION
## Summary

The generated CLI embedder module eagerly imports `@agentic-kit/ollama` at module top level. Because the generated CLI statically loads every command at boot (`commands.ts` → `agent/agent-skill` → `embedder`), this crashes the entire CLI with `MODULE_NOT_FOUND` whenever the optional `@agentic-kit/ollama` package isn't installed — even for plain CRUD commands. This broke constructive-hub's `cli-e2e` job after the latest SDK regeneration shipped the eager import into the committed CLI.

## Fix

Defer the provider import in the codegen template (`graphql/codegen/src/core/codegen/templates/embedder.ts`): remove the top-level `import OllamaClient from '@agentic-kit/ollama'` and move it to a memoized dynamic `import('@agentic-kit/ollama')` inside the embedder closure, throwing a friendly "install @agentic-kit/ollama" error only if the ollama embedder is actually invoked.

- `createOllamaEmbedder` / `resolveEmbedder` / `buildEmbedder` stay **synchronous** (no signature change → no ripple into generated `agent-skill` callers)
- `baseUrl` / `model` / `generateEmbedding(text, model)` / `result.embedding` preserved
- `--auto-embed` behavior unchanged; matches the existing `await import()` idiom in the codegen

## Verification

`pnpm --filter @constructive-io/graphql-codegen build` passes (tsc CJS + ESM + `copy:templates`); the shipped `dist` template has no top-level `@agentic-kit/ollama` import. Cross-checked against the package's actual `export default OllamaClient` and `generateEmbedding(text, model?)` signature.

## Follow-up

After this is published (new `@constructive-io/graphql-codegen` > 4.47.0), constructive-db regenerates `sdk/constructive-cli/` (and adds `@agentic-kit/ollama` to `optionalDependencies`), which lets constructive-hub remove its temporary `cli-e2e` skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
