### PR TITLE
feat: add inflection-db to PGPM module map and export required extensions

### DIFF
--- a/pgpm/core/src/modules/modules.ts
+++ b/pgpm/core/src/modules/modules.ts
@@ -15,6 +15,7 @@ export const PGPM_MODULE_MAP: Record<string, string> = {
   'metaschema-schema': '@pgpm/metaschema-schema',
   'services': '@pgpm/services',
   'pgpm-inflection': '@pgpm/inflection',
+  'inflection-db': '@pgpm/inflection-db',
   'pgpm-jwt-claims': '@pgpm/jwt-claims',
   'pgpm-stamps': '@pgpm/stamps',
   'pgpm-totp': '@pgpm/totp',

--- a/pgpm/export/src/export-utils.ts
+++ b/pgpm/export/src/export-utils.ts
@@ -30,6 +30,7 @@ export const DB_REQUIRED_EXTENSIONS = [
   'ltree',
   'metaschema-schema',
   'pgpm-inflection',
+  'inflection-db',
   'pgpm-uuid',
   'pgpm-utils',
   'pgpm-database-jobs',


### PR DESCRIPTION
## Summary

Registers the newly published `@pgpm/inflection-db` package so it's available to the pgpm toolchain:

- `PGPM_MODULE_MAP['inflection-db'] = '@pgpm/inflection-db'` — enables `pgpm install` resolution
- `DB_REQUIRED_EXTENSIONS` gains `'inflection-db'` — ensures database exports include the extension

This is the companion change to [pgpm-modules#78](https://github.com/constructive-io/pgpm-modules/pull/78) (published `@pgpm/inflection-db`) and [constructive-db#1516](https://github.com/constructive-io/constructive-db/pull/1516) (syncs constructive-db to use the published version and reverts inlined `inflection.underscore` calls back to `inflection_db.*`).

Link to Devin session: https://app.devin.ai/sessions/9d079a6032fc40e8985a55fead8c4268
Requested by: @pyramation