### PR TITLE
chore: replace em dashes with hyphens in package descriptions

### DIFF
--- a/agentic/agentic-server/package.json
+++ b/agentic/agentic-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentic-server",
   "version": "0.8.0",
-  "description": "Standalone Express LLM service — agent threads, chat streaming, billing metering, and inference logging via express-context",
+  "description": "Standalone Express LLM service - agent threads, chat streaming, billing metering, and inference logging via express-context",
   "main": "index.js",
   "module": "esm/index.js",
   "types": "index.d.ts",

--- a/graphile/graphile-bucket-provisioner-plugin/package.json
+++ b/graphile/graphile-bucket-provisioner-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graphile-bucket-provisioner-plugin",
   "version": "0.13.0",
-  "description": "Bucket provisioning plugin for PostGraphile v5 — auto-provisions S3 buckets on bucket table mutations",
+  "description": "Bucket provisioning plugin for PostGraphile v5 - auto-provisions S3 buckets on bucket table mutations",
   "author": "Constructive <developers@constructive.io>",
   "homepage": "https://github.com/constructive-io/constructive",
   "license": "MIT",

--- a/graphile/graphile-i18n/package.json
+++ b/graphile/graphile-i18n/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graphile-i18n",
   "version": "1.4.1",
-  "description": "PostGraphile v5 i18n plugin — language-aware fields from @i18n translation tables with Accept-Language negotiation and fallback chains",
+  "description": "PostGraphile v5 i18n plugin - language-aware fields from @i18n translation tables with Accept-Language negotiation and fallback chains",
   "author": "Constructive <developers@constructive.io>",
   "homepage": "https://github.com/constructive-io/constructive",
   "license": "MIT",

--- a/graphile/graphile-llm/package.json
+++ b/graphile/graphile-llm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graphile-llm",
   "version": "0.16.1",
-  "description": "LLM integration plugin for PostGraphile v5 — server-side text-to-vector embedding and text companion fields for pgvector columns",
+  "description": "LLM integration plugin for PostGraphile v5 - server-side text-to-vector embedding and text companion fields for pgvector columns",
   "author": "Constructive <developers@constructive.io>",
   "homepage": "https://github.com/constructive-io/constructive",
   "license": "MIT",

--- a/graphile/graphile-ltree/package.json
+++ b/graphile/graphile-ltree/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graphile-ltree",
   "version": "1.12.1",
-  "description": "PostGraphile v5 ltree plugin — auto-detects ltree columns, exposes slash-path folder fields, and provides containment/glob filter operators",
+  "description": "PostGraphile v5 ltree plugin - auto-detects ltree columns, exposes slash-path folder fields, and provides containment/glob filter operators",
   "author": "Constructive <developers@constructive.io>",
   "homepage": "https://github.com/constructive-io/constructive",
   "license": "MIT",

--- a/graphile/graphile-pg-aggregates/package.json
+++ b/graphile/graphile-pg-aggregates/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graphile-pg-aggregates",
   "version": "1.8.1",
-  "description": "PostGraphile v5 aggregate plugin — sum, avg, min, max, stddev, variance, distinctCount, groupedAggregates with groupBy + having, orderBy relational aggregates",
+  "description": "PostGraphile v5 aggregate plugin - sum, avg, min, max, stddev, variance, distinctCount, groupedAggregates with groupBy + having, orderBy relational aggregates",
   "author": "Constructive <developers@constructive.io>",
   "homepage": "https://github.com/constructive-io/constructive",
   "license": "MIT",

--- a/graphile/graphile-presigned-url-plugin/package.json
+++ b/graphile/graphile-presigned-url-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graphile-presigned-url-plugin",
   "version": "0.21.0",
-  "description": "Presigned URL upload plugin for PostGraphile v5 — requestUploadUrl mutation and downloadUrl computed field",
+  "description": "Presigned URL upload plugin for PostGraphile v5 - requestUploadUrl mutation and downloadUrl computed field",
   "author": "Constructive <developers@constructive.io>",
   "homepage": "https://github.com/constructive-io/constructive",
   "license": "MIT",

--- a/graphile/graphile-realtime-subscriptions/package.json
+++ b/graphile/graphile-realtime-subscriptions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graphile-realtime-subscriptions",
   "version": "0.9.0",
-  "description": "Realtime subscription plugin for PostGraphile v5 — per-table GraphQL subscriptions via LISTEN/NOTIFY",
+  "description": "Realtime subscription plugin for PostGraphile v5 - per-table GraphQL subscriptions via LISTEN/NOTIFY",
   "author": "Constructive <developers@constructive.io>",
   "homepage": "https://github.com/constructive-io/constructive",
   "license": "MIT",

