### PR TITLE
refactor: remove inflection-db from export required deps

### DIFF
--- a/pgpm/core/src/modules/modules.ts
+++ b/pgpm/core/src/modules/modules.ts
@@ -15,7 +15,6 @@ export const PGPM_MODULE_MAP: Record<string, string> = {
   'metaschema-schema': '@pgpm/metaschema-schema',
   'services': '@pgpm/services',
   'pgpm-inflection': '@pgpm/inflection',
-  'inflection-db': '@pgpm/inflection-db',
   'pgpm-jwt-claims': '@pgpm/jwt-claims',
   'pgpm-stamps': '@pgpm/stamps',
   'pgpm-totp': '@pgpm/totp',

--- a/pgpm/export/src/export-utils.ts
+++ b/pgpm/export/src/export-utils.ts
@@ -30,7 +30,6 @@ export const DB_REQUIRED_EXTENSIONS = [
   'ltree',
   'metaschema-schema',
   'pgpm-inflection',
-  'inflection-db',
   'pgpm-uuid',
   'pgpm-utils',
   'pgpm-database-jobs',


### PR DESCRIPTION
## Summary

Removes `inflection-db` from `DB_REQUIRED_EXTENSIONS` and `PGPM_MODULE_MAP` — exported/sandbox databases no longer need it installed.

Runtime code in constructive-db now calls `inflection.underscore()` directly (companion PR: constructive-io/constructive-db#1520), so `inflection-db` is purely a provisioning-time dependency.

Link to Devin session: https://app.devin.ai/sessions/9d079a6032fc40e8985a55fead8c4268
Requested by: @pyramation