### PR TITLE
feat(server): activate DB-backed HTTP route resolution (Stage B)

### DIFF
--- a/__fixtures__/seed/services/routes.sql
+++ b/__fixtures__/seed/services/routes.sql
@@ -1,0 +1,41 @@
+-- Shared fixture: Stage B HTTP routes for the app.test.constructive.io domain
+--
+-- Exercises services_public.resolve_http_route against the app domain seeded in
+-- services/test-data.sql. Routes are intentionally scoped so that /graphql has
+-- NO route (proving legacy host->api fallthrough still serves GraphQL), while a
+-- site prefix and a webhook function route demonstrate typed dispatch.
+--
+-- Depends on: services/setup.sql, services/test-data.sql
+
+SET session_replication_role TO replica;
+
+-- site target at a specific prefix (NOT '/', so it never shadows /graphql)
+INSERT INTO services_public.http_routes
+  (id, database_id, domain_id, path, method, target_kind, site_id, priority)
+VALUES (
+  'a0000000-0000-4000-8000-000000000001',
+  '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9',
+  '41181146-890e-4991-9da7-3dddf87d9e78',
+  '/welcome',
+  NULL,
+  'site',
+  '90000000-0000-4000-8000-000000000001',
+  0
+) ON CONFLICT (id) DO NOTHING;
+
+-- function target (webhook channel) for a specific POST path
+INSERT INTO services_public.http_routes
+  (id, database_id, domain_id, path, method, target_kind, channel, function_definition_id, priority)
+VALUES (
+  'a0000000-0000-4000-8000-000000000002',
+  '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9',
+  '41181146-890e-4991-9da7-3dddf87d9e78',
+  '/hooks/stripe',
+  'POST',
+  'function',
+  'webhook',
+  '90000000-0000-4000-8000-000000000002',
+  0
+) ON CONFLICT (id) DO NOTHING;
+
+SET session_replication_role TO DEFAULT;

--- a/__fixtures__/seed/services/routes.sql
+++ b/__fixtures__/seed/services/routes.sql
@@ -11,7 +11,7 @@ SET session_replication_role TO replica;
 
 -- site target at a specific prefix (NOT '/', so it never shadows /graphql)
 INSERT INTO services_public.http_routes
