### PR TITLE
docs: add npx skills add commands to FOOTER.md and pgpm CLI README

### DIFF
--- a/FOOTER.md
+++ b/FOOTER.md
@@ -48,6 +48,17 @@ Common issues and solutions for pgpm, PostgreSQL, and testing.
 
 * [constructive-skills](https://github.com/constructive-io/constructive-skills): **📖 Platform documentation and AI agent skills** — feature catalog, blueprint reference, SDK guides (i18n, billing, limits, events, uploads, security, entities, search, AI), and deployment guides.
 
+Install skills for AI coding agents:
+
+```bash
+# All platform skills (security, blueprints, codegen, billing, etc.)
+npx skills add constructive-io/constructive-skills
+
+# Individual repo skills (pgpm, testing, CLI, search, etc.)
+npx skills add https://github.com/constructive-io/constructive --skill pgpm
+npx skills add https://github.com/constructive-io/constructive --skill constructive-testing
+```
+
 ## Credits
 
 **🛠 Built by the [Constructive](https://constructive.io) team — creators of modular Postgres tooling for secure, composable backends. If you like our work, contribute on [GitHub](https://github.com/constructive-io).**

--- a/pgpm/cli/README.md
+++ b/pgpm/cli/README.md
@@ -454,3 +454,17 @@ Most commands support these global options:
 - `--help, -h` - Show help information
 - `--version, -v` - Show version information
 - `--cwd <dir>` - Set working directory
+
+## AI Agent Skills
+
+Install the pgpm skill for AI coding agents (Devin, Claude Code, Cursor, Copilot):
+
+```bash
+npx skills add https://github.com/constructive-io/constructive --skill pgpm
+```
+
+For the full Constructive platform skills (security, blueprints, codegen, billing, etc.):
+
+```bash
+npx skills add constructive-io/constructive-skills
+```


### PR DESCRIPTION
## Summary

Adds `npx skills add` install commands to two places:

1. **`FOOTER.md`** — new install block under the existing "Documentation & Skills" section:
   ```bash
   npx skills add constructive-io/constructive-skills
   npx skills add https://github.com/constructive-io/constructive --skill pgpm
   npx skills add https://github.com/constructive-io/constructive --skill constructive-testing
   ```
   This propagates to all package READMEs that use the shared footer.

2. **`pgpm/cli/README.md`** — new "AI Agent Skills" section at the bottom with the pgpm-specific install command and a pointer to the full platform skills.

Link to Devin session: https://app.devin.ai/sessions/03c02f34a67c4e869e8abbaacc71c5c5
Requested by: @pyramation