### PR TITLE
chore(12factor-env): remove secret file support

### DIFF
--- a/packages/12factor-env/README.md
+++ b/packages/12factor-env/README.md
@@ -16,9 +16,9 @@
   </a>
 </p>
 
-> Environment variable validation with secret file support for 12-factor apps
+> Environment variable validation for 12-factor apps
 
-A TypeScript library for validating environment variables with built-in support for Docker/Kubernetes secret files. Built on top of [envalid](https://github.com/af/envalid) with additional features for reading secrets from files.
+A TypeScript library for validating environment variables. Built on top of [envalid](https://github.com/af/envalid).
 
 ## Installation
 
@@ -115,49 +115,6 @@ parseEnvBoolean('YES'); // true
 parseEnvNumber('42');   // 42
 ```
 
-## Secret File Support
-
-This library supports reading secrets from files, which is useful for Docker secrets and Kubernetes secrets that are mounted as files.
-
-### Direct Secret Files
-
-Secrets can be read from `/run/secrets/` (or a custom path via `ENV_SECRETS_PATH`):
-
-```ts
-import { env, str } from '12factor-env';
-
-// If /run/secrets/DATABASE_PASSWORD exists, it will be read automatically
-const config = env(process.env, {
-  DATABASE_PASSWORD: str()
-});
-```
-
-### _FILE Suffix Pattern
-
-You can also use the `_FILE` suffix pattern commonly used with Docker:
-
-```bash
-# Set the path to the secret file
-export DATABASE_PASSWORD_FILE=/run/secrets/db-password
-```
-
-```ts
-import { env, str } from '12factor-env';
-
-// Will read from the file specified in DATABASE_PASSWORD_FILE
-const config = env(process.env, {
-  DATABASE_PASSWORD: str()
-});
-```
-
-### Custom Secrets Path
-
-Set `ENV_SECRETS_PATH` to change the default secrets directory:
-
-```bash
-export ENV_SECRETS_PATH=/custom/secrets/path
-```
-
 ## Validators
 
 All validators from [envalid](https://github.com/af/envalid) are re-exported:
@@ -195,39 +152,6 @@ Main function to validate environment variables.
 - `inputEnv` - The environment object (usually `process.env`)
 - `secrets` - Required environment variables
 - `vars` - Optional environment variables
-
-### `secret(envFile)`
-
-Create a validator for a secret file:
-
-```ts
-import { env, secret } from '12factor-env';
-
-const config = env(process.env, {
-  DB_PASSWORD: secret('DATABASE_PASSWORD')
-});
-```
-
-### `getSecret(name)`
-
-Read a secret from a file:
-
-```ts
-import { getSecret } from '12factor-env';
-
-const password = getSecret('DATABASE_PASSWORD');
-```
-
-### `secretPath(name)`
-
-Resolve the full path to a secret file:
-
-```ts
-import { secretPath } from '12factor-env';
-
-const path = secretPath('DATABASE_PASSWORD');
-// Returns: /run/secrets/DATABASE_PASSWORD
-```
 
 ## Re-exports from envalid
 

--- a/packages/12factor-env/__tests__/env.test.ts
+++ b/packages/12factor-env/__tests__/env.test.ts
@@ -1,7 +1,3 @@
-import { mkdirSync, rmSync,unlinkSync, writeFileSync } from 'fs';
-import { tmpdir } from 'os';
-import { join } from 'path';
-
 import {
   bool,
   boolish,
@@ -23,19 +19,6 @@ import {
 
 describe('env', () => {
   const ORIGINAL_ENV = { ...process.env };
-  const testDir = join(tmpdir(), 'env-test-' + process.pid);
-
-  beforeAll(() => {
-    mkdirSync(testDir, { recursive: true });
-  });
-
-  afterAll(() => {
-    try {
-      rmSync(testDir, { recursive: true });
-    } catch {
-      // ignore cleanup errors
-    }
-  });
 
   afterEach(() => {
     // Remove any env var added during the test
@@ -46,31 +29,6 @@ describe('env', () => {
     }
     // Restore original values
     Object.assign(process.env, ORIGINAL_ENV);
-  });
-
-  describe('_FILE secret detection', () => {
-    it('should discover secrets via _FILE suffix pattern in original env', () => {
-      const secretPath = join(testDir, 'api-secret');
-      writeFileSync(secretPath, 'super-secret-value');
-
-      try {
-        // API_KEY_FILE is in env but API_KEY is not in vars
-        // This tests the fix: secretEnv should use inputEnv, not varEnv
-        const result = env(
-          {
-            API_KEY_FILE: secretPath,
-            PORT: '3000'
-          },
-          { API_KEY: str() },
-          { PORT: port() }
-        );
-
-        expect(result.API_KEY).toBe('super-secret-value');
-        expect(result.PORT).toBe(3000);
-      } finally {
-        unlinkSync(secretPath);
-      }
-    });
   });
 
   describe('access to vars', () => {
@@ -86,38 +44,6 @@ describe('env', () => {
 
       expect(result.MAILGUN_KEY).toBe('test-key');
       expect(result.MAILGUN_DOMAIN).toBe('mg.example.com');
-    });
-  });
-
-  describe('precedence', () => {
-    it('should prefer file secret over plain env when both exist', () => {
-      const secretPath = join(testDir, 'api-key-secret');
-      writeFileSync(secretPath, 'from-file');
-
-      try {
-        const result = env(
-          {
-            API_KEY: 'from-env',
-            API_KEY_FILE: secretPath
-          },
-          { API_KEY: str() },
-          {}
-        );
-
-        expect(result.API_KEY).toBe('from-file');
-      } finally {
-        unlinkSync(secretPath);
-      }
-    });
-
-    it('should use plain env when no file secret exists', () => {
-      const result = env(
-        { API_KEY: 'from-env' },
-        { API_KEY: str() },
-        {}
-      );
-
-      expect(result.API_KEY).toBe('from-env');
     });
   });
 
@@ -161,52 +87,6 @@ describe('env', () => {
       expect(result.API_KEY).toBe('test-key');
       expect(result.PORT).toBe(8080);
       expect(result.DEBUG).toBe(false);
-    });
-  });
-
-  describe('ENV_SECRETS_PATH resolution', () => {
-    it('A5: should read secrets from ENV_SECRETS_PATH directory', () => {
-      // Write file named 'API_KEY' (not API_KEY_FILE) to temp dir
-      const secretPath = join(testDir, 'API_KEY');
-      writeFileSync(secretPath, 'secret-from-path');
-
-      // Set ENV_SECRETS_PATH - now works without module reload thanks to lazy getSecretsPath()
-      process.env.ENV_SECRETS_PATH = testDir;
-
-      try {
-        const result = env(
-          {}, // No API_KEY_FILE, no API_KEY in env
-          { API_KEY: str() },
-          {}
-        );
-        expect(result.API_KEY).toBe('secret-from-path');
-      } finally {
-        unlinkSync(secretPath);
-      }
-    });
-  });
-
-  describe('fallback behavior', () => {
-    it('B1: _FILE present but file missing + env secret present → fallback', () => {
-      const result = env(
-        {
-          API_KEY: 'fallback-value',
-          API_KEY_FILE: '/nonexistent/path'
-        },
-        { API_KEY: str() },
-        {}
-      );
-      expect(result.API_KEY).toBe('fallback-value');
-    });
-
-    it('B2: _FILE present but file missing + env secret missing → throw', () => {
-      expect(() => {
-        env(
-          { API_KEY_FILE: '/nonexistent/path' },
-          { API_KEY: str() },
-          {}
-        );
-      }).toThrow(/API_KEY/);
     });
   });
 

--- a/packages/12factor-env/package.json
+++ b/packages/12factor-env/package.json
@@ -2,7 +2,7 @@
   "name": "12factor-env",
   "version": "1.17.0",
   "author": "Constructive <developers@constructive.io>",
-  "description": "Environment variable validation with secret file support for 12-factor apps",
+  "description": "Environment variable validation for 12-factor apps",
   "main": "index.js",
   "module": "esm/index.js",
   "types": "index.d.ts",
@@ -41,9 +41,6 @@
     "env",
     "validation",
     "12factor",
-    "secrets",
-    "kubernetes",
-    "docker",
     "constructive"
   ]
 }

--- a/packages/12factor-env/src/index.ts
+++ b/packages/12factor-env/src/index.ts
@@ -13,8 +13,6 @@ import {
   str,
   testOnly,
   url} from 'envalid';
-import { readFileSync } from 'fs';
-import { join,resolve } from 'path';
 
 /**
  * NODE_ENV resolved with "house" semantics.
@@ -114,67 +112,6 @@ const cleanEnv = <S extends Record<string, ValidatorSpec<unknown>>>(
   });
 };
 
-/**
- * Get the secrets path lazily to allow ENV_SECRETS_PATH changes at runtime
- */
-const getSecretsPath = (): string =>
-  process.env.ENV_SECRETS_PATH ?? '/run/secrets/';
-
-/**
- * Resolve the full path to a secret file
- */
-const secretPath = (name: string): string =>
-  name.startsWith('/') ? name : resolve(join(getSecretsPath(), name));
-
-/**
- * Read a secret from a file
- * @param secret - The secret file name or path
- * @returns The secret value or undefined if not found
- */
-const getSecret = (secret: string | undefined): string | undefined => {
-  if (!secret) return undefined;
-  try {
-    const value = readFileSync(secretPath(secret), 'utf-8');
-    return value.trim();
-  } catch {
-    return undefined;
-  }
-};
-
-/**
- * Read secrets from files based on the secret props configuration
- * Supports both direct secret files and _FILE suffix pattern
- */
-const secretEnv = <T extends Record<string, ValidatorSpec<unknown>>>(
-  inputEnv: Record<string, string | undefined>,
-  secretProps: T
-): Record<string, string> => {
-  return Object.keys(secretProps).reduce<Record<string, string>>((m, k) => {
-    // Try to read secret directly from file
-    const secret = getSecret(k);
-    if (secret) {
-      m[k] = secret;
-    } else {
-      // Try _FILE suffix pattern (e.g., DATABASE_PASSWORD_FILE)
-      const secretFileKey = `${k}_FILE`;
-      if (Object.prototype.hasOwnProperty.call(inputEnv, secretFileKey)) {
-        const secretFileValue = getSecret(inputEnv[secretFileKey]);
-        if (secretFileValue) {
-          m[k] = secretFileValue;
-        }
-      }
-    }
-    return m;
-  }, {});
-};
-
-/**
- * Create a validator for a secret file
- * @param envFile - The environment variable name for the secret file
- */
-const secret = (envFile?: string): ValidatorSpec<string> =>
-  str({ default: getSecret(envFile) });
-
 // ── Fallback classes ─────────────────────────────────────────────────────────
 //
 // A var's real distinction is not "optional vs required" but "is there an honest
@@ -246,7 +183,7 @@ const boolish = makeValidator<boolean>((value: string) => {
 type Specs = Record<string, ValidatorSpec<unknown>>;
 
 /**
- * Validate environment variables with secret file support
+ * Validate environment variables
  *
  * @param inputEnv - The environment object (usually process.env)
  * @param secrets - Required environment variables (validated with envalid)
@@ -276,13 +213,7 @@ const env = <S extends Specs, V extends Specs>(
   // First pass: validate optional vars
   const varEnv = cleanEnv(inputEnv, vars);
 
-  // Read secrets from files
-  const _secrets = secretEnv(inputEnv, secrets);
-
-  // Second pass: validate secrets with file values merged in
-  // Include inputEnv first so env vars (e.g., Kubernetes secretKeyRef) are available,
-  // then varEnv overrides, then file-based secrets have highest priority
-  const mergedEnv = { ...inputEnv, ...varEnv, ..._secrets } as unknown as Record<string, string | undefined>;
+  const mergedEnv = { ...inputEnv, ...varEnv } as unknown as Record<string, string | undefined>;
   return cleanEnv(mergedEnv, { ...secrets, ...vars }) as unknown as CleanedEnv<S & V>;
 };
 
@@ -296,8 +227,6 @@ export {
   env,
   EnvError,
   EnvMissingError,
-  getSecret,
-  getSecretsPath,
   host,
   json,
   makeValidator,
@@ -307,9 +236,6 @@ export {
   parseEnvNumber,
   port,
   required,
-  secret,
-  secretEnv,
-  secretPath,
   str,
   testOnly,
   url,

--- a/packages/postmaster/__tests__/send.test.ts
+++ b/packages/postmaster/__tests__/send.test.ts
@@ -1,8 +1,4 @@
-import { writeFileSync, unlinkSync, mkdirSync, rmSync } from 'fs';
-import { join } from 'path';
-import { tmpdir } from 'os';
-
-import { send, resetClient } from '../src';
+import { resetClient,send } from '../src';
 
 // Enhanced mock to capture actual arguments passed to messages.create
 const mockCreate = jest.fn().mockResolvedValue({ id: 'mock-message-id' });
@@ -17,19 +13,6 @@ jest.mock('mailgun.js', () => {
 
 describe('send', () => {
   const ORIGINAL_ENV = { ...process.env };
-  const testDir = join(tmpdir(), 'postmaster-test-' + process.pid);
-
-  beforeAll(() => {
-    mkdirSync(testDir, { recursive: true });
-  });
-
-  afterAll(() => {
-    try {
-      rmSync(testDir, { recursive: true });
-    } catch {
-      // ignore cleanup errors
-    }
-  });
 
   beforeEach(() => {
     mockCreate.mockClear();
@@ -53,8 +36,7 @@ describe('send', () => {
     process.env.MAILGUN_FROM = 'sender@example.com';
     process.env.MAILGUN_REPLY = 'reply@example.com';
 
-    // This should not throw ReferenceError when accessing vars
-    // The bug was that secretEnv used varEnv instead of inputEnv
+    // This should not throw ReferenceError when accessing vars.
     await expect(
       send({
         to: 'recipient@example.com',
@@ -124,25 +106,6 @@ describe('send', () => {
     ).resolves.not.toThrow();
   });
 
-  describe('file-based secrets', () => {
-    it('C1: MAILGUN_KEY_FILE only (no MAILGUN_KEY) → send succeeds', async () => {
-      const keyPath = join(testDir, 'mailgun-key');
-      writeFileSync(keyPath, 'file-api-key');
-
-      process.env.MAILGUN_KEY_FILE = keyPath;
-      process.env.MAILGUN_DOMAIN = 'mg.example.com';
-      process.env.MAILGUN_FROM = 'sender@example.com';
-      process.env.MAILGUN_REPLY = 'reply@example.com';
-      // No MAILGUN_KEY set directly
-
-      await expect(
-        send({ to: 'test@example.com', subject: 'Test', text: 'Body' })
-      ).resolves.not.toThrow();
-
-      unlinkSync(keyPath);
-    });
-  });
-
   describe('resetClient behavior', () => {
     it('C2: resetClient() forces env re-read', async () => {
       process.env.MAILGUN_KEY = 'key1';
@@ -179,7 +142,6 @@ describe('send', () => {
 
     it('D2: Missing MAILGUN_KEY → throw', async () => {
       delete process.env.MAILGUN_KEY;
-      delete process.env.MAILGUN_KEY_FILE;
       process.env.MAILGUN_DOMAIN = 'mg.example.com';
       process.env.MAILGUN_FROM = 'sender@example.com';
       process.env.MAILGUN_REPLY = 'reply@example.com';


### PR DESCRIPTION
## Summary
Remove filesystem-backed secret resolution from `12factor-env` and standardize configuration on Kubernetes/Knative-style environment injection.

- Delete implicit `/run/secrets/<name>` lookup and the `${NAME}_FILE` convention.
- Remove the related `secret`, `getSecret`, `secretPath`, `getSecretsPath`, and `secretEnv` APIs.
- Update package documentation, metadata, and dependent tests to describe/use direct environment values only.

Link to Devin session: https://app.devin.ai/sessions/1d0f77fdeaf849ea88960b9f8566fa13
Requested by: @pyramation