### PR TITLE
refactor(env): dedup env parsers to 12factor-env + centralize jobs gateway placeholders

### DIFF
--- a/graphile/graphile-cache/package.json
+++ b/graphile/graphile-cache/package.json
@@ -29,6 +29,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "12factor-env": "workspace:^",
     "@pgpmjs/logger": "workspace:^",
     "express": "^5.2.1",
     "grafserv": "1.0.0",

--- a/graphile/graphile-cache/src/graphile-cache.ts
+++ b/graphile/graphile-cache/src/graphile-cache.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import { parseEnvNumber } from '12factor-env';
 import { Logger } from '@pgpmjs/logger';
 import { LRUCache } from 'lru-cache';
 import { pgCache } from 'pg-cache';
@@ -58,15 +59,11 @@ export interface CacheConfig {
 export function getCacheConfig(): CacheConfig {
   const isDevelopment = process.env.NODE_ENV === 'development';
 
-  const max = process.env.GRAPHILE_CACHE_MAX
-    ? parseInt(process.env.GRAPHILE_CACHE_MAX, 10)
-    : 50;
+  const max = parseEnvNumber(process.env.GRAPHILE_CACHE_MAX) ?? 50;
 
-  const ttl = process.env.GRAPHILE_CACHE_TTL_MS
-    ? parseInt(process.env.GRAPHILE_CACHE_TTL_MS, 10)
-    : isDevelopment
-      ? FIVE_MINUTES_MS
-      : ONE_YEAR;
+  const ttl =
+    parseEnvNumber(process.env.GRAPHILE_CACHE_TTL_MS) ??
+    (isDevelopment ? FIVE_MINUTES_MS : ONE_YEAR);
 
   return { max, ttl };
 }

--- a/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
+++ b/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
@@ -75,6 +75,11 @@ exports[`getEnvOptions merges pgpm defaults, graphql defaults, config, env, and 
     ],
   },
   "jobs": {
+    "gateway": {
+      "callbackPort": 12345,
+      "callbackUrl": "http://callback:12345",
+      "gatewayUrl": "http://gateway:8080",
+    },
     "scheduler": {
       "gracefulShutdown": true,
       "hostname": "scheduler-0",

--- a/jobs/job-utils/src/runtime.ts
+++ b/jobs/job-utils/src/runtime.ts
@@ -96,22 +96,12 @@ export const getSchedulerHostname = (): string => {
 export const getJobGatewayConfig = () => {
   const opts: PgpmOptions = getEnvOptions();
   const gateway = opts.jobs?.gateway ?? {};
-  const defaults = jobsDefaults.gateway ?? {
-    gatewayUrl: 'http://gateway:8080',
-    callbackUrl: 'http://callback:12345',
-    callbackPort: 12345
-  };
+  const defaults = jobsDefaults.gateway ?? {};
 
   return {
-    gatewayUrl:
-      gateway.gatewayUrl ||
-      defaults.gatewayUrl,
-    callbackUrl:
-      gateway.callbackUrl ||
-      defaults.callbackUrl,
-    callbackPort:
-      gateway.callbackPort ??
-      defaults.callbackPort
+    gatewayUrl: gateway.gatewayUrl || defaults.gatewayUrl,
+    callbackUrl: gateway.callbackUrl || defaults.callbackUrl,
+    callbackPort: gateway.callbackPort ?? defaults.callbackPort
   };
 };
 

--- a/jobs/knative-job-service/src/index.ts
+++ b/jobs/knative-job-service/src/index.ts
@@ -10,7 +10,7 @@ import {
   getSchedulerHostname,
   getWorkerHostname
 } from '@constructive-io/job-utils';
-import { parseEnvBoolean } from '@pgpmjs/env';
+import { parseEnvBoolean, parseEnvList } from '@pgpmjs/env';
 import { Logger } from '@pgpmjs/logger';
 import retry from 'async-retry';
 import { Client } from 'pg';
@@ -289,14 +289,6 @@ export class KnativeJobsSvc {
   }
 }
 
-const parseList = (value?: string): string[] => {
-  if (!value) return [];
-  return value
-    .split(',')
-    .map((item) => item.trim())
-    .filter(Boolean);
-};
-
 const parsePortMap = (value?: string): Record<string, number> => {
   if (!value) return {};
 
@@ -339,7 +331,7 @@ const buildFunctionsOptionsFromEnv = (): KnativeJobsSvcOptions['functions'] => {
     return { enabled: true };
   }
 
-  const names = parseList(rawFunctions) as FunctionName[];
+  const names = (parseEnvList(rawFunctions) ?? []) as FunctionName[];
   if (!names.length) return undefined;
 
   const services: FunctionServiceConfig[] = names.map((name) => ({

--- a/packages/12factor-env/__tests__/env.test.ts
+++ b/packages/12factor-env/__tests__/env.test.ts
@@ -14,6 +14,7 @@ import {
   isProduction,
   isTest,
   parseEnvBoolean,
+  parseEnvList,
   parseEnvNumber,
   port,
   required,
@@ -366,6 +367,15 @@ describe('env', () => {
       expect(parseEnvNumber('nan')).toBeUndefined();
       expect(parseEnvNumber('')).toBeUndefined();
       expect(parseEnvNumber(undefined)).toBeUndefined();
+    });
+
+    it('parseEnvList splits, trims and drops empty entries', () => {
+      expect(parseEnvList('a,b,c')).toEqual(['a', 'b', 'c']);
+      expect(parseEnvList(' a , b ,, c ')).toEqual(['a', 'b', 'c']);
+      expect(parseEnvList('solo')).toEqual(['solo']);
+      expect(parseEnvList(',')).toEqual([]);
+      expect(parseEnvList('')).toBeUndefined();
+      expect(parseEnvList(undefined)).toBeUndefined();
     });
 
     it('boolish validator accepts TRUE/yes that envalid bool rejects', () => {

--- a/packages/12factor-env/src/index.ts
+++ b/packages/12factor-env/src/index.ts
@@ -231,6 +231,18 @@ const parseEnvNumber = (val?: string): number | undefined => {
 };
 
 /**
+ * Parse a comma-separated env value into a trimmed, non-empty string list;
+ * unset/blank => undefined.
+ */
+const parseEnvList = (val?: string): string[] | undefined => {
+  if (!val) return undefined;
+  return val
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+};
+
+/**
  * Lenient boolean validator. Unlike envalid's built-in `bool` (which rejects
  * e.g. `TRUE`/`yes`), this accepts `true`/`1`/`yes` case-insensitively. Safe to
  * combine with a boolean `default`/`devDefault` (envalid also runs the validator
@@ -304,6 +316,7 @@ export {
   num,
   // Lenient coercion
   parseEnvBoolean,
+  parseEnvList,
   parseEnvNumber,
   port,
   required,

--- a/pgpm/env/__tests__/__snapshots__/merge.test.ts.snap
+++ b/pgpm/env/__tests__/__snapshots__/merge.test.ts.snap
@@ -48,6 +48,11 @@ exports[`getEnvOptions merges defaults, config, env, and overrides 1`] = `
     "verbose": false,
   },
   "jobs": {
+    "gateway": {
+      "callbackPort": 12345,
+      "callbackUrl": "http://callback:12345",
+      "gatewayUrl": "http://gateway:8080",
+    },
     "scheduler": {
       "gracefulShutdown": true,
       "hostname": "scheduler-0",

--- a/pgpm/env/__tests__/assert.test.ts
+++ b/pgpm/env/__tests__/assert.test.ts
@@ -43,6 +43,8 @@ describe('findUnsafeProductionDefaults', () => {
     expect(joined).toContain('cdn.awsSecretKey');
     expect(joined).toContain('db.connections.app.password');
     expect(joined).toContain('pg.host');
+    expect(joined).toContain('jobs.gateway.gatewayUrl');
+    expect(joined).toContain('jobs.gateway.callbackUrl');
     // Never leak the value itself (paths mention ".password", but never the
     // actual secret/host strings baked into pgpmDefaults).
     expect(joined).not.toContain('app_password');
@@ -50,6 +52,8 @@ describe('findUnsafeProductionDefaults', () => {
     expect(joined).not.toContain('minioadmin');
     expect(joined).not.toContain('localhost');
     expect(joined).not.toContain('test-bucket');
+    expect(joined).not.toContain('http://gateway');
+    expect(joined).not.toContain('http://callback');
   });
 
   it('reports no issues when every sensitive field is overridden', () => {

--- a/pgpm/env/__tests__/merge.test.ts
+++ b/pgpm/env/__tests__/merge.test.ts
@@ -271,7 +271,9 @@ describe('getEnvOptions', () => {
         AWS_SECRET_KEY: 'realsecret',
         CDN_ENDPOINT: 'https://s3.example.com',
         CDN_PUBLIC_URL_PREFIX: 'https://cdn.example.com',
-        BUCKET_NAME: 'prod-bucket'
+        BUCKET_NAME: 'prod-bucket',
+        INTERNAL_GATEWAY_URL: 'http://gateway.internal:8080',
+        INTERNAL_JOBS_CALLBACK_URL: 'http://callback.internal:12345'
       };
       expect(() => getEnvOptions({}, emptyCwd(), safeEnv)).not.toThrow();
     });

--- a/pgpm/env/src/assert.ts
+++ b/pgpm/env/src/assert.ts
@@ -42,7 +42,9 @@ const SENSITIVE_FIELDS: SensitiveField[] = [
   { path: 'server.host', severity: 'host', envHint: 'SERVER_HOST' },
   { path: 'cdn.endpoint', severity: 'host', envHint: 'CDN_ENDPOINT' },
   { path: 'cdn.publicUrlPrefix', severity: 'host', envHint: 'CDN_PUBLIC_URL_PREFIX' },
-  { path: 'cdn.bucketName', severity: 'host', envHint: 'BUCKET_NAME' }
+  { path: 'cdn.bucketName', severity: 'host', envHint: 'BUCKET_NAME' },
+  { path: 'jobs.gateway.gatewayUrl', severity: 'host', envHint: 'INTERNAL_GATEWAY_URL' },
+  { path: 'jobs.gateway.callbackUrl', severity: 'host', envHint: 'INTERNAL_JOBS_CALLBACK_URL' }
 ];
 
 const getPath = (obj: unknown, path: string): unknown =>

--- a/pgpm/env/src/env.ts
+++ b/pgpm/env/src/env.ts
@@ -1,15 +1,7 @@
-import { parseEnvBoolean, parseEnvNumber } from '12factor-env';
+import { parseEnvBoolean, parseEnvList, parseEnvNumber } from '12factor-env';
 import { PgpmOptions, BucketProvider } from '@pgpmjs/types';
 
-export { parseEnvBoolean, parseEnvNumber };
-
-const parseEnvStringArray = (val?: string): string[] | undefined => {
-  if (!val) return undefined;
-  return val
-    .split(',')
-    .map(s => s.trim())
-    .filter(Boolean);
-};
+export { parseEnvBoolean, parseEnvList, parseEnvNumber };
 
 /**
  * Parse core PGPM environment variables.
@@ -174,7 +166,7 @@ export const getEnvVars = (env: NodeJS.ProcessEnv = process.env): PgpmOptions =>
             supportAny: parseEnvBoolean(JOBS_SUPPORT_ANY)
           }),
           ...(JOBS_SUPPORTED && {
-            supported: parseEnvStringArray(JOBS_SUPPORTED)
+            supported: parseEnvList(JOBS_SUPPORTED)
           })
         },
         scheduler: {
@@ -182,7 +174,7 @@ export const getEnvVars = (env: NodeJS.ProcessEnv = process.env): PgpmOptions =>
             supportAny: parseEnvBoolean(JOBS_SUPPORT_ANY)
           }),
           ...(JOBS_SUPPORTED && {
-            supported: parseEnvStringArray(JOBS_SUPPORTED)
+            supported: parseEnvList(JOBS_SUPPORTED)
           })
         }
       }),

--- a/pgpm/env/src/index.ts
+++ b/pgpm/env/src/index.ts
@@ -10,7 +10,7 @@ export {
   resolvePnpmWorkspace,
   resolveWorkspaceByType
 } from './config';
-export { getEnvVars, getNodeEnv, parseEnvBoolean, parseEnvNumber } from './env';
+export { getEnvVars, getNodeEnv, parseEnvBoolean, parseEnvList, parseEnvNumber } from './env';
 export { getConnEnvOptions, getDeploymentEnvOptions,getEnvOptions } from './merge';
 export { replaceArrays,walkUp } from './utils';
 export type { DeploymentOptions,PgpmOptions, PgTestConnectionOptions } from '@pgpmjs/types';

--- a/pgpm/types/src/pgpm.ts
+++ b/pgpm/types/src/pgpm.ts
@@ -2,7 +2,7 @@ import { execSync } from 'child_process';
 import { PgConfig } from 'pg-env';
 
 import { PgpmDriverConfig } from './driver';
-import { JobsConfig } from './jobs';
+import { JobsConfig, jobsDefaults } from './jobs';
 
 /**
  * Authentication options for test client sessions
@@ -343,27 +343,7 @@ export const pgpmDefaults: PgpmOptions = {
       useTx: false
     }
   },
-  jobs: {
-    schema: {
-      schema: 'app_jobs'
-    },
-    worker: {
-      schema: 'app_jobs',
-      hostname: 'worker-0',
-      supportAny: true,
-      supported: [],
-      pollInterval: 1000,
-      gracefulShutdown: true
-    },
-    scheduler: {
-      schema: 'app_jobs',
-      hostname: 'scheduler-0',
-      supportAny: true,
-      supported: [],
-      pollInterval: 1000,
-      gracefulShutdown: true
-    }
-  },
+  jobs: jobsDefaults,
   errorOutput: {
     queryHistoryLimit: 30,
     maxLength: 10000,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -402,6 +402,9 @@ importers:
 
   graphile/graphile-cache:
     dependencies:
+      12factor-env:
+        specifier: workspace:^
+        version: link:../../packages/12factor-env/dist
       '@pgpmjs/logger':
         specifier: workspace:^
         version: link:../../pgpm/logger/dist
@@ -3159,6 +3162,9 @@ importers:
 
   postgres/pg-cache:
     dependencies:
+      12factor-env:
+        specifier: workspace:^
+        version: link:../../packages/12factor-env/dist
       '@pgpmjs/logger':
         specifier: workspace:^
         version: link:../../pgpm/logger/dist
@@ -3228,6 +3234,10 @@ importers:
     publishDirectory: dist
 
   postgres/pg-env:
+    dependencies:
+      12factor-env:
+        specifier: workspace:^
+        version: link:../../packages/12factor-env/dist
     devDependencies:
       makage:
         specifier: ^0.3.0

--- a/postgres/pg-cache/package.json
+++ b/postgres/pg-cache/package.json
@@ -29,6 +29,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "12factor-env": "workspace:^",
     "@pgpmjs/logger": "workspace:^",
     "@pgpmjs/types": "workspace:^",
     "lru-cache": "^11.2.7",

--- a/postgres/pg-cache/src/lru.ts
+++ b/postgres/pg-cache/src/lru.ts
@@ -1,3 +1,4 @@
+import { parseEnvNumber } from '12factor-env';
 import { Logger } from '@pgpmjs/logger';
 import { LRUCache } from 'lru-cache';
 import pg from 'pg';
@@ -25,12 +26,6 @@ export interface PgCacheConfig {
   ttl: number;
 }
 
-const parseEnvInt = (val: string | undefined, fallback: number): number => {
-  if (!val) return fallback;
-  const n = parseInt(val, 10);
-  return isNaN(n) ? fallback : n;
-};
-
 /**
  * Read cache configuration from environment variables.
  *
@@ -40,8 +35,8 @@ const parseEnvInt = (val: string | undefined, fallback: number): number => {
  */
 export function getPgCacheConfig(): PgCacheConfig {
   return {
-    max: parseEnvInt(process.env.PG_CACHE_MAX, 50),
-    ttl: parseEnvInt(process.env.PG_CACHE_TTL_MS, ONE_YEAR),
+    max: parseEnvNumber(process.env.PG_CACHE_MAX) ?? 50,
+    ttl: parseEnvNumber(process.env.PG_CACHE_TTL_MS) ?? ONE_YEAR,
   };
 }
 

--- a/postgres/pg-cache/src/pg.ts
+++ b/postgres/pg-cache/src/pg.ts
@@ -1,3 +1,4 @@
+import { parseEnvNumber } from '12factor-env';
 import pg from 'pg';
 import { getPgEnvOptions, PgConfig, PgPoolConfig } from 'pg-env';
 import { Logger } from '@pgpmjs/logger';
@@ -16,12 +17,6 @@ export const buildConnectionString = (
 ): string =>
   `postgres://${user}:${password}@${host}:${port}/${database}`;
 
-const parseEnvInt = (val: string | undefined, fallback: number): number => {
-  if (!val) return fallback;
-  const n = parseInt(val, 10);
-  return isNaN(n) ? fallback : n;
-};
-
 /**
  * Read per-pool configuration from environment variables.
  *
@@ -32,9 +27,9 @@ const parseEnvInt = (val: string | undefined, fallback: number): number => {
  */
 export function getPgPoolConfig(overrides?: PgPoolConfig): pg.PoolConfig {
   return {
-    max: overrides?.max ?? parseEnvInt(process.env.PG_POOL_MAX, 5),
-    idleTimeoutMillis: overrides?.idleTimeoutMillis ?? parseEnvInt(process.env.PG_POOL_IDLE_TIMEOUT_MS, 30000),
-    connectionTimeoutMillis: overrides?.connectionTimeoutMillis ?? parseEnvInt(process.env.PG_POOL_CONNECTION_TIMEOUT_MS, 5000),
+    max: overrides?.max ?? parseEnvNumber(process.env.PG_POOL_MAX) ?? 5,
+    idleTimeoutMillis: overrides?.idleTimeoutMillis ?? parseEnvNumber(process.env.PG_POOL_IDLE_TIMEOUT_MS) ?? 30000,
+    connectionTimeoutMillis: overrides?.connectionTimeoutMillis ?? parseEnvNumber(process.env.PG_POOL_CONNECTION_TIMEOUT_MS) ?? 5000,
     ...(overrides?.allowExitOnIdle !== undefined && { allowExitOnIdle: overrides.allowExitOnIdle }),
   };
 }

--- a/postgres/pg-env/package.json
+++ b/postgres/pg-env/package.json
@@ -35,6 +35,9 @@
     "config",
     "constructive"
   ],
+  "dependencies": {
+    "12factor-env": "workspace:^"
+  },
   "devDependencies": {
     "makage": "^0.3.0"
   }

--- a/postgres/pg-env/src/env.ts
+++ b/postgres/pg-env/src/env.ts
@@ -1,9 +1,6 @@
-import { defaultPgConfig,PgConfig } from './pg-config';
+import { parseEnvNumber } from '12factor-env';
 
-const parseEnvNumber = (val?: string): number | undefined => {
-  const num = Number(val);
-  return !isNaN(num) ? num : undefined;
-};
+import { defaultPgConfig,PgConfig } from './pg-config';
 
 export const getPgEnvVars = (): Partial<PgConfig> => {
   const {


### PR DESCRIPTION
## Summary

Follow-up cleanup to the env-hardening effort: route every duplicated env-var parser through `12factor-env` and stop duplicating placeholder defaults. No runtime behavior changes except the intentional one noted below.

**Parser dedup** — deletes local copies and imports the shared helpers:
- `12factor-env` gains `parseEnvList` (comma-split → trimmed, non-empty list; unset/blank → `undefined`), exported + tested.
- `pgpm/env`: local `parseEnvStringArray` → shared `parseEnvList` (re-exported for consumers).
- `postgres/pg-env`: local `parseEnvNumber` → shared (adds `12factor-env` workspace dep).
- `postgres/pg-cache` (`pg.ts`, `lru.ts`): two identical `parseEnvInt(val, fallback)` copies → `parseEnvNumber(...) ?? fallback`.
- `graphile/graphile-cache`: inline `parseInt(process.env...)` → `parseEnvNumber`.
- `jobs/knative-job-service`: local `parseList` → `parseEnvList(raw) ?? []` (preserves the "unset ⇒ `[]`" selection semantics).

Left alone deliberately (not equivalent to the shared helper): `pgpm/cli`'s `parseList` (CLI flag flattening), `csv-to-pg`'s `parseBoolean` (arbitrary CSV values), and `graphql-server`'s `parseBooleanEnv` (accepts `on`/`off` + tri-state fallback). Standalone `Number(process.env.PORT)` boot reads in function/example packages are single-use entrypoint reads, not config-layer parsers.

**Placeholder centralization** — the jobs gateway placeholder URLs lived in three places:
```ts
// pgpm/types: pgpmDefaults.jobs duplicated most of jobsDefaults but omitted gateway
jobs: { schema, worker, scheduler }        // →  jobs: jobsDefaults

// job-utils/runtime.ts: inline fallback duplicating jobsDefaults.gateway
const defaults = jobsDefaults.gateway ?? { gatewayUrl: 'http://gateway:8080', ... }
                                       // →  ?? {}
```
Now `pgpmDefaults.jobs` *is* `jobsDefaults` (single source, and it carries `gateway`), so the production-safety assert can see the gateway placeholders. Added to `SENSITIVE_FIELDS`:
```ts
{ path: 'jobs.gateway.gatewayUrl',  severity: 'host', envHint: 'INTERNAL_GATEWAY_URL' }
{ path: 'jobs.gateway.callbackUrl', severity: 'host', envHint: 'INTERNAL_JOBS_CALLBACK_URL' }
```

**Only behavior change:** merged `pgpmDefaults` now includes the `jobs.gateway` block (previously absent from `pgpmDefaults`, present only in `jobsDefaults`). Values are identical to what `getJobGatewayConfig` already fell back to, so runtime resolution is unchanged; in `NODE_ENV=production` these placeholders now warn (throw under `STRICT_ENV=throw`) like the other baked dev defaults. Merge snapshot + assert/merge tests updated accordingly.


Link to Devin session: https://app.devin.ai/sessions/b4f03ceb2daf4231b0d30dbee3ae89da
Requested by: @pyramation