### PR TITLE
Fix GraphQL private header routing priority mismatch

### DIFF
--- a/graphql/server/src/middleware/__tests__/api.test.ts
+++ b/graphql/server/src/middleware/__tests__/api.test.ts
@@ -1,0 +1,117 @@
+jest.mock('pg-cache', () => ({
+  getPgPool: jest.fn(),
+}));
+
+jest.mock('@constructive-io/express-context', () => ({
+  createDefaultRegistry: jest.fn(() => ({
+    resolve: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+import type { Request } from 'express';
+import type { Pool } from 'pg';
+import { svcCache } from '@pgpmjs/server-utils';
+import { getPgPool } from 'pg-cache';
+
+import type { ApiOptions } from '../../types';
+import { getApiConfig, getSvcKey } from '../api';
+
+const mockGetPgPool = getPgPool as jest.MockedFunction<typeof getPgPool>;
+
+const createRequest = (headers: Record<string, string>): Request => {
+  const normalized = new Map(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]),
+  );
+
+  return {
+    protocol: 'http',
+    originalUrl: '/graphql',
+    get: jest.fn((name: string) => normalized.get(name.toLowerCase())),
+  } as unknown as Request;
+};
+
+const createPrivateOptions = (): ApiOptions => ({
+  pg: {
+    database: 'constructive',
+  },
+  api: {
+    isPublic: false,
+    metaSchemas: ['metaschema_public'],
+  },
+} as unknown as ApiOptions);
+
+describe('api middleware routing priority', () => {
+  beforeEach(() => {
+    svcCache.clear();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    svcCache.clear();
+  });
+
+  it('uses X-Api-Name before X-Schemata when building private service keys', () => {
+    const req = createRequest({
+      host: 'admin.localhost',
+      'X-Database-Id': 'db-123',
+      'X-Api-Name': 'customer-api',
+      'X-Schemata': 'services_public',
+    });
+
+    expect(getSvcKey(createPrivateOptions(), req)).toBe('api:db-123:customer-api');
+  });
+
+  it('uses the same X-Api-Name priority when resolving and caching API config', async () => {
+    const query = jest.fn(async (_sql: string, params: unknown[]) => {
+      if (Array.isArray(params[0])) {
+        return {
+          rows: (params[0] as string[]).map((schemaName) => ({
+            schema_name: schemaName,
+          })),
+        };
+      }
+
+      if (params[0] === 'db-123' && params[1] === 'customer-api') {
+        return {
+          rows: [{
+            api_id: 'api-123',
+            database_id: 'db-123',
+            dbname: 'tenant_db',
+            role_name: 'api_role',
+            anon_role: 'api_anon',
+            is_public: false,
+            schemas: ['api_public'],
+          }],
+        };
+      }
+
+      return { rows: [] };
+    });
+
+    mockGetPgPool.mockReturnValue({ query } as unknown as Pool);
+
+    const req = createRequest({
+      host: 'admin.localhost',
+      'X-Database-Id': 'db-123',
+      'X-Api-Name': 'customer-api',
+      'X-Schemata': 'services_public',
+    });
+
+    const result = await getApiConfig(createPrivateOptions(), req);
+
+    expect(req.svc_key).toBe('api:db-123:customer-api');
+    expect(result).toMatchObject({
+      apiId: 'api-123',
+      dbname: 'tenant_db',
+      anonRole: 'api_anon',
+      roleName: 'api_role',
+      schema: ['api_public'],
+      databaseId: 'db-123',
+      isPublic: false,
+    });
+    expect(svcCache.get('api:db-123:customer-api')).toBe(result);
+    expect(query.mock.calls).toEqual(expect.arrayContaining([
+      [expect.stringContaining('FROM services_public.apis'), ['db-123', 'customer-api', false]],
+    ]));
+  });
+});

--- a/graphql/server/src/middleware/api.ts
+++ b/graphql/server/src/middleware/api.ts
@@ -120,12 +120,7 @@ interface ResolveContext {
   domain: string;
   subdomain: string | null;
   cacheKey: string;
-  headers: {
-    schemata?: string;
-    apiName?: string;
-    metaSchema?: string;
-    databaseId?: string;
-  };
+  headers: RoutingHeaders;
 }
 
 type ResolutionMode = 
@@ -134,6 +129,15 @@ type ResolutionMode =
   | 'api-name-header'
   | 'meta-schema-header'
   | 'domain-lookup';
+
+type PrivateHeaderMode = Exclude<ResolutionMode, 'services-disabled' | 'domain-lookup'>;
+
+interface RoutingHeaders {
+  schemata?: string;
+  apiName?: string;
+  metaSchema?: string;
+  databaseId?: string;
+}
 
 // =============================================================================
 // Module Resolution (via loader registry)
@@ -208,6 +212,20 @@ const isApiError = (result: ApiConfigResult): result is ApiError =>
 const parseCommaSeparatedHeader = (value: string): string[] =>
   value.split(',').map((s) => s.trim()).filter(Boolean);
 
+const getPrivateHeaderMode = (headers: RoutingHeaders): PrivateHeaderMode | null => {
+  if (headers.apiName) return 'api-name-header';
+  if (headers.schemata) return 'schemata-header';
+  if (headers.metaSchema) return 'meta-schema-header';
+  return null;
+};
+
+const getRoutingHeaders = (req: Request): RoutingHeaders => ({
+  schemata: req.get('X-Schemata'),
+  apiName: req.get('X-Api-Name'),
+  metaSchema: req.get('X-Meta-Schema'),
+  databaseId: req.get('X-Database-Id'),
+});
+
 const getUrlDomains = (req: Request): { domain: string; subdomains: string[] } => {
   const fullUrl = `${req.protocol}://${req.get('host')}${req.originalUrl}`;
   const parsed = parseUrl(fullUrl);
@@ -227,14 +245,16 @@ export const getSvcKey = (opts: ApiOptions, req: Request): string => {
   const baseKey = subdomains.filter((n) => n !== 'www').concat(domain).join('.');
 
   if (opts.api?.isPublic === false) {
-    if (req.get('X-Api-Name')) {
-      return `api:${req.get('X-Database-Id')}:${req.get('X-Api-Name')}`;
+    const headers = getRoutingHeaders(req);
+    const mode = getPrivateHeaderMode(headers);
+    if (mode === 'api-name-header') {
+      return `api:${headers.databaseId}:${headers.apiName}`;
     }
-    if (req.get('X-Schemata')) {
-      return `schemata:${req.get('X-Database-Id')}:${req.get('X-Schemata')}`;
+    if (mode === 'schemata-header') {
+      return `schemata:${headers.databaseId}:${headers.schemata}`;
     }
-    if (req.get('X-Meta-Schema')) {
-      return `metaschema:api:${req.get('X-Database-Id')}`;
+    if (mode === 'meta-schema-header') {
+      return `metaschema:api:${headers.databaseId}`;
     }
   }
   return baseKey;
@@ -319,9 +339,7 @@ const determineMode = (ctx: ResolveContext): ResolutionMode => {
   
   if (opts.api?.enableServicesApi === false) return 'services-disabled';
   if (opts.api?.isPublic === false) {
-    if (headers.schemata) return 'schemata-header';
-    if (headers.apiName) return 'api-name-header';
-    if (headers.metaSchema) return 'meta-schema-header';
+    return getPrivateHeaderMode(headers) ?? 'domain-lookup';
   }
   return 'domain-lookup';
 };
@@ -479,12 +497,7 @@ export const getApiConfig = async (
     domain,
     subdomain,
     cacheKey,
-    headers: {
-      schemata: req.get('X-Schemata'),
-      apiName: req.get('X-Api-Name'),
-      metaSchema: req.get('X-Meta-Schema'),
-      databaseId: req.get('X-Database-Id'),
-    },
+    headers: getRoutingHeaders(req),
   };
 
   // Validate schemas upfront for modes that need them


### PR DESCRIPTION
## Summary

Align private GraphQL API routing priority between `getSvcKey()` and `determineMode()`.

Previously, requests containing both `X-Api-Name` and `X-Schemata` could be cached under an `api:<db>:<apiName>` service key while being resolved through the `schemata-header` path. That could store an admin-style schema-header API structure under a named API cache key.

This PR makes both paths use the same private header priority:

`X-Api-Name > X-Schemata > X-Meta-Schema`

## Changes

- Added a shared private header mode helper used by both service-key generation and mode selection.
- Kept existing `X-Api-Name` service-key semantics unchanged.
- Added regression tests for mixed `X-Api-Name` / `X-Schemata` requests.

## Validation

- `pnpm --filter @constructive-io/graphql-server exec jest src/middleware/__tests__/api.test.ts --runInBand`
- `pnpm --filter @constructive-io/graphql-server build`
- `pnpm --filter @constructive-io/graphql-server exec jest --runInBand`