### PR TITLE
feat(pgpm-core): shared SQL header model + control-only cross-package dep mode

### DIFF
--- a/pgpm/core/__tests__/files/sql-header.test.ts
+++ b/pgpm/core/__tests__/files/sql-header.test.ts
@@ -1,0 +1,187 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import {
+  parsePgpmHeader,
+  renameInHeader,
+  scanDeployScript,
+  verifyPlanMatchesHeaders,
+  writePgpmScript
+} from '../../src/files/sql/header';
+
+const LEGACY = `-- Deploy my-module:tables/users to pg
+-- requires: schema
+-- requires: other-pkg:tables/accounts
+
+BEGIN;
+CREATE TABLE app.users (id serial primary key);
+COMMIT;
+`;
+
+const MODERN = `-- Deploy tables/users
+-- requires: schema
+
+CREATE TABLE app.users (id serial primary key);
+`;
+
+const WRITER_COLON = `-- Deploy: tables/users
+-- made with <3 @ constructive.io
+
+-- requires: schema
+
+CREATE TABLE app.users (id serial primary key);
+`;
+
+describe('parsePgpmHeader', () => {
+  it('parses the legacy sqitch-compatible format', () => {
+    const { header, body } = parsePgpmHeader(LEGACY);
+    expect(header.verb).toBe('Deploy');
+    expect(header.project).toBe('my-module');
+    expect(header.change).toBe('tables/users');
+    expect(header.toPg).toBe(true);
+    expect(header.requires.map(r => r.raw)).toEqual(['schema', 'other-pkg:tables/accounts']);
+    expect(header.requires[1].ref?.package).toBe('other-pkg');
+    expect(body).toContain('CREATE TABLE app.users');
+  });
+
+  it('parses the modern format without project or to pg', () => {
+    const { header } = parsePgpmHeader(MODERN);
+    expect(header.verb).toBe('Deploy');
+    expect(header.project).toBeNull();
+    expect(header.change).toBe('tables/users');
+    expect(header.toPg).toBe(false);
+    expect(header.requires.map(r => r.raw)).toEqual(['schema']);
+  });
+
+  it('parses the writer colon format with interleaved comments', () => {
+    const { header } = parsePgpmHeader(WRITER_COLON);
+    expect(header.change).toBe('tables/users');
+    expect(header.requires.map(r => r.raw)).toEqual(['schema']);
+  });
+
+  it('parses Revert and Verify headers', () => {
+    expect(parsePgpmHeader('-- Revert my-module:schema to pg\n\nDROP SCHEMA app;\n').header.verb).toBe('Revert');
+    expect(parsePgpmHeader('-- Verify my-module:schema to pg\n\nSELECT 1;\n').header.verb).toBe('Verify');
+  });
+
+  it('parses tag references in requires', () => {
+    const { header } = parsePgpmHeader('-- Deploy x\n-- requires: pkg:@v1\n\nSELECT 1;\n');
+    expect(header.requires[0].raw).toBe('pkg:@v1');
+    expect(header.requires[0].ref?.package).toBe('pkg');
+    expect(header.requires[0].ref?.tag).toBe('v1');
+  });
+
+  it('round-trips content byte-exactly', () => {
+    for (const content of [LEGACY, MODERN, WRITER_COLON, 'SELECT 1;\n', '']) {
+      expect(writePgpmScript(parsePgpmHeader(content))).toBe(content);
+    }
+  });
+});
+
+describe('renameInHeader', () => {
+  it('rewrites the header identity and matching requires', () => {
+    const script = parsePgpmHeader(LEGACY);
+    const count = renameInHeader(script, new Map([
+      ['tables/users', 'tables/app_users'],
+      ['schema', 'app_schema']
+    ]));
+    expect(count).toBe(2);
+    expect(script.header.change).toBe('tables/app_users');
+    const out = writePgpmScript(script);
+    expect(out).toContain('-- Deploy my-module:tables/app_users to pg');
+    expect(out).toContain('-- requires: app_schema');
+    expect(out).toContain('-- requires: other-pkg:tables/accounts');
+    expect(out).toContain('CREATE TABLE app.users');
+  });
+
+  it('rewrites package-qualified requires but leaves tag refs untouched', () => {
+    const script = parsePgpmHeader('-- Deploy x\n-- requires: pkg:tables/users\n-- requires: pkg:@v1\n\nSELECT 1;\n');
+    const count = renameInHeader(script, new Map([['tables/users', 'tables/app_users']]));
+    expect(count).toBe(1);
+    const out = writePgpmScript(script);
+    expect(out).toContain('-- requires: pkg:tables/app_users');
+    expect(out).toContain('-- requires: pkg:@v1');
+  });
+
+  it('is a no-op when nothing matches', () => {
+    const script = parsePgpmHeader(MODERN);
+    expect(renameInHeader(script, new Map([['nope', 'nada']]))).toBe(0);
+    expect(writePgpmScript(script)).toBe(MODERN);
+  });
+});
+
+describe('scanDeployScript', () => {
+  const makeKey = (change: string) => `/deploy/${change}.sql`;
+
+  it('collects requires lines verbatim', () => {
+    const { requires } = scanDeployScript(LEGACY, {
+      key: '/deploy/tables/users.sql',
+      extname: 'my-module',
+      makeKey
+    });
+    expect(requires).toEqual(['schema', 'other-pkg:tables/accounts']);
+  });
+
+  it('throws on project mismatch', () => {
+    expect(() =>
+      scanDeployScript(LEGACY, { key: '/deploy/tables/users.sql', extname: 'other', makeKey })
+    ).toThrow(/Mismatched project name/);
+  });
+
+  it('throws on path identity mismatch', () => {
+    expect(() =>
+      scanDeployScript(LEGACY, { key: '/deploy/tables/accounts.sql', extname: 'my-module', makeKey })
+    ).toThrow(/path or internal name mismatch/);
+    expect(() =>
+      scanDeployScript(MODERN, { key: '/deploy/tables/accounts.sql', extname: 'my-module', makeKey })
+    ).toThrow(/wrong place or is named wrong/);
+  });
+});
+
+describe('verifyPlanMatchesHeaders', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'pgpm-header-'));
+    mkdirSync(join(dir, 'deploy', 'tables'), { recursive: true });
+    writeFileSync(join(dir, 'pgpm.plan'), `%syntax-version=1.0.0
+%project=my-module
+%uri=my-module
+
+schema 2024-01-01T00:00:00Z Test <t@e.com> # schema
+tables/users [schema] 2024-01-02T00:00:00Z Test <t@e.com> # users
+`);
+    writeFileSync(join(dir, 'deploy', 'schema.sql'), '-- Deploy my-module:schema to pg\n\nCREATE SCHEMA app;\n');
+    writeFileSync(join(dir, 'deploy', 'tables', 'users.sql'), LEGACY.replace('-- requires: other-pkg:tables/accounts\n', ''));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('reports no issues for a consistent module', () => {
+    expect(verifyPlanMatchesHeaders(dir)).toEqual([]);
+  });
+
+  it('reports missing deploy files', () => {
+    rmSync(join(dir, 'deploy', 'tables', 'users.sql'));
+    const issues = verifyPlanMatchesHeaders(dir);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].kind).toBe('missing-file');
+  });
+
+  it('reports identity mismatches', () => {
+    writeFileSync(join(dir, 'deploy', 'tables', 'users.sql'), '-- Deploy my-module:tables/accounts to pg\n-- requires: schema\n\nSELECT 1;\n');
+    const issues = verifyPlanMatchesHeaders(dir);
+    expect(issues.map(i => i.kind)).toContain('identity-mismatch');
+  });
+
+  it('reports requires drift between plan and headers', () => {
+    writeFileSync(join(dir, 'deploy', 'tables', 'users.sql'), '-- Deploy my-module:tables/users to pg\n\nSELECT 1;\n');
+    const issues = verifyPlanMatchesHeaders(dir);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].kind).toBe('requires-drift');
+    expect(issues[0].message).toContain('schema');
+  });
+});

