### PR TITLE
feat(pgpm): pluggable migration-driver contract + generic plugin loader

### DIFF
--- a/pgpm/cli/__tests__/driver.test.ts
+++ b/pgpm/cli/__tests__/driver.test.ts
@@ -1,0 +1,94 @@
+import {
+  activateDriver,
+  driverOverrideFromArgv,
+  PGLITE_DRIVER_PLUGIN,
+  resolveDriverConfig,
+} from '../src/utils/driver';
+
+describe('driverOverrideFromArgv', () => {
+  it('returns undefined with no flags (built-in pg path)', () => {
+    expect(driverOverrideFromArgv({})).toBeUndefined();
+  });
+
+  it('maps bare --pglite to the pglite plugin, in-memory', () => {
+    expect(driverOverrideFromArgv({ pglite: true })).toEqual({
+      plugin: PGLITE_DRIVER_PLUGIN,
+      options: undefined,
+    });
+  });
+
+  it('maps --pglite=<dataDir> to a persisted dataDir', () => {
+    expect(driverOverrideFromArgv({ pglite: './local.db' })).toEqual({
+      plugin: PGLITE_DRIVER_PLUGIN,
+      options: { dataDir: './local.db' },
+    });
+  });
+
+  it('ignores --pglite=false', () => {
+    expect(driverOverrideFromArgv({ pglite: false })).toBeUndefined();
+  });
+
+  it('maps --driver <pkg> to an arbitrary plugin', () => {
+    expect(driverOverrideFromArgv({ driver: '@acme/turso-adapter' })).toEqual({
+      plugin: '@acme/turso-adapter',
+    });
+  });
+
+  it('prefers --pglite over --driver when both are present', () => {
+    expect(driverOverrideFromArgv({ pglite: true, driver: '@acme/turso-adapter' })).toEqual({
+      plugin: PGLITE_DRIVER_PLUGIN,
+      options: undefined,
+    });
+  });
+});
+
+describe('resolveDriverConfig', () => {
+  it('returns undefined when nothing is configured or overridden', () => {
+    expect(resolveDriverConfig(undefined, undefined)).toBeUndefined();
+  });
+
+  it('returns the configured driver when there is no override', () => {
+    const configured = { plugin: PGLITE_DRIVER_PLUGIN, options: { dataDir: './a' } };
+    expect(resolveDriverConfig(configured, undefined)).toBe(configured);
+  });
+
+  it('lets an override win over config', () => {
+    const configured = { plugin: '@acme/turso-adapter' };
+    expect(resolveDriverConfig(configured, { plugin: PGLITE_DRIVER_PLUGIN })).toEqual({
+      plugin: PGLITE_DRIVER_PLUGIN,
+      options: {},
+    });
+  });
+
+  it('merges override options over configured options for the same plugin', () => {
+    const configured = {
+      plugin: PGLITE_DRIVER_PLUGIN,
+      options: { dataDir: './cfg', extensions: ['vector'] },
+    };
+    expect(
+      resolveDriverConfig(configured, { plugin: PGLITE_DRIVER_PLUGIN, options: { dataDir: './override' } })
+    ).toEqual({
+      plugin: PGLITE_DRIVER_PLUGIN,
+      options: { dataDir: './override', extensions: ['vector'] },
+    });
+  });
+});
+
+describe('activateDriver', () => {
+  it('returns undefined on the built-in server path (no driver)', async () => {
+    await expect(activateDriver(undefined, undefined, process.cwd())).resolves.toBeUndefined();
+  });
+
+  it('throws a clear install hint when the plugin cannot be resolved', async () => {
+    await expect(
+      activateDriver({ plugin: '@pgpmjs/pglite-adapter' }, undefined, '/nonexistent-project-root')
+    ).rejects.toThrow(/is not installed in this project[\s\S]*@electric-sql\/pglite/);
+  });
+
+  it('throws when the resolved module is not a driver plugin', async () => {
+    // `pg-env` resolves from the monorepo but does not export createPgpmDriver.
+    await expect(
+      activateDriver({ plugin: 'pg-env' }, undefined, __dirname)
+    ).rejects.toThrow(/does not export createPgpmDriver/);
+  });
+});

