### PR TITLE
feat: always set jwt.claims.principal_id in pgSettings

### DIFF
--- a/graphql/server/src/middleware/graphile.ts
+++ b/graphql/server/src/middleware/graphile.ts
@@ -270,10 +270,8 @@ const buildPreset = (
             pgSettings['jwt.claims.kind'] = req.token.kind;
           }
 
-          // Principal identity (service accounts / bots)
-          if (req.token.principal_id) {
-            pgSettings['jwt.claims.principal_id'] = req.token.principal_id;
-          }
+          // Principal identity — always set; equals user_id for human sessions
+          pgSettings['jwt.claims.principal_id'] = req.token.principal_id || req.token.user_id;
 
           // Enforce read-only transactions for read_only credentials
           if (req.token.access_level === 'read_only') {


### PR DESCRIPTION
## Summary

The server middleware in `graphile.ts` previously only set `jwt.claims.principal_id` when `req.token.principal_id` was truthy — meaning human sessions (which have no explicit principal) never had the GUC set, so `current_principal_id()` returned NULL.

Now it's always set for authenticated requests:

```diff
-          // Principal identity (service accounts / bots)
-          if (req.token.principal_id) {
-            pgSettings['jwt.claims.principal_id'] = req.token.principal_id;
-          }
+          // Principal identity — always set; equals user_id for human sessions
+          pgSettings['jwt.claims.principal_id'] = req.token.principal_id || req.token.user_id;
```

This aligns with `constructive-db` PR #1701 (merged), where `add_job` and all log generators now read `jwt_public.current_principal_id()` directly with no coalesce fallback — NULL means a bug in the auth layer, not an expected state.

Link to Devin session: https://app.devin.ai/sessions/7f352320916e401d847dfac1748ad64f
Requested by: @pyramation