### PR TITLE
feat(export): install app-scope + function-resolution in exported databases

### DIFF
--- a/pgpm/core/src/modules/modules.ts
+++ b/pgpm/core/src/modules/modules.ts
@@ -9,8 +9,10 @@ export type ModuleMap = Record<string, Module>;
  * Native PostgreSQL extensions (plpgsql, uuid-ossp, etc.) are not included.
  */
 export const PGPM_MODULE_MAP: Record<string, string> = {
+  'pgpm-app-scope': '@pgpm/app-scope',
   'pgpm-base32': '@pgpm/base32',
   'pgpm-database-jobs': '@pgpm/database-jobs',
+  'pgpm-function-resolution': '@pgpm/function-resolution',
   'metaschema-modules': '@pgpm/metaschema-modules',
   'metaschema-schema': '@pgpm/metaschema-schema',
   'services': '@pgpm/services',

--- a/pgpm/export/src/export-utils.ts
+++ b/pgpm/export/src/export-utils.ts
@@ -36,6 +36,8 @@ export const DB_REQUIRED_EXTENSIONS = [
   'pgpm-utils',
   'pgpm-database-jobs',
   'pgpm-jwt-claims',
+  'pgpm-app-scope',
+  'pgpm-function-resolution',
   'pgpm-stamps',
   'pgpm-base32',
   'pgpm-totp',


### PR DESCRIPTION
## Summary

Generated triggers in exported/tenant databases now call `function_resolution.enqueue` / `function_resolution.resolve_invocation` and `app_scope.frames` (the portable scope-resolution modules published as `@pgpm/app-scope` and `@pgpm/function-resolution`, replacing the old `metaschema_private` resolver closure). The export flow must therefore install those two pgpm modules into every exported database, or deploys fail with missing `app_scope`/`function_resolution` functions.

Two additions wire them into the existing export machinery:

```diff
# pgpm/core/src/modules/modules.ts — control-name → npm-name map used by getMissingInstallableModules
 export const PGPM_MODULE_MAP = {
+  'pgpm-app-scope': '@pgpm/app-scope',
   'pgpm-base32': '@pgpm/base32',
   'pgpm-database-jobs': '@pgpm/database-jobs',
+  'pgpm-function-resolution': '@pgpm/function-resolution',
   ...
 }

# pgpm/export/src/export-utils.ts — required extensions written into exported DB modules + install check
 export const DB_REQUIRED_EXTENSIONS = [
   ...
   'pgpm-database-jobs',
   'pgpm-jwt-claims',
+  'pgpm-app-scope',
+  'pgpm-function-resolution',
   'pgpm-stamps',
   ...
 ]
```

`DB_REQUIRED_EXTENSIONS` drives both the extension `requires` written into exported database modules and the `detectMissingModules` prompt; `PGPM_MODULE_MAP` lets `getMissingInstallableModules` resolve each control name to its npm package for `pgpm install`. Both packages are published (0.33.0). `metaschema-modules` (a transitive dependency of app-scope/function-resolution) is not added explicitly — it is pulled in as an npm dependency of the two new packages and via control-file `requires` at deploy time.

## Testing
- `pgpm/export` `export-utils.test.ts`: 22/22 pass.
- `pgpm/core` `__tests__/modules`: 28/28 pass (against postgres-plus:18).
- Full workspace `pnpm run build` succeeds with the changes.
- Remaining `pgpm/export` integration-test failures are pre-existing (require DB/env packages) and identical with and without this change; `pgpm/export` is not part of the CI matrix.

Link to Devin session: https://app.devin.ai/sessions/5ce15e7e50b3454496cf8e613b53280e
Requested by: @pyramation