### PR TITLE
ci: switch Docker, build, and unit-tests to ubuntu-latest

### DIFF
--- a/.github/workflows/docker-constructive.yaml
+++ b/.github/workflows/docker-constructive.yaml
@@ -21,7 +21,7 @@ jobs:
         include:
           - platform: linux/amd64
             arch: amd64
-            runner: blacksmith-4vcpu-ubuntu-2404      # x86_64
+            runner: ubuntu-latest                     # x86_64
           - platform: linux/arm64
             arch: arm64
             runner: blacksmith-4vcpu-ubuntu-2404-arm  # native arm
@@ -113,7 +113,7 @@ jobs:
   # multi-arch manifest for each tag.
   publish-constructive-manifest:
     if: github.event_name != 'pull_request'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: build-push-constructive
 
     permissions:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -41,7 +41,7 @@ concurrency:
 jobs:
   build-push:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read

--- a/.github/workflows/examples-integration.yaml
+++ b/.github/workflows/examples-integration.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   examples-types:
     if: github.event.pull_request.draft != true
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -36,7 +36,7 @@ jobs:
   # =========================================================================
   build:
     if: github.event.pull_request.draft != true
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Configure Git (for tests)
@@ -79,7 +79,7 @@ jobs:
   # =========================================================================
   unit-tests:
     needs: build
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

Moves jobs that don't need Blacksmith runners to `ubuntu-latest` (4 vCPU, included in GitHub plan):

**Docker:**
- `docker-constructive.yaml` amd64 build → `ubuntu-latest` (ARM stays on `blacksmith-4vcpu-ubuntu-2404-arm` for native builds), manifest job → `ubuntu-latest`
- `docker.yaml` → `ubuntu-latest` (workflow_dispatch only, uses QEMU for multi-arch)

**Tests:**
- `run-tests.yaml` build job → `ubuntu-latest` (just `pnpm install` + `pnpm build`, no services)
- `run-tests.yaml` unit-tests → `ubuntu-latest` (pure JS/TS, no DB or MinIO)
- `examples-integration.yaml` → `ubuntu-latest` (just build + codegen test)

**Kept on Blacksmith 4-vCPU:** `pg-tests` and `integration-tests` — these use PostgreSQL/MinIO service containers and benefit from Blacksmith's faster I/O.

Link to Devin session: https://app.devin.ai/sessions/fe72bc0f6d1f474391932141c9e37584
Requested by: @pyramation