### PR TITLE
feat(pgpm-core): rebundleModule — per-chunk packageModule merge with byte-identical gate

### DIFF
--- a/pgpm/core/__tests__/rebundle/module.test.ts
+++ b/pgpm/core/__tests__/rebundle/module.test.ts
@@ -1,0 +1,123 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+
+import { packageModule } from '../../src/packaging/package';
+import { rebundleModule } from '../../src/rebundle';
+
+let sourceDir: string;
+let outputDir: string;
+
+const PLAN = `%syntax-version=1.0.0
+%project=my-module
+%uri=my-module
+
+schemas/auth/schema 2024-01-01T00:00:00Z Dev <dev@example.com> # schema
+schemas/auth/tables/users [schemas/auth/schema] 2024-01-01T00:00:01Z Dev <dev@example.com> # users
+schemas/billing/schema [schemas/auth/schema] 2024-01-01T00:00:02Z Dev <dev@example.com> # billing schema
+schemas/billing/tables/invoices [schemas/billing/schema schemas/auth/tables/users] 2024-01-01T00:00:03Z Dev <dev@example.com> # invoices
+@v1.0.0 2024-01-01T00:00:04Z Dev <dev@example.com> # release
+`;
+
+const DEPLOY: Record<string, string> = {
+  'schemas/auth/schema': 'CREATE SCHEMA auth;',
+  'schemas/auth/tables/users': 'CREATE TABLE auth.users (id int PRIMARY KEY);',
+  'schemas/billing/schema': 'CREATE SCHEMA billing;',
+  'schemas/billing/tables/invoices':
+    'CREATE TABLE billing.invoices (id int PRIMARY KEY, user_id int REFERENCES auth.users(id));',
+};
+
+const REVERT: Record<string, string> = {
+  'schemas/auth/schema': 'DROP SCHEMA auth;',
+  'schemas/auth/tables/users': 'DROP TABLE auth.users;',
+  'schemas/billing/schema': 'DROP SCHEMA billing;',
+  'schemas/billing/tables/invoices': 'DROP TABLE billing.invoices;',
+};
+
+function write(rel: string, content: string): void {
+  const file = join(sourceDir, rel);
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, content);
+}
+
+beforeEach(() => {
+  sourceDir = mkdtempSync(join(tmpdir(), 'pgpm-rb-src-'));
+  outputDir = mkdtempSync(join(tmpdir(), 'pgpm-rb-out-'));
+  writeFileSync(join(sourceDir, 'pgpm.plan'), PLAN);
+  writeFileSync(join(sourceDir, 'my-module.control'), `default_version = '0.0.1'\n`);
+  writeFileSync(join(sourceDir, 'package.json'), JSON.stringify({ name: 'my-module', version: '0.0.1' }));
+
+  for (const [change, sql] of Object.entries(DEPLOY)) {
+    write(`deploy/${change}.sql`, `-- Deploy ${change}\nBEGIN;\n${sql}\nCOMMIT;\n`);
+  }
+  for (const [change, sql] of Object.entries(REVERT)) {
+    write(`revert/${change}.sql`, `-- Revert ${change}\nBEGIN;\n${sql}\nCOMMIT;\n`);
+  }
+  for (const change of Object.keys(DEPLOY)) {
+    write(`verify/${change}.sql`, `-- Verify ${change}\nBEGIN;\nSELECT 1;\nROLLBACK;\n`);
+  }
+});
+
+afterEach(() => {
+  rmSync(sourceDir, { recursive: true, force: true });
+  rmSync(outputDir, { recursive: true, force: true });
+});
+
+describe('rebundleModule', () => {
+  it('writes one merged migration per chunk and a chunk-quotient plan', async () => {
+    const result = await rebundleModule(sourceDir, { outputDir, overwrite: true });
+
+    expect(result.chunks.map(c => c.name)).toEqual(['auth', 'billing']);
+    for (const chunk of ['auth', 'billing']) {
+      expect(existsSync(join(outputDir, 'deploy', `${chunk}.sql`))).toBe(true);
+      expect(existsSync(join(outputDir, 'revert', `${chunk}.sql`))).toBe(true);
+      expect(existsSync(join(outputDir, 'verify', `${chunk}.sql`))).toBe(true);
+    }
+
+    const plan = readFileSync(join(outputDir, 'pgpm.plan'), 'utf-8');
+    expect(plan).toContain('%project=my-module');
+    expect(plan).toMatch(/^auth$/m);
+    expect(plan).toMatch(/^billing \[auth\]/m);
+    // Tag remapped onto its chunk (invoices was the last billing member).
+    expect(plan).toContain('@v1.0.0');
+  });
+
+  it('copies control/Makefile metadata but regenerates the plan', async () => {
+    await rebundleModule(sourceDir, { outputDir, overwrite: true });
+    expect(existsSync(join(outputDir, 'my-module.control'))).toBe(true);
+    expect(readFileSync(join(outputDir, 'my-module.control'), 'utf-8')).toContain("default_version = '0.0.1'");
+  });
+
+  it('merges members into a single transaction per chunk', async () => {
+    await rebundleModule(sourceDir, { outputDir, overwrite: true });
+    const authDeploy = readFileSync(join(outputDir, 'deploy', 'auth.sql'), 'utf-8');
+    // Exactly one BEGIN/COMMIT wrapping both merged statements.
+    expect(authDeploy.match(/BEGIN;/g)).toHaveLength(1);
+    expect(authDeploy.match(/COMMIT;/g)).toHaveLength(1);
+    expect(authDeploy).toContain('CREATE SCHEMA auth');
+    expect(authDeploy).toContain('CREATE TABLE auth.users');
+    // Verify chunk rolls back rather than commits.
+    const authVerify = readFileSync(join(outputDir, 'verify', 'auth.sql'), 'utf-8');
+    expect(authVerify).toContain('ROLLBACK;');
+  });
+
+  it('is byte-identical: packageModule(source) === packageModule(output)', async () => {
+    const result = await rebundleModule(sourceDir, { outputDir, overwrite: true });
+    expect(result.invariant.ok).toBe(true);
+
+    const src = await packageModule(sourceDir);
+    const out = await packageModule(outputDir);
+    expect(out.sql).toEqual(src.sql);
+  });
+
+  it('is byte-identical for the single-chunk dial position', async () => {
+    const result = await rebundleModule(sourceDir, { outputDir, overwrite: true, boundary: 'none' });
+    expect(result.chunks).toHaveLength(1);
+    expect(result.invariant.ok).toBe(true);
+  });
+
+  it('refuses to overwrite a non-empty output dir without overwrite', async () => {
+    writeFileSync(join(outputDir, 'sentinel'), 'x');
+    await expect(rebundleModule(sourceDir, { outputDir })).rejects.toThrow(/not empty/);
+  });
+});