--- a/graphile/graphile-realtime-test/package.json
+++ b/graphile/graphile-realtime-test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graphile-realtime-test",
   "version": "0.10.1",
-  "description": "Subscription testing utilities for graphile-realtime-subscriptions — smart tag injection, grafast.subscribe() helpers, and pg_notify simulation",
+  "description": "Subscription testing utilities for graphile-realtime-subscriptions - smart tag injection, grafast.subscribe() helpers, and pg_notify simulation",
   "author": "Constructive <developers@constructive.io>",
   "homepage": "https://github.com/constructive-io/constructive",
   "license": "MIT",

--- a/graphile/graphile-search/package.json
+++ b/graphile/graphile-search/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graphile-search",
   "version": "1.19.1",
-  "description": "Unified PostGraphile v5 search plugin — abstracts tsvector, BM25, pg_trgm, and pgvector behind a single adapter-based architecture with composite searchScore",
+  "description": "Unified PostGraphile v5 search plugin - abstracts tsvector, BM25, pg_trgm, and pgvector behind a single adapter-based architecture with composite searchScore",
   "author": "Constructive <developers@constructive.io>",
   "homepage": "https://github.com/constructive-io/constructive",
   "license": "MIT",

--- a/packages/bucket-provisioner/package.json
+++ b/packages/bucket-provisioner/package.json
@@ -2,7 +2,7 @@
   "name": "@constructive-io/bucket-provisioner",
   "version": "0.13.0",
   "author": "Constructive <developers@constructive.io>",
-  "description": "S3-compatible bucket provisioning library — create buckets, configure privacy policies, CORS, and access controls",
+  "description": "S3-compatible bucket provisioning library - create buckets, configure privacy policies, CORS, and access controls",
   "main": "index.js",
   "module": "esm/index.js",
   "types": "index.d.ts",

--- a/packages/express-context/package.json
+++ b/packages/express-context/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@constructive-io/express-context",
   "version": "0.8.0",
-  "description": "Extractable Express middleware for Constructive tenant context — domain resolution, JWT auth, pgSettings, and withPgClient",
+  "description": "Extractable Express middleware for Constructive tenant context - domain resolution, JWT auth, pgSettings, and withPgClient",
   "author": "Constructive <developers@constructive.io>",
   "homepage": "https://github.com/constructive-io/constructive",
   "license": "MIT",

--- a/packages/llm-env/package.json
+++ b/packages/llm-env/package.json
@@ -2,7 +2,7 @@
   "name": "@constructive-io/llm-env",
   "version": "0.2.0",
   "author": "Constructive <developers@constructive.io>",
-  "description": "LLM environment configuration — single source of truth for all LLM-related env vars and defaults",
+  "description": "LLM environment configuration - single source of truth for all LLM-related env vars and defaults",
   "main": "index.js",
   "module": "esm/index.js",
   "types": "index.d.ts",

--- a/postgres/pgsql-test/package.json
+++ b/postgres/pgsql-test/package.json
@@ -2,7 +2,7 @@
   "name": "pgsql-test",
   "version": "4.18.1",
   "author": "Constructive <developers@constructive.io>",
-  "description": "pgsql-test offers isolated, role-aware, and rollback-friendly PostgreSQL environments for integration tests — giving developers realistic test coverage without external state pollution",
+  "description": "pgsql-test offers isolated, role-aware, and rollback-friendly PostgreSQL environments for integration tests - giving developers realistic test coverage without external state pollution",
   "main": "index.js",
   "module": "esm/index.js",
   "types": "index.d.ts",

--- a/uploads/s3-utils/package.json
+++ b/uploads/s3-utils/package.json
@@ -2,7 +2,7 @@
   "name": "@constructive-io/s3-utils",
   "version": "2.19.0",
   "author": "Constructive <developers@constructive.io>",
-  "description": "Unified S3 utilities — client factory, file operations, presigned URLs",
+  "description": "Unified S3 utilities - client factory, file operations, presigned URLs",
   "main": "index.js",
   "module": "esm/index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## Summary
Replaces `—` (em dash) with `-` in the `description` field of 15 package.json files (introduced in #1330). No other fields contained em dashes.

Link to Devin session: https://app.devin.ai/sessions/b5b424619f9c439997408dea3dd9958f
Requested by: @pyramation