### PR TITLE
ci: fix pg_isready health check to use -U postgres

### DIFF
--- a/.agents/skills/pgpm/references/ci-cd.md
+++ b/.agents/skills/pgpm/references/ci-cd.md
@@ -37,7 +37,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
     options: >-
-      --health-cmd pg_isready
+      --health-cmd "pg_isready -U postgres"
       --health-interval 10s
       --health-timeout 5s
       --health-retries 5
@@ -55,7 +55,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
     options: >-
-      --health-cmd pg_isready
+      --health-cmd "pg_isready -U postgres"
       --health-interval 10s
       --health-timeout 5s
       --health-retries 5
@@ -164,7 +164,7 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U postgres"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -187,7 +187,7 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U postgres"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -281,7 +281,7 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U postgres"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5


### PR DESCRIPTION
## Summary

Docker health checks run as `root` inside the container. `pg_isready` without `-U` defaults to the OS username (`root`), causing `FATAL: role "root" does not exist` every 10s in CI logs.

Fix: `pg_isready` → `pg_isready -U postgres` in:
- `.github/workflows/run-tests.yaml` (2 occurrences — pg-tests and integration-tests jobs)
- `.agents/skills/pgpm/references/ci-cd.md` (3 occurrences — skill doc examples)

Link to Devin session: https://app.devin.ai/sessions/0d80c09a68154da68d1524f93741d21f
Requested by: @pyramation