### PR TITLE
refactor(graphile): extract shared plugin helpers into graphile-plugin-utils

### DIFF
--- a/graphile/graphile-connection-filter/package.json
+++ b/graphile/graphile-connection-filter/package.json
@@ -39,6 +39,9 @@
   "bugs": {
     "url": "https://github.com/constructive-io/constructive/issues"
   },
+  "dependencies": {
+    "graphile-plugin-utils": "workspace:^"
+  },
   "devDependencies": {
     "@types/node": "^22.19.11",
     "graphile-test": "workspace:^",

--- a/graphile/graphile-connection-filter/src/utils.ts
+++ b/graphile/graphile-connection-filter/src/utils.ts
@@ -2,36 +2,20 @@
  * Utility functions for the connection filter plugin.
  */
 
+import { isComputedScalarAttributeResource } from 'graphile-plugin-utils';
+
+// Shared helpers now live in graphile-plugin-utils. Re-exported here so the
+// plugin's public API (see index.ts) stays backward compatible.
+export {
+  getQueryBuilder,
+  isComputedScalarAttributeResource
+} from 'graphile-plugin-utils';
+
 /**
  * Check if a value is an empty object (no own enumerable keys).
  */
 export function isEmpty(o: unknown): boolean {
   return typeof o === 'object' && o !== null && Object.keys(o).length === 0;
-}
-
-/**
- * Check if a pgResource is a computed scalar attribute function.
- * A computed attribute is a function that:
- * - has parameters
- * - returns a scalar (no attributes on codec)
- * - is unique (returns single row)
- * - first parameter's codec has attributes (i.e. takes a table row)
- */
-export function isComputedScalarAttributeResource(s: any): boolean {
-  if (!s.parameters || s.parameters.length < 1) {
-    return false;
-  }
-  if (s.codec.attributes) {
-    return false;
-  }
-  if (!s.isUnique) {
-    return false;
-  }
-  const firstParameter = s.parameters[0];
-  if (!firstParameter?.codec.attributes) {
-    return false;
-  }
-  return true;
 }
 
 /**
@@ -46,53 +30,6 @@ export function getComputedAttributeResources(build: any, source: any): any[] {
       s.parameters[0].codec === source.codec
   );
   return computedAttributeSources;
-}
-
-/**
- * Walks from a PgCondition up to the PgSelectQueryBuilder.
- * Uses the .parent property on PgCondition to traverse up the chain,
- * following Benjie's pattern from postgraphile-plugin-fulltext-filter.
- *
- * This is used by satellite plugins (search, BM25, pgvector) that need
- * to access the query builder from within a filter's apply callback
- * to inject SELECT expressions (for ranking/scoring) and ORDER BY clauses.
- *
- * @param build - The Graphile Build object (needs build.dataplanPg.PgCondition)
- * @param $condition - The PgCondition instance from the filter apply callback
- * @returns The PgSelectQueryBuilder if found, or null
- */
-export function getQueryBuilder(
-  build: GraphileBuild.Build,
-  $condition: any
-): any | null {
-  const PgCondition = build.dataplanPg?.PgCondition;
-  if (!PgCondition) return null;
-
-  let current = $condition;
-  const { alias } = current;
-
-  // Walk up through nested PgConditions (e.g. and/or/not)
-  // Note: PgCondition.parent is protected, so we use bracket notation
-  // to access it from outside the class hierarchy.
-  while (
-    current &&
-    current instanceof PgCondition &&
-    current.alias === alias
-  ) {
-    current = (current as any)['parent'];
-  }
-
-  // Verify we found a query builder with matching alias
-  // Using duck-typing per Benjie's pattern
-  if (
-    current &&
-    typeof current.selectAndReturnIndex === 'function' &&
-    current.alias === alias
-  ) {
-    return current;
-  }
-
-  return null;
 }
 
 /**

--- a/graphile/graphile-function-bindings/README.md
+++ b/graphile/graphile-function-bindings/README.md
@@ -1,5 +1,18 @@
 # graphile-function-bindings
 
+<p align="center" width="100%">
+  <img height="250" src="https://raw.githubusercontent.com/constructive-io/constructive/refs/heads/main/assets/outline-logo.svg" />
+</p>
+
+<p align="center" width="100%">
+  <a href="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml">
+    <img height="20" src="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml/badge.svg" />
+  </a>
+   <a href="https://github.com/constructive-io/constructive/blob/main/LICENSE"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
+   <a href="https://www.npmjs.com/package/graphile-function-bindings"><img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/constructive?filename=graphile%2Fgraphile-function-bindings%2Fpackage.json"/></a>
+</p>
+
+
 PostGraphile v5 plugin that exposes API-bound compute functions as typed
 GraphQL mutations.
 

--- a/graphile/graphile-function-bindings/src/plugin.ts
+++ b/graphile/graphile-function-bindings/src/plugin.ts
@@ -35,6 +35,7 @@ import { Logger } from '@pgpmjs/logger';
 import { QueryBuilder, type SqlValue } from '@constructive-io/query-builder';
 import { access, context as grafastContext, lambda, object } from 'grafast';
 import type { GraphileConfig } from 'graphile-config';
+import { isValidNameError } from 'graphql';
 import { toCamelCase, toConstantCase, toPascalCase } from 'inflekt';
 
 import type { DerivedField, DerivedInput } from './derive';
@@ -63,8 +64,6 @@ interface LoadedBinding extends FunctionBindingRow {
 interface FunctionBindingsBuildInput {
   bindings: LoadedBinding[];
 }
-
-const IDENT_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
 async function loadBindings(
   pgService: GraphileConfig.PgServiceConfiguration,
@@ -197,7 +196,7 @@ export function createFunctionBindingsPlugin(
           const newFields: Record<string, any> = {};
 
           for (const binding of loaded.bindings) {
-            if (!IDENT_RE.test(toCamelCase(binding.alias))) {
+            if (isValidNameError(toCamelCase(binding.alias))) {
               log.warn(`Skipping binding "${binding.alias}": alias is not a valid GraphQL name`);
               continue;
             }

--- a/graphile/graphile-pg-aggregates/package.json
+++ b/graphile/graphile-pg-aggregates/package.json
@@ -40,6 +40,9 @@
   "bugs": {
     "url": "https://github.com/constructive-io/constructive/issues"
   },
+  "dependencies": {
+    "graphile-plugin-utils": "workspace:^"
+  },
   "devDependencies": {
     "@types/node": "^22.19.11",
     "graphile-test": "workspace:^",

--- a/graphile/graphile-pg-aggregates/src/FilterRelationalAggregatesPlugin.ts
+++ b/graphile/graphile-pg-aggregates/src/FilterRelationalAggregatesPlugin.ts
@@ -12,6 +12,7 @@ import type {
 import type { GrafastInputFieldConfigMap, Modifier } from 'grafast';
 import type {} from 'graphile-build';
 import type {} from 'graphile-connection-filter';
+import { isComputedScalarAttributeResource } from 'graphile-plugin-utils';
 import type {
   GraphQLInputObjectType,
   GraphQLInputObjectTypeConfig,
@@ -900,27 +901,4 @@ interface PgAggregateConditionExpressionClass {
   ): PgAggregateConditionExpression;
 }
 
-function isComputedScalarAttributeResource(
-  s: PgResource<any, any, any, any, any>
-): s is PgResource<
-  string,
-  PgCodec,
-  never[],
-  PgResourceParameter[],
-  PgRegistry
-> {
-  if (!s.parameters || s.parameters.length < 1) {
-    return false;
-  }
-  if (s.codec.attributes) {
-    return false;
-  }
-  if (!s.isUnique) {
-    return false;
-  }
-  const firstParameter = s.parameters[0] as PgResourceParameter;
-  if (!firstParameter?.codec.attributes) {
-    return false;
-  }
-  return true;
-}
+

--- a/graphile/graphile-pg-aggregates/src/utils.ts
+++ b/graphile/graphile-pg-aggregates/src/utils.ts
@@ -1,6 +1,7 @@
-import type { PgResource, PgResourceParameter } from '@dataplan/pg';
+import type { PgResource } from '@dataplan/pg';
 import type { GraphileBuild } from 'graphile-build';
 import type {} from 'graphile-build-pg';
+import { isComputedScalarAttributeResource } from 'graphile-plugin-utils';
 
 export function getComputedAttributeResources(
   build: GraphileBuild.Build,
@@ -8,24 +9,11 @@ export function getComputedAttributeResources(
 ) {
   const computedAttributeResources = Object.values(
     build.input.pgRegistry.pgResources
-  ).filter((s) => {
-    if (!s.parameters || s.parameters.length < 1) {
-      return false;
-    }
-    if (s.codec.attributes) {
-      return false;
-    }
-    if (!s.isUnique) {
-      return false;
-    }
-    if (s.codec.arrayOfCodec) {
-      return false;
-    }
-    const firstParameter = s.parameters[0] as PgResourceParameter;
-    if (firstParameter.codec !== resource.codec) {
-      return false;
-    }
-    return true;
-  });
+  ).filter(
+    (s) =>
+      isComputedScalarAttributeResource(s) &&
+      !s.codec.arrayOfCodec &&
+      s.parameters[0].codec === resource.codec
+  );
   return computedAttributeResources;
 }

--- a/graphile/graphile-plugin-utils/README.md
+++ b/graphile/graphile-plugin-utils/README.md
@@ -1,0 +1,66 @@
+# graphile-plugin-utils
+
+<p align="center" width="100%">
+  <img height="250" src="https://raw.githubusercontent.com/constructive-io/constructive/refs/heads/main/assets/outline-logo.svg" />
+</p>
+
+<p align="center" width="100%">
+  <a href="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml">
+    <img height="20" src="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml/badge.svg" />
+  </a>
+   <a href="https://github.com/constructive-io/constructive/blob/main/LICENSE"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
+   <a href="https://www.npmjs.com/package/graphile-plugin-utils"><img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/constructive?filename=graphile%2Fgraphile-plugin-utils%2Fpackage.json"/></a>
+</p>
+
+
+Shared internals for Constructive's PostGraphile v5 plugins. This package holds
+the small cross-plugin helpers that would otherwise be duplicated across
+`graphile-connection-filter`, `graphile-search`, and `graphile-pg-aggregates`,
+so there is a single home for them and no plugin has to depend on a sibling
+feature plugin just to borrow a utility.
+
+## Installation
+
+```bash
+npm install graphile-plugin-utils
+```
+
+## API
+
+### `getQueryBuilder(build, $condition)`
+
+Walks from a `PgCondition` up to its `PgSelectQueryBuilder`, following Benjie's
+pattern from `postgraphile-plugin-fulltext-filter`. Satellite filter plugins
+(search, BM25, pgvector) use it from inside a filter's `apply` callback to
+inject `SELECT` expressions (for ranking/scoring) and `ORDER BY` clauses.
+
+```ts
+import { getQueryBuilder } from 'graphile-plugin-utils';
+
+const qb = getQueryBuilder(build, $condition);
+if (qb) {
+  qb.orderBy({ /* ... */ });
+}
+```
+
+Returns the query builder, or `null` when it cannot be resolved (e.g. the build
+does not expose `dataplanPg.PgCondition`).
+
+### `isComputedScalarAttributeResource(resource)`
+
+Type guard for a computed scalar attribute function — a `pgResource` that takes
+a table row as its first parameter, returns a scalar, and is unique. Used to
+recognise computed columns exposed as functions when building filters and
+aggregates.
+
+```ts
+import { isComputedScalarAttributeResource } from 'graphile-plugin-utils';
+
+const computed = Object.values(build.input.pgRegistry.pgResources).filter(
+  isComputedScalarAttributeResource
+);
+```
+
+## License
+
+MIT

--- a/graphile/graphile-plugin-utils/jest.config.js
+++ b/graphile/graphile-plugin-utils/jest.config.js
@@ -1,0 +1,18 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        babelConfig: false,
+        tsconfig: 'tsconfig.json',
+      },
+    ],
+  },
+  transformIgnorePatterns: [`/node_modules/*`],
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  modulePathIgnorePatterns: ['dist/*']
+};

--- a/graphile/graphile-plugin-utils/package.json
+++ b/graphile/graphile-plugin-utils/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "graphile-search",
-  "version": "1.20.1",
-  "description": "Unified PostGraphile v5 search plugin — abstracts tsvector, BM25, pg_trgm, and pgvector behind a single adapter-based architecture with composite searchScore",
+  "name": "graphile-plugin-utils",
+  "version": "1.0.0",
+  "description": "Shared internals for Constructive PostGraphile v5 plugins - PgCondition query-builder walker and pg-resource introspection helpers",
   "author": "Constructive <developers@constructive.io>",
   "homepage": "https://github.com/constructive-io/constructive",
   "license": "MIT",
@@ -14,7 +14,7 @@
     "build": "makage build",
     "build:dev": "makage build --dev",
     "lint": "eslint . --fix",
-    "test": "jest --forceExit",
+    "test": "jest --passWithNoTests",
     "test:watch": "jest --watch"
   },
   "publishConfig": {
@@ -25,20 +25,22 @@
     "type": "git",
     "url": "https://github.com/constructive-io/constructive"
   },
+  "keywords": [
+    "postgraphile",
+    "graphile",
+    "constructive",
+    "plugin",
+    "postgres",
+    "graphql",
+    "utils",
+    "v5"
+  ],
   "bugs": {
     "url": "https://github.com/constructive-io/constructive/issues"
   },
-  "dependencies": {
-    "graphile-plugin-utils": "workspace:^"
-  },
   "devDependencies": {
     "@types/node": "^22.19.11",
-    "@types/pg": "^8.20.0",
-    "graphile-connection-filter": "workspace:^",
-    "graphile-test": "workspace:^",
-    "makage": "^0.3.0",
-    "pg": "^8.21.0",
-    "pgsql-test": "workspace:^"
+    "makage": "^0.3.0"
   },
   "peerDependencies": {
     "@dataplan/pg": "1.0.3",
@@ -48,21 +50,5 @@
     "graphql": "16.13.0",
     "pg-sql2": "5.0.1",
     "postgraphile": "5.0.3"
-  },
-  "keywords": [
-    "postgraphile",
-    "graphile",
-    "constructive",
-    "plugin",
-    "postgres",
-    "graphql",
-    "search",
-    "unified-search",
-    "tsvector",
-    "bm25",
-    "pg_trgm",
-    "pgvector",
-    "hybrid-search",
-    "searchScore"
-  ]
+  }
 }

--- a/graphile/graphile-plugin-utils/src/__tests__/pg-resources.test.ts
+++ b/graphile/graphile-plugin-utils/src/__tests__/pg-resources.test.ts
@@ -1,0 +1,45 @@
+import { isComputedScalarAttributeResource } from '../pg-resources';
+
+const tableCodec = { attributes: { id: {} } };
+const scalarCodec = {};
+
+function resource(overrides: any): any {
+  return {
+    isUnique: true,
+    codec: scalarCodec,
+    parameters: [{ codec: tableCodec }],
+    ...overrides
+  };
+}
+
+describe('isComputedScalarAttributeResource', () => {
+  it('accepts a unique scalar function taking a table row', () => {
+    expect(isComputedScalarAttributeResource(resource({}))).toBe(true);
+  });
+
+  it('rejects a resource without parameters', () => {
+    expect(isComputedScalarAttributeResource(resource({ parameters: [] }))).toBe(
+      false
+    );
+  });
+
+  it('rejects a table-returning resource (codec has attributes)', () => {
+    expect(
+      isComputedScalarAttributeResource(resource({ codec: tableCodec }))
+    ).toBe(false);
+  });
+
+  it('rejects a non-unique resource', () => {
+    expect(
+      isComputedScalarAttributeResource(resource({ isUnique: false }))
+    ).toBe(false);
+  });
+
+  it('rejects when the first parameter is not a table row', () => {
+    expect(
+      isComputedScalarAttributeResource(
+        resource({ parameters: [{ codec: scalarCodec }] })
+      )
+    ).toBe(false);
+  });
+});

--- a/graphile/graphile-plugin-utils/src/index.ts
+++ b/graphile/graphile-plugin-utils/src/index.ts
@@ -1,0 +1,7 @@
+// Shared internals for Constructive PostGraphile v5 plugins.
+
+// PgCondition → PgSelectQueryBuilder walker (search / BM25 / pgvector)
+export { getQueryBuilder } from './query-builder';
+
+// pg-resource introspection helpers (connection-filter / pg-aggregates)
+export { isComputedScalarAttributeResource } from './pg-resources';

--- a/graphile/graphile-plugin-utils/src/pg-resources.ts
+++ b/graphile/graphile-plugin-utils/src/pg-resources.ts
@@ -1,0 +1,42 @@
+import type {
+  PgCodec,
+  PgRegistry,
+  PgResource,
+  PgResourceParameter
+} from '@dataplan/pg';
+
+/**
+ * Whether a pgResource is a computed scalar attribute function, i.e. one that:
+ * - takes at least one parameter,
+ * - returns a scalar (its codec has no attributes),
+ * - is unique (returns a single row),
+ * - and takes a table row as its first parameter (that parameter's codec has
+ *   attributes).
+ *
+ * Shared by the connection-filter and pg-aggregates plugins, which both need
+ * to recognise computed columns exposed as functions.
+ */
+export function isComputedScalarAttributeResource(
+  s: PgResource<any, any, any, any, any>
+): s is PgResource<
+  string,
+  PgCodec,
+  never[],
+  PgResourceParameter[],
+  PgRegistry
+> {
+  if (!s.parameters || s.parameters.length < 1) {
+    return false;
+  }
+  if (s.codec.attributes) {
+    return false;
+  }
+  if (!s.isUnique) {
+    return false;
+  }
+  const firstParameter = s.parameters[0] as PgResourceParameter;
+  if (!firstParameter?.codec.attributes) {
+    return false;
+  }
+  return true;
+}

