### PR TITLE
feat(graphql-test): auto-derive principal_id from user_id in setContext

### DIFF
--- a/graphql/test/src/get-connections.ts
+++ b/graphql/test/src/get-connections.ts
@@ -33,6 +33,16 @@ const createConnectionsBase = async (
   const conn: GetConnectionResult = await getPgConnections(input, seedAdapters);
   const { pg, db, teardown: dbTeardown } = conn;
 
+  // Auto-derive principal_id from user_id on every setContext call
+  // (same behavior as constructive-test for pgsql-test clients).
+  const origSetContext = db.setContext.bind(db);
+  db.setContext = (ctx: Record<string, string | null>) => {
+    if (ctx['jwt.claims.user_id'] && !('jwt.claims.principal_id' in ctx)) {
+      ctx = { ...ctx, 'jwt.claims.principal_id': ctx['jwt.claims.user_id'] };
+    }
+    origSetContext(ctx);
+  };
+
   const gqlContext = GraphQLTest(input, conn);
   await gqlContext.setup();
 


### PR DESCRIPTION
## Summary

Adds `principal_id` auto-derivation to `@constructive-io/graphql-test`'s `createConnectionsBase`, matching what `constructive-test` already does for `pgsql-test` clients.

```ts
// in createConnectionsBase, after getting conn from pgsql-test:
const origSetContext = db.setContext.bind(db);
db.setContext = (ctx) => {
  if (ctx['jwt.claims.user_id'] && !('jwt.claims.principal_id' in ctx)) {
    ctx = { ...ctx, 'jwt.claims.principal_id': ctx['jwt.claims.user_id'] };
  }
  origSetContext(ctx);
};
```

This eliminates the need for manual `origSetContext` wrappers in test files that use `@constructive-io/graphql-test` (e.g. `provisioned-db.graphql.test.ts`, `auth-stepup.integration.test.ts` in constructive-db).

Link to Devin session: https://app.devin.ai/sessions/5220b056d43d4c55951185f8e889371b
Requested by: @pyramation