### PR TITLE
chore: add constructive logo header to READMEs missing it

### DIFF
--- a/graphile/graphile-ltree/README.md
+++ b/graphile/graphile-ltree/README.md
@@ -1,5 +1,9 @@
 # graphile-ltree
 
+<p align="center" width="100%">
+  <img height="250" src="https://raw.githubusercontent.com/constructive-io/constructive/refs/heads/main/assets/outline-logo.svg" />
+</p>
+
 PostGraphile v5 plugin for PostgreSQL's ltree hierarchical data type.
 
 Auto-detects ltree columns, exposes slash-path folder fields, and provides containment/glob filter operators for hierarchical data.

--- a/graphile/graphile-realtime-subscriptions/README.md
+++ b/graphile/graphile-realtime-subscriptions/README.md
@@ -1,5 +1,9 @@
 # graphile-realtime-subscriptions
 
+<p align="center" width="100%">
+  <img height="250" src="https://raw.githubusercontent.com/constructive-io/constructive/refs/heads/main/assets/outline-logo.svg" />
+</p>
+
 Realtime subscription plugin for PostGraphile v5 — per-table GraphQL subscriptions via LISTEN/NOTIFY.
 
 ## Overview

--- a/graphql/realtime-test/README.md
+++ b/graphql/realtime-test/README.md
@@ -1,5 +1,9 @@
 # @constructive-io/graphql-realtime-test
 
+<p align="center" width="100%">
+  <img height="250" src="https://raw.githubusercontent.com/constructive-io/constructive/refs/heads/main/assets/outline-logo.svg" />
+</p>
+
 Constructive-level wrapper around `graphile-realtime-test` that pre-loads the
 full `ConstructivePreset` (auth, RLS, storage, search, realtime subscriptions,
 etc.) into the GraphQL schema used for subscription testing.

--- a/packages/llm-env/README.md
+++ b/packages/llm-env/README.md
@@ -1,5 +1,9 @@
 # @constructive-io/llm-env
 
+<p align="center" width="100%">
+  <img height="250" src="https://raw.githubusercontent.com/constructive-io/constructive/refs/heads/main/assets/outline-logo.svg" />
+</p>
+
 Single source of truth for all LLM-related environment variables and defaults.
 Follows the same conventions as `@pgpmjs/env`.
 


### PR DESCRIPTION
## Summary

Adds the standard constructive logo header (`outline-logo.svg`) to 4 package READMEs that were missing it:

- `packages/llm-env` (new package from PR #1293)
- `graphile/graphile-ltree`
- `graphile/graphile-realtime-subscriptions`
- `graphql/realtime-test`

Skipped `packages/safegres` — it intentionally uses its own Safegres brand logo.

Link to Devin session: https://app.devin.ai/sessions/4a9f098c74fb4cb6a9b6868fcff321db
Requested by: @pyramation