--- a/graphile/graphile-plugin-utils/src/query-builder.ts
+++ b/graphile/graphile-plugin-utils/src/query-builder.ts
@@ -1,0 +1,51 @@
+import type { GraphileBuild } from 'graphile-build';
+// Side-effect type import: graphile-build-pg augments GraphileBuild.Build with
+// the `dataplanPg` helpers used below.
+import type {} from 'graphile-build-pg';
+
+/**
+ * Walks from a PgCondition up to the PgSelectQueryBuilder.
+ * Uses the `.parent` property on PgCondition to traverse up the chain,
+ * following Benjie's pattern from postgraphile-plugin-fulltext-filter.
+ *
+ * This is used by satellite plugins (search, BM25, pgvector) that need to
+ * access the query builder from within a filter's apply callback to inject
+ * SELECT expressions (for ranking/scoring) and ORDER BY clauses.
+ *
+ * @param build - The Graphile Build object (needs build.dataplanPg.PgCondition)
+ * @param $condition - The PgCondition instance from the filter apply callback
+ * @returns The PgSelectQueryBuilder if found, or null
+ */
+export function getQueryBuilder(
+  build: GraphileBuild.Build,
+  $condition: any
+): any | null {
+  const PgCondition = build.dataplanPg?.PgCondition;
+  if (!PgCondition) return null;
+
+  let current = $condition;
+  const { alias } = current;
+
+  // Walk up through nested PgConditions (e.g. and/or/not)
+  // Note: PgCondition.parent is protected, so we use bracket notation
+  // to access it from outside the class hierarchy.
+  while (
+    current &&
+    current instanceof PgCondition &&
+    current.alias === alias
+  ) {
+    current = (current as any)['parent'];
+  }
+
+  // Verify we found a query builder with matching alias
+  // Using duck-typing per Benjie's pattern
+  if (
+    current &&
+    typeof current.selectAndReturnIndex === 'function' &&
+    current.alias === alias
+  ) {
+    return current;
+  }
+
+  return null;
+}

