### PR TITLE
fix(pgpm): make default roles map match opt-in client role bootstrap

### DIFF
--- a/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
+++ b/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
@@ -44,7 +44,6 @@ exports[`getEnvOptions merges pgpm defaults, graphql defaults, config, env, and 
       "administrator": "administrator",
       "anonymous": "anonymous",
       "authenticated": "authenticated",
-      "authenticatedClient": "authenticated_client",
       "default": "anonymous",
     },
     "rootDb": "postgres",

--- a/pgpm/core/__tests__/roles/roles-sql-generators.test.ts
+++ b/pgpm/core/__tests__/roles/roles-sql-generators.test.ts
@@ -1,8 +1,8 @@
 import {
   generateCreateBaseRolesSQL,
   generateCreateClientRoleSQL,
-  generateCreateUserSQL,
   generateCreateTestUsersSQL,
+  generateCreateUserSQL,
   generateRemoveUserSQL
 } from '../../src/roles';
 
@@ -75,12 +75,12 @@ describe('Role SQL Generators - Input Validation', () => {
       }).toThrow('generateCreateClientRoleSQL: roles is missing required properties');
     });
 
-    it('should throw an error when roles.authenticatedClient is missing', () => {
-      expect(() => {
-        generateCreateClientRoleSQL({
-          authenticated: 'authenticated'
-        });
-      }).toThrow('generateCreateClientRoleSQL: roles is missing required properties');
+    it('should default the client role name when roles.authenticatedClient is missing', () => {
+      const sql = generateCreateClientRoleSQL({
+        authenticated: 'authenticated'
+      });
+      expect(sql).toContain('authenticated_client');
+      expect(sql).toContain('CREATE ROLE');
     });
 
     it('should generate valid SQL when all roles are provided', () => {

--- a/pgpm/core/src/roles/index.ts
+++ b/pgpm/core/src/roles/index.ts
@@ -127,16 +127,16 @@ export function generateCreateClientRoleSQL(
       'Ensure getConnEnvOptions().roles is defined.'
     );
   }
-  if (!roles.authenticated || !roles.authenticatedClient) {
+  if (!roles.authenticated) {
     throw new Error(
       'generateCreateClientRoleSQL: roles is missing required properties. ' +
-      `Got: authenticated=${roles.authenticated}, authenticatedClient=${roles.authenticatedClient}. ` +
+      `Got: authenticated=${roles.authenticated}. ` +
       'Ensure all role names are defined in your configuration.'
     );
   }
   const r = {
     authenticated: roles.authenticated,
-    authenticatedClient: roles.authenticatedClient
+    authenticatedClient: roles.authenticatedClient ?? 'authenticated_client'
   };
 
   return `

--- a/pgpm/env/__tests__/__snapshots__/merge.test.ts.snap
+++ b/pgpm/env/__tests__/__snapshots__/merge.test.ts.snap
@@ -29,7 +29,6 @@ exports[`getEnvOptions merges defaults, config, env, and overrides 1`] = `
       "administrator": "administrator",
       "anonymous": "anonymous",
       "authenticated": "authenticated",
-      "authenticatedClient": "authenticated_client",
       "default": "anonymous",
     },
     "rootDb": "postgres",

--- a/pgpm/types/src/pgpm.ts
+++ b/pgpm/types/src/pgpm.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'child_process';
 import { PgConfig } from 'pg-env';
+
 import { PgpmDriverConfig } from './driver';
 import { JobsConfig } from './jobs';
 
@@ -303,7 +304,6 @@ export const pgpmDefaults: PgpmOptions = {
       anonymous: 'anonymous',
       authenticated: 'authenticated',
       administrator: 'administrator',
-      authenticatedClient: 'authenticated_client',
       default: 'anonymous'
     },
     useLocksForRoles: false
@@ -313,13 +313,13 @@ export const pgpmDefaults: PgpmOptions = {
     port: 5432,
     user: 'postgres',
     password: 'password',
-    database: 'postgres',
+    database: 'postgres'
   },
   server: {
     host: 'localhost',
     port: 3000,
     trustProxy: false,
-    strictAuth: false,
+    strictAuth: false
   },
   cdn: {
     provider: 'minio',


### PR DESCRIPTION
## Summary

Since `authenticated_client` became opt-in (`pgpm admin-users bootstrap --client`), the default `roles` map returned by `getConnEnvOptions()` still advertised it, so consumers that verify every role in the map after a default bootstrap fail (e.g. constructive-db's `fun-k8s` k8s e2e: `Required roles not found: authenticated_client`).

Reconcile the two:

- `@pgpmjs/types` defaults: drop `authenticatedClient` from the default `roles` map — it only lists roles the default bootstrap actually creates. The `RoleMapping.authenticatedClient` field remains for explicit configuration.
- `@pgpmjs/core` `generateCreateClientRoleSQL`: default to `'authenticated_client'` when `roles.authenticatedClient` is unset, so `bootstrap --client` keeps working without explicit config:

```diff
-  if (!roles.authenticated || !roles.authenticatedClient) { throw ... }
+  if (!roles.authenticated) { throw ... }
   const r = {
     authenticated: roles.authenticated,
-    authenticatedClient: roles.authenticatedClient
+    authenticatedClient: roles.authenticatedClient ?? 'authenticated_client'
   };
```

Once published, the temporary patch in constructive-db (`fun-k8s` calling `bootstrapClientRole` explicitly, added in constructive-io/constructive-db#2133) can be reverted.

Tests: updated `roles-sql-generators` test (missing `authenticatedClient` now defaults instead of throwing) and the `@pgpmjs/env` merge snapshot.

Link to Devin session: https://app.devin.ai/sessions/8fee29d00c194dfabfcaa221dcbe1bcb
Requested by: @pyramation