### PR TITLE
feat(pgpm-core): renameChanges — atomic change rename/move across files, headers, and plan

### DIFF
--- a/pgpm/core/__tests__/files/rename-changes.test.ts
+++ b/pgpm/core/__tests__/files/rename-changes.test.ts
@@ -1,0 +1,208 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+
+import {
+  deriveRenamesFromSchemaMapping,
+  renameChanges,
+  renameInPlanContent,
+  validateRenames
+} from '../../src/refactor/rename';
+
+let moduleDir: string;
+
+const PLAN = `%syntax-version=1.0.0
+%project=my-module
+%uri=my-module
+
+schemas/my-app/schema 2024-01-01T00:00:00Z Dev <dev@example.com> # add schema
+schemas/my-app/tables/users [schemas/my-app/schema] 2024-01-01T00:00:01Z Dev <dev@example.com> # add users
+schemas/my-app/tables/posts [schemas/my-app/schema schemas/my-app/tables/users] 2024-01-01T00:00:02Z Dev <dev@example.com> # add posts
+schemas/other/functions/fn [schemas/my-app/tables/users auth:schemas/auth/tables/users] 2024-01-01T00:00:03Z Dev <dev@example.com> # fn
+@v1.0.0 2024-01-01T00:00:04Z Dev <dev@example.com> # release
+`;
+
+function writeScript(rel: string, content: string): void {
+  const file = join(moduleDir, rel);
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, content);
+}
+
+beforeEach(() => {
+  moduleDir = mkdtempSync(join(tmpdir(), 'pgpm-rename-'));
+  writeFileSync(join(moduleDir, 'pgpm.plan'), PLAN);
+
+  writeScript('deploy/schemas/my-app/schema.sql', `-- Deploy schemas/my-app/schema
+
+CREATE SCHEMA "my-app";
+`);
+  writeScript('deploy/schemas/my-app/tables/users.sql', `-- Deploy my-module:schemas/my-app/tables/users to pg
+-- requires: schemas/my-app/schema
+
+CREATE TABLE "my-app".users (id int);
+`);
+  writeScript('deploy/schemas/my-app/tables/posts.sql', `-- Deploy schemas/my-app/tables/posts
+-- requires: schemas/my-app/schema
+-- requires: schemas/my-app/tables/users
+
+CREATE TABLE "my-app".posts (id int);
+`);
+  writeScript('deploy/schemas/other/functions/fn.sql', `-- Deploy schemas/other/functions/fn
+-- requires: schemas/my-app/tables/users
+-- requires: auth:schemas/auth/tables/users
+
+CREATE FUNCTION other.fn() RETURNS void LANGUAGE sql AS $$ SELECT 1 $$;
+`);
+  writeScript('revert/schemas/my-app/tables/users.sql', `-- Revert schemas/my-app/tables/users
+
+DROP TABLE "my-app".users;
+`);
+  writeScript('verify/schemas/my-app/tables/users.sql', `-- Verify schemas/my-app/tables/users
+
+SELECT 1;
+`);
+});
+
+afterEach(() => {
+  rmSync(moduleDir, { recursive: true, force: true });
+});
+
+describe('validateRenames', () => {
+  it('rejects unknown source changes', () => {
+    expect(() => validateRenames(moduleDir, new Map([['nope', 'x']]))).toThrow(/unknown change/);
+  });
+
+  it('rejects targets colliding with existing changes', () => {
+    expect(() =>
+      validateRenames(moduleDir, new Map([['schemas/my-app/schema', 'schemas/my-app/tables/users']]))
+    ).toThrow(/already exists/);
+  });
+
+  it('rejects duplicate targets and self renames', () => {
+    expect(() =>
+      validateRenames(
+        moduleDir,
+        new Map([
+          ['schemas/my-app/schema', 'x'],
+          ['schemas/my-app/tables/users', 'x']
+        ])
+      )
+    ).toThrow(/same target/);
+    expect(() =>
+      validateRenames(moduleDir, new Map([['schemas/my-app/schema', 'schemas/my-app/schema']]))
+    ).toThrow(/itself/);
+  });
+
+  it('allows swapping through the rename map itself', () => {
+    expect(() =>
+      validateRenames(moduleDir, new Map([['schemas/my-app/schema', 'schemas/my_app/schema']]))
+    ).not.toThrow();
+  });
+});
+
+describe('renameInPlanContent', () => {
+  it('rewrites change names and plain dependency refs, preserving format', () => {
+    const renames = new Map([['schemas/my-app/tables/users', 'schemas/my_app/tables/users']]);
+    const out = renameInPlanContent(PLAN, renames);
+    expect(out).toContain('schemas/my_app/tables/users [schemas/my-app/schema] 2024-01-01T00:00:01Z');
+    expect(out).toContain('[schemas/my-app/schema schemas/my_app/tables/users]');
+    expect(out).toContain('[schemas/my_app/tables/users auth:schemas/auth/tables/users]');
+    // cross-package ref untouched
+    expect(out).toContain('auth:schemas/auth/tables/users');
+    // metadata untouched
+    expect(out).toContain('%project=my-module');
+  });
+
+  it('does not rewrite partial-name matches', () => {
+    const renames = new Map([['schemas/my-app/schema', 'schemas/my_app/schema']]);
+    const out = renameInPlanContent(PLAN, renames);
+    // longer change names sharing the prefix are untouched
+    expect(out).toContain('schemas/my-app/tables/users [schemas/my_app/schema]');
+    expect(out).toContain('schemas/my-app/tables/posts [schemas/my_app/schema schemas/my-app/tables/users]');
+  });
+});
+
+describe('renameChanges', () => {
+  it('moves files, rewrites headers of moved scripts and dependents, and rewrites the plan', () => {
+    const renames = new Map([
+      ['schemas/my-app/schema', 'schemas/my_app/schema'],
+      ['schemas/my-app/tables/users', 'schemas/my_app/tables/users'],
+      ['schemas/my-app/tables/posts', 'schemas/my_app/tables/posts']
+    ]);
+    const result = renameChanges(moduleDir, renames);
+
+    // files moved in all three script dirs
+    expect(existsSync(join(moduleDir, 'deploy/schemas/my_app/tables/users.sql'))).toBe(true);
+    expect(existsSync(join(moduleDir, 'deploy/schemas/my-app/tables/users.sql'))).toBe(false);
+    expect(existsSync(join(moduleDir, 'revert/schemas/my_app/tables/users.sql'))).toBe(true);
+    expect(existsSync(join(moduleDir, 'verify/schemas/my_app/tables/users.sql'))).toBe(true);
+    // old empty dirs cleaned up
+    expect(existsSync(join(moduleDir, 'deploy/schemas/my-app'))).toBe(false);
+    expect(result.filesMoved.length).toBe(5);
+
+    // moved script headers rewritten (identity + requires), format preserved
+    const users = readFileSync(join(moduleDir, 'deploy/schemas/my_app/tables/users.sql'), 'utf-8');
+    expect(users).toContain('-- Deploy my-module:schemas/my_app/tables/users to pg');
+    expect(users).toContain('-- requires: schemas/my_app/schema');
+    // body untouched
+    expect(users).toContain('CREATE TABLE "my-app".users (id int);');
+
+    // dependent outside the rename set has requires rewritten, cross-package ref untouched
+    const fn = readFileSync(join(moduleDir, 'deploy/schemas/other/functions/fn.sql'), 'utf-8');
+    expect(fn).toContain('-- requires: schemas/my_app/tables/users');
+    expect(fn).toContain('-- requires: auth:schemas/auth/tables/users');
+
+    // plan rewritten
+    const plan = readFileSync(join(moduleDir, 'pgpm.plan'), 'utf-8');
+    expect(plan).toContain('schemas/my_app/tables/posts [schemas/my_app/schema schemas/my_app/tables/users]');
+    expect(plan).toContain('[schemas/my_app/tables/users auth:schemas/auth/tables/users]');
+    expect(result.planRewritten).toBe(true);
+  });
+
+  it('is a no-op for an empty rename map', () => {
+    const before = readFileSync(join(moduleDir, 'pgpm.plan'), 'utf-8');
+    const result = renameChanges(moduleDir, new Map());
+    expect(result.filesMoved).toEqual([]);
+    expect(result.planRewritten).toBe(false);
+    expect(readFileSync(join(moduleDir, 'pgpm.plan'), 'utf-8')).toBe(before);
+  });
+
+  it('dry run reports without touching the filesystem', () => {
+    const renames = new Map([['schemas/my-app/tables/users', 'schemas/my_app/tables/users']]);
+    const before = readFileSync(join(moduleDir, 'deploy/schemas/my-app/tables/users.sql'), 'utf-8');
+    const result = renameChanges(moduleDir, renames, { dryRun: true });
+
+    expect(existsSync(join(moduleDir, 'deploy/schemas/my-app/tables/users.sql'))).toBe(true);
+    expect(existsSync(join(moduleDir, 'deploy/schemas/my_app/tables/users.sql'))).toBe(false);
+    expect(readFileSync(join(moduleDir, 'deploy/schemas/my-app/tables/users.sql'), 'utf-8')).toBe(before);
+    expect(readFileSync(join(moduleDir, 'pgpm.plan'), 'utf-8')).toBe(PLAN);
+    expect(result.dryRunReport!.length).toBeGreaterThan(0);
+    expect(result.planRewritten).toBe(true);
+  });
+
+  it('throws when a target file already exists on disk', () => {
+    writeScript('deploy/schemas/my_app/tables/users.sql', '-- Deploy schemas/my_app/tables/users\n');
+    expect(() =>
+      renameChanges(moduleDir, new Map([['schemas/my-app/tables/users', 'schemas/my_app/tables/users']]))
+    ).toThrow(/already exists/);
+  });
+});
+
+describe('deriveRenamesFromSchemaMapping', () => {
+  it('derives renames for changes under renamed schemas only', () => {
+    const renames = deriveRenamesFromSchemaMapping(moduleDir, new Map([['my-app', 'my_app']]));
+    expect(renames.get('schemas/my-app/schema')).toBe('schemas/my_app/schema');
+    expect(renames.get('schemas/my-app/tables/users')).toBe('schemas/my_app/tables/users');
+    expect(renames.get('schemas/my-app/tables/posts')).toBe('schemas/my_app/tables/posts');
+    expect(renames.has('schemas/other/functions/fn')).toBe(false);
+    expect(renames.size).toBe(3);
+  });
+
+  it('composes with renameChanges end to end', () => {
+    const renames = deriveRenamesFromSchemaMapping(moduleDir, new Map([['my-app', 'my_app']]));
+    const result = renameChanges(moduleDir, renames);
+    expect(result.planRewritten).toBe(true);
+    const plan = readFileSync(join(moduleDir, 'pgpm.plan'), 'utf-8');
+    expect(plan).not.toContain('schemas/my-app/');
+  });
+});

