### PR TITLE
fix: remove speculative is_read_only checks from graphile middleware

### DIFF
--- a/graphql/server/src/middleware/graphile.ts
+++ b/graphql/server/src/middleware/graphile.ts
@@ -275,13 +275,8 @@ const buildPreset = (
             pgSettings['jwt.claims.principal_id'] = req.token.principal_id;
           }
 
-          // Enforce read-only transactions for read_only credentials or
-          // read-only principals (is_read_only flag from authenticate())
-          if (
-            req.token.access_level === 'read_only' ||
-            req.token.is_read_only === true ||
-            req.token.is_read_only === 'true'
-          ) {
+          // Enforce read-only transactions for read_only credentials
+          if (req.token.access_level === 'read_only') {
             pgSettings['default_transaction_read_only'] = 'on';
           }
 


### PR DESCRIPTION
## Summary

Removes the speculative `is_read_only` checks added in #1313. `authenticate()` doesn't return `is_read_only` — those branches were dead code that only compiled because `ConstructiveAPIToken` has `[key: string]: unknown`.

```diff
- if (
-   req.token.access_level === 'read_only' ||
-   req.token.is_read_only === true ||
-   req.token.is_read_only === 'true'
- ) {
+ if (req.token.access_level === 'read_only') {
    pgSettings['default_transaction_read_only'] = 'on';
  }
```

Link to Devin session: https://app.devin.ai/sessions/2709986191b44c85ad3cad28840e7abe
Requested by: @pyramation