### PR TITLE
feat(pgpm): harden `pgpm extension` as the canonical enable-later path

### DIFF
--- a/pgpm/cli/__tests__/extensions.test.ts
+++ b/pgpm/cli/__tests__/extensions.test.ts
@@ -2,6 +2,7 @@ jest.setTimeout(60000);
 process.env.PGPM_SKIP_UPDATE_CHECK = 'true';
 
 import { PgpmPackage } from '@pgpmjs/core';
+import { readFileSync, writeFileSync } from 'fs';
 import { sync as glob } from 'glob';
 import { Inquirerer, ParsedArgs } from 'inquirerer';
 import * as path from 'path';
@@ -101,5 +102,74 @@ describe('cmds:extension', () => {
     expect(updatedProject.getModuleControlFile()).toMatchSnapshot('updated - control file');
     expect(updatedProject.getModuleDependencies('my-module')).toMatchSnapshot('updated - module dependencies');
     expect(updatedProject.getRequiredModules()).toMatchSnapshot('updated - required modules');
+  });
+
+  // Helper: scaffold a workspace + module with a starting set of extensions.
+  const scaffoldModule = async (extensions: string[]) => {
+    const workspacePath = fixture.fixturePath('ws');
+    const modulePath = path.join(workspacePath, 'packages', 'my-module');
+    await runCommand({
+      _: ['init', 'workspace'],
+      cwd: fixture.tempDir,
+      name: 'ws',
+      workspace: true
+    });
+    await runCommand({
+      _: ['init'],
+      cwd: workspacePath,
+      name: 'my-module',
+      moduleName: 'my-module',
+      extensions
+    });
+    return modulePath;
+  };
+
+  it('adds a dependency non-interactively with --add', async () => {
+    const modulePath = await scaffoldModule(['citext']);
+
+    await runCommand({ _: ['extension'], cwd: modulePath, add: 'uuid-ossp' });
+
+    expect(new PgpmPackage(modulePath).getRequiredModules()).toEqual([
+      'citext',
+      'uuid-ossp'
+    ]);
+  });
+
+  it('removes a dependency non-interactively with --remove', async () => {
+    const modulePath = await scaffoldModule(['citext', 'uuid-ossp']);
+
+    await runCommand({ _: ['extension'], cwd: modulePath, remove: 'uuid-ossp' });
+
+    expect(new PgpmPackage(modulePath).getRequiredModules()).toEqual(['citext']);
+  });
+
+  it('replaces the dependency set non-interactively with --set', async () => {
+    const modulePath = await scaffoldModule(['citext', 'uuid-ossp']);
+
+    await runCommand({ _: ['extension'], cwd: modulePath, set: 'plpgsql,hstore' });
+
+    expect(new PgpmPackage(modulePath).getRequiredModules()).toEqual([
+      'plpgsql',
+      'hstore'
+    ]);
+  });
+
+  it('preserves custom .control fields when changing dependencies', async () => {
+    const modulePath = await scaffoldModule(['citext']);
+    const project = new PgpmPackage(modulePath);
+    const controlPath = path.join(modulePath, `${project.getModuleName()}.control`);
+
+    // Hand-tune a custom field that init does not emit.
+    const original = readFileSync(controlPath, 'utf8');
+    writeFileSync(controlPath, `${original}schema = my_schema\n`);
+
+    await runCommand({ _: ['extension'], cwd: modulePath, add: 'uuid-ossp' });
+
+    const updated = readFileSync(controlPath, 'utf8');
+    expect(updated).toMatch(/schema = my_schema/);
+    expect(new PgpmPackage(modulePath).getRequiredModules()).toEqual([
+      'citext',
+      'uuid-ossp'
+    ]);
   });
 });

--- a/pgpm/cli/src/commands/extension.ts
+++ b/pgpm/cli/src/commands/extension.ts
@@ -6,15 +6,40 @@ Extension Command:
 
   pgpm extension [OPTIONS]
 