--- a/pgpm/core/__tests__/slice/slice.test.ts
+++ b/pgpm/core/__tests__/slice/slice.test.ts
@@ -342,6 +342,43 @@ schemas/public/functions/get_user [schemas/auth/tables/users] 2024-01-02T00:00:0
       expect(publicPkg!.planContent).toContain('auth:schemas/auth/tables/users');
     });
 
+    it('should drop per-change cross-package refs in control-only mode', () => {
+      const planContent = `%syntax-version=1.0.0
+%project=test-project
+
+schemas/auth/tables/users 2024-01-01T00:00:00Z Developer <dev@example.com>
+schemas/public/functions/get_user [schemas/auth/tables/users] 2024-01-02T00:00:00Z Developer <dev@example.com>
+schemas/public/functions/get_user_v2 [schemas/public/functions/get_user] 2024-01-03T00:00:00Z Developer <dev@example.com>
+`;
+      const planPath = join(testDir, 'control-only.plan');
+      writeFileSync(planPath, planContent);
+
+      const result = slicePlan({
+        sourcePlan: planPath,
+        outputDir: join(testDir, 'output-control-only'),
+        strategy: { type: 'folder' },
+        crossPackageDepMode: 'control-only'
+      });
+
+      const publicPkg = result.packages.find(p => p.name === 'public');
+      expect(publicPkg).toBeDefined();
+
+      // Package-level dependency is preserved in the control file
+      expect(publicPkg!.packageDependencies).toContain('auth');
+      expect(publicPkg!.controlContent).toContain(`requires = 'auth'`);
+
+      // But no per-change cross-package ref remains in the plan
+      expect(publicPkg!.planContent).not.toContain('auth:');
+
+      // Internal dependencies are untouched
+      const getUserV2 = publicPkg!.changes.find(c => c.name === 'schemas/public/functions/get_user_v2');
+      expect(getUserV2!.dependencies).toEqual(['schemas/public/functions/get_user']);
+
+      // The dependent change loses only the cross-package ref
+      const getUser = publicPkg!.changes.find(c => c.name === 'schemas/public/functions/get_user');
+      expect(getUser!.dependencies).toEqual([]);
+    });
+
     it('should slice using pattern strategy', () => {
       const planContent = `%syntax-version=1.0.0
 %project=test-project

--- a/pgpm/core/src/files/sql/header.ts
+++ b/pgpm/core/src/files/sql/header.ts
@@ -1,0 +1,357 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import { parsePlanFile } from '../plan/parser';
+import { parseReference, ParsedReference } from '../plan/validators';
+
+/**
+ * A parsed `-- requires:` line from a pgpm SQL script header.
+ */
+export interface PgpmHeaderRequire {
+  /** The dependency reference exactly as written (e.g. `schema`, `pkg:tables/users`, `pkg:@v1`). */
+  raw: string;
+  /** Structured breakdown of the reference (package/change/tag), when parseable. */
+  ref: ParsedReference | null;
+}
+
+/**
+ * The parsed header block of a pgpm SQL script (deploy/revert/verify).
+ *
+ * The header is everything from the top of the file through the last
+ * header-relevant comment line (`-- Deploy|Revert|Verify ...`,
+ * `-- requires: ...`, and any interleaved comment/blank lines), with the
+ * remainder of the file preserved as `body`.
+ */
+export interface PgpmHeader {
+  /** Header verb: Deploy, Revert or Verify. Null when no header line was found. */
+  verb: 'Deploy' | 'Revert' | 'Verify' | null;
+  /** The project (extension) name from `-- Deploy <project>:<change>`, if present. */
+  project: string | null;
+  /**
+   * The change name from the header line. By convention this must equal the
+   * script's path identity: `deploy/<change>.sql`.
+   */
+  change: string | null;
+  /** Whether the header line carried the legacy ` to pg` suffix. */
+  toPg: boolean;
+  /** Parsed `-- requires:` dependencies, in file order. */
+  requires: PgpmHeaderRequire[];
+  /** The raw header lines, byte-exact, in file order. */
+  lines: string[];
+}
+
+/**
+ * Result of splitting a SQL script into header and body.
+ */
+export interface ParsedPgpmScript {
+  header: PgpmHeader;
+  /** Everything after the header block, byte-exact. */
+  body: string;
+}
+
+const HEADER_LINE = /^--\s*(Deploy|Revert|Verify)\b(:)?\s*(.*?)\s*$/;
+const REQUIRES_LINE = /^--\s*requires:\s*(.*?)\s*$/;
+const COMMENT_LINE = /^\s*--/;
+const TO_PG_SUFFIX = /\s+to\s+pg\s*$/;
+
+/**
+ * Parse the header block of a pgpm SQL script into a structured model.
+ *
+ * Recognizes both header formats:
+ *   `-- Deploy <project>:<change> to pg` (legacy sqitch-compatible)
+ *   `-- Deploy <change>` / `-- Deploy: <change>` (new)
+ * along with `-- requires: <ref>` lines where `<ref>` may be a plain change
+ * name, `{package}:{change}`, `@tag`, or `{package}:@tag`.
+ *
+ * The parse is lossless: `header.lines` plus `body` reassemble the original
+ * content byte-exactly (see {@link writePgpmScript}).
+ */
+export function parsePgpmHeader(content: string): ParsedPgpmScript {
+  const header: PgpmHeader = {
+    verb: null,
+    project: null,
+    change: null,
+    toPg: false,
+    requires: [],
+    lines: []
+  };
+
+  const lines = content.split('\n');
+  let lastHeaderIdx = -1;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (line.trim() === '') {
+      continue;
+    }
+    if (!COMMENT_LINE.test(line)) {
+      break;
+    }
+
+    const headerMatch = line.match(HEADER_LINE);
+    if (headerMatch && header.verb === null) {
+      header.verb = headerMatch[1] as PgpmHeader['verb'];
+      let target = headerMatch[3];
+      if (TO_PG_SUFFIX.test(target)) {
+        header.toPg = true;
+        target = target.replace(TO_PG_SUFFIX, '');
+      }
+      const colonIndex = target.indexOf(':');
+      if (colonIndex > 0 && /^[a-zA-Z0-9_-]+$/.test(target.substring(0, colonIndex))) {
+        header.project = target.substring(0, colonIndex);
+        header.change = target.substring(colonIndex + 1).trim();
+      } else {
+        header.change = target.trim() || null;
+      }
+      lastHeaderIdx = i;
+      continue;
+    }
+
+    const requiresMatch = line.match(REQUIRES_LINE);
+    if (requiresMatch) {
+      const raw = requiresMatch[1];
+      header.requires.push({ raw, ref: parseReference(raw) });
+      lastHeaderIdx = i;
+      continue;
+    }
+    // Other comment lines (e.g. attribution) before/between header lines are
+    // tolerated but only absorbed into the header when a later header line
+    // follows; trailing comments belong to the body.
+  }
+
+  header.lines = lines.slice(0, lastHeaderIdx + 1);
+  return {
+    header,
+    body: lines.slice(lastHeaderIdx + 1).join('\n')
+  };
+}
+
+/**
+ * Serialize a header back to its raw lines. When the structured fields have
+ * been modified via {@link renameInHeader}, the raw lines already reflect the
+ * change; this simply joins header and body losslessly.
+ */
+export function writePgpmScript(script: ParsedPgpmScript): string {
+  if (script.header.lines.length === 0) return script.body;
+  return script.header.lines.join('\n') + '\n' + script.body;
+}
+
+/**
+ * Rewrite change names in a script header according to a rename map
+ * (old change name -> new change name). Rewrites both the `-- Deploy` line's
+ * change identity and any `-- requires:` lines referencing renamed changes,
+ * preserving format (project qualifier, ` to pg` suffix, tag refs untouched).
+ *
+ * Returns the number of substitutions applied; mutates `script` in place.
+ */
+export function renameInHeader(
+  script: ParsedPgpmScript,
+  renames: Map<string, string>
+): number {
+  const { header } = script;
+  let count = 0;
+
+  const renameRef = (raw: string): string | null => {
+    const ref = parseReference(raw);
+    if (!ref) {
+      const to = renames.get(raw);
+      return to ?? null;
+    }
+    if (ref.tag || ref.symbolic || ref.relative) return null;
+    const change = ref.change;
+    if (!change) return null;
+    const to = renames.get(change);
+    if (!to) return null;
+    return ref.package ? `${ref.package}:${to}` : to;
+  };
+
+  header.lines = header.lines.map(line => {
+    const headerMatch = line.match(HEADER_LINE);
+    if (headerMatch && header.change && renames.has(header.change)) {
+      const to = renames.get(header.change)!;
+      const oldTarget = header.project ? `${header.project}:${header.change}` : header.change;
+      const newTarget = header.project ? `${header.project}:${to}` : to;
+      const rewritten = line.replace(oldTarget, newTarget);
+      if (rewritten !== line) {
+        header.change = to;
+        count++;
+        return rewritten;
+      }
+      return line;
+    }
+
+    const requiresMatch = line.match(REQUIRES_LINE);
+    if (requiresMatch) {
+      const raw = requiresMatch[1];
+      const renamed = renameRef(raw);
+      if (renamed !== null) {
+        count++;
+        return line.replace(raw, renamed);
+      }
+    }
+    return line;
+  });
+
+  header.requires = header.requires.map(req => {
+    const renamed = renameRef(req.raw);
+    if (renamed === null) return req;
+    return { raw: renamed, ref: parseReference(renamed) };
+  });
+
+  return count;
+}
+
+/**
+ * Options for {@link scanDeployScript}.
+ */
+export interface ScanDeployScriptOptions {
+  /** The script's path identity key (e.g. `/deploy/tables/users.sql`). */
+  key: string;
+  /** The current extension (project) name. */
+  extname: string;
+  /** Maps a change name to its path identity key. */
+  makeKey: (change: string) => string;
+}
+
+/**
+ * Scan a deploy script the way dependency resolution historically has:
+ * line-by-line over the whole file, collecting `-- requires: <ref>` lines
+ * verbatim and validating any `-- Deploy <project>:<change>[ to pg]` line
+ * against the script's path identity and project name.
+ *
+ * Kept strictly line-regex-compatible with the original resolver behavior
+ * (requires lines are honored anywhere in the file, and the legacy
+ * `-- Deploy: <change>` colon form is not identity-validated).
+ *
+ * @throws when the Deploy line's project or change identity mismatches.
+ */
+export function scanDeployScript(
+  content: string,
+  options: ScanDeployScriptOptions
+): { requires: string[] } {
+  const { key, extname, makeKey } = options;
+  const requires: string[] = [];
+
+  for (const line of content.split('\n')) {
+    const requiresMatch = line.match(/^-- requires: (.*)/);
+    if (requiresMatch) {
+      requires.push(requiresMatch[1].trim());
+      continue;
+    }
+
+    if (/:/.test(line)) {
+      const m2 = line.match(/^-- Deploy ([^:]*):([\w\/]+)(?:\s+to\s+pg)?/);
+      if (m2) {
+        const actualProject = m2[1];
+        const keyToTest = m2[2];
+
+        if (extname !== actualProject) {
+          throw new Error(
+            `Mismatched project name in deploy file:
+          Expected project: ${extname}
+          Found in line   : ${actualProject}
+          Line            : ${line}`
+          );
+        }
+
+        const expectedKey = makeKey(keyToTest);
+        if (key !== expectedKey) {
+          throw new Error(
+            `Deployment script path or internal name mismatch:
+          Expected key    : ${key}
+          Found in line   : ${expectedKey}
+          Line            : ${line}`
+          );
+        }
+      }
+    } else {
+      const m2 = line.match(/^-- Deploy (.*?)(?:\s+to\s+pg)?\s*$/);
+      if (m2) {
+        const keyToTest = m2[1].trim();
+        if (key !== makeKey(keyToTest)) {
+          throw new Error(
+            'deployment script in wrong place or is named wrong internally\n' + line
+          );
+        }
+      }
+    }
+  }
+
+  return { requires };
+}
+
+/**
+ * A single plan-vs-header discrepancy found by {@link verifyPlanMatchesHeaders}.
+ */
+export interface HeaderDriftIssue {
+  change: string;
+  file: string;
+  kind: 'missing-file' | 'identity-mismatch' | 'requires-drift';
+  message: string;
+}
+
+/**
+ * Verify that every change in a module's pgpm.plan has a deploy script whose
+ * header identity matches its path, and report dependency drift between the
+ * plan's dep lists and the scripts' `-- requires:` lines.
+ *
+ * Read-only diagnostic; returns issues rather than throwing.
+ */
+export function verifyPlanMatchesHeaders(moduleDir: string): HeaderDriftIssue[] {
+  const issues: HeaderDriftIssue[] = [];
+  const planPath = join(moduleDir, 'pgpm.plan');
+  const parsed = parsePlanFile(planPath);
+  if (!parsed.data) {
+    throw new Error(`Failed to parse plan file: ${planPath}`);
+  }
+
+  for (const planChange of parsed.data.changes) {
+    const change = planChange.name;
+    const file = join(moduleDir, 'deploy', `${change}.sql`);
+    let content: string;
+    try {
+      content = readFileSync(file, 'utf-8');
+    } catch {
+      issues.push({
+        change,
+        file,
+        kind: 'missing-file',
+        message: `deploy script not found for plan change "${change}"`
+      });
+      continue;
+    }
+
+    const { header } = parsePgpmHeader(content);
+    if (header.change && header.change !== change) {
+      issues.push({
+        change,
+        file,
+        kind: 'identity-mismatch',
+        message: `header declares "${header.change}" but path identity is "${change}"`
+      });
+    }
+
+    const planDeps = new Set(planChange.dependencies || []);
+    const headerDeps = new Set(header.requires.map(r => r.raw));
+    const missingInHeader = [...planDeps].filter(d => !headerDeps.has(d));
+    const missingInPlan = [...headerDeps].filter(d => !planDeps.has(d));
+    if (missingInHeader.length > 0 || missingInPlan.length > 0) {
+      const parts: string[] = [];
+      if (missingInHeader.length > 0) {
+        parts.push(`in plan but not in header requires: ${missingInHeader.join(', ')}`);
+      }
+      if (missingInPlan.length > 0) {
+        parts.push(`in header requires but not in plan: ${missingInPlan.join(', ')}`);
+      }
+      issues.push({
+        change,
+        file,
+        kind: 'requires-drift',
+        message: parts.join('; ')
+      });
+    }
+  }
+
+  return issues;
+}

--- a/pgpm/core/src/files/sql/index.ts
+++ b/pgpm/core/src/files/sql/index.ts
@@ -1,1 +1,2 @@
+export * from './header';
 export * from './writer';

--- a/pgpm/core/src/resolution/deps.ts
+++ b/pgpm/core/src/resolution/deps.ts
@@ -4,6 +4,7 @@ import { join,relative } from 'path';
 
 import { PgpmPackage } from '../core/class/pgpm';
 import { parsePlanFile } from '../files/plan/parser';
+import { scanDeployScript } from '../files/sql/header';
 import { ExtendedPlanFile } from '../files/types';
 import { errors } from '@pgpmjs/types';
 
@@ -476,94 +477,46 @@ export const resolveDependencies = (
 
   for (const file of files) {
     const data = readFileSync(file, 'utf-8');
-    const lines = data.split('\n');
     const key = '/' + relative(packageDir, file);
     deps[key] = [];
 
-    for (const line of lines) {
-      // Handle requires statements
-      const requiresMatch = line.match(/^-- requires: (.*)/);
-      if (requiresMatch) {
-        const dep = requiresMatch[1].trim();
-        
-        // For 'preserve' mode, just add the dependency as-is (like original getDeps)
-        if (tagResolution === 'preserve') {
-          deps[key].push(dep);
-          continue;
-        }
-        
-        // For other modes, handle tag resolution
-        if (dep.includes('@')) {
-          const match = dep.match(/^([^:]+):@(.+)$/);
-          if (match) {
-            const [, projectName, tagName] = match;
-            const taggedChange = resolveTagToChange(projectName, tagName);
-            
-            if (taggedChange) {
-              if (tagResolution === 'resolve') {
-                // Full resolution: replace tag with actual change
-                const resolvedDep = `${projectName}:${taggedChange}`;
-                deps[key].push(resolvedDep);
-              } else if (tagResolution === 'internal') {
-                // Internal resolution: keep tag in deps but track mapping
-                tagMappings[dep] = `${projectName}:${taggedChange}`;
-                deps[key].push(dep);
-              }
-            } else {
-              // Could not resolve tag, keep it as is
-              deps[key].push(dep);
-            }
-          } else {
-            // Invalid tag format, keep as is
-            deps[key].push(dep);
-          }
-        } else {
-          // Not a tag, keep as is
-          deps[key].push(dep);
-        }
+    const { requires } = scanDeployScript(data, { key, extname, makeKey });
+
+    for (const dep of requires) {
+      // For 'preserve' mode, just add the dependency as-is (like original getDeps)
+      if (tagResolution === 'preserve') {
+        deps[key].push(dep);
         continue;
       }
 
-      // Handle deploy statements - exactly as in original
-      let m2;
-      let keyToTest;
+      // For other modes, handle tag resolution
+      if (dep.includes('@')) {
+        const match = dep.match(/^([^:]+):@(.+)$/);
+        if (match) {
+          const [, projectName, tagName] = match;
+          const taggedChange = resolveTagToChange(projectName, tagName);
 
-      if (/:/.test(line)) {
-        m2 = line.match(/^-- Deploy ([^:]*):([\w\/]+)(?:\s+to\s+pg)?/);
-        if (m2) {
-          const actualProject = m2[1];
-          keyToTest = m2[2];
-        
-          if (extname !== actualProject) {
-            throw new Error(
-              `Mismatched project name in deploy file:
-          Expected project: ${extname}
-          Found in line   : ${actualProject}
-          Line            : ${line}`
-            );
+          if (taggedChange) {
+            if (tagResolution === 'resolve') {
+              // Full resolution: replace tag with actual change
+              const resolvedDep = `${projectName}:${taggedChange}`;
+              deps[key].push(resolvedDep);
+            } else if (tagResolution === 'internal') {
+              // Internal resolution: keep tag in deps but track mapping
+              tagMappings[dep] = `${projectName}:${taggedChange}`;
+              deps[key].push(dep);
+            }
+          } else {
+            // Could not resolve tag, keep it as is
+            deps[key].push(dep);
           }
-        
-          const expectedKey = makeKey(keyToTest);
-          if (key !== expectedKey) {
-            throw new Error(
-              `Deployment script path or internal name mismatch:
-          Expected key    : ${key}
-          Found in line   : ${expectedKey}
-          Line            : ${line}`
-            );
-          }
+        } else {
+          // Invalid tag format, keep as is
+          deps[key].push(dep);
         }
-
       } else {
-        m2 = line.match(/^-- Deploy (.*?)(?:\s+to\s+pg)?\s*$/);
-        if (m2) {
-          keyToTest = m2[1].trim();
-          if (key !== makeKey(keyToTest)) {
-            throw new Error(
-              'deployment script in wrong place or is named wrong internally\n' + line
-            );
-          }
-        }
+        // Not a tag, keep as is
+        deps[key].push(dep);
       }
     }
   }

--- a/pgpm/core/src/slice/slice.ts
+++ b/pgpm/core/src/slice/slice.ts
@@ -9,7 +9,8 @@ import {
   SliceWarning,
   SliceStats,
   GroupingStrategy,
-  PatternStrategy
+  PatternStrategy,
+  CrossPackageDepMode
 } from './types';
 import { minimatch } from 'minimatch';
 
@@ -439,8 +440,11 @@ export function generateSinglePackage(
   graph: DependencyGraph,
   changeToPackage: Map<string, string>,
   pkgDeps: Set<string>,
-  useTagsForCrossPackageDeps: boolean = false
+  crossPackageDeps: boolean | CrossPackageDepMode = 'change'
 ): PackageOutput {
+  // Back-compat: earlier signature took useTagsForCrossPackageDeps: boolean
+  const crossPackageDepMode: CrossPackageDepMode =
+    crossPackageDeps === true ? 'tag' : crossPackageDeps === false ? 'change' : crossPackageDeps;
   // Sort changes in topological order within package
   const sortedChanges = topologicalSortWithinPackage(changes, graph);
 
@@ -464,7 +468,13 @@ export function generateSinglePackage(
         newDeps.push(dep);
       } else {
         // Cross-package dependency
-        if (useTagsForCrossPackageDeps) {
+        if (crossPackageDepMode === 'control-only') {
+          // Dropped from the plan line; carried by the control file's
+          // `requires` (extension install ordering deploys the whole
+          // dependency package first)
+          continue;
+        }
+        if (crossPackageDepMode === 'tag') {
           // Find latest tag in the dependency package
           const depPkgChanges = [...graph.nodes.keys()]
             .filter(c => changeToPackage.get(c) === depPkg);
@@ -593,7 +603,7 @@ export function slicePlan(config: SliceConfig): SliceResult {
       graph,
       changeToPackage,
       packageDeps.get(pkgName) || new Set(),
-      config.useTagsForCrossPackageDeps || false
+      config.crossPackageDepMode ?? (config.useTagsForCrossPackageDeps ? 'tag' : 'change')
     );
 
     packages.push(pkgOutput);

--- a/pgpm/core/src/slice/types.ts
+++ b/pgpm/core/src/slice/types.ts
@@ -19,12 +19,29 @@ export interface SliceConfig {
   /** Whether to use tags for cross-package deps */
   useTagsForCrossPackageDeps?: boolean;
 
+  /**
+   * How cross-package dependencies are recorded in sliced plans:
+   * - 'change' (default): per-change refs (`{package}:{change}`)
+   * - 'tag': per-change tag refs (`{package}:@tag`) when available
+   *   (equivalent to `useTagsForCrossPackageDeps: true`)
+   * - 'control-only': drop per-change cross-package refs from plan lines
+   *   entirely; the dependency is carried only by the control file's
+   *   `requires` (extension install ordering deploys the whole dependency
+   *   package first, which subsumes any per-change ordering constraint)
+   */
+  crossPackageDepMode?: CrossPackageDepMode;
+
   /** Minimum changes per package (merge smaller groups) */
   minChangesPerPackage?: number;
 
   /** Author for generated plan files */
   author?: string;
 }
+
+/**
+ * How cross-package dependencies are represented in sliced plan files
+ */
+export type CrossPackageDepMode = 'change' | 'tag' | 'control-only';
 
 /**
  * Grouping strategy for slicing


### PR DESCRIPTION
## Summary

Atom 1 of the schema-transformation platform plan (constructive-io/constructive-planning#1226, design in #1225): a single shared model for pgpm SQL script headers, plus the `control-only` cross-package dependency mode for `slicePlan`.

**New `files/sql/header.ts`** (exported via `files/sql`):
- `parsePgpmHeader(content) → { header: PgpmHeader, body }` — structured, lossless parse of `-- Deploy|Revert|Verify` + `-- requires:` header blocks. Handles all three formats in the wild: legacy `-- Deploy proj:change to pg`, modern `-- Deploy change`, and the writer's `-- Deploy: change`. `header.lines` + `body` reassemble the file byte-exactly (`writePgpmScript`).
- `renameInHeader(script, renames)` — rewrites header identity and matching `-- requires:` refs (package-qualified refs handled; tag refs untouched). This is the primitive the rename/move atom (Atom 3) and bundle transpilation build on.
- `scanDeployScript(content, { key, extname, makeKey })` — the resolver's historical whole-file line scan, extracted verbatim from `resolution/deps.ts` (same regexes, same identity-mismatch errors). `resolveDependencies` now consumes it; behavior unchanged, all 390 existing tests pass.
- `verifyPlanMatchesHeaders(moduleDir) → HeaderDriftIssue[]` — new read-only drift gate comparing `pgpm.plan` changes/deps against deploy scripts (`missing-file` / `identity-mismatch` / `requires-drift`).

**Slice: `crossPackageDepMode: 'change' | 'tag' | 'control-only'`** on `SliceConfig`:
- `'change'` (default) and `'tag'` are today's behaviors (`useTagsForCrossPackageDeps` still honored as an alias for `'tag'`).
- `'control-only'` drops per-change cross-package refs from sliced plan lines entirely; the dependency is carried only by the control file's `requires = '<pkg>'`. Extension install ordering deploys the whole dependency package first, which subsumes any per-change ordering constraint — this is the "abstract the detail, depend on the module" mode from the modularization discussion (#1225 deep dive 4).

No breaking changes: all additions are opt-in; `generateSinglePackage`'s trailing param accepts the old boolean or the new mode.

Note: `pnpm lint` currently fails repo-wide on main (ESLint 9 installed but only `.eslintrc.json` present) — unrelated to this change; typecheck via `pnpm build` and full `pnpm test` (390/390) pass.

Link to Devin session: https://app.devin.ai/sessions/ad40d16f38a349b48eb7ce9375e27e6e
Requested by: @pyramation