### PR TITLE
fix(export): remove field conflictDoNothing override

### DIFF
--- a/packages/express-context/src/loaders/auth-settings.ts
+++ b/packages/express-context/src/loaders/auth-settings.ts
@@ -16,8 +16,15 @@ import { createModuleLoader } from './create-loader';
 
 // ─── SQL ────────────────────────────────────────────────────────────────────
 
+// The column was renamed auth_settings_table -> auth_settings_table_name
+// (Graphile inflection collision with auth_settings_table_id); read whichever
+// exists so the server works against both old and new metaschema versions.
 const AUTH_SETTINGS_DISCOVERY_SQL = `
-  SELECT s.schema_name, sm.auth_settings_table AS table_name
+  SELECT s.schema_name,
+         coalesce(
+           to_jsonb(sm) ->> 'auth_settings_table_name',
+           to_jsonb(sm) ->> 'auth_settings_table'
+         ) AS table_name
   FROM metaschema_modules_public.sessions_module sm
   JOIN metaschema_public.schema s ON s.id = sm.schema_id
   LIMIT 1

--- a/pgpm/export/src/export-utils.ts
+++ b/pgpm/export/src/export-utils.ts
@@ -178,9 +178,6 @@ export interface MetaExportTableEntry {
  * values must come from DDL defaults at deploy time.
  */
 export const META_TABLE_OVERRIDES: Record<string, Omit<TableConfig, 'schema' | 'table'>> = {
-  field: {
-    conflictDoNothing: true
-  },
   sites: {
     typeOverrides: {
       og_image: 'image',


### PR DESCRIPTION
## Summary

Follow-up to constructive-io/constructive-db#2184 (Graphile inflection-collision renames).

1. **Remove `field: { conflictDoNothing: true }` from `META_TABLE_OVERRIDES`** (`pgpm/export/src/export-utils.ts`). This override made exported `metaschema_public.field` INSERTs use `ON CONFLICT DO NOTHING`, silently dropping rows that collided with `databases_field_uniq_names_idx` (the index guarding PostGraphile inflection collisions like `action` vs `action_id`). Colliding names are now fixed at the source, so future collisions fail loudly at deploy time instead of silently losing metadata. The `conflictDoNothing` option itself remains on `TableConfig` — only the `field` override is removed.

2. **`express-context` authSettings loader: read the renamed column** (`packages/express-context/src/loaders/auth-settings.ts`). `sessions_module.auth_settings_table` was renamed to `auth_settings_table_name`; the discovery query now reads whichever exists:
```sql
coalesce(to_jsonb(sm) ->> 'auth_settings_table_name', to_jsonb(sm) ->> 'auth_settings_table') AS table_name
```
so the server works against both old and new metaschema versions.

Note: constructive-db's `platform-ui-k8s` CI job runs against `constructiveio/constructive:latest`, so PR 2184's k8s check will keep failing until this PR merges and the image republishes.

Link to Devin session: https://app.devin.ai/sessions/b0cb3356cae14cc28fa469b4f8fd3e1d
Requested by: @pyramation