--- a/pgpm/core/src/index.ts
+++ b/pgpm/core/src/index.ts
@@ -14,6 +14,7 @@ export * from './core/boilerplate-scanner';
 
 // Export package-files functionality (now integrated into core)
 export * from './files';
+export * from './refactor';
 export { cleanSql } from './migrate/clean';
 export { PgpmMigrate } from './migrate/client';
 export { PgpmInit } from './init/client';

--- a/pgpm/core/src/refactor/index.ts
+++ b/pgpm/core/src/refactor/index.ts
@@ -1,0 +1,1 @@
+export * from './rename';

--- a/pgpm/core/src/refactor/rename.ts
+++ b/pgpm/core/src/refactor/rename.ts
@@ -1,0 +1,235 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmdirSync, statSync, writeFileSync } from 'fs';
+import { dirname, join, relative, sep } from 'path';
+
+import { parsePlanFileSimple } from '../files/plan/parser';
+import { parsePgpmHeader, renameInHeader, writePgpmScript } from '../files/sql/header';
+
+const SCRIPT_DIRS = ['deploy', 'revert', 'verify'] as const;
+
+/**
+ * Options for {@link renameChanges}.
+ */
+export interface RenameChangesOptions {
+  /** Report planned operations without touching the filesystem. Default: false */
+  dryRun?: boolean;
+}
+
+/**
+ * Result of a {@link renameChanges} run.
+ */
+export interface RenameChangesResult {
+  /** deploy/revert/verify script files moved (old path -> new path, module-relative). */
+  filesMoved: Array<{ from: string; to: string }>;
+  /** Script files whose headers were rewritten (identity and/or requires). */
+  headersRewritten: string[];
+  /** Whether pgpm.plan was rewritten. */
+  planRewritten: boolean;
+  /** Dry-run report lines (only populated when dryRun). */
+  dryRunReport?: string[];
+}
+
+function escapeRe(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function findSqlFiles(dir: string): string[] {
+  const files: string[] = [];
+  if (!existsSync(dir)) return files;
+  const entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...findSqlFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.sql')) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function removeEmptyDirs(dir: string, stopAt: string): void {
+  let current = dir;
+  while (current !== stopAt && current.startsWith(stopAt)) {
+    if (!existsSync(current) || readdirSync(current).length > 0) return;
+    rmdirSync(current);
+    current = dirname(current);
+  }
+}
+
+/**
+ * Validate a rename map against a module directory: every source change must
+ * exist in the plan, no target may collide with an existing change, and no
+ * two sources may map to the same target.
+ *
+ * @throws on any violation.
+ */
+export function validateRenames(moduleDir: string, renames: Map<string, string>): void {
+  const planPath = join(moduleDir, 'pgpm.plan');
+  const plan = parsePlanFileSimple(planPath);
+  const changeNames = new Set(plan.changes.map(c => c.name));
+
+  const targets = new Set<string>();
+  for (const [from, to] of renames) {
+    if (from === to) {
+      throw new Error(`Rename maps change to itself: ${from}`);
+    }
+    if (!changeNames.has(from)) {
+      throw new Error(`Cannot rename unknown change: ${from}`);
+    }
+    if (changeNames.has(to) && !renames.has(to)) {
+      throw new Error(`Rename target already exists in plan: ${to}`);
+    }
+    if (targets.has(to)) {
+      throw new Error(`Multiple changes rename to the same target: ${to}`);
+    }
+    targets.add(to);
+  }
+}
+
+/**
+ * Rewrite change names in a pgpm.plan's content according to a rename map.
+ * Textual and format-preserving: only the change-name token at the start of a
+ * change line, plain (same-package) dependency refs inside `[...]`, and tag
+ * lines' change field are rewritten; timestamps, planners, comments,
+ * cross-package refs, and tag refs are untouched.
+ */
+export function renameInPlanContent(content: string, renames: Map<string, string>): string {
+  const froms = Array.from(renames.keys()).sort((a, b) => b.length - a.length);
+
+  return content
+    .split('\n')
+    .map(line => {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith('%')) return line;
+
+      let result = line;
+      for (const from of froms) {
+        const to = renames.get(from)!;
+        const re = new RegExp(`(^|[\\s\\[])${escapeRe(from)}(?=$|[\\s\\]@])`, 'g');
+        result = result.replace(re, `$1${to}`);
+      }
+      return result;
+    })
+    .join('\n');
+}
+
+/**
+ * Atomically rename/move changes within a pgpm module: the coupled 4-way
+ * rewrite of (1) deploy/revert/verify script files on disk, (2) the moved
+ * scripts' own header identity, (3) `-- requires:` headers in every script
+ * that references a renamed change, and (4) the pgpm.plan.
+ *
+ * SQL statement bodies are NOT touched: schema-name rewrites inside SQL are a
+ * separate AST-level concern for callers to compose (e.g. transform passes).
+ */
+export function renameChanges(
+  moduleDir: string,
+  renames: Map<string, string>,
+  options: RenameChangesOptions = {}
+): RenameChangesResult {
+  const dryRun = options.dryRun ?? false;
+  const result: RenameChangesResult = {
+    filesMoved: [],
+    headersRewritten: [],
+    planRewritten: false
+  };
+  if (dryRun) result.dryRunReport = [];
+
+  if (renames.size === 0) return result;
+  validateRenames(moduleDir, renames);
+
+  // 1. Move script files
+  for (const scriptDir of SCRIPT_DIRS) {
+    for (const [from, to] of renames) {
+      const oldPath = join(moduleDir, scriptDir, `${from}.sql`);
+      if (!existsSync(oldPath) || !statSync(oldPath).isFile()) continue;
+      const newPath = join(moduleDir, scriptDir, `${to}.sql`);
+      if (existsSync(newPath)) {
+        throw new Error(`Rename target file already exists: ${relative(moduleDir, newPath)}`);
+      }
+      if (dryRun) {
+        result.dryRunReport!.push(`Would move: ${relative(moduleDir, oldPath)} -> ${relative(moduleDir, newPath)}`);
+      } else {
+        mkdirSync(dirname(newPath), { recursive: true });
+        renameSync(oldPath, newPath);
+        removeEmptyDirs(dirname(oldPath), join(moduleDir, scriptDir));
+      }
+      result.filesMoved.push({
+        from: [scriptDir, `${from}.sql`].join(sep),
+        to: [scriptDir, `${to}.sql`].join(sep)
+      });
+    }
+  }
+
+  // 2 + 3. Rewrite headers in every script (identity of moved files,
+  // requires of dependents)
+  for (const scriptDir of SCRIPT_DIRS) {
+    const dir = join(moduleDir, scriptDir);
+    for (const file of findSqlFiles(dir)) {
+      const content = readFileSync(file, 'utf-8');
+      const script = parsePgpmHeader(content);
+      const count = renameInHeader(script, renames);
+      if (count === 0) continue;
+      const rewritten = writePgpmScript(script);
+      if (rewritten === content) continue;
+      if (dryRun) {
+        result.dryRunReport!.push(`Would rewrite header: ${relative(moduleDir, file)}`);
+      } else {
+        writeFileSync(file, rewritten);
+      }
+      result.headersRewritten.push(relative(moduleDir, file));
+    }
+  }
+
+  // In dry-run mode files were not moved, so dependents' headers are found at
+  // their original paths above; the moved files' own headers are still
+  // reported through the same scan.
+
+  // 4. Rewrite pgpm.plan
+  const planPath = join(moduleDir, 'pgpm.plan');
+  const planContent = readFileSync(planPath, 'utf-8');
+  const newPlanContent = renameInPlanContent(planContent, renames);
+  if (newPlanContent !== planContent) {
+    if (dryRun) {
+      result.dryRunReport!.push('Would rewrite: pgpm.plan');
+    } else {
+      writeFileSync(planPath, newPlanContent);
+    }
+    result.planRewritten = true;
+  }
+
+  return result;
+}
+
+/**
+ * Derive a change rename map from a schema mapping (old schema name -> new
+ * schema name) by rewriting the `schemas/<name>/` path segment of every plan
+ * change that lives under a renamed schema.
+ *
+ * This is the module-level counterpart of directory-based schema renames:
+ * `schemas/my-app/tables/users` with mapping `my-app -> my_app` yields
+ * `schemas/my_app/tables/users`.
+ */
+export function deriveRenamesFromSchemaMapping(
+  moduleDir: string,
+  schemaMapping: Map<string, string>
+): Map<string, string> {
+  const renames = new Map<string, string>();
+  const planPath = join(moduleDir, 'pgpm.plan');
+  const plan = parsePlanFileSimple(planPath);
+  const schemas = Array.from(schemaMapping.keys()).sort((a, b) => b.length - a.length);
+
+  for (const change of plan.changes) {
+    let renamed = change.name;
+    for (const schema of schemas) {
+      const to = schemaMapping.get(schema);
+      if (!to || to === schema) continue;
+      const re = new RegExp(`(^|/)(schemas/)${escapeRe(schema)}(/|$)`, 'g');
+      renamed = renamed.replace(re, `$1$2${to}$3`);
+    }
+    if (renamed !== change.name) {
+      renames.set(change.name, renamed);
+    }
+  }
+  return renames;
+}