--- a/pgpm/core/src/packaging/package.ts
+++ b/pgpm/core/src/packaging/package.ts
@@ -34,8 +34,8 @@ interface WritePackageOptions extends PackageModuleOptions {
   packageDir: string;
 }
 
-const filterStatements = (stmts: RawStmt[], extension: boolean): RawStmt[] => {
-  if (!extension) return stmts;
+const filterStatements = (stmts: RawStmt[], stripTransactions: boolean): RawStmt[] => {
+  if (!stripTransactions) return stmts;
   return stmts.filter(node => {
     const stmt = node.stmt;
     return !stmt.hasOwnProperty('TransactionStmt') && 
@@ -43,9 +43,61 @@ const filterStatements = (stmts: RawStmt[], extension: boolean): RawStmt[] => {
   });
 };
 
+export interface MergeSqlOptions {
+  /** Strip `TransactionStmt`/`CreateExtensionStmt` before deparsing (extension mode) */
+  stripTransactions?: boolean;
+  /** Prepend a `\echo ... \quit` extension guard line */
+  echoExtensionName?: string;
+  pretty?: boolean;
+  functionDelimiter?: string;
+}
+
+/**
+ * Merge a concatenated SQL string into a single deparsed script.
+ *
+ * Parses the input, optionally strips transaction/extension statements, deparses
+ * with a stable function delimiter, and round-trips the result to detect any AST
+ * drift. This is the shared engine behind `packageModule` (whole-module packaging)
+ * and per-chunk rebundling — both must merge statements identically.
+ */
+export const mergeSqlStatements = async (
+  sql: string,
+  { stripTransactions = false, echoExtensionName, pretty = true, functionDelimiter = '$EOFCODE$' }: MergeSqlOptions = {}
+): Promise<{ sql: string; diff?: boolean; tree1?: string; tree2?: string }> => {
+  if (!sql?.trim()) {
+    return { sql: '' };
+  }
+
+  const parsed = await parse(sql);
+  parsed.stmts = filterStatements(parsed.stmts as any, stripTransactions);
+
+  const topLine = echoExtensionName
+    ? `\\echo Use "CREATE EXTENSION ${echoExtensionName}" to load this file. \\quit\n`
+    : '';
+
+  const finalSql = await deparse(parsed, { pretty, functionDelimiter });
+
+  const tree1 = parsed.stmts;
+  const reparsed = await parse(finalSql);
+  const tree2 = filterStatements(reparsed.stmts as any, stripTransactions);
+
+  const results: { sql: string; diff?: boolean; tree1?: string; tree2?: string } = {
+    sql: `${topLine}${finalSql}`,
+  };
+
+  const diff = JSON.stringify(cleanTree(tree1)) !== JSON.stringify(cleanTree(tree2));
+  if (diff) {
+    results.diff = true;
+    results.tree1 = JSON.stringify(cleanTree(tree1), null, 2);
+    results.tree2 = JSON.stringify(cleanTree(tree2), null, 2);
+  }
+
+  return results;
+};
+
 export const packageModule = async (
   packageDir: string,
-  { usePlan = true, extension = true, pretty = true, functionDelimiter = '$EOFCODE$', outputDiff = false }: PackageModuleOptions = {}
+  { usePlan = true, extension = true, pretty = true, functionDelimiter = '$EOFCODE$' }: PackageModuleOptions = {}
 ): Promise<{ sql: string; diff?: boolean; tree1?: string; tree2?: string }> => {
   const resolveFn = usePlan ? resolveWithPlan : resolve;
   const sql = resolveFn(packageDir);
@@ -58,40 +110,12 @@ export const packageModule = async (
   const extname = getExtensionName(packageDir);
 
   try {
-    const parsed = await parse(sql);
-    parsed.stmts = filterStatements(parsed.stmts as any, extension);
-
-    const topLine = extension
-      ? `\\echo Use "CREATE EXTENSION ${extname}" to load this file. \\quit\n`
-      : '';
-
-    const finalSql = await deparse(parsed, {
+    return await mergeSqlStatements(sql, {
+      stripTransactions: extension,
+      echoExtensionName: extension ? extname : undefined,
       pretty,
-      functionDelimiter
+      functionDelimiter,
     });
-
-    const tree1 = parsed.stmts;
-    const reparsed = await parse(finalSql);
-    const tree2 = filterStatements(reparsed.stmts as any, extension);
-
-    const results: {
-      sql: string;
-      diff?: boolean;
-      tree1?: string;
-      tree2?: string;
-    } = {
-      sql: `${topLine}${finalSql}`,
-    };
-
-    const diff =
-      JSON.stringify(cleanTree(tree1)) !== JSON.stringify(cleanTree(tree2));
-    if (diff) {
-      results.diff = true;
-      results.tree1 = JSON.stringify(cleanTree(tree1), null, 2);
-      results.tree2 = JSON.stringify(cleanTree(tree2), null, 2);
-    }
-
-    return results;
   } catch (e) {
     log.error(`❌ Failed to parse SQL for ${packageDir}`);
     console.error(e);

--- a/pgpm/core/src/rebundle/index.ts
+++ b/pgpm/core/src/rebundle/index.ts
@@ -1,2 +1,3 @@
 export * from './types';
 export * from './rebundle';
+export * from './module';

--- a/pgpm/core/src/rebundle/module.ts
+++ b/pgpm/core/src/rebundle/module.ts
@@ -1,0 +1,116 @@
+import { copyFileSync, existsSync, mkdirSync, readdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+import { Change, Tag } from '../files/types';
+import { parsePlanFile } from '../files/plan/parser';
+import { mergeSqlStatements, packageModule } from '../packaging/package';
+import { generatePlanContent } from '../slice/slice';
+import { assembleChunkSql, rebundlePlan } from './rebundle';
+import { RebundleModuleOptions, RebundleModuleResult } from './types';
+
+const SCRIPT_DIRS = ['deploy', 'revert', 'verify'] as const;
+
+/**
+ * Wrap a merged chunk body in a single transaction. Deploy/revert commit;
+ * verify rolls back (a verify script must leave no trace). The individual
+ * member files' own BEGIN/COMMIT were stripped during the merge, so each
+ * rebundled chunk deploys as exactly one transaction.
+ */
+function wrapTransaction(body: string, scriptType: (typeof SCRIPT_DIRS)[number]): string {
+  const trimmed = body.trim();
+  const tail = scriptType === 'verify' ? 'ROLLBACK;' : 'COMMIT;';
+  return `BEGIN;\n\n${trimmed}\n\n${tail}\n`;
+}
+
+/**
+ * Copy any top-level files (control, Makefile, package.json, README, ...) from
+ * the source module, excluding the plan and the per-change script directories
+ * which are regenerated. The rebundled module stays the same extension — same
+ * name, same control `requires` — only its internal change set collapses.
+ */
+function copyModuleMetadata(sourceDir: string, outputDir: string): void {
+  for (const entry of readdirSync(sourceDir, { withFileTypes: true })) {
+    if (entry.isDirectory()) continue;
+    if (entry.name === 'pgpm.plan') continue;
+    copyFileSync(join(sourceDir, entry.name), join(outputDir, entry.name));
+  }
+}
+
+/**
+ * Materialize a rebundled module: merge each chunk's member scripts into a
+ * single deparsed migration (reusing `packageModule`'s merge engine), write the
+ * chunk-quotient plan, and verify the result is byte-identical when packaged.
+ *
+ * Reuses existing plumbing throughout — `rebundlePlan` for the chunk model,
+ * `mergeSqlStatements`/`packageModule` for statement merging and the gate,
+ * `generatePlanContent` for the chunk plan, and the source control/Makefile
+ * verbatim.
+ */
+export async function rebundleModule(
+  sourceDir: string,
+  options: RebundleModuleOptions
+): Promise<RebundleModuleResult> {
+  const { outputDir, overwrite = false, pretty = true, functionDelimiter = '$EOFCODE$', ...strategy } = options;
+
+  if (existsSync(outputDir) && readdirSync(outputDir).length > 0 && !overwrite) {
+    throw new Error(`Output directory is not empty: ${outputDir}. Pass overwrite: true to replace.`);
+  }
+
+  const plan = rebundlePlan(sourceDir, strategy);
+
+  // Tags anchor on the last member of the chunk that sealed at them; remap each
+  // to its chunk name so `deploy --to @tag` still lands on a real change.
+  const parsed = parsePlanFile(join(sourceDir, 'pgpm.plan'));
+  const sourceTags: Tag[] = parsed.data?.tags ?? [];
+  const memberToChunk = new Map<string, string>();
+  for (const chunk of plan.chunks) {
+    for (const member of chunk.deploy) memberToChunk.set(member, chunk.name);
+  }
+  const remappedTags: Tag[] = sourceTags.map(tag => ({
+    ...tag,
+    change: memberToChunk.get(tag.change) ?? tag.change,
+  }));
+
+  mkdirSync(outputDir, { recursive: true });
+  for (const dir of SCRIPT_DIRS) mkdirSync(join(outputDir, dir), { recursive: true });
+  copyModuleMetadata(sourceDir, outputDir);
+
+  const written: RebundleModuleResult['written'] = [];
+
+  for (const chunk of plan.chunks) {
+    const paths = { chunk: chunk.name } as RebundleModuleResult['written'][number];
+    for (const dir of SCRIPT_DIRS) {
+      const merged = await mergeSqlStatements(assembleChunkSql(sourceDir, chunk, dir), {
+        stripTransactions: true,
+        pretty,
+        functionDelimiter,
+      });
+      const rel = join(dir, `${chunk.name}.sql`);
+      writeFileSync(join(outputDir, rel), wrapTransaction(merged.sql, dir));
+      paths[dir] = rel;
+    }
+    written.push(paths);
+  }
+
+  // Chunk-quotient plan: one change per chunk, deps are earlier chunk names.
+  const planEntries: Change[] = plan.chunks.map(chunk => ({
+    name: chunk.name,
+    dependencies: chunk.dependencies,
+  }));
+  writeFileSync(
+    join(outputDir, 'pgpm.plan'),
+    generatePlanContent(plan.project, planEntries, remappedTags)
+  );
+
+  // Byte-identical gate: packaging the source and the rebundled module must
+  // produce the same consolidated extension SQL.
+  const sourcePkg = await packageModule(sourceDir, { pretty, functionDelimiter });
+  const outputPkg = await packageModule(outputDir, { pretty, functionDelimiter });
+  const invariant = {
+    ok: sourcePkg.sql === outputPkg.sql,
+    sourceDiff: !!sourcePkg.diff,
+    outputDiff: !!outputPkg.diff,
+  };
+
+  return { ...plan, outputDir, written, invariant };
+}

--- a/pgpm/core/src/rebundle/rebundle.ts
+++ b/pgpm/core/src/rebundle/rebundle.ts
@@ -155,6 +155,7 @@ export function rebundlePlan(moduleDir: string, strategy: RebundleStrategy = {})
     deployOrder: creationOrder,
     warnings,
     sourceChanges: planResult.data.changes,
+    project: planResult.data.package,
   };
 }
 

--- a/pgpm/core/src/rebundle/types.ts
+++ b/pgpm/core/src/rebundle/types.ts
@@ -70,4 +70,38 @@ export interface RebundleResult {
 
   /** The source changes (in plan order) that were rebundled */
   sourceChanges: Change[];
+
+  /** The source module's project name (from the plan `%project` header) */
+  project: string;
+}
+
+/**
+ * Options for materializing a rebundled module to disk.
+ */
+export interface RebundleModuleOptions extends RebundleStrategy {
+  /** Directory to write the rebundled module into */
+  outputDir: string;
+
+  /** Overwrite an existing, non-empty output directory (default: false) */
+  overwrite?: boolean;
+
+  /** Deparse pretty-printing (default: true) */
+  pretty?: boolean;
+
+  /** Function body delimiter used during deparse (default: '$EOFCODE$') */
+  functionDelimiter?: string;
+}
+
+/**
+ * Result of materializing a rebundled module.
+ */
+export interface RebundleModuleResult extends RebundleResult {
+  /** Directory the rebundled module was written to */
+  outputDir: string;
+
+  /** Per-chunk merged file paths, relative to outputDir */
+  written: { chunk: string; deploy: string; revert: string; verify: string }[];
+
+  /** Byte-identical gate result: packageModule(source) === packageModule(output) */
+  invariant: { ok: boolean; sourceDiff: boolean; outputDiff: boolean };
 }


### PR DESCRIPTION
## Summary

Atom 4, second slice: turns the chunk *plan* from `rebundlePlan` (#1411) into actual merged migrations on disk. `rebundleModule(sourceDir, { outputDir, ...strategy })` writes a rebundled module whose per-change files collapse to one migration per chunk, gated byte-identical against the original when packaged.

The merge reuses `packageModule`'s exact engine rather than a second implementation. `packageModule` is refactored to extract that engine as `mergeSqlStatements`:

```ts
// shared by whole-module packaging and per-chunk rebundling
mergeSqlStatements(sql, { stripTransactions, echoExtensionName, pretty, functionDelimiter })
//   parse → filter(TransactionStmt/CreateExtensionStmt) → deparse → round-trip diff

packageModule(dir) = mergeSqlStatements(resolveWithPlan(dir), { stripTransactions: extension, echoExtensionName: extname })
```

Per chunk and per direction, `rebundleModule` merges the member scripts (transactions stripped) and re-wraps in one transaction — deploy/revert `COMMIT`, verify `ROLLBACK` — so each chunk deploys as exactly one transaction:

```
deploy/<chunk>.sql = BEGIN; <merge(members, deploy order)> COMMIT;
revert/<chunk>.sql = BEGIN; <merge(members, reverse order)> COMMIT;
verify/<chunk>.sql = BEGIN; <merge(members, deploy order)> ROLLBACK;
```

It then writes a chunk-quotient `pgpm.plan` (one change per chunk, deps = earlier chunk names, via `generatePlanContent`) and remaps tags onto their sealing chunk. The module stays the same extension — control/Makefile/package.json are copied verbatim, only the internal change set collapses.

**Gate.** `rebundleModule` returns `invariant`, and packaging both directories must match:

```ts
packageModule(sourceDir).sql === packageModule(outputDir).sql
```

This holds because merging strips the inner transactions and preserves statement order, so re-packaging strips the re-added wrappers and yields the same AST. Any deparse instability is caught by the existing round-trip diff.

Additive only; nothing calls `rebundleModule` yet. Follow-ups: classifier-driven boundaries (Atom 2 facts choosing seams) and the `control-only` cross-chunk dep mode for published module forks.

## Test plan
- 6 new `rebundleModule` tests (real DDL, no DB): per-chunk files + chunk-quotient plan, metadata copy, single-transaction merge (one BEGIN/COMMIT; verify ROLLBACK), **byte-identical gate** at folder and single-chunk dial positions, overwrite guard.
- Existing packaging/modules/resolution suites: 62 tests + 29 snapshots green (confirms the `packageModule` extraction is behavior-preserving).
- 11 `rebundlePlan` tests still green; `tsc --noEmit` and `pnpm build` clean.

Link to Devin session: https://app.devin.ai/sessions/ad40d16f38a349b48eb7ce9375e27e6e
Requested by: @pyramation