### PR TITLE
feat: propagate principal_id through Express middleware and PostGraphile pgSettings

### DIFF
--- a/graphql/server/src/middleware/graphile.ts
+++ b/graphql/server/src/middleware/graphile.ts
@@ -270,8 +270,18 @@ const buildPreset = (
             pgSettings['jwt.claims.kind'] = req.token.kind;
           }
 
-          // Enforce read-only transactions for read_only credentials (API keys, etc.)
-          if (req.token.access_level === 'read_only') {
+          // Principal identity (service accounts / bots)
+          if (req.token.principal_id) {
+            pgSettings['jwt.claims.principal_id'] = req.token.principal_id;
+          }
+
+          // Enforce read-only transactions for read_only credentials or
+          // read-only principals (is_read_only flag from authenticate())
+          if (
+            req.token.access_level === 'read_only' ||
+            req.token.is_read_only === true ||
+            req.token.is_read_only === 'true'
+          ) {
             pgSettings['default_transaction_read_only'] = 'on';
           }
 

--- a/graphql/server/src/middleware/types.ts
+++ b/graphql/server/src/middleware/types.ts
@@ -3,6 +3,7 @@ import type { ApiStructure } from '../types';
 export type ConstructiveAPIToken = {
   id?: string;
   user_id?: string;
+  principal_id?: string;
   session_id?: string;
   access_level?: string;
   kind?: string;

--- a/packages/express-context/src/pg-settings.ts
+++ b/packages/express-context/src/pg-settings.ts
@@ -46,6 +46,11 @@ export function buildPgSettings(input: PgSettingsInput): Record<string, string> 
     settings['jwt.claims.session_id'] = token.session_id;
   }
 
+  // Principal identity (service accounts / bots)
+  if (token?.principal_id) {
+    settings['jwt.claims.principal_id'] = token.principal_id;
+  }
+
   // Database context
   if (api.databaseId) {
     settings['jwt.claims.database_id'] = api.databaseId;

--- a/packages/express-context/src/types.ts
+++ b/packages/express-context/src/types.ts
@@ -126,6 +126,7 @@ export type ApiConfigResult = ApiStructure | ApiError | null;
 export type ConstructiveAPIToken = {
   id?: string;
   user_id?: string;
+  principal_id?: string;
   session_id?: string;
   access_level?: string;
   kind?: string;


### PR DESCRIPTION
## Summary

Implements the **constructive portion** of [constructive-planning#1074](https://github.com/constructive-io/constructive-planning/issues/1074) (Phase 1f: Server/Middleware GUC Propagation for Principal Identity).

Once `authenticate()` returns `principal_id` (from the companion constructive-db PR), the middleware needs to propagate it as a PostgreSQL GUC so `jwt_public.current_principal_id()` resolves at runtime.

### Changes

**`types.ts`** — adds `principal_id?: string` to `ConstructiveAPIToken`:
```typescript
export type ConstructiveAPIToken = {
  id?: string;
  user_id?: string;
  principal_id?: string;  // NEW
  session_id?: string;
  access_level?: string;
  kind?: string;
  [key: string]: unknown;
};
```

**`pg-settings.ts`** — sets GUC in `buildPgSettings()`:
```typescript
if (token?.principal_id) {
  settings['jwt.claims.principal_id'] = token.principal_id;
}
```

**`graphile.ts`** — sets GUC in PostGraphile pgSettings callback + enforces read-only for `is_read_only` principals:
```typescript
if (req.token.principal_id) {
  pgSettings['jwt.claims.principal_id'] = req.token.principal_id;
}
if (req.token.access_level === 'read_only' ||
    req.token.is_read_only === true ||
    req.token.is_read_only === 'true') {
  pgSettings['default_transaction_read_only'] = 'on';
}
```

Human sessions are unaffected — `principal_id` is `undefined`/NULL, so `current_principal_id()` falls back to `current_user_id()`.

### Companion PR

The database side (adding `principal_id` to `session_credentials` and `authenticate()` return type) lives in constructive-io/constructive-db branch `feat/principal-id-authenticate`.

Link to Devin session: https://app.devin.ai/sessions/2709986191b44c85ad3cad28840e7abe
Requested by: @pyramation