### PR TITLE
ci: downsize pg/integration/ai test tiers from 4vcpu to 2vcpu

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -143,7 +143,7 @@ jobs:
   # =========================================================================
   pg-tests:
     needs: build
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -194,6 +194,9 @@ jobs:
       PGPORT: 5432
       PGUSER: postgres
       PGPASSWORD: password
+      # Pin an explicit heap cap: on smaller runners Node's memory-derived
+      # default can land near ~2GB and OOM Jest.
+      NODE_OPTIONS: '--max-old-space-size=4096'
 
     services:
       pg_db:
@@ -259,7 +262,7 @@ jobs:
   # =========================================================================
   integration-tests:
     needs: build
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -296,6 +299,9 @@ jobs:
       AWS_ACCESS_KEY: minioadmin
       AWS_SECRET_KEY: minioadmin
       AWS_REGION: us-east-1
+      # Pin an explicit heap cap: on smaller runners Node's memory-derived
+      # default can land near ~2GB and OOM Jest.
+      NODE_OPTIONS: '--max-old-space-size=4096'
 
     services:
       pg_db:
@@ -375,7 +381,7 @@ jobs:
   # =========================================================================
   ai-tests:
     needs: build
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -389,6 +395,9 @@ jobs:
       PGPORT: 5432
       PGUSER: postgres
       PGPASSWORD: password
+      # Pin an explicit heap cap: on smaller runners Node's memory-derived
+      # default can land near ~2GB and OOM Jest.
+      NODE_OPTIONS: '--max-old-space-size=4096'
 
     services:
       pg_db:


### PR DESCRIPTION
## Summary
Drops the `pg-tests`, `integration-tests`, and `ai-tests` tiers in `run-tests.yaml` from `blacksmith-4vcpu-ubuntu-2404` to `blacksmith-2vcpu-ubuntu-2404`. On a recent main run these ~30 matrix jobs each spend only **1–21s in the actual `Test` step** — the ~45–60s of fixed setup (artifact download, `pnpm install`, Postgres tune/seed, `fixtures:install`) dominates. They are not CPU-bound, so 4vCPU is wasted spend; 2vCPU should roughly halve their cost with negligible wall-clock change.

Also pins `NODE_OPTIONS=--max-old-space-size=4096` on those tiers, since on smaller runners Node's memory-derived default heap can land near ~2GB and OOM Jest (observed in constructive-db's equivalent experiment).

Unchanged: `build` and `unit-tests` stay on `ubuntu-latest`.

Follow-up worth considering (not in this PR): the many tiny pg/integration jobs each re-pay ~45s of fixed overhead; batching them (like the `unit-tests` tier already does) would cut cost further than runner sizing alone.


Link to Devin session: https://app.devin.ai/sessions/180599d6e0c1419994599efb1eabd9b5
Requested by: @pyramation