### PR TITLE
docs(pgpm skill): document zero-config init + non-interactive pgpm extension

### DIFF
--- a/.agents/skills/pgpm/SKILL.md
+++ b/.agents/skills/pgpm/SKILL.md
@@ -40,9 +40,10 @@ pgpm init workspace
 cd my-database-project
 pnpm install
 
-# 4. Create a module
+# 4. Create a module (scaffolds with no extensions by default)
 pgpm init
-# Enter module name (e.g., "pets") and select extensions
+# Enter module name (e.g., "pets"). Add extensions later with `pgpm extension`,
+# or up front with `pgpm init --extensions a,b`
 
 # 5. Add a change
 cd packages/pets
@@ -78,11 +79,11 @@ Dependencies `[...]` must come immediately after the change name, before the tim
 
 ### .control File
 
-Each module has a `.control` file declaring its name and PostgreSQL extension dependencies:
+Each module has a `.control` file declaring its name and PostgreSQL extension dependencies. A freshly-scaffolded module has **no** `requires` line (zero extensions by default); it appears once you add a dependency:
 ```
 comment = 'My database module'
 default_version = '0.0.1'
-requires = 'uuid-ossp,plpgsql'
+requires = 'pgcrypto,pgpm-base32'
 ```
 
 The `requires` field uses **control file names** (e.g., `pgpm-base32`), NOT npm names (e.g., `@pgpm/base32`). See [references/module-naming.md](references/module-naming.md) for details.
@@ -137,7 +138,7 @@ pgpm handles extension creation during deploy. Declare extensions in your `.cont
 | `pgpm revert --to <change>` | Revert changes back to a specific point |
 | `pgpm tag <version>` | Tag current state for targeted deploys |
 | `pgpm install <module>` | Install a pgpm module dependency |
-| `pgpm extension` | Interactive dependency selector |
+| `pgpm extension [--add/--remove/--set a,b]` | Manage module dependencies (flags are non-interactive; no flags = interactive picker) |
 | `pgpm test-packages` | Test all packages |
 | `pgpm test-packages --full-cycle` | Test deploy → verify → revert → redeploy |
 | `pgpm docker start` | Start PostgreSQL container |
@@ -303,7 +304,10 @@ In `noTty` mode, `inquirerer` uses defaults where available and throws with the 
    pgpm deploy --database mydb --package my-module --yes --recursive
    ```
 
-5. **`pgpm init` and `pgpm extension` are fully interactive** — they require multi-step input (names, selections). Do not use them in scripts. Instead, create `.control`, `pgpm.plan`, and `package.json` files directly.
+5. **`pgpm init` and `pgpm extension` support non-interactive use.**
+   - `pgpm init --moduleName <module> --extensions a,b` scaffolds without prompting (no `--extensions` means zero extensions). Only the module name would otherwise prompt, so pass `--moduleName` (`pgpm init workspace` uses `--name`).
+   - `pgpm extension --add <a,b>` / `--remove <a,b>` / `--set <a,b>` change a module's `requires` without a prompt.
+   Running either with no args is interactive.
 
 6. **`pgpm test-packages` does NOT prompt** — safe to run without any flags.
 
@@ -319,8 +323,8 @@ In `noTty` mode, `inquirerer` uses defaults where available and throws with the 
 | `pgpm revert` | `--yes --database <name>` | Confirms before reverting |
 | `pgpm test-packages` | None | Non-interactive by default |
 | `pgpm verify` | None | Non-interactive |
-| `pgpm init` | N/A | Fully interactive — don't use in CI |
-| `pgpm extension` | N/A | Fully interactive — don't use in CI |
+| `pgpm init` | `--moduleName <module> [--extensions a,b]` | Non-interactive with `--moduleName`; no `--extensions` = zero extensions |
+| `pgpm extension` | `--add/--remove/--set a,b` | Non-interactive with a flag; no flag = interactive picker |
 
 ## Troubleshooting Quick Reference
 

--- a/.agents/skills/pgpm/references/cli.md
+++ b/.agents/skills/pgpm/references/cli.md
@@ -128,9 +128,15 @@ pgpm upgrade-modules --modules @pgpm/base32,@pgpm/faker
 pgpm upgrade-modules --workspace --all
 ```
 
-**pgpm extension** — Interactively manage module dependencies
+**pgpm extension** — Manage a module's dependencies (the `.control` `requires` line)
 
 ```bash
+# Non-interactive (edits only the requires line; preserves other .control fields)
+pgpm extension --add pgcrypto,citext   # add one or more
+pgpm extension --remove pgcrypto       # remove one or more
+pgpm extension --set pgpm-base32       # replace the whole set
+
+# Interactive picker (no flags)
 pgpm extension
 ```
 
@@ -142,8 +148,12 @@ pgpm extension
 # Create new workspace
 pgpm init workspace
 
-# Create new module (inside workspace)
+# Create new module (inside workspace) — scaffolds with NO extensions by default
 pgpm init
+
+# Pre-select extensions non-interactively, or open the interactive picker
+pgpm init --extensions plpgsql,pgcrypto
+pgpm init --with-extensions
 
 # Use full template path (recommended)
 pgpm init --template pnpm/module

--- a/.agents/skills/pgpm/references/dependencies.md
+++ b/.agents/skills/pgpm/references/dependencies.md
@@ -60,25 +60,32 @@ Module metadata and extension dependencies live in the `.control` file:
 # pets.control
 comment = 'Pet management module'
 default_version = '0.0.1'
-requires = 'uuid-ossp,plpgsql'
+requires = 'pgcrypto'
 ```
 
 | Field | Purpose |
 |-------|---------|
 | `comment` | Module description |
 | `default_version` | Semantic version |
