### PR TITLE
feat(server): environment-aware routing (local vs production)

### DIFF
--- a/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
+++ b/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
@@ -107,6 +107,15 @@ exports[`getEnvOptions merges pgpm defaults, graphql defaults, config, env, and 
     "port": 5432,
     "user": "env-user",
   },
+  "routing": {
+    "localHostSuffixes": [
+      "localhost",
+      "127.0.0.1",
+      "::1",
+      ".local",
+      ".test",
+    ],
+  },
   "server": {
     "host": "localhost",
     "port": 5000,

--- a/graphql/env/src/env.ts
+++ b/graphql/env/src/env.ts
@@ -1,4 +1,4 @@
-import { ConstructiveOptions } from '@constructive-io/graphql-types';
+import { ConstructiveOptions, HttpRouteMode, RoutingEnv } from '@constructive-io/graphql-types';
 
 /**
  * Parse GraphQL-related environment variables.
@@ -7,6 +7,25 @@ import { ConstructiveOptions } from '@constructive-io/graphql-types';
 const parseEnvBoolean = (val?: string): boolean | undefined => {
   if (val === undefined) return undefined;
   return ['true', '1', 'yes'].includes(val.toLowerCase());
+};
+
+const VALID_ROUTE_MODES: readonly HttpRouteMode[] = ['off', 'shadow', 'on'];
+const VALID_ROUTING_ENVS: readonly RoutingEnv[] = ['local', 'production'];
+
+const parseRouteMode = (val?: string): HttpRouteMode | undefined => {
+  if (val === undefined) return undefined;
+  const lower = val.toLowerCase();
+  return (VALID_ROUTE_MODES as readonly string[]).includes(lower)
+    ? (lower as HttpRouteMode)
+    : undefined;
+};
+
+const parseRoutingEnv = (val?: string): RoutingEnv | undefined => {
+  if (val === undefined) return undefined;
+  const lower = val.toLowerCase();
+  return (VALID_ROUTING_ENVS as readonly string[]).includes(lower)
+    ? (lower as RoutingEnv)
+    : undefined;
 };
 
 /**
@@ -34,9 +53,26 @@ export const getGraphQLEnvVars = (env: NodeJS.ProcessEnv = process.env): Partial
     CHAT_PROVIDER,
     CHAT_MODEL,
     CHAT_BASE_URL,
+
+    HTTP_ROUTE_RESOLVER_MODE,
+    ROUTING_ENV,
+    ROUTING_LOCAL_HOST_SUFFIXES,
   } = env;
 
+  const routeMode = parseRouteMode(HTTP_ROUTE_RESOLVER_MODE);
+  const routingEnv = parseRoutingEnv(ROUTING_ENV);
+  const localHostSuffixes = ROUTING_LOCAL_HOST_SUFFIXES
+    ? ROUTING_LOCAL_HOST_SUFFIXES.split(',').map(s => s.trim()).filter(Boolean)
+    : undefined;
+
   return {
+    ...((routeMode || routingEnv || localHostSuffixes) && {
+      routing: {
+        ...(routeMode && { mode: routeMode }),
+        ...(routingEnv && { env: routingEnv }),
+        ...(localHostSuffixes && { localHostSuffixes }),
+      },
+    }),
     graphile: {
       ...(GRAPHILE_SCHEMA && {
         schema: GRAPHILE_SCHEMA.includes(',')

--- a/graphql/server-test/__tests__/route-env.integration.test.ts
+++ b/graphql/server-test/__tests__/route-env.integration.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Routing environment (local vs production) integration tests.
+ *
+ * Drives the real GraphQL server through SuperTest to prove the developer-
+ * experience behaviors that let host-based routing work on a laptop without
+ * real DNS / domain verification / TLS:
+ *
+ *   - Host normalization: a Host header carrying a port (app.test...:5678, the
+ *     normal shape on localhost) still matches an unported domain row and
+ *     dispatches — without this, host routing is unusable in local dev.
+ *   - Secure-context simulation: in `local` env a plain-HTTP request to a public
+ *     host is treated as secure (TLS simulated); in `production` the same request
+ *     is flagged insecure unless X-Forwarded-Proto=https. Known local hosts are
+ *     always secure.
+ *
+ * mode + env are read per-request from HTTP_ROUTE_RESOLVER_MODE / ROUTING_ENV.
+ *
+ * Run tests:
+ *   pnpm test -- --testPathPattern=route-env.integration
+ */
+
+import path from 'path';
+import { getConnections, seed } from '../src';
+import type supertest from 'supertest';
+
+jest.setTimeout(30000);
+
+const sharedSeedRoot = path.join(__dirname, '..', '..', '..', '__fixtures__', 'seed');
+const shared = (...segments: string[]) => path.join(sharedSeedRoot, ...segments);
+
+const schemas = ['simple-pets-public', 'simple-pets-pets-public'];
+const metaSchemas = ['services_public', 'metaschema_public', 'metaschema_modules_public'];
+
+const seedFiles = [
+  shared('services', 'setup.sql'),
+  shared('app-schemas', 'simple-pets', 'schema.sql'),
+  shared('services', 'test-data.sql'),
+  shared('app-schemas', 'simple-pets', 'test-data.sql'),
+  shared('services', 'routes.sql'),
+];
+
+const API_HOST = 'app.test.constructive.io';
+const SITE_ID = '90000000-0000-4000-8000-000000000001';
+
+let request: supertest.Agent;
+let teardown: () => Promise<void>;
+
+const OLD_MODE = process.env.HTTP_ROUTE_RESOLVER_MODE;
+const OLD_ENV = process.env.ROUTING_ENV;
+const setMode = (mode: string) => {
+  process.env.HTTP_ROUTE_RESOLVER_MODE = mode;
+};
+const setEnv = (env: string) => {
+  process.env.ROUTING_ENV = env;
+};
+
+beforeAll(async () => {
+  ({ request, teardown } = await getConnections(
+    {
+      schemas,
+      authRole: 'anonymous',
+      server: {
+        api: {
+          enableServicesApi: true,
+          isPublic: true,
+          metaSchemas,
+        },
+      },
+    },
+    [seed.sqlfile(seedFiles)]
+  ));
+});
+
+afterAll(async () => {
+  process.env.HTTP_ROUTE_RESOLVER_MODE = OLD_MODE;
+  process.env.ROUTING_ENV = OLD_ENV;
+  await teardown();
+});
+
+describe('host normalization (local dev unblocker)', () => {
+  beforeAll(() => setMode('on'));
+
+  it('matches a ported Host header against an unported domain row', async () => {
+    // The Host on localhost is typically "host:port". Pre-normalization this
+    // would NOT match the "app.test.constructive.io" domain row -> 404.
+    const res = await request.get('/welcome').set('Host', `${API_HOST}:5678`);
+    expect(res.status).toBe(200);
+    expect(res.headers['x-constructive-route']).toBe(`site:${SITE_ID}`);
+  });
+
+  it('is case-insensitive on the host', async () => {
+    const res = await request.get('/welcome').set('Host', 'App.Test.Constructive.IO:443');
+    expect(res.status).toBe(200);
+    expect(res.headers['x-constructive-route']).toBe(`site:${SITE_ID}`);
+  });
+});
+
+describe('secure-context simulation (local vs production)', () => {
+  // Use shadow mode: behavior is unchanged, but the router still annotates the
+  // environment + secure decision, so we can compare local vs production on the
+  // exact same plain-HTTP request.
+  beforeAll(() => setMode('shadow'));
+
+  it('local: a plain-HTTP request to a public host is annotated secure', async () => {
+    setEnv('local');
+    const res = await request
+      .post('/graphql')
+      .set('Host', API_HOST)
+      .send({ query: '{ __typename }' });
+
+    expect(res.status).toBe(200); // behavior preserved
+    expect(res.headers['x-constructive-route-env']).toBe('local');
+    expect(res.headers['x-constructive-route-secure']).toBe('true');
+  });
+
+  it('production: the SAME plain-HTTP request to the SAME host is flagged insecure', async () => {
+    setEnv('production');
+    const res = await request
+      .post('/graphql')
+      .set('Host', API_HOST)
+      .send({ query: '{ __typename }' });
+
+    expect(res.status).toBe(200); // behavior still preserved
+    expect(res.headers['x-constructive-route-env']).toBe('production');
+    expect(res.headers['x-constructive-route-secure']).toBe('false');
+  });
+
+  it('production: X-Forwarded-Proto=https is honored as secure', async () => {
+    setEnv('production');
+    const res = await request
+      .post('/graphql')
+      .set('Host', API_HOST)
+      .set('X-Forwarded-Proto', 'https')
+      .send({ query: '{ __typename }' });
+
+    expect(res.headers['x-constructive-route-env']).toBe('production');
+    expect(res.headers['x-constructive-route-secure']).toBe('true');
+  });
+
+  it('production: a known local dev host is always secure (TLS never blocks localhost)', async () => {
+    setEnv('production');
+    const res = await request.post('/graphql').set('Host', 'app.localhost:3000').send({ query: '{ __typename }' });
+
+    expect(res.headers['x-constructive-route-env']).toBe('production');
+    expect(res.headers['x-constructive-route-secure']).toBe('true');
+  });
+});

--- a/graphql/server/src/middleware/__tests__/route.test.ts
+++ b/graphql/server/src/middleware/__tests__/route.test.ts
@@ -10,15 +10,24 @@ import type { ApiOptions } from '../../types';
 import {
   createRouteMiddleware,
   getHttpRouteMode,
-  resolveHttpRoute
+  isLocalHost,
+  isSecureRequest,
+  normalizeHost,
+  resolveHttpRoute,
+  resolveRouteMode,
+  resolveRoutingEnv
 } from '../route';
 
 const mockGetPgPool = getPgPool as jest.MockedFunction<typeof getPgPool>;
 
-const OLD_ENV = process.env.HTTP_ROUTE_RESOLVER_MODE;
+const OLD_MODE = process.env.HTTP_ROUTE_RESOLVER_MODE;
+const OLD_ROUTING_ENV = process.env.ROUTING_ENV;
+const OLD_NODE_ENV = process.env.NODE_ENV;
 
 afterAll(() => {
-  process.env.HTTP_ROUTE_RESOLVER_MODE = OLD_ENV;
+  process.env.HTTP_ROUTE_RESOLVER_MODE = OLD_MODE;
+  process.env.ROUTING_ENV = OLD_ROUTING_ENV;
+  process.env.NODE_ENV = OLD_NODE_ENV;
 });
 
 const routeRow = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
@@ -49,11 +58,23 @@ const poolThrowing = (code: string): Pool => ({
   })
 } as unknown as Pool);
 
-const createRequest = (host: string, path: string, method: string): Request =>
+const createRequest = (
+  host: string,
+  path: string,
+  method: string,
+  extraHeaders: Record<string, string> = {},
+  protocol = 'http'
+): Request =>
   ({
     method,
     path,
-    get: (name: string) => (name.toLowerCase() === 'host' ? host : undefined)
+    protocol,
+    secure: protocol === 'https',
+    get: (name: string) => {
+      const key = name.toLowerCase();
+      if (key === 'host') return host;
+      return extraHeaders[key];
+    }
   } as unknown as Request);
 
 const createResponse = () => {
@@ -98,6 +119,83 @@ describe('getHttpRouteMode', () => {
     expect(getHttpRouteMode()).toBe('on');
     process.env.HTTP_ROUTE_RESOLVER_MODE = 'off';
     expect(getHttpRouteMode()).toBe('off');
+  });
+});
+
+describe('normalizeHost', () => {
+  it('lowercases and strips the port', () => {
+    expect(normalizeHost('App.Localhost:5678')).toBe('app.localhost');
+    expect(normalizeHost('acme.test.constructive.io:443')).toBe('acme.test.constructive.io');
+  });
+  it('leaves a bare host unchanged', () => {
+    expect(normalizeHost('acme.test')).toBe('acme.test');
+  });
+  it('keeps an IPv6 literal (drops only the port)', () => {
+    expect(normalizeHost('[::1]:3000')).toBe('[::1]');
+  });
+  it('returns empty string for empty input', () => {
+    expect(normalizeHost('')).toBe('');
+  });
+});
+
+describe('isLocalHost', () => {
+  const suffixes = ['localhost', '127.0.0.1', '::1', '.local', '.test'];
+  it('matches localhost and its subdomains', () => {
+    expect(isLocalHost('localhost', suffixes)).toBe(true);
+    expect(isLocalHost('app.localhost', suffixes)).toBe(true);
+  });
+  it('matches dotted dev suffixes', () => {
+    expect(isLocalHost('acme.test', suffixes)).toBe(true);
+    expect(isLocalHost('foo.local', suffixes)).toBe(true);
+  });
+  it('matches loopback literals', () => {
+    expect(isLocalHost('127.0.0.1', suffixes)).toBe(true);
+    expect(isLocalHost('[::1]', suffixes)).toBe(true);
+  });
+  it('does not match a public host', () => {
+    expect(isLocalHost('acme.constructive.io', suffixes)).toBe(false);
+  });
+});
+
+describe('resolveRouteMode / resolveRoutingEnv precedence', () => {
+  it('env var HTTP_ROUTE_RESOLVER_MODE wins over typed config', () => {
+    process.env.HTTP_ROUTE_RESOLVER_MODE = 'on';
+    expect(resolveRouteMode({ routing: { mode: 'off' } } as unknown as ApiOptions)).toBe('on');
+  });
+  it('falls back to typed config when env var unset', () => {
+    delete process.env.HTTP_ROUTE_RESOLVER_MODE;
+    expect(resolveRouteMode({ routing: { mode: 'on' } } as unknown as ApiOptions)).toBe('on');
+  });
+  it('ROUTING_ENV wins, then config, then NODE_ENV', () => {
+    process.env.ROUTING_ENV = 'production';
+    expect(resolveRoutingEnv({ routing: { env: 'local' } } as unknown as ApiOptions)).toBe('production');
+    delete process.env.ROUTING_ENV;
+    expect(resolveRoutingEnv({ routing: { env: 'local' } } as unknown as ApiOptions)).toBe('local');
+    delete (process.env as Record<string, string | undefined>).ROUTING_ENV;
+    process.env.NODE_ENV = 'production';
+    expect(resolveRoutingEnv({} as unknown as ApiOptions)).toBe('production');
+    process.env.NODE_ENV = 'test';
+    expect(resolveRoutingEnv({} as unknown as ApiOptions)).toBe('local');
+  });
+});
+
+describe('isSecureRequest (local vs production)', () => {
+  const suffixes = ['localhost', '127.0.0.1', '::1', '.local', '.test'];
+  it('local env: a public host over plain http is treated as secure (TLS simulated)', () => {
+    const req = createRequest('acme.constructive.io', '/', 'GET', {}, 'http');
+    expect(isSecureRequest(req, 'local', 'acme.constructive.io', suffixes)).toBe(true);
+  });
+  it('production env: same public host over plain http is NOT secure', () => {
+    const req = createRequest('acme.constructive.io', '/', 'GET', {}, 'http');
+    expect(isSecureRequest(req, 'production', 'acme.constructive.io', suffixes)).toBe(false);
+  });
+  it('production env: X-Forwarded-Proto=https is secure', () => {
+    const req = createRequest('acme.constructive.io', '/', 'GET', { 'x-forwarded-proto': 'https' }, 'http');
+    expect(isSecureRequest(req, 'production', 'acme.constructive.io', suffixes)).toBe(true);
+  });
+  it('production env: a local dev host is always secure', () => {
+    const req = createRequest('app.localhost', '/', 'GET', {}, 'http');
+    expect(isSecureRequest(req, 'production', 'app.localhost', suffixes)).toBe(true);
   });
 });
 
@@ -203,5 +301,40 @@ describe('createRouteMiddleware', () => {
     await createRouteMiddleware(opts)(req, createResponse() as Response, next);
     expect(next).toHaveBeenCalled();
     expect(req.routeApiId).toBeUndefined();
+  });
+
+  it('normalizes the host (drops the port) before resolving', async () => {
+    process.env.HTTP_ROUTE_RESOLVER_MODE = 'on';
+    const pool = poolReturning([routeRow()]);
+    mockGetPgPool.mockReturnValue(pool);
+    const req = createRequest('acme.test:5678', '/graphql', 'POST');
+    await createRouteMiddleware(opts)(req, createResponse() as Response, jest.fn() as NextFunction);
+    expect(pool.query).toHaveBeenCalledWith(expect.any(String), ['acme.test', '/graphql', 'POST']);
+  });
+
+  it('annotates env + secure headers; local treats http public host as secure', async () => {
+    delete process.env.ROUTING_ENV;
+    process.env.NODE_ENV = 'test';
+    process.env.HTTP_ROUTE_RESOLVER_MODE = 'shadow';
+    mockGetPgPool.mockReturnValue(poolReturning([]));
+    const req = createRequest('acme.constructive.io', '/graphql', 'POST', {}, 'http');
+    const res = createResponse();
+    await createRouteMiddleware(opts)(req, res as Response, jest.fn() as NextFunction);
+    expect(req.routeEnv).toBe('local');
+    expect(req.routeSecure).toBe(true);
+    expect(res.headers['X-Constructive-Route-Env']).toBe('local');
+    expect(res.headers['X-Constructive-Route-Secure']).toBe('true');
+  });
+
+  it('production: same http public host is flagged insecure', async () => {
+    process.env.HTTP_ROUTE_RESOLVER_MODE = 'shadow';
+    mockGetPgPool.mockReturnValue(poolReturning([]));
+    const prodOpts = { ...opts, routing: { env: 'production' } } as unknown as ApiOptions;
+    const req = createRequest('acme.constructive.io', '/graphql', 'POST', {}, 'http');
+    const res = createResponse();
+    await createRouteMiddleware(prodOpts)(req, res as Response, jest.fn() as NextFunction);
+    expect(req.routeEnv).toBe('production');
+    expect(req.routeSecure).toBe(false);
+    expect(res.headers['X-Constructive-Route-Secure']).toBe('false');
   });
 });

--- a/graphql/server/src/middleware/route.ts
+++ b/graphql/server/src/middleware/route.ts
@@ -27,15 +27,25 @@
  * matching route this middleware is a no-op and the request falls through to the
  * existing domain -> api resolution. Behavior is unchanged until routes exist.
  *
- * Mode (HTTP_ROUTE_RESOLVER_MODE, default "shadow"):
+ * Mode (routing.mode, or HTTP_ROUTE_RESOLVER_MODE, default "shadow"):
  *   - off    : middleware does nothing.
  *   - shadow : resolve + attach req.httpRoute + log, but never change behavior
  *              (used to verify parity against the legacy host-router before flip).
  *   - on     : dispatch on the resolved target.
+ *
+ * Deployment environment (routing.env, or ROUTING_ENV, derived from NODE_ENV):
+ *   - local      : developer machine. Ingress concerns that cannot work on
+ *                  localhost (public DNS domain verification, ACME/HTTPS certs)
+ *                  are simulated as satisfied, so a laptop serving plain HTTP is
+ *                  never blocked. The request is always treated as secure.
+ *   - production : secure context is derived from the request (X-Forwarded-Proto
+ *                  / req.protocol), not assumed. Known local dev hosts are still
+ *                  treated as secure so mixed setups don't break.
  */
 
 import './types';
 
+import type { HttpRouteMode, RoutingEnv } from '@constructive-io/graphql-types';
 import { Logger } from '@pgpmjs/logger';
 import { NextFunction, Request, Response } from 'express';
 import { Pool } from 'pg';
@@ -45,7 +55,8 @@ import { ApiOptions } from '../types';
 
 const log = new Logger('route');
 
-export type HttpRouteMode = 'off' | 'shadow' | 'on';
+// Re-export routing types so existing importers of this module keep working.
+export type { HttpRouteMode, RoutingEnv };
 
 export type HttpRouteTargetKind =
   | 'api'
@@ -96,17 +107,99 @@ const RESOLVE_ROUTE_SQL = `
 const RESOLVER_ABSENT_CODES = new Set(['42883', '42P01', '3F000', '42P04']);
 
 const VALID_MODES: readonly HttpRouteMode[] = ['off', 'shadow', 'on'];
+const VALID_ENVS: readonly RoutingEnv[] = ['local', 'production'];
+
+const DEFAULT_LOCAL_HOST_SUFFIXES = [
+  'localhost',
+  '127.0.0.1',
+  '::1',
+  '.local',
+  '.test'
+];
 
 /**
- * Prototype feature flag. Read once from the environment in a single place;
- * this graduates into the typed env-options system when Stage B is promoted
- * out of prototype.
+ * Resolve the dispatch mode. Precedence: explicit HTTP_ROUTE_RESOLVER_MODE env
+ * var (runtime override) > typed `routing.mode` config > default `shadow`.
+ * The env var keeps highest precedence so operators (and tests) can flip mode
+ * at runtime without rebuilding config.
  */
-export const getHttpRouteMode = (): HttpRouteMode => {
-  const raw = (process.env.HTTP_ROUTE_RESOLVER_MODE ?? 'shadow').toLowerCase();
-  return (VALID_MODES as readonly string[]).includes(raw)
-    ? (raw as HttpRouteMode)
-    : 'shadow';
+export const resolveRouteMode = (opts?: ApiOptions): HttpRouteMode => {
+  const raw = (process.env.HTTP_ROUTE_RESOLVER_MODE ?? '').toLowerCase();
+  if ((VALID_MODES as readonly string[]).includes(raw)) return raw as HttpRouteMode;
+  const configured = opts?.routing?.mode;
+  if (configured && (VALID_MODES as readonly string[]).includes(configured)) {
+    return configured;
+  }
+  return 'shadow';
+};
+
+/** Back-compat alias (no-arg): reads env var / default only. */
+export const getHttpRouteMode = (): HttpRouteMode => resolveRouteMode();
+
+/**
+ * Resolve the deployment environment. Precedence: ROUTING_ENV env var > typed
+ * `routing.env` config > derived from NODE_ENV (production when
+ * NODE_ENV==='production', otherwise local).
+ */
+export const resolveRoutingEnv = (opts?: ApiOptions): RoutingEnv => {
+  const raw = (process.env.ROUTING_ENV ?? '').toLowerCase();
+  if ((VALID_ENVS as readonly string[]).includes(raw)) return raw as RoutingEnv;
+  const configured = opts?.routing?.env;
+  if (configured && (VALID_ENVS as readonly string[]).includes(configured)) {
+    return configured;
+  }
+  return process.env.NODE_ENV === 'production' ? 'production' : 'local';
+};
+
+const resolveLocalHostSuffixes = (opts?: ApiOptions): string[] => {
+  const configured = opts?.routing?.localHostSuffixes;
+  return configured && configured.length ? configured : DEFAULT_LOCAL_HOST_SUFFIXES;
+};
+
+/**
+ * Normalize an incoming Host header for domain matching: lowercase and drop the
+ * port. Without this a local request to `app.localhost:5678` would never match
+ * a `app.localhost` domain row — the single biggest blocker to exercising
+ * host-based routing on a developer machine.
+ */
+export const normalizeHost = (host: string): string => {
+  const trimmed = (host ?? '').trim().toLowerCase();
+  if (!trimmed) return '';
+  // IPv6 literal, e.g. "[::1]:3000" -> "[::1]"
+  if (trimmed.startsWith('[')) {
+    const close = trimmed.indexOf(']');
+    return close === -1 ? trimmed : trimmed.slice(0, close + 1);
+  }
+  const colon = trimmed.indexOf(':');
+  return colon === -1 ? trimmed : trimmed.slice(0, colon);
+};
+
+/** Whether a normalized host is a known local development host. */
+export const isLocalHost = (host: string, suffixes: string[]): boolean => {
+  const bare = host.replace(/^\[|\]$/g, '');
+  return suffixes.some((suffix) => {
+    const s = suffix.toLowerCase();
+    if (s.startsWith('.')) return host.endsWith(s);
+    return host === s || bare === s || host.endsWith(`.${s}`);
+  });
+};
+
+/**
+ * Whether the request should be treated as a secure (TLS) context. In `local`
+ * env TLS is simulated as satisfied; known local hosts are always secure; in
+ * `production` the scheme is derived from X-Forwarded-Proto / req.protocol.
+ */
+export const isSecureRequest = (
+  req: Request,
+  env: RoutingEnv,
+  host: string,
+  suffixes: string[]
+): boolean => {
+  if (isLocalHost(host, suffixes)) return true;
+  if (env === 'local') return true;
+  const forwarded = (req.get('x-forwarded-proto') ?? '').split(',')[0].trim().toLowerCase();
+  if (forwarded) return forwarded === 'https';
+  return req.protocol === 'https' || req.secure === true;
 };
 
 const toMatch = (row: ResolveHttpRouteRow): HttpRouteMatch | null => {
@@ -192,13 +285,21 @@ const sendSitePlaceholder = (res: Response, match: HttpRouteMatch): void => {
  * middleware so an `api` target can hand the resolved api id downstream.
  */
 export const createRouteMiddleware = (opts: ApiOptions) => {
+  const suffixes = resolveLocalHostSuffixes(opts);
   return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    const mode = getHttpRouteMode();
+    const mode = resolveRouteMode(opts);
     if (mode === 'off' || opts.api?.enableServicesApi === false) {
       return next();
     }
 
-    const host = req.get('host') ?? '';
+    const host = normalizeHost(req.get('host') ?? '');
+    const env = resolveRoutingEnv(opts);
+    const secure = isSecureRequest(req, env, host, suffixes);
+    req.routeEnv = env;
+    req.routeSecure = secure;
+    res.set('X-Constructive-Route-Env', env);
+    res.set('X-Constructive-Route-Secure', String(secure));
+
     const match = await resolveHttpRoute(getPgPool(opts.pg), host, req.path, req.method);
 
     req.httpRoute = match ?? undefined;
@@ -208,7 +309,7 @@ export const createRouteMiddleware = (opts: ApiOptions) => {
     if (mode === 'shadow') {
       log.debug(
         `[shadow] ${req.method} ${host}${req.path} -> ${match.targetKind}` +
-          `${match.channel ? `:${match.channel}` : ''} (scope=${match.routeScope})`
+          `${match.channel ? `:${match.channel}` : ''} (scope=${match.routeScope}, env=${env}, secure=${secure})`
       );
       return next();
     }

--- a/graphql/server/src/middleware/types.ts
+++ b/graphql/server/src/middleware/types.ts
@@ -1,3 +1,5 @@
+import type { RoutingEnv } from '@constructive-io/graphql-types';
+
 import type { ApiStructure } from '../types';
 import type { HttpRouteMatch } from './route';
 
@@ -23,6 +25,10 @@ declare global {
       httpRoute?: HttpRouteMatch;
       /** api id chosen by an `api` route target; consumed by the api middleware. */
       routeApiId?: string;
+      /** Routing deployment environment resolved for this request (local | production). */
+      routeEnv?: RoutingEnv;
+      /** Whether the request is served over a secure context (TLS real or simulated locally). */
+      routeSecure?: boolean;
       token?: ConstructiveAPIToken;
       /** Device token from constructive_device_token cookie for trusted device tracking */
       deviceToken?: string;

--- a/graphql/server/src/types.ts
+++ b/graphql/server/src/types.ts
@@ -1,5 +1,5 @@
+import type { ApiOptions as ApiConfig, RoutingOptions } from '@constructive-io/graphql-types';
 import type { PgpmOptions } from '@pgpmjs/types';
-import type { ApiOptions as ApiConfig } from '@constructive-io/graphql-types';
 
 // Re-export shared types from express-context (single source of truth)
 export type {
@@ -14,7 +14,7 @@ export type {
   PubkeyChallengeSettings,
   PublicKeyChallengeData,
   RlsModule,
-  WebauthnSettings,
+  WebauthnSettings
 } from '@constructive-io/express-context';
 
-export type ApiOptions = PgpmOptions & { api?: ApiConfig };
+export type ApiOptions = PgpmOptions & { api?: ApiConfig; routing?: RoutingOptions };

--- a/graphql/types/src/constructive.ts
+++ b/graphql/types/src/constructive.ts
@@ -19,6 +19,7 @@ import {
   apiDefaults
 } from './graphile';
 import { LlmOptions } from './llm';
+import { RoutingOptions, routingDefaults } from './routing';
 
 /**
  * GraphQL-specific options for Constructive
@@ -30,6 +31,8 @@ export interface ConstructiveGraphQLOptions {
   features?: GraphileFeatureOptions;
   /** API configuration options */
   api?: ApiOptions;
+  /** HTTP route resolver / request-plane routing configuration */
+  routing?: RoutingOptions;
 }
 
 /**
@@ -59,6 +62,8 @@ export interface ConstructiveOptions extends PgpmOptions, ConstructiveGraphQLOpt
   jobs?: JobsConfig;
   /** LLM provider configuration (embeddings, chat, RAG) */
   llm?: LlmOptions;
+  /** HTTP route resolver / request-plane routing configuration */
+  routing?: RoutingOptions;
 }
 
 /**
@@ -67,7 +72,8 @@ export interface ConstructiveOptions extends PgpmOptions, ConstructiveGraphQLOpt
 export const constructiveGraphqlDefaults: ConstructiveGraphQLOptions = {
   graphile: graphileDefaults,
   features: graphileFeatureDefaults,
-  api: apiDefaults
+  api: apiDefaults,
+  routing: routingDefaults
 };
 
 /**

--- a/graphql/types/src/index.ts
+++ b/graphql/types/src/index.ts
@@ -8,6 +8,14 @@ export {
   apiDefaults
 } from './graphile';
 
+// Export routing types
+export {
+  HttpRouteMode,
+  RoutingEnv,
+  RoutingOptions,
+  routingDefaults
+} from './routing';
+
 // Export Constructive combined types
 export {
   ConstructiveGraphQLOptions,

--- a/graphql/types/src/routing.ts
+++ b/graphql/types/src/routing.ts
@@ -1,0 +1,60 @@
+/**
+ * HTTP route resolution configuration.
+ *
+ * These options control the Stage B request-plane router (the middleware that
+ * consumes `services_public.resolve_http_route`). They graduate the prototype
+ * `HTTP_ROUTE_RESOLVER_MODE` env flag into typed configuration and add a
+ * deployment-environment switch so local development behaves differently from
+ * production without needing real DNS, domain verification, or TLS.
+ */
+
+/**
+ * Route resolver dispatch mode.
+ *
+ * - `off`    : the router never runs; requests use legacy domain -> api resolution.
+ * - `shadow` : resolve + attach the match + log, but never change behavior
+ *              (used to verify parity against the legacy host-router).
+ * - `on`     : dispatch on the resolved typed target.
+ */
+export type HttpRouteMode = 'off' | 'shadow' | 'on';
+
+/**
+ * Deployment environment for routing.
+ *
+ * - `local`      : developer machine. Real ingress concerns that cannot work on
+ *                  localhost (public DNS domain verification, ACME/HTTPS cert
+ *                  issuance) are simulated as satisfied so they never block dev.
+ * - `production` : real ingress. Secure context is derived from the request
+ *                  (`X-Forwarded-Proto`), not assumed.
+ */
+export type RoutingEnv = 'local' | 'production';
+
+/**
+ * Configuration for the HTTP route resolver / request-plane router.
+ */
+export interface RoutingOptions {
+  /** Dispatch mode. Defaults to `shadow`. */
+  mode?: HttpRouteMode;
+  /**
+   * Deployment environment. When unset, callers derive it from `NODE_ENV`
+   * (`production` when `NODE_ENV==='production'`, otherwise `local`).
+   */
+  env?: RoutingEnv;
+  /**
+   * Host suffixes treated as local development hosts. Requests to these hosts
+   * are always considered secure (TLS simulated) regardless of environment, so
+   * a laptop serving plain HTTP is never blocked.
+   */
+  localHostSuffixes?: string[];
+}
+
+/**
+ * Default routing configuration.
+ *
+ * `mode` and `env` are intentionally left unset so the resolver can apply
+ * runtime precedence (explicit env var > typed config > derived default)
+ * without a baked-in value shadowing an operator's env var.
+ */
+export const routingDefaults: RoutingOptions = {
+  localHostSuffixes: ['localhost', '127.0.0.1', '::1', '.local', '.test']
+};


### PR DESCRIPTION
## Summary

Makes the Stage B route resolver behave differently in **local dev** vs **production**, so host-based routing is usable on a laptop without the production-only prerequisites it can't satisfy locally (public DNS, domain-ownership verification, ACME/TLS). Also graduates the prototype `HTTP_ROUTE_RESOLVER_MODE` env flag into typed config, as promised in #1379.

Stacked on `feat/http-routes-stage-b` (#1379); retargets to `main` once that merges.

Three behavioral pieces:

1. **Typed routing config.** New `RoutingOptions` in `graphql-types`, merged through `graphql-env`:
   ```ts
   interface RoutingOptions {
     mode?: 'off' | 'shadow' | 'on';      // was process.env.HTTP_ROUTE_RESOLVER_MODE
     env?: 'local' | 'production';
     localHostSuffixes?: string[];        // default: localhost, 127.0.0.1, ::1, .local, .test
   }
   ```
   Env vars still work and keep highest precedence (runtime override): `resolveRouteMode` = `HTTP_ROUTE_RESOLVER_MODE` > `routing.mode` > `shadow`; `resolveRoutingEnv` = `ROUTING_ENV` > `routing.env` > (`NODE_ENV==='production' ? production : local`).

2. **Host normalization** (the actual local-dev unblocker). On localhost the `Host` header is `host:port`, which never matched an unported `domains` row:
   ```ts
   normalizeHost('App.Localhost:5678') // -> 'app.localhost'
   normalizeHost('[::1]:3000')         // -> '[::1]'
   ```
   Applied before `resolve_http_route`, so a ported host now dispatches.

3. **Secure-context simulation.** Instead of requiring real TLS locally:
   ```ts
   isSecureRequest(req, env, host, suffixes):
     if isLocalHost(host, suffixes) return true      // dev hosts always secure
     if env === 'local'            return true       // TLS simulated on a laptop
     return xForwardedProto === 'https' || req.protocol === 'https'
   ```
   The router sets `req.routeEnv` / `req.routeSecure` and annotates responses with `X-Constructive-Route-Env` and `X-Constructive-Route-Secure` (observable, doesn't change dispatch). Same plain-HTTP request → `secure=true` locally, `secure=false` in production unless `X-Forwarded-Proto: https`.

No proprietary gateway/forwarding logic; typed targets still resolve exactly as in #1379. This is the open-source foundation the future domain-verification / certificate layers gate on (strict in production, simulated locally).

## Tests
- `graphql/server` unit (`route.test.ts`): 33 pass (added `normalizeHost`, `isLocalHost`, `isSecureRequest`, mode/env precedence, host-port normalization, local-vs-production header annotation).
- `graphql/server-test` real-HTTP integration (`route-env.integration.test.ts`, 6 new): ported/uppercased Host still dispatches; same HTTP request annotated `secure=true` local vs `secure=false` production; `X-Forwarded-Proto=https` honored; `app.localhost` always secure. Existing `route-stageb` suite (7) still green.
- `graphql/env` snapshot updated for the new `routing` defaults.


Link to Devin session: https://app.devin.ai/sessions/6a56839376234d2898022fd95e0d0ccd
Requested by: @pyramation