--- a/graphile/graphile-plugin-utils/tsconfig.esm.json
+++ b/graphile/graphile-plugin-utils/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/esm",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "declaration": false
+  }
+}

--- a/graphile/graphile-plugin-utils/tsconfig.json
+++ b/graphile/graphile-plugin-utils/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src/**/*"]
+}

--- a/graphile/graphile-search/src/plugin.ts
+++ b/graphile/graphile-search/src/plugin.ts
@@ -23,7 +23,7 @@ import 'graphile-connection-filter';
 import { TYPES } from '@dataplan/pg';
 import type { PgCodecWithAttributes } from '@dataplan/pg';
 import type { GraphileConfig } from 'graphile-config';
-import { getQueryBuilder } from 'graphile-connection-filter';
+import { getQueryBuilder } from 'graphile-plugin-utils';
 import type { SearchAdapter, SearchableColumn, UnifiedSearchOptions } from './types';
 
 // ─── TypeScript Namespace Augmentations ──────────────────────────────────────

--- a/graphql/server/src/middleware/fn.ts
+++ b/graphql/server/src/middleware/fn.ts
@@ -19,12 +19,11 @@
  */
 
 import { Logger } from '@pgpmjs/logger';
+import { isUuid } from '@pgpmjs/server-utils';
 import { QueryBuilder, type SqlValue } from '@constructive-io/query-builder';
 import express, { Request, Response, Router } from 'express';
 
 const log = new Logger('fn');
