### PR TITLE
feat: add GuardStepUp node type to node-type-registry

### DIFF
--- a/packages/node-type-registry/src/codegen/generate-types.ts
+++ b/packages/node-type-registry/src/codegen/generate-types.ts
@@ -1673,7 +1673,7 @@ function buildProgram(meta?: MetaTableInfo[]): string {
   statements.push(buildFieldDefaultInterface());
 
   // -- Parameter interfaces grouped by category --
-  const categoryOrder = ['billing', 'check', 'data', 'event', 'limit', 'limit_enforce', 'limit_track', 'limit_warning', 'search', 'job', 'process', 'authz', 'relation', 'view'];
+  const categoryOrder = ['billing', 'check', 'data', 'event', 'guard', 'limit', 'limit_enforce', 'limit_track', 'limit_warning', 'search', 'job', 'process', 'authz', 'relation', 'view'];
   for (const cat of categoryOrder) {
     const nts = categories.get(cat);
     if (!nts || nts.length === 0) continue;

--- a/packages/node-type-registry/src/guard/index.ts
+++ b/packages/node-type-registry/src/guard/index.ts
@@ -1,0 +1,1 @@
+export { GuardStepUp } from './step-up';

--- a/packages/node-type-registry/src/guard/step-up.ts
+++ b/packages/node-type-registry/src/guard/step-up.ts
@@ -1,0 +1,41 @@
+import { conditionDefs, conditionProperties } from '../conditions';
+import type { NodeTypeDefinition } from '../types';
+
+export const GuardStepUp: NodeTypeDefinition = {
+  name: 'GuardStepUp',
+  slug: 'guard_step_up',
+  category: 'guard',
+  display_name: 'Guard Step-Up',
+  description:
+    'Attaches a BEFORE trigger that calls require_step_up() to enforce recent ' +
+    'password or MFA verification before allowing mutations. Requires a ' +
+    'provisioned sessions_module (with app_settings_auth) for the target database. ' +
+    'The step_up_window is read from app_settings_auth at runtime (default 30 minutes). ' +
+    'Supports compound conditions (AND/OR/NOT), watch_fields (fire only when specific ' +
+    'fields change), and simple condition_field/condition_value leaf conditions.',
+  parameter_schema: {
+    type: 'object',
+    $defs: conditionDefs,
+    properties: {
+      step_up_type: {
+        type: 'string',
+        enum: ['password', 'mfa', 'password_or_mfa'],
+        description:
+          'Which verification method satisfies the step-up requirement',
+        default: 'password_or_mfa',
+      },
+      events: {
+        type: 'array',
+        items: {
+          type: 'string',
+          enum: ['INSERT', 'UPDATE', 'DELETE'],
+        },
+        description: 'Which DML events require step-up verification',
+        default: ['UPDATE', 'DELETE'],
+      },
+      ...conditionProperties,
+    },
+    required: [],
+  },
+  tags: ['guard', 'triggers', 'auth', 'step-up', 'mfa', 'security'],
+};

--- a/packages/node-type-registry/src/index.ts
+++ b/packages/node-type-registry/src/index.ts
@@ -3,6 +3,7 @@ export * from './blueprint-types.generated';
 export * from './conditions';
 export * from './data';
 export * from './event';
+export * from './guard';
 export * from './job';
 export * from './limit';
 export * from './module-presets';
@@ -14,6 +15,7 @@ export * from './view';
 import * as authz from './authz';
 import * as data from './data';
 import * as event from './event';
+import * as guard from './guard';
 import * as job from './job';
 import * as limit from './limit';
 import * as process from './process';
@@ -25,6 +27,7 @@ export const allNodeTypes: NodeTypeDefinition[] = [
   ...Object.values(authz),
   ...Object.values(data),
   ...Object.values(event),
+  ...Object.values(guard),
   ...Object.values(job),
   ...Object.values(limit),
   ...Object.values(process),


### PR DESCRIPTION
## Summary

Adds a new `guard` category to the node-type-registry with `GuardStepUp` — a BEFORE trigger node that enforces `require_step_up()` (recent password/MFA verification) before allowing DML operations.

```ts
// Blueprint usage:
{ $type: 'GuardStepUp', data: { events: ['UPDATE', 'DELETE'], step_up_type: 'password_or_mfa' } }

// With compound conditions (require step-up only when role changes to admin):
{ $type: 'GuardStepUp', data: {
    events: ['UPDATE'],
    conditions: { AND: [
      { field: 'role', op: '=', value: 'admin', row: 'NEW' },
      { field: 'role', op: '!=', value: 'admin', row: 'OLD' }
    ]}
}}
```

Uses the existing `conditionDefs`/`conditionProperties` from `conditions/` for compound AND/OR/NOT support, `watch_fields`, and simple leaf conditions.

Added `'guard'` to `categoryOrder` in `generate-types.ts` so `GuardStepUpParams` interface is emitted during codegen.

Mirrors the generator implementation in constructive-db [#1541](https://github.com/constructive-io/constructive-db/pull/1541).

Link to Devin session: https://app.devin.ai/sessions/05f55404de8b435db075244b6edb4006
Requested by: @pyramation