### PR TITLE
fix: replace workspace:^ in peerDependencies with real version ranges

### DIFF
--- a/graphile/graphile-llm/package.json
+++ b/graphile/graphile-llm/package.json
@@ -40,7 +40,7 @@
     "graphile-build": "5.0.2",
     "graphile-build-pg": "5.0.2",
     "graphile-config": "1.0.1",
-    "graphile-search": "workspace:^",
+    "graphile-search": "^1.18.0",
     "graphile-utils": "5.0.0",
     "graphql": "16.13.0",
     "pg-sql2": "5.0.1",

--- a/graphile/graphile-ltree/package.json
+++ b/graphile/graphile-ltree/package.json
@@ -34,7 +34,7 @@
     "graphile-build": "5.0.2",
     "graphile-build-pg": "5.0.2",
     "graphile-config": "1.0.1",
-    "graphile-connection-filter": "workspace:^",
+    "graphile-connection-filter": "^1.13.0",
     "graphql": "16.13.0",
     "pg-sql2": "5.0.1",
     "postgraphile": "5.0.3"

--- a/graphile/graphile-pg-aggregates/package.json
+++ b/graphile/graphile-pg-aggregates/package.json
@@ -52,7 +52,7 @@
     "graphile-build": "5.0.2",
     "graphile-build-pg": "5.0.2",
     "graphile-config": "1.0.1",
-    "graphile-connection-filter": "workspace:^",
+    "graphile-connection-filter": "^1.13.0",
     "graphql": "16.13.0",
     "pg-sql2": "5.0.1",
     "postgraphile": "5.0.3"

--- a/graphile/graphile-postgis/package.json
+++ b/graphile/graphile-postgis/package.json
@@ -46,7 +46,7 @@
     "graphile-build": "5.0.2",
     "graphile-build-pg": "5.0.2",
     "graphile-config": "1.0.1",
-    "graphile-connection-filter": "workspace:^",
+    "graphile-connection-filter": "^1.13.0",
     "graphql": "16.13.0",
     "pg-sql2": "5.0.1",
     "postgraphile": "5.0.3"


### PR DESCRIPTION
## Summary

`npm install -g pgpm` fails with `EUNSUPPORTEDPROTOCOL: Unsupported URL Type "workspace:"` because `graphile-llm@0.14.0` was published with `"graphile-search": "workspace:^"` in its `peerDependencies`.

The `workspace:` protocol is a pnpm feature that should be replaced with real versions during publish, but the lerna/makage publish pipeline doesn't replace it in `peerDependencies` — only in `dependencies`.

The dependency chain: `pgpm` → `@pgpmjs/export` → `@pgpmjs/migrate-client` → `@constructive-io/graphql-query` → `graphile-settings` → `graphile-llm@0.14.0` (boom).

**Fix:** replace `workspace:^` with real version ranges in `peerDependencies` across 4 packages:

```diff
# graphile-llm
- "graphile-search": "workspace:^"
+ "graphile-search": "^1.18.0"

# graphile-postgis, graphile-pg-aggregates, graphile-ltree
- "graphile-connection-filter": "workspace:^"
+ "graphile-connection-filter": "^1.13.0"
```

Only `graphile-llm` is currently broken on npm; the other three are preventive fixes (same pattern, not yet leaked to published versions).

Link to Devin session: https://app.devin.ai/sessions/8405d6fc90a04e5e9e17471f7eb69e33
Requested by: @pyramation