### PR TITLE
feat(pgpm-core): rebundle category boundary — classifier-driven chunk seams

### DIFF
--- a/pgpm/core/__tests__/rebundle/rebundle.test.ts
+++ b/pgpm/core/__tests__/rebundle/rebundle.test.ts
@@ -95,6 +95,65 @@ describe('rebundlePlan', () => {
     // Members remain in contiguous source order across the split.
     expect(result.chunks.flatMap(c => c.deploy)).toEqual(CHANGES);
   });
+
+  it('groups changes by the classifier category with boundary "category"', () => {
+    // Facts-driven seam: auth-* is security, billing-* is data. The chunk names
+    // follow meaning, not the folder path ('auth'/'billing').
+    const category: Record<string, string> = {
+      'schemas/auth/schema': 'security',
+      'schemas/auth/tables/users': 'security',
+      'schemas/auth/tables/sessions': 'security',
+      'schemas/billing/schema': 'data',
+      'schemas/billing/tables/invoices': 'data',
+    };
+    const result = rebundlePlan(moduleDir, {
+      boundary: 'category',
+      categoryOf: name => category[name],
+    });
+
+    expect(result.deployOrder).toEqual(['security', 'data']);
+    expect(result.chunks.find(c => c.name === 'security')!.deploy).toEqual([
+      'schemas/auth/schema',
+      'schemas/auth/tables/users',
+      'schemas/auth/tables/sessions',
+    ]);
+    expect(result.chunks.find(c => c.name === 'data')!.dependencies).toEqual(['security']);
+    // The carve is still byte-identical to the original module.
+    expect(verifyRebundleInvariant(moduleDir, result).ok).toBe(true);
+  });
+
+  it('falls back to the folder key for changes categoryOf does not classify', () => {
+    // Only classify the billing changes; the rest fall back to their folder key.
+    const result = rebundlePlan(moduleDir, {
+      boundary: 'category',
+      categoryOf: name => (name.startsWith('schemas/billing/') ? 'billing-domain' : undefined),
+    });
+
+    expect(result.deployOrder).toEqual(['auth', 'billing-domain']);
+    expect(verifyRebundleInvariant(moduleDir, result).ok).toBe(true);
+  });
+
+  it('keeps interleaved categories contiguous (suffixed) and byte-identical', () => {
+    // A category that reappears non-contiguously must NOT merge across the gap —
+    // that would reorder statements and break the invariant. Instead each run
+    // seals into its own ordinal-suffixed chunk.
+    const category: Record<string, string> = {
+      'schemas/auth/schema': 'core',
+      'schemas/auth/tables/users': 'aux',
+      'schemas/auth/tables/sessions': 'core', // 'core' reappears after 'aux'
+      'schemas/billing/schema': 'aux', // 'aux' reappears after the second 'core'
+      'schemas/billing/tables/invoices': 'aux',
+    };
+    const result = rebundlePlan(moduleDir, {
+      boundary: 'category',
+      categoryOf: name => category[name],
+    });
+
+    // Non-contiguous reuse → suffixed runs, never a merge across the gap.
+    expect(result.chunks.map(c => c.name)).toEqual(['core', 'aux', 'core~2', 'aux~2']);
+    expect(result.chunks.flatMap(c => c.deploy)).toEqual(CHANGES);
+    expect(verifyRebundleInvariant(moduleDir, result).ok).toBe(true);
+  });
 });
 
 describe('assembleChunkSql', () => {

--- a/pgpm/core/src/rebundle/rebundle.ts
+++ b/pgpm/core/src/rebundle/rebundle.ts
@@ -20,9 +20,18 @@ import { Chunk, RebundleResult, RebundleStrategy } from './types';
  */
 function boundaryKey(changeName: string, strategy: RebundleStrategy): string {
   if (strategy.boundary === 'none') return '';
-  const depth = strategy.depth ?? 1;
-  const prefix = strategy.prefixToStrip ?? 'schemas';
-  return extractPackageFromPath(changeName, depth, prefix);
+
+  const folderKey = (): string =>
+    extractPackageFromPath(changeName, strategy.depth ?? 1, strategy.prefixToStrip ?? 'schemas');
+
+  if (strategy.boundary === 'category') {
+    // Classifier/facts-driven seam: the caller decides each change's category;
+    // fall back to the folder key for changes it doesn't classify.
+    const category = strategy.categoryOf?.(changeName);
+    return category ?? folderKey();
+  }
+
+  return folderKey();
 }
 
 /**

--- a/pgpm/core/src/rebundle/types.ts
+++ b/pgpm/core/src/rebundle/types.ts
@@ -16,8 +16,22 @@ export interface RebundleStrategy {
    * - 'folder' (default): start a new chunk when the folder-derived key
    *   changes (uses the same path extraction as slice's folder strategy)
    * - 'none': one chunk for the whole module, subject only to `maxChunkSize`
+   * - 'category': start a new chunk when the caller-supplied `categoryOf` key
+   *   changes — the facts/classifier-driven seam. Lets the seams follow meaning
+   *   (e.g. security, roles, admin) instead of paths. `categoryOf` is required;
+   *   for changes it returns `undefined` for, the folder key is used as a
+   *   fallback so partial classification degrades gracefully.
    */
-  boundary?: 'folder' | 'none';
+  boundary?: 'folder' | 'none' | 'category';
+
+  /**
+   * Seam key for a change under `boundary: 'category'`. Consecutive changes
+   * sharing a key merge into one chunk (same greedy, contiguity-preserving rule
+   * as the folder boundary — so the byte-identical invariant is unaffected).
+   * pgpm-core stays classifier-agnostic: callers derive the category however
+   * they like (e.g. from `classifyStatements` facts) and pass it in here.
+   */
+  categoryOf?: (changeName: string) => string | undefined;
 
   /** Depth in the change path used to derive the folder key (default: 1) */
   depth?: number;


### PR DESCRIPTION
## Summary

Adds a `'category'` chunk boundary to `rebundlePlan` (and, for free, to `rebundleModule`/`rebundleWorkspace`, which pass the strategy through). This is the "carve by meaning" seam: instead of folder paths deciding where chunks split, a caller-supplied `categoryOf(change)` does — so a monolith can be sliced into `security` / `roles` / `admin` modules rather than `schemas/<folder>` modules.

pgpm-core stays classifier-agnostic — the facts→category mapping (the moat) lives in the caller (e.g. constructive-db's `classifyStatements`). Core only gains the generic seam mechanism:

```ts
interface RebundleStrategy {
  boundary?: 'folder' | 'none' | 'category';   // + 'category'
  categoryOf?: (changeName: string) => string | undefined;   // seam key for 'category'
}

// only boundaryKey() changed:
function boundaryKey(change, s) {
  if (s.boundary === 'none') return '';
  const folderKey = () => extractPackageFromPath(change, s.depth ?? 1, s.prefixToStrip ?? 'schemas');
  if (s.boundary === 'category') return s.categoryOf?.(change) ?? folderKey();  // fallback = graceful
  return folderKey();
}
```

`assignChunks` is untouched: it still greedily accumulates *consecutive* changes sharing a key and seals on key-change / tag / `maxChunkSize`. So:

- **Contiguity is preserved** — a category that reappears non-contiguously does NOT merge across the gap; each run seals into an ordinal-suffixed chunk (`core`, `aux`, `core~2`, ...). This is deliberate: merging across a gap would reorder statements and break the invariant the user flagged (deploy topological / verify in deploy order / revert reversed).
- **The byte-identical invariant holds unchanged** in category mode, at every dial position.
- Changes `categoryOf` returns `undefined` for fall back to the folder key, so partial classification degrades gracefully.

Purely additive; default stays `'folder'`. No existing caller behavior changes.

## Testing
New `rebundlePlan` cases in `__tests__/rebundle/rebundle.test.ts`:
- groups by `categoryOf` key (`security`/`data`), chunk names follow meaning not path, cross-category dep still derived (`data` → `security`), invariant byte-identical;
- unclassified changes fall back to the folder key;
- interleaved categories seal into suffixed contiguous chunks (`core`,`aux`,`core~2`,`aux~2`) and stay byte-identical.

`tsc --noEmit` clean; full `pgpm/core` suite 439/439; `pnpm build` clean.

## Next
The constructive-db side: derive `categoryOf` from `classifyStatements` facts (securityRelevant / roles / kind) behind a profile, and feed it into `rebundleWorkspace` — turning the monolith carve from folders into security/functionality/users/admin modules.

Link to Devin session: https://app.devin.ai/sessions/ad40d16f38a349b48eb7ce9375e27e6e
Requested by: @pyramation