### PR TITLE
fix(export): remove vestigial config_secrets_org_module and fail loudly on missing tables

### DIFF
--- a/pgpm/export/__tests__/cross-flow-parity.test.ts
+++ b/pgpm/export/__tests__/cross-flow-parity.test.ts
@@ -19,6 +19,7 @@ import { toCamelCase } from 'inflekt';
 
 import { exportMeta } from '../src/export-meta';
 import { exportGraphQLMeta } from '../src/export-graphql-meta';
+import { buildMetaTableShimsSQL } from '../test-utils/shim-utils';
 import { GraphQLClient } from '../src/graphql-client';
 import { META_TABLE_CONFIG, FieldType } from '../src/export-utils';
 import { getGraphQLQueryName, getGraphQLTypeName, GraphQLTypeInfo } from '../src/graphql-naming';
@@ -61,7 +62,7 @@ function createMockGraphQLClient(pgClient: PgTestClient): GraphQLClient {
     // Reverse-lookup: find the META_TABLE_CONFIG entry whose GraphQL type name matches
     let matchedKey: string | undefined;
     for (const [key, config] of Object.entries(META_TABLE_CONFIG)) {
-      if (getGraphQLTypeName(config.table) === typeName) {
+      if ((config.gqlTypeName || getGraphQLTypeName(config.table)) === typeName) {
         matchedKey = key;
         break;
       }
@@ -422,6 +423,8 @@ describe('Cross-flow parity: exportMeta vs exportGraphQLMeta', () => {
             sign_out_function text
           );
         `);
+
+        await pg.query(buildMetaTableShimsSQL());
 
         // Seed data
         await pg.query(`

--- a/pgpm/export/__tests__/export-flow.test.ts
+++ b/pgpm/export/__tests__/export-flow.test.ts
@@ -22,6 +22,7 @@ import type { PgConfig } from 'pg-env';
 
 import { PgpmPackage, PgpmMigrate } from '@pgpmjs/core';
 import { exportMigrations } from '../src/export-migrations';
+import { buildMetaTableShimsSQL } from '../test-utils/shim-utils';
 
 // Increase timeout for this test as it involves workspace setup and deployment
 jest.setTimeout(120000);
@@ -252,6 +253,7 @@ describe('Export Flow E2E', () => {
 
         // Create shim schemas + tables
         await pg.query(SCHEMA_SHIMS_SQL);
+        await pg.query(buildMetaTableShimsSQL());
 
         // Deploy the test module
         const deployer = new PgpmMigrate(config);

--- a/pgpm/export/__tests__/export-meta.test.ts
+++ b/pgpm/export/__tests__/export-meta.test.ts
@@ -63,7 +63,6 @@ describe('Export Meta Config Validation', () => {
       'devices_module', 'identity_providers_module',
       'notifications_module', 'plans_module',
       'realtime_module', 'session_secrets_module',
-      'config_secrets_org_module',
       'infra_secrets_module', 'infra_config_module',
       'internal_secrets_module',
       'i18n_module', 'agent_module',

--- a/pgpm/export/__tests__/export-parity.test.ts
+++ b/pgpm/export/__tests__/export-parity.test.ts
@@ -49,6 +49,7 @@ import { exportMigrations } from '../src/export-migrations';
 import { exportMeta } from '../src/export-meta';
 import { GraphQLClient } from '../src/graphql-client';
 import { exportGraphQLMeta } from '../src/export-graphql-meta';
+import { buildMetaTableShimsSQL } from '../test-utils/shim-utils';
 import { toCamelCase } from 'inflekt';
 import { getConnections, seed } from 'pgsql-test';
 
@@ -254,6 +255,7 @@ describe('export parity — SQL vs GraphQL (integration)', () => {
 
         // Create shim schemas + tables
         await pgClient.query(SCHEMA_SHIMS_SQL);
+        await pgClient.query(buildMetaTableShimsSQL());
 
         // Seed data
         await pgClient.query(SEED_SQL);
@@ -502,6 +504,7 @@ describe('export parity — SQL vs GraphQL (integration)', () => {
         await migrate.initialize();
 
         await pgClient.query(SCHEMA_SHIMS_SQL);
+        await pgClient.query(buildMetaTableShimsSQL());
 
         // Seed the database row + schemas (required by exportMigrations)
         await pgClient.query(`

--- a/pgpm/export/src/export-graphql-meta.ts
+++ b/pgpm/export/src/export-graphql-meta.ts
@@ -131,11 +131,17 @@ export const exportGraphQLMeta = async ({
 
   const queryAndParse = async (key: string) => {
     const tableConfig = META_TABLE_CONFIG[key];
-    if (!tableConfig) return;
+    if (!tableConfig) {
+      throw new Error(`exportGraphQLMeta: no META_TABLE_CONFIG entry for '${key}'`);
+    }
 
     // Build fields dynamically: either from hardcoded config or via introspection
     const { fields: configFields, enumFields } = await buildDynamicFieldsFromGraphQL(client, tableConfig);
-    if (Object.keys(configFields).length === 0) return;
+    if (Object.keys(configFields).length === 0) {
+      throw new Error(
+        `exportGraphQLMeta: table ${tableConfig.schema}.${tableConfig.table} not exposed in the GraphQL schema or has no matching fields`
+      );
+    }
 
     const pgFieldNames = Object.keys(configFields);
     const graphqlFieldsFragment = buildFieldsFragment(pgFieldNames, configFields);
@@ -146,99 +152,83 @@ export const exportGraphQLMeta = async ({
       ? { id: database_id }
       : { databaseId: database_id };
 
-    try {
-      const rows = await client.fetchAllNodes(
-        graphqlQueryName,
-        graphqlFieldsFragment,
-        condition
-      );
+    const rows = await client.fetchAllNodes(
+      graphqlQueryName,
+      graphqlFieldsFragment,
+      condition
+    );
 
-      if (rows.length > 0) {
-        // Convert camelCase GraphQL keys back to snake_case for the Parser
-        // Also convert interval objects back to Postgres interval strings
-        // and normalize enum values from CONSTANT_CASE back to lowercase
-        const pgRows = rows.map(row => {
-          const pgRow = graphqlRowToPostgresRow(row);
-          for (const [fieldName, fieldType] of Object.entries(configFields)) {
-            // Convert interval fields from {seconds, minutes, ...} objects to strings
-            if (fieldType === 'interval' && pgRow[fieldName] && typeof pgRow[fieldName] === 'object') {
-              pgRow[fieldName] = intervalToPostgres(pgRow[fieldName] as Record<string, number | null>);
-            }
-            // Truncate timestamptz to second precision for parity with SQL flow
-            // PostGraphile's Datetime scalar preserves full millisecond precision,
-            // but the pg driver + our SQL flow truncates to .000Z via Date rounding
-            if (fieldType === 'timestamptz' && typeof pgRow[fieldName] === 'string') {
-              const d = new Date(pgRow[fieldName] as string);
-              if (!isNaN(d.getTime())) {
-                pgRow[fieldName] = new Date(Math.floor(d.getTime() / 1000) * 1000).toISOString();
-              }
-            }
-          }
-          // Normalize enum values: custom inflector uppercases them to CONSTANT_CASE,
-          // but PostgreSQL stores them in lowercase — convert back for parity with SQL flow
-          for (const fieldName of enumFields) {
-            if (typeof pgRow[fieldName] === 'string') {
-              pgRow[fieldName] = (pgRow[fieldName] as string).toLowerCase();
-            }
-          }
-          return pgRow;
-        });
-
-        // Filter fields to only those that exist in the returned data
-        // This mirrors the dynamic field building in the SQL version
-        const returnedKeys = new Set<string>();
-        for (const row of pgRows) {
-          for (const k of Object.keys(row)) {
-            returnedKeys.add(k);
-          }
-        }
-
-        const dynamicFields: Record<string, FieldType> = {};
+    if (rows.length > 0) {
+      // Convert camelCase GraphQL keys back to snake_case for the Parser
+      // Also convert interval objects back to Postgres interval strings
+      // and normalize enum values from CONSTANT_CASE back to lowercase
+      const pgRows = rows.map(row => {
+        const pgRow = graphqlRowToPostgresRow(row);
         for (const [fieldName, fieldType] of Object.entries(configFields)) {
-          if (returnedKeys.has(fieldName)) {
-            dynamicFields[fieldName] = fieldType;
+          // Convert interval fields from {seconds, minutes, ...} objects to strings
+          if (fieldType === 'interval' && pgRow[fieldName] && typeof pgRow[fieldName] === 'object') {
+            pgRow[fieldName] = intervalToPostgres(pgRow[fieldName] as Record<string, number | null>);
           }
-        }
-
-        if (Object.keys(dynamicFields).length === 0) return;
-
-        // Omit columnDefaults columns from row data so the Parser never sees them.
-        // configFields already excludes them (via buildDynamicFieldsFromGraphQL),
-        // so dynamicFields won't contain them either — but the pgRow data still does.
-        if (tableConfig.columnDefaults) {
-          for (const colName of Object.keys(tableConfig.columnDefaults)) {
-            for (const row of pgRows) {
-              delete row[colName];
+          // Truncate timestamptz to second precision for parity with SQL flow
+          // PostGraphile's Datetime scalar preserves full millisecond precision,
+          // but the pg driver + our SQL flow truncates to .000Z via Date rounding
+          if (fieldType === 'timestamptz' && typeof pgRow[fieldName] === 'string') {
+            const d = new Date(pgRow[fieldName] as string);
+            if (!isNaN(d.getTime())) {
+              pgRow[fieldName] = new Date(Math.floor(d.getTime() / 1000) * 1000).toISOString();
             }
           }
         }
+        // Normalize enum values: custom inflector uppercases them to CONSTANT_CASE,
+        // but PostgreSQL stores them in lowercase — convert back for parity with SQL flow
+        for (const fieldName of enumFields) {
+          if (typeof pgRow[fieldName] === 'string') {
+            pgRow[fieldName] = (pgRow[fieldName] as string).toLowerCase();
+          }
+        }
+        return pgRow;
+      });
 
-        const parser = new Parser({
-          schema: tableConfig.schema,
-          table: tableConfig.table,
-          conflictDoNothing: tableConfig.conflictDoNothing,
-          fields: dynamicFields
-        });
-
-        const parsed = await parser.parse(pgRows);
-        if (parsed) {
-          sql[key] = parsed;
+      // Filter fields to only those that exist in the returned data
+      // This mirrors the dynamic field building in the SQL version
+      const returnedKeys = new Set<string>();
+      for (const row of pgRows) {
+        for (const k of Object.keys(row)) {
+          returnedKeys.add(k);
         }
       }
-    } catch (err: unknown) {
-      // If the GraphQL query fails (e.g. table not exposed), skip silently
-      // similar to how the SQL version handles 42P01 (undefined_table)
-      const message = err instanceof Error ? err.message : String(err);
-      if (
-        message.includes('Cannot query field') ||
-        message.includes('is not defined by type') ||
-        message.includes('Unknown field') ||
-        (message.includes('Field') && message.includes('not found'))
-      ) {
-        // Field/table not available in the GraphQL schema — skip
-        return;
+
+      const dynamicFields: Record<string, FieldType> = {};
+      for (const [fieldName, fieldType] of Object.entries(configFields)) {
+        if (returnedKeys.has(fieldName)) {
+          dynamicFields[fieldName] = fieldType;
+        }
       }
-      throw err;
+
+      if (Object.keys(dynamicFields).length === 0) return;
+
+      // Omit columnDefaults columns from row data so the Parser never sees them.
+      // configFields already excludes them (via buildDynamicFieldsFromGraphQL),
+      // so dynamicFields won't contain them either — but the pgRow data still does.
+      if (tableConfig.columnDefaults) {
+        for (const colName of Object.keys(tableConfig.columnDefaults)) {
+          for (const row of pgRows) {
+            delete row[colName];
+          }
+        }
+      }
+
+      const parser = new Parser({
+        schema: tableConfig.schema,
+        table: tableConfig.table,
+        conflictDoNothing: tableConfig.conflictDoNothing,
+        fields: dynamicFields
+      });
+
+      const parsed = await parser.parse(pgRows);
+      if (parsed) {
+        sql[key] = parsed;
+      }
     }
   };
 
@@ -330,7 +320,6 @@ export const exportGraphQLMeta = async ({
     queryAndParse('plans_module'),
     queryAndParse('realtime_module'),
     queryAndParse('session_secrets_module'),
-    queryAndParse('config_secrets_org_module'),
     queryAndParse('infra_secrets_module'),
     queryAndParse('infra_config_module'),
     queryAndParse('internal_secrets_module'),

--- a/pgpm/export/src/export-meta.ts
+++ b/pgpm/export/src/export-meta.ts
@@ -89,22 +89,23 @@ export const exportMeta = async ({ opts, dbname, database_id }: ExportMetaParams
   const parserFields: Record<string, Record<string, FieldType>> = {};
 
   // Build parser dynamically by querying actual columns from the database
-  const getParser = async (key: string): Promise<Parser | null> => {
+  const getParser = async (key: string): Promise<Parser> => {
     if (parsers[key]) {
       return parsers[key];
     }
 
     const tableConfig = META_TABLE_CONFIG[key];
     if (!tableConfig) {
-      return null;
+      throw new Error(`exportMeta: no META_TABLE_CONFIG entry for '${key}'`);
     }
 
     // Build fields dynamically based on actual database columns
     const dynamicFields = await buildDynamicFields(pool, tableConfig);
 
     if (Object.keys(dynamicFields).length === 0) {
-      // No columns found (table doesn't exist or no matching columns)
-      return null;
+      throw new Error(
+        `exportMeta: table ${tableConfig.schema}.${tableConfig.table} not found or has no matching columns`
+      );
     }
 
     parserFields[key] = dynamicFields;
@@ -121,55 +122,44 @@ export const exportMeta = async ({ opts, dbname, database_id }: ExportMetaParams
   };
 
   const queryAndParse = async (key: string, query: string) => {
-    try {
-      const parser = await getParser(key);
-      if (!parser) {
-        return;
-      }
+    const parser = await getParser(key);
 
-      const result = await pool.query(query, [database_id]);
-      if (result.rows.length) {
-        // Truncate timestamptz to second precision to match PostGraphile's Datetime scalar
-        // which truncates milliseconds in the GraphQL flow
-        const fields = parserFields[key];
-        if (fields) {
-          for (const row of result.rows) {
-            for (const [fieldName, fieldType] of Object.entries(fields)) {
-              if (fieldType === 'timestamptz') {
-                const val = row[fieldName];
-                if (val instanceof Date) {
-                  // Truncate to second precision and convert to ISO string
-                  // so both SQL and GraphQL flows pass the same value type to the Parser
-                  row[fieldName] = new Date(Math.floor(val.getTime() / 1000) * 1000).toISOString();
-                }
+    const result = await pool.query(query, [database_id]);
+    if (result.rows.length) {
+      // Truncate timestamptz to second precision to match PostGraphile's Datetime scalar
+      // which truncates milliseconds in the GraphQL flow
+      const fields = parserFields[key];
+      if (fields) {
+        for (const row of result.rows) {
+          for (const [fieldName, fieldType] of Object.entries(fields)) {
+            if (fieldType === 'timestamptz') {
+              const val = row[fieldName];
+              if (val instanceof Date) {
+                // Truncate to second precision and convert to ISO string
+                // so both SQL and GraphQL flows pass the same value type to the Parser
+                row[fieldName] = new Date(Math.floor(val.getTime() / 1000) * 1000).toISOString();
               }
             }
           }
         }
+      }
 
-        // Omit columnDefaults columns from row data so the Parser never sees them.
-        // The Parser's field config already excludes them (via buildDynamicFields),
-        // so they would be ignored anyway, but removing them from the data is cleaner.
-        const tblCfg = META_TABLE_CONFIG[key];
-        if (tblCfg?.columnDefaults) {
-          for (const colName of Object.keys(tblCfg.columnDefaults)) {
-            for (const row of result.rows) {
-              delete row[colName];
-            }
+      // Omit columnDefaults columns from row data so the Parser never sees them.
+      // The Parser's field config already excludes them (via buildDynamicFields),
+      // so they would be ignored anyway, but removing them from the data is cleaner.
+      const tblCfg = META_TABLE_CONFIG[key];
+      if (tblCfg?.columnDefaults) {
+        for (const colName of Object.keys(tblCfg.columnDefaults)) {
+          for (const row of result.rows) {
+            delete row[colName];
           }
         }
+      }
 
-        const parsed = await parser.parse(result.rows);
-        if (parsed) {
-          sql[key] = parsed;
-        }
+      const parsed = await parser.parse(result.rows);
+      if (parsed) {
+        sql[key] = parsed;
       }
-    } catch (err: unknown) {
-      const pgError = err as { code?: string };
-      if (pgError.code === '42P01') {
-        return;
-      }
-      throw err;
     }
   };
 
@@ -259,7 +249,6 @@ export const exportMeta = async ({ opts, dbname, database_id }: ExportMetaParams
   await queryAndParse('plans_module', `SELECT * FROM metaschema_modules_public.plans_module WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('realtime_module', `SELECT * FROM metaschema_modules_public.realtime_module WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('session_secrets_module', `SELECT * FROM metaschema_modules_public.session_secrets_module WHERE database_id = $1 ORDER BY id`);
-  await queryAndParse('config_secrets_org_module', `SELECT * FROM metaschema_modules_public.config_secrets_org_module WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('infra_secrets_module', `SELECT * FROM metaschema_modules_public.infra_secrets_module WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('infra_config_module', `SELECT * FROM metaschema_modules_public.infra_config_module WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('internal_secrets_module', `SELECT * FROM metaschema_modules_public.internal_secrets_module WHERE database_id = $1 ORDER BY id`);

--- a/pgpm/export/src/export-utils.ts
+++ b/pgpm/export/src/export-utils.ts
@@ -171,7 +171,6 @@ export const META_TABLE_ORDER = [
   'plans_module',
   'realtime_module',
   'session_secrets_module',
-  'config_secrets_org_module',
   'infra_secrets_module',
   'infra_config_module',
   'internal_secrets_module',
@@ -552,10 +551,6 @@ export const META_TABLE_CONFIG: Record<string, TableConfig> = {
   session_secrets_module: {
     schema: 'metaschema_modules_public',
     table: 'session_secrets_module'
-  },
-  config_secrets_org_module: {
-    schema: 'metaschema_modules_public',
-    table: 'config_secrets_org_module'
   },
   infra_secrets_module: {
     schema: 'metaschema_modules_public',

--- a/pgpm/export/test-utils/shim-utils.ts
+++ b/pgpm/export/test-utils/shim-utils.ts
@@ -1,0 +1,24 @@
+import { META_TABLE_CONFIG } from '../src/export-utils';
+
+/**
+ * Generates CREATE TABLE IF NOT EXISTS statements for every table in
+ * META_TABLE_CONFIG so strict export flows (which throw on missing tables)
+ * can run against minimal test databases. Hand-written shims with real
+ * columns take precedence because of IF NOT EXISTS.
+ */
+export const buildMetaTableShimsSQL = (): string => {
+  const stmts: string[] = [];
+  const schemas = new Set<string>();
+  for (const cfg of Object.values(META_TABLE_CONFIG)) {
+    schemas.add(cfg.schema);
+  }
+  for (const schema of schemas) {
+    stmts.push(`CREATE SCHEMA IF NOT EXISTS ${schema};`);
+  }
+  for (const cfg of Object.values(META_TABLE_CONFIG)) {
+    stmts.push(
+      `CREATE TABLE IF NOT EXISTS ${cfg.schema}."${cfg.table}" (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid);`
+    );
+  }
+  return stmts.join('\n');
+};


### PR DESCRIPTION
## Summary

Follow-up cleanup to #1347:

- **Remove `config_secrets_org_module`** from `META_TABLE_ORDER`, `META_TABLE_CONFIG`, both export flows, and test expectations — the table no longer exists in constructive-db (old rename of `org_secrets_module`); it was only tolerated because the exporter silently skipped missing tables.
- **Exporters now throw instead of silently skipping** when a META table is missing:
  - `exportMeta`: `getParser` returns `Promise<Parser>` and throws `no META_TABLE_CONFIG entry for '<key>'` / `table <schema>.<table> not found or has no matching columns`; the 42P01 swallow in `queryAndParse` is gone.
  - `exportGraphQLMeta`: `queryAndParse` throws when the table isn't exposed in the GraphQL schema; the `Cannot query field`-style catch-and-skip is gone.

  This means a missing table registration fails the export loudly instead of silently dropping seed rows (the failure mode that broke `fun up` after the config_secrets split).
- **Tests**: minimal test databases now get shim tables for every `META_TABLE_CONFIG` entry via `test-utils/shim-utils.ts` (`CREATE TABLE IF NOT EXISTS ... (id uuid, database_id uuid)` — hand-written shims win via IF NOT EXISTS). The cross-flow mock GraphQL client now honors `gqlTypeName` overrides (surfaced by strict throwing: `i18n_module` → `I18NModule`).

All 142 tests in `pgpm/export` pass.

Link to Devin session: https://app.devin.ai/sessions/5bb10a6b46d140489059ffe311c2f06a
Requested by: @pyramation