### PR TITLE
feat: add DataDenormalized node type to registry

### DIFF
--- a/packages/node-type-registry/src/data/data-denormalized.ts
+++ b/packages/node-type-registry/src/data/data-denormalized.ts
@@ -1,0 +1,70 @@
+import type { NodeTypeDefinition } from '../types';
+
+export const DataDenormalized: NodeTypeDefinition = {
+  name: 'DataDenormalized',
+  slug: 'data_denormalized',
+  category: 'data',
+  display_name: 'Denormalized Field',
+  description: 'Creates INSERT and UPDATE triggers that copy field values from a referenced (parent) table into the current table whenever the FK changes. Used to denormalize frequently-read columns (e.g. database_id on junction tables) so that RLS and queries can filter locally without joining.',
+  parameter_schema: {
+    type: 'object',
+    properties: {
+      field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'FK field on this table that references the parent row (e.g. view_id)'
+      },
+      set_fields: {
+        type: 'array',
+        items: {
+          type: 'string',
+          format: 'column-ref'
+        },
+        description: 'Field names on this table to be populated from the parent (e.g. ["database_id"])'
+      },
+      ref_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Field on the parent table that is the FK target (e.g. id)'
+      },
+      ref_fields: {
+        type: 'array',
+        items: {
+          type: 'string',
+          format: 'column-ref'
+        },
+        description: 'Field names on the parent table to copy from (e.g. ["database_id"])'
+      },
+      use_updates: {
+        type: 'boolean',
+        description: 'If true, also creates an UPDATE trigger so changes to the FK re-copy values',
+        default: true
+      },
+      update_defaults: {
+        type: 'boolean',
+        description: 'If true, sets the default value of set_fields to uuid_nil() so they are populated by the trigger',
+        default: true
+      },
+      func_name: {
+        type: 'string',
+        description: 'Custom function name suffix (defaults to the FK field name)'
+      },
+      func_order: {
+        type: 'integer',
+        description: 'Trigger ordering (0-padded). Lower numbers fire first',
+        default: 0
+      }
+    },
+    required: [
+      'field',
+      'set_fields',
+      'ref_field',
+      'ref_fields'
+    ]
+  },
+  tags: [
+    'trigger',
+    'denormalization',
+    'schema'
+  ]
+};

--- a/packages/node-type-registry/src/data/index.ts
+++ b/packages/node-type-registry/src/data/index.ts
@@ -4,6 +4,7 @@ export { CheckNotEqual } from './check-not-equal';
 export { CheckOneOf } from './check-one-of';
 export { DataBulk } from './data-bulk';
 export { DataCompositeField } from './data-composite-field';
+export { DataDenormalized } from './data-denormalized';
 export { DataDirectOwner } from './data-direct-owner';
 export { DataEntityMembership } from './data-entity-membership';
 export { DataForceCurrentUser } from './data-force-current-user';


### PR DESCRIPTION
## Summary

Registers `DataDenormalized` as a proper node type in `node-type-registry`. This was previously only available as a module config table (`metaschema_modules_public.denormalized_table_field`) with no registry entry — meaning it wasn't discoverable via the node type system or documented in skills.

`DataDenormalized` creates INSERT/UPDATE triggers that copy field values from a referenced parent table into the current table whenever the FK changes. Primary use case: denormalizing `database_id` onto junction tables so RLS policies can filter locally without joining through the parent.

```ts
// packages/node-type-registry/src/data/data-denormalized.ts
export const DataDenormalized: NodeTypeDefinition = {
  name: 'DataDenormalized',
  category: 'data',
  parameter_schema: {
    required: ['field', 'set_fields', 'ref_field', 'ref_fields'],
    properties: {
      field:          { format: 'column-ref' },  // FK on this table
      set_fields:     { items: { format: 'column-ref' } },  // fields to populate
      ref_field:      { format: 'column-ref' },  // FK target on parent
      ref_fields:     { items: { format: 'column-ref' } },  // fields to copy from parent
      use_updates:    { default: true },
      update_defaults:{ default: true },
      func_order:     { default: 0 },
    }
  }
};
```

Parameters mirror the existing `metaschema_generators.denormalized_table_field()` signature. Wiring into `table_module()` dispatch is a follow-up in constructive-db.

Link to Devin session: https://app.devin.ai/sessions/12842f98263d4815b6713291efc825ad
Requested by: @pyramation