### PR TITLE
feat: add Docker Hub publishing to constructive image CI

### DIFF
--- a/.github/workflows/docker-constructive.yaml
+++ b/.github/workflows/docker-constructive.yaml
@@ -123,6 +123,7 @@ jobs:
     env:
       REPO: ghcr.io/${{ github.repository_owner }}
       IMAGE_NAME: constructive
+      DOCKERHUB_IMAGE: constructiveio/constructive
 
     steps:
       - name: Set up Docker Buildx
@@ -135,6 +136,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
@@ -142,7 +149,7 @@ jobs:
           path: ${{ runner.temp }}/digests
           merge-multiple: true
 
-      - name: Extract metadata
+      - name: Extract metadata (GHCR)
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -155,7 +162,20 @@ jobs:
             type=sha,format=short,prefix=
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Create and push multi-arch manifests
+      - name: Extract metadata (Docker Hub)
+        id: meta-dockerhub
+        uses: docker/metadata-action@v5
+        with:
+          images: docker.io/${{ env.DOCKERHUB_IMAGE }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,format=short,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Create and push multi-arch manifests (GHCR)
         run: |
           set -euo pipefail
 
@@ -178,12 +198,27 @@ jobs:
             exit 1
           fi
 
-          echo "Creating manifests for tags:"
+          echo "Creating GHCR manifests for tags:"
           echo "${{ steps.meta.outputs.tags }}"
 
-          # metadata-action outputs tags as a newline-separated list
           echo "${{ steps.meta.outputs.tags }}" | while read -r tag; do
             [ -z "$tag" ] && continue
             echo "Creating multi-arch manifest for $tag"
             docker buildx imagetools create -t "$tag" $digests
+          done
+
+      - name: Copy multi-arch manifests to Docker Hub
+        if: github.ref == 'refs/heads/main'
+        run: |
+          set -euo pipefail
+
+          ghcr_image="${{ env.REPO }}/${{ env.IMAGE_NAME }}"
+
+          echo "Copying manifests to Docker Hub:"
+          echo "${{ steps.meta-dockerhub.outputs.tags }}"
+
+          echo "${{ steps.meta-dockerhub.outputs.tags }}" | while read -r tag; do
+            [ -z "$tag" ] && continue
+            echo "Copying to $tag"
+            docker buildx imagetools create -t "$tag" "${ghcr_image}:latest"
           done


### PR DESCRIPTION
## Summary

Adds Docker Hub publishing alongside the existing GHCR publish in the `docker-constructive` workflow. After GHCR multi-arch manifests are assembled, a new step copies them to `docker.io/constructiveio/constructive` (only on `main` branch pushes).

This enables the `constructive-db` K8s local dev setup to pull a pre-built GraphQL server image from Docker Hub without needing GHCR auth or rebuilding the entire constructive monorepo from source.

**Changes to `publish-constructive-manifest` job:**
- Add Docker Hub login step (requires `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` repo secrets)
- Add `meta-dockerhub` metadata extraction for Docker Hub tags
- Add `Copy multi-arch manifests to Docker Hub` step using `docker buildx imagetools create` to mirror from GHCR

No changes to the build job — images are still built and pushed by digest to GHCR only. The Docker Hub copy happens post-assembly via `imagetools create`, avoiding redundant builds.

Link to Devin session: https://app.devin.ai/sessions/7308698edc054a55b1b7e6414263f077
Requested by: @pyramation