### PR TITLE
fix(codegen): include partition keys in hooks update/delete mutation variables

### DIFF
--- a/graphql/codegen/src/core/codegen/index.ts
+++ b/graphql/codegen/src/core/codegen/index.ts
@@ -249,6 +249,7 @@ export function generate(options: GenerateOptions): GenerateResult {
   const mutationHooks = generateAllMutationHooks(tables, {
     reactQueryEnabled,
     useCentralizedKeys,
+    typeRegistry: customOperations?.typeRegistry,
   });
   for (const hook of mutationHooks) {
     files.push({

--- a/graphql/codegen/src/core/codegen/mutations.ts
+++ b/graphql/codegen/src/core/codegen/mutations.ts
@@ -9,7 +9,7 @@
  */
 import * as t from '@babel/types';
 
-import type { Table } from '../../types/schema';
+import type { Table, TypeRegistry } from '../../types/schema';
 import {
   addJSDocComment,
   buildSelectionArgsCall,
@@ -50,11 +50,14 @@ import {
   getCreateMutationFileName,
   getCreateMutationHookName,
   getCreateMutationName,
+  getDeleteInputTypeName,
   getDeleteMutationFileName,
   getDeleteMutationHookName,
   getDeleteMutationName,
+  getExtraInputKeys,
   getPrimaryKeyInfo,
   getTableNames,
+  getUpdateInputTypeName,
   getUpdateMutationFileName,
   getUpdateMutationHookName,
   getUpdateMutationName,
@@ -70,6 +73,7 @@ export interface GeneratedMutationFile {
 export interface MutationGeneratorOptions {
   reactQueryEnabled?: boolean;
   useCentralizedKeys?: boolean;
+  typeRegistry?: TypeRegistry;
 }
 
 function buildMutationResultType(
@@ -332,7 +336,7 @@ export function generateUpdateMutationHook(
   table: Table,
   options: MutationGeneratorOptions = {},
 ): GeneratedMutationFile | null {
-  const { reactQueryEnabled = true, useCentralizedKeys = true } = options;
+  const { reactQueryEnabled = true, useCentralizedKeys = true, typeRegistry } = options;
 
   if (!reactQueryEnabled) return null;
   if (table.query?.update === null) return null;
@@ -354,6 +358,14 @@ export function generateUpdateMutationHook(
 
   const pkTsType =
     pkField.tsType === 'string' ? t.tsStringKeyword() : t.tsNumberKeyword();
+
+  const updateInputTypeName = getUpdateInputTypeName(table);
+  const updateExtraKeys = getExtraInputKeys(
+    updateInputTypeName,
+    new Set(pkFields.map((pk) => pk.name)),
+    patchFieldName,
+    typeRegistry,
+  );
 
   const statements: t.Statement[] = [];
 
@@ -409,11 +421,21 @@ export function generateUpdateMutationHook(
     ),
   );
 
-  // Variable type: { pkField: type; patchFieldName: PatchType }
+  // Variable type: { pkField: type; extraKeys...; patchFieldName: PatchType }
   const updateVarType = t.tsTypeLiteral([
     t.tsPropertySignature(
       t.identifier(pkField.name),
       t.tsTypeAnnotation(pkTsType),
+    ),
+    ...updateExtraKeys.map((ek) =>
+      t.tsPropertySignature(
+        t.identifier(ek.name),
+        t.tsTypeAnnotation(
+          ek.tsType === 'number' ? t.tsNumberKeyword() :
+          ek.tsType === 'boolean' ? t.tsBooleanKeyword() :
+          t.tsStringKeyword()
+        ),
+      ),
     ),
     t.tsPropertySignature(
       t.identifier(patchFieldName),
@@ -485,6 +507,7 @@ export function generateUpdateMutationHook(
   //   getClient().singular.update({ where: { pkField }, data: patchFieldName, select: ... }).unwrap()
   const destructParam = t.objectPattern([
     shorthandProp(pkField.name),
+    ...updateExtraKeys.map((ek) => shorthandProp(ek.name)),
     shorthandProp(patchFieldName),
   ]);
   destructParam.typeAnnotation = t.tsTypeAnnotation(updateVarType);
@@ -494,7 +517,10 @@ export function generateUpdateMutationHook(
       singularName,
       'update',
       t.objectExpression([
-        objectProp('where', t.objectExpression([shorthandProp(pkField.name)])),
+        objectProp('where', t.objectExpression([
+          shorthandProp(pkField.name),
+          ...updateExtraKeys.map((ek) => shorthandProp(ek.name)),
+        ])),
         objectProp('data', t.identifier(patchFieldName)),
         objectProp(
           'select',
@@ -592,7 +618,7 @@ export function generateDeleteMutationHook(
   table: Table,
   options: MutationGeneratorOptions = {},
 ): GeneratedMutationFile | null {
-  const { reactQueryEnabled = true, useCentralizedKeys = true } = options;
+  const { reactQueryEnabled = true, useCentralizedKeys = true, typeRegistry } = options;
 
   if (!reactQueryEnabled) return null;
   if (table.query?.delete === null) return null;
@@ -611,6 +637,14 @@ export function generateDeleteMutationHook(
 
   const pkTsType =
     pkField.tsType === 'string' ? t.tsStringKeyword() : t.tsNumberKeyword();
+
+  const deleteInputTypeName = getDeleteInputTypeName(table);
+  const deleteExtraKeys = getExtraInputKeys(
+    deleteInputTypeName,
+    new Set(pkFields.map((pk) => pk.name)),
+    null,
+    typeRegistry,
+  );
 
   const statements: t.Statement[] = [];
 
@@ -666,11 +700,21 @@ export function generateDeleteMutationHook(
     ),
   );
 
-  // Variable type: { pkField: type }
+  // Variable type: { pkField: type; extraKeys... }
   const deleteVarType = t.tsTypeLiteral([
     t.tsPropertySignature(
       t.identifier(pkField.name),
       t.tsTypeAnnotation(pkTsType),
+    ),
+    ...deleteExtraKeys.map((ek) =>
+      t.tsPropertySignature(
+        t.identifier(ek.name),
+        t.tsTypeAnnotation(
+          ek.tsType === 'number' ? t.tsNumberKeyword() :
+          ek.tsType === 'boolean' ? t.tsBooleanKeyword() :
+          t.tsStringKeyword()
+        ),
+      ),
     ),
   ]);
 
@@ -736,7 +780,10 @@ export function generateDeleteMutationHook(
 
   // mutationFn: ({ pkField }: { pkField: type }) =>
   //   getClient().singular.delete({ where: { pkField }, select: ... }).unwrap()
-  const destructParam = t.objectPattern([shorthandProp(pkField.name)]);
+  const destructParam = t.objectPattern([
+    shorthandProp(pkField.name),
+    ...deleteExtraKeys.map((ek) => shorthandProp(ek.name)),
+  ]);
   destructParam.typeAnnotation = t.tsTypeAnnotation(deleteVarType);
   const mutationFnExpr = t.arrowFunctionExpression(
     [destructParam],
@@ -744,7 +791,10 @@ export function generateDeleteMutationHook(
       singularName,
       'delete',
       t.objectExpression([
-        objectProp('where', t.objectExpression([shorthandProp(pkField.name)])),
+        objectProp('where', t.objectExpression([
+          shorthandProp(pkField.name),
+          ...deleteExtraKeys.map((ek) => shorthandProp(ek.name)),
+        ])),
         objectProp(
           'select',
           t.memberExpression(t.identifier('args'), t.identifier('select')),

--- a/graphql/codegen/src/core/codegen/orm/model-generator.ts
+++ b/graphql/codegen/src/core/codegen/orm/model-generator.ts
@@ -15,6 +15,7 @@ import {
   getCreateMutationName,
   getDeleteInputTypeName,
   getDeleteMutationName,
+  getExtraInputKeys,
   getFilterTypeName,
   getGeneratedFileHeader,
   getOrderByTypeName,
@@ -25,6 +26,7 @@ import {
   lcFirst,
   ucFirst,
 } from '../utils';
+import type { ExtraInputKey } from '../utils';
 
 export interface GeneratedModelFile {
   fileName: string;
@@ -168,43 +170,7 @@ function strictSelectGuard(selectTypeName: string): t.TSType {
   );
 }
 
-interface ExtraInputKey {
-  name: string;
-  gqlType: string;
-  tsType: string;
-}
-
-/**
- * Discover extra required fields on a mutation input type beyond the standard
- * ones (clientMutationId, PK fields, patch field). PostGraphile adds these for
- * partitioned tables (e.g. databaseId as the partition key).
- */
-function getExtraInputKeys(
-  inputTypeName: string,
-  pkFieldNames: Set<string>,
-  patchFieldName: string | null,
-  typeRegistry?: TypeRegistry,
-): ExtraInputKey[] {
-  if (!typeRegistry) return [];
-  const inputType = typeRegistry.get(inputTypeName);
-  if (!inputType || inputType.kind !== 'INPUT_OBJECT' || !inputType.inputFields) return [];
-
-  const skip = new Set<string>(['clientMutationId', ...(patchFieldName ? [patchFieldName] : [])]);
-  for (const pk of pkFieldNames) skip.add(pk);
-
-  const extras: ExtraInputKey[] = [];
-  for (const field of inputType.inputFields) {
-    if (skip.has(field.name)) continue;
-    if (field.type.kind !== 'NON_NULL') continue;
-    const innerName = field.type.ofType?.name;
-    if (!innerName) continue;
-    let tsType = 'string';
-    if (innerName === 'Int' || innerName === 'Float' || innerName === 'BigFloat') tsType = 'number';
-    else if (innerName === 'Boolean') tsType = 'boolean';
-    extras.push({ name: field.name, gqlType: innerName, tsType });
-  }
-  return extras;
-}
+// ExtraInputKey type and getExtraInputKeys are imported from ../utils
 
 export function generateModelFile(
   table: Table,

--- a/graphql/codegen/src/core/codegen/utils.ts
+++ b/graphql/codegen/src/core/codegen/utils.ts
@@ -315,6 +315,48 @@ export function getDeleteInputTypeName(table: Table): string {
 }
 
 // ============================================================================
+// Extra input keys (partition keys for update/delete mutations)
+// ============================================================================
+
+export interface ExtraInputKey {
+  name: string;
+  gqlType: string;
+  tsType: string;
+}
+
+/**
+ * Discover extra required fields on a mutation input type beyond the standard
+ * ones (clientMutationId, PK fields, patch field). PostGraphile adds these for
+ * partitioned tables (e.g. databaseId as the partition key).
+ */
+export function getExtraInputKeys(
+  inputTypeName: string,
+  pkFieldNames: Set<string>,
+  patchFieldName: string | null,
+  typeRegistry?: TypeRegistry,
+): ExtraInputKey[] {
+  if (!typeRegistry) return [];
+  const inputType = typeRegistry.get(inputTypeName);
+  if (!inputType || inputType.kind !== 'INPUT_OBJECT' || !inputType.inputFields) return [];
+
+  const skip = new Set<string>(['clientMutationId', ...(patchFieldName ? [patchFieldName] : [])]);
+  for (const pk of pkFieldNames) skip.add(pk);
+
+  const extras: ExtraInputKey[] = [];
+  for (const field of inputType.inputFields) {
+    if (skip.has(field.name)) continue;
+    if (field.type.kind !== 'NON_NULL') continue;
+    const innerName = field.type.ofType?.name;
+    if (!innerName) continue;
+    let tsType = 'string';
+    if (innerName === 'Int' || innerName === 'Float' || innerName === 'BigFloat') tsType = 'number';
+    else if (innerName === 'Boolean') tsType = 'boolean';
+    extras.push({ name: field.name, gqlType: innerName, tsType });
+  }
+  return extras;
+}
+
+// ============================================================================
 // Type mapping: GraphQL → TypeScript
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Extends the partition key fix from PR #1295 (ORM model generator) to also cover React Query mutation hooks.

Previously, `generateUpdateMutationHook` and `generateDeleteMutationHook` only included the primary key field in the mutation variable type. For partitioned tables (e.g. those with `databaseId`), the generated hooks would produce type errors because the ORM's `where` type now requires the extra keys.

**Changes:**

1. **Extracted `getExtraInputKeys` to shared `utils.ts`** — was previously a private function in `model-generator.ts`. Both ORM and hooks generators now import from the same source.

2. **`mutations.ts` — `generateUpdateMutationHook`**: discovers extra required fields via `typeRegistry`, adds them to `updateVarType`, the destructured arrow param, and the ORM `.where` object.

3. **`mutations.ts` — `generateDeleteMutationHook`**: same treatment — extra keys appear in `deleteVarType`, destructured param, and `.where`.

4. **`MutationGeneratorOptions`** gains `typeRegistry?: TypeRegistry`, threaded from `index.ts` via `customOperations.typeRegistry`.

```diff
// Before (generated hook):
mutate({ id: 'abc' })
// → Error: databaseId is required

// After:
mutate({ id: 'abc', databaseId: 'xyz' })
// → works
```

Link to Devin session: https://app.devin.ai/sessions/b2291a8e333e445aa125a2efd1996206
Requested by: @pyramation