--- a/pgpm/cli/src/utils/driver.ts
+++ b/pgpm/cli/src/utils/driver.ts
@@ -1,0 +1,107 @@
+import {
+  PGPM_DRIVER_EXPORT,
+  PgpmDriverConfig,
+  PgpmDriverFactory,
+  PgpmDriverSession,
+} from '@pgpmjs/types';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+
+/** Package name of the built-in PGlite driver plugin (the `--pglite` alias). */
+export const PGLITE_DRIVER_PLUGIN = '@pgpmjs/pglite-adapter';
+
+/**
+ * Resolve the effective driver config from `pgpm.json` and CLI overrides.
+ *
+ * Precedence: an explicit override (from `--driver <pkg>` or the `--pglite`
+ * alias) beats the configured `driver` block. `--pglite=<dataDir>` sets
+ * `options.dataDir`. Returns undefined for the built-in `pg` (server) path.
+ */
+export function resolveDriverConfig(
+  configured: PgpmDriverConfig | undefined,
+  override?: { plugin: string; options?: Record<string, unknown> }
+): PgpmDriverConfig | undefined {
+  if (override) {
+    // Merge override options over configured options when targeting the same plugin.
+    const base =
+      configured && configured.plugin === override.plugin ? configured.options : undefined;
+    return {
+      plugin: override.plugin,
+      options: { ...base, ...override.options },
+    };
+  }
+  return configured;
+}
+
+/**
+ * Translate the `--pglite` / `--driver` argv into a driver override.
+ *
+ * - `--pglite` (bare)        → PGlite in-memory
+ * - `--pglite=./local.db`    → PGlite persisted to `./local.db`
+ * - `--driver <pkg>`         → arbitrary driver plugin
+ */
+export function driverOverrideFromArgv(argv: {
+  pglite?: boolean | string;
+  driver?: string;
+}): { plugin: string; options?: Record<string, unknown> } | undefined {
+  if (argv.pglite !== undefined && argv.pglite !== false) {
+    const options =
+      typeof argv.pglite === 'string' && argv.pglite.length > 0
+        ? { dataDir: argv.pglite }
+        : undefined;
+    return { plugin: PGLITE_DRIVER_PLUGIN, options };
+  }
+  if (argv.driver) {
+    return { plugin: argv.driver };
+  }
+  return undefined;
+}
+
+/**
+ * Load and activate the configured driver plugin, resolving it from the
+ * *consumer's* project (`cwd`) — the same way ESLint/Babel resolve plugins.
+ * pgpm ships no backend dependencies; the plugin is declared by the user's
+ * project. Returns undefined on the built-in server path.
+ *
+ * Resolution uses `createRequire` from `node:module` (not the ambient
+ * `require`) so it behaves identically in both makage build outputs: the CJS
+ * bundle and the `es2022` ESM bundle, where a bare `require`/`require.resolve`
+ * is undefined at runtime.
+ */
+export async function activateDriver(
+  configured: PgpmDriverConfig | undefined,
+  override: { plugin: string; options?: Record<string, unknown> } | undefined,
+  cwd: string
+): Promise<PgpmDriverSession | undefined> {
+  const cfg = resolveDriverConfig(configured, override);
+  if (!cfg) return undefined;
+
+  // A require bound to the consumer's project directory. `createRequire` is the
+  // one primitive available and identical in both CJS and ESM runtimes.
+  const requireFrom = createRequire(join(cwd, 'package.json'));
+
+  let mod: Record<string, unknown>;
+  try {
+    const entry = requireFrom.resolve(cfg.plugin);
+    mod = requireFrom(entry);
+  } catch {
+    const extra = cfg.plugin.includes('pglite') ? ' @electric-sql/pglite' : '';
+    throw new Error(
+      `pgpm driver "${cfg.plugin}" is not installed in this project.\n` +
+        `Run: npm i ${cfg.plugin}${extra}`
+    );
+  }
+
+  // Support both a direct named export and an interop `default` wrapper.
+  const factory = (mod[PGPM_DRIVER_EXPORT] ??
+    (mod.default as Record<string, unknown> | undefined)?.[PGPM_DRIVER_EXPORT]) as
+    | PgpmDriverFactory
+    | undefined;
+  if (typeof factory !== 'function') {
+    throw new Error(
+      `"${cfg.plugin}" does not export ${PGPM_DRIVER_EXPORT} — it is not a pgpm driver plugin.`
+    );
+  }
+
+  return factory(cfg.options);
+}

