### PR TITLE
feat(graphile-settings): wire GraphileLlmPreset into createConstructivePreset

### DIFF
--- a/__fixtures__/seed/services/setup.sql
+++ b/__fixtures__/seed/services/setup.sql
@@ -289,7 +289,7 @@ CREATE TABLE IF NOT EXISTS services_public.database_settings (
   enable_many_to_many boolean NOT NULL DEFAULT true,
   enable_connection_filter boolean NOT NULL DEFAULT true,
   enable_ltree boolean NOT NULL DEFAULT true,
-  enable_llm boolean NOT NULL DEFAULT false,
+  enable_llm boolean NOT NULL DEFAULT true,
   enable_realtime boolean NOT NULL DEFAULT false,
   enable_bulk boolean NOT NULL DEFAULT false,
   enable_i18n boolean NOT NULL DEFAULT false,

--- a/graphile/graphile-llm/src/preset.ts
+++ b/graphile/graphile-llm/src/preset.ts
@@ -10,8 +10,8 @@
  * - Adds `{column}Text: String` companion fields on mutation inputs for vector columns
  * - Optionally enables billing/metering via the LlmMeteringPlugin
  *
- * This preset is standalone — it is NOT included in ConstructivePreset by default.
- * Projects that want LLM features opt in by adding it to their preset.
+ * Included in ConstructivePreset when `enableLlm` is true (the default).
+ * Can also be used standalone by adding it directly to your preset's `extends` array.
  *
  * @example
  * ```typescript

--- a/graphile/graphile-settings/package.json
+++ b/graphile/graphile-settings/package.json
@@ -52,6 +52,7 @@
     "graphile-bulk-mutations": "workspace:^",
     "graphile-config": "1.0.1",
     "graphile-connection-filter": "workspace:^",
+    "graphile-llm": "workspace:^",
     "graphile-i18n": "workspace:^",
     "graphile-ltree": "workspace:^",
     "graphile-pg-aggregates": "workspace:^",

--- a/graphile/graphile-settings/src/presets/constructive-preset.ts
+++ b/graphile/graphile-settings/src/presets/constructive-preset.ts
@@ -9,6 +9,7 @@ import { createPostgisOperatorFactory,GraphilePostgisPreset } from 'graphile-pos
 import { PresignedUrlPreset } from 'graphile-presigned-url-plugin';
 import { RealtimeSubscriptionsPreset } from 'graphile-realtime-subscriptions';
 import { createMatchesOperatorFactory, createTrgmOperatorFactories,UnifiedSearchPreset } from 'graphile-search';
+import { GraphileLlmPreset } from 'graphile-llm';
 import { UploadPreset } from 'graphile-upload-plugin';
 
 import { getBucketProvisionerConnection } from '../bucket-provisioner-resolver';
@@ -60,7 +61,7 @@ const DEFAULTS: Required<ConstructivePresetOptions> = {
   enableManyToMany: true,
   enableConnectionFilter: true,
   enableLtree: true,
-  enableLlm: false,
+  enableLlm: true,
   enableRealtime: false,
   enableBulk: false,
   enableI18n: false
@@ -74,7 +75,7 @@ const DEFAULTS: Required<ConstructivePresetOptions> = {
  * its corresponding plugin preset is included; when `false` it is omitted.
  *
  * Calling with no arguments produces the same preset as the previous static
- * `ConstructivePreset` (everything on except aggregates and LLM).
+ * `ConstructivePreset` (everything on except aggregates).
  *
  * CORE PRESETS (always included):
  * - MinimalPreset (PostGraphile without Node/Relay)
@@ -98,7 +99,7 @@ const DEFAULTS: Required<ConstructivePresetOptions> = {
  * - enableRealtime          -> RealtimeSubscriptionsPreset (off by default)
  * - enableBulk              -> BulkMutationPreset (off by default)
  * - enableI18n              -> I18nPreset (off by default)
- * - enableLlm               -> (no plugin yet, reserved for future use)
+ * - enableLlm               -> GraphileLlmPreset (auto-embed unifiedSearch, vector text fields)
  *
  * RELATION FILTERS (when enableConnectionFilter is true):
  * - Forward: filter child by parent
@@ -203,6 +204,10 @@ export function createConstructivePreset(
     presets.push(I18nPreset());
   }
 
+  if (opts.enableLlm) {
+    presets.push(GraphileLlmPreset());
+  }
+
   // ----- connectionFilterOperatorFactories -----
   // Only include operator factories for features that are actually enabled.
   // graphile-config replaces (not concatenates) arrays when merging presets,
@@ -258,7 +263,7 @@ export function createConstructivePreset(
 }
 
 /**
- * Default Constructive preset -- everything enabled except aggregates and LLM.
+ * Default Constructive preset -- everything enabled except aggregates.
  * Backwards-compatible: identical to the previous static ConstructivePreset.
  */
 export const ConstructivePreset: GraphileConfig.Preset = createConstructivePreset();

--- a/graphql/server/src/middleware/__tests__/upload.test.ts
+++ b/graphql/server/src/middleware/__tests__/upload.test.ts
@@ -6,6 +6,10 @@ import { createUploadAuthenticateMiddleware } from '../upload';
 
 jest.mock('pg-cache', () => ({
   getPgPool: jest.fn(),
+  pgCache: {
+    registerCleanupCallback: jest.fn(() => jest.fn()),
+    close: jest.fn(),
+  },
 }));
 
 jest.mock('pg-query-context', () => jest.fn());

--- a/graphql/server/src/middleware/graphile.ts
+++ b/graphql/server/src/middleware/graphile.ts
@@ -200,7 +200,7 @@ const reqLabel = (req: Request): string => (req.requestId ? `[${req.requestId}]`
  * When `databaseSettings` are available the flags are forwarded to
  * `createConstructivePreset()` which conditionally includes each
  * plugin preset.  Without settings the default preset is used
- * (everything on except aggregates and LLM).
+ * (everything on except aggregates).
  */
 const buildPreset = (
   pool: import('pg').Pool,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -911,6 +911,9 @@ importers:
       graphile-i18n:
         specifier: workspace:^
         version: link:../graphile-i18n/dist
+      graphile-llm:
+        specifier: workspace:^
+        version: link:../graphile-llm/dist
       graphile-ltree:
         specifier: workspace:^
         version: link:../graphile-ltree/dist


### PR DESCRIPTION
## Summary

`enableLlm` was a placeholder flag in `createConstructivePreset()` — it existed in `ConstructivePresetOptions` and the `database_settings` table but was a no-op (comment: "no plugin yet, reserved for future use").

This wires it to `GraphileLlmPreset()` and flips the default to `true`:

```diff
 // constructive-preset.ts
+if (opts.enableLlm) {
+  presets.push(GraphileLlmPreset());
+}

 // DEFAULTS
-enableLlm: false,
+enableLlm: true,

 // database_settings DDL
-enable_llm boolean NOT NULL DEFAULT false,
+enable_llm boolean NOT NULL DEFAULT true,
```

When active, `unifiedSearch: "text"` auto-embeds via the configured LLM provider and pgvector joins the RRF fusion — zero client API changes. If no embedder is configured (no `llm_module` row, no env vars), gracefully degrades to text-only search.

Tenants can still opt out with `enable_llm = false` in their `database_settings` / `api_settings` row.

Also fixes `upload.test.ts` — `graphile-settings` now transitively loads `graphile-cache` (via `graphile-llm`), which calls `pgCache.registerCleanupCallback` at module init. The test's `pg-cache` mock was missing the `pgCache` export.

Link to Devin session: https://app.devin.ai/sessions/4a9f098c74fb4cb6a9b6868fcff321db
Requested by: @pyramation