### PR TITLE
ci: tune Postgres durability in pg test jobs

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -223,6 +223,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Durability is irrelevant for throwaway CI databases. Disabling fsync
+      # and synchronous commit avoids checkpoint I/O stalls on CI runners.
+      - name: Tune Postgres for CI (disable durability)
+        run: pnpm --filter pgpm exec node dist/index.js tune --yes
+
       - name: Seed app_user
         run: |
           pnpm --filter pgpm exec node dist/index.js admin-users bootstrap --yes
@@ -331,6 +336,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Durability is irrelevant for throwaway CI databases. Disabling fsync
+      # and synchronous commit avoids checkpoint I/O stalls on CI runners.
+      - name: Tune Postgres for CI (disable durability)
+        run: pnpm --filter pgpm exec node dist/index.js tune --yes
+
       - name: Seed app_user
         run: |
           pnpm --filter pgpm exec node dist/index.js admin-users bootstrap --yes
@@ -401,6 +411,11 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      # Durability is irrelevant for throwaway CI databases. Disabling fsync
+      # and synchronous commit avoids checkpoint I/O stalls on CI runners.
+      - name: Tune Postgres for CI (disable durability)
+        run: pnpm --filter pgpm exec node dist/index.js tune --yes
 
       - name: Seed app_user
         run: |


### PR DESCRIPTION
## Summary

Adds a `Tune Postgres for CI (disable durability)` step before `Seed app_user` in the three Postgres-backed jobs (`pg-tests`, `integration-tests`, `ai-tests`) of run-tests.yaml. Solves the self-referential case by invoking the workspace-built CLI — `pnpm --filter pgpm exec node dist/index.js tune --yes` — which exists since #1336 and is built by the upstream `build` job, so no npm release dependency.

Tuning applies `fsync/synchronous_commit/full_page_writes = off`, `checkpoint_timeout = 30min`, `max_wal_size = 8GB` via `ALTER SYSTEM` + `pg_reload_conf()`, eliminating checkpoint I/O stalls on CI runners (root cause of flakiness fixed in constructive-io/constructive-db#1925).

Link to Devin session: https://app.devin.ai/sessions/7943c7526d254aa4828be110fbb3f272
Requested by: @pyramation