--- a/pgpm/cli/src/utils/index.ts
+++ b/pgpm/cli/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './database';
+export * from './driver';
 export * from './display';
 export * from './deployed-changes';
 export * from './module-utils';

--- a/pgpm/types/src/driver.ts
+++ b/pgpm/types/src/driver.ts
@@ -1,0 +1,67 @@
+/**
+ * Pluggable migration-backend ("driver") contract.
+ *
+ * pgpm's engine only needs a node-`pg`-shaped pool/client (see `pg-cache` /
+ * `pgsql-client` seams). A *driver plugin* is a package that registers those
+ * factories against some backend (e.g. in-process PGlite) and tells pgpm which
+ * server-only steps to skip. pgpm core/CLI depend on this contract only — never
+ * on any specific backend or its dependencies. The plugin is resolved from the
+ * *consumer's* project, exactly like ESLint/Babel resolve plugins and presets.
+ */
+
+/**
+ * What a backend can and cannot do, so the CLI can generically skip server-only
+ * steps instead of hard-coding per-backend branches.
+ */
+export interface PgpmDriverCapabilities {
+    /** `false` → skip `createdb` / `--createdb` (the instance *is* the database). */
+    createdb: boolean;
+    /** `false` → skip `pg_dump` / `pgpm dump` (or the plugin provides its own dump). */
+    dump: boolean;
+    /** `false` → skip docker / server-lifecycle commands. */
+    serverLifecycle: boolean;
+    /**
+     * `false` → single-session backend: skip the two-connection `admin-users`
+     * bootstrap; roles are provisioned in-band instead.
+     */
+    multiConnection: boolean;
+}
+
+/**
+ * The activated backend session returned by a driver plugin. The plugin has
+ * already registered its pool/client factories by the time this resolves.
+ */
+export interface PgpmDriverSession {
+    /** Backend capabilities used to gate server-only CLI steps. */
+    capabilities: PgpmDriverCapabilities;
+    /** Restore the previously-active factories and release backend resources. */
+    teardown: () => Promise<void>;
+}
+
+/**
+ * The well-known entrypoint every driver plugin must export as
+ * `createPgpmDriver`. Called by the CLI after it resolves the plugin from the
+ * consumer's `node_modules`. Implementations register their pool/client
+ * factories (via the `pg-cache` / `pgsql-client` seams) and return their
+ * capabilities plus a teardown.
+ */
+export type PgpmDriverFactory = (
+    options?: Record<string, unknown>
+) => Promise<PgpmDriverSession>;
+
+/**
+ * Selects and configures a pluggable migration backend. Configured under the
+ * `driver` key of `pgpm.json`; undefined means the built-in `pg` (server) path.
+ */
+export interface PgpmDriverConfig {
+    /**
+     * Package name of the driver plugin, resolved from the consumer's
+     * `node_modules` (e.g. `@pgpmjs/pglite-adapter`).
+     */
+    plugin: string;
+    /** Opaque options forwarded to the plugin's `createPgpmDriver(options)`. */
+    options?: Record<string, unknown>;
+}
+
+/** Named export a driver plugin module must expose. */
+export const PGPM_DRIVER_EXPORT = 'createPgpmDriver' as const;

