### PR TITLE
Make module loader TTL bounded by default

### DIFF
--- a/packages/express-context/src/loaders/__tests__/create-loader.test.ts
+++ b/packages/express-context/src/loaders/__tests__/create-loader.test.ts
@@ -1,0 +1,81 @@
+import { createModuleLoader } from '../create-loader';
+import type { LoaderContext } from '../types';
+
+function makeContext(databaseId: string, apiId?: string): LoaderContext {
+  return {
+    servicesPool: {} as LoaderContext['servicesPool'],
+    tenantPool: {} as LoaderContext['tenantPool'],
+    databaseId,
+    apiId,
+    dbname: `tenant_${databaseId}`,
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('createModuleLoader', () => {
+  it('does not refresh the TTL on cache hits by default', async () => {
+    let calls = 0;
+    const loader = createModuleLoader<number>({
+      name: 'boundedDefault',
+      ttlMs: 200,
+      resolve: async () => ++calls,
+    });
+    const ctx = makeContext('db-1');
+
+    await expect(loader.resolve(ctx)).resolves.toBe(1);
+
+    await sleep(100);
+    await expect(loader.resolve(ctx)).resolves.toBe(1);
+
+    await sleep(120);
+    await expect(loader.resolve(ctx)).resolves.toBe(2);
+    expect(calls).toBe(2);
+  });
+
+  it('allows loaders to opt into refreshing the TTL on cache hits', async () => {
+    let calls = 0;
+    const loader = createModuleLoader<number>({
+      name: 'slidingOverride',
+      ttlMs: 200,
+      updateAgeOnGet: true,
+      resolve: async () => ++calls,
+    });
+    const ctx = makeContext('db-1');
+
+    await expect(loader.resolve(ctx)).resolves.toBe(1);
+
+    await sleep(100);
+    await expect(loader.resolve(ctx)).resolves.toBe(1);
+
+    await sleep(120);
+    await expect(loader.resolve(ctx)).resolves.toBe(1);
+    expect(calls).toBe(1);
+  });
+
+  it('invalidates both database and database:api cache keys for a database', async () => {
+    let calls = 0;
+    const loader = createModuleLoader<string>({
+      name: 'invalidateByDatabase',
+      ttlMs: 10_000,
+      resolve: async (ctx) => `${ctx.databaseId}:${ctx.apiId ?? 'none'}:${++calls}`,
+    });
+    const dbOnlyCtx = makeContext('db-1');
+    const apiCtx = makeContext('db-1', 'api-1');
+    const otherDbCtx = makeContext('db-2');
+
+    await expect(loader.resolve(dbOnlyCtx)).resolves.toBe('db-1:none:1');
+    await expect(loader.resolve(apiCtx)).resolves.toBe('db-1:api-1:2');
+    await expect(loader.resolve(otherDbCtx)).resolves.toBe('db-2:none:3');
+    expect(loader.cacheSize).toBe(3);
+
+    loader.invalidate('db-1');
+    expect(loader.cacheSize).toBe(1);
+
+    await expect(loader.resolve(dbOnlyCtx)).resolves.toBe('db-1:none:4');
+    await expect(loader.resolve(apiCtx)).resolves.toBe('db-1:api-1:5');
+    await expect(loader.resolve(otherDbCtx)).resolves.toBe('db-2:none:3');
+  });
+});

--- a/packages/express-context/src/loaders/create-loader.ts
+++ b/packages/express-context/src/loaders/create-loader.ts
@@ -18,6 +18,12 @@ export interface CreateLoaderOptions<T> {
   ttlMs?: number;
   /** Max cache entries before LRU eviction (default: 100) */
   max?: number;
+  /**
+   * Whether cache hits refresh the TTL.
+   * Defaults to false so ttlMs is a bounded staleness window.
+   * Set true only for intentionally sliding caches.
+   */
+  updateAgeOnGet?: boolean;
   /** The actual resolution function. Called on cache miss. */
   resolve: (ctx: LoaderContext) => Promise<T | undefined>;
 }
@@ -30,7 +36,7 @@ export function createModuleLoader<T>(opts: CreateLoaderOptions<T>): ModuleLoade
   const cache = new LRUCache<string, T | undefined>({
     max: opts.max ?? DEFAULT_MAX,
     ttl: opts.ttlMs ?? DEFAULT_TTL_MS,
-    updateAgeOnGet: true,
+    updateAgeOnGet: opts.updateAgeOnGet ?? false,
     allowStale: false,
   });
 


### PR DESCRIPTION
## Summary
- Change `createModuleLoader` so cache hits do not refresh TTL by default.
- Add an explicit `updateAgeOnGet` option for loaders that intentionally need sliding TTL / idle-expiry semantics.
- Add unit coverage for bounded default TTL behavior, opt-in sliding TTL behavior, and database-scoped invalidation across `databaseId` / `databaseId:apiId` cache keys.

## Why
`createModuleLoader` is used for runtime settings that may change while the server process is still running. If cache hits refresh the TTL by default, a hot setting effectively becomes a sliding cache entry: every read pushes the expiration window forward. Under steady traffic, that can keep a stale value alive far beyond the configured `ttlMs`, and in practice it may not be reloaded from the database until traffic pauses or the process invalidates the key explicitly.

The safer default is to treat `ttlMs` as a bounded staleness window: once a value is cached, it can be reused until that original window expires, but reads do not extend the window. This makes freshness easier to reason about for loader-backed settings.

Loaders that truly want read-time TTL refresh can still opt in with `updateAgeOnGet: true`. Requiring that option to be explicit is intentional: sliding TTL is a different freshness contract, and a maintainer adding it is very likely making a deliberate trade-off for an idle-expiry cache rather than accidentally inheriting it as the global default.

## Example
Suppose `authSettingsLoader` caches auth/OAuth runtime settings with a 5 minute TTL, and login traffic reads those settings continuously.

With the old default (`updateAgeOnGet: true`):
- settings are loaded at 12:00;
- an admin or generated API update changes the settings at 12:02;
- each login request keeps refreshing the cached entry's age;
- under continuous traffic, the 12:00 value can remain in use well past 12:05 because the cache entry keeps getting renewed on reads.

With the new default (`updateAgeOnGet: false`):
- settings are still loaded at 12:00;
- reads between 12:00 and 12:05 can reuse the cached value;
- after the original 5 minute TTL expires, the next read reloads from the database, even if the setting was read constantly during that window.

That keeps the configured TTL as the maximum normal staleness window for loader-backed settings, while preserving an explicit escape hatch for loaders that intentionally want sliding idle-expiry behavior.

## Testing
- `../../node_modules/.bin/jest --config jest.config.js src/loaders/__tests__/create-loader.test.ts --runInBand`
- `../../node_modules/.bin/jest --config jest.config.js --runInBand`
- `../../node_modules/.bin/makage build --dev`
