### PR TITLE
feat(query-builder): insert exprs, join ON filters, fromFunction, orderBy/groupBy exprs, clone

### DIFF
--- a/.agents/skills/query-builder/SKILL.md
+++ b/.agents/skills/query-builder/SKILL.md
@@ -3,7 +3,7 @@ name: query-builder
 description: "AST-backed PostgreSQL query builder — fluent API for SELECT/INSERT/UPDATE/DELETE with SDK-style JSON where filters, expression helpers, JOINs, CTEs, ON CONFLICT, RETURNING, parameterized values. Uses pg-ast + pgsql-deparser. Use when building parameterized SQL queries, writing test helpers, or working with TableClient in constructive-test."
 metadata:
   author: constructive-io
-  version: "2.0.0"
+  version: "2.1.0"
 ---
 
 # @constructive-io/query-builder
@@ -132,6 +132,13 @@ new QueryBuilder()
     { name: 'Alice', email: 'alice@example.com' },
     { name: 'Bob', email: 'bob@example.com' },
   ])
+  .build();
+
+// Values may be expressions
+new QueryBuilder()
+  .table('jobs')
+  .insert({ name: 'job-1', created_at: fn('now') })
+  .returning(['id'])
   .build();
 
 // Upsert (ON CONFLICT)
@@ -267,6 +274,10 @@ new QueryBuilder()
 - **Auto-parameterization**: All values become `ParamRef` nodes (`$1`, `$2`, ...) — values are never inlined into SQL.
 - **Deparser output**: `deparseSync()` produces pretty-printed multiline SQL. Tests should use flexible regex patterns with `\s*` for whitespace matching.
 - **NULL handling**: `.where({ col: { isNull: true } })` produces `col IS NULL`; `{ isNull: false }` produces `col IS NOT NULL` (no parameterization for NULL).
+- **JOIN ON conditions**: besides the 4-arg column form, joins accept a `Filter` or `Expr`: `.innerJoin('customers', and(eq(col('o.customer_id'), col('customers.id')), eq(col('customers.region'), 'us')))` or `.leftJoin('customers', { 'c.active': { equalTo: true } }, { schema: 'crm', alias: 'c' })`.
+- **Set-returning functions**: `.fromFunction('get_rows', [7], { schema: 'app', as: 'r' })` → `SELECT ... FROM app.get_rows($1) AS r`; joins/where/order compose over it like a table.
+- **ORDER BY / GROUP BY expressions**: `.orderBy(fn('lower', [col('name')]), 'DESC')` and `.groupBy([fn('date_trunc', [lit('day'), col('created_at')])])`.
+- **Cloning**: builders are mutable; `.clone()` copies configured state so `base.clone().where(...)` never mutates `base`.
 
 ## TableClient Integration
 

--- a/postgres/query-builder/README.md
+++ b/postgres/query-builder/README.md
@@ -277,6 +277,17 @@ new QueryBuilder()
 // INSERT INTO users (name) VALUES ($1) RETURNING id, lower(name) AS name_lower
 ```
 
+INSERT values accept expressions too:
+
+```ts
+new QueryBuilder()
+  .table('jobs')
+  .insert({ name: 'job-1', created_at: fn('now') })
+  .returning(['id'])
+  .build();
+// INSERT INTO jobs (name, created_at) VALUES ($1, now()) RETURNING id
+```
+
 ### JOINs
 
 ```ts