--- a/pgpm/types/src/index.ts
+++ b/pgpm/types/src/index.ts
@@ -1,3 +1,4 @@
+export * from './driver';
 export * from './error';
 export * from './error-factory';
 export * from './pg-error-format';

--- a/pgpm/types/src/pgpm.ts
+++ b/pgpm/types/src/pgpm.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'child_process';
 import { PgConfig } from 'pg-env';
+import { PgpmDriverConfig } from './driver';
 import { JobsConfig } from './jobs';
 
 /**
@@ -257,6 +258,12 @@ export interface PgpmOptions {
     errorOutput?: ErrorOutputOptions;
     /** SMTP email configuration */
     smtp?: SmtpOptions;
+    /**
+     * Pluggable migration backend. Undefined = built-in `pg` (server) path.
+     * Set `driver.plugin` to a package (e.g. `@pgpmjs/pglite-adapter`) resolved
+     * from the consumer's `node_modules`.
+     */
+    driver?: PgpmDriverConfig;
 }
 
 /**


### PR DESCRIPTION
## Summary

Step 1 of making pgpm **pluggable** so it can target alternate backends (PGlite now, others like Turso/libSQL later) **without pgpm core/CLI depending on any backend**. This PR is pure additive plumbing — the built-in `pg` (server) path is unchanged (a `driver` is undefined by default).

**The contract** (`@pgpmjs/types`): a driver plugin is any package exporting a well-known factory. pgpm depends only on this interface, never on a backend or its deps.

```ts
export type PgpmDriverFactory =
  (options?) => Promise<{ capabilities: PgpmDriverCapabilities; teardown: () => Promise<void> }>;

export interface PgpmDriverConfig { plugin: string; options?: Record<string, unknown>; }
// PgpmOptions gains: driver?: PgpmDriverConfig   (undefined = built-in pg path)
```

`capabilities` (`createdb` / `dump` / `serverLifecycle` / `multiConnection`) will later let the CLI *generically* skip server-only steps instead of hard-coding `if (pglite)`.

**The loader** (`pgpm/cli/src/utils/driver.ts`): resolves the plugin **from the consumer's project**, exactly like ESLint/Babel resolve plugins — pgpm ships zero backend deps.

```ts
const requireFrom = createRequire(join(cwd, 'package.json'));
const mod = requireFrom(requireFrom.resolve(cfg.plugin));
return (mod.createPgpmDriver ?? mod.default?.createPgpmDriver)(cfg.options);
```

- **makage dual-build safe:** uses `createRequire` from `node:module`, *not* bare `require.resolve` / `await import()`. In the ESM bundle (`module: es2022`) a bare `require` is `undefined` at runtime; in the CJS bundle tsc downlevels `import()` back to `require`. `createRequire` behaves identically in both — verified against `dist/` and `dist/esm/`.
- `driverOverrideFromArgv` maps `--pglite` (bare → in-memory), `--pglite=<dir>` (→ `options.dataDir`), and `--driver <pkg>`; `--pglite` wins over `--driver`.
- `resolveDriverConfig` handles precedence (override beats `pgpm.json`) and option merging for the same plugin.
- Clear errors: "not installed in this project" (with `npm i` hint) and "does not export createPgpmDriver".

## Tests

13 unit tests in `pgpm/cli/__tests__/driver.test.ts` (arg mapping, config precedence/merge, server-path passthrough, missing-plugin + non-plugin errors). Both `@pgpmjs/types` and `pgpm/cli` build (CJS + ESM).

## Not in this PR (follow-ups per the plan)

Wiring `activateDriver` into `deploy`/`verify`/`revert` with capability-driven guards; `@pgpmjs/pglite-adapter` implementing `createPgpmDriver`; `pgpm init --pglite`; the `pglite/*` boilerplate family. Then Turso/libSQL as a separate plugin.

Link to Devin session: https://app.devin.ai/sessions/424b76f81a60499493ac946b57136ad9
Requested by: @pyramation