### PR TITLE
fix(express-context): read auth_settings_table_name directly

### DIFF
--- a/packages/express-context/src/loaders/auth-settings.ts
+++ b/packages/express-context/src/loaders/auth-settings.ts
@@ -16,15 +16,8 @@ import { createModuleLoader } from './create-loader';
 
 // ─── SQL ────────────────────────────────────────────────────────────────────
 
-// The column was renamed auth_settings_table -> auth_settings_table_name
-// (Graphile inflection collision with auth_settings_table_id); read whichever
-// exists so the server works against both old and new metaschema versions.
 const AUTH_SETTINGS_DISCOVERY_SQL = `
-  SELECT s.schema_name,
-         coalesce(
-           to_jsonb(sm) ->> 'auth_settings_table_name',
-           to_jsonb(sm) ->> 'auth_settings_table'
-         ) AS table_name
+  SELECT s.schema_name, sm.auth_settings_table_name AS table_name
   FROM metaschema_modules_public.sessions_module sm
   JOIN metaschema_public.schema s ON s.id = sm.schema_id
   LIMIT 1


### PR DESCRIPTION
## Summary
Removes the transitional `coalesce` shim in the auth-settings loader now that constructive-db has renamed the column everywhere (constructive-db#2194 merged).

The column `sessions_module.auth_settings_table` was renamed to `auth_settings_table_name` to avoid a PostGraphile inflection collision with `auth_settings_table_id`. #1376 added a compatibility read that tolerated both names:

```sql
coalesce(to_jsonb(sm) ->> 'auth_settings_table_name',
         to_jsonb(sm) ->> 'auth_settings_table') AS table_name
```

Since every metaschema now has the renamed column, this reverts to a direct read:

```sql
SELECT s.schema_name, sm.auth_settings_table_name AS table_name
FROM metaschema_modules_public.sessions_module sm
JOIN metaschema_public.schema s ON s.id = sm.schema_id
LIMIT 1
```

Link to Devin session: https://app.devin.ai/sessions/b0cb3356cae14cc28fa469b4f8fd3e1d
Requested by: @pyramation