### PR TITLE
docs(pglite): restyle pglite-test + pglite-adapter READMEs to match sibling test libs

### DIFF
--- a/postgres/pglite-adapter/README.md
+++ b/postgres/pglite-adapter/README.md
@@ -1,5 +1,21 @@
 # @pgpmjs/pglite-adapter
 
+<p align="center" width="100%">
+  <img height="250" src="https://raw.githubusercontent.com/constructive-io/constructive/refs/heads/main/assets/outline-logo.svg" />
+</p>
+
+<p align="center" width="100%">
+  <a href="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml">
+    <img height="20" src="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml/badge.svg" />
+  </a>
+  <a href="https://github.com/constructive-io/constructive/blob/main/LICENSE">
+    <img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/>
+  </a>
+  <a href="https://www.npmjs.com/package/@pgpmjs/pglite-adapter">
+    <img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/constructive?filename=postgres%2Fpglite-adapter%2Fpackage.json"/>
+  </a>
+</p>
+
 A PGlite driver for pgpm. It registers an **in-process** [PGlite](https://github.com/electric-sql/pglite)
 instance (WASM Postgres) as the `pg-cache` pool factory, so the **unmodified**
 pgpm engine deploys, verifies, and reverts migrations against PGlite with **no
@@ -7,6 +23,14 @@ Postgres server and no socket**.
 
 All `@electric-sql/pglite*` dependencies live here — `@pgpmjs/core`, `pg-cache`,
 and `pgsql-test` never import them.
+
+## Install
+
+```sh
+npm install @pgpmjs/pglite-adapter @electric-sql/pglite
+```
+
+`@electric-sql/pglite` is a peer dependency, so you pin the version.
 
 ## How it works
 

--- a/postgres/pglite-test/README.md
+++ b/postgres/pglite-test/README.md
@@ -1,18 +1,52 @@
 # pglite-test
 
-A drop-in [`pgsql-test`](../pgsql-test) `getConnections()` backed by an in-process
-[**PGlite**](https://github.com/electric-sql/pglite) instance (WASM Postgres) —
-**no Postgres server, no `createdb`, no `psql`, no TCP.**
+<p align="center" width="100%">
+  <img height="250" src="https://raw.githubusercontent.com/constructive-io/constructive/refs/heads/main/assets/outline-logo.svg" />
+</p>
 
-It follows the same pattern as `drizzle-orm-test` / `supabase-test`: a thin
-`getConnections()` wrapper that composes the existing `pg-cache` / `pgsql-client`
-seams.
+<p align="center" width="100%">
+  <a href="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml">
+    <img height="20" src="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml/badge.svg" />
+  </a>
+  <a href="https://github.com/constructive-io/constructive/blob/main/LICENSE">
+    <img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/>
+  </a>
+  <a href="https://www.npmjs.com/package/pglite-test">
+    <img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/constructive?filename=postgres%2Fpglite-test%2Fpackage.json"/>
+  </a>
+</p>
 
-- [`@pgpmjs/pglite-adapter`](../pglite-adapter)'s `registerPglite()` routes
-  `pg-cache`'s `getPgPool()` at PGlite, so `seed.pgpm()` deploys your module into
-  it with the unmodified pgpm engine.
-- `pgsql-client`'s client-factory seam routes `PgTestClient`'s underlying
-  `pg.Client` at the same PGlite session.
+`pglite-test` is a [**PGlite**](https://github.com/electric-sql/pglite)-optimized version of [`pgsql-test`](https://www.npmjs.com/package/pgsql-test) that runs entirely **in-process** — no Postgres server, no `createdb`, no `psql`, no TCP. It provides instant, isolated PostgreSQL databases for testing with automatic transaction rollbacks, context switching, and clean seeding, all backed by ElectricSQL's WASM build of Postgres. It's ideal for local-first development and especially great for GitHub Actions and CI/CD — **no service container required**.
+
+Like [`supabase-test`](https://www.npmjs.com/package/supabase-test) and [`drizzle-orm-test`](https://www.npmjs.com/package/drizzle-orm-test), it's a thin `getConnections()` wrapper that composes the existing `pg-cache` / `pgsql-client` seams, so your tests read exactly like `pgsql-test`.
+
+## Install
+
+```sh
+npm install pglite-test
+```
+
+You also install PGlite yourself (it's a peer dependency, so you pin the version):
+
+```sh
+npm install @electric-sql/pglite
+```
+
+## Features
+
+* 🚀 **Zero infrastructure** — pure WASM, no Postgres server, no Docker, no service container in CI
+* ⚡ **Instant test DBs** — spin up an isolated in-process instance per suite
+* 🔄 **Per-test rollback** — every test runs in its own transaction/savepoint (ref-counted for the single session)
+* 🛡️ **RLS-friendly** — role-based auth via `.setContext()` (full GUC support)
+* 🌱 **pgpm-native seeding** — deploy your real modules with the unmodified pgpm engine via `seed.pgpm()`
+* 🧠 **pgvector & friends** — register WASM extensions (`vector`, `pg_trgm`, …) at construction
+* 🧪 **Compatible with any async runner** — works with `Jest`, `Mocha`, etc.
+* 🧹 **Auto teardown** — no residue, no reboots, just clean exits
+
+## How it works
+
+- [`@pgpmjs/pglite-adapter`](https://www.npmjs.com/package/@pgpmjs/pglite-adapter)'s `registerPglite()` routes `pg-cache`'s `getPgPool()` at an in-process PGlite instance, so `seed.pgpm()` deploys your module into it with the **unmodified pgpm engine**.
+- `pgsql-client`'s client-factory seam routes `PgTestClient`'s underlying `pg.Client` at the same PGlite session.
 
 ## Usage
 
@@ -47,32 +81,17 @@ it('queries the pgpm-deployed schema', async () => {
 });
 ```
 
-Jest must run with `NODE_OPTIONS=--experimental-vm-modules` (PGlite loads a WASM
-module); the package's `test` script sets this.
-
-## Single-session model
-
-PGlite is one in-process session, so `pg` and `db` share it. That differs from
-`pgsql-test` (two authenticated connections on a real server):
-
-- Transaction control is **ref-counted** (`SharedTxn`) so the standard
-  two-client `beforeEach`/`afterEach` harness emits exactly one
-  `BEGIN`/`SAVEPOINT`/`ROLLBACK`/`COMMIT` per test. The single-client (`db` only)
-  pattern also works.
-- Role-based RLS uses `setContext({ role })` (i.e. `SET LOCAL role`) on the shared
-  session rather than separate authenticated connections. Any role you switch to
-  must exist — create it via `pglite.extensionSql` (e.g.
-  `['CREATE ROLE authenticated;']`).
-- `publish()` (commit-and-continue) is not supported under the shared-session
-  coordinator.
+Jest must run with `NODE_OPTIONS=--experimental-vm-modules` (PGlite loads a WASM module); the package's `test` script sets this.
 
 ## Options
 
 ```typescript
+import { vector } from '@electric-sql/pglite-pgvector';
+
 await getConnections(
   {
     pglite: {
-      dataDir: undefined,          // in-memory by default
+      dataDir: undefined,           // in-memory by default
       extensions: { vector },       // WASM extensions (e.g. pglite-pgvector)
       extensionSql: [               // run once after ready
         'CREATE EXTENSION IF NOT EXISTS vector;',
@@ -83,3 +102,17 @@ await getConnections(
   [seed.pgpm()]                     // default seed adapter
 );
 ```
+
+## Single-session model
+
+PGlite is one in-process session, so `pg` and `db` share it. That differs from `pgsql-test` (two authenticated connections on a real server):
+
+- Transaction control is **ref-counted** (`SharedTxn`) so the standard two-client `beforeEach`/`afterEach` harness emits exactly one `BEGIN`/`SAVEPOINT`/`ROLLBACK`/`COMMIT` per test. The single-client (`db` only) pattern also works.
+- Role-based RLS uses `setContext({ role })` (i.e. `SET LOCAL role`) on the shared session rather than separate authenticated connections. Any role you switch to must exist — create it via `pglite.extensionSql` (e.g. `['CREATE ROLE authenticated;']`).
+- `publish()` (commit-and-continue) is not supported under the shared-session coordinator.
+
+## Related
+
+- [`@pgpmjs/pglite-adapter`](https://www.npmjs.com/package/@pgpmjs/pglite-adapter) — the in-process PGlite driver that both this package and the pgpm engine ride on.
+- [`pgsql-test`](https://www.npmjs.com/package/pgsql-test) — the server-backed original this mirrors.
+- [`supabase-test`](https://www.npmjs.com/package/supabase-test) · [`drizzle-orm-test`](https://www.npmjs.com/package/drizzle-orm-test) — sibling `getConnections()` wrappers.


### PR DESCRIPTION
## Summary

The `pglite-test` README on npm was plain text compared to our other test-framework packages. This restyles both new pglite READMEs to match `supabase-test` / `drizzle-orm-test`:

- **Logo + badge header** (CI status, MIT license, npm package-version) — same `outline-logo.svg` + shields the siblings use.
- **`## Install`** section (incl. the `@electric-sql/pglite` peer dep the consumer pins).
- **`## Features`** bullet list (zero-infra / instant DBs / per-test rollback / RLS / pgpm seeding / pgvector / auto teardown).

No code changes — docs only. The existing technical content (single-session `SharedTxn` model, options, how the `pg-cache`/`pgsql-client` seams compose) is preserved. `@pgpmjs/pglite-adapter` gets the same header + an Install section for consistency.

Link to Devin session: https://app.devin.ai/sessions/424b76f81a60499493ac946b57136ad9
Requested by: @pyramation