### PR TITLE
feat(pgpm): zero-config extensions cleanup + --pglite init flag (consolidated)

### DIFF
--- a/.agents/skills/pgpm/SKILL.md
+++ b/.agents/skills/pgpm/SKILL.md
@@ -40,9 +40,10 @@ pgpm init workspace
 cd my-database-project
 pnpm install
 
-# 4. Create a module
+# 4. Create a module (scaffolds with no extensions by default)
 pgpm init
-# Enter module name (e.g., "pets") and select extensions
+# Enter module name (e.g., "pets"). Add extensions later with `pgpm extension`,
+# or up front with `pgpm init --extensions a,b`
 
 # 5. Add a change
 cd packages/pets
@@ -78,11 +79,11 @@ Dependencies `[...]` must come immediately after the change name, before the tim
 
 ### .control File
 
-Each module has a `.control` file declaring its name and PostgreSQL extension dependencies:
+Each module has a `.control` file declaring its name and PostgreSQL extension dependencies. A freshly-scaffolded module has **no** `requires` line (zero extensions by default); it appears once you add a dependency:
 ```
 comment = 'My database module'
 default_version = '0.0.1'
-requires = 'uuid-ossp,plpgsql'
+requires = 'pgcrypto,pgpm-base32'
 ```
 
 The `requires` field uses **control file names** (e.g., `pgpm-base32`), NOT npm names (e.g., `@pgpm/base32`). See [references/module-naming.md](references/module-naming.md) for details.
@@ -137,7 +138,7 @@ pgpm handles extension creation during deploy. Declare extensions in your `.cont
 | `pgpm revert --to <change>` | Revert changes back to a specific point |
 | `pgpm tag <version>` | Tag current state for targeted deploys |
 | `pgpm install <module>` | Install a pgpm module dependency |
-| `pgpm extension` | Interactive dependency selector |
+| `pgpm extension [--add/--remove/--set a,b]` | Manage module dependencies (flags are non-interactive; no flags = interactive picker) |
 | `pgpm test-packages` | Test all packages |
 | `pgpm test-packages --full-cycle` | Test deploy → verify → revert → redeploy |
 | `pgpm docker start` | Start PostgreSQL container |
@@ -303,7 +304,10 @@ In `noTty` mode, `inquirerer` uses defaults where available and throws with the 
    pgpm deploy --database mydb --package my-module --yes --recursive
    ```
 
-5. **`pgpm init` and `pgpm extension` are fully interactive** — they require multi-step input (names, selections). Do not use them in scripts. Instead, create `.control`, `pgpm.plan`, and `package.json` files directly.
+5. **`pgpm init` and `pgpm extension` support non-interactive use.**
+   - `pgpm init --moduleName <module> --extensions a,b` scaffolds without prompting (no `--extensions` means zero extensions). Only the module name would otherwise prompt, so pass `--moduleName` (`pgpm init workspace` uses `--name`).
+   - `pgpm extension --add <a,b>` / `--remove <a,b>` / `--set <a,b>` change a module's `requires` without a prompt.
+   Running either with no args is interactive.
 
 6. **`pgpm test-packages` does NOT prompt** — safe to run without any flags.
 
@@ -319,8 +323,8 @@ In `noTty` mode, `inquirerer` uses defaults where available and throws with the 
 | `pgpm revert` | `--yes --database <name>` | Confirms before reverting |
 | `pgpm test-packages` | None | Non-interactive by default |
 | `pgpm verify` | None | Non-interactive |
-| `pgpm init` | N/A | Fully interactive — don't use in CI |
-| `pgpm extension` | N/A | Fully interactive — don't use in CI |
+| `pgpm init` | `--moduleName <module> [--extensions a,b]` | Non-interactive with `--moduleName`; no `--extensions` = zero extensions |
+| `pgpm extension` | `--add/--remove/--set a,b` | Non-interactive with a flag; no flag = interactive picker |
 
 ## Troubleshooting Quick Reference
 

--- a/.agents/skills/pgpm/references/cli.md
+++ b/.agents/skills/pgpm/references/cli.md
@@ -128,9 +128,15 @@ pgpm upgrade-modules --modules @pgpm/base32,@pgpm/faker
 pgpm upgrade-modules --workspace --all
 ```
 
-**pgpm extension** — Interactively manage module dependencies
+**pgpm extension** — Manage a module's dependencies (the `.control` `requires` line)
 
 ```bash
+# Non-interactive (edits only the requires line; preserves other .control fields)
+pgpm extension --add pgcrypto,citext   # add one or more
+pgpm extension --remove pgcrypto       # remove one or more
+pgpm extension --set pgpm-base32       # replace the whole set
+
+# Interactive picker (no flags)
 pgpm extension
 ```
 
@@ -142,8 +148,12 @@ pgpm extension
 # Create new workspace
 pgpm init workspace
 
-# Create new module (inside workspace)
+# Create new module (inside workspace) — scaffolds with NO extensions by default
 pgpm init
+
+# Pre-select extensions non-interactively, or open the interactive picker
+pgpm init --extensions plpgsql,pgcrypto
+pgpm init --with-extensions
 
 # Use full template path (recommended)
 pgpm init --template pnpm/module

--- a/.agents/skills/pgpm/references/dependencies.md
+++ b/.agents/skills/pgpm/references/dependencies.md
@@ -60,25 +60,32 @@ Module metadata and extension dependencies live in the `.control` file:
 # pets.control
 comment = 'Pet management module'
 default_version = '0.0.1'
-requires = 'uuid-ossp,plpgsql'
+requires = 'pgcrypto'
 ```
 
 | Field | Purpose |
 |-------|---------|
 | `comment` | Module description |
 | `default_version` | Semantic version |
