### PR TITLE
ci: skip draft PRs and remove PR trigger from Docker workflow

### DIFF
--- a/.github/workflows/docker-constructive.yaml
+++ b/.github/workflows/docker-constructive.yaml
@@ -6,11 +6,6 @@ on:
       - main
       - v1
       - release/*
-  pull_request:
-    branches:
-      - main
-      - v1
-    types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch: {}
 
 concurrency:

--- a/.github/workflows/examples-integration.yaml
+++ b/.github/workflows/examples-integration.yaml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   examples-types:
+    if: github.event.pull_request.draft != true
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -35,6 +35,7 @@ jobs:
   # BUILD (single job – runs once, shared by all test jobs)
   # =========================================================================
   build:
+    if: github.event.pull_request.draft != true
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Summary

Three changes to reduce wasted CI minutes:

1. **`run-tests.yaml`**: Add `if: github.event.pull_request.draft != true` to the `build` job. All test jobs (unit-tests ×4, pg-tests ×14, integration-tests ×10) depend on `build` via `needs:`, so they auto-skip on draft PRs.

2. **`docker-constructive.yaml`**: Remove `pull_request` trigger. The `build-push-constructive` job already had `if: github.event_name != 'pull_request'` so PR runs were doing nothing useful — just creating skipped workflow runs. Now Docker only triggers on push to `main`/`v1`/`release/*` or `workflow_dispatch`.

3. **`examples-integration.yaml`**: Add draft filter to `examples-types` job.

Link to Devin session: https://app.devin.ai/sessions/fe72bc0f6d1f474391932141c9e37584
Requested by: @pyramation