### PR TITLE
ci: switch notify-e2e trigger job to ubuntu-latest

### DIFF
--- a/.github/workflows/notify-e2e.yml
+++ b/.github/workflows/notify-e2e.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   trigger-tests:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Trigger submodule update in constructive-hub
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary

Moves `notify-e2e.yml` `trigger-tests` from `blacksmith-2vcpu-ubuntu-2404` → `ubuntu-latest`. This job is a single `github-script` API call to dispatch `submodule-updated` to constructive-hub — no build, no checkout, no tests.

Link to Devin session: https://app.devin.ai/sessions/fe72bc0f6d1f474391932141c9e37584
Requested by: @pyramation