-
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 interface BindingRow {
   id: string;
@@ -176,7 +175,7 @@ async function handleGetInvocation(req: Request, res: Response): Promise<void> {
   }
 
   const id = req.params.id;
-  if (!UUID_RE.test(id)) {
+  if (!isUuid(id)) {
     notFound(res);
     return;
   }

--- a/packages/server-utils/src/__tests__/utils.test.ts
+++ b/packages/server-utils/src/__tests__/utils.test.ts
@@ -1,0 +1,23 @@
+import { isUuid } from '../utils';
+
+describe('isUuid', () => {
+  it('accepts a canonical lowercase uuid', () => {
+    expect(isUuid('123e4567-e89b-12d3-a456-426614174000')).toBe(true);
+  });
+
+  it('accepts an uppercase uuid', () => {
+    expect(isUuid('123E4567-E89B-12D3-A456-426614174000')).toBe(true);
+  });
+
+  it('rejects a non-uuid string', () => {
+    expect(isUuid('not-a-uuid')).toBe(false);
+  });
+
+  it('rejects a uuid with a trailing character', () => {
+    expect(isUuid('123e4567-e89b-12d3-a456-426614174000x')).toBe(false);
+  });
+
+  it('rejects the empty string', () => {
+    expect(isUuid('')).toBe(false);
+  });
+});

--- a/packages/server-utils/src/utils.ts
+++ b/packages/server-utils/src/utils.ts
@@ -1,5 +1,11 @@
 import { Express, NextFunction,Request, Response } from 'express';
 
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Whether a string is a canonical (8-4-4-4-12) UUID. */
+export const isUuid = (value: string): boolean => UUID_RE.test(value);
+
 export const healthz = (app: Express): void => {
   app.get('/healthz', (req: Request, res: Response) => {
     // could be checking db, etc..

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -452,6 +452,9 @@ importers:
       graphile-config:
         specifier: 1.0.1
         version: 1.0.1
+      graphile-plugin-utils:
+        specifier: workspace:^
+        version: link:../graphile-plugin-utils/dist
       graphql:
         specifier: 16.13.0
         version: 16.13.0
@@ -705,6 +708,9 @@ importers:
       graphile-connection-filter:
         specifier: ^1.13.0
         version: 1.14.0(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(postgraphile@5.0.3(bc368b92b12e127d4eb1f1e143433708))
+      graphile-plugin-utils:
+        specifier: workspace:^
+        version: link:../graphile-plugin-utils/dist
       graphql:
         specifier: 16.13.0
         version: 16.13.0
@@ -727,6 +733,38 @@ importers:
       pgsql-test:
         specifier: workspace:^
         version: link:../../postgres/pgsql-test/dist
+    publishDirectory: dist
+
+  graphile/graphile-plugin-utils:
+    dependencies:
+      '@dataplan/pg':
+        specifier: 1.0.3
+        version: 1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      graphile-build:
+        specifier: 5.0.2
+        version: 5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)
+      graphile-build-pg:
+        specifier: 5.0.2
+        version: 5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-config:
+        specifier: 1.0.1
+        version: 1.0.1
+      graphql:
+        specifier: 16.13.0
+        version: 16.13.0
+      pg-sql2:
+        specifier: 5.0.1
+        version: 5.0.1
+      postgraphile:
+        specifier: 5.0.3
+        version: 5.0.3(f0a861a74cc4311fffaf615b439fe994)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.11
+        version: 22.19.19
+      makage:
+        specifier: ^0.3.0
+        version: 0.3.0
     publishDirectory: dist
 
   graphile/graphile-postgis:
@@ -1007,6 +1045,9 @@ importers:
       graphile-config:
         specifier: 1.0.1
         version: 1.0.1
+      graphile-plugin-utils:
+        specifier: workspace:^
+        version: link:../graphile-plugin-utils/dist
       graphql:
         specifier: 16.13.0
         version: 16.13.0


### PR DESCRIPTION
## Summary

Follow-up to #1369. An audit of all 20 `graphile/*` plugins found the flagged "move to a utility" items are weak candidates (single-consumer scalar maps, semantically-distinct identifier regexes), but surfaced a *real* accidental shared surface worth formalizing:

- `graphile-search` imported `getQueryBuilder` **from `graphile-connection-filter`** — a satellite plugin depending on a feature plugin just to borrow a helper (wrong dependency direction).
- `isComputedScalarAttributeResource` was **copy-pasted** into `graphile-pg-aggregates` instead of imported.
- `getQueryBuilder`'s own comment already described it as shared infra for "search, BM25, pgvector".

This PR creates **`graphile-plugin-utils`** as the home for those genuinely-shared helpers and repoints the three plugins, then folds in the low-risk cleanups from the review.

### New package `graphile/graphile-plugin-utils`
Standard makage/CJS+ESM package (mirrors `graphile-cache`), with the logo/badge README header and DB-free unit tests. Exports:
- `getQueryBuilder(build, $condition)` — PgCondition → PgSelectQueryBuilder walker.
- `isComputedScalarAttributeResource(resource)` — computed-scalar-attribute type guard.

### Repointed consumers
```
before:  graphile-search ──> graphile-connection-filter   (only for getQueryBuilder)
         graphile-pg-aggregates: local copy of isComputedScalarAttributeResource

after:   graphile-connection-filter ─┐
         graphile-search             ├──> graphile-plugin-utils
         graphile-pg-aggregates      ┘
```
- `graphile-connection-filter` imports the helpers and **re-exports** `getQueryBuilder` / `isComputedScalarAttributeResource` from its `index.ts` (via `utils.ts`), so its public API is unchanged (back-compat shim).
- `graphile-search` imports `getQueryBuilder` from `graphile-plugin-utils`.
- `graphile-pg-aggregates` drops its duplicated `isComputedScalarAttributeResource` and its `getComputedAttributeResources` now composes the shared guard (keeping its extra `arrayOfCodec` + codec-equality filtering, so behavior is unchanged).

### Low-risk cleanups (from the #1369 review)
- **`graphile-function-bindings`**: replace the hand-rolled `IDENT_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/` with graphql-js's own `isValidNameError` (the invalid-alias skip is now `if (isValidNameError(toCamelCase(binding.alias)))`). Not shared into a generic util because SQL identifiers and GraphQL names have different semantics.
- **`graphile-function-bindings/README.md`**: add the standard centered logo + CI/license/npm badge header that every sibling has.
- **`@pgpmjs/server-utils`**: add `isUuid(value)` and consume it in `graphql/server/src/middleware/fn.ts` in place of the inline `UUID_RE`. UUID validation is a server concern, not a Graphile-plugin one, so it goes here rather than the new package.

Deliberately **not** moved: `DerivedScalar` / `PG_TYPE_SCALARS` / `JSON_SCHEMA_SCALARS` (single consumer, specific to function-binding input derivation) and the SQL `IDENTIFIER_PATTERN` in `graphile-sql-expression-validator` (SQL identifier ≠ GraphQL name).

## RLS
No change to `createFnRouter`'s security model — the only edit to `fn.ts` swaps the inline UUID regex for `isUuid`. Invocation inserts still set `function_definition_id` + `api_binding_id` at `status = 'pending'`, run through `ctx.withPgClient` (request pgSettings + JWT claims), and are gated by the DB api-provenance policy.

## Testing
- `graphile-plugin-utils` unit tests: 5/5 pass. `@pgpmjs/server-utils` `isUuid` tests: 5/5 pass.
- REST `fn-routes` integration: 7/7 pass (incl. non-uuid id → 404 exercising `isUuid`).
- `graphile-function-bindings`: 21 pass, 1 fail — the pre-existing local-only grafast `reading 'items'` error (`resize.invocation`), green in CI.
- Full workspace build (51 projects) passes.
- `graphile-connection-filter` / `graphile-pg-aggregates` DB suites fail locally with the same grafast `reading 'items'` error on plain top-level queries (`allItems`, `allProducts`); verified **identical** failures on clean `main` (67 failed / 17 passed) — pre-existing environment issue, not a regression.

## Caveats
- Repo-wide `pnpm lint` is broken independent of this change (ESLint 9 pinned but only a legacy `.eslintrc.json` exists) and CI has no lint step; new code matches each package's existing style by hand.
- `graphile-plugin-utils` is versioned `1.0.0` (lerna independent versioning will manage subsequent bumps).

Link to Devin session: https://app.devin.ai/sessions/c9bfa831acc54a3ba2382bfc69495712
Requested by: @pyramation