@@ -295,6 +306,58 @@ const { text, values } = new QueryBuilder()
 ```
 
 Supported join types: `.innerJoin()`, `.leftJoin()`, `.rightJoin()`, `.fullJoin()`.
+
+ON conditions also accept a JSON filter or an expression, for multi-condition or value-comparing joins:
+
+```ts
+import { and, eq, col } from '@constructive-io/query-builder';
+
+new QueryBuilder()
+  .table('orders', 'o')
+  .select(['o.id'])
+  .innerJoin('customers', and(
+    eq(col('o.customer_id'), col('customers.id')),
+    eq(col('customers.region'), 'us')
+  ))
+  .build();
+// JOIN customers ON o.customer_id = customers.id AND customers.region = $1
+
+new QueryBuilder()
+  .table('orders', 'o')
+  .select(['o.id'])
+  .leftJoin('customers', { 'c.active': { equalTo: true } }, { schema: 'crm', alias: 'c' })
+  .build();
+// LEFT JOIN crm.customers AS c ON c.active = $1
+```
+
+### Set-returning functions (fromFunction)
+
+Use a function as the FROM source with a range alias:
+
+```ts
+new QueryBuilder()
+  .select(['r.id', 'r.name'])
+  .fromFunction('get_rows', [7], { as: 'r' })
+  .where({ 'r.status': { equalTo: 'ok' } })
+  .build();
+// SELECT r.id, r.name FROM get_rows($1) AS r WHERE r.status = $2
+```
+
+Joins, WHERE filters, ORDER BY, etc. compose over the function source like a table.
+
+### Cloning
+
+Builders are mutable; `.clone()` copies the configured state so variants never affect the base:
+
+```ts
+const base = new QueryBuilder()
+  .table('jobs')
+  .select(['id'])
+  .where({ status: { equalTo: 'queued' } });
+
+const urgent = base.clone().where({ priority: { greaterThan: 5 } }).limit(1);
+// base is unchanged
+```
 
 ### CTEs (WITH clauses)
 
@@ -424,6 +487,14 @@ new QueryBuilder()
   .orderBy('name', 'ASC', 'FIRST')
   .build();
 
+// ORDER BY / GROUP BY expressions
+new QueryBuilder()
+  .table('events')
+  .select([{ expr: fn('date_trunc', [lit('day'), col('created_at')]), as: 'day' }])
+  .groupBy([fn('date_trunc', [lit('day'), col('created_at')])])
+  .orderBy(fn('lower', [col('name')]), 'DESC')
+  .build();
+
 // DISTINCT
 new QueryBuilder()
   .table('events')
@@ -451,16 +522,16 @@ new QueryBuilder()
 | `.select(columns)` | Build a SELECT with given columns (use `['*']` for all) |
 | `.selectCall(as, fnName, args?, opts?)` | Append a computed function-call column |
 | `.selectExpr(as, expr)` | Append a computed expression column |
-| `.insert(data)` | Build an INSERT (single row object or array of rows) |
+| `.insert(data)` | Build an INSERT (single row object or array of rows; values may be `Expr`) |
 | `.update(data)` | Build an UPDATE with `{ column: value \| Expr }` SET pairs |
 | `.delete()` | Build a DELETE |
 | `.where(...predicates)` | JSON filters and/or expressions (AND-combined across calls) |
-| `.innerJoin(table, leftCol, op, rightCol)` | INNER JOIN |
-| `.leftJoin(table, leftCol, op, rightCol)` | LEFT JOIN |
-| `.rightJoin(table, leftCol, op, rightCol)` | RIGHT JOIN |
-| `.fullJoin(table, leftCol, op, rightCol)` | FULL JOIN |
-| `.orderBy(col, dir?, nulls?)` | ORDER BY clause |
-| `.groupBy(columns)` | GROUP BY clause |
+| `.innerJoin(table, on, opts?)` | INNER JOIN; `on` is `(leftCol, op, rightCol)` or a `Filter`/`Expr` |
+| `.leftJoin(table, on, opts?)` | LEFT JOIN |
+| `.rightJoin(table, on, opts?)` | RIGHT JOIN |
+| `.fullJoin(table, on, opts?)` | FULL JOIN |
+| `.orderBy(col \| expr, dir?, nulls?)` | ORDER BY clause |
+| `.groupBy(columns)` | GROUP BY clause (column names or `Expr`s) |
 | `.having(...predicates)` | HAVING clause (JSON filters and/or expressions) |
 | `.limit(n)` | LIMIT clause |
 | `.offset(n)` | OFFSET clause |
@@ -470,6 +541,8 @@ new QueryBuilder()
 | `.with(name, subquery)` | CTE (WITH clause) |
 | `.withRecursive(name, subquery)` | Recursive CTE |
 | `.call(fnName, args?, opts?)` | Function/procedure call; `opts: { schema?, as? }`; args positional array or named record |
+| `.fromFunction(fnName, args?, opts?)` | Set-returning function as FROM source; `opts: { schema?, as? }` |
+| `.clone()` | Copy the builder for safe composition |
 | `.build()` | Returns `{ text: string, values: SqlValue[] }` |
 | `.toSQL()` | Returns just the SQL string |
 

--- a/postgres/query-builder/__tests__/query-builder.test.ts
+++ b/postgres/query-builder/__tests__/query-builder.test.ts
@@ -1341,4 +1341,208 @@ describe('QueryBuilder', () => {
       expect(values).toEqual(['2026-01-01']);
     });
   });
+
+  // =========================================================================
+  // Expressions in INSERT values
+  // =========================================================================
+  describe('INSERT Expression Values', () => {
+    it('should accept expressions in insert values', () => {
+      const { text, values } = new QueryBuilder()
+        .table('jobs')
+        .insert({
+          name: 'job-1',
+          created_at: fn('now'),
+          priority: add(lit(1), 2)
+        })
+        .returning(['id'])
+        .build();
+
+      expect(text).toMatch(/INSERT INTO jobs/);
+      expect(text).toMatch(/now\(\)/);
+      expect(text).toMatch(/1\s*\+\s*\$2/);
+      expect(values).toEqual(['job-1', 2]);
+    });
+
+    it('should accept expressions in multi-row inserts', () => {
+      const { text, values } = new QueryBuilder()
+        .table('events')
+        .insert([
+          { kind: 'a', at: fn('now') },
+          { kind: 'b', at: fn('now') }
+        ])
+        .build();
+
+      expect(text).toMatch(/now\(\)/);
+      expect(values).toEqual(['a', 'b']);
+    });
+  });
+
+  // =========================================================================
+  // JOIN ON with filters and expressions
+  // =========================================================================
+  describe('JOIN ON Filters and Expressions', () => {
+    it('should keep the classic 4-arg column form working', () => {
+      const { text } = new QueryBuilder()
+        .table('orders', 'o')
+        .select(['o.id'])
+        .innerJoin('customers', 'o.customer_id', '=', 'customers.id')
+        .build();
+
+      expect(text).toMatch(/JOIN customers ON o\.customer_id = customers\.id/);
+    });
+
+    it('should accept an expression ON condition', () => {
+      const { text, values } = new QueryBuilder()
+        .table('orders', 'o')
+        .select(['o.id'])
+        .innerJoin('customers', and(
+          eq(col('o.customer_id'), col('customers.id')),
+          eq(col('customers.region'), 'us')
+        ))
+        .build();
+
+      expect(text).toMatch(/JOIN customers ON\s+o\.customer_id = customers\.id\s+AND customers\.region = \$1/s);
+      expect(values).toEqual(['us']);
+    });
+
+    it('should accept a JSON filter ON condition', () => {
+      const { text, values } = new QueryBuilder()
+        .table('orders', 'o')
+        .select(['o.id'])
+        .leftJoin('c_alias', {
+          'c.active': { equalTo: true },
+          'c.tier': { in: ['gold', 'silver'] }
+        }, { schema: 'crm', alias: 'c' })
+        .build();
+
+      expect(text).toMatch(/LEFT JOIN crm\.c_alias AS c ON/s);
+      expect(text).toMatch(/c\.active = \$1/);
+      expect(text).toMatch(/c\.tier IN \(\$2, \$3\)/);
+      expect(values).toEqual([true, 'gold', 'silver']);
+    });
+  });
+
+  // =========================================================================
+  // fromFunction (set-returning function source)
+  // =========================================================================
+  describe('fromFunction', () => {
+    it('should build SELECT ... FROM fn(...) with a range alias', () => {
+      const { text, values } = new QueryBuilder()
+        .select(['r.id', 'r.name'])
+        .fromFunction('get_rows', [7], { as: 'r' })
+        .build();
+
+      expect(text).toMatch(/SELECT/);
+      expect(text).toMatch(/FROM get_rows\(\$1\) AS r/);
+      expect(values).toEqual([7]);
+    });
+
+    it('should support schema qualification and named args', () => {
+      const { text, values } = new QueryBuilder()
+        .fromFunction('get_users', { active: true }, { schema: 'app', as: 'u' })
+        .build();
+
+      expect(text).toMatch(/FROM app\.get_users\(active => \$1\) AS u/);
+      expect(text).toMatch(/SELECT\s+\*/s);
+      expect(values).toEqual([true]);
+    });
+
+    it('should support joining against a function source', () => {
+      const { text } = new QueryBuilder()
+        .select(['r.id', 't.name'])
+        .fromFunction('get_rows', [], { as: 'r' })
+        .innerJoin('teams', 'r.team_id', '=', 't.id', { alias: 't' })
+        .build();
+
+      expect(text).toMatch(/FROM get_rows\(\) AS r/);
+      expect(text).toMatch(/JOIN teams AS t ON r\.team_id = t\.id/);
+    });
+
+    it('should support where filters over function sources', () => {
+      const { text, values } = new QueryBuilder()
+        .select(['r.id'])
+        .fromFunction('get_rows', [], { as: 'r' })
+        .where({ 'r.status': { equalTo: 'ok' } })
+        .build();
+
+      expect(text).toMatch(/WHERE\s+r\.status = \$1/s);
+      expect(values).toEqual(['ok']);
+    });
+  });
+
+  // =========================================================================
+  // Expressions in ORDER BY / GROUP BY
+  // =========================================================================
+  describe('ORDER BY / GROUP BY Expressions', () => {
+    it('should order by an expression', () => {
+      const { text } = new QueryBuilder()
+        .table('users')
+        .select(['id'])
+        .orderBy(fn('lower', [col('name')]), 'DESC')
+        .build();
+
+      expect(text).toMatch(/ORDER BY\s+lower\(\s*name\s*\) DESC/s);
+    });
+
+    it('should group by an expression', () => {
+      const { text } = new QueryBuilder()
+        .table('events')
+        .select([{ expr: fn('date_trunc', [lit('day'), col('created_at')]), as: 'day' }])
+        .groupBy([fn('date_trunc', [lit('day'), col('created_at')])])
+        .build();
+
+      expect(text).toMatch(/GROUP BY\s+date_trunc\(/s);
+    });
+
+    it('should still group and order by column names', () => {
+      const { text } = new QueryBuilder()
+        .table('orders')
+        .select(['customer_id'])
+        .groupBy(['customer_id'])
+        .orderBy('customer_id', 'ASC', 'LAST')
+        .build();
+
+      expect(text).toMatch(/GROUP BY\s+customer_id/s);
+      expect(text).toMatch(/ORDER BY\s+customer_id ASC NULLS LAST/s);
+    });
+  });
+
+  // =========================================================================
+  // clone()
+  // =========================================================================
+  describe('clone', () => {
+    it('should not mutate the original when chaining on a clone', () => {
+      const base = new QueryBuilder()
+        .table('jobs')
+        .select(['id'])
+        .where({ status: { equalTo: 'queued' } });
+
+      const escalated = base.clone().where({ priority: { greaterThan: 5 } }).limit(1);
+
+      const baseOut = base.build();
+      const escalatedOut = escalated.build();
+
+      expect(baseOut.text).not.toMatch(/priority/);
+      expect(baseOut.text).not.toMatch(/LIMIT/);
+      expect(baseOut.values).toEqual(['queued']);
+
+      expect(escalatedOut.text).toMatch(/priority > \$2/);
+      expect(escalatedOut.text).toMatch(/LIMIT 1/);
+      expect(escalatedOut.values).toEqual(['queued', 5]);
+    });
+
+    it('should clone inserts, updates, joins and order specs independently', () => {
+      const base = new QueryBuilder()
+        .table('users')
+        .update({ name: 'a' })
+        .where({ id: { equalTo: 1 } })
+        .returning(['id']);
+
+      const other = base.clone().update({ name: 'b', updated_at: fn('now') });
+
+      expect(base.build().values).toEqual(['a', 1]);
+      expect(other.build().values).toEqual(['b', 1]);
+      expect(other.build().text).toMatch(/now\(\)/);
+    });
+  });
 });

--- a/postgres/query-builder/src/query-builder.ts
+++ b/postgres/query-builder/src/query-builder.ts
@@ -71,7 +71,7 @@ export interface SelectExpr {
 export type SelectItem = string | SelectExpr;
 
 interface OrderBySpec {
-  column: string;
+  column: string | Expr;
   direction: SortDir;
   nulls?: NullsOrder;
 }
@@ -81,7 +81,7 @@ interface JoinSpec {
   schema?: string;
   table: string;
   alias?: string;
-  on: JoinOn;
+  on: JoinOn | Filter | Expr;
 }
 
 interface JoinOn {
@@ -89,6 +89,8 @@ interface JoinOn {
   operator: string;
   value: string;
 }
+
+type JoinOpts = { schema?: string; alias?: string };
 
 interface CteSpec {
   name: string;
@@ -175,14 +177,14 @@ function constNode(val: SqlValue) {
   return nodes.aConst({ sval: ast.string({ sval: val }) });
 }
 
-function sortByNode(col: string, dir: SortDir, nullsOrd?: NullsOrder) {
+function sortByNode(target: unknown, dir: SortDir, nullsOrd?: NullsOrder) {
   const dirMap: Record<SortDir, string> = { ASC: 'SORTBY_ASC', DESC: 'SORTBY_DESC' };
   const nullsMap: Record<string, string> = {
     FIRST: 'SORTBY_NULLS_FIRST',
     LAST: 'SORTBY_NULLS_LAST',
   };
   return nodes.sortBy({
-    node: colRef(col),
+    node: target as any,
     sortby_dir: dirMap[dir] as any,
     sortby_nulls: (nullsOrd ? nullsMap[nullsOrd] : 'SORTBY_NULLS_DEFAULT') as any,
   });
@@ -359,14 +361,15 @@ export class QueryBuilder {
   private _tableAlias: string | undefined;
   private _selectItems: SelectItem[] = [];
   private _distinct: boolean = false;
-  private _insertData: Record<string, SqlValue>[] | undefined;
+  private _insertData: Record<string, Operand>[] | undefined;
   private _updateData: Record<string, Operand> | undefined;
   private _isDelete: boolean = false;
   private _wherePredicates: (Filter | Expr)[] = [];
   private _joins: JoinSpec[] = [];
-  private _groupByColumns: string[] = [];
+  private _groupByColumns: (string | Expr)[] = [];
   private _havingPredicates: (Filter | Expr)[] = [];
   private _orderBySpecs: OrderBySpec[] = [];
+  private _fromFunction: { name: string; args?: FnArgs; schema?: string; as?: string } | undefined;
   private _limitValue: number | undefined;
   private _offsetValue: number | undefined;
   private _returning: SelectItem[] | undefined;
@@ -420,7 +423,7 @@ export class QueryBuilder {
   // INSERT
   // -------------------------------------------------------------------------
 
-  insert(data: Record<string, SqlValue> | Record<string, SqlValue>[]): this {
+  insert(data: Record<string, Operand> | Record<string, Operand>[]): this {
     this._insertData = Array.isArray(data) ? data : [data];
     return this;
   }
@@ -465,46 +468,65 @@ export class QueryBuilder {
   // JOIN
   // -------------------------------------------------------------------------
 
+  // ON condition: either the classic 4-arg column form
+  //   .join('INNER', 't', 'a.id', '=', 't.a_id')
+  // or a Filter / expression
+  //   .join('INNER', 't', and(eq(col('a.id'), col('t.a_id')), eq(col('t.kind'), 'x')))
+  join(kind: 'INNER' | 'LEFT' | 'RIGHT' | 'FULL', table: string, on: Filter | Expr, opts?: JoinOpts): this;
+  join(kind: 'INNER' | 'LEFT' | 'RIGHT' | 'FULL', table: string, onColumn: string, operator: string, onValue: string, opts?: JoinOpts): this;
   join(
     kind: 'INNER' | 'LEFT' | 'RIGHT' | 'FULL',
     table: string,
-    onColumn: string,
-    operator: string,
-    onValue: string,
-    opts?: { schema?: string; alias?: string },
+    onOrColumn: Filter | Expr | string,
+    operatorOrOpts?: string | JoinOpts,
+    onValue?: string,
+    maybeOpts?: JoinOpts,
   ): this {
     const joinKind = `JOIN_${kind}` as JoinKind;
+    const isColumnForm = typeof onOrColumn === 'string';
+    const opts = (isColumnForm ? maybeOpts : operatorOrOpts as JoinOpts | undefined);
+    const on: JoinOn | Filter | Expr = isColumnForm
+      ? { column: onOrColumn, operator: operatorOrOpts as string, value: onValue! }
+      : onOrColumn;
     this._joins.push({
       kind: joinKind,
       schema: opts?.schema,
       table,
       alias: opts?.alias,
-      on: { column: onColumn, operator, value: onValue },
+      on,
     });
     return this;
   }
 
-  innerJoin(table: string, onCol: string, op: string, onVal: string, opts?: { schema?: string; alias?: string }): this {
-    return this.join('INNER', table, onCol, op, onVal, opts);
+  innerJoin(table: string, on: Filter | Expr, opts?: JoinOpts): this;
+  innerJoin(table: string, onCol: string, op: string, onVal: string, opts?: JoinOpts): this;
+  innerJoin(table: string, a: any, b?: any, c?: any, d?: any): this {
+    return this.join('INNER', table, a, b, c, d);
   }
 
-  leftJoin(table: string, onCol: string, op: string, onVal: string, opts?: { schema?: string; alias?: string }): this {
-    return this.join('LEFT', table, onCol, op, onVal, opts);
+  leftJoin(table: string, on: Filter | Expr, opts?: JoinOpts): this;
+  leftJoin(table: string, onCol: string, op: string, onVal: string, opts?: JoinOpts): this;
+  leftJoin(table: string, a: any, b?: any, c?: any, d?: any): this {
+    return this.join('LEFT', table, a, b, c, d);
   }
 
-  rightJoin(table: string, onCol: string, op: string, onVal: string, opts?: { schema?: string; alias?: string }): this {
-    return this.join('RIGHT', table, onCol, op, onVal, opts);
+  rightJoin(table: string, on: Filter | Expr, opts?: JoinOpts): this;
+  rightJoin(table: string, onCol: string, op: string, onVal: string, opts?: JoinOpts): this;
+  rightJoin(table: string, a: any, b?: any, c?: any, d?: any): this {
+    return this.join('RIGHT', table, a, b, c, d);
   }
 
-  fullJoin(table: string, onCol: string, op: string, onVal: string, opts?: { schema?: string; alias?: string }): this {
-    return this.join('FULL', table, onCol, op, onVal, opts);
+  fullJoin(table: string, on: Filter | Expr, opts?: JoinOpts): this;
+  fullJoin(table: string, onCol: string, op: string, onVal: string, opts?: JoinOpts): this;
+  fullJoin(table: string, a: any, b?: any, c?: any, d?: any): this {
+    return this.join('FULL', table, a, b, c, d);
   }
 
   // -------------------------------------------------------------------------
   // GROUP BY / HAVING
   // -------------------------------------------------------------------------
 
-  groupBy(columns: string[]): this {
+  groupBy(columns: (string | Expr)[]): this {
     this._groupByColumns.push(...columns);
     return this;
   }
@@ -518,7 +540,7 @@ export class QueryBuilder {
   // ORDER BY / LIMIT / OFFSET
   // -------------------------------------------------------------------------
 
-  orderBy(column: string, direction: SortDir = 'ASC', nulls?: NullsOrder): this {
+  orderBy(column: string | Expr, direction: SortDir = 'ASC', nulls?: NullsOrder): this {
     this._orderBySpecs.push({ column, direction, nulls });
     return this;
   }
@@ -565,6 +587,50 @@ export class QueryBuilder {
     return this;
   }
 
+  // Set-returning function as the FROM source, with an optional range alias:
+  //   .select(['r.id']).fromFunction('get_rows', [7], { as: 'r' })
+  //   -> SELECT r.id FROM get_rows($1) AS r
+  fromFunction(name: string, args?: FnArgs, opts?: { schema?: string; as?: string }): this {
+    this._fromFunction = { name, args, schema: opts?.schema ?? this._schema, as: opts?.as };
+    return this;
+  }
+
+  // Deep-enough copy for safe composition: cloning then chaining never
+  // mutates the original builder. Referenced sub-builders (CTEs, subquery
+  // operands) are shared — building never mutates their configured state.
+  clone(): QueryBuilder {
+    const c = new QueryBuilder();
+    c._schema = this._schema;
+    c._table = this._table;
+    c._tableAlias = this._tableAlias;
+    c._selectItems = this._selectItems.map((i) => (typeof i === 'string' ? i : { ...i }));
+    c._distinct = this._distinct;
+    c._insertData = this._insertData?.map((row) => ({ ...row }));
+    c._updateData = this._updateData ? { ...this._updateData } : undefined;
+    c._isDelete = this._isDelete;
+    c._wherePredicates = [...this._wherePredicates];
+    c._joins = this._joins.map((j) => ({ ...j }));
+    c._groupByColumns = [...this._groupByColumns];
+    c._havingPredicates = [...this._havingPredicates];
+    c._orderBySpecs = this._orderBySpecs.map((s) => ({ ...s }));
+    c._limitValue = this._limitValue;
+    c._offsetValue = this._offsetValue;
+    c._returning = this._returning
+      ? this._returning.map((i) => (typeof i === 'string' ? i : { ...i }))
+      : undefined;
+    c._ctes = this._ctes.map((cte) => ({ ...cte }));
+    c._onConflict = this._onConflict
+      ? {
+        ...this._onConflict,
+        columns: this._onConflict.columns ? [...this._onConflict.columns] : undefined,
+        updateColumns: this._onConflict.updateColumns ? { ...this._onConflict.updateColumns } : undefined,
+      }
+      : undefined;
+    c._funcCall = this._funcCall ? { ...this._funcCall } : undefined;
+    c._fromFunction = this._fromFunction ? { ...this._fromFunction } : undefined;
+    return c;
+  }
+
   // -------------------------------------------------------------------------
   // Build
   // -------------------------------------------------------------------------
@@ -572,6 +638,9 @@ export class QueryBuilder {
   build(): QueryOutput {
     if (this._funcCall) {
       return this._buildFuncCall();
+    }
+    if (!this._table && this._fromFunction) {
+      return this._buildSelect();
     }
     if (!this._table) {
       throw new Error('Table name is not specified.');
@@ -849,30 +918,49 @@ export class QueryBuilder {
   // Internal: FROM clause with JOINs (wrapped nodes for fromClause arrays)
   // -------------------------------------------------------------------------
 
+  private _joinQuals(on: JoinOn | Filter | Expr): unknown {
+    if (isExpr(on)) {
+      return on(this._alloc);
+    }
+    if (typeof (on as JoinOn).column === 'string' && typeof (on as JoinOn).operator === 'string') {
+      const j = on as JoinOn;
+      return operatorExpr(colRef(j.column), j.operator, colRef(j.value));
+    }
+    return this._filterToNode(on as Filter);
+  }
+
   private _buildFromClause(): unknown[] {
-    const baseTable = wrappedRangeVar(this._table!, this._schema, this._tableAlias);
+    const base = this._fromFunction
+      ? this._rangeFunctionNode(this._fromFunction)
+      : wrappedRangeVar(this._table!, this._schema, this._tableAlias);
 
     if (this._joins.length === 0) {
-      return [baseTable];
+      return [base];
     }
 
-    let result: unknown = baseTable;
+    let result: unknown = base;
     for (const j of this._joins) {
       const rightTable = wrappedRangeVar(j.table, j.schema, j.alias);
-
-      const onLeft = colRef(j.on.column);
-      const onRight = colRef(j.on.value as string);
-      const quals = operatorExpr(onLeft, j.on.operator, onRight);
-
       result = nodes.joinExpr({
         jointype: j.kind as any,
         larg: result as any,
         rarg: rightTable as any,
-        quals: quals as any,
+        quals: this._joinQuals(j.on) as any,
       });
     }
 
     return [result];
+  }
+
+  private _rangeFunctionNode(spec: { name: string; args?: FnArgs; schema?: string; as?: string }): unknown {
+    const funcNode = funcCallNode(spec.name, buildFnArgNodes(spec.args, this._alloc), spec.schema);
+    return nodes.rangeFunction({
+      functions: [nodes.list({ items: [funcNode] as any[] })] as any[],
+      lateral: false,
+      ordinality: false,
+      is_rowsfrom: false,
+      alias: spec.as ? ast.alias({ aliasname: spec.as }) : undefined,
+    });
   }
 
   // -------------------------------------------------------------------------
@@ -882,17 +970,21 @@ export class QueryBuilder {
   private _buildSelectInternal(startParamIndex: number = 0): unknown {
     this._paramIndex = startParamIndex;
 
-    const targetList = this._buildTargetList(this._selectItems);
+    const targetList = this._buildTargetList(
+      this._selectItems.length > 0 ? this._selectItems : ['*']
+    );
 
     const whereClause = this._buildPredicates(this._wherePredicates);
     const havingClause = this._buildPredicates(this._havingPredicates);
 
     const groupClause = this._groupByColumns.length > 0
-      ? this._groupByColumns.map((col) => colRef(col))
+      ? this._groupByColumns.map((g) => (isExpr(g) ? g(this._alloc) : colRef(g)))
       : undefined;
 
     const sortClause = this._orderBySpecs.length > 0
-      ? this._orderBySpecs.map((s) => sortByNode(s.column, s.direction, s.nulls))
+      ? this._orderBySpecs.map((s) =>
+        sortByNode(isExpr(s.column) ? s.column(this._alloc) : colRef(s.column), s.direction, s.nulls)
+      )
       : undefined;
 
     const limitCount = this._limitValue !== undefined
@@ -946,7 +1038,7 @@ export class QueryBuilder {
     const cols = columns.map((c) => resTargetCol(c));
 
     const valuesLists = rows.map((row) => {
-      const items = columns.map((c) => this._addParam(row[c]));
+      const items = columns.map((c) => operandToNode(row[c], this._alloc));
       return nodes.list({ items: items as any[] });
     });
 


### PR DESCRIPTION
## Summary

Five additive composability improvements to `@constructive-io/query-builder` (no breaking changes; existing signatures keep working):

- **`insert()` values accept `Expr`** — matches `update()`: `insert({ name: 'job-1', created_at: fn('now'), priority: add(lit(1), 2) })`.
- **JOIN ON accepts `Filter | Expr`** — new overloads alongside the classic 4-arg form:
  ```ts
  .innerJoin('customers', and(eq(col('o.customer_id'), col('customers.id')), eq(col('customers.region'), 'us')))
  .leftJoin('customers', { 'c.active': { equalTo: true } }, { schema: 'crm', alias: 'c' })
  ```
  enabling multi-condition and value-comparing joins (parameterized).
- **`fromFunction(name, args, { schema, as })`** — set-returning function as the FROM source with a range alias: `SELECT r.id FROM app.get_rows($1) AS r`; joins/where/order compose over it like a table (previously only the implicit alias-less `.select().call()` mode existed).
- **`orderBy()`/`groupBy()` accept `Expr`** — `orderBy(fn('lower', [col('name')]), 'DESC')`, `groupBy([fn('date_trunc', [lit('day'), col('created_at')])])`.
- **`clone()`** — copies configured state so `base.clone().where(...)` never mutates `base` (builders are mutable; needed for the compute-worker base-query composition pattern). Referenced sub-builders (CTEs/subqueries) are shared since building doesn't mutate their configured state.

Also: `SELECT` target list now defaults to `*` when `.select()` was never called (needed for bare `fromFunction()`; previously produced an empty target list).

14 new tests (111 total). README + `.agents/skills/query-builder/SKILL.md` updated.

Link to Devin session: https://app.devin.ai/sessions/3766c470681e402680eae001e9679801
Requested by: @pyramation