### PR TITLE
feat(pgpm): default `pgpm init` to no extensions (opt-in via flags)

### DIFF
--- a/pgpm/cli/__tests__/__snapshots__/init.test.ts.snap
+++ b/pgpm/cli/__tests__/__snapshots__/init.test.ts.snap
@@ -11,6 +11,84 @@ superuser = false
 "
 `;
 
+exports[`cmds:init initializes module with no extensions by default: module-no-extensions - argv 1`] = `
+{
+  "_": [
+    "init",
+  ],
+  "access": "public",
+  "cwd": "<CWD>",
+  "email": "tester@example.com",
+  "fromBranch": "main",
+  "fullName": "Tester",
+  "license": "MIT",
+  "moduleDesc": "no-ext-module",
+  "moduleName": "no-ext-module",
+  "name": "no-ext-module",
+  "packageIdentifier": "no-ext-module",
+  "repo": "https://github.com/constructive-io/pgpm-boilerplates.git",
+  "repoName": "no-ext-module",
+  "username": "tester",
+}
+`;
+
+exports[`cmds:init initializes module with no extensions by default: module-no-extensions - files 1`] = `
+[
+  "tsconfig.json",
+  "pnpm-workspace.yaml",
+  "pgpm.json",
+  "package.json",
+  "lerna.json",
+  "README.md",
+  "LICENSE",
+  ".prettierrc.json",
+  ".gitignore",
+  ".eslintrc.json",
+  "packages/no-ext-module/pgpm.plan",
+  "packages/no-ext-module/package.json",
+  "packages/no-ext-module/no-ext-module.control",
+  "packages/no-ext-module/jest.config.js",
+  "packages/no-ext-module/README.md",
+  "packages/no-ext-module/Makefile",
+  "packages/no-ext-module/LICENSE",
+  "packages/no-ext-module/__tests__/basic.test.ts",
+  "packages/my-module/pgpm.plan",
+  "packages/my-module/package.json",
+  "packages/my-module/my-module.control",
+  "packages/my-module/jest.config.js",
+  "packages/my-module/README.md",
+  "packages/my-module/Makefile",
+  "packages/my-module/LICENSE",
+  "packages/my-module/__tests__/basic.test.ts",
+  ".github/workflows/ci.yml",
+]
+`;
+
+exports[`cmds:init initializes module with no extensions by default: module-no-extensions - result 1`] = `
+{
+  "_": [
+    "init",
+  ],
+  "access": "public",
+  "cwd": "<CWD>",
+  "email": "tester@example.com",
+  "fromBranch": "main",
+  "fullName": "Tester",
+  "license": "MIT",
+  "moduleDesc": "no-ext-module",
+  "moduleName": "no-ext-module",
+  "name": "no-ext-module",
+  "packageIdentifier": "no-ext-module",
+  "repo": "https://github.com/constructive-io/pgpm-boilerplates.git",
+  "repoName": "no-ext-module",
+  "username": "tester",
+}
+`;
+
+exports[`cmds:init initializes module with no extensions by default: module-no-extensions - transformResults 1`] = `[]`;
+
+exports[`cmds:init initializes module with no extensions by default: module-no-extensions - writeResults 1`] = `[]`;
+
 exports[`cmds:init initializes module: module-only - argv 1`] = `
 {
   "_": [

--- a/pgpm/cli/__tests__/init.test.ts
+++ b/pgpm/cli/__tests__/init.test.ts
@@ -109,6 +109,28 @@ describe('cmds:init', () => {
     expect(cnc.getModuleControlFile()).toMatchSnapshot();
   });
 
+  it('initializes module with no extensions by default', async () => {
+    const workspaceDir = path.join(fixture.tempDir, 'my-workspace');
+    const moduleDir = path.join(workspaceDir, 'packages', 'no-ext-module');
+
+    // A bare `pgpm init` (no --extensions / --with-extensions) must scaffold a
+    // module whose .control has no `requires` line.
+    await runInitTest(
+      {
+        _: ['init'],
+        cwd: workspaceDir,
+        name: 'no-ext-module',
+        moduleName: 'no-ext-module'
+      },
+      'module-no-extensions'
+    );
+
+    const cnc = new PgpmPackage(moduleDir);
+    const control = cnc.getModuleControlFile();
+    expect(control).not.toMatch(/requires\s*=/);
+    expect(cnc.getRequiredModules()).toEqual([]);
+  });
+
   describe('with custom templates', () => {
     it('initializes workspace with --template', async () => {
       const { mockInput, mockOutput } = environment;

--- a/pgpm/cli/src/commands/init/index.ts
+++ b/pgpm/cli/src/commands/init/index.ts
@@ -46,11 +46,16 @@ Options:
   --boilerplate           Prompt to select from available boilerplates
   --create-workspace, -w  Create a workspace first, then create the module inside it
   --use-skills            Use npx skills CLI for skill installation (slower, writes skills-lock.json)
+  --extensions <a,b>      Extensions to require in the new module (default: none).
+                          Add them later instead with \`${binaryName} extension\`.
+  --with-extensions       Prompt interactively for extensions during module init
 
 Examples:
-  ${binaryName} init                                   Initialize new module (default)
+  ${binaryName} init                                   Initialize new module (default, no extensions)
   ${binaryName} init workspace                         Initialize new workspace
   ${binaryName} init module                            Initialize new module explicitly
+  ${binaryName} init --extensions uuid-ossp,citext     Initialize module requiring extensions
+  ${binaryName} init --with-extensions                 Pick extensions interactively
   ${binaryName} init workspace --dir <variant>         Use variant templates
   ${binaryName} init --template pnpm/module            Use full template path (dir + type)
   ${binaryName} init --boilerplate                     Select from available boilerplates
@@ -605,8 +610,28 @@ async function handleModuleInit(
     },
   ];
 
-  // Only ask for extensions if this is a pgpm template
-  if (isPgpmTemplate && project.workspacePath) {
+  // Extensions are opt-in: a bare `pgpm init` scaffolds a module with no
+  // extensions (no `requires` line). Extensions are added explicitly later via
+  // `pgpm extension`, or up front via `--extensions a,b` (non-interactive) or
+  // `--with-extensions` (interactive picker). This matches the zero-config init
+  // of comparable tools (sqitch, prisma, drizzle, dbmate, ...).
+  // Normalize `--extensions a,b` (a comma string from the CLI) into an array so
+  // it is consumed the same way as a programmatic string[].
+  if (typeof (argv as any).extensions === 'string') {
+    (argv as any).extensions = (argv as any).extensions
+      .split(',')
+      .map((s: string) => s.trim())
+      .filter(Boolean);
+  }
+  const extensionsProvided = (argv as any).extensions !== undefined;
+  const wantExtensionsPrompt = Boolean(
+    (argv as any).withExtensions || argv['with-extensions']
+  );
+  if (
+    isPgpmTemplate &&
+    project.workspacePath &&
+    (extensionsProvided || wantExtensionsPrompt)
+  ) {
     const availExtensions = await project.getAvailableModules();
     moduleQuestions.push({
       name: 'extensions',
@@ -614,8 +639,7 @@ async function handleModuleInit(
       options: availExtensions,
       type: 'checkbox',
       allowCustomOptions: true,
-      required: true,
-      default: ['plpgsql', 'uuid-ossp'],
+      default: [],
     });
   }
 


### PR DESCRIPTION
## Summary

`pgpm init` no longer forces an extensions decision. A bare `pgpm init` now scaffolds a module with **no extensions** — its `.control` has no `requires =` line — matching the zero-config init of comparable tools (sqitch, prisma, drizzle, dbmate, supabase, ...). Extensions become an explicit, lazy opt-in.

This is **PR A** of the extensions-DX cleanup. `plpgsql` is always present in Postgres (requiring it was noise) and `uuid-ossp` is legacy (`gen_random_uuid()` is core since PG13), so neither belongs in the default scaffold. Follow-ups: PR B hardens `pgpm extension` as the canonical enable-later path (non-destructive `.control` rewrite + `--add`/`--set`/`--remove`); PR C refreshes the tutorials.

### What changed

The forced checkbox in `pgpm/cli/src/commands/init/index.ts` was:
```ts
// before: always prompted, pre-checked, and required
moduleQuestions.push({ name: 'extensions', type: 'checkbox',
  required: true, default: ['plpgsql', 'uuid-ossp'] });
```
Now the question is **only added when the user opts in**, and never defaults anything:
```ts
if (typeof argv.extensions === 'string')            // normalize `--extensions a,b`
  argv.extensions = argv.extensions.split(',').map(s => s.trim()).filter(Boolean);

const extensionsProvided   = argv.extensions !== undefined;      // `--extensions a,b`
const wantExtensionsPrompt = Boolean(argv.withExtensions || argv['with-extensions']);

if (isPgpmTemplate && project.workspacePath &&
    (extensionsProvided || wantExtensionsPrompt)) {
  moduleQuestions.push({ name: 'extensions', type: 'checkbox',
    allowCustomOptions: true, default: [] });   // no `required`, no default
}
```

So:
- `pgpm init` → no extensions (no `requires` line).
- `pgpm init --extensions uuid-ossp,citext` → non-interactive knob (unchanged extraction path; also the back-compat bridge).
- `pgpm init --with-extensions` → interactive picker, empty default, not required.

No core changes needed — `generateControlFileContent` already omits `requires =` for an empty list, and deploy already skips `CREATE EXTENSION` when there are none.

### Tests
- Added regression test: bare `pgpm init` produces a `.control` with **no** `requires` line and `getRequiredModules() === []`.
- Existing init/install/extensions/package suites pass unchanged — they pass `extensions` explicitly, so they exercise the opt-in path. Snapshots regenerated for the new test only.

Note: repo-wide `pnpm lint` currently fails on an unrelated pre-existing ESLint v9 config issue (no `eslint.config.js`); `tsc --noEmit` and the package build are clean.


Link to Devin session: https://app.devin.ai/sessions/424b76f81a60499493ac946b57136ad9
Requested by: @pyramation