### PR TITLE
feat: add CheckScopedForeignKey node type to registry

### DIFF
--- a/packages/node-type-registry/src/data/check-scoped-foreign-key.ts
+++ b/packages/node-type-registry/src/data/check-scoped-foreign-key.ts
@@ -1,0 +1,59 @@
+import type { NodeTypeDefinition } from '../types';
+
+export const CheckScopedForeignKey: NodeTypeDefinition = {
+  name: 'CheckScopedForeignKey',
+  slug: 'check_scoped_foreign_key',
+  category: 'check',
+  display_name: 'Check Scoped Foreign Key',
+  description:
+    'BEFORE INSERT trigger that validates all FK references resolve to the same scope value (e.g. database_id). Prevents cross-scope linking where a user with access to multiple scopes could create invalid cross-scope references. Works on junction tables (2+ FKs) and child tables (1 FK validated against the row\'s own scope field).',
+  parameter_schema: {
+    type: 'object',
+    properties: {
+      scope_field: {
+        type: 'string',
+        format: 'column-ref',
+        description:
+          'Scope field on this table to validate against (e.g. "database_id"). If set, the trigger also checks that all referenced scope values match NEW.scope_field. If omitted, only checks that all references match each other.',
+        default: 'database_id'
+      },
+      references: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            field: {
+              type: 'string',
+              format: 'column-ref',
+              description: 'FK field on this table (e.g. "view_id")'
+            },
+            ref_table: {
+              type: 'string',
+              description:
+                'Target table name (e.g. "view"). Schema is resolved from the table registry.'
+            },
+            ref_field: {
+              type: 'string',
+              format: 'column-ref',
+              description: 'PK field on the target table (e.g. "id")',
+              default: 'id'
+            },
+            ref_scope_field: {
+              type: 'string',
+              format: 'column-ref',
+              description:
+                'Scope field on the target table to read (e.g. "database_id")',
+              default: 'database_id'
+            }
+          },
+          required: ['field', 'ref_table']
+        },
+        description:
+          'FK references to validate. Each target\'s scope field must resolve to the same value.',
+        minItems: 1
+      }
+    },
+    required: ['references']
+  },
+  tags: ['check', 'trigger', 'security', 'scope-isolation', 'foreign-key']
+};

--- a/packages/node-type-registry/src/data/data-denormalized.ts
+++ b/packages/node-type-registry/src/data/data-denormalized.ts
@@ -1,0 +1,70 @@
+import type { NodeTypeDefinition } from '../types';
+
+export const DataDenormalized: NodeTypeDefinition = {
+  name: 'DataDenormalized',
+  slug: 'data_denormalized',
+  category: 'data',
+  display_name: 'Denormalized Field',
+  description: 'Creates INSERT and UPDATE triggers that copy field values from a referenced (parent) table into the current table whenever the FK changes. Used to denormalize frequently-read columns (e.g. database_id on junction tables) so that RLS and queries can filter locally without joining.',
+  parameter_schema: {
+    type: 'object',
+    properties: {
+      field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'FK field on this table that references the parent row (e.g. view_id)'
+      },
+      set_fields: {
+        type: 'array',
+        items: {
+          type: 'string',
+          format: 'column-ref'
+        },
+        description: 'Field names on this table to be populated from the parent (e.g. ["database_id"])'
+      },
+      ref_field: {
+        type: 'string',
+        format: 'column-ref',
+        description: 'Field on the parent table that is the FK target (e.g. id)'
+      },
+      ref_fields: {
+        type: 'array',
+        items: {
+          type: 'string',
+          format: 'column-ref'
+        },
+        description: 'Field names on the parent table to copy from (e.g. ["database_id"])'
+      },
+      use_updates: {
+        type: 'boolean',
+        description: 'If true, also creates an UPDATE trigger so changes to the FK re-copy values',
+        default: true
+      },
+      update_defaults: {
+        type: 'boolean',
+        description: 'If true, sets the default value of set_fields to uuid_nil() so they are populated by the trigger',
+        default: true
+      },
+      func_name: {
+        type: 'string',
+        description: 'Custom function name suffix (defaults to the FK field name)'
+      },
+      func_order: {
+        type: 'integer',
+        description: 'Trigger ordering (0-padded). Lower numbers fire first',
+        default: 0
+      }
+    },
+    required: [
+      'field',
+      'set_fields',
+      'ref_field',
+      'ref_fields'
+    ]
+  },
+  tags: [
+    'trigger',
+    'denormalization',
+    'schema'
+  ]
+};

--- a/packages/node-type-registry/src/data/index.ts
+++ b/packages/node-type-registry/src/data/index.ts
@@ -4,6 +4,7 @@ export { CheckNotEqual } from './check-not-equal';
 export { CheckOneOf } from './check-one-of';
 export { DataBulk } from './data-bulk';
 export { DataCompositeField } from './data-composite-field';
+export { DataDenormalized } from './data-denormalized';
 export { DataDirectOwner } from './data-direct-owner';
 export { DataEntityMembership } from './data-entity-membership';
 export { DataForceCurrentUser } from './data-force-current-user';

--- a/packages/node-type-registry/src/data/index.ts
+++ b/packages/node-type-registry/src/data/index.ts
@@ -2,6 +2,7 @@ export { CheckGreaterThan } from './check-greater-than';
 export { CheckLessThan } from './check-less-than';
 export { CheckNotEqual } from './check-not-equal';
 export { CheckOneOf } from './check-one-of';
+export { CheckScopedForeignKey } from './check-scoped-foreign-key';
 export { DataBulk } from './data-bulk';
 export { DataCompositeField } from './data-composite-field';
 export { DataDenormalized } from './data-denormalized';


### PR DESCRIPTION
## Summary

Adds `CheckScopedForeignKey` to the node type registry — a BEFORE INSERT trigger validator that prevents cross-scope FK linking.

**Problem:** On junction tables (e.g. `view_table` with `view_id` + `table_id`), a user with access to multiple databases can INSERT a row linking records from different databases. RLS only checks "can you access this row" — it doesn't validate that all FKs point to the same scope.

**Solution:** New `Check*` category node type with `parameter_schema`:

```typescript
{
  scope_field: 'database_id',  // optional — also validates NEW.scope_field matches
  references: [
    { field: 'view_id', ref_table: 'view', ref_scope_field: 'database_id' },
    { field: 'table_id', ref_table: 'table', ref_scope_field: 'database_id' }
  ]
}
```

The generator (in constructive-db) creates a BEFORE INSERT trigger that SELECTs each target's scope value and raises if any mismatch. Works for junction tables (2+ refs) and child tables (1 ref validated against the row's own scope field).

Companion PR: constructive-io/constructive-db (generator + table_module dispatch).

Link to Devin session: https://app.devin.ai/sessions/12842f98263d4815b6713291efc825ad
Requested by: @pyramation