### PR TITLE
feat: scoped-routing resolution via resolve_route() in api middleware (Lane B)

### DIFF
--- a/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
+++ b/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
@@ -5,6 +5,7 @@ exports[`getEnvOptions merges pgpm defaults, graphql defaults, config, env, and 
   "api": {
     "anonRole": "env_anon",
     "defaultDatabaseId": "override_db",
+    "enableScopedRouting": false,
     "enableServicesApi": false,
     "exposedSchemas": [
       "public",
@@ -16,6 +17,7 @@ exports[`getEnvOptions merges pgpm defaults, graphql defaults, config, env, and 
       "env_meta2",
     ],
     "roleName": "env_role",
+    "scopedRoutingSchema": "constructive_routing_public",
   },
   "cdn": {
     "awsAccessKey": "minioadmin",

--- a/graphql/server/src/middleware/__tests__/routing.test.ts
+++ b/graphql/server/src/middleware/__tests__/routing.test.ts
@@ -55,42 +55,42 @@ const createPool = (query: jest.Mock): Pool => ({ query } as unknown as Pool);
 describe('resolveRoute', () => {
   it('returns the row when a route matches', async () => {
     const query = jest.fn().mockResolvedValue({ rows: [matchedRoute()] });
-    const row = await resolveRoute(createPool(query), 'constructive_routing_public', 'api.example.com', '/', 'GET');
+    const row = await resolveRoute(createPool(query), 'constructive_routing_public', 'api.example.com');
     expect(row?.route_binding_id).toBe('rb-1');
     expect(query).toHaveBeenCalledWith(
-      expect.stringContaining('"constructive_routing_public".resolve_route($1, $2, $3)'),
-      ['api.example.com', '/', 'GET']
+      expect.stringContaining(`"constructive_routing_public".resolve_route($1, '/', NULL)`),
+      ['api.example.com']
     );
   });
 
   it('returns null on the contract no-match row (route_binding_id IS NULL)', async () => {
     const query = jest.fn().mockResolvedValue({ rows: [noMatchRoute()] });
-    const row = await resolveRoute(createPool(query), 'constructive_routing_public', 'nope.example.com', '/', 'GET');
+    const row = await resolveRoute(createPool(query), 'constructive_routing_public', 'nope.example.com');
     expect(row).toBeNull();
   });
 
   it('returns null when the resolver function is not installed', async () => {
     const query = jest.fn().mockRejectedValue(Object.assign(new Error('undefined function'), { code: '42883' }));
-    const row = await resolveRoute(createPool(query), 'constructive_routing_public', 'api.example.com', '/', 'GET');
+    const row = await resolveRoute(createPool(query), 'constructive_routing_public', 'api.example.com');
     expect(row).toBeNull();
   });
 
   it('returns null when the routing schema does not exist', async () => {
     const query = jest.fn().mockRejectedValue(Object.assign(new Error('invalid schema'), { code: '3F000' }));
-    const row = await resolveRoute(createPool(query), 'constructive_routing_public', 'api.example.com', '/', 'GET');
+    const row = await resolveRoute(createPool(query), 'constructive_routing_public', 'api.example.com');
     expect(row).toBeNull();
   });
 
   it('rethrows unexpected database errors', async () => {
     const query = jest.fn().mockRejectedValue(Object.assign(new Error('boom'), { code: '57P01' }));
     await expect(
-      resolveRoute(createPool(query), 'constructive_routing_public', 'api.example.com', '/', 'GET')
+      resolveRoute(createPool(query), 'constructive_routing_public', 'api.example.com')
     ).rejects.toThrow('boom');
   });
 
   it('rejects unsafe schema names without querying', async () => {
     const query = jest.fn();
-    const row = await resolveRoute(createPool(query), 'bad"; DROP TABLE x;--', 'api.example.com', '/', 'GET');
+    const row = await resolveRoute(createPool(query), 'bad"; DROP TABLE x;--', 'api.example.com');
     expect(row).toBeNull();
     expect(query).not.toHaveBeenCalled();
   });
@@ -159,7 +159,7 @@ describe('getApiConfig with scoped routing enabled', () => {
     rows: (params[0] as string[]).map((schemaName) => ({ schema_name: schemaName })),
   });
 
-  it('resolves via resolve_route before the legacy domain lookup', async () => {
+  it('resolves via resolve_route (host only) before the legacy domain lookup', async () => {
     const query = jest.fn(async (sql: string, params: unknown[]) => {
       if (sql.includes('information_schema.schemata')) return schemaValidationRows(params);
       if (sql.includes('resolve_route')) return { rows: [matchedRoute()] };
@@ -172,7 +172,7 @@ describe('getApiConfig with scoped routing enabled', () => {
     expect(result).toEqual(expect.objectContaining({ apiId: 'api-1', dbname: 'tenant_db' }));
     expect(query).toHaveBeenCalledWith(
       expect.stringContaining('resolve_route'),
-      ['api.example.com', '/graphql', 'POST']
+      ['api.example.com']
     );
   });
 

--- a/graphql/server/src/middleware/__tests__/routing.test.ts
+++ b/graphql/server/src/middleware/__tests__/routing.test.ts
@@ -1,0 +1,217 @@
+jest.mock('pg-cache', () => ({
+  getPgPool: jest.fn(),
+}));
+
+jest.mock('@constructive-io/express-context', () => ({
+  createDefaultRegistry: jest.fn(() => ({
+    resolve: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+import type { Request } from 'express';
+import type { Pool } from 'pg';
+import { svcCache } from '@pgpmjs/server-utils';
+import { getPgPool } from 'pg-cache';
+
+import type { ApiOptions } from '../../types';
+import { getApiConfig } from '../api';
+import { ResolvedRoute, resolveRoute, routeToApiStructure } from '../routing';
+
+const mockGetPgPool = getPgPool as jest.MockedFunction<typeof getPgPool>;
+
+const matchedRoute = (overrides: Partial<ResolvedRoute> = {}): ResolvedRoute => ({
+  route_binding_id: 'rb-1',
+  hostname: 'api.example.com',
+  matched_wildcard: false,
+  matched_path: '/',
+  method: null,
+  priority: 0,
+  domain_id: 'dom-1',
+  target_catalog_id: 'cat-1',
+  target_module: 'apis',
+  target_source_id: 'api-src-1',
+  target_owner_scope: 'database',
+  target_owner_key: 'db-1',
+  resolved_config: {
+    api_id: 'api-1',
+    database_id: 'db-1',
+    dbname: 'tenant_db',
+    role_name: 'api_role',
+    anon_role: 'api_anon',
+    is_public: true,
+    schemas: ['app_public'],
+  },
+  verification_status: 'verified',
+  tls_status: 'ready',
+  tls_secret_name: 'tls-api-example-com',
+  ...overrides,
+});
+
+const noMatchRoute = (): ResolvedRoute =>
+  matchedRoute({ route_binding_id: null, target_module: null, resolved_config: null });
+
+const createPool = (query: jest.Mock): Pool => ({ query } as unknown as Pool);
+
+describe('resolveRoute', () => {
+  it('returns the row when a route matches', async () => {
+    const query = jest.fn().mockResolvedValue({ rows: [matchedRoute()] });
+    const row = await resolveRoute(createPool(query), 'constructive_routing_public', 'api.example.com', '/', 'GET');
+    expect(row?.route_binding_id).toBe('rb-1');
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining('"constructive_routing_public".resolve_route($1, $2, $3)'),
+      ['api.example.com', '/', 'GET']
+    );
+  });
+
+  it('returns null on the contract no-match row (route_binding_id IS NULL)', async () => {
+    const query = jest.fn().mockResolvedValue({ rows: [noMatchRoute()] });
+    const row = await resolveRoute(createPool(query), 'constructive_routing_public', 'nope.example.com', '/', 'GET');
+    expect(row).toBeNull();
+  });
+
+  it('returns null when the resolver function is not installed', async () => {
+    const query = jest.fn().mockRejectedValue(Object.assign(new Error('undefined function'), { code: '42883' }));
+    const row = await resolveRoute(createPool(query), 'constructive_routing_public', 'api.example.com', '/', 'GET');
+    expect(row).toBeNull();
+  });
+
+  it('returns null when the routing schema does not exist', async () => {
+    const query = jest.fn().mockRejectedValue(Object.assign(new Error('invalid schema'), { code: '3F000' }));
+    const row = await resolveRoute(createPool(query), 'constructive_routing_public', 'api.example.com', '/', 'GET');
+    expect(row).toBeNull();
+  });
+
+  it('rethrows unexpected database errors', async () => {
+    const query = jest.fn().mockRejectedValue(Object.assign(new Error('boom'), { code: '57P01' }));
+    await expect(
+      resolveRoute(createPool(query), 'constructive_routing_public', 'api.example.com', '/', 'GET')
+    ).rejects.toThrow('boom');
+  });
+
+  it('rejects unsafe schema names without querying', async () => {
+    const query = jest.fn();
+    const row = await resolveRoute(createPool(query), 'bad"; DROP TABLE x;--', 'api.example.com', '/', 'GET');
+    expect(row).toBeNull();
+    expect(query).not.toHaveBeenCalled();
+  });
+});
+
+describe('routeToApiStructure', () => {
+  const opts = { pg: { database: 'constructive' }, api: { isPublic: true } } as unknown as ApiOptions;
+
+  it('maps an api-target route onto ApiStructure', () => {
+    const structure = routeToApiStructure(matchedRoute(), opts);
+    expect(structure).toEqual(
+      expect.objectContaining({
+        apiId: 'api-1',
+        databaseId: 'db-1',
+        dbname: 'tenant_db',
+        roleName: 'api_role',
+        anonRole: 'api_anon',
+        schema: ['app_public'],
+        isPublic: true,
+      })
+    );
+  });
+
+  it('returns null for non-api targets', () => {
+    expect(routeToApiStructure(matchedRoute({ target_module: 'sites' }), opts)).toBeNull();
+  });
+
+  it('returns null when resolved_config lacks api essentials', () => {
+    expect(routeToApiStructure(matchedRoute({ resolved_config: {} }), opts)).toBeNull();
+  });
+});
+
+describe('getApiConfig with scoped routing enabled', () => {
+  const createRequest = (headers: Record<string, string>): Request => {
+    const normalized = new Map(
+      Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]),
+    );
+    return {
+      protocol: 'http',
+      originalUrl: '/graphql',
+      path: '/graphql',
+      method: 'POST',
+      get: jest.fn((name: string) => normalized.get(name.toLowerCase())),
+    } as unknown as Request;
+  };
+
+  const createOptions = (enableScopedRouting: boolean): ApiOptions => ({
+    pg: { database: 'constructive' },
+    api: {
+      isPublic: true,
+      metaSchemas: ['metaschema_public'],
+      enableScopedRouting,
+    },
+  } as unknown as ApiOptions);
+
+  beforeEach(() => {
+    svcCache.clear();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    svcCache.clear();
+  });
+
+  const schemaValidationRows = (params: unknown[]) => ({
+    rows: (params[0] as string[]).map((schemaName) => ({ schema_name: schemaName })),
+  });
+
+  it('resolves via resolve_route before the legacy domain lookup', async () => {
+    const query = jest.fn(async (sql: string, params: unknown[]) => {
+      if (sql.includes('information_schema.schemata')) return schemaValidationRows(params);
+      if (sql.includes('resolve_route')) return { rows: [matchedRoute()] };
+      throw new Error(`unexpected legacy query: ${sql}`);
+    });
+    mockGetPgPool.mockReturnValue(createPool(query) as never);
+
+    const result = await getApiConfig(createOptions(true), createRequest({ host: 'api.example.com' }));
+
+    expect(result).toEqual(expect.objectContaining({ apiId: 'api-1', dbname: 'tenant_db' }));
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining('resolve_route'),
+      ['api.example.com', '/graphql', 'POST']
+    );
+  });
+
+  it('falls back to the legacy domain lookup when resolve_route has no match', async () => {
+    const query = jest.fn(async (sql: string, params: unknown[]) => {
+      if (sql.includes('information_schema.schemata')) return schemaValidationRows(params);
+      if (sql.includes('resolve_route')) return { rows: [noMatchRoute()] };
+      if (sql.includes('services_public.domains')) {
+        return {
+          rows: [{
+            api_id: 'legacy-api',
+            database_id: 'db-legacy',
+            dbname: 'legacy_db',
+            role_name: 'authenticated',
+            anon_role: 'anon',
+            is_public: true,
+            schemas: ['app_public'],
+          }],
+        };
+      }
+      return { rows: [] };
+    });
+    mockGetPgPool.mockReturnValue(createPool(query) as never);
+
+    const result = await getApiConfig(createOptions(true), createRequest({ host: 'legacy.example.com' }));
+
+    expect(result).toEqual(expect.objectContaining({ apiId: 'legacy-api', dbname: 'legacy_db' }));
+  });
+
+  it('does not call resolve_route when scoped routing is disabled', async () => {
+    const query = jest.fn(async (sql: string, params: unknown[]) => {
+      if (sql.includes('information_schema.schemata')) return schemaValidationRows(params);
+      if (sql.includes('resolve_route')) throw new Error('resolve_route should not be called');
+      return { rows: [] };
+    });
+    mockGetPgPool.mockReturnValue(createPool(query) as never);
+
+    await getApiConfig(createOptions(false), createRequest({ host: 'api.example.com' }));
+
+    expect(query.mock.calls.some(([sql]) => String(sql).includes('resolve_route'))).toBe(false);
+  });
+});

--- a/graphql/server/src/middleware/api.ts
+++ b/graphql/server/src/middleware/api.ts
@@ -14,6 +14,7 @@ import { getPgPool } from 'pg-cache';
 import errorPage50x from '../errors/50x';
 import errorPage404Message from '../errors/404-message';
 import { ApiConfigResult, ApiError, ApiOptions, ApiStructure, AuthSettings, DatabaseSettings, PubkeyChallengeSettings, RlsModule, WebauthnSettings } from '../types';
+import { resolveRoute, routeToApiStructure } from './routing';
 import './types';
 
 const log = new Logger('api');
@@ -121,6 +122,9 @@ interface ResolveContext {
   subdomain: string | null;
   cacheKey: string;
   headers: RoutingHeaders;
+  host: string;
+  path: string;
+  method: string;
 }
 
 type ResolutionMode = 
@@ -399,6 +403,48 @@ const resolveMetaSchemaHeader = (
   return createAdminStructure(ctx.opts, validatedSchemas, ctx.headers.databaseId);
 };
 
+/**
+ * Scoped routing plane resolution (additive): one indexed resolve_route()
+ * call against the compiled hostname/route bindings. Returns null (fall back
+ * to the legacy services_public lookup) when disabled, unmatched, resolver
+ * not installed, or the target is not an api surface.
+ */
+const resolveScopedRoute = async (ctx: ResolveContext): Promise<ApiStructure | null> => {
+  const { opts, pool, host, path, method } = ctx;
+  if (!opts.api?.enableScopedRouting) return null;
+
+  const schema = opts.api?.scopedRoutingSchema || 'constructive_routing_public';
+  const route = await resolveRoute(pool, schema, host, path, method);
+  if (!route) return null;
+
+  const structure = routeToApiStructure(route, opts);
+  if (!structure) return null;
+
+  log.debug(`[scoped-routing] resolved host=${host} path=${path} → api=${structure.apiId} db=${structure.dbname}`);
+
+  if (!structure.databaseId || !structure.apiId) return structure;
+
+  const loaderCtx = buildLoaderContext(pool, opts, {
+    api_id: structure.apiId,
+    database_id: structure.databaseId,
+    dbname: structure.dbname,
+    role_name: structure.roleName,
+    anon_role: structure.anonRole,
+    is_public: structure.isPublic ?? false,
+    schemas: structure.schema,
+  });
+  const settings = await resolveModuleSettings(defaultRegistry, loaderCtx);
+  return {
+    ...structure,
+    rlsModule: settings.rlsModule,
+    authSettings: settings.authSettings,
+    corsOrigins: settings.corsOrigins,
+    databaseSettings: settings.databaseSettings,
+    pubkeyChallengeSettings: settings.pubkeyChallengeSettings,
+    webauthnSettings: settings.webauthnSettings,
+  };
+};
+
 const resolveDomainLookup = async (ctx: ResolveContext): Promise<ApiStructure | null> => {
   const { opts, pool, domain, subdomain } = ctx;
   const isPublic = opts.api?.isPublic ?? false;
@@ -498,6 +544,9 @@ export const getApiConfig = async (
     subdomain,
     cacheKey,
     headers: getRoutingHeaders(req),
+    host: req.get('host') || '',
+    path: req.path || req.originalUrl || '/',
+    method: req.method || 'GET',
   };
 
   // Validate schemas upfront for modes that need them
@@ -540,7 +589,10 @@ export const getApiConfig = async (
       break;
 
     case 'domain-lookup':
-      result = await resolveDomainLookup(ctx);
+      result = await resolveScopedRoute(ctx);
+      if (!result) {
+        result = await resolveDomainLookup(ctx);
+      }
       if (!result && apiOpts.isPublic) {
         const fallback = await buildDevFallbackError(ctx, req);
         if (fallback) return fallback;
@@ -573,6 +625,9 @@ export const createApiMiddleware = (opts: ApiOptions) => {
         subdomain: null,
         cacheKey: 'meta-api-off',
         headers: {},
+        host: '',
+        path: '/',
+        method: req.method || 'GET',
       });
       req.databaseId = req.api.databaseId;
       req.svc_key = 'meta-api-off';

--- a/graphql/server/src/middleware/api.ts
+++ b/graphql/server/src/middleware/api.ts
@@ -123,8 +123,6 @@ interface ResolveContext {
   cacheKey: string;
   headers: RoutingHeaders;
   host: string;
-  path: string;
-  method: string;
 }
 
 type ResolutionMode = 
@@ -404,23 +402,25 @@ const resolveMetaSchemaHeader = (
 };
 
 /**
- * Scoped routing plane resolution (additive): one indexed resolve_route()
- * call against the compiled hostname/route bindings. Returns null (fall back
- * to the legacy services_public lookup) when disabled, unmatched, resolver
- * not installed, or the target is not an api surface.
+ * Scoped routing plane resolution (additive, host-only): one indexed
+ * resolve_route() call against the compiled hostname/route bindings.
+ * Path/method routing belongs to Traefik/Ingress — the server only maps
+ * host → tenant/api/db/role. Returns null (fall back to the legacy
+ * services_public lookup) when disabled, unmatched, resolver not installed,
+ * or the target is not an api surface.
  */
 const resolveScopedRoute = async (ctx: ResolveContext): Promise<ApiStructure | null> => {
-  const { opts, pool, host, path, method } = ctx;
+  const { opts, pool, host } = ctx;
   if (!opts.api?.enableScopedRouting) return null;
 
   const schema = opts.api?.scopedRoutingSchema || 'constructive_routing_public';
-  const route = await resolveRoute(pool, schema, host, path, method);
+  const route = await resolveRoute(pool, schema, host);
   if (!route) return null;
 
   const structure = routeToApiStructure(route, opts);
   if (!structure) return null;
 
-  log.debug(`[scoped-routing] resolved host=${host} path=${path} → api=${structure.apiId} db=${structure.dbname}`);
+  log.debug(`[scoped-routing] resolved host=${host} → api=${structure.apiId} db=${structure.dbname}`);
 
   if (!structure.databaseId || !structure.apiId) return structure;
 
@@ -545,8 +545,6 @@ export const getApiConfig = async (
     cacheKey,
     headers: getRoutingHeaders(req),
     host: req.get('host') || '',
-    path: req.path || req.originalUrl || '/',
-    method: req.method || 'GET',
   };
 
   // Validate schemas upfront for modes that need them
@@ -626,8 +624,6 @@ export const createApiMiddleware = (opts: ApiOptions) => {
         cacheKey: 'meta-api-off',
         headers: {},
         host: '',
-        path: '/',
-        method: req.method || 'GET',
       });
       req.databaseId = req.api.databaseId;
       req.svc_key = 'meta-api-off';

--- a/graphql/server/src/middleware/routing.ts
+++ b/graphql/server/src/middleware/routing.ts
@@ -1,0 +1,132 @@
+import { Logger } from '@pgpmjs/logger';
+import { Pool } from 'pg';
+
+import { ApiOptions, ApiStructure } from '../types';
+
+const log = new Logger('routing');
+
+// =============================================================================
+// Scoped routing plane (resolve_route contract)
+// =============================================================================
+//
+// One indexed call resolves an incoming request across scopes:
+//
+//   SELECT * FROM <schema>.resolve_route(request_host, request_path, request_method)
+//
+// Contract (constructive-db docs/architecture/scoped-domain-routing.md):
+// a single row is always returned; no match → route_binding_id IS NULL.
+// resolved_config is a jsonb snapshot the server consumes without further
+// lookups.
+
+/** Row shape returned by <schema>.resolve_route() — frozen DB↔server contract. */
+export interface ResolvedRoute {
+  route_binding_id: string | null;
+  hostname: string | null;
+  matched_wildcard: boolean | null;
+  matched_path: string | null;
+  method: string | null;
+  priority: number | null;
+  domain_id: string | null;
+  target_catalog_id: string | null;
+  target_module: string | null;
+  target_source_id: string | null;
+  target_owner_scope: string | null;
+  target_owner_key: string | null;
+  resolved_config: Record<string, unknown> | null;
+  verification_status: string | null;
+  tls_status: string | null;
+  tls_secret_name: string | null;
+}
+
+const RESOLVER_FUNCTION = 'resolve_route';
+
+const isValidSchemaName = (name: string): boolean =>
+  /^[a-z_][a-z0-9_]*$/.test(name);
+
+/**
+ * Resolve host/path/method through the compiled scoped-routing plane.
+ * Returns null when there is no match (route_binding_id IS NULL) or when the
+ * resolver is not installed in the target database — callers fall back to the
+ * legacy services_public lookup in both cases.
+ */
+export const resolveRoute = async (
+  pool: Pool,
+  schema: string,
+  host: string,
+  path: string,
+  method: string
+): Promise<ResolvedRoute | null> => {
+  if (!isValidSchemaName(schema)) {
+    log.warn(`[resolve-route] invalid routing schema name: ${schema}`);
+    return null;
+  }
+
+  try {
+    const result = await pool.query<ResolvedRoute>(
+      `SELECT * FROM "${schema}".${RESOLVER_FUNCTION}($1, $2, $3)`,
+      [host, path, method]
+    );
+    const row = result.rows[0];
+    if (!row || row.route_binding_id === null) {
+      log.debug(`[resolve-route] no match for host=${host} path=${path} method=${method}`);
+      return null;
+    }
+    return row;
+  } catch (error: unknown) {
+    const err = error as { code?: string; message?: string };
+    // 42883 undefined_function / 3F000 invalid_schema_name: resolver not
+    // installed in this database — treat as no-match so the caller falls back.
+    if (err.code === '42883' || err.code === '3F000') {
+      log.debug(`[resolve-route] resolver not installed (${err.code}); falling back`);
+      return null;
+    }
+    throw error;
+  }
+};
+
+/**
+ * Config keys the scoped api surface folds into `config` (and route
+ * `resolved_config`) that the server maps onto ApiStructure.
+ */
+interface ApiSurfaceConfig {
+  api_id?: string;
+  database_id?: string;
+  dbname?: string;
+  role_name?: string;
+  anon_role?: string;
+  is_public?: boolean;
+  schemas?: string[];
+}
+
+/**
+ * Map a resolved api-target route onto the legacy ApiStructure shape consumed
+ * by the rest of the middleware chain. Returns null when the route target is
+ * not an api surface or its resolved_config lacks the api essentials — the
+ * caller falls back to the legacy lookup.
+ */
+export const routeToApiStructure = (
+  route: ResolvedRoute,
+  opts: ApiOptions
+): ApiStructure | null => {
+  if (route.target_module !== 'apis' && route.target_module !== 'api') {
+    return null;
+  }
+
+  const config = (route.resolved_config ?? {}) as ApiSurfaceConfig;
+  if (!config.dbname || !config.schemas?.length) {
+    log.debug('[resolve-route] api target missing dbname/schemas in resolved_config; falling back');
+    return null;
+  }
+
+  return {
+    apiId: config.api_id ?? route.target_source_id ?? undefined,
+    dbname: config.dbname || opts.pg?.database || '',
+    anonRole: config.anon_role || 'anon',
+    roleName: config.role_name || 'authenticated',
+    schema: config.schemas,
+    apiModules: [],
+    domains: [],
+    databaseId: config.database_id,
+    isPublic: config.is_public ?? (opts.api?.isPublic ?? false),
+  };
+};

--- a/graphql/server/src/middleware/routing.ts
+++ b/graphql/server/src/middleware/routing.ts
@@ -9,14 +9,15 @@ const log = new Logger('routing');
 // Scoped routing plane (resolve_route contract)
 // =============================================================================
 //
-// One indexed call resolves an incoming request across scopes:
+// One indexed call resolves an incoming request across scopes. The server's
+// projection is HOST-ONLY: Traefik/Ingress owns L7 path/method routing, so
+// the server always calls the frozen contract with the root path and no
+// method:
 //
-//   SELECT * FROM <schema>.resolve_route(request_host, request_path, request_method)
+//   SELECT * FROM <schema>.resolve_route(request_host, '/', NULL)
 //
 // Contract (constructive-db docs/architecture/scoped-domain-routing.md):
 // a single row is always returned; no match → route_binding_id IS NULL.
-// resolved_config is a jsonb snapshot the server consumes without further
-// lookups.
 
 /** Row shape returned by <schema>.resolve_route() — frozen DB↔server contract. */
 export interface ResolvedRoute {
@@ -44,7 +45,8 @@ const isValidSchemaName = (name: string): boolean =>
   /^[a-z_][a-z0-9_]*$/.test(name);
 
 /**
- * Resolve host/path/method through the compiled scoped-routing plane.
+ * Resolve a hostname through the compiled scoped-routing plane (host-only:
+ * path/method routing belongs to Traefik/Ingress, not the server).
  * Returns null when there is no match (route_binding_id IS NULL) or when the
  * resolver is not installed in the target database — callers fall back to the
  * legacy services_public lookup in both cases.
@@ -52,9 +54,7 @@ const isValidSchemaName = (name: string): boolean =>
 export const resolveRoute = async (
   pool: Pool,
   schema: string,
-  host: string,
-  path: string,
-  method: string
+  host: string
 ): Promise<ResolvedRoute | null> => {
   if (!isValidSchemaName(schema)) {
     log.warn(`[resolve-route] invalid routing schema name: ${schema}`);
@@ -63,12 +63,12 @@ export const resolveRoute = async (
 
   try {
     const result = await pool.query<ResolvedRoute>(
-      `SELECT * FROM "${schema}".${RESOLVER_FUNCTION}($1, $2, $3)`,
-      [host, path, method]
+      `SELECT * FROM "${schema}".${RESOLVER_FUNCTION}($1, '/', NULL)`,
+      [host]
     );
     const row = result.rows[0];
     if (!row || row.route_binding_id === null) {
-      log.debug(`[resolve-route] no match for host=${host} path=${path} method=${method}`);
+      log.debug(`[resolve-route] no match for host=${host}`);
       return null;
     }
     return row;

--- a/graphql/types/src/graphile.ts
+++ b/graphql/types/src/graphile.ts
@@ -42,6 +42,14 @@ export interface ApiOptions {
   isPublic?: boolean;
   /** Schemas containing metadata tables */
   metaSchemas?: string[];
+  /**
+   * Enable scoped-routing resolution via <schema>.resolve_route() before the
+   * legacy services_public domain lookup. Additive: when the resolver returns
+   * no match (or is not installed), resolution falls back to the legacy path.
+   */
+  enableScopedRouting?: boolean;
+  /** Schema containing the compiled resolve_route() resolver */
+  scopedRoutingSchema?: string;
 }
 
 /**
@@ -77,4 +85,6 @@ export const apiDefaults: ApiOptions = {
     'metaschema_public',
     'metaschema_modules_public',
   ],
+  enableScopedRouting: false,
+  scopedRoutingSchema: 'constructive_routing_public',
 };


### PR DESCRIPTION
## Summary

Lane B of constructive-planning#1214: the GraphQL server can resolve incoming hostnames through the compiled scoped-routing plane shipped in constructive-db (now the typed per-type catalog, constructive-db#2345), via the frozen DB↔server contract.

**Host-only projection (per the routing boundary decision):** Traefik/Ingress owns host→workload and L7 path/method routing; the server is a dumb Deployment that only maps host → tenant/api/db/role. So the server always calls the frozen SQL contract with the root path and no method:

```sql
SELECT * FROM <scopedRoutingSchema>.resolve_route(host, '/', NULL)
```

The `resolve_route()` function signature and return shape are unchanged — only how the server calls it. Server-side path/method matching is dropped from the scoped path (it was also inconsistent with the host-wide svc cache key).

**Additive and opt-in** — no behavior change by default:
- `ApiOptions.enableScopedRouting` (default `false`) and `ApiOptions.scopedRoutingSchema` (default `constructive_routing_public`) in `@constructive-io/graphql-types`.
- `middleware/routing.ts`: `resolveRoute(pool, schema, host)` (typed `ResolvedRoute` matching the contract row; treats the contract no-match row `route_binding_id IS NULL`, missing resolver `42883`, or missing schema `3F000` as "no match") and `routeToApiStructure()` (maps an api-target route's `resolved_config` — `{dbname, role_name, anon_role, schemas, api_id, database_id, is_public}` — onto the existing `ApiStructure`).
- In `getApiConfig` domain-lookup mode: `resolveScopedRoute(ctx) ?? resolveDomainLookup(ctx)` — scoped plane first, then the legacy `services_public.domains` query remains the authoritative fallback. Module settings (RLS/auth/CORS/…) still resolve through the existing loader registry.

Full read-cutover (scoped plane authoritative, legacy queries removed) is a later phase per the migration plan in constructive-db `docs/architecture/scoped-domain-routing.md`.

Unit tests in `routing.test.ts` cover host-only invocation (`resolve_route($1, '/', NULL)` with `[host]` only), the contract no-match row, resolver-not-installed fallback, error rethrow, schema-name validation, ApiStructure mapping, and scoped-first/legacy-fallback resolution order in `getApiConfig`.

Link to Devin session: https://app.devin.ai/sessions/9a83c1e46fc744c487980aee5844f556
Requested by: @pyramation