-  Manage module dependencies.
+  Manage the extensions / module dependencies of the current module
+  (the \`requires\` line of its .control file).
 
 Options:
   --help, -h              Show this help message
   --cwd <directory>       Working directory (default: current directory)
+  --add <a,b>             Add one or more dependencies (non-interactive)
+  --remove <a,b>          Remove one or more dependencies (non-interactive)
+  --set <a,b>             Replace all dependencies with this exact set (non-interactive)
 
 Examples:
-  pgpm extension           Manage dependencies for current module
+  pgpm extension                       Manage dependencies interactively
+  pgpm extension --add uuid-ossp       Add a dependency
+  pgpm extension --add pgcrypto,citext Add several dependencies
+  pgpm extension --remove uuid-ossp    Remove a dependency
+  pgpm extension --set plpgsql         Replace the dependency set
 `;
+
+/**
+ * Parse a flag that may be a comma-separated string, a single value, or an
+ * array (repeated flags) into a clean string[].
+ */
+const parseList = (value: unknown): string[] => {
+  if (Array.isArray(value)) {
+    return value.flatMap((v) => parseList(v));
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  return [];
+};
 
 export default async (
   argv: Partial<ParsedArgs>,
@@ -34,15 +59,34 @@ export default async (
     throw new Error('You must run this command inside a PGPM module.');
   }
 
-  const info = project.getModuleInfo();
   const installed = project.getRequiredModules();
+
+  // Non-interactive mode: --set / --add / --remove let CI and scripts change
+  // dependencies without a prompt. --set replaces the whole set; --add/--remove
+  // mutate the current set.
+  const setProvided = argv.set !== undefined;
+  const addList = parseList(argv.add);
+  const removeList = parseList(argv.remove);
+
+  if (setProvided || addList.length > 0 || removeList.length > 0) {
+    const base = setProvided ? parseList(argv.set) : [...installed];
+    const withAdds = [...base];
+    for (const ext of addList) {
+      if (!withAdds.includes(ext)) withAdds.push(ext);
+    }
+    const next = withAdds.filter((ext) => !removeList.includes(ext));
+    project.setModuleDependencies(next);
+    return;
+  }
+
+  const info = project.getModuleInfo();
   const available = await project.getAvailableModules();
-  const filtered = available.filter(name => name !== info.extname);
+  const filtered = available.filter((name) => name !== info.extname);
 
   const questions: Question[] = [
     {
       name: 'extensions',
-      message: 'Which modules does this one depend on?',
+      message: 'Which extensions / modules does this one depend on?',
       type: 'checkbox',
       allowCustomOptions: true,
       options: filtered,
@@ -52,8 +96,8 @@ export default async (
 
   const answers = await prompter.prompt(argv, questions);
   const selected = (answers.extensions as OptionValue[])
-    .filter(opt => opt.selected)
-    .map(opt => opt.name);
+    .filter((opt) => opt.selected)
+    .map((opt) => opt.name);
 
   project.setModuleDependencies(selected);
 };

--- a/pgpm/core/__tests__/core/__snapshots__/plan-writing.test.ts.snap
+++ b/pgpm/core/__tests__/core/__snapshots__/plan-writing.test.ts.snap
@@ -24,7 +24,7 @@ procedures/generate_secret [pg-verify:procedures/verify_view] 2017-08-11T08:11:5
 exports[`PgpmPackage.writeModulePlan writes a plan with project references (utils) 1`] = `
 {
   "ctrl": "# pg-verify extension
-comment = 'pg-verify extension'
+comment = 'PostgreSQL verification utilities'
 default_version = '0.0.1'
 module_pathname = '$libdir/pg-verify'
 requires = 'some-native-module,pg-utilities'

--- a/pgpm/core/__tests__/files/extension/writer.test.ts
+++ b/pgpm/core/__tests__/files/extension/writer.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { writeExtensions, generateControlFileContent } from '../../../src/files/extension/writer';
+import { writeExtensions, generateControlFileContent, upsertRequiresLine } from '../../../src/files/extension/writer';
 import { getInstalledExtensions } from '../../../src/files/extension/reader';
 
 describe('extension writer', () => {
@@ -97,6 +97,44 @@ describe('extension writer', () => {
       });
 
       expect(content).toContain('schema = public');
+    });
+  });
+
+  describe('upsertRequiresLine', () => {
+    const base = generateControlFileContent({
+      name: 'test-module',
+      version: '1.0.0',
+      requires: ['pgcrypto'],
+      schema: 'my_schema'
+    });
+
+    it('replaces an existing requires line and preserves other fields', () => {
+      const result = upsertRequiresLine(base, ['pgcrypto', 'postgis']);
+      expect(result).toContain("requires = 'pgcrypto,postgis'");
+      expect(result).toContain('schema = my_schema');
+      expect(result).toContain("comment = 'test-module extension'");
+    });
+
+    it('removes the requires line when the set is empty', () => {
+      const result = upsertRequiresLine(base, []);
+      expect(result).not.toContain('requires =');
+      expect(result).toContain('schema = my_schema');
+    });
+
+    it('inserts a requires line before relocatable when none exists', () => {
+      const noRequires = generateControlFileContent({
+        name: 'test-module',
+        version: '1.0.0',
+        requires: []
+      });
+      expect(noRequires).not.toContain('requires =');
+
+      const result = upsertRequiresLine(noRequires, ['citext']);
+      const lines = result.split('\n');
+      const requiresIdx = lines.findIndex((l) => /^requires\s*=/.test(l));
+      const relocatableIdx = lines.findIndex((l) => /^relocatable\s*=/.test(l));
+      expect(requiresIdx).toBeGreaterThanOrEqual(0);
+      expect(requiresIdx).toBeLessThan(relocatableIdx);
     });
   });
 

--- a/pgpm/core/__tests__/modules/__snapshots__/module-installation.test.ts.snap
+++ b/pgpm/core/__tests__/modules/__snapshots__/module-installation.test.ts.snap
@@ -28,7 +28,7 @@ exports[`installModule() installs a package and updates package.json dependencie
 
 exports[`installModule() installs a package and updates package.json dependencies 2`] = `
 "# totp extension
-comment = 'totp extension'
+comment = 'skitch project'
 default_version = '0.0.1'
 module_pathname = '$libdir/totp'
 requires = 'pgcrypto,pgpm-base32,pgpm-verify,plpgsql,uuid-ossp'

--- a/pgpm/core/src/files/extension/writer.ts
+++ b/pgpm/core/src/files/extension/writer.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 
 import { getExtensionInfo } from './reader';
 
@@ -73,7 +73,45 @@ superuser = ${superuser}\n`;
 }
 
 /**
+ * Update (or insert/remove) the `requires =` line of an existing .control file
+ * in place, preserving every other field and the file's formatting. Used when
+ * changing a module's dependencies after init (e.g. via `pgpm extension`) so
+ * hand-tuned fields (comment, schema, relocatable, module_pathname) survive.
+ */
+export function upsertRequiresLine(
+  content: string,
+  requires: string[]
+): string {
+  const lines = content.split('\n');
+  const idx = lines.findIndex((line) => /^\s*requires\s*=/.test(line));
+
+  if (requires.length === 0) {
+    if (idx !== -1) lines.splice(idx, 1);
+    return lines.join('\n');
+  }
+
+  const requiresLine = `requires = '${requires.join(',')}'`;
+  if (idx !== -1) {
+    lines[idx] = requiresLine;
+    return lines.join('\n');
+  }
+
+  // Insert to match generated ordering (before relocatable/superuser/schema).
+  const insertAt = lines.findIndex((line) =>
+    /^\s*(relocatable|superuser|schema)\s*=/.test(line)
+  );
+  if (insertAt !== -1) {
+    lines.splice(insertAt, 0, requiresLine);
+  } else {
+    lines.push(requiresLine);
+  }
+  return lines.join('\n');
+}
+
+/**
  * Write the control file for the extension.
+ * If the file already exists, only its `requires` line is updated so that any
+ * custom fields are preserved; otherwise a fresh file is generated.
  */
 export const writeExtensionControlFile = (
   outputPath: string,
@@ -81,6 +119,11 @@ export const writeExtensionControlFile = (
   extensions: string[],
   version: string
 ): void => {
+  if (existsSync(outputPath)) {
+    const existing = readFileSync(outputPath, 'utf-8');
+    writeFileSync(outputPath, upsertRequiresLine(existing, extensions));
+    return;
+  }
   const content = generateControlFileContent({
     name: extname,
     version,


### PR DESCRIPTION
## Summary

Follow-up to #1355 (init now defaults to no extensions). This makes `pgpm extension` the ergonomic way to add/remove a module's extensions/dependencies *after* init, fixing two rough edges that made it a poor primary path:

1. **Non-destructive `.control` rewrite.** Previously `writeExtensionControlFile` regenerated the whole file from defaults, silently dropping any hand-tuned fields (`schema`, `comment`, `relocatable`, `superuser`, `module_pathname`). Now, when the file already exists, only its `requires =` line is updated in place.
2. **Non-interactive flags** (`--add` / `--remove` / `--set`) so CI and scripts can change dependencies without a prompt (the command was interactive-only).

### `.control` rewrite (`pgpm/core/src/files/extension/writer.ts`)

New `upsertRequiresLine(content, requires)` — pure string transform:
```ts
// existing requires line -> replaced in place
// no requires line + non-empty -> inserted before relocatable/superuser/schema
// empty requires -> line removed
```
`writeExtensionControlFile` now branches:
```ts
if (existsSync(outputPath)) writeFileSync(outputPath, upsertRequiresLine(read(outputPath), extensions));
else writeFileSync(outputPath, generateControlFileContent({ name, version, requires: extensions }));
```
During `initModule` the file doesn't exist yet, so the generate path is unchanged (init snapshots untouched).

### CLI flags (`pgpm/cli/src/commands/extension.ts`)

```
pgpm extension --add uuid-ossp        # add to current set
pgpm extension --add pgcrypto,citext  # comma or repeated flags
pgpm extension --remove uuid-ossp     # remove from current set
pgpm extension --set plpgsql,hstore   # replace the whole set
pgpm extension                        # unchanged interactive picker
```
`--set` replaces; `--add`/`--remove` mutate the current `requires`. All route through the existing `project.setModuleDependencies()` (keeps circular-dep validation). Interactive prompt message clarified to "extensions / modules".

### Tests
- `writer.test.ts`: unit tests for `upsertRequiresLine` (replace / remove / insert-position). Existing `writeExtensions` tests still pass (init-time generate → subsequent upsert produce identical output).
- `extensions.test.ts`: `--add`, `--remove`, `--set`, and a case asserting a custom `schema = my_schema` field survives a dependency change.

Note: repo-wide `pnpm lint` still fails on the unrelated pre-existing ESLint v9 config issue; `tsc --noEmit` and builds are clean for both `@pgpmjs/core` and `pgpm/cli`.


Link to Devin session: https://app.devin.ai/sessions/424b76f81a60499493ac946b57136ad9
Requested by: @pyramation