### PR TITLE
feat(pgpm-core): rebundleWorkspace initScaffold — optional pgpm init boilerplate

### DIFF
--- a/pgpm/core/__tests__/rebundle/workspace-init-scaffold.test.ts
+++ b/pgpm/core/__tests__/rebundle/workspace-init-scaffold.test.ts
@@ -1,0 +1,112 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+
+import { rebundleWorkspace } from '../../src/rebundle';
+import { pgpmPath } from '../../src/workspace/paths';
+
+// initScaffold fetches the pgpm boilerplate repo over the network (same as the
+// `pgpm init` template tests), so allow extra time.
+jest.setTimeout(120000);
+
+let sourceDir: string;
+let outputDir: string;
+
+const PLAN = `%syntax-version=1.0.0
+%project=shop
+%uri=shop
+
+schemas/auth/schema 2024-01-01T00:00:00Z Dev <dev@example.com> # schema
+schemas/auth/tables/users [schemas/auth/schema] 2024-01-01T00:00:01Z Dev <dev@example.com> # users
+schemas/billing/schema [schemas/auth/schema] 2024-01-01T00:00:02Z Dev <dev@example.com> # billing schema
+schemas/billing/tables/invoices [schemas/billing/schema schemas/auth/tables/users] 2024-01-01T00:00:03Z Dev <dev@example.com> # invoices
+`;
+
+const DEPLOY: Record<string, string> = {
+  'schemas/auth/schema': 'CREATE SCHEMA auth;',
+  'schemas/auth/tables/users': 'CREATE TABLE auth.users (id int PRIMARY KEY);',
+  'schemas/billing/schema': 'CREATE SCHEMA billing;',
+  'schemas/billing/tables/invoices':
+    'CREATE TABLE billing.invoices (id int PRIMARY KEY, user_id int REFERENCES auth.users(id));',
+};
+
+const REVERT: Record<string, string> = {
+  'schemas/auth/schema': 'DROP SCHEMA auth;',
+  'schemas/auth/tables/users': 'DROP TABLE auth.users;',
+  'schemas/billing/schema': 'DROP SCHEMA billing;',
+  'schemas/billing/tables/invoices': 'DROP TABLE billing.invoices;',
+};
+
+function write(rel: string, content: string): void {
+  const file = join(sourceDir, rel);
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, content);
+}
+
+beforeEach(() => {
+  sourceDir = mkdtempSync(join(tmpdir(), 'pgpm-ws-src-'));
+  outputDir = mkdtempSync(join(tmpdir(), 'pgpm-ws-init-'));
+  writeFileSync(join(sourceDir, 'pgpm.plan'), PLAN);
+  writeFileSync(join(sourceDir, 'shop.control'), `default_version = '0.0.1'\n`);
+  writeFileSync(join(sourceDir, 'package.json'), JSON.stringify({ name: 'shop', version: '0.0.1' }));
+
+  for (const [change, sql] of Object.entries(DEPLOY)) {
+    write(`deploy/${change}.sql`, `-- Deploy ${change}\nBEGIN;\n${sql}\nCOMMIT;\n`);
+  }
+  for (const [change, sql] of Object.entries(REVERT)) {
+    write(`revert/${change}.sql`, `-- Revert ${change}\nBEGIN;\n${sql}\nCOMMIT;\n`);
+  }
+  for (const change of Object.keys(DEPLOY)) {
+    write(`verify/${change}.sql`, `-- Verify ${change}\nBEGIN;\nSELECT 1;\nROLLBACK;\n`);
+  }
+});
+
+afterEach(() => {
+  rmSync(sourceDir, { recursive: true, force: true });
+  rmSync(outputDir, { recursive: true, force: true });
+});
+
+describe('rebundleWorkspace initScaffold', () => {
+  it('scaffolds the full pgpm init shell and writes merged pgpm files on top', async () => {
+    const result = await rebundleWorkspace(sourceDir, {
+      outputDir,
+      overwrite: true,
+      initScaffold: true,
+    });
+
+    // Same chunking + byte-identical gate as the minimal writer.
+    expect(result.packages.map(p => p.name)).toEqual(['auth', 'billing']);
+    expect(result.invariant.ok).toBe(true);
+
+    // Workspace-root boilerplate that the minimal writer omits.
+    for (const f of ['pgpm.json', 'pnpm-workspace.yaml', 'lerna.json', 'tsconfig.json']) {
+      expect(existsSync(join(outputDir, f))).toBe(true);
+    }
+    // Discoverable as a pgpm workspace.
+    expect(pgpmPath(outputDir)).toBe(outputDir);
+
+    for (const pkg of ['auth', 'billing']) {
+      const dir = join(outputDir, 'packages', pkg);
+      // pgpm files written by writeMinimalModule (merged chunk output).
+      expect(existsSync(join(dir, 'pgpm.plan'))).toBe(true);
+      expect(existsSync(join(dir, `${pkg}.control`))).toBe(true);
+      expect(existsSync(join(dir, 'Makefile'))).toBe(true);
+      expect(existsSync(join(dir, 'deploy', `${pkg}.sql`))).toBe(true);
+      expect(existsSync(join(dir, 'revert', `${pkg}.sql`))).toBe(true);
+      expect(existsSync(join(dir, 'verify', `${pkg}.sql`))).toBe(true);
+      // Developer shell from the init boilerplate that the minimal writer omits.
+      expect(existsSync(join(dir, 'package.json'))).toBe(true);
+      expect(existsSync(join(dir, 'README.md'))).toBe(true);
+      expect(existsSync(join(dir, 'jest.config.js'))).toBe(true);
+    }
+
+    // The scaffolded (richer) package.json is preserved, not clobbered by the
+    // minimal writer.
+    const authPkg = JSON.parse(readFileSync(join(outputDir, 'packages', 'auth', 'package.json'), 'utf-8'));
+    expect(authPkg.name).toBeTruthy();
+
+    // control-only default still carries the cross-chunk dep via requires.
+    const billingControl = readFileSync(join(outputDir, 'packages', 'billing', 'billing.control'), 'utf-8');
+    expect(billingControl).toContain("requires = 'auth'");
+  });
+});