-| `requires` | PostgreSQL extensions needed |
+| `requires` | PostgreSQL extensions / module dependencies needed (omitted when there are none) |
+
+New modules scaffold with no extensions, so there is no `requires` line until you add a dependency.
 
 ## Adding Extension Dependencies
 
 When your module needs PostgreSQL extensions:
 
 ```bash
-# Interactive mode
+# Non-interactive (edits only the requires line)
+pgpm extension --add pgcrypto,citext
+pgpm extension --remove citext
+pgpm extension --set pgcrypto
+
+# Interactive picker
 pgpm extension
 
 # Or edit .control directly
-requires = 'uuid-ossp,plpgsql,pgcrypto'
+requires = 'pgcrypto,citext'
 ```
 
 ## Dependency Resolution

--- a/.agents/skills/pgpm/references/extensions.md
+++ b/.agents/skills/pgpm/references/extensions.md
@@ -79,16 +79,28 @@ See `references/module-naming.md` for the full naming convention.
 
 ## Adding Dependencies
 
-### Interactive: `pgpm extension`
+> New modules scaffold with **no** extensions (no `requires` line). Add them explicitly, either up front at init (`pgpm init --extensions a,b` / `--with-extensions`) or afterward with `pgpm extension` (below).
 
-Run inside a module directory to interactively select dependencies:
+### `pgpm extension`
+
+Run inside a module directory to change its dependencies. It rewrites only the `requires` line of the `.control` file, preserving every other field (comment, schema, relocatable, ...).
+
+**Non-interactive (preferred for scripts/CI):**
 
 ```bash
 cd packages/my-module
+pgpm extension --add pgcrypto          # add one or more (--add a,b)
+pgpm extension --remove pgcrypto       # remove one or more
+pgpm extension --set pgcrypto,citext   # replace the whole requires set
+```
+
+**Interactive:**
+
+```bash
 pgpm extension
 ```
 
-This shows a checkbox picker of all available modules in the workspace. Selected items are written to the `.control` file's `requires` list. You can also type custom extension names for native Postgres extensions.
+With no flags it shows a checkbox picker of all available modules in the workspace. Selected items are written to the `.control` file's `requires` list. You can also type custom extension names for native Postgres extensions.
 
 ### Installing npm-published pgpm modules: `pgpm install`
 
@@ -107,7 +119,7 @@ pgpm install
 
 `pgpm install` downloads the module from npm and places it in the workspace's `extensions/` directory (e.g., `extensions/@pgpm/base32/`).
 
-After installing, use `pgpm extension` to add the installed module to your `.control` file's `requires`.
+After installing, use `pgpm extension --add <control-name>` to add the installed module to your `.control` file's `requires`.
 
 ### Manual Editing
 
@@ -174,7 +186,7 @@ This is fully automatic — you never need to manually order extension creation.
 ### Add a pgpm module dependency
 
 1. Install: `pgpm install @pgpm/base32`
-2. Add to requires: `pgpm extension` (interactive) or edit `.control`
+2. Add to requires: `pgpm extension --add pgpm-base32` (or run `pgpm extension` interactively, or edit `.control`)
 3. Deploy — pgpm deploys `@pgpm/base32` before your module
 
 ### Check what's installed

--- a/.agents/skills/pgpm/references/workspace.md
+++ b/.agents/skills/pgpm/references/workspace.md
@@ -53,11 +53,12 @@ Inside the workspace:
 pgpm init
 ```
 
-Enter module details:
+Enter the module name:
 ```sh
 ? Enter module name: pets
-? Select extensions: uuid-ossp, plpgsql
 ```
+
+Modules scaffold with no extensions by default. Add them later with `pgpm extension --add <ext>`, or up front with `pgpm init --extensions <a,b>`.
 
 This creates:
 ```text
@@ -93,10 +94,10 @@ Points pgpm to your modules directory.
 # pets.control
 comment = 'Pet adoption module'
 default_version = '0.0.1'