### PR DESCRIPTION
## Summary

Atom 3 of the schema-transform platform plan (constructive-planning #1226, builds on the Atom 1 header model): a first-class rename/move primitive for pgpm changes in new `pgpm/core/src/refactor/rename.ts`, exported from `@pgpmjs/core`.

A rename is a coupled 4-way rewrite, now done atomically by `renameChanges(moduleDir, renames, { dryRun? })`:

1. move `deploy|revert|verify/<change>.sql` files (creating dirs, pruning emptied ones)
2. rewrite the moved scripts' own header identity (`-- Deploy [project:]change[ to pg]`) via `renameInHeader`
3. rewrite `-- requires:` headers in every *dependent* script (plain and same-package refs; cross-package/tag/symbolic refs untouched)
4. rewrite `pgpm.plan` textually/format-preservingly via `renameInPlanContent` (change tokens, `[deps]`, tag lines — timestamps/planners/comments/`pkg:` refs untouched)

SQL statement *bodies* are intentionally not touched — schema-name rewrites inside SQL remain the caller's AST-transform concern (transform-schemas), so this primitive composes as parse → rename → transform.

Also:
- `deriveRenamesFromSchemaMapping(moduleDir, schemaMapping)` — maps a schema rename (e.g. `my-app → my_app`) to the change renames for every plan change under `schemas/<old>/`, mirroring what constructive-db's `transform-directory.ts` does with directory renames + regexes today.
- `validateRenames` — rejects unknown sources, colliding targets (unless the target is itself renamed away), duplicate targets, self-renames; `renameChanges` also refuses to overwrite existing files on disk.

Purely additive; no existing code paths changed. 12 new tests; full pgpm/core suite green (402/402). Next step per the plan: refactor constructive-db's `transform-directory.ts` onto this with a byte-identical generated-output gate.

Note: `pnpm lint` in pgpm/core fails on main already (ESLint 9 vs `.eslintrc` config, preexisting, same as noted on #1401).

Link to Devin session: https://app.devin.ai/sessions/ad40d16f38a349b48eb7ce9375e27e6e
Requested by: @pyramation