### PR TITLE
feat(env): enforce production-safe env at the getEnvOptions chokepoint (warn mode)

### DIFF
--- a/pgpm/env/__tests__/merge.test.ts
+++ b/pgpm/env/__tests__/merge.test.ts
@@ -1,8 +1,9 @@
-import { getConnEnvOptions, getEnvOptions } from '../src/merge';
 import { pgpmDefaults, PgpmOptions } from '@pgpmjs/types';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+
+import { getConnEnvOptions, getEnvOptions } from '../src/merge';
 
 const writeConfig = (dir: string, config: Record<string, unknown>): void => {
   fs.writeFileSync(path.join(dir, 'pgpm.json'), JSON.stringify(config, null, 2));
@@ -224,5 +225,55 @@ describe('getEnvOptions', () => {
     expect(result.jobs?.worker?.supported).toEqual(['delta', 'epsilon']);
     expect(result.jobs?.scheduler?.supported).toEqual(['gamma', 'zeta']);
     expect(result.packages).toEqual(['testing/*', 'extensions/*']);
+  });
+
+  describe('production safety enforcement', () => {
+    // Empty cwd so no pgpm.json overrides the dangerous built-in defaults.
+    const emptyCwd = (): string =>
+      (tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pgpm-env-prod-')));
+
+    it('does not throw for bare defaults outside production', () => {
+      expect(() =>
+        getEnvOptions({}, emptyCwd(), { NODE_ENV: 'development' })
+      ).not.toThrow();
+    });
+
+    it('throws in production when secrets/hosts are left at dev defaults (STRICT_ENV=throw)', () => {
+      expect(() =>
+        getEnvOptions({}, emptyCwd(), { NODE_ENV: 'production', STRICT_ENV: 'throw' })
+      ).toThrow(/Unsafe production environment/);
+    });
+
+    it('warns (does not throw) in production by default', () => {
+      const spy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      try {
+        expect(() =>
+          getEnvOptions({}, emptyCwd(), { NODE_ENV: 'production' })
+        ).not.toThrow();
+        expect(spy).toHaveBeenCalled();
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('does not throw in production when sensitive values are provided via env', () => {
+      const safeEnv: NodeJS.ProcessEnv = {
+        NODE_ENV: 'production',
+        STRICT_ENV: 'throw',
+        PGHOST: 'db.internal',
+        PGDATABASE: 'appdb',
+        PGPASSWORD: 's3cret-pg',
+        PGROOTDATABASE: 'app_root',
+        SERVER_HOST: '0.0.0.0',
+        DB_CONNECTIONS_APP_PASSWORD: 's3cret-app',
+        DB_CONNECTIONS_ADMIN_PASSWORD: 's3cret-admin',
+        AWS_ACCESS_KEY: 'AKIAREAL',
+        AWS_SECRET_KEY: 'realsecret',
+        CDN_ENDPOINT: 'https://s3.example.com',
+        CDN_PUBLIC_URL_PREFIX: 'https://cdn.example.com',
+        BUCKET_NAME: 'prod-bucket'
+      };
+      expect(() => getEnvOptions({}, emptyCwd(), safeEnv)).not.toThrow();
+    });
   });
 });

--- a/pgpm/env/src/assert.ts
+++ b/pgpm/env/src/assert.ts
@@ -15,6 +15,9 @@ import { getStrictEnvMode, isProduction } from '12factor-env';
  * (i.e. neither config file, env var, nor override replaced it) AND we are in
  * production. Enforcement is gated by `STRICT_ENV` (see `12factor-env`): `warn`
  * by default (log loudly, keep booting) and `throw` once the fleet is clean.
+ *
+ * `getEnvOptions` calls this on every invocation, so warnings are de-duplicated
+ * per-process (by message) to avoid log spam; `throw` always throws.
  */
 
 type Severity = 'secret' | 'host';
@@ -70,6 +73,8 @@ export const findUnsafeProductionDefaults = (opts: PgpmOptions): string[] => {
   return issues;
 };
 
+const warnedMessages = new Set<string>();
+
 /**
  * Assert that the merged PGPM options are safe for production. No-op outside
  * production (per `12factor-env`'s house `NODE_ENV` semantics, so tests and CI
@@ -91,6 +96,9 @@ export const assertProductionEnvOptions = (
   if (getStrictEnvMode(env) === 'throw') {
     throw new Error(message);
   }
+
+  if (warnedMessages.has(message)) return;
+  warnedMessages.add(message);
   // eslint-disable-next-line no-console
   console.warn(`[pgpm-env] ${message}\n(set STRICT_ENV=throw to make this fatal)`);
 };

--- a/pgpm/env/src/merge.ts
+++ b/pgpm/env/src/merge.ts
@@ -1,5 +1,7 @@
+import { DeploymentOptions,pgpmDefaults, PgpmOptions, PgTestConnectionOptions } from '@pgpmjs/types';
 import deepmerge from 'deepmerge';
-import { pgpmDefaults, PgpmOptions, PgTestConnectionOptions, DeploymentOptions } from '@pgpmjs/types';
+
+import { assertProductionEnvOptions } from './assert';
 import { loadConfigSync } from './config';
 import { getEnvVars } from './env';
 import { replaceArrays } from './utils';
@@ -25,9 +27,15 @@ export const getEnvOptions = (
   const configOptions = loadConfigSync(cwd);
   const envOptions = getEnvVars(env);
   
-  return deepmerge.all([pgpmDefaults, configOptions, envOptions, overrides], {
+  const merged = deepmerge.all([pgpmDefaults, configOptions, envOptions, overrides], {
     arrayMerge: replaceArrays
   });
+
+  // In production, surface (warn) or reject (STRICT_ENV=throw) sensitive options
+  // still left at their built-in dev defaults. No-op in dev/test/CI.
+  assertProductionEnvOptions(merged, env);
+
+  return merged;
 };
 
 export const getConnEnvOptions = (overrides: Partial<PgTestConnectionOptions> = {}, cwd: string = process.cwd()): PgTestConnectionOptions => {


### PR DESCRIPTION
## Summary

Arms the production-safety assert shipped in #1386. That PR added `assertProductionEnvOptions` but nothing called it — this PR wires it into the single house chokepoint so it actually protects deploys.

`@constructive-io/graphql-env`'s `getEnvOptions` delegates to `@pgpmjs/env`'s `getEnvOptions`, so calling the assert **once** inside the latter covers everything that resolves env config: graphql server boot, `pgpm deploy`/`verify`/`revert`, the jobs worker, `getConnEnvOptions`/`getDeploymentEnvOptions` (which call `getEnvOptions` internally), etc. — no need to touch 40+ call sites.

```ts
// pgpm/env getEnvOptions
const merged = deepmerge.all([pgpmDefaults, config, envVars, overrides], …);
assertProductionEnvOptions(merged, env);   // NEW
return merged;
```

**Behavior (unchanged for everyone today):**
- Dev/test/CI → **no-op**. `isProduction` uses house `NODE_ENV` semantics: unset ⇒ development, and `GITHUB_ACTIONS=true` ⇒ test — so CI never trips even if `NODE_ENV=production` is set in a container job.
- Production, default `STRICT_ENV` → **warns** (once per distinct message; `getEnvOptions` is called many times, so warnings are de-duplicated per-process) about any sensitive option still at its built-in dev default (`pg.password`, app/admin passwords, `minioadmin` keys, `localhost` hosts/endpoints). Never logs the value, only the option path + env var to set.
- Production + `STRICT_ENV=throw` → **throws**. This is the one-line flip to make after a release of clean warn-logs.

So nothing breaks on merge; production deploys simply start surfacing unsafe baked defaults in logs.

## Testing
- `pgpm/env`: 22 tests pass (4 new on `getEnvOptions`): no-op in dev; throws in prod under `STRICT_ENV=throw` with bare defaults; warns (no throw) in prod by default; does **not** throw in prod when the sensitive values are supplied via env (`PGPASSWORD`, `AWS_ACCESS_KEY`, `CDN_ENDPOINT`, …) even under `STRICT_ENV=throw`.
- Existing `getEnvOptions`/`getConnEnvOptions` snapshot + merge tests unchanged (they pass an explicit non-prod `env`, so the assert no-ops).

## Follow-up
Once a production release confirms clean warn-logs, flip the fleet to `STRICT_ENV=throw` (env/config only — no code change needed).

Link to Devin session: https://app.devin.ai/sessions/b4f03ceb2daf4231b0d30dbee3ae89da
Requested by: @pyramation