### PR TITLE
feat(export): add integration_providers_module to meta export

### DIFF
--- a/pgpm/export/src/export-graphql-meta.ts
+++ b/pgpm/export/src/export-graphql-meta.ts
@@ -326,6 +326,7 @@ export const exportGraphQLMeta = async ({
     queryAndParse('billing_provider_module'),
     queryAndParse('devices_module'),
     queryAndParse('identity_providers_module'),
+    queryAndParse('integration_providers_module'),
     queryAndParse('notifications_module'),
     queryAndParse('plans_module'),
     queryAndParse('realtime_module'),

--- a/pgpm/export/src/export-meta.ts
+++ b/pgpm/export/src/export-meta.ts
@@ -255,6 +255,7 @@ export const exportMeta = async ({ opts, dbname, database_id }: ExportMetaParams
   await queryAndParse('billing_provider_module', `SELECT * FROM metaschema_modules_public.billing_provider_module WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('devices_module', `SELECT * FROM metaschema_modules_public.devices_module WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('identity_providers_module', `SELECT * FROM metaschema_modules_public.identity_providers_module WHERE database_id = $1 ORDER BY id`);
+  await queryAndParse('integration_providers_module', `SELECT * FROM metaschema_modules_public.integration_providers_module WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('notifications_module', `SELECT * FROM metaschema_modules_public.notifications_module WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('plans_module', `SELECT * FROM metaschema_modules_public.plans_module WHERE database_id = $1 ORDER BY id`);
   await queryAndParse('realtime_module', `SELECT * FROM metaschema_modules_public.realtime_module WHERE database_id = $1 ORDER BY id`);

--- a/pgpm/export/src/export-utils.ts
+++ b/pgpm/export/src/export-utils.ts
@@ -167,6 +167,7 @@ export const META_TABLE_ORDER = [
   'billing_provider_module',
   'devices_module',
   'identity_providers_module',
+  'integration_providers_module',
   'notifications_module',
   'plans_module',
   'realtime_module',
@@ -535,6 +536,10 @@ export const META_TABLE_CONFIG: Record<string, TableConfig> = {
   identity_providers_module: {
     schema: 'metaschema_modules_public',
     table: 'identity_providers_module'
+  },
+  integration_providers_module: {
+    schema: 'metaschema_modules_public',
+    table: 'integration_providers_module'
   },
   notifications_module: {
     schema: 'metaschema_modules_public',


### PR DESCRIPTION
## Summary
Adds `metaschema_modules_public.integration_providers_module` to the `@pgpmjs/export` meta export path, upstreaming the local `patches/@pgpmjs+export@0.26.4.patch` used in constructive-db (so that patch can be dropped once this is released).

Changes (all in `pgpm/export`):
- `META_TABLE_ORDER` + `META_TABLE_CONFIG`: new `integration_providers_module` entry, placed after `identity_providers_module`
- `exportMeta` (SQL flow): `SELECT * FROM metaschema_modules_public.integration_providers_module WHERE database_id = $1 ORDER BY id`
- `exportGraphQLMeta` (GraphQL flow): corresponding `queryAndParse('integration_providers_module')`

Fields are discovered dynamically at export time, so no per-field config is needed; on databases where the table doesn't exist yet, the exporter skips it silently (existing 42P01 / introspection-miss behavior).

`pnpm test` in `pgpm/export`: 142/142 pass.

Link to Devin session: https://app.devin.ai/sessions/fa0bd53e497742d2ab69753d3a7b3f4c
Requested by: @pyramation