-  (id, database_id, domain_id, path, method, target_kind, site_id, priority)
+  (id, database_id, domain_id, path, method, target_kind, target_id, priority)
 VALUES (
   'a0000000-0000-4000-8000-000000000001',
   '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9',
@@ -23,9 +23,9 @@ VALUES (
   0
 ) ON CONFLICT (id) DO NOTHING;
 
--- function target (webhook channel) for a specific POST path
+-- function target for a specific POST path
 INSERT INTO services_public.http_routes
-  (id, database_id, domain_id, path, method, target_kind, channel, function_definition_id, priority)
+  (id, database_id, domain_id, path, method, target_kind, target_id, priority)
 VALUES (
   'a0000000-0000-4000-8000-000000000002',
   '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9',
@@ -33,7 +33,6 @@ VALUES (
   '/hooks/stripe',
   'POST',
   'function',
-  'webhook',
   '90000000-0000-4000-8000-000000000002',
   0
 ) ON CONFLICT (id) DO NOTHING;

--- a/__fixtures__/seed/services/setup.sql
+++ b/__fixtures__/seed/services/setup.sql
@@ -244,10 +244,11 @@ CREATE TABLE IF NOT EXISTS services_public.api_modules (
 -- HTTP ROUTES (Stage B) + resolver
 -- =====================================================
 --
--- Mirrors the constructive-db route storage + resolver contract
--- (services_public.resolve_http_route). Two scopes exist in production
--- (platform_http_routes / http_routes); the resolver unions both. Routes are
--- unseeded by default — tests insert their own.
+-- Mirrors the constructive-db single-table route storage + resolver contract
+-- (services_public.resolve_http_route). A single http_routes table fans a host
+-- out to typed targets via (target_kind, target_id); platform is just a
+-- database, so there is no separate route tier. Routes are unseeded by
+-- default — tests insert their own.
 
 CREATE TABLE IF NOT EXISTS services_public.http_routes (
   id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
@@ -255,13 +256,8 @@ CREATE TABLE IF NOT EXISTS services_public.http_routes (
   domain_id uuid NOT NULL,
   path text NOT NULL DEFAULT '/',
   method text,
-  target_kind text NOT NULL CHECK (target_kind IN ('api', 'site', 'service', 'function', 'bucket')),
-  channel text,
-  api_id uuid,
-  site_id uuid,
-  service_id uuid,
-  function_definition_id uuid,
-  bucket_id uuid,
+  target_kind text NOT NULL CHECK (target_kind IN ('api', 'site', 'function', 'bucket', 'service')),
+  target_id uuid NOT NULL,
   priority int NOT NULL DEFAULT 0,
   is_active boolean NOT NULL DEFAULT true,
   CONSTRAINT hr_db_fkey FOREIGN KEY (database_id) REFERENCES metaschema_public.database (id) ON DELETE CASCADE,
@@ -269,92 +265,33 @@ CREATE TABLE IF NOT EXISTS services_public.http_routes (
 );
 CREATE INDEX IF NOT EXISTS http_routes_domain_id_idx ON services_public.http_routes (domain_id);
 
-CREATE TABLE IF NOT EXISTS services_public.platform_http_routes (
-  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
-  domain_id uuid NOT NULL,
-  path text NOT NULL DEFAULT '/',
-  method text,
-  target_kind text NOT NULL CHECK (target_kind IN ('api', 'site', 'service', 'function', 'bucket')),
-  channel text,
-  api_id uuid,
-  site_id uuid,
-  service_id uuid,
-  function_definition_id uuid,
-  bucket_id uuid,
-  priority int NOT NULL DEFAULT 0,
-  is_active boolean NOT NULL DEFAULT true,
-  CONSTRAINT phr_domain_fkey FOREIGN KEY (domain_id) REFERENCES services_public.domains (id) ON DELETE CASCADE
-);
-CREATE INDEX IF NOT EXISTS platform_http_routes_domain_id_idx ON services_public.platform_http_routes (domain_id);
-
 CREATE OR REPLACE FUNCTION services_public.resolve_http_route(
   p_host text,
   p_path text,
   p_method text,
   OUT route_id uuid,
+  OUT database_id uuid,
   OUT domain_id uuid,
   OUT matched_path text,
   OUT method text,
   OUT target_kind text,
-  OUT channel text,
-  OUT api_id uuid,
-  OUT site_id uuid,
-  OUT service_id uuid,
-  OUT function_definition_id uuid,
-  OUT bucket_id uuid,
-  OUT route_scope text
+  OUT target_id uuid
 ) RETURNS record AS $_PGFN_$
 SELECT
-  route_id, domain_id, matched_path, method, target_kind, channel,
-  api_id, site_id, service_id, function_definition_id, bucket_id, route_scope
-FROM (
-  SELECT
-    r.id AS route_id,
-    r.domain_id AS domain_id,
-    r.path AS matched_path,
-    r.method AS method,
-    r.target_kind::text AS target_kind,
-    CASE r.target_kind WHEN 'function' THEN r.channel ELSE NULL END::text AS channel,
-    CASE r.target_kind WHEN 'api' THEN r.api_id ELSE NULL END AS api_id,
-    CASE r.target_kind WHEN 'site' THEN r.site_id ELSE NULL END AS site_id,
-    CASE r.target_kind WHEN 'service' THEN r.service_id ELSE NULL END AS service_id,
-    CASE r.target_kind WHEN 'function' THEN r.function_definition_id ELSE NULL END AS function_definition_id,
-    CASE r.target_kind WHEN 'bucket' THEN r.bucket_id ELSE NULL END AS bucket_id,
-    'platform' AS route_scope,
-    length(r.path) AS path_length,
-    r.method IS NOT NULL AS method_specific,
-    r.priority AS priority
-  FROM services_public.platform_http_routes AS r
-  INNER JOIN services_public.domains AS d ON d.id = r.domain_id
-  WHERE lower(concat_ws('.', d.subdomain, d.domain)) = split_part(lower(p_host), ':', 1)
-    AND ((r.path = '/' OR (concat('/', ltrim(COALESCE(p_path, '/'), '/')) = r.path
-      OR "left"(concat('/', ltrim(COALESCE(p_path, '/'), '/')), length(r.path) + 1) = (r.path || '/')))
-      AND ((r.method IS NULL OR upper(r.method) = upper(p_method)) AND r.is_active))
-  UNION ALL
-  SELECT
-    r.id AS route_id,
-    r.domain_id AS domain_id,
-    r.path AS matched_path,
-    r.method AS method,
-    r.target_kind::text AS target_kind,
-    CASE r.target_kind WHEN 'function' THEN r.channel ELSE NULL END::text AS channel,
-    CASE r.target_kind WHEN 'api' THEN r.api_id ELSE NULL END AS api_id,
-    CASE r.target_kind WHEN 'site' THEN r.site_id ELSE NULL END AS site_id,
-    CASE r.target_kind WHEN 'service' THEN r.service_id ELSE NULL END AS service_id,
-    CASE r.target_kind WHEN 'function' THEN r.function_definition_id ELSE NULL END AS function_definition_id,
-    CASE r.target_kind WHEN 'bucket' THEN r.bucket_id ELSE NULL END AS bucket_id,
-    'database' AS route_scope,
-    length(r.path) AS path_length,
-    r.method IS NOT NULL AS method_specific,
-    r.priority AS priority
-  FROM services_public.http_routes AS r
-  INNER JOIN services_public.domains AS d ON d.id = r.domain_id
-  WHERE lower(concat_ws('.', d.subdomain, d.domain)) = split_part(lower(p_host), ':', 1)
-    AND ((r.path = '/' OR (concat('/', ltrim(COALESCE(p_path, '/'), '/')) = r.path
-      OR "left"(concat('/', ltrim(COALESCE(p_path, '/'), '/')), length(r.path) + 1) = (r.path || '/')))
-      AND ((r.method IS NULL OR upper(r.method) = upper(p_method)) AND r.is_active))
-) AS candidates
-ORDER BY path_length DESC, method_specific DESC, priority DESC, route_id ASC
+  r.id AS route_id,
+  r.database_id AS database_id,
+  r.domain_id AS domain_id,
+  r.path AS matched_path,
+  r.method AS method,
+  r.target_kind AS target_kind,
+  r.target_id AS target_id
+FROM services_public.http_routes AS r
+INNER JOIN services_public.domains AS d ON d.id = r.domain_id
+WHERE lower(concat_ws('.', d.subdomain, d.domain)) = split_part(lower(p_host), ':', 1)
+  AND ((r.path = '/' OR (concat('/', ltrim(COALESCE(p_path, '/'), '/')) = r.path
+    OR "left"(concat('/', ltrim(COALESCE(p_path, '/'), '/')), length(r.path) + 1) = (r.path || '/')))
+    AND ((r.method IS NULL OR upper(r.method) = upper(p_method)) AND r.is_active))
+ORDER BY length(r.path) DESC, (r.method IS NOT NULL) DESC, r.priority DESC, r.id ASC
 LIMIT 1
 $_PGFN_$ LANGUAGE sql STABLE SECURITY DEFINER;
 
@@ -455,5 +392,4 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON services_public.database_settings TO adm
 GRANT SELECT, INSERT, UPDATE, DELETE ON services_public.api_settings TO administrator, authenticated, anonymous;
 GRANT SELECT, INSERT, UPDATE, DELETE ON metaschema_modules_public.rls_module TO administrator, authenticated, anonymous;
 GRANT SELECT, INSERT, UPDATE, DELETE ON services_public.http_routes TO administrator, authenticated, anonymous;
-GRANT SELECT, INSERT, UPDATE, DELETE ON services_public.platform_http_routes TO administrator, authenticated, anonymous;
 GRANT EXECUTE ON FUNCTION services_public.resolve_http_route(text, text, text) TO administrator, authenticated, anonymous;

--- a/__fixtures__/seed/services/setup.sql
+++ b/__fixtures__/seed/services/setup.sql
@@ -241,6 +241,124 @@ CREATE TABLE IF NOT EXISTS services_public.api_modules (
 );
 
 -- =====================================================
+-- HTTP ROUTES (Stage B) + resolver
+-- =====================================================
+--
+-- Mirrors the constructive-db route storage + resolver contract
+-- (services_public.resolve_http_route). Two scopes exist in production
+-- (platform_http_routes / http_routes); the resolver unions both. Routes are
+-- unseeded by default — tests insert their own.
+
+CREATE TABLE IF NOT EXISTS services_public.http_routes (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  database_id uuid NOT NULL,
+  domain_id uuid NOT NULL,
+  path text NOT NULL DEFAULT '/',
+  method text,
+  target_kind text NOT NULL CHECK (target_kind IN ('api', 'site', 'service', 'function', 'bucket')),
+  channel text,
+  api_id uuid,
+  site_id uuid,
+  service_id uuid,
+  function_definition_id uuid,
+  bucket_id uuid,
+  priority int NOT NULL DEFAULT 0,
+  is_active boolean NOT NULL DEFAULT true,
+  CONSTRAINT hr_db_fkey FOREIGN KEY (database_id) REFERENCES metaschema_public.database (id) ON DELETE CASCADE,
+  CONSTRAINT hr_domain_fkey FOREIGN KEY (domain_id) REFERENCES services_public.domains (id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS http_routes_domain_id_idx ON services_public.http_routes (domain_id);
+
+CREATE TABLE IF NOT EXISTS services_public.platform_http_routes (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  domain_id uuid NOT NULL,
+  path text NOT NULL DEFAULT '/',
+  method text,
+  target_kind text NOT NULL CHECK (target_kind IN ('api', 'site', 'service', 'function', 'bucket')),
+  channel text,
+  api_id uuid,
+  site_id uuid,
+  service_id uuid,
+  function_definition_id uuid,
+  bucket_id uuid,
+  priority int NOT NULL DEFAULT 0,
+  is_active boolean NOT NULL DEFAULT true,
+  CONSTRAINT phr_domain_fkey FOREIGN KEY (domain_id) REFERENCES services_public.domains (id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS platform_http_routes_domain_id_idx ON services_public.platform_http_routes (domain_id);
+
+CREATE OR REPLACE FUNCTION services_public.resolve_http_route(
+  p_host text,
+  p_path text,
+  p_method text,
+  OUT route_id uuid,
+  OUT domain_id uuid,
+  OUT matched_path text,
+  OUT method text,
+  OUT target_kind text,
+  OUT channel text,
+  OUT api_id uuid,
+  OUT site_id uuid,
+  OUT service_id uuid,
+  OUT function_definition_id uuid,
+  OUT bucket_id uuid,
+  OUT route_scope text
+) RETURNS record AS $_PGFN_$
+SELECT
+  route_id, domain_id, matched_path, method, target_kind, channel,
+  api_id, site_id, service_id, function_definition_id, bucket_id, route_scope
+FROM (
+  SELECT
+    r.id AS route_id,
+    r.domain_id AS domain_id,
+    r.path AS matched_path,
+    r.method AS method,
+    r.target_kind::text AS target_kind,
+    CASE r.target_kind WHEN 'function' THEN r.channel ELSE NULL END::text AS channel,
+    CASE r.target_kind WHEN 'api' THEN r.api_id ELSE NULL END AS api_id,
+    CASE r.target_kind WHEN 'site' THEN r.site_id ELSE NULL END AS site_id,
+    CASE r.target_kind WHEN 'service' THEN r.service_id ELSE NULL END AS service_id,
+    CASE r.target_kind WHEN 'function' THEN r.function_definition_id ELSE NULL END AS function_definition_id,
+    CASE r.target_kind WHEN 'bucket' THEN r.bucket_id ELSE NULL END AS bucket_id,
+    'platform' AS route_scope,
+    length(r.path) AS path_length,
+    r.method IS NOT NULL AS method_specific,
+    r.priority AS priority
+  FROM services_public.platform_http_routes AS r
+  INNER JOIN services_public.domains AS d ON d.id = r.domain_id
+  WHERE lower(concat_ws('.', d.subdomain, d.domain)) = split_part(lower(p_host), ':', 1)
+    AND ((r.path = '/' OR (concat('/', ltrim(COALESCE(p_path, '/'), '/')) = r.path
+      OR "left"(concat('/', ltrim(COALESCE(p_path, '/'), '/')), length(r.path) + 1) = (r.path || '/')))
+      AND ((r.method IS NULL OR upper(r.method) = upper(p_method)) AND r.is_active))
+  UNION ALL
+  SELECT
+    r.id AS route_id,
+    r.domain_id AS domain_id,
+    r.path AS matched_path,
+    r.method AS method,
+    r.target_kind::text AS target_kind,
+    CASE r.target_kind WHEN 'function' THEN r.channel ELSE NULL END::text AS channel,
+    CASE r.target_kind WHEN 'api' THEN r.api_id ELSE NULL END AS api_id,
+    CASE r.target_kind WHEN 'site' THEN r.site_id ELSE NULL END AS site_id,
+    CASE r.target_kind WHEN 'service' THEN r.service_id ELSE NULL END AS service_id,
+    CASE r.target_kind WHEN 'function' THEN r.function_definition_id ELSE NULL END AS function_definition_id,
+    CASE r.target_kind WHEN 'bucket' THEN r.bucket_id ELSE NULL END AS bucket_id,
+    'database' AS route_scope,
+    length(r.path) AS path_length,
+    r.method IS NOT NULL AS method_specific,
+    r.priority AS priority
+  FROM services_public.http_routes AS r
+  INNER JOIN services_public.domains AS d ON d.id = r.domain_id
+  WHERE lower(concat_ws('.', d.subdomain, d.domain)) = split_part(lower(p_host), ':', 1)
+    AND ((r.path = '/' OR (concat('/', ltrim(COALESCE(p_path, '/'), '/')) = r.path
+      OR "left"(concat('/', ltrim(COALESCE(p_path, '/'), '/')), length(r.path) + 1) = (r.path || '/')))
+      AND ((r.method IS NULL OR upper(r.method) = upper(p_method)) AND r.is_active))
+) AS candidates
+ORDER BY path_length DESC, method_specific DESC, priority DESC, route_id ASC
+LIMIT 1
+$_PGFN_$ LANGUAGE sql STABLE SECURITY DEFINER;
+
+-- =====================================================
 -- MODULES TABLES
 -- =====================================================
 
@@ -336,3 +454,6 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON services_public.api_modules TO administr
 GRANT SELECT, INSERT, UPDATE, DELETE ON services_public.database_settings TO administrator, authenticated, anonymous;
 GRANT SELECT, INSERT, UPDATE, DELETE ON services_public.api_settings TO administrator, authenticated, anonymous;
 GRANT SELECT, INSERT, UPDATE, DELETE ON metaschema_modules_public.rls_module TO administrator, authenticated, anonymous;
+GRANT SELECT, INSERT, UPDATE, DELETE ON services_public.http_routes TO administrator, authenticated, anonymous;
+GRANT SELECT, INSERT, UPDATE, DELETE ON services_public.platform_http_routes TO administrator, authenticated, anonymous;
+GRANT EXECUTE ON FUNCTION services_public.resolve_http_route(text, text, text) TO administrator, authenticated, anonymous;

--- a/graphql/server-test/__tests__/route-stageb.integration.test.ts
+++ b/graphql/server-test/__tests__/route-stageb.integration.test.ts
@@ -40,6 +40,7 @@ const seedFiles = [
 
 const API_HOST = 'app.test.constructive.io';
 const SITE_ID = '90000000-0000-4000-8000-000000000001';
+const FUNCTION_ID = '90000000-0000-4000-8000-000000000002';
 
 let request: supertest.Agent;
 let teardown: () => Promise<void>;
@@ -114,7 +115,7 @@ describe('on mode (authoritative)', () => {
 
     expect(res.status).toBe(501);
     expect(res.body.targetKind).toBe('function');
-    expect(res.body.channel).toBe('webhook');
+    expect(res.body.targetId).toBe(FUNCTION_ID);
   });
 
   it('unrouted /graphql falls through to legacy host->api (GraphQL still serves)', async () => {

--- a/graphql/server-test/__tests__/route-stageb.integration.test.ts
+++ b/graphql/server-test/__tests__/route-stageb.integration.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Stage B HTTP Route Integration Tests
+ *
+ * Drives the real GraphQL server (Express + PostGraphile) through SuperTest with
+ * services_public.resolve_http_route wired in via the route middleware. Proves:
+ *
+ *   - shadow (default): routing never changes behavior; GraphQL still serves and
+ *     a site route is NOT dispatched.
+ *   - on: typed dispatch — `site` target serves a placeholder, `function` target
+ *     returns a typed 501, and an unrouted path (/graphql) falls through to the
+ *     legacy host -> api resolution so GraphQL keeps working.
+ *   - off: resolver is never consulted.
+ *
+ * The mode is read per-request from HTTP_ROUTE_RESOLVER_MODE, so each test sets
+ * it before issuing requests.
+ *
+ * Run tests:
+ *   pnpm test -- --testPathPattern=route-stageb.integration
+ */
+
+import path from 'path';
+import { getConnections, seed } from '../src';
+import type supertest from 'supertest';
+
+jest.setTimeout(30000);
+
+const sharedSeedRoot = path.join(__dirname, '..', '..', '..', '__fixtures__', 'seed');
+const shared = (...segments: string[]) => path.join(sharedSeedRoot, ...segments);
+
+const schemas = ['simple-pets-public', 'simple-pets-pets-public'];
+const metaSchemas = ['services_public', 'metaschema_public', 'metaschema_modules_public'];
+
+const seedFiles = [
+  shared('services', 'setup.sql'),
+  shared('app-schemas', 'simple-pets', 'schema.sql'),
+  shared('services', 'test-data.sql'),
+  shared('app-schemas', 'simple-pets', 'test-data.sql'),
+  shared('services', 'routes.sql'),
+];
+
+const API_HOST = 'app.test.constructive.io';
+const SITE_ID = '90000000-0000-4000-8000-000000000001';
+
+let request: supertest.Agent;
+let teardown: () => Promise<void>;
+
+const OLD_MODE = process.env.HTTP_ROUTE_RESOLVER_MODE;
+const setMode = (mode: string) => {
+  process.env.HTTP_ROUTE_RESOLVER_MODE = mode;
+};
+
+beforeAll(async () => {
+  ({ request, teardown } = await getConnections(
+    {
+      schemas,
+      authRole: 'anonymous',
+      server: {
+        api: {
+          enableServicesApi: true,
+          isPublic: true,
+          metaSchemas,
+        },
+      },
+    },
+    [seed.sqlfile(seedFiles)]
+  ));
+});
+
+afterAll(async () => {
+  process.env.HTTP_ROUTE_RESOLVER_MODE = OLD_MODE;
+  await teardown();
+});
+
+describe('shadow mode (default-safe)', () => {
+  beforeAll(() => setMode('shadow'));
+
+  it('GraphQL still serves normally', async () => {
+    const res = await request
+      .post('/graphql')
+      .set('Host', API_HOST)
+      .send({ query: '{ __typename }' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.__typename).toBe('Query');
+  });
+
+  it('does NOT dispatch a site route (no override)', async () => {
+    const res = await request.get('/welcome').set('Host', API_HOST);
+    expect(res.headers['x-constructive-route']).toBeUndefined();
+    expect(res.status).not.toBe(200);
+  });
+});
+
+describe('on mode (authoritative)', () => {
+  beforeAll(() => setMode('on'));
+
+  it('site target serves a typed placeholder', async () => {
+    const res = await request.get('/welcome').set('Host', API_HOST);
+    expect(res.status).toBe(200);
+    expect(res.headers['x-constructive-route']).toBe(`site:${SITE_ID}`);
+  });
+
+  it('site prefix matches sub-paths', async () => {
+    const res = await request.get('/welcome/pricing').set('Host', API_HOST);
+    expect(res.status).toBe(200);
+    expect(res.headers['x-constructive-route']).toBe(`site:${SITE_ID}`);
+  });
+
+  it('function target returns a typed 501 (no handler in open-source)', async () => {
+    const res = await request
+      .post('/hooks/stripe')
+      .set('Host', API_HOST)
+      .send({ event: 'charge.succeeded' });
+
+    expect(res.status).toBe(501);
+    expect(res.body.targetKind).toBe('function');
+    expect(res.body.channel).toBe('webhook');
+  });
+
+  it('unrouted /graphql falls through to legacy host->api (GraphQL still serves)', async () => {
+    const res = await request
+      .post('/graphql')
+      .set('Host', API_HOST)
+      .send({ query: '{ __typename }' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.__typename).toBe('Query');
+  });
+});
+
+describe('off mode', () => {
+  beforeAll(() => setMode('off'));
+
+  it('never dispatches typed targets', async () => {
+    const res = await request
+      .post('/hooks/stripe')
+      .set('Host', API_HOST)
+      .send({});
+    expect(res.status).not.toBe(501);
+  });
+});

--- a/graphql/server/src/middleware/__tests__/api.test.ts
+++ b/graphql/server/src/middleware/__tests__/api.test.ts
@@ -61,6 +61,49 @@ describe('api middleware routing priority', () => {
     expect(getSvcKey(createPrivateOptions(), req)).toBe('api:db-123:customer-api');
   });
 
+  it('resolves and caches by api_id when a route selects the api (Stage B)', async () => {
+    const query = jest.fn(async (sql: string, params: unknown[]) => {
+      if (Array.isArray(params[0])) {
+        return {
+          rows: (params[0] as string[]).map((schemaName) => ({ schema_name: schemaName })),
+        };
+      }
+      if (sql.includes('WHERE a.id = $1') && params[0] === 'route-api-9') {
+        return {
+          rows: [{
+            api_id: 'route-api-9',
+            database_id: 'db-777',
+            dbname: 'routed_db',
+            role_name: 'authenticated',
+            anon_role: 'anonymous',
+            is_public: true,
+            schemas: ['routed_public'],
+          }],
+        };
+      }
+      return { rows: [] };
+    });
+
+    mockGetPgPool.mockReturnValue({ query } as unknown as Pool);
+
+    const req = createRequest({ host: 'app.localhost' });
+    req.routeApiId = 'route-api-9';
+
+    const result = await getApiConfig(createPrivateOptions(), req);
+
+    expect(req.svc_key).toBe('route-api:route-api-9');
+    expect(result).toMatchObject({
+      apiId: 'route-api-9',
+      dbname: 'routed_db',
+      databaseId: 'db-777',
+      schema: ['routed_public'],
+    });
+    expect(svcCache.get('route-api:route-api-9')).toBe(result);
+    expect(query.mock.calls).toEqual(expect.arrayContaining([
+      [expect.stringContaining('WHERE a.id = $1'), ['route-api-9']],
+    ]));
+  });
+
   it('uses the same X-Api-Name priority when resolving and caching API config', async () => {
     const query = jest.fn(async (_sql: string, params: unknown[]) => {
       if (Array.isArray(params[0])) {

--- a/graphql/server/src/middleware/__tests__/route.test.ts
+++ b/graphql/server/src/middleware/__tests__/route.test.ts
@@ -23,17 +23,12 @@ afterAll(() => {
 
 const routeRow = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
   route_id: 'route-1',
+  database_id: 'db-1',
   domain_id: 'domain-1',
   matched_path: '/graphql',
   method: null,
   target_kind: 'api',
-  channel: null,
-  api_id: 'api-1',
-  site_id: null,
-  service_id: null,
-  function_definition_id: null,
-  bucket_id: null,
-  route_scope: 'database',
+  target_id: 'api-1',
   ...overrides
 });
 
@@ -104,7 +99,7 @@ describe('getHttpRouteMode', () => {
 describe('resolveHttpRoute', () => {
   it('maps a row into a typed match', async () => {
     const match = await resolveHttpRoute(poolReturning([routeRow()]), 'acme.test', '/graphql', 'POST');
-    expect(match).toMatchObject({ targetKind: 'api', apiId: 'api-1', routeScope: 'database' });
+    expect(match).toMatchObject({ targetKind: 'api', targetId: 'api-1', databaseId: 'db-1' });
   });
 
   it('returns null when nothing matches', async () => {
@@ -145,7 +140,7 @@ describe('createRouteMiddleware', () => {
     const next = jest.fn() as NextFunction;
     await createRouteMiddleware(opts)(req, res as Response, next);
     expect(next).toHaveBeenCalled();
-    expect(req.httpRoute).toMatchObject({ targetKind: 'api', apiId: 'api-1' });
+    expect(req.httpRoute).toMatchObject({ targetKind: 'api', targetId: 'api-1' });
     expect(req.routeApiId).toBeUndefined();
     expect(res.status).not.toHaveBeenCalled();
   });
@@ -163,7 +158,7 @@ describe('createRouteMiddleware', () => {
   it('on mode / site target: serves a typed placeholder', async () => {
     process.env.HTTP_ROUTE_RESOLVER_MODE = 'on';
     mockGetPgPool.mockReturnValue(
-      poolReturning([routeRow({ target_kind: 'site', api_id: null, site_id: 'site-9' })])
+      poolReturning([routeRow({ target_kind: 'site', target_id: 'site-9' })])
     );
     const req = createRequest('acme.test', '/', 'GET');
     const res = createResponse();
@@ -180,9 +175,7 @@ describe('createRouteMiddleware', () => {
       poolReturning([
         routeRow({
           target_kind: 'function',
-          api_id: null,
-          function_definition_id: 'fn-1',
-          channel: 'sync'
+          target_id: 'fn-1'
         })
       ])
     );
@@ -192,7 +185,7 @@ describe('createRouteMiddleware', () => {
     await createRouteMiddleware(opts)(req, res as Response, next);
     expect(next).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(501);
-    expect(res.body).toMatchObject({ targetKind: 'function', channel: 'sync', functionDefinitionId: 'fn-1' });
+    expect(res.body).toMatchObject({ targetKind: 'function', targetId: 'fn-1' });
   });
 
   it('on mode / no match: falls through to legacy resolution', async () => {

--- a/graphql/server/src/middleware/__tests__/route.test.ts
+++ b/graphql/server/src/middleware/__tests__/route.test.ts
@@ -1,0 +1,207 @@
+jest.mock('pg-cache', () => ({
+  getPgPool: jest.fn()
+}));
+
+import type { NextFunction, Request, Response } from 'express';
+import type { Pool } from 'pg';
+import { getPgPool } from 'pg-cache';
+
+import type { ApiOptions } from '../../types';
+import {
+  createRouteMiddleware,
+  getHttpRouteMode,
+  resolveHttpRoute
+} from '../route';
+
+const mockGetPgPool = getPgPool as jest.MockedFunction<typeof getPgPool>;
+
+const OLD_ENV = process.env.HTTP_ROUTE_RESOLVER_MODE;
+
+afterAll(() => {
+  process.env.HTTP_ROUTE_RESOLVER_MODE = OLD_ENV;
+});
+
+const routeRow = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+  route_id: 'route-1',
+  domain_id: 'domain-1',
+  matched_path: '/graphql',
+  method: null,
+  target_kind: 'api',
+  channel: null,
+  api_id: 'api-1',
+  site_id: null,
+  service_id: null,
+  function_definition_id: null,
+  bucket_id: null,
+  route_scope: 'database',
+  ...overrides
+});
+
+const poolReturning = (rows: unknown[]): Pool => ({
+  query: jest.fn(async () => ({ rows }))
+} as unknown as Pool);
+
+const poolThrowing = (code: string): Pool => ({
+  query: jest.fn(async () => {
+    const err = new Error('boom') as Error & { code?: string };
+    err.code = code;
+    throw err;
+  })
+} as unknown as Pool);
+
+const createRequest = (host: string, path: string, method: string): Request =>
+  ({
+    method,
+    path,
+    get: (name: string) => (name.toLowerCase() === 'host' ? host : undefined)
+  } as unknown as Request);
+
+const createResponse = () => {
+  const res: Partial<Response> & {
+    statusCode?: number;
+    body?: unknown;
+    headers: Record<string, string>;
+  } = {
+    headers: {}
+  };
+  res.status = jest.fn((code: number) => {
+    res.statusCode = code;
+    return res as Response;
+  }) as unknown as Response['status'];
+  res.json = jest.fn((body: unknown) => {
+    res.body = body;
+    return res as Response;
+  }) as unknown as Response['json'];
+  res.send = jest.fn((body: unknown) => {
+    res.body = body;
+    return res as Response;
+  }) as unknown as Response['send'];
+  res.set = jest.fn((k: string, v: string) => {
+    res.headers[k] = v;
+    return res as Response;
+  }) as unknown as Response['set'];
+  return res;
+};
+
+const opts = { pg: { database: 'constructive' }, api: {} } as unknown as ApiOptions;
+
+describe('getHttpRouteMode', () => {
+  it('defaults to shadow when unset or invalid', () => {
+    delete process.env.HTTP_ROUTE_RESOLVER_MODE;
+    expect(getHttpRouteMode()).toBe('shadow');
+    process.env.HTTP_ROUTE_RESOLVER_MODE = 'nonsense';
+    expect(getHttpRouteMode()).toBe('shadow');
+  });
+
+  it('reads off/shadow/on case-insensitively', () => {
+    process.env.HTTP_ROUTE_RESOLVER_MODE = 'ON';
+    expect(getHttpRouteMode()).toBe('on');
+    process.env.HTTP_ROUTE_RESOLVER_MODE = 'off';
+    expect(getHttpRouteMode()).toBe('off');
+  });
+});
+
+describe('resolveHttpRoute', () => {
+  it('maps a row into a typed match', async () => {
+    const match = await resolveHttpRoute(poolReturning([routeRow()]), 'acme.test', '/graphql', 'POST');
+    expect(match).toMatchObject({ targetKind: 'api', apiId: 'api-1', routeScope: 'database' });
+  });
+
+  it('returns null when nothing matches', async () => {
+    expect(await resolveHttpRoute(poolReturning([]), 'acme.test', '/', 'GET')).toBeNull();
+  });
+
+  it('returns null (never throws) when the resolver is absent', async () => {
+    expect(await resolveHttpRoute(poolThrowing('42883'), 'acme.test', '/', 'GET')).toBeNull();
+  });
+
+  it('returns null when host is empty', async () => {
+    const pool = poolReturning([routeRow()]);
+    expect(await resolveHttpRoute(pool, '', '/', 'GET')).toBeNull();
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+});
+
+describe('createRouteMiddleware', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('off mode: never queries and always falls through', async () => {
+    process.env.HTTP_ROUTE_RESOLVER_MODE = 'off';
+    const pool = poolReturning([routeRow()]);
+    mockGetPgPool.mockReturnValue(pool);
+    const req = createRequest('acme.test', '/graphql', 'POST');
+    const next = jest.fn() as NextFunction;
+    await createRouteMiddleware(opts)(req, createResponse() as Response, next);
+    expect(next).toHaveBeenCalled();
+    expect(req.routeApiId).toBeUndefined();
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+
+  it('shadow mode: attaches match but never changes behavior', async () => {
+    process.env.HTTP_ROUTE_RESOLVER_MODE = 'shadow';
+    mockGetPgPool.mockReturnValue(poolReturning([routeRow()]));
+    const req = createRequest('acme.test', '/graphql', 'POST');
+    const res = createResponse();
+    const next = jest.fn() as NextFunction;
+    await createRouteMiddleware(opts)(req, res as Response, next);
+    expect(next).toHaveBeenCalled();
+    expect(req.httpRoute).toMatchObject({ targetKind: 'api', apiId: 'api-1' });
+    expect(req.routeApiId).toBeUndefined();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('on mode / api target: sets routeApiId and falls through', async () => {
+    process.env.HTTP_ROUTE_RESOLVER_MODE = 'on';
+    mockGetPgPool.mockReturnValue(poolReturning([routeRow()]));
+    const req = createRequest('acme.test', '/graphql', 'POST');
+    const next = jest.fn() as NextFunction;
+    await createRouteMiddleware(opts)(req, createResponse() as Response, next);
+    expect(next).toHaveBeenCalled();
+    expect(req.routeApiId).toBe('api-1');
+  });
+
+  it('on mode / site target: serves a typed placeholder', async () => {
+    process.env.HTTP_ROUTE_RESOLVER_MODE = 'on';
+    mockGetPgPool.mockReturnValue(
+      poolReturning([routeRow({ target_kind: 'site', api_id: null, site_id: 'site-9' })])
+    );
+    const req = createRequest('acme.test', '/', 'GET');
+    const res = createResponse();
+    const next = jest.fn() as NextFunction;
+    await createRouteMiddleware(opts)(req, res as Response, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['X-Constructive-Route']).toBe('site:site-9');
+  });
+
+  it('on mode / function target: typed 501', async () => {
+    process.env.HTTP_ROUTE_RESOLVER_MODE = 'on';
+    mockGetPgPool.mockReturnValue(
+      poolReturning([
+        routeRow({
+          target_kind: 'function',
+          api_id: null,
+          function_definition_id: 'fn-1',
+          channel: 'sync'
+        })
+      ])
+    );
+    const req = createRequest('acme.test', '/hooks/x', 'POST');
+    const res = createResponse();
+    const next = jest.fn() as NextFunction;
+    await createRouteMiddleware(opts)(req, res as Response, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(501);
+    expect(res.body).toMatchObject({ targetKind: 'function', channel: 'sync', functionDefinitionId: 'fn-1' });
+  });
+
+  it('on mode / no match: falls through to legacy resolution', async () => {
+    process.env.HTTP_ROUTE_RESOLVER_MODE = 'on';
+    mockGetPgPool.mockReturnValue(poolReturning([]));
+    const req = createRequest('acme.test', '/graphql', 'POST');
+    const next = jest.fn() as NextFunction;
+    await createRouteMiddleware(opts)(req, createResponse() as Response, next);
+    expect(next).toHaveBeenCalled();
+    expect(req.routeApiId).toBeUndefined();
+  });
+});

--- a/graphql/server/src/middleware/api.ts
+++ b/graphql/server/src/middleware/api.ts
@@ -67,6 +67,23 @@ const API_NAME_LOOKUP_SQL = `
   LIMIT 1
 `;
 
+const API_BY_ID_LOOKUP_SQL = `
+  SELECT 
+    a.id as api_id,
+    a.database_id,
+    a.dbname,
+    a.role_name,
+    a.anon_role,
+    a.is_public,
+    COALESCE(array_agg(s.schema_name) FILTER (WHERE s.schema_name IS NOT NULL), '{}') as schemas
+  FROM services_public.apis a
+  LEFT JOIN services_public.api_schemas aps ON a.id = aps.api_id
+  LEFT JOIN metaschema_public.schema s ON aps.schema_id = s.id
+  WHERE a.id = $1
+  GROUP BY a.id, a.database_id, a.dbname, a.role_name, a.anon_role, a.is_public
+  LIMIT 1
+`;
+
 const API_LIST_SQL = `
   SELECT 
     a.id,
@@ -120,11 +137,13 @@ interface ResolveContext {
   domain: string;
   subdomain: string | null;
   cacheKey: string;
+  routeApiId?: string | null;
   headers: RoutingHeaders;
 }
 
 type ResolutionMode = 
   | 'services-disabled'
+  | 'route-api'
   | 'schemata-header'
   | 'api-name-header'
   | 'meta-schema-header'
@@ -325,6 +344,14 @@ const queryByApiName = async (
   return result.rows[0] ?? null;
 };
 
+const queryByApiId = async (
+  pool: Pool,
+  apiId: string,
+): Promise<ApiRow | null> => {
+  const result = await pool.query<ApiRow>(API_BY_ID_LOOKUP_SQL, [apiId]);
+  return result.rows[0] ?? null;
+};
+
 const queryApiList = async (pool: Pool, isPublic: boolean): Promise<ApiListRow[]> => {
   const result = await pool.query<ApiListRow>(API_LIST_SQL, [isPublic]);
   return result.rows;
@@ -338,6 +365,9 @@ const determineMode = (ctx: ResolveContext): ResolutionMode => {
   const { opts, headers } = ctx;
   
   if (opts.api?.enableServicesApi === false) return 'services-disabled';
+  // An `api` route target (Stage B) resolves the api directly by id, ahead of
+  // host/header heuristics.
+  if (ctx.routeApiId) return 'route-api';
   if (opts.api?.isPublic === false) {
     return getPrivateHeaderMode(headers) ?? 'domain-lookup';
   }
@@ -397,6 +427,22 @@ const resolveMetaSchemaHeader = (
   validatedSchemas: string[]
 ): ApiStructure => {
   return createAdminStructure(ctx.opts, validatedSchemas, ctx.headers.databaseId);
+};
+
+const resolveByRouteApi = async (ctx: ResolveContext): Promise<ApiStructure | null> => {
+  const { opts, pool, routeApiId } = ctx;
+  if (!routeApiId) return null;
+
+  const row = await queryByApiId(pool, routeApiId);
+  if (!row) {
+    log.debug(`[route-api] No API found for api_id=${routeApiId}`);
+    return null;
+  }
+
+  const loaderCtx = buildLoaderContext(pool, opts, row);
+  const settings = await resolveModuleSettings(defaultRegistry, loaderCtx);
+  log.debug(`[route-api] resolved api_id=${routeApiId} schemas: [${row.schemas?.join(', ')}]`);
+  return toApiStructure(row, opts, settings);
 };
 
 const resolveDomainLookup = async (ctx: ResolveContext): Promise<ApiStructure | null> => {
@@ -479,7 +525,10 @@ export const getApiConfig = async (
   const pool = getPgPool(opts.pg);
   const { domain, subdomains } = getUrlDomains(req);
   const subdomain = getSubdomain(subdomains);
-  const cacheKey = getSvcKey(opts, req);
+  // An `api` route target (Stage B) selects the api by id; cache it under a
+  // dedicated key so it never collides with host/header-based resolution.
+  const routeApiId = req.routeApiId ?? null;
+  const cacheKey = routeApiId ? `route-api:${routeApiId}` : getSvcKey(opts, req);
 
   req.svc_key = cacheKey;
 
@@ -497,6 +546,7 @@ export const getApiConfig = async (
     domain,
     subdomain,
     cacheKey,
+    routeApiId,
     headers: getRoutingHeaders(req),
   };
 
@@ -537,6 +587,10 @@ export const getApiConfig = async (
 
     case 'meta-schema-header':
       result = resolveMetaSchemaHeader(ctx, validatedSchemas);
+      break;
+
+    case 'route-api':
+      result = await resolveByRouteApi(ctx);
       break;
 
     case 'domain-lookup':

--- a/graphql/server/src/middleware/route.ts
+++ b/graphql/server/src/middleware/route.ts
@@ -4,7 +4,7 @@
  * Consumes the database-side `services_public.resolve_http_route(host, path,
  * method)` contract and turns a request into a typed target:
  *
- *   host + path + method  ->  { target_kind, channel, api_id, site_id, ... }
+ *   host + path + method  ->  { target_kind, target_id }
  *
  * This is the request-plane counterpart to the routing table that lives in
  * constructive-db (PR #2214). The resolver decides *which typed thing* serves a
@@ -17,8 +17,8 @@
  *                 cost unless a host is deliberately shared.
  *   - site     -> served by the site handler (Track 2 SSR lands the full
  *                 contract; this returns a typed placeholder for now).
- *   - function -> recognized (with channel); full sync/page/webhook dispatch is
- *                 tracked separately. Returns a typed 501 for now.
+ *   - function -> recognized; full sync/page/webhook dispatch is tracked
+ *                 separately. Returns a typed 501 for now.
  *   - bucket   -> recognized; object serving is a follow-up. Typed 501.
  *   - service  -> recognized; the only target that may point at a customer-owned
  *                 workload in its own namespace. Typed 501.
@@ -56,38 +56,27 @@ export type HttpRouteTargetKind =
 
 export interface HttpRouteMatch {
   routeId: string;
+  databaseId: string;
   domainId: string;
   matchedPath: string;
   method: string | null;
   targetKind: HttpRouteTargetKind;
-  channel: string | null;
-  apiId: string | null;
-  siteId: string | null;
-  serviceId: string | null;
-  functionDefinitionId: string | null;
-  bucketId: string | null;
-  routeScope: string;
+  targetId: string;
 }
 
 interface ResolveHttpRouteRow {
   route_id: string | null;
+  database_id: string | null;
   domain_id: string | null;
   matched_path: string | null;
   method: string | null;
   target_kind: HttpRouteTargetKind | null;
-  channel: string | null;
-  api_id: string | null;
-  site_id: string | null;
-  service_id: string | null;
-  function_definition_id: string | null;
-  bucket_id: string | null;
-  route_scope: string | null;
+  target_id: string | null;
 }
 
 const RESOLVE_ROUTE_SQL = `
   SELECT
-    route_id, domain_id, matched_path, method, target_kind, channel,
-    api_id, site_id, service_id, function_definition_id, bucket_id, route_scope
+    route_id, database_id, domain_id, matched_path, method, target_kind, target_id
   FROM services_public.resolve_http_route($1, $2, $3)
 `;
 
@@ -110,20 +99,15 @@ export const getHttpRouteMode = (): HttpRouteMode => {
 };
 
 const toMatch = (row: ResolveHttpRouteRow): HttpRouteMatch | null => {
-  if (!row || !row.route_id || !row.target_kind) return null;
+  if (!row || !row.route_id || !row.target_kind || !row.target_id) return null;
   return {
     routeId: row.route_id,
+    databaseId: row.database_id ?? '',
     domainId: row.domain_id ?? '',
     matchedPath: row.matched_path ?? '',
     method: row.method,
     targetKind: row.target_kind,
-    channel: row.channel,
-    apiId: row.api_id,
-    siteId: row.site_id,
-    serviceId: row.service_id,
-    functionDefinitionId: row.function_definition_id,
-    bucketId: row.bucket_id,
-    routeScope: row.route_scope ?? ''
+    targetId: row.target_id
   };
 };
 
@@ -164,11 +148,7 @@ const sendNotImplemented = (
   res.status(501).json({
     error: 'Route target not yet served',
     targetKind: match.targetKind,
-    channel: match.channel,
-    routeScope: match.routeScope,
-    ...(match.functionDefinitionId ? { functionDefinitionId: match.functionDefinitionId } : {}),
-    ...(match.bucketId ? { bucketId: match.bucketId } : {}),
-    ...(match.serviceId ? { serviceId: match.serviceId } : {})
+    targetId: match.targetId
   });
 };
 
@@ -179,10 +159,10 @@ const sendSitePlaceholder = (res: Response, match: HttpRouteMatch): void => {
   res
     .status(200)
     .set('Content-Type', 'text/html; charset=utf-8')
-    .set('X-Constructive-Route', `site:${match.siteId ?? ''}`)
+    .set('X-Constructive-Route', `site:${match.targetId}`)
     .send(
       `<!doctype html><html><head><meta charset="utf-8"><title>site</title></head>` +
-        `<body data-site-id="${match.siteId ?? ''}" data-route-scope="${match.routeScope}">` +
+        `<body data-site-id="${match.targetId}">` +
         `<!-- resolved via services_public.resolve_http_route --></body></html>`
     );
 };
@@ -207,8 +187,7 @@ export const createRouteMiddleware = (opts: ApiOptions) => {
 
     if (mode === 'shadow') {
       log.debug(
-        `[shadow] ${req.method} ${host}${req.path} -> ${match.targetKind}` +
-          `${match.channel ? `:${match.channel}` : ''} (scope=${match.routeScope})`
+        `[shadow] ${req.method} ${host}${req.path} -> ${match.targetKind}:${match.targetId}`
       );
       return next();
     }
@@ -216,9 +195,7 @@ export const createRouteMiddleware = (opts: ApiOptions) => {
     // mode === 'on'
     switch (match.targetKind) {
     case 'api':
-      if (match.apiId) {
-        req.routeApiId = match.apiId;
-      }
+      req.routeApiId = match.targetId;
       return next();
     case 'site':
       return sendSitePlaceholder(res, match);

--- a/graphql/server/src/middleware/route.ts
+++ b/graphql/server/src/middleware/route.ts
@@ -1,0 +1,233 @@
+/**
+ * route — HTTP route resolution (Stage B)
+ *
+ * Consumes the database-side `services_public.resolve_http_route(host, path,
+ * method)` contract and turns a request into a typed target:
+ *
+ *   host + path + method  ->  { target_kind, channel, api_id, site_id, ... }
+ *
+ * This is the request-plane counterpart to the routing table that lives in
+ * constructive-db (PR #2214). The resolver decides *which typed thing* serves a
+ * request; this middleware performs the dispatch:
+ *
+ *   - api      -> stash req.routeApiId; the api middleware resolves that api by
+ *                 id and the request flows into the normal GraphQL path. This is
+ *                 the host-only fast path (api on its own subdomain) — a single
+ *                 default route per api, so there is no per-request path fan-out
+ *                 cost unless a host is deliberately shared.
+ *   - site     -> served by the site handler (Track 2 SSR lands the full
+ *                 contract; this returns a typed placeholder for now).
+ *   - function -> recognized (with channel); full sync/page/webhook dispatch is
+ *                 tracked separately. Returns a typed 501 for now.
+ *   - bucket   -> recognized; object serving is a follow-up. Typed 501.
+ *   - service  -> recognized; the only target that may point at a customer-owned
+ *                 workload in its own namespace. Typed 501.
+ *
+ * Safety: routes are unseeded by default (constructive-db PR #2217), so with no
+ * matching route this middleware is a no-op and the request falls through to the
+ * existing domain -> api resolution. Behavior is unchanged until routes exist.
+ *
+ * Mode (HTTP_ROUTE_RESOLVER_MODE, default "shadow"):
+ *   - off    : middleware does nothing.
+ *   - shadow : resolve + attach req.httpRoute + log, but never change behavior
+ *              (used to verify parity against the legacy host-router before flip).
+ *   - on     : dispatch on the resolved target.
+ */
+
+import './types';
+
+import { Logger } from '@pgpmjs/logger';
+import { NextFunction, Request, Response } from 'express';
+import { Pool } from 'pg';
+import { getPgPool } from 'pg-cache';
+
+import { ApiOptions } from '../types';
+
+const log = new Logger('route');
+
+export type HttpRouteMode = 'off' | 'shadow' | 'on';
+
+export type HttpRouteTargetKind =
+  | 'api'
+  | 'site'
+  | 'service'
+  | 'function'
+  | 'bucket';
+
+export interface HttpRouteMatch {
+  routeId: string;
+  domainId: string;
+  matchedPath: string;
+  method: string | null;
+  targetKind: HttpRouteTargetKind;
+  channel: string | null;
+  apiId: string | null;
+  siteId: string | null;
+  serviceId: string | null;
+  functionDefinitionId: string | null;
+  bucketId: string | null;
+  routeScope: string;
+}
+
+interface ResolveHttpRouteRow {
+  route_id: string | null;
+  domain_id: string | null;
+  matched_path: string | null;
+  method: string | null;
+  target_kind: HttpRouteTargetKind | null;
+  channel: string | null;
+  api_id: string | null;
+  site_id: string | null;
+  service_id: string | null;
+  function_definition_id: string | null;
+  bucket_id: string | null;
+  route_scope: string | null;
+}
+
+const RESOLVE_ROUTE_SQL = `
+  SELECT
+    route_id, domain_id, matched_path, method, target_kind, channel,
+    api_id, site_id, service_id, function_definition_id, bucket_id, route_scope
+  FROM services_public.resolve_http_route($1, $2, $3)
+`;
+
+// Postgres error codes that mean "this database predates the route resolver".
+// Treated as "no route" so the request always falls back to the legacy path.
+const RESOLVER_ABSENT_CODES = new Set(['42883', '42P01', '3F000', '42P04']);
+
+const VALID_MODES: readonly HttpRouteMode[] = ['off', 'shadow', 'on'];
+
+/**
+ * Prototype feature flag. Read once from the environment in a single place;
+ * this graduates into the typed env-options system when Stage B is promoted
+ * out of prototype.
+ */
+export const getHttpRouteMode = (): HttpRouteMode => {
+  const raw = (process.env.HTTP_ROUTE_RESOLVER_MODE ?? 'shadow').toLowerCase();
+  return (VALID_MODES as readonly string[]).includes(raw)
+    ? (raw as HttpRouteMode)
+    : 'shadow';
+};
+
+const toMatch = (row: ResolveHttpRouteRow): HttpRouteMatch | null => {
+  if (!row || !row.route_id || !row.target_kind) return null;
+  return {
+    routeId: row.route_id,
+    domainId: row.domain_id ?? '',
+    matchedPath: row.matched_path ?? '',
+    method: row.method,
+    targetKind: row.target_kind,
+    channel: row.channel,
+    apiId: row.api_id,
+    siteId: row.site_id,
+    serviceId: row.service_id,
+    functionDefinitionId: row.function_definition_id,
+    bucketId: row.bucket_id,
+    routeScope: row.route_scope ?? ''
+  };
+};
+
+/**
+ * Resolve a request to a typed route target, or null when nothing matches.
+ * Never throws: a missing resolver (un-migrated database) or any query error
+ * resolves to null so the caller falls back to legacy behavior.
+ */
+export const resolveHttpRoute = async (
+  pool: Pool,
+  host: string,
+  path: string,
+  method: string
+): Promise<HttpRouteMatch | null> => {
+  if (!host) return null;
+  try {
+    const { rows } = await pool.query<ResolveHttpRouteRow>(RESOLVE_ROUTE_SQL, [
+      host,
+      path || '/',
+      method || 'GET'
+    ]);
+    return rows[0] ? toMatch(rows[0]) : null;
+  } catch (err: unknown) {
+    const code = (err as { code?: string })?.code;
+    if (code && RESOLVER_ABSENT_CODES.has(code)) {
+      log.debug(`resolve_http_route unavailable (code=${code}); falling back`);
+      return null;
+    }
+    log.debug(`resolve_http_route error: ${(err as Error)?.message}; falling back`);
+    return null;
+  }
+};
+
+const sendNotImplemented = (
+  res: Response,
+  match: HttpRouteMatch
+): void => {
+  res.status(501).json({
+    error: 'Route target not yet served',
+    targetKind: match.targetKind,
+    channel: match.channel,
+    routeScope: match.routeScope,
+    ...(match.functionDefinitionId ? { functionDefinitionId: match.functionDefinitionId } : {}),
+    ...(match.bucketId ? { bucketId: match.bucketId } : {}),
+    ...(match.serviceId ? { serviceId: match.serviceId } : {})
+  });
+};
+
+const sendSitePlaceholder = (res: Response, match: HttpRouteMatch): void => {
+  // Track 2 (sites SSR) lands the real rendering + deep-link/SEO contract.
+  // Until then a resolved site target returns a typed, cacheable placeholder
+  // rather than a 404, so routing is demonstrably wired end to end.
+  res
+    .status(200)
+    .set('Content-Type', 'text/html; charset=utf-8')
+    .set('X-Constructive-Route', `site:${match.siteId ?? ''}`)
+    .send(
+      `<!doctype html><html><head><meta charset="utf-8"><title>site</title></head>` +
+        `<body data-site-id="${match.siteId ?? ''}" data-route-scope="${match.routeScope}">` +
+        `<!-- resolved via services_public.resolve_http_route --></body></html>`
+    );
+};
+
+/**
+ * Express middleware. Mounted after domain parsing and before the api
+ * middleware so an `api` target can hand the resolved api id downstream.
+ */
+export const createRouteMiddleware = (opts: ApiOptions) => {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const mode = getHttpRouteMode();
+    if (mode === 'off' || opts.api?.enableServicesApi === false) {
+      return next();
+    }
+
+    const host = req.get('host') ?? '';
+    const match = await resolveHttpRoute(getPgPool(opts.pg), host, req.path, req.method);
+
+    req.httpRoute = match ?? undefined;
+
+    if (!match) return next();
+
+    if (mode === 'shadow') {
+      log.debug(
+        `[shadow] ${req.method} ${host}${req.path} -> ${match.targetKind}` +
+          `${match.channel ? `:${match.channel}` : ''} (scope=${match.routeScope})`
+      );
+      return next();
+    }
+
+    // mode === 'on'
+    switch (match.targetKind) {
+    case 'api':
+      if (match.apiId) {
+        req.routeApiId = match.apiId;
+      }
+      return next();
+    case 'site':
+      return sendSitePlaceholder(res, match);
+    case 'function':
+    case 'bucket':
+    case 'service':
+      return sendNotImplemented(res, match);
+    default:
+      return next();
+    }
+  };
+};

--- a/graphql/server/src/middleware/types.ts
+++ b/graphql/server/src/middleware/types.ts
@@ -1,4 +1,5 @@
 import type { ApiStructure } from '../types';
+import type { HttpRouteMatch } from './route';
 
 export type ConstructiveAPIToken = {
   id?: string;
@@ -18,6 +19,10 @@ declare global {
       clientIp?: string;
       databaseId?: string;
       requestId?: string;
+      /** Typed target resolved by services_public.resolve_http_route (Stage B). */
+      httpRoute?: HttpRouteMatch;
+      /** api id chosen by an `api` route target; consumed by the api middleware. */
+      routeApiId?: string;
       token?: ConstructiveAPIToken;
       /** Device token from constructive_device_token cookie for trusted device tracking */
       deviceToken?: string;

--- a/graphql/server/src/server.ts
+++ b/graphql/server/src/server.ts
@@ -31,6 +31,7 @@ import { createFnRouter } from './middleware/fn';
 import { flush, flushService } from './middleware/flush';
 import { graphile } from './middleware/graphile';
 import { multipartBridge } from './middleware/multipart-bridge';
+import { createRouteMiddleware } from './middleware/route';
 import { createDebugDatabaseMiddleware } from './middleware/observability/debug-db';
 import { debugMemory } from './middleware/observability/debug-memory';
 import { localObservabilityOnly } from './middleware/observability/guard';
@@ -163,6 +164,10 @@ class Server {
     app.use(requestIp.mw());
     app.use(requestIdMiddleware());
     app.use(requestLogger);
+    // Stage B: resolve host+path+method to a typed target via
+    // services_public.resolve_http_route. An `api` target sets req.routeApiId
+    // (consumed by `api` below); with no match it falls through unchanged.
+    app.use(createRouteMiddleware(effectiveOpts));
     app.use(api);
     app.use(authenticate);
     app.use(createContextMiddleware({ pg: effectiveOpts.pg, loaders: createDefaultRegistry() }));


### PR DESCRIPTION
## Summary

Stage B wires the constructive-db routing table (`services_public.resolve_http_route`, PR #2214) into the GraphQL server as an **opt-in request-plane router**. A hostname is no longer a 1→1 pointer to an API — host + path + method now resolve to a typed target (`api` / `site` / `function` / `bucket` / `service`), all served from **shared platform apps** (tenant isolation stays `database_id` + RLS; no per-customer namespace).

Crucially this is **backward-compatible and off-by-default-behavior**: routes are unseeded in production, and any no-match / un-migrated database / resolver error falls through to the existing `domain → api` lookup. GraphQL, GraphiQL, auth, cookies, CORS, health and WS transport are untouched.

### Request flow

```
request(host, path, method)
  → parseDomains
  → createRouteMiddleware      # NEW: resolve_http_route(host, path, method)
      off    → next()
      shadow → attach req.httpRoute + log, then next()   (parity check, no behavior change)
      on     → api      → req.routeApiId = api_id; next()  → api middleware resolves API by id
               site     → typed placeholder (Track 2 SSR lands real render)
               function → typed 501 (+channel)
               bucket   → typed 501
               service  → typed 501   (only target that may point at a customer namespace)
               no match → next()  → legacy domain→api
  → api → authenticate → context → graphile
```

### API-by-id resolution (new path in `middleware/api.ts`)

```ts
// getApiConfig: an `api` route target selects the API by id, cached under a
// dedicated key so it never collides with host/header resolution.
const routeApiId = req.routeApiId ?? null;
const cacheKey = routeApiId ? `route-api:${routeApiId}` : getSvcKey(opts, req);

// determineMode: route target takes precedence over host/header heuristics
if (ctx.routeApiId) return 'route-api';   // → resolveByRouteApi → SELECT ... WHERE a.id = $1
```

Mode is read from `HTTP_ROUTE_RESOLVER_MODE` (`off` | `shadow` | `on`, default `shadow`) — a prototype flag documented to graduate into the typed `getEnvOptions` system when Stage B is promoted out of prototype.

### Safety / non-goals

- No default route seeding (honors constructive-db PR #2217 "leave HTTP routes unseeded").
- `resolveHttpRoute` never throws: absent-resolver Postgres codes (`42883`/`42P01`/`3F000`/`42P04`) and any query error resolve to `null` → legacy fallthrough.
- site/function/bucket/service dispatch is intentionally a **typed placeholder / 501**, not real forwarding — no closed-source gateway logic enters this repo.
- No `constructive-db` change needed; the resolver contract already exists there.

### Tests

- `middleware/__tests__/route.test.ts` — mode parsing, row→match mapping, absent-resolver fallback, off/shadow/on dispatch (12).
- `middleware/__tests__/api.test.ts` — new: resolves + caches by `api_id` under `route-api:<id>` key.
- `server-test/__tests__/route-stageb.integration.test.ts` — real server + SuperTest: shadow safety, `on` site placeholder + prefix match, function typed 501, unrouted `/graphql` legacy fallthrough, `off` no-op (7).
- Fixture route tables + `resolve_http_route` mirror added to `__fixtures__/seed/services/`.

Local: `graphql/server` 121/121, `graphql/server-test` route+existing suites green (upload suite failures are a pre-existing MinIO/upload-plugin env gap, verified identical on `main`).


Link to Devin session: https://app.devin.ai/sessions/6a56839376234d2898022fd95e0d0ccd
Requested by: @pyramation