### PR TITLE
feat(pgpm): add `pgpm tune` command for throwaway environments

### DIFF
--- a/pgpm/cli/src/commands.ts
+++ b/pgpm/cli/src/commands.ts
@@ -27,6 +27,7 @@ import revert from './commands/revert';
 import slice from './commands/slice';
 import tag from './commands/tag';
 import testPackages from './commands/test-packages';
+import tune from './commands/tune';
 import verify from './commands/verify';
 import { usageText } from './utils';
 
@@ -66,6 +67,7 @@ export const createPgpmCommandMap = (skipPgTeardown: boolean = false): Record<st
         rename: pgt(renameCmd),
         slice,
         'test-packages': pgt(testPackages),
+        tune: pgt(tune),
         upgrade: pgt(upgrade),
         up: pgt(upgrade),
         cache,

--- a/pgpm/cli/src/commands/tune.ts
+++ b/pgpm/cli/src/commands/tune.ts
@@ -1,0 +1,95 @@
+import { Logger } from '@pgpmjs/logger';
+import { CLIOptions, Inquirerer } from 'inquirerer';
+import { getPgPool } from 'pg-cache';
+
+const log = new Logger('tune');
+
+const tuneUsageText = `
+Tune Command:
+
+  pgpm tune [OPTIONS]
+
+  Tune PostgreSQL for throwaway environments (CI, local dev, test containers).
+  Disables durability guarantees to eliminate checkpoint/fsync I/O stalls,
+  which can make DDL-heavy workloads (e.g. provisioning) dramatically faster
+  and more reliable on slow disks.
+
+  Applies via ALTER SYSTEM + pg_reload_conf() (no restart required):
+
+    fsync = off
+    synchronous_commit = off
+    full_page_writes = off
+    checkpoint_timeout = 30min
+    max_wal_size = 8GB
+
+  WARNING: These settings can cause data loss or corruption on crash.
+  Only use against disposable databases — never production.
+
+Options:
+  --help, -h              Show this help message
+  --yes                   Skip confirmation prompt
+  --reset                 Restore all settings above to server defaults
+
+Examples:
+  pgpm tune --yes         Tune a CI/test database (non-interactive)
+  pgpm tune --reset --yes Restore default durability settings
+`;
+
+const TUNE_SETTINGS: Record<string, string> = {
+  fsync: 'off',
+  synchronous_commit: 'off',
+  full_page_writes: 'off',
+  checkpoint_timeout: '30min',
+  max_wal_size: '8GB'
+};
+
+export default async (
+  argv: Partial<Record<string, any>>,
+  prompter: Inquirerer,
+  _options: CLIOptions
+) => {
+  if (argv.help || argv.h) {
+    console.log(tuneUsageText);
+    process.exit(0);
+  }
+
+  const reset = argv.reset === true;
+
+  const { yes } = await prompter.prompt(argv, [
+    {
+      type: 'confirm',
+      name: 'yes',
+      message: reset
+        ? 'Restore PostgreSQL durability settings to server defaults?'
+        : 'Disable PostgreSQL durability? This risks data loss on crash and must never be used in production.',
+      default: false
+    }
+  ]);
+
+  if (!yes) {
+    log.info('Operation cancelled.');
+    return;
+  }
+
+  const db = await getPgPool({
+    database: 'postgres'
+  });
+
+  for (const [setting, value] of Object.entries(TUNE_SETTINGS)) {
+    if (reset) {
+      await db.query(`ALTER SYSTEM RESET ${setting};`);
+      log.info(`reset ${setting}`);
+    } else {
+      await db.query(`ALTER SYSTEM SET ${setting} = '${value}';`);
+      log.info(`set ${setting} = ${value}`);
+    }
+  }
+
+  await db.query('SELECT pg_reload_conf();');
+
+  log.success(
+    reset
+      ? 'PostgreSQL durability settings restored to defaults.'
+      : 'PostgreSQL tuned for throwaway environments (durability disabled).'
+  );
+};

--- a/pgpm/cli/src/utils/display.ts
+++ b/pgpm/cli/src/utils/display.ts
@@ -27,6 +27,7 @@ export const usageText = `
     analyze            Analyze database structure
     rename             Rename database changes
     admin-users        Manage admin users
+    tune               Tune PostgreSQL for throwaway environments (CI/test)
 
   Testing:
     test-packages      Run integration tests on all workspace packages


### PR DESCRIPTION
## Summary

Adds `pgpm tune` — a CLI command that disables PostgreSQL durability for throwaway databases (CI service containers, local dev, test containers). Motivated by CI flakiness in constructive-db (constructive-io/constructive-db#1925): WAL checkpoints stalling on runner disk I/O were pushing DDL-heavy provisioning tests past their jest timeouts. With this command, that repo's workflow psql one-liner can become `pgpm tune --yes`.

Applies via `ALTER SYSTEM` + `pg_reload_conf()` (all SIGHUP-reloadable — no restart):

```
fsync = off
synchronous_commit = off
full_page_writes = off
checkpoint_timeout = 30min
max_wal_size = 8GB
```

Usage:

```
pgpm tune --yes          # non-interactive (CI)
pgpm tune --reset --yes  # ALTER SYSTEM RESET back to server defaults
```

Follows the `admin-users bootstrap` pattern (prompter confirm gated by `--yes`, `getPgPool` from pg-cache, `Logger`); registered in `createPgpmCommandMap` with the pg-teardown wrapper. Verified against a live postgres-plus:18 container: settings apply and reset correctly.

Note: `pnpm lint` currently fails repo-wide (ESLint 9 installed but config is `.eslintrc.json`) — pre-existing, unrelated to this change.

Link to Devin session: https://app.devin.ai/sessions/7943c7526d254aa4828be110fbb3f272
Requested by: @pyramation