-requires = 'uuid-ossp,plpgsql'
+requires = 'pgcrypto'
 ```
 
-Declares module name, description, version, and dependencies.
+Declares module name, description, version, and dependencies. A freshly-scaffolded module has no `requires` line until you add a dependency.
 
 ### pgpm.plan (Migration Plan)
 

--- a/pgpm/cli/__tests__/extensions.test.ts
+++ b/pgpm/cli/__tests__/extensions.test.ts
@@ -2,6 +2,7 @@ jest.setTimeout(60000);
 process.env.PGPM_SKIP_UPDATE_CHECK = 'true';
 
 import { PgpmPackage } from '@pgpmjs/core';
+import { readFileSync, writeFileSync } from 'fs';
 import { sync as glob } from 'glob';
 import { Inquirerer, ParsedArgs } from 'inquirerer';
 import * as path from 'path';
@@ -101,5 +102,74 @@ describe('cmds:extension', () => {
     expect(updatedProject.getModuleControlFile()).toMatchSnapshot('updated - control file');
     expect(updatedProject.getModuleDependencies('my-module')).toMatchSnapshot('updated - module dependencies');
     expect(updatedProject.getRequiredModules()).toMatchSnapshot('updated - required modules');
+  });
+
+  // Helper: scaffold a workspace + module with a starting set of extensions.
+  const scaffoldModule = async (extensions: string[]) => {
+    const workspacePath = fixture.fixturePath('ws');
+    const modulePath = path.join(workspacePath, 'packages', 'my-module');
+    await runCommand({
+      _: ['init', 'workspace'],
+      cwd: fixture.tempDir,
+      name: 'ws',
+      workspace: true
+    });
+    await runCommand({
+      _: ['init'],
+      cwd: workspacePath,
+      name: 'my-module',
+      moduleName: 'my-module',
+      extensions
+    });
+    return modulePath;
+  };
+
+  it('adds a dependency non-interactively with --add', async () => {
+    const modulePath = await scaffoldModule(['citext']);
+
+    await runCommand({ _: ['extension'], cwd: modulePath, add: 'uuid-ossp' });
+
+    expect(new PgpmPackage(modulePath).getRequiredModules()).toEqual([
+      'citext',
+      'uuid-ossp'
+    ]);
+  });
+
+  it('removes a dependency non-interactively with --remove', async () => {
+    const modulePath = await scaffoldModule(['citext', 'uuid-ossp']);
+
+    await runCommand({ _: ['extension'], cwd: modulePath, remove: 'uuid-ossp' });
+
+    expect(new PgpmPackage(modulePath).getRequiredModules()).toEqual(['citext']);
+  });
+
+  it('replaces the dependency set non-interactively with --set', async () => {
+    const modulePath = await scaffoldModule(['citext', 'uuid-ossp']);
+
+    await runCommand({ _: ['extension'], cwd: modulePath, set: 'plpgsql,hstore' });
+
+    expect(new PgpmPackage(modulePath).getRequiredModules()).toEqual([
+      'plpgsql',
+      'hstore'
+    ]);
+  });
+
+  it('preserves custom .control fields when changing dependencies', async () => {
+    const modulePath = await scaffoldModule(['citext']);
+    const project = new PgpmPackage(modulePath);
+    const controlPath = path.join(modulePath, `${project.getModuleName()}.control`);
+
+    // Hand-tune a custom field that init does not emit.
+    const original = readFileSync(controlPath, 'utf8');
+    writeFileSync(controlPath, `${original}schema = my_schema\n`);
+
+    await runCommand({ _: ['extension'], cwd: modulePath, add: 'uuid-ossp' });
+
+    const updated = readFileSync(controlPath, 'utf8');
+    expect(updated).toMatch(/schema = my_schema/);
+    expect(new PgpmPackage(modulePath).getRequiredModules()).toEqual([
+      'citext',
+      'uuid-ossp'
+    ]);
   });
 });

--- a/pgpm/cli/__tests__/init.boilerplate.test.ts
+++ b/pgpm/cli/__tests__/init.boilerplate.test.ts
@@ -1,0 +1,98 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { DEFAULT_TEMPLATE_REPO, PGLITE_TEMPLATE_REPO } from '@pgpmjs/core';
+
+import {
+  persistBoilerplateSource,
+  readBoilerplateSource,
+  resolveInitTemplateRepo,
+} from '../src/commands/init/boilerplate';
+
+describe('resolveInitTemplateRepo', () => {
+  it('defaults to the pgpm boilerplates repo (not explicit)', () => {
+    expect(resolveInitTemplateRepo({})).toEqual({
+      templateRepo: DEFAULT_TEMPLATE_REPO,
+      repoWasExplicit: false,
+    });
+  });
+
+  it('maps --pglite to the pglite boilerplates repo (explicit)', () => {
+    expect(resolveInitTemplateRepo({ pglite: true })).toEqual({
+      templateRepo: PGLITE_TEMPLATE_REPO,
+      repoWasExplicit: true,
+    });
+  });
+
+  it('lets --repo win over --pglite', () => {
+    const custom = 'https://github.com/acme/my-boilerplates.git';
+    expect(resolveInitTemplateRepo({ repo: custom, pglite: true })).toEqual({
+      templateRepo: custom,
+      repoWasExplicit: true,
+    });
+  });
+});
+
+describe('persist/read boilerplate source', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pgpm-boilerplate-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('records the source into an existing pgpm.json and reads it back', () => {
+    fs.writeFileSync(
+      path.join(dir, 'pgpm.json'),
+      `${JSON.stringify({ packages: ['packages/*'] }, null, 2)}\n`
+    );
+
+    persistBoilerplateSource(dir, { repo: PGLITE_TEMPLATE_REPO });
+
+    const config = JSON.parse(fs.readFileSync(path.join(dir, 'pgpm.json'), 'utf8'));
+    expect(config.packages).toEqual(['packages/*']);
+    expect(config.boilerplates).toEqual({ repo: PGLITE_TEMPLATE_REPO });
+
+    expect(readBoilerplateSource(dir)).toEqual({
+      repo: PGLITE_TEMPLATE_REPO,
+      branch: undefined,
+      dir: undefined,
+    });
+  });
+
+  it('persists optional branch and dir when provided', () => {
+    fs.writeFileSync(
+      path.join(dir, 'pgpm.json'),
+      `${JSON.stringify({ packages: ['packages/*'] }, null, 2)}\n`
+    );
+
+    persistBoilerplateSource(dir, {
+      repo: PGLITE_TEMPLATE_REPO,
+      branch: 'main',
+      dir: 'pglite',
+    });
+
+    expect(readBoilerplateSource(dir)).toEqual({
+      repo: PGLITE_TEMPLATE_REPO,
+      branch: 'main',
+      dir: 'pglite',
+    });
+  });
+
+  it('is a no-op when there is no pgpm.json (does not create one)', () => {
+    persistBoilerplateSource(dir, { repo: PGLITE_TEMPLATE_REPO });
+    expect(fs.existsSync(path.join(dir, 'pgpm.json'))).toBe(false);
+  });
+
+  it('returns undefined when the workspace has no recorded source', () => {
+    fs.writeFileSync(
+      path.join(dir, 'pgpm.json'),
+      `${JSON.stringify({ packages: ['packages/*'] }, null, 2)}\n`
+    );
+    expect(readBoilerplateSource(dir)).toBeUndefined();
+  });
+});

--- a/pgpm/cli/__tests__/init.boilerplate.test.ts
+++ b/pgpm/cli/__tests__/init.boilerplate.test.ts
@@ -2,13 +2,15 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { DEFAULT_TEMPLATE_REPO, PGLITE_TEMPLATE_REPO } from '@pgpmjs/core';
+import { DEFAULT_TEMPLATE_REPO, TEMPLATE_REPOS } from '@pgpmjs/core';
 
 import {
   persistBoilerplateSource,
   readBoilerplateSource,
   resolveInitTemplateRepo,
 } from '../src/commands/init/boilerplate';
+
+const PGLITE_TEMPLATE_REPO = TEMPLATE_REPOS.pglite;
 
 describe('resolveInitTemplateRepo', () => {
   it('defaults to the pgpm boilerplates repo (not explicit)', () => {

--- a/pgpm/cli/__tests__/init.test.ts
+++ b/pgpm/cli/__tests__/init.test.ts
@@ -2,7 +2,7 @@ jest.setTimeout(60000);
 process.env.PGPM_SKIP_UPDATE_CHECK = 'true';
 process.env.PGPM_SKIP_SKILL_INSTALL = 'true';
 
-import { PgpmPackage, PGLITE_TEMPLATE_REPO } from '@pgpmjs/core';
+import { PgpmPackage, TEMPLATE_REPOS } from '@pgpmjs/core';
 import { existsSync, readFileSync } from 'fs';
 import { sync as glob } from 'glob';
 import { Inquirerer, ParsedArgs } from 'inquirerer';
@@ -16,6 +16,8 @@ import {
   TestFixture,
   withInitDefaults
 } from '../test-utils';
+
+const PGLITE_TEMPLATE_REPO = TEMPLATE_REPOS.pglite;
 
 const beforeEachSetup = setupTests();
 

--- a/pgpm/cli/__tests__/init.test.ts
+++ b/pgpm/cli/__tests__/init.test.ts
@@ -2,14 +2,15 @@ jest.setTimeout(60000);
 process.env.PGPM_SKIP_UPDATE_CHECK = 'true';
 process.env.PGPM_SKIP_SKILL_INSTALL = 'true';
 
-import { PgpmPackage } from '@pgpmjs/core';
-import { existsSync } from 'fs';
+import { PgpmPackage, PGLITE_TEMPLATE_REPO } from '@pgpmjs/core';
+import { existsSync, readFileSync } from 'fs';
 import { sync as glob } from 'glob';
 import { Inquirerer, ParsedArgs } from 'inquirerer';
 import * as path from 'path';
 
 import { commands } from '../src/commands';
 import {
+  addInitDefaults,
   setupTests,
   TestEnvironment,
   TestFixture,
@@ -628,6 +629,77 @@ describe('cmds:init', () => {
         expect(existsSync(nestedWs)).toBe(false);
       },
       120000
+    );
+  });
+
+  describe('--pglite flag', () => {
+    const shouldSkipGitHubTests = process.env.CI === 'true' && !process.env.ALLOW_NETWORK_TESTS;
+
+    (shouldSkipGitHubTests ? it.skip : it)(
+      'records the pglite repo on the workspace and inherits it for modules',
+      async () => {
+        const { mockInput, mockOutput } = environment;
+        const prompter = new Inquirerer({
+          input: mockInput,
+          output: mockOutput,
+          noTty: true
+        });
+
+        const wsName = 'ws-pglite';
+        const wsRoot = path.join(fixture.tempDir, wsName);
+
+        // 1) Create a pglite workspace. --pglite must NOT be overridden by a
+        //    default repo, so build argv directly (withInitDefaults injects --repo).
+        await commands(addInitDefaults({
+          _: ['init', 'workspace'],
+          cwd: fixture.tempDir,
+          name: wsName,
+          workspace: true,
+          pglite: true,
+          fromBranch: 'main'
+        }), prompter, {
+          noTty: true,
+          input: mockInput,
+          output: mockOutput,
+          version: '1.0.0',
+          minimistOpts: {}
+        });
+
+        // Workspace records the pglite boilerplate source so modules inherit it.
+        const wsConfig = JSON.parse(
+          readFileSync(path.join(wsRoot, 'pgpm.json'), 'utf8')
+        );
+        expect(wsConfig.boilerplates?.repo).toBe(PGLITE_TEMPLATE_REPO);
+
+        // 2) A bare `pgpm init` (no --pglite) inside the workspace inherits it.
+        const modName = 'pglite-mod';
+        await commands(addInitDefaults({
+          _: ['init'],
+          cwd: wsRoot,
+          moduleName: modName,
+          name: modName,
+          extensions: ['plpgsql'],
+          fromBranch: 'main'
+        }), prompter, {
+          noTty: true,
+          input: mockInput,
+          output: mockOutput,
+          version: '1.0.0',
+          minimistOpts: {}
+        });
+
+        const modDir = path.join(wsRoot, 'packages', modName);
+        expect(existsSync(path.join(modDir, 'pgpm.plan'))).toBe(true);
+
+        // The inherited pglite module template swaps in pglite-test.
+        const modPkg = JSON.parse(
+          readFileSync(path.join(modDir, 'package.json'), 'utf8')
+        );
+        const devDeps = modPkg.devDependencies ?? {};
+        expect(devDeps['pglite-test']).toBeDefined();
+        expect(devDeps['pgsql-test']).toBeUndefined();
+      },
+      180000
     );
   });
 });

--- a/pgpm/cli/src/commands/extension.ts
+++ b/pgpm/cli/src/commands/extension.ts
@@ -6,15 +6,40 @@ Extension Command:
 
   pgpm extension [OPTIONS]
 
-  Manage module dependencies.
+  Manage the extensions / module dependencies of the current module
+  (the \`requires\` line of its .control file).
 
 Options:
   --help, -h              Show this help message
   --cwd <directory>       Working directory (default: current directory)
+  --add <a,b>             Add one or more dependencies (non-interactive)
+  --remove <a,b>          Remove one or more dependencies (non-interactive)
+  --set <a,b>             Replace all dependencies with this exact set (non-interactive)
 
 Examples:
-  pgpm extension           Manage dependencies for current module
+  pgpm extension                       Manage dependencies interactively
+  pgpm extension --add uuid-ossp       Add a dependency
+  pgpm extension --add pgcrypto,citext Add several dependencies
+  pgpm extension --remove uuid-ossp    Remove a dependency
+  pgpm extension --set plpgsql         Replace the dependency set
 `;
