### PR TITLE
docs(pglite-test): drop authenticated_client from roles prose

### DIFF
--- a/postgres/pglite-test/README.md
+++ b/postgres/pglite-test/README.md
@@ -107,8 +107,8 @@ await getConnections(
 
 On a server, `pgsql-test` bootstraps the standard app roles at `createdb`. PGlite
 has no `createdb` — it boots as a lone superuser — so by default `getConnections()`
-creates the same roles for you before seeding: `anonymous`, `authenticated`,
-`administrator` (with `BYPASSRLS`), and `authenticated_client`, using the same
+creates the same roles for you before seeding: `anonymous`, `authenticated`, and
+`administrator` (with `BYPASSRLS`), using the same
 attributes as the server bootstrap. That's why `db.setContext({ role: 'authenticated' })`
 just works with no manual `CREATE ROLE`. Custom role *names* come from `db.roles`
 (a `RoleMapping`), exactly like `pgsql-test`.

--- a/postgres/pglite-test/src/index.ts
+++ b/postgres/pglite-test/src/index.ts
@@ -52,7 +52,7 @@ export interface PgliteConnectionOpts extends GetConnectionOpts {
     extensionSql?: string[];
     /**
      * Auto-create the standard app roles (`anonymous` / `authenticated` /
-     * `administrator` / `authenticated_client`) with the same attributes
+     * `administrator`) with the same attributes
      * pgsql-test's server bootstrap uses, before seeding. This is what lets a
      * bare `getConnections()` switch into an app role via `db.setContext()`
      * with no manual `CREATE ROLE`. Defaults to `true`.


### PR DESCRIPTION
## Summary

Follow-up to #1359. Per request, stop mentioning `authenticated_client` in user-facing docs — the role is still created by the default bootstrap (behavior unchanged), it's just no longer enumerated in the README and the `roles` JSDoc.

- `README.md` "Roles": `anonymous`, `authenticated`, `administrator` (with `BYPASSRLS`) — drops `authenticated_client` from the list.
- `src/index.ts` `roles` option JSDoc: same trim.

No code/behavior change; `roles.test.ts` still verifies the full standard set (including the client role) is created.


Link to Devin session: https://app.devin.ai/sessions/424b76f81a60499493ac946b57136ad9
Requested by: @pyramation