### PR TITLE
docs: add constructive-principals skill for application-layer usage

### DIFF
--- a/.agents/skills/constructive-principals/SKILL.md
+++ b/.agents/skills/constructive-principals/SKILL.md
@@ -1,0 +1,279 @@
+---
+name: constructive-principals
+description: "Principal identity system at the application layer — ORM, CLI, and hooks usage for creating/managing principals (scoped sub-identities). Covers the dual-claim JWT model, principal lifecycle via SDK, org scoping with principal_entities, and AuthzHumanOnly enforcement. Use when asked to 'create a principal', 'manage API agents', 'scope an API key', 'use principals', or when building principal management features."
+metadata:
+  author: constructive-io
+  version: "1.0.0"
+  triggers: "user, model"
+---
+
+# Principals — Application Layer
+
+Principals are scoped sub-identities (user type=3) that authenticate via API keys with a subset of their parent human's permissions. This skill covers how to use principals from the ORM, CLI, and React hooks.
+
+For SQL-level internals, see the `constructive-db-principals` skill in the `constructive-db` repo.
+
+## When to Apply
+
+Use this skill when:
+- Creating or deleting principals via ORM, CLI, or hooks
+- Building UI for principal management
+- Scoping a principal to specific orgs via `principal_entities`
+- Understanding the dual-claim JWT model at the application layer
+
+## Core Concepts
+
+### Dual-Claim JWT Model
+
+Two JWT claims are always present. For normal human sessions, both are identical:
+
+| Claim | Resolves To | Application Use |
+|-------|-------------|-----------------|
+| `jwt.claims.user_id` | Always the human | Billing, ownership, peoplestamps |
+| `jwt.claims.principal_id` | The principal (or same as user_id for humans) | SPRT permission lookups |
+
+When authenticating with a principal's API key, `user_id` stays the human owner and `principal_id` becomes the principal's identity. All existing ownership checks (`created_by`, `updated_by`, billing) continue to attribute to the human.
+
+### User Types
+
+```
+1 = User (human)
+2 = Organization
+3 = Principal (scoped sub-identity)
+```
+
+### AuthzHumanOnly
+
+All principal management mutations (`create_principal`, `delete_principal`) are guarded by `AuthzHumanOnly` — only the owning human can call them. A principal session cannot create or delete other principals.
+
+### Org Scoping
+
+Principals can be restricted to specific orgs via `principal_entities`:
+- **No entries** = unrestricted (inherits access to all parent's orgs)
+- **1+ entries** = restricted to only those specific orgs
+
+## ORM Usage
+
+### Create a principal
+
+```typescript
+const result = await db.createPrincipal({
+  data: {
+    name: 'billing-bot',
+    allowedMask: null,       // null = inherit all parent permissions
+    isReadOnly: false,
+    bypassStepUp: true,
+    entityIds: null           // null = unrestricted org access
+  },
+  select: {
+    id: true,
+    userId: true,
+    name: true,
+    ownerIdId: true
+  }
+}).execute();
+
+const principal = result.unwrap();
+```
+
+### Create a principal scoped to specific orgs
+
+```typescript
+const result = await db.createPrincipal({
+  data: {
+    name: 'org-a-only-bot',
+    allowedMask: null,
+    isReadOnly: true,
+    bypassStepUp: true,
+    entityIds: [orgAId, orgBId]  // restrict to these orgs
+  },
+  select: { id: true, name: true }
+}).execute();
+```
+
+### Delete a principal
+
+```typescript
+const result = await db.deletePrincipal({
+  data: {
+    principalId: principalId
+  },
+  select: { success: true }
+}).execute();
+```
+
+### Query principals (owner sees own only)
+
+```typescript
+const principals = await db.principal.findMany({
+  select: {
+    id: true,
+    name: true,
+    userId: true,
+    allowedMask: true,
+    isReadOnly: true,
+    bypassStepUp: true
+  }
+}).execute();
+```
+
+### Query principal entity scoping
+
+```typescript
+const scoping = await db.principalEntity.findMany({
+  where: { principalId: principalId },
+  select: {
+    id: true,
+    principalId: true,
+    entityId: true
+  }
+}).execute();
+```
+
+## CLI Usage
+
+### Create a principal
+
+```bash
+csdk create-principal \
+  --name "ci-deploy" \
+  --is-read-only false \
+  --bypass-step-up true
+```
+
+### Create with org scoping
+
+```bash
+csdk create-principal \
+  --name "org-scoped-bot" \
+  --entity-ids "<org-uuid-1>,<org-uuid-2>" \
+  --is-read-only true
+```
+
+### Delete a principal
+
+```bash
+csdk delete-principal --principal-id "<principal-uuid>"
+```
+
+### List principals
+
+```bash
+csdk principal list
+```
+
+### List principal entities (org scoping)
+
+```bash
+csdk principal-entity list --principal-id "<principal-uuid>"
+```
+
+## React Hooks Usage
+
+### Create a principal
+
+```typescript
+import { useCreatePrincipalMutation } from './hooks';
+
+const { mutate: createPrincipal } = useCreatePrincipalMutation();
+
+createPrincipal({
+  input: {
+    name: 'my-bot',
+    allowedMask: null,
+    isReadOnly: false,
+    bypassStepUp: true,
+    entityIds: null
+  }
+});
+```
+
+### Delete a principal
+
+```typescript
+import { useDeletePrincipalMutation } from './hooks';
+
+const { mutate: deletePrincipal } = useDeletePrincipalMutation();
+
+deletePrincipal({
+  input: { principalId: principalId }
+});
+```
+
+### Query principals
+
+```typescript
+import { usePrincipalsQuery } from './hooks';
+
+const { data, isLoading } = usePrincipalsQuery({
+  selection: {
+    fields: {
+      id: true,
+      name: true,
+      userId: true,
+      isReadOnly: true
+    }
+  }
+});
+```
+
+## Error Handling
+
+All principal mutations return discriminated union results. Handle errors with `.unwrap()` or `.unwrapOr()`:
+
+```typescript
+const result = await db.createPrincipal({
+  data: { name: 'bot', allowedMask: null, isReadOnly: false, bypassStepUp: true, entityIds: null },
+  select: { id: true }
+}).execute();
+
+// Throws on error
+const principal = result.unwrap();
+
+// Or handle gracefully
+const principal = result.unwrapOr(null);
+if (!principal) {
+  // handle error
+}
+```
+
+### Expected errors
+
+| Error | Cause |
+|-------|-------|
+| `NOT_AUTHENTICATED` | No valid session |
+| `PRINCIPAL_CANNOT_CREATE_PRINCIPAL` | A principal session tried to create another principal (AuthzHumanOnly) |
+| `PRINCIPAL_CANNOT_DELETE_PRINCIPAL` | A principal session tried to delete a principal (AuthzHumanOnly) |
+| `PRINCIPAL_NOT_FOUND` | The principal ID doesn't exist |
+| `NOT_OWNER` | Caller doesn't own the principal |
+
+## Workflow: Create a Principal with an API Key
+
+A typical workflow to create a fully usable principal:
+
+```typescript
+// 1. Create the principal (human session required)
+const principal = (await db.createPrincipal({
+  data: { name: 'deploy-bot', allowedMask: null, isReadOnly: false, bypassStepUp: true, entityIds: null },
+  select: { id: true, userId: true }
+}).execute()).unwrap();
+
+// 2. Create an API key for the principal
+const apiKey = (await db.createApiKey({
+  data: {
+    principalId: principal.id,
+    name: 'deploy-bot-key'
+  },
+  select: { id: true, secret: true }
+}).execute()).unwrap();
+
+// 3. The API key secret can now be used to authenticate as this principal
+// When authenticated, jwt.claims.principal_id = principal.userId
+// and jwt.claims.user_id = the human who created it
+```
+
+## References
+
+- `constructive-db-principals` skill — SQL-level internals (module generator, SPRT integration, RLS policies)
+- `constructive-db-security` skill — AuthzHumanOnly policy details
+- `references/principal-fields.md` — Field reference for principals and principal_entities tables

--- a/.agents/skills/constructive-principals/references/principal-fields.md
+++ b/.agents/skills/constructive-principals/references/principal-fields.md
@@ -1,0 +1,71 @@
+---
+name: constructive-principals-fields
+description: Field reference for principals and principal_entities tables — columns, types, defaults, and constraints.
+---
+
+# Principal Field Reference
+
+## `principals` table
+
+| Field | GraphQL Name | Type | Default | Description |
+|-------|-------------|------|---------|-------------|
+| `id` | `id` | UUID | auto | Primary key |
+| `owner_id` | `ownerId` | UUID (FK → users) | — | Parent human who owns this principal |
+| `user_id` | `userId` | UUID (FK → users) | — | Principal's identity row (type=3) |
+| `name` | `name` | String | — | Display name (e.g., `'billing-bot'`) |
+| `allowed_mask` | `allowedMask` | BitVarying | NULL | Permission subset bitmask. NULL = all parent permissions |
+| `is_read_only` | `isReadOnly` | Boolean | false | Read-only mode flag |
+| `bypass_step_up` | `bypassStepUp` | Boolean | true | Skip MFA step-up (principals can't do MFA) |
+| `created_at` | `createdAt` | DateTime | now() | Creation timestamp |
+| `updated_at` | `updatedAt` | DateTime | now() | Last update timestamp |
+
+**RLS:** `AuthzDirectOwner` on `owner_id` — users can only SELECT their own principals.
+
+**Mutations:** `create_principal` and `delete_principal` (both AuthzHumanOnly, SECURITY DEFINER).
+
+## `principal_entities` table
+
+| Field | GraphQL Name | Type | Default | Description |
+|-------|-------------|------|---------|-------------|
+| `id` | `id` | UUID | auto | Primary key |
+| `principal_id` | `principalId` | UUID (FK → principals, CASCADE) | — | The principal being scoped |
+| `entity_id` | `entityId` | UUID (FK → users) | — | The org this principal can access |
+
+**Unique constraint:** `(principal_id, entity_id)` — no duplicate scoping.
+
+**RLS:** `AuthzDirectOwner` via the principal's `owner_id` (joined through `principal_id → principals.owner_id`).
+
+**Scoping semantics:**
+- No rows = unrestricted (principal inherits access to all parent's orgs)
+- 1+ rows = restricted to only those specific orgs
+
+## `create_principal` mutation
+
+| Parameter | GraphQL Name | Type | Required | Description |
+|-----------|-------------|------|----------|-------------|
+| `name` | `name` | String | Yes | Display name |
+| `allowed_mask` | `allowedMask` | BitVarying | No | Permission bitmask (NULL = all) |
+| `entity_ids` | `entityIds` | [UUID] | No | Org IDs to scope to (NULL = unrestricted) |
+| `is_read_only` | `isReadOnly` | Boolean | No | Default: false |
+| `bypass_step_up` | `bypassStepUp` | Boolean | No | Default: true |
+
+**Returns:** The created principal record.
+
+**Guards:** AuthzHumanOnly — only callable by human sessions.
+
+**Side effects:**
+1. Creates a `users` row with `type = 3`
+2. Creates a `principals` row
+3. If `entity_ids` provided, creates `principal_entities` rows
+
+## `delete_principal` mutation
+
+| Parameter | GraphQL Name | Type | Required | Description |
+|-----------|-------------|------|----------|-------------|
+| `principal_id` | `principalId` | UUID | Yes | The principal to delete |
+
+**Returns:** Success indicator.
+
+**Guards:** AuthzHumanOnly + ownership check (must own the principal).
+
+**Side effects:** CASCADE deletes the principal's `users` row, `principal_entities` rows, SPRT entries, and any associated credentials/sessions.


### PR DESCRIPTION
## Summary

Adds the `constructive-principals` skill documenting how to use principals (scoped sub-identities) from the ORM, CLI, and React hooks.

Covers:
- `createPrincipal` / `deletePrincipal` ORM operations with `entity_ids` org scoping
- CLI commands for principal CRUD and listing
- React Query hooks (`useCreatePrincipalMutation`, `usePrincipalsQuery`, etc.)
- Error handling (discriminated unions, expected error codes like `PRINCIPAL_CANNOT_CREATE_PRINCIPAL`)
- Full workflow example: create principal → create API key → authenticate
- Field reference for `principals` and `principal_entities` tables

Companion PR in `constructive-io/constructive-db` adds the SQL-level skill (`constructive-db-principals`) and `AuthzHumanOnly` to security docs.

Link to Devin session: https://app.devin.ai/sessions/a105617379774bdea66b414d6503c97d
Requested by: @pyramation