+
+/**
+ * Parse a flag that may be a comma-separated string, a single value, or an
+ * array (repeated flags) into a clean string[].
+ */
+const parseList = (value: unknown): string[] => {
+  if (Array.isArray(value)) {
+    return value.flatMap((v) => parseList(v));
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  return [];
+};
 
 export default async (
   argv: Partial<ParsedArgs>,
@@ -34,15 +59,34 @@ export default async (
     throw new Error('You must run this command inside a PGPM module.');
   }
 
-  const info = project.getModuleInfo();
   const installed = project.getRequiredModules();
+
+  // Non-interactive mode: --set / --add / --remove let CI and scripts change
+  // dependencies without a prompt. --set replaces the whole set; --add/--remove
+  // mutate the current set.
+  const setProvided = argv.set !== undefined;
+  const addList = parseList(argv.add);
+  const removeList = parseList(argv.remove);
+
+  if (setProvided || addList.length > 0 || removeList.length > 0) {
+    const base = setProvided ? parseList(argv.set) : [...installed];
+    const withAdds = [...base];
+    for (const ext of addList) {
+      if (!withAdds.includes(ext)) withAdds.push(ext);
+    }
+    const next = withAdds.filter((ext) => !removeList.includes(ext));
+    project.setModuleDependencies(next);
+    return;
+  }
+
+  const info = project.getModuleInfo();
   const available = await project.getAvailableModules();
-  const filtered = available.filter(name => name !== info.extname);
+  const filtered = available.filter((name) => name !== info.extname);
 
   const questions: Question[] = [
     {
       name: 'extensions',
-      message: 'Which modules does this one depend on?',
+      message: 'Which extensions / modules does this one depend on?',
       type: 'checkbox',
       allowCustomOptions: true,
       options: filtered,
@@ -52,8 +96,8 @@ export default async (
 
   const answers = await prompter.prompt(argv, questions);
   const selected = (answers.extensions as OptionValue[])
-    .filter(opt => opt.selected)
-    .map(opt => opt.name);
+    .filter((opt) => opt.selected)
+    .map((opt) => opt.name);
 
   project.setModuleDependencies(selected);
 };

--- a/pgpm/cli/src/commands/init/boilerplate.ts
+++ b/pgpm/cli/src/commands/init/boilerplate.ts
@@ -1,11 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import {
-  DEFAULT_TEMPLATE_REPO,
-  PGLITE_TEMPLATE_REPO,
-  PgpmPackage,
-} from '@pgpmjs/core';
+import { DEFAULT_TEMPLATE_REPO, PgpmPackage, TEMPLATE_REPOS } from '@pgpmjs/core';
 
 /**
  * A template/boilerplate source, recorded on a workspace so that modules
@@ -33,7 +29,7 @@ export function resolveInitTemplateRepo(flags: {
     typeof flags.repo === 'string'
       ? flags.repo
       : pglite
-        ? PGLITE_TEMPLATE_REPO
+        ? TEMPLATE_REPOS.pglite
         : DEFAULT_TEMPLATE_REPO;
   return { templateRepo, repoWasExplicit };
 }

--- a/pgpm/cli/src/commands/init/boilerplate.ts
+++ b/pgpm/cli/src/commands/init/boilerplate.ts
@@ -1,0 +1,78 @@
+import fs from 'fs';
+import path from 'path';
+
+import {
+  DEFAULT_TEMPLATE_REPO,
+  PGLITE_TEMPLATE_REPO,
+  PgpmPackage,
+} from '@pgpmjs/core';
+
+/**
+ * A template/boilerplate source, recorded on a workspace so that modules
+ * created inside it inherit the same repo without re-specifying flags.
+ */
+export interface BoilerplateSource {
+  repo: string;
+  branch?: string;
+  dir?: string;
+}
+
+/**
+ * Resolve the template repo for an `init` invocation from its flags.
+ *
+ * Precedence: explicit `--repo` wins, then `--pglite` (sugar for the pglite
+ * boilerplates repo), otherwise the default repo.
+ */
+export function resolveInitTemplateRepo(flags: {
+  repo?: unknown;
+  pglite?: boolean;
+}): { templateRepo: string; repoWasExplicit: boolean } {
+  const pglite = Boolean(flags.pglite);
+  const repoWasExplicit = typeof flags.repo === 'string' || pglite;
+  const templateRepo =
+    typeof flags.repo === 'string'
+      ? flags.repo
+      : pglite
+        ? PGLITE_TEMPLATE_REPO
+        : DEFAULT_TEMPLATE_REPO;
+  return { templateRepo, repoWasExplicit };
+}
+
+/**
+ * Record the boilerplate source on a freshly scaffolded workspace's `pgpm.json`
+ * so that `pgpm init` (module) inside it inherits the same template repo.
+ * Only writes into an existing pgpm.json (pgpm.config.js workspaces are skipped).
+ */
+export function persistBoilerplateSource(
+  workspaceDir: string,
+  source: BoilerplateSource
+): void {
+  const configPath = path.join(workspaceDir, 'pgpm.json');
+  if (!fs.existsSync(configPath)) return;
+
+  try {
+    const raw = fs.readFileSync(configPath, 'utf8');
+    const config = JSON.parse(raw);
+    config.boilerplates = {
+      repo: source.repo,
+      ...(source.branch ? { branch: source.branch } : {}),
+      ...(source.dir ? { dir: source.dir } : {}),
+    };
+    fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+  } catch {
+    // Non-fatal: inheritance is a convenience, not a correctness requirement.
+  }
+}
+
+/**
+ * Read a previously recorded boilerplate source from the enclosing workspace's
+ * config (see {@link persistBoilerplateSource}).
+ */
+export function readBoilerplateSource(cwd: string): BoilerplateSource | undefined {
+  const project = new PgpmPackage(cwd);
+  const recorded = project.config?.boilerplates;
+  if (recorded?.repo) {
+    return { repo: recorded.repo, branch: recorded.branch, dir: recorded.dir };
+  }
+  return undefined;
+}

--- a/pgpm/cli/src/commands/init/index.ts
+++ b/pgpm/cli/src/commands/init/index.ts
@@ -18,6 +18,12 @@ import { resolveWorkspaceByType } from '@pgpmjs/env';
 import { errors } from '@pgpmjs/types';
 import { CLIOptions, Inquirerer, OptionValue, Question, registerDefaultResolver } from 'inquirerer';
 
+import {
+  persistBoilerplateSource,
+  readBoilerplateSource,
+  resolveInitTemplateRepo,
+} from './boilerplate';
+
 const DEFAULT_MOTD = `
                  |              _   _
      ===         |.===.        '\\-//\`
@@ -40,6 +46,9 @@ Options:
   --help, -h              Show this help message
   --cwd <directory>       Working directory (default: current directory)
   --repo <repo>           Template repo (default: https://github.com/constructive-io/pgpm-boilerplates.git)
+  --pglite                Use the PGlite boilerplates (in-process WASM Postgres, no server/Docker).
+                          Sugar for --repo https://github.com/constructive-io/pglite-boilerplates.git.
+                          Recorded on the workspace so later \`init\` calls inherit it automatically.
   --from-branch <branch>  Branch/tag to use when cloning repo
   --dir <variant>         Template variant directory (e.g., supabase, drizzle)
   --template, -t <path>   Full template path (e.g., pnpm/module) - combines dir and fromPath
@@ -57,6 +66,8 @@ Examples:
   ${binaryName} init --repo owner/repo                 Use templates from GitHub repository
   ${binaryName} init --repo owner/repo --from-branch develop  Use specific branch
   ${binaryName} init --dir pnpm -w                     Create pnpm workspace + module in one command
+  ${binaryName} init workspace --pglite                Create a PGlite (in-process) workspace
+  ${binaryName} init --pglite                          Create a PGlite module (inherited automatically inside a --pglite workspace)
 `;
 };
 
@@ -76,7 +87,13 @@ export default async (
 
 async function handleInit(argv: Partial<Record<string, any>>, prompter: Inquirerer) {
   const { cwd = process.cwd() } = argv;
-  const templateRepo = (argv.repo as string) ?? DEFAULT_TEMPLATE_REPO;
+  // `--pglite` is sugar for the pglite boilerplates repo; `--repo` overrides it.
+  // `repoWasExplicit` means a module created inside a workspace should NOT
+  // inherit the workspace's recorded repo (the user pinned one).
+  const { templateRepo, repoWasExplicit } = resolveInitTemplateRepo({
+    repo: argv.repo,
+    pglite: Boolean(argv.pglite),
+  });
   const branch = argv.fromBranch as string | undefined;
   const noTty = Boolean((argv as any).noTty || argv['no-tty'] || argv.tty === false || process.env.CI === 'true');
   const useBoilerplatePrompt = Boolean(argv.boilerplate);
@@ -144,6 +161,7 @@ async function handleInit(argv: Partial<Record<string, any>>, prompter: Inquirer
       noTty,
       cwd,
       useNpxSkills,
+      repoWasExplicit,
     });
   }
 
@@ -158,6 +176,7 @@ async function handleInit(argv: Partial<Record<string, any>>, prompter: Inquirer
     requiresWorkspace: inspection.config?.requiresWorkspace,
     createWorkspace,
     useNpxSkills,
+    repoWasExplicit,
   }, wasExplicitModuleRequest);
 }
 
@@ -288,6 +307,12 @@ interface InitContext {
    * If true, use npx skills CLI instead of built-in shallow clone.
    */
   useNpxSkills?: boolean;
+  /**
+   * True when the user pinned a template source explicitly (`--repo`/`--pglite`).
+   * When false, a module created inside a workspace inherits the workspace's
+   * recorded boilerplate repo (see `PgpmWorkspaceConfig.boilerplates`).
+   */
+  repoWasExplicit?: boolean;
 }
 
 function installSkills(skills: BoilerplateSkill[], cwd: string, useNpxSkills: boolean): void {
@@ -393,6 +418,17 @@ async function handleWorkspaceInit(
     prompter
   });
 
+  // Record a non-default template source on the workspace so that modules
+  // created later inside it (`pgpm init`) inherit the same boilerplate repo
+  // without re-specifying `--pglite`/`--repo`.
+  if (ctx.templateRepo !== DEFAULT_TEMPLATE_REPO) {
+    persistBoilerplateSource(targetPath, {
+      repo: ctx.templateRepo,
+      branch: ctx.branch,
+      dir: ctx.dir,
+    });
+  }
+
   // Check for .motd file and print it, or use default ASCII art
   const motdPath = path.join(targetPath, '.motd');
   let motd = DEFAULT_MOTD;
@@ -443,9 +479,14 @@ function resolveWorkspaceTemplateRepo(options: {
 }): WorkspaceTemplateConfig {
   const { templateRepo, branch, dir, workspaceType, cwd } = options;
 
-  // Determine the dir to use for workspace template
-  // If dir is specified, use it; otherwise use the workspaceType as the dir variant
-  const workspaceDir = dir || workspaceType;
+  // Determine the dir to use for workspace template.
+  // - Explicit --dir always wins.
+  // - For the default repo (which holds several families), fall back to the
+  //   workspaceType (pgpm/pnpm) as the variant dir.
+  // - For a custom/single-family repo (e.g. --pglite), leave dir undefined so
+  //   the repo's own .boilerplates.json resolves the family (e.g. `pglite/`).
+  const isDefaultRepo = templateRepo === DEFAULT_TEMPLATE_REPO;
+  const workspaceDir = dir || (isDefaultRepo ? workspaceType : undefined);
 
   // Try to find workspace template in the specified repo
   try {
@@ -485,6 +526,18 @@ async function handleModuleInit(
   ctx: InitContext,
   wasExplicitModuleRequest: boolean = false
 ) {
+  // Inherit the boilerplate source recorded on the enclosing workspace (e.g. by
+  // `pgpm init workspace --pglite`) unless the user pinned one explicitly. This
+  // makes a bare `pgpm init` inside a pglite workspace scaffold pglite modules.
+  if (!ctx.repoWasExplicit) {
+    const inherited = readBoilerplateSource(ctx.cwd);
+    if (inherited) {
+      ctx.templateRepo = inherited.repo;
+      ctx.branch = inherited.branch;
+      ctx.dir = inherited.dir;
+    }
+  }
+
   // Determine workspace requirement (defaults to 'pgpm' for backward compatibility)
   const workspaceType = ctx.requiresWorkspace ?? 'pgpm';
   // Whether this is a pgpm-managed template (creates pgpm.plan, .control files)
@@ -528,6 +581,7 @@ async function handleModuleInit(
           dir: workspaceTemplateConfig.dir,
           noTty: ctx.noTty,
           cwd: ctx.cwd,
+          repoWasExplicit: ctx.repoWasExplicit,
         });
 
         // Update context to point to new workspace and continue with module creation
@@ -576,6 +630,7 @@ async function handleModuleInit(
               dir: ctx.dir,
               noTty: ctx.noTty,
               cwd: ctx.cwd,
+              repoWasExplicit: ctx.repoWasExplicit,
             });
           }
         }

--- a/pgpm/core/__tests__/core/__snapshots__/plan-writing.test.ts.snap
+++ b/pgpm/core/__tests__/core/__snapshots__/plan-writing.test.ts.snap
@@ -24,7 +24,7 @@ procedures/generate_secret [pg-verify:procedures/verify_view] 2017-08-11T08:11:5
 exports[`PgpmPackage.writeModulePlan writes a plan with project references (utils) 1`] = `
 {
   "ctrl": "# pg-verify extension
-comment = 'pg-verify extension'
+comment = 'PostgreSQL verification utilities'
 default_version = '0.0.1'
 module_pathname = '$libdir/pg-verify'
 requires = 'some-native-module,pg-utilities'

--- a/pgpm/core/__tests__/files/extension/writer.test.ts
+++ b/pgpm/core/__tests__/files/extension/writer.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { writeExtensions, generateControlFileContent } from '../../../src/files/extension/writer';
+import { writeExtensions, generateControlFileContent, upsertRequiresLine } from '../../../src/files/extension/writer';
 import { getInstalledExtensions } from '../../../src/files/extension/reader';
 
 describe('extension writer', () => {
@@ -97,6 +97,44 @@ describe('extension writer', () => {
       });
 
       expect(content).toContain('schema = public');
+    });
+  });
+
+  describe('upsertRequiresLine', () => {
+    const base = generateControlFileContent({
+      name: 'test-module',
+      version: '1.0.0',
+      requires: ['pgcrypto'],
+      schema: 'my_schema'
+    });
+
+    it('replaces an existing requires line and preserves other fields', () => {
+      const result = upsertRequiresLine(base, ['pgcrypto', 'postgis']);
+      expect(result).toContain("requires = 'pgcrypto,postgis'");
+      expect(result).toContain('schema = my_schema');
+      expect(result).toContain("comment = 'test-module extension'");
+    });
+
+    it('removes the requires line when the set is empty', () => {
+      const result = upsertRequiresLine(base, []);
+      expect(result).not.toContain('requires =');
+      expect(result).toContain('schema = my_schema');
+    });
+
+    it('inserts a requires line before relocatable when none exists', () => {
+      const noRequires = generateControlFileContent({
+        name: 'test-module',
+        version: '1.0.0',
+        requires: []
+      });
+      expect(noRequires).not.toContain('requires =');
+
+      const result = upsertRequiresLine(noRequires, ['citext']);
+      const lines = result.split('\n');
+      const requiresIdx = lines.findIndex((l) => /^requires\s*=/.test(l));
+      const relocatableIdx = lines.findIndex((l) => /^relocatable\s*=/.test(l));
+      expect(requiresIdx).toBeGreaterThanOrEqual(0);
+      expect(requiresIdx).toBeLessThan(relocatableIdx);
     });
   });
 

--- a/pgpm/core/__tests__/modules/__snapshots__/module-installation.test.ts.snap
+++ b/pgpm/core/__tests__/modules/__snapshots__/module-installation.test.ts.snap
@@ -28,7 +28,7 @@ exports[`installModule() installs a package and updates package.json dependencie
 
 exports[`installModule() installs a package and updates package.json dependencies 2`] = `
 "# totp extension
-comment = 'totp extension'
+comment = 'skitch project'
 default_version = '0.0.1'
 module_pathname = '$libdir/totp'
 requires = 'pgcrypto,pgpm-base32,pgpm-verify,plpgsql,uuid-ossp'

--- a/pgpm/core/src/core/template-scaffold.ts
+++ b/pgpm/core/src/core/template-scaffold.ts
@@ -99,10 +99,19 @@ export interface ScaffoldTemplateResult {
   questions?: Question[];
 }
 
-export const DEFAULT_TEMPLATE_REPO =
-  'https://github.com/constructive-io/pgpm-boilerplates.git';
-export const PGLITE_TEMPLATE_REPO =
-  'https://github.com/constructive-io/pglite-boilerplates.git';
+/**
+ * Registry of known boilerplate template repos, keyed by flavor. Add new
+ * backends (e.g. `turso`) here rather than sprinkling flavor-specific
+ * constants across the codebase.
+ */
+export const TEMPLATE_REPOS = {
+  default: 'https://github.com/constructive-io/pgpm-boilerplates.git',
+  pglite: 'https://github.com/constructive-io/pglite-boilerplates.git'
+} as const;
+
+export type TemplateRepoFlavor = keyof typeof TEMPLATE_REPOS;
+
+export const DEFAULT_TEMPLATE_REPO = TEMPLATE_REPOS.default;
 export const DEFAULT_TEMPLATE_TTL_MS = 1 * 24 * 60 * 60 * 1000; // 1 day
 export const DEFAULT_TEMPLATE_TOOL_NAME = 'pgpm';
 

--- a/pgpm/core/src/core/template-scaffold.ts
+++ b/pgpm/core/src/core/template-scaffold.ts
@@ -101,6 +101,8 @@ export interface ScaffoldTemplateResult {
 
 export const DEFAULT_TEMPLATE_REPO =
   'https://github.com/constructive-io/pgpm-boilerplates.git';
+export const PGLITE_TEMPLATE_REPO =
+  'https://github.com/constructive-io/pglite-boilerplates.git';
 export const DEFAULT_TEMPLATE_TTL_MS = 1 * 24 * 60 * 60 * 1000; // 1 day
 export const DEFAULT_TEMPLATE_TOOL_NAME = 'pgpm';
 

--- a/pgpm/core/src/files/extension/writer.ts
+++ b/pgpm/core/src/files/extension/writer.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 
 import { getExtensionInfo } from './reader';
 
@@ -73,7 +73,45 @@ superuser = ${superuser}\n`;
 }
 
 /**
+ * Update (or insert/remove) the `requires =` line of an existing .control file
+ * in place, preserving every other field and the file's formatting. Used when
+ * changing a module's dependencies after init (e.g. via `pgpm extension`) so
+ * hand-tuned fields (comment, schema, relocatable, module_pathname) survive.
+ */
+export function upsertRequiresLine(
+  content: string,
+  requires: string[]
+): string {
+  const lines = content.split('\n');
+  const idx = lines.findIndex((line) => /^\s*requires\s*=/.test(line));
+
+  if (requires.length === 0) {
+    if (idx !== -1) lines.splice(idx, 1);
+    return lines.join('\n');
+  }
+
+  const requiresLine = `requires = '${requires.join(',')}'`;
+  if (idx !== -1) {
+    lines[idx] = requiresLine;
+    return lines.join('\n');
+  }
+
+  // Insert to match generated ordering (before relocatable/superuser/schema).
+  const insertAt = lines.findIndex((line) =>
+    /^\s*(relocatable|superuser|schema)\s*=/.test(line)
+  );
+  if (insertAt !== -1) {
+    lines.splice(insertAt, 0, requiresLine);
+  } else {
+    lines.push(requiresLine);
+  }
+  return lines.join('\n');
+}
+
+/**
  * Write the control file for the extension.
+ * If the file already exists, only its `requires` line is updated so that any
+ * custom fields are preserved; otherwise a fresh file is generated.
  */
 export const writeExtensionControlFile = (
   outputPath: string,
@@ -81,6 +119,11 @@ export const writeExtensionControlFile = (
   extensions: string[],
   version: string
 ): void => {
+  if (existsSync(outputPath)) {
+    const existing = readFileSync(outputPath, 'utf-8');
+    writeFileSync(outputPath, upsertRequiresLine(existing, extensions));
+    return;
+  }
   const content = generateControlFileContent({
     name: extname,
     version,

--- a/pgpm/types/src/pgpm.ts
+++ b/pgpm/types/src/pgpm.ts
@@ -209,6 +209,20 @@ export interface PgpmWorkspaceConfig {
   };
   /** Deployment configuration for the workspace */
   deployment?: Omit<DeploymentOptions, 'toChange'>;
+  /**
+   * Template source recorded at scaffold time when the workspace is created
+   * from a non-default boilerplate repo (e.g. via `pgpm init workspace --pglite`
+   * or `--repo`). `pgpm init` reads this so modules created inside the workspace
+   * inherit the same boilerplate source without re-specifying the flag.
+   */
+  boilerplates?: {
+    /** Template repository URL */
+    repo: string;
+    /** Branch/tag to clone */
+    branch?: string;
+    /** Template variant directory */
+    dir?: string;
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

Consolidates three PRs (#1354, #1356, #1357) into one. Together they finish the extensions-workflow cleanup and add the `--pglite` init flag. Pairs with the docs consolidation in `constructive-io/constructive.io`.

### 1. Harden `pgpm extension` (was #1356)
Makes `pgpm extension` the canonical enable-later path:
- **Non-destructive `.control` rewrite** — edits only the `requires =` line, preserving custom fields (`schema`, `comment`, `relocatable`, `module_pathname`, …) instead of regenerating the file from defaults.
- **Non-interactive flags** `--add`/`--remove`/`--set` for CI/scripts; no flags ⇒ interactive picker (unchanged).
- Snapshots updated to reflect that custom fields now survive a dependency change (the desired behavior).

### 2. `--pglite` init flag with workspace inheritance (was #1354)
`--pglite` is sugar over `--repo` pointing at [`pglite-boilerplates`](https://github.com/constructive-io/pglite-boilerplates):
```
pgpm init workspace --pglite   # records boilerplates:{repo} in workspace pgpm.json
pgpm init                      # inside that workspace → inherits pglite, no flag
pgpm init --pglite | --repo …  # explicit flags still override
```
Resolve/persist/read helpers live in `pgpm/cli/src/commands/init/boilerplate.ts` (network-free unit tests); new `PGLITE_TEMPLATE_REPO` constant and optional `PgpmWorkspaceConfig.boilerplates` type.

### 3. pgpm skill docs (was #1357)
Updates `.agents/skills/pgpm/` to document zero-config init + the non-interactive `pgpm extension` flags, and corrects the now-false "fully interactive — don't use in CI" claims.

(PR A, #1355 — defaulting `pgpm init` to no extensions — already merged and is the base these build on.)

### Tests
All three branches' suites merged cleanly (no conflicts): extension writer/command unit + integration tests, init flag resolution + gated e2e, updated snapshots. 37/37 green on each source PR.

Link to Devin session: https://app.devin.ai/sessions/424b76f81a60499493ac946b57136ad9
Requested by: @pyramation