-| `requires` | PostgreSQL extensions needed |
+| `requires` | PostgreSQL extensions / module dependencies needed (omitted when there are none) |
+
+New modules scaffold with no extensions, so there is no `requires` line until you add a dependency.
 
 ## Adding Extension Dependencies
 
 When your module needs PostgreSQL extensions:
 
 ```bash
-# Interactive mode
+# Non-interactive (edits only the requires line)
+pgpm extension --add pgcrypto,citext
+pgpm extension --remove citext
+pgpm extension --set pgcrypto
+
+# Interactive picker
 pgpm extension
 
 # Or edit .control directly
-requires = 'uuid-ossp,plpgsql,pgcrypto'
+requires = 'pgcrypto,citext'
 ```
 
 ## Dependency Resolution

--- a/.agents/skills/pgpm/references/extensions.md
+++ b/.agents/skills/pgpm/references/extensions.md
@@ -79,16 +79,28 @@ See `references/module-naming.md` for the full naming convention.
 
 ## Adding Dependencies
 
-### Interactive: `pgpm extension`
+> New modules scaffold with **no** extensions (no `requires` line). Add them explicitly, either up front at init (`pgpm init --extensions a,b` / `--with-extensions`) or afterward with `pgpm extension` (below).
 
-Run inside a module directory to interactively select dependencies:
+### `pgpm extension`
+
+Run inside a module directory to change its dependencies. It rewrites only the `requires` line of the `.control` file, preserving every other field (comment, schema, relocatable, ...).
+
+**Non-interactive (preferred for scripts/CI):**
 
 ```bash
 cd packages/my-module
+pgpm extension --add pgcrypto          # add one or more (--add a,b)
+pgpm extension --remove pgcrypto       # remove one or more
+pgpm extension --set pgcrypto,citext   # replace the whole requires set
+```
+
+**Interactive:**
+
+```bash
 pgpm extension
 ```
 
-This shows a checkbox picker of all available modules in the workspace. Selected items are written to the `.control` file's `requires` list. You can also type custom extension names for native Postgres extensions.
+With no flags it shows a checkbox picker of all available modules in the workspace. Selected items are written to the `.control` file's `requires` list. You can also type custom extension names for native Postgres extensions.
 
 ### Installing npm-published pgpm modules: `pgpm install`
 
@@ -107,7 +119,7 @@ pgpm install
 
 `pgpm install` downloads the module from npm and places it in the workspace's `extensions/` directory (e.g., `extensions/@pgpm/base32/`).
 
-After installing, use `pgpm extension` to add the installed module to your `.control` file's `requires`.
+After installing, use `pgpm extension --add <control-name>` to add the installed module to your `.control` file's `requires`.
 
 ### Manual Editing
 
@@ -174,7 +186,7 @@ This is fully automatic — you never need to manually order extension creation.
 ### Add a pgpm module dependency
 
 1. Install: `pgpm install @pgpm/base32`
-2. Add to requires: `pgpm extension` (interactive) or edit `.control`
+2. Add to requires: `pgpm extension --add pgpm-base32` (or run `pgpm extension` interactively, or edit `.control`)
 3. Deploy — pgpm deploys `@pgpm/base32` before your module
 
 ### Check what's installed

--- a/.agents/skills/pgpm/references/workspace.md
+++ b/.agents/skills/pgpm/references/workspace.md
@@ -53,11 +53,12 @@ Inside the workspace:
 pgpm init
 ```
 
-Enter module details:
+Enter the module name:
 ```sh
 ? Enter module name: pets
-? Select extensions: uuid-ossp, plpgsql
 ```
+
+Modules scaffold with no extensions by default. Add them later with `pgpm extension --add <ext>`, or up front with `pgpm init --extensions <a,b>`.
 
 This creates:
 ```text
@@ -93,10 +94,10 @@ Points pgpm to your modules directory.
 # pets.control
 comment = 'Pet adoption module'
 default_version = '0.0.1'
-requires = 'uuid-ossp,plpgsql'
+requires = 'pgcrypto'
 ```
 
-Declares module name, description, version, and dependencies.
+Declares module name, description, version, and dependencies. A freshly-scaffolded module has no `requires` line until you add a dependency.
 
 ### pgpm.plan (Migration Plan)
 


### PR DESCRIPTION
## Summary

Brings the `pgpm` agent skill in line with the new extensions workflow (default-no-extensions `pgpm init` + hardened `pgpm extension`). The most important fix is a **correctness one**: the skill previously told agents that `pgpm init` and `pgpm extension` are "fully interactive — don't use in CI", which is now false.

Changes across `.agents/skills/pgpm/`:

- **`SKILL.md`**: quickstart no longer says "select extensions"; the `.control` section notes a fresh module has no `requires` line; the command table and the CI-safety section now describe the non-interactive paths:
  - `pgpm init --moduleName <module> [--extensions a,b]` (no `--extensions` ⇒ zero extensions; `init workspace` uses `--name`)
  - `pgpm extension --add/--remove/--set a,b` (no flag ⇒ interactive picker)
- **`references/extensions.md`**, **`references/cli.md`**, **`references/dependencies.md`**, **`references/workspace.md`**: document the `--add/--remove/--set` flags, note that `pgpm extension` rewrites only the `requires` line (preserving custom `.control` fields), and drop the legacy `requires = 'uuid-ossp,plpgsql'` examples in favor of `pgcrypto`/module deps.

Docs-only; no code changes. Pairs with the tutorial refresh in `constructive-io/constructive.io#14`.

Link to Devin session: https://app.devin.ai/sessions/424b76f81a60499493ac946b57136ad9
Requested by: @pyramation