### PR TITLE
feat(http-routes): consume single-table resolver contract (Stage B)

### DIFF
--- a/__fixtures__/seed/services/routes.sql
+++ b/__fixtures__/seed/services/routes.sql
@@ -11,7 +11,7 @@ SET session_replication_role TO replica;
 
 -- site target at a specific prefix (NOT '/', so it never shadows /graphql)
 INSERT INTO services_public.http_routes
-  (id, database_id, domain_id, path, method, target_kind, site_id, priority)
+  (id, database_id, domain_id, path, method, target_kind, target_id, priority)
 VALUES (
   'a0000000-0000-4000-8000-000000000001',
   '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9',
@@ -23,9 +23,9 @@ VALUES (
   0
 ) ON CONFLICT (id) DO NOTHING;
 
--- function target (webhook channel) for a specific POST path
+-- function target for a specific POST path
 INSERT INTO services_public.http_routes
-  (id, database_id, domain_id, path, method, target_kind, channel, function_definition_id, priority)
+  (id, database_id, domain_id, path, method, target_kind, target_id, priority)
 VALUES (
   'a0000000-0000-4000-8000-000000000002',
   '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9',
@@ -33,7 +33,6 @@ VALUES (
   '/hooks/stripe',
   'POST',
   'function',
-  'webhook',
   '90000000-0000-4000-8000-000000000002',
   0
 ) ON CONFLICT (id) DO NOTHING;

--- a/__fixtures__/seed/services/setup.sql
+++ b/__fixtures__/seed/services/setup.sql
@@ -244,10 +244,11 @@ CREATE TABLE IF NOT EXISTS services_public.api_modules (
 -- HTTP ROUTES (Stage B) + resolver
 -- =====================================================
 --
--- Mirrors the constructive-db route storage + resolver contract
--- (services_public.resolve_http_route). Two scopes exist in production
--- (platform_http_routes / http_routes); the resolver unions both. Routes are
--- unseeded by default — tests insert their own.
+-- Mirrors the constructive-db single-table route storage + resolver contract
+-- (services_public.resolve_http_route). A single http_routes table fans a host
+-- out to typed targets via (target_kind, target_id); platform is just a
+-- database, so there is no separate route tier. Routes are unseeded by
+-- default — tests insert their own.
 
 CREATE TABLE IF NOT EXISTS services_public.http_routes (
   id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
@@ -255,13 +256,8 @@ CREATE TABLE IF NOT EXISTS services_public.http_routes (
   domain_id uuid NOT NULL,
   path text NOT NULL DEFAULT '/',
   method text,
-  target_kind text NOT NULL CHECK (target_kind IN ('api', 'site', 'service', 'function', 'bucket')),
-  channel text,
-  api_id uuid,
-  site_id uuid,
-  service_id uuid,
-  function_definition_id uuid,
-  bucket_id uuid,
+  target_kind text NOT NULL CHECK (target_kind IN ('api', 'site', 'function', 'bucket', 'service')),
+  target_id uuid NOT NULL,
   priority int NOT NULL DEFAULT 0,
   is_active boolean NOT NULL DEFAULT true,
   CONSTRAINT hr_db_fkey FOREIGN KEY (database_id) REFERENCES metaschema_public.database (id) ON DELETE CASCADE,
@@ -269,92 +265,33 @@ CREATE TABLE IF NOT EXISTS services_public.http_routes (
 );
 CREATE INDEX IF NOT EXISTS http_routes_domain_id_idx ON services_public.http_routes (domain_id);
 
-CREATE TABLE IF NOT EXISTS services_public.platform_http_routes (
-  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
-  domain_id uuid NOT NULL,
-  path text NOT NULL DEFAULT '/',
-  method text,
-  target_kind text NOT NULL CHECK (target_kind IN ('api', 'site', 'service', 'function', 'bucket')),
-  channel text,
-  api_id uuid,
-  site_id uuid,
-  service_id uuid,
-  function_definition_id uuid,
-  bucket_id uuid,
-  priority int NOT NULL DEFAULT 0,
-  is_active boolean NOT NULL DEFAULT true,
-  CONSTRAINT phr_domain_fkey FOREIGN KEY (domain_id) REFERENCES services_public.domains (id) ON DELETE CASCADE
-);
-CREATE INDEX IF NOT EXISTS platform_http_routes_domain_id_idx ON services_public.platform_http_routes (domain_id);
-
 CREATE OR REPLACE FUNCTION services_public.resolve_http_route(
   p_host text,
   p_path text,
   p_method text,
   OUT route_id uuid,
+  OUT database_id uuid,
   OUT domain_id uuid,
   OUT matched_path text,
   OUT method text,
   OUT target_kind text,
-  OUT channel text,
-  OUT api_id uuid,
-  OUT site_id uuid,
-  OUT service_id uuid,
-  OUT function_definition_id uuid,
-  OUT bucket_id uuid,
-  OUT route_scope text
+  OUT target_id uuid
 ) RETURNS record AS $_PGFN_$
 SELECT
-  route_id, domain_id, matched_path, method, target_kind, channel,
-  api_id, site_id, service_id, function_definition_id, bucket_id, route_scope
-FROM (
-  SELECT
-    r.id AS route_id,
-    r.domain_id AS domain_id,
-    r.path AS matched_path,
-    r.method AS method,
-    r.target_kind::text AS target_kind,
-    CASE r.target_kind WHEN 'function' THEN r.channel ELSE NULL END::text AS channel,
-    CASE r.target_kind WHEN 'api' THEN r.api_id ELSE NULL END AS api_id,
-    CASE r.target_kind WHEN 'site' THEN r.site_id ELSE NULL END AS site_id,
-    CASE r.target_kind WHEN 'service' THEN r.service_id ELSE NULL END AS service_id,
-    CASE r.target_kind WHEN 'function' THEN r.function_definition_id ELSE NULL END AS function_definition_id,
-    CASE r.target_kind WHEN 'bucket' THEN r.bucket_id ELSE NULL END AS bucket_id,
-    'platform' AS route_scope,
-    length(r.path) AS path_length,
-    r.method IS NOT NULL AS method_specific,
-    r.priority AS priority
-  FROM services_public.platform_http_routes AS r
-  INNER JOIN services_public.domains AS d ON d.id = r.domain_id
-  WHERE lower(concat_ws('.', d.subdomain, d.domain)) = split_part(lower(p_host), ':', 1)
-    AND ((r.path = '/' OR (concat('/', ltrim(COALESCE(p_path, '/'), '/')) = r.path
-      OR "left"(concat('/', ltrim(COALESCE(p_path, '/'), '/')), length(r.path) + 1) = (r.path || '/')))
-      AND ((r.method IS NULL OR upper(r.method) = upper(p_method)) AND r.is_active))
-  UNION ALL
-  SELECT
-    r.id AS route_id,
-    r.domain_id AS domain_id,
-    r.path AS matched_path,
-    r.method AS method,
-    r.target_kind::text AS target_kind,
-    CASE r.target_kind WHEN 'function' THEN r.channel ELSE NULL END::text AS channel,
-    CASE r.target_kind WHEN 'api' THEN r.api_id ELSE NULL END AS api_id,
-    CASE r.target_kind WHEN 'site' THEN r.site_id ELSE NULL END AS site_id,
-    CASE r.target_kind WHEN 'service' THEN r.service_id ELSE NULL END AS service_id,
-    CASE r.target_kind WHEN 'function' THEN r.function_definition_id ELSE NULL END AS function_definition_id,
-    CASE r.target_kind WHEN 'bucket' THEN r.bucket_id ELSE NULL END AS bucket_id,
-    'database' AS route_scope,
-    length(r.path) AS path_length,
-    r.method IS NOT NULL AS method_specific,
-    r.priority AS priority
-  FROM services_public.http_routes AS r
-  INNER JOIN services_public.domains AS d ON d.id = r.domain_id
-  WHERE lower(concat_ws('.', d.subdomain, d.domain)) = split_part(lower(p_host), ':', 1)
-    AND ((r.path = '/' OR (concat('/', ltrim(COALESCE(p_path, '/'), '/')) = r.path
-      OR "left"(concat('/', ltrim(COALESCE(p_path, '/'), '/')), length(r.path) + 1) = (r.path || '/')))
-      AND ((r.method IS NULL OR upper(r.method) = upper(p_method)) AND r.is_active))
-) AS candidates
-ORDER BY path_length DESC, method_specific DESC, priority DESC, route_id ASC
+  r.id AS route_id,
+  r.database_id AS database_id,
+  r.domain_id AS domain_id,
+  r.path AS matched_path,
+  r.method AS method,
+  r.target_kind AS target_kind,
+  r.target_id AS target_id
+FROM services_public.http_routes AS r
+INNER JOIN services_public.domains AS d ON d.id = r.domain_id
+WHERE lower(concat_ws('.', d.subdomain, d.domain)) = split_part(lower(p_host), ':', 1)
+  AND ((r.path = '/' OR (concat('/', ltrim(COALESCE(p_path, '/'), '/')) = r.path
+    OR "left"(concat('/', ltrim(COALESCE(p_path, '/'), '/')), length(r.path) + 1) = (r.path || '/')))
+    AND ((r.method IS NULL OR upper(r.method) = upper(p_method)) AND r.is_active))
+ORDER BY length(r.path) DESC, (r.method IS NOT NULL) DESC, r.priority DESC, r.id ASC
 LIMIT 1
 $_PGFN_$ LANGUAGE sql STABLE SECURITY DEFINER;
 
@@ -455,5 +392,4 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON services_public.database_settings TO adm
 GRANT SELECT, INSERT, UPDATE, DELETE ON services_public.api_settings TO administrator, authenticated, anonymous;
 GRANT SELECT, INSERT, UPDATE, DELETE ON metaschema_modules_public.rls_module TO administrator, authenticated, anonymous;
 GRANT SELECT, INSERT, UPDATE, DELETE ON services_public.http_routes TO administrator, authenticated, anonymous;
-GRANT SELECT, INSERT, UPDATE, DELETE ON services_public.platform_http_routes TO administrator, authenticated, anonymous;
 GRANT EXECUTE ON FUNCTION services_public.resolve_http_route(text, text, text) TO administrator, authenticated, anonymous;

--- a/graphql/server-test/__tests__/route-stageb.integration.test.ts
+++ b/graphql/server-test/__tests__/route-stageb.integration.test.ts
@@ -40,6 +40,7 @@ const seedFiles = [
 
 const API_HOST = 'app.test.constructive.io';
 const SITE_ID = '90000000-0000-4000-8000-000000000001';
+const FUNCTION_ID = '90000000-0000-4000-8000-000000000002';
 
 let request: supertest.Agent;
 let teardown: () => Promise<void>;
@@ -114,7 +115,7 @@ describe('on mode (authoritative)', () => {
 
     expect(res.status).toBe(501);
     expect(res.body.targetKind).toBe('function');
-    expect(res.body.channel).toBe('webhook');
+    expect(res.body.targetId).toBe(FUNCTION_ID);
   });
 
   it('unrouted /graphql falls through to legacy host->api (GraphQL still serves)', async () => {

--- a/graphql/server/src/middleware/__tests__/route.test.ts
+++ b/graphql/server/src/middleware/__tests__/route.test.ts
@@ -23,17 +23,12 @@ afterAll(() => {
 
 const routeRow = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
   route_id: 'route-1',
+  database_id: 'db-1',
   domain_id: 'domain-1',
   matched_path: '/graphql',
   method: null,
   target_kind: 'api',
-  channel: null,
-  api_id: 'api-1',
-  site_id: null,
-  service_id: null,
-  function_definition_id: null,
-  bucket_id: null,
-  route_scope: 'database',
+  target_id: 'api-1',
   ...overrides
 });
 
@@ -104,7 +99,7 @@ describe('getHttpRouteMode', () => {
 describe('resolveHttpRoute', () => {
   it('maps a row into a typed match', async () => {
     const match = await resolveHttpRoute(poolReturning([routeRow()]), 'acme.test', '/graphql', 'POST');
-    expect(match).toMatchObject({ targetKind: 'api', apiId: 'api-1', routeScope: 'database' });
+    expect(match).toMatchObject({ targetKind: 'api', targetId: 'api-1', databaseId: 'db-1' });
   });
 
   it('returns null when nothing matches', async () => {
@@ -145,7 +140,7 @@ describe('createRouteMiddleware', () => {
     const next = jest.fn() as NextFunction;
     await createRouteMiddleware(opts)(req, res as Response, next);
     expect(next).toHaveBeenCalled();
-    expect(req.httpRoute).toMatchObject({ targetKind: 'api', apiId: 'api-1' });
+    expect(req.httpRoute).toMatchObject({ targetKind: 'api', targetId: 'api-1' });
     expect(req.routeApiId).toBeUndefined();
     expect(res.status).not.toHaveBeenCalled();
   });
@@ -163,7 +158,7 @@ describe('createRouteMiddleware', () => {
   it('on mode / site target: serves a typed placeholder', async () => {
     process.env.HTTP_ROUTE_RESOLVER_MODE = 'on';
     mockGetPgPool.mockReturnValue(
-      poolReturning([routeRow({ target_kind: 'site', api_id: null, site_id: 'site-9' })])
+      poolReturning([routeRow({ target_kind: 'site', target_id: 'site-9' })])
     );
     const req = createRequest('acme.test', '/', 'GET');
     const res = createResponse();
@@ -180,9 +175,7 @@ describe('createRouteMiddleware', () => {
       poolReturning([
         routeRow({
           target_kind: 'function',
-          api_id: null,
-          function_definition_id: 'fn-1',
-          channel: 'sync'
+          target_id: 'fn-1'
         })
       ])
     );
@@ -192,7 +185,7 @@ describe('createRouteMiddleware', () => {
     await createRouteMiddleware(opts)(req, res as Response, next);
     expect(next).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(501);
-    expect(res.body).toMatchObject({ targetKind: 'function', channel: 'sync', functionDefinitionId: 'fn-1' });
+    expect(res.body).toMatchObject({ targetKind: 'function', targetId: 'fn-1' });
   });
 
   it('on mode / no match: falls through to legacy resolution', async () => {

--- a/graphql/server/src/middleware/route.ts
+++ b/graphql/server/src/middleware/route.ts
@@ -4,7 +4,7 @@
  * Consumes the database-side `services_public.resolve_http_route(host, path,
  * method)` contract and turns a request into a typed target:
  *
- *   host + path + method  ->  { target_kind, channel, api_id, site_id, ... }
+ *   host + path + method  ->  { target_kind, target_id }
  *
  * This is the request-plane counterpart to the routing table that lives in
  * constructive-db (PR #2214). The resolver decides *which typed thing* serves a
@@ -17,8 +17,8 @@
  *                 cost unless a host is deliberately shared.
  *   - site     -> served by the site handler (Track 2 SSR lands the full
  *                 contract; this returns a typed placeholder for now).
- *   - function -> recognized (with channel); full sync/page/webhook dispatch is
- *                 tracked separately. Returns a typed 501 for now.
+ *   - function -> recognized; full sync/page/webhook dispatch is tracked
+ *                 separately. Returns a typed 501 for now.
  *   - bucket   -> recognized; object serving is a follow-up. Typed 501.
  *   - service  -> recognized; the only target that may point at a customer-owned
  *                 workload in its own namespace. Typed 501.
@@ -56,38 +56,27 @@ export type HttpRouteTargetKind =
 
 export interface HttpRouteMatch {
   routeId: string;
+  databaseId: string;
   domainId: string;
   matchedPath: string;
   method: string | null;
   targetKind: HttpRouteTargetKind;
-  channel: string | null;
-  apiId: string | null;
-  siteId: string | null;
-  serviceId: string | null;
-  functionDefinitionId: string | null;
-  bucketId: string | null;
-  routeScope: string;
+  targetId: string;
 }
 
 interface ResolveHttpRouteRow {
   route_id: string | null;
+  database_id: string | null;
   domain_id: string | null;
   matched_path: string | null;
   method: string | null;
   target_kind: HttpRouteTargetKind | null;
-  channel: string | null;
-  api_id: string | null;
-  site_id: string | null;
-  service_id: string | null;
-  function_definition_id: string | null;
-  bucket_id: string | null;
-  route_scope: string | null;
+  target_id: string | null;
 }
 
 const RESOLVE_ROUTE_SQL = `
   SELECT
-    route_id, domain_id, matched_path, method, target_kind, channel,
-    api_id, site_id, service_id, function_definition_id, bucket_id, route_scope
+    route_id, database_id, domain_id, matched_path, method, target_kind, target_id
   FROM services_public.resolve_http_route($1, $2, $3)
 `;
 
@@ -110,20 +99,15 @@ export const getHttpRouteMode = (): HttpRouteMode => {
 };
 
 const toMatch = (row: ResolveHttpRouteRow): HttpRouteMatch | null => {
-  if (!row || !row.route_id || !row.target_kind) return null;
+  if (!row || !row.route_id || !row.target_kind || !row.target_id) return null;
   return {
     routeId: row.route_id,
+    databaseId: row.database_id ?? '',
     domainId: row.domain_id ?? '',
     matchedPath: row.matched_path ?? '',
     method: row.method,
     targetKind: row.target_kind,
-    channel: row.channel,
-    apiId: row.api_id,
-    siteId: row.site_id,
-    serviceId: row.service_id,
-    functionDefinitionId: row.function_definition_id,
-    bucketId: row.bucket_id,
-    routeScope: row.route_scope ?? ''
+    targetId: row.target_id
   };
 };
 
@@ -164,11 +148,7 @@ const sendNotImplemented = (
   res.status(501).json({
     error: 'Route target not yet served',
     targetKind: match.targetKind,
-    channel: match.channel,
-    routeScope: match.routeScope,
-    ...(match.functionDefinitionId ? { functionDefinitionId: match.functionDefinitionId } : {}),
-    ...(match.bucketId ? { bucketId: match.bucketId } : {}),
-    ...(match.serviceId ? { serviceId: match.serviceId } : {})
+    targetId: match.targetId
   });
 };
 
@@ -179,10 +159,10 @@ const sendSitePlaceholder = (res: Response, match: HttpRouteMatch): void => {
   res
     .status(200)
     .set('Content-Type', 'text/html; charset=utf-8')
-    .set('X-Constructive-Route', `site:${match.siteId ?? ''}`)
+    .set('X-Constructive-Route', `site:${match.targetId}`)
     .send(
       `<!doctype html><html><head><meta charset="utf-8"><title>site</title></head>` +
-        `<body data-site-id="${match.siteId ?? ''}" data-route-scope="${match.routeScope}">` +
+        `<body data-site-id="${match.targetId}">` +
         `<!-- resolved via services_public.resolve_http_route --></body></html>`
     );
 };
@@ -207,8 +187,7 @@ export const createRouteMiddleware = (opts: ApiOptions) => {
 
     if (mode === 'shadow') {
       log.debug(
-        `[shadow] ${req.method} ${host}${req.path} -> ${match.targetKind}` +
-          `${match.channel ? `:${match.channel}` : ''} (scope=${match.routeScope})`
+        `[shadow] ${req.method} ${host}${req.path} -> ${match.targetKind}:${match.targetId}`
       );
       return next();
     }
@@ -216,9 +195,7 @@ export const createRouteMiddleware = (opts: ApiOptions) => {
     // mode === 'on'
     switch (match.targetKind) {
     case 'api':
-      if (match.apiId) {
-        req.routeApiId = match.apiId;
-      }
+      req.routeApiId = match.targetId;
       return next();
     case 'site':
       return sendSitePlaceholder(res, match);


### PR DESCRIPTION
## Summary

Consumer-side update for the constructive-db change that collapses HTTP routing to a single `http_routes` table (constructive-io/constructive-db#2221). The `services_public.resolve_http_route(host, path, method)` contract now returns a discriminated `(target_kind, target_id)` pair instead of five typed target columns plus `channel`/`route_scope`, so the fixture mirror and route middleware are updated to match.

Resolver row / match shape:

```
-  route_id, domain_id, matched_path, method, target_kind, channel,
-  api_id, site_id, service_id, function_definition_id, bucket_id, route_scope
+  route_id, database_id, domain_id, matched_path, method, target_kind, target_id
```

Dispatch for the only wired target kind is a direct rename; everything else stays a typed placeholder/501:

```ts
case 'api':
-  if (match.apiId) req.routeApiId = match.apiId;
+  req.routeApiId = match.targetId;
   return next();
```

`off`/`shadow`/`on` modes, the never-throws resolver fallback (`RESOLVER_ABSENT_CODES`), and local/prod behavior are unchanged. Site/function/bucket/service dispatch is intentionally left as placeholders (site → HTML stub keyed by `target_id`; others → typed 501) — no forwarding logic added.

## Changes

- `graphql/server/src/middleware/route.ts` — `HttpRouteMatch`/`ResolveHttpRouteRow` use `databaseId`/`targetId`; `RESOLVE_ROUTE_SQL` selects the 7-column contract; placeholders/shadow logging key off `target_id`.
- `__fixtures__/seed/services/setup.sql` — drop `platform_http_routes`, the five typed columns, `channel`, `route_scope`; single `http_routes` table + single-SELECT resolver mirroring the generated module (and drop the stale platform grant).
- `__fixtures__/seed/services/routes.sql` — inserts use `(target_kind, target_id)`.
- Tests: `middleware/__tests__/route.test.ts` (unit, 12 passed) and `graphql/server-test/__tests__/route-stageb.integration.test.ts` (integration, 7 passed) updated to the new contract.


Link to Devin session: https://app.devin.ai/sessions/294a09fc91f04a8e8d681b10eeaa430c
Requested by: @pyramation