--- a/pgpm/core/__tests__/rebundle/workspace-init-scaffold.test.ts
+++ b/pgpm/core/__tests__/rebundle/workspace-init-scaffold.test.ts
@@ -101,9 +101,10 @@ describe('rebundleWorkspace initScaffold', () => {
     }
 
     // The scaffolded (richer) package.json is preserved, not clobbered by the
-    // minimal writer.
+    // minimal writer, and carries the Constructive license (not MIT).
     const authPkg = JSON.parse(readFileSync(join(outputDir, 'packages', 'auth', 'package.json'), 'utf-8'));
     expect(authPkg.name).toBeTruthy();
+    expect(authPkg.license).toBe('CONSTRUCTIVE');
 
     // control-only default still carries the cross-chunk dep via requires.
     const billingControl = readFileSync(join(outputDir, 'packages', 'billing', 'billing.control'), 'utf-8');

--- a/pgpm/core/__tests__/rebundle/workspace.test.ts
+++ b/pgpm/core/__tests__/rebundle/workspace.test.ts
@@ -81,6 +81,10 @@ describe('rebundleWorkspace', () => {
     expect(existsSync(join(outputDir, 'pgpm.json'))).toBe(true);
     const cfg = JSON.parse(readFileSync(join(outputDir, 'pgpm.json'), 'utf-8'));
     expect(cfg.packages).toEqual(['packages/*']);
+
+    // Emitted package.json defaults to the Constructive license (not MIT).
+    const authPkg = JSON.parse(readFileSync(join(outputDir, 'packages', 'auth', 'package.json'), 'utf-8'));
+    expect(authPkg.license).toBe('CONSTRUCTIVE');
   });
 
   it('control-only (default): cross-chunk dep lives in control requires, not the plan', async () => {

--- a/pgpm/core/src/rebundle/types.ts
+++ b/pgpm/core/src/rebundle/types.ts
@@ -124,6 +124,24 @@ export interface RebundleWorkspaceOptions extends RebundleStrategy {
 
   /** How cross-chunk deps are represented (default: 'control-only') */
   crossChunkDepMode?: CrossChunkDepMode;
+
+  /**
+   * When `true`, scaffold each emitted module (and the workspace root) from the
+   * real `pgpm init` boilerplate template (`scaffoldTemplate`) before writing
+   * the merged pgpm files on top — so the output carries the full developer
+   * shell (README/LICENSE/jest/tests, workspace `pnpm-workspace.yaml`/`lerna.json`
+   * /tsconfig/lint/CI) rather than the minimal deployable set.
+   *
+   * Defaults to `false` (the lightweight, network-free minimal writer). Setting
+   * it `true` fetches the boilerplate repo (network), matching `pgpm init`.
+   */
+  initScaffold?: boolean;
+
+  /** Template repo for `initScaffold` (defaults to the pgpm boilerplates repo) */
+  templateRepo?: string;
+
+  /** Branch/tag for the `initScaffold` template repo */
+  templateBranch?: string;
 }
 
 /**

--- a/pgpm/core/src/rebundle/types.ts
+++ b/pgpm/core/src/rebundle/types.ts
@@ -142,6 +142,12 @@ export interface RebundleWorkspaceOptions extends RebundleStrategy {
 
   /** Branch/tag for the `initScaffold` template repo */
   templateBranch?: string;
+
+  /**
+   * License for the emitted module package.json (and the `pgpm init` answers
+   * when `initScaffold` is set). Defaults to 'CONSTRUCTIVE'.
+   */
+  license?: string;
 }
 
 /**

--- a/pgpm/core/src/rebundle/workspace.ts
+++ b/pgpm/core/src/rebundle/workspace.ts
@@ -42,6 +42,7 @@ export async function rebundleWorkspace(
     initScaffold = false,
     templateRepo = DEFAULT_TEMPLATE_REPO,
     templateBranch,
+    license = 'CONSTRUCTIVE',
     ...strategy
   } = options;
 
@@ -72,7 +73,7 @@ export async function rebundleWorkspace(
       outputDir,
       templateRepo,
       branch: templateBranch,
-      answers: workspaceAnswers(outputDir),
+      answers: workspaceAnswers(outputDir, license),
       noTty: true,
     });
   } else {
@@ -98,7 +99,7 @@ export async function rebundleWorkspace(
         outputDir: pkgDir,
         templateRepo,
         branch: templateBranch,
-        answers: moduleAnswers(chunk.name),
+        answers: moduleAnswers(chunk.name, license),
         noTty: true,
       });
     }
@@ -125,6 +126,7 @@ export async function rebundleWorkspace(
       scripts,
       tags: remappedTags.filter(t => t.change === chunk.name),
       requires: deps,
+      license,
       overwrite: true,
       // When scaffolded, keep the boilerplate's richer package.json.
       writePackageJson: !initScaffold,
@@ -154,7 +156,7 @@ function planChangeDeps(deps: string[], mode: CrossChunkDepMode): string[] {
  * deterministic placeholders (the generated pgpm files are the real payload);
  * the workspace name derives from the output directory.
  */
-function workspaceAnswers(outputDir: string): Record<string, string> {
+function workspaceAnswers(outputDir: string, license: string): Record<string, string> {
   const name = basename(outputDir) || 'rebundled-workspace';
   return {
     name,
@@ -163,12 +165,12 @@ function workspaceAnswers(outputDir: string): Record<string, string> {
     moduleName: name,
     username: 'constructive-io',
     repoName: name,
-    license: 'MIT',
+    license,
   };
 }
 
 /** Non-interactive answers for the `pgpm init` module template. */
-function moduleAnswers(name: string): Record<string, string> {
+function moduleAnswers(name: string, license: string): Record<string, string> {
   return {
     name,
     moduleName: name,
@@ -179,7 +181,7 @@ function moduleAnswers(name: string): Record<string, string> {
     email: 'noreply@constructive.io',
     username: 'constructive-io',
     access: 'public',
-    license: 'MIT',
+    license,
   };
 }
 

--- a/pgpm/core/src/rebundle/workspace.ts
+++ b/pgpm/core/src/rebundle/workspace.ts
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { basename, join } from 'path';
 
+import { DEFAULT_TEMPLATE_REPO, scaffoldTemplate } from '../core/template-scaffold';
 import { Change, Tag } from '../files/types';
 import { parsePlanFile } from '../files/plan/parser';
 import { mergeSqlStatements } from '../packaging/package';
@@ -38,6 +39,9 @@ export async function rebundleWorkspace(
     pretty = true,
     functionDelimiter = '$EOFCODE$',
     crossChunkDepMode = 'control-only',
+    initScaffold = false,
+    templateRepo = DEFAULT_TEMPLATE_REPO,
+    templateBranch,
     ...strategy
   } = options;
 
@@ -59,7 +63,21 @@ export async function rebundleWorkspace(
     change: memberToChunk.get(tag.change) ?? tag.change,
   }));
 
-  writeMinimalWorkspace(outputDir, { packages: ['packages/*'] });
+  if (initScaffold) {
+    // Lay down the full `pgpm init` workspace shell (pgpm.json, pnpm-workspace,
+    // lerna.json, tsconfig, lint/format configs, CI); the merged pgpm files are
+    // written on top per module below.
+    await scaffoldTemplate({
+      fromPath: 'workspace',
+      outputDir,
+      templateRepo,
+      branch: templateBranch,
+      answers: workspaceAnswers(outputDir),
+      noTty: true,
+    });
+  } else {
+    writeMinimalWorkspace(outputDir, { packages: ['packages/*'] });
+  }
 
   const byDeployOrder = [...plan.chunks].sort(
     (a, b) => plan.deployOrder.indexOf(a.name) - plan.deployOrder.indexOf(b.name)
@@ -70,6 +88,20 @@ export async function rebundleWorkspace(
   for (const chunk of byDeployOrder) {
     const pkgRel = join('packages', chunk.name);
     const pkgDir = join(outputDir, pkgRel);
+
+    if (initScaffold) {
+      // Scaffold the module's developer shell (package.json, jest.config.js,
+      // README, LICENSE, __tests__); writeMinimalModule overwrites the pgpm
+      // files (pgpm.plan, .control, Makefile, deploy/revert/verify) below.
+      await scaffoldTemplate({
+        fromPath: 'module',
+        outputDir: pkgDir,
+        templateRepo,
+        branch: templateBranch,
+        answers: moduleAnswers(chunk.name),
+        noTty: true,
+      });
+    }
 
     const scripts: Record<string, { deploy: string; revert: string; verify: string }> = {
       [chunk.name]: {
@@ -94,6 +126,8 @@ export async function rebundleWorkspace(
       tags: remappedTags.filter(t => t.change === chunk.name),
       requires: deps,
       overwrite: true,
+      // When scaffolded, keep the boilerplate's richer package.json.
+      writePackageJson: !initScaffold,
     });
 
     packages.push({ name: chunk.name, dir: pkgRel, dependencies: [...deps] });
@@ -113,6 +147,40 @@ export async function rebundleWorkspace(
 function planChangeDeps(deps: string[], mode: CrossChunkDepMode): string[] {
   if (mode === 'control-only') return [];
   return deps.map(dep => `${dep}:${dep}`);
+}
+
+/**
+ * Non-interactive answers for the `pgpm init` workspace template. Values are
+ * deterministic placeholders (the generated pgpm files are the real payload);
+ * the workspace name derives from the output directory.
+ */
+function workspaceAnswers(outputDir: string): Record<string, string> {
+  const name = basename(outputDir) || 'rebundled-workspace';
+  return {
+    name,
+    fullName: 'Constructive',
+    email: 'noreply@constructive.io',
+    moduleName: name,
+    username: 'constructive-io',
+    repoName: name,
+    license: 'MIT',
+  };
+}
+
+/** Non-interactive answers for the `pgpm init` module template. */
+function moduleAnswers(name: string): Record<string, string> {
+  return {
+    name,
+    moduleName: name,
+    moduleDesc: `${name} module`,
+    description: `${name} module`,
+    repoName: name,
+    fullName: 'Constructive',
+    email: 'noreply@constructive.io',
+    username: 'constructive-io',
+    access: 'public',
+    license: 'MIT',
+  };
 }
 
 /**

--- a/pgpm/core/src/workspace/minimal.ts
+++ b/pgpm/core/src/workspace/minimal.ts
@@ -35,6 +35,9 @@ export interface WriteMinimalModuleOptions {
   /** package.json version (default '0.0.1') */
   version?: string;
 
+  /** package.json license (default 'CONSTRUCTIVE') */
+  license?: string;
+
   /** Overwrite an existing directory (default: false) */
   overwrite?: boolean;
 
@@ -61,6 +64,7 @@ export function writeMinimalModule(moduleDir: string, options: WriteMinimalModul
     tags = [],
     requires = [],
     version = '0.0.1',
+    license = 'CONSTRUCTIVE',
     overwrite = false,
     writePackageJson = true,
   } = options;
@@ -92,7 +96,7 @@ export function writeMinimalModule(moduleDir: string, options: WriteMinimalModul
   if (writePackageJson) {
     fs.writeFileSync(
       path.join(moduleDir, 'package.json'),
-      JSON.stringify({ name, version, description: `${name} module`, license: 'MIT' }, null, 2) + '\n'
+      JSON.stringify({ name, version, description: `${name} module`, license }, null, 2) + '\n'
     );
   }
 }

--- a/pgpm/core/src/workspace/minimal.ts
+++ b/pgpm/core/src/workspace/minimal.ts
@@ -37,6 +37,13 @@ export interface WriteMinimalModuleOptions {
 
   /** Overwrite an existing directory (default: false) */
   overwrite?: boolean;
+
+  /**
+   * Write a minimal `package.json` (default: true). Set `false` to preserve an
+   * existing one — e.g. when a richer package.json was already scaffolded by
+   * `pgpm init` and only the pgpm files should be written on top.
+   */
+  writePackageJson?: boolean;
 }
 
 /**
@@ -47,7 +54,16 @@ export interface WriteMinimalModuleOptions {
  * network-fetched boilerplate (README/LICENSE/jest/tests/lint configs).
  */
 export function writeMinimalModule(moduleDir: string, options: WriteMinimalModuleOptions): void {
-  const { name, changes, scripts, tags = [], requires = [], version = '0.0.1', overwrite = false } = options;
+  const {
+    name,
+    changes,
+    scripts,
+    tags = [],
+    requires = [],
+    version = '0.0.1',
+    overwrite = false,
+    writePackageJson = true,
+  } = options;
 
   if (fs.existsSync(moduleDir) && fs.readdirSync(moduleDir).length > 0 && !overwrite) {
     throw new Error(`Module directory is not empty: ${moduleDir}. Pass overwrite: true to replace.`);
@@ -73,10 +89,12 @@ export function writeMinimalModule(moduleDir: string, options: WriteMinimalModul
   fs.writeFileSync(path.join(moduleDir, 'pgpm.plan'), generatePlanContent(name, changes, tags));
   fs.writeFileSync(path.join(moduleDir, `${name}.control`), generateModuleControl(name, requires, version));
   fs.writeFileSync(path.join(moduleDir, 'Makefile'), generateModuleMakefile(name, version));
-  fs.writeFileSync(
-    path.join(moduleDir, 'package.json'),
-    JSON.stringify({ name, version, description: `${name} module`, license: 'MIT' }, null, 2) + '\n'
-  );
+  if (writePackageJson) {
+    fs.writeFileSync(
+      path.join(moduleDir, 'package.json'),
+      JSON.stringify({ name, version, description: `${name} module`, license: 'MIT' }, null, 2) + '\n'
+    );
+  }
 }
 
 export interface WriteMinimalWorkspaceOptions {


### PR DESCRIPTION
## Summary

Adds an opt-in `initScaffold` boolean to `rebundleWorkspace`. When `true`, each emitted module (and the workspace root) is scaffolded from the real `pgpm init` boilerplate (`scaffoldTemplate`) — so the output carries the full developer shell — and the merged chunk pgpm files are written on top. Default `false` keeps today's lightweight, network-free minimal writer. Purely additive; no change to existing callers.

```ts
// default (unchanged): minimal deployable set via writeMinimalWorkspace/writeMinimalModule
await rebundleWorkspace(src, { outputDir });

// new: full `pgpm init` shell + merged pgpm files on top (fetches boilerplate repo)
await rebundleWorkspace(src, { outputDir, initScaffold: true });
```

What `initScaffold: true` adds vs the minimal writer:
- workspace root: `pnpm-workspace.yaml`, `lerna.json`, `tsconfig.json`, lint/format configs, CI (plus `pgpm.json`) instead of just `pgpm.json`
- per module: `README.md`, `jest.config.js`, `__tests__/`, and the boilerplate's richer `package.json`

Mechanics (additive):
```
if (initScaffold)  scaffoldTemplate({ fromPath: 'workspace', outputDir, ... })   // root shell
else               writeMinimalWorkspace(outputDir)                              // today's behavior

for each chunk:
  if (initScaffold) scaffoldTemplate({ fromPath: 'module', outputDir: pkgDir, ... })  // module shell
  writeMinimalModule(pkgDir, { ..., writePackageJson: !initScaffold })               // pgpm files on top
```

- The pgpm files (`pgpm.plan`, `<name>.control`, `Makefile`, `deploy/revert/verify`) are always produced by `writeMinimalModule`, so the merged chunk output and the byte-identical workspace invariant are identical in both modes — the boilerplate only supplies the surrounding developer files.
- New `writeMinimalModule` option `writePackageJson` (default `true`); set `false` under `initScaffold` so the boilerplate's richer `package.json` is preserved rather than clobbered.
- `templateRepo` / `templateBranch` passthroughs allow pointing at a custom/pinned boilerplate repo.

### License
Emitted `package.json` (and the `initScaffold` answers) now default to `CONSTRUCTIVE` — the license the generated monoliths this tooling slices already use (`application/constructive`, `services/constructive-services`) — instead of `MIT`. Overridable via a new `license?: string` option on `rebundleWorkspace` (and `writeMinimalModule`).

## Testing
- New `__tests__/rebundle/workspace-init-scaffold.test.ts`: with `initScaffold: true`, asserts the byte-identical invariant still holds, the pgpm files are written per module, the init boilerplate files (workspace `pnpm-workspace.yaml`/`lerna.json`/`tsconfig.json`; module `README.md`/`jest.config.js`) are present, the package.json license is `CONSTRUCTIVE`, the workspace is discoverable via `pgpmPath`, and control-only cross-chunk deps still land in `requires`. (Fetches the boilerplate repo over the network, like the existing `pgpm init` template tests.)
- Minimal-path `workspace.test.ts` also asserts the `CONSTRUCTIVE` license default.
- `tsc --noEmit` clean; full `pgpm/core` suite green; `pnpm build` clean.

Link to Devin session: https://app.devin.ai/sessions/ad40d16f38a349b48eb7ce9375e27e6e
Requested by: @pyramation