### PR TITLE
feat(pgpm-core): pgpm-ast — unified PgpmModule/Change/Script AST with lossless read/write

### DIFF
--- a/pgpm/core/__tests__/ast/module.test.ts
+++ b/pgpm/core/__tests__/ast/module.test.ts
@@ -1,0 +1,161 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+
+import {
+  readModule,
+  serializePlan,
+  serializeScript,
+  verifyModuleRoundTrip,
+  writeModule
+} from '../../src/ast';
+
+let sourceDir: string;
+
+const PLAN = `%syntax-version=1.0.0
+%project=my-module
+%uri=my-module
+
+schemas/auth/schema 2024-01-01T00:00:00Z Dev <dev@example.com> # add schema
+schemas/auth/tables/users [schemas/auth/schema] 2024-01-01T00:00:01Z Dev <dev@example.com> # add users
+schemas/billing/schema [schemas/auth/schema] 2024-01-01T00:00:02Z Dev <dev@example.com> # add billing
+`;
+
+const CONTROL = `# my-module extension
+comment = 'my-module extension'
+default_version = '0.0.1'
+module_pathname = '$libdir/my-module'
+requires = 'citext,plpgsql'
+relocatable = false
+superuser = false
+`;
+
+const DEPLOY: Record<string, string> = {
+  'schemas/auth/schema': 'CREATE SCHEMA auth;',
+  'schemas/auth/tables/users': 'CREATE TABLE auth.users (id int PRIMARY KEY);',
+  'schemas/billing/schema': 'CREATE SCHEMA billing;'
+};
+
+function write(rel: string, content: string): void {
+  const file = join(sourceDir, rel);
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, content);
+}
+
+beforeEach(() => {
+  sourceDir = mkdtempSync(join(tmpdir(), 'pgpm-ast-src-'));
+  writeFileSync(join(sourceDir, 'pgpm.plan'), PLAN);
+  writeFileSync(join(sourceDir, 'my-module.control'), CONTROL);
+  for (const [change, sql] of Object.entries(DEPLOY)) {
+    write(`deploy/${change}.sql`, `-- Deploy ${change}\nBEGIN;\n${sql}\nCOMMIT;\n`);
+    write(`revert/${change}.sql`, `-- Revert ${change}\nBEGIN;\nDROP THING;\nCOMMIT;\n`);
+    // verify intentionally omitted for one change to exercise null scripts
+    if (change !== 'schemas/billing/schema') {
+      write(`verify/${change}.sql`, `-- Verify ${change}\nBEGIN;\nSELECT 1;\nROLLBACK;\n`);
+    }
+  }
+});
+
+afterEach(() => {
+  rmSync(sourceDir, { recursive: true, force: true });
+});
+
+describe('readModule', () => {
+  it('builds a plan-ordered module AST with parsed control + scripts', () => {
+    const mod = readModule(sourceDir);
+
+    expect(mod.name).toBe('my-module');
+    expect(mod.dir).toBe(sourceDir);
+    expect(mod.changes.map(c => c.name)).toEqual([
+      'schemas/auth/schema',
+      'schemas/auth/tables/users',
+      'schemas/billing/schema'
+    ]);
+
+    expect(mod.control).not.toBeNull();
+    expect(mod.control!.fileName).toBe('my-module.control');
+    expect(mod.control!.version).toBe('0.0.1');
+    expect(mod.control!.requires).toEqual(['citext', 'plpgsql']);
+  });
+
+  it('parses each change header and preserves dependencies', () => {
+    const mod = readModule(sourceDir);
+    const users = mod.changes.find(c => c.name === 'schemas/auth/tables/users')!;
+
+    expect(users.plan.dependencies).toEqual(['schemas/auth/schema']);
+    expect(users.deploy).not.toBeNull();
+    expect(users.deploy!.header.verb).toBe('Deploy');
+    expect(users.deploy!.header.change).toBe('schemas/auth/tables/users');
+    expect(users.deploy!.body).toContain('CREATE TABLE auth.users');
+  });
+
+  it('marks a missing script as null', () => {
+    const mod = readModule(sourceDir);
+    const billing = mod.changes.find(c => c.name === 'schemas/billing/schema')!;
+    expect(billing.deploy).not.toBeNull();
+    expect(billing.verify).toBeNull();
+  });
+
+  it('throws when there is no pgpm.plan', () => {
+    const empty = mkdtempSync(join(tmpdir(), 'pgpm-ast-empty-'));
+    try {
+      expect(() => readModule(empty)).toThrow(/No pgpm\.plan/);
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('writeModule (lossless copy)', () => {
+  it('reproduces plan, control, and scripts byte-for-byte', () => {
+    const mod = readModule(sourceDir);
+    const outDir = mkdtempSync(join(tmpdir(), 'pgpm-ast-out-'));
+    try {
+      writeModule(mod, { outDir });
+
+      expect(readFileSync(join(outDir, 'pgpm.plan'), 'utf-8')).toBe(PLAN);
+      expect(readFileSync(join(outDir, 'my-module.control'), 'utf-8')).toBe(CONTROL);
+      for (const [change, sql] of Object.entries(DEPLOY)) {
+        expect(readFileSync(join(outDir, 'deploy', `${change}.sql`), 'utf-8')).toBe(
+          `-- Deploy ${change}\nBEGIN;\n${sql}\nCOMMIT;\n`
+        );
+      }
+      // omitted verify stays omitted
+      const rereadMod = readModule(outDir);
+      expect(rereadMod.changes.find(c => c.name === 'schemas/billing/schema')!.verify).toBeNull();
+    } finally {
+      rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('serialize helpers', () => {
+  it('serializeScript is byte-identical to source header+body', () => {
+    const mod = readModule(sourceDir);
+    for (const change of mod.changes) {
+      for (const script of [change.deploy, change.revert, change.verify]) {
+        if (!script) continue;
+        expect(serializeScript(script)).toBe(script.raw);
+      }
+    }
+  });
+
+  it('serializePlan round-trips the plan structurally', () => {
+    const mod = readModule(sourceDir);
+    const once = serializePlan(mod);
+    // re-parsing the serialized plan and serializing again is stable
+    const outDir = mkdtempSync(join(tmpdir(), 'pgpm-ast-plan-'));
+    try {
+      writeModule(mod, { outDir, fromRaw: false });
+      expect(serializePlan(readModule(outDir))).toBe(once);
+    } finally {
+      rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('verifyModuleRoundTrip', () => {
+  it('reports no drift for a well-formed module', () => {
+    expect(verifyModuleRoundTrip(sourceDir)).toEqual([]);
+  });
+});

--- a/pgpm/core/src/ast/index.ts
+++ b/pgpm/core/src/ast/index.ts
@@ -1,0 +1,12 @@
+/**
+ * pgpm-ast: the unified in-memory AST for pgpm modules ("AST for the migrations").
+ *
+ * Composes the existing file-level parsers (plan, control, SQL header) into a
+ * single typed {@link PgpmModuleAst} object that operators transform, then writes
+ * it back losslessly. Lives under `pgpm/core/src/ast` so it can later be lifted
+ * into a standalone leaf `pgpm/ast` package as a pure file move.
+ */
+export * from './reader';
+export * from './roundtrip';
+export * from './types';
+export * from './writer';

--- a/pgpm/core/src/ast/reader.ts
+++ b/pgpm/core/src/ast/reader.ts
@@ -1,0 +1,82 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+import { parseControlFile } from '../files/extension/reader';
+import { parsePlanFile } from '../files/plan/parser';
+import { parsePgpmHeader } from '../files/sql/header';
+import { readScript, scriptExists } from '../files/sql-scripts/reader';
+import {
+  PgpmChangeAst,
+  PgpmControlAst,
+  PgpmModuleAst,
+  PgpmScriptAst,
+  PgpmScriptKind
+} from './types';
+
+function readScriptAst(
+  dir: string,
+  kind: PgpmScriptKind,
+  change: string
+): PgpmScriptAst | null {
+  if (!scriptExists(dir, kind, change)) return null;
+  const raw = readScript(dir, kind, change);
+  const { header, body } = parsePgpmHeader(raw);
+  return { kind, header, body, raw };
+}
+
+/**
+ * Read a pgpm module directory into the unified {@link PgpmModuleAst}.
+ *
+ * Composes the existing plan parser, control reader, and SQL header parser — it
+ * does not re-implement any parsing. The module is addressed by plan order: the
+ * `changes` array follows `pgpm.plan`, and each change eagerly parses its
+ * deploy/revert/verify scripts (missing ones are `null`). Every leaf retains its
+ * byte-exact source so {@link writeModule} can reproduce the module losslessly.
+ *
+ * @throws when `dir` has no `pgpm.plan`, or the plan fails to parse.
+ */
+export function readModule(dir: string): PgpmModuleAst {
+  const planPath = join(dir, 'pgpm.plan');
+  if (!existsSync(planPath)) {
+    throw new Error(`No pgpm.plan found in module directory: ${dir}`);
+  }
+
+  const planRaw = readFileSync(planPath, 'utf-8');
+  const parsed = parsePlanFile(planPath);
+  if (!parsed.data) {
+    const detail = parsed.errors
+      .map(e => `line ${e.line}: ${e.message}`)
+      .join('; ');
+    throw new Error(`Failed to parse plan file ${planPath}: ${detail}`);
+  }
+
+  const plan = parsed.data;
+  const name = plan.package;
+
+  let control: PgpmControlAst | null = null;
+  if (name) {
+    const fileName = `${name}.control`;
+    const controlPath = join(dir, fileName);
+    if (existsSync(controlPath)) {
+      const raw = readFileSync(controlPath, 'utf-8');
+      const info = parseControlFile(controlPath, dir);
+      control = {
+        fileName,
+        name,
+        requires: info.requires,
+        version: info.version,
+        raw
+      };
+    }
+  }
+
+  const changes: PgpmChangeAst[] = plan.changes.map(planChange => ({
+    name: planChange.name,
+    plan: planChange,
+    deploy: readScriptAst(dir, 'deploy', planChange.name),
+    revert: readScriptAst(dir, 'revert', planChange.name),
+    verify: readScriptAst(dir, 'verify', planChange.name)
+  }));
+
+  return { dir, name, plan, planRaw, control, changes };
+}

--- a/pgpm/core/src/ast/roundtrip.ts
+++ b/pgpm/core/src/ast/roundtrip.ts
@@ -1,0 +1,79 @@
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { readModule } from './reader';
+import { serializePlan, serializeScript, writeModule } from './writer';
+
+/**
+ * A single discrepancy found by {@link verifyModuleRoundTrip}.
+ */
+export interface RoundTripIssue {
+  kind: 'script-drift' | 'plan-drift' | 'change-count' | 'change-identity';
+  change?: string;
+  script?: string;
+  message: string;
+}
+
+/**
+ * Read-only invariant check for the module AST: proves a module survives a
+ * read → serialize → re-read cycle without drifting.
+ *
+ * Guarantees checked:
+ *   - every script serializes byte-identically to its source (the SQL header
+ *     parser is lossless), and
+ *   - the plan serialization is idempotent and the structured change set is
+ *     stable across a serialize → re-read round trip.
+ *
+ * Returns the issues found rather than throwing.
+ */
+export function verifyModuleRoundTrip(dir: string): RoundTripIssue[] {
+  const issues: RoundTripIssue[] = [];
+  const module = readModule(dir);
+
+  for (const change of module.changes) {
+    for (const script of [change.deploy, change.revert, change.verify]) {
+      if (!script) continue;
+      if (serializeScript(script) !== script.raw) {
+        issues.push({
+          kind: 'script-drift',
+          change: change.name,
+          script: script.kind,
+          message: 'header serialize is not byte-identical to source'
+        });
+      }
+    }
+  }
+
+  const planOnce = serializePlan(module);
+  const tmp = mkdtempSync(join(tmpdir(), 'pgpm-ast-rt-'));
+  try {
+    writeModule(module, { outDir: tmp, fromRaw: false });
+    const reread = readModule(tmp);
+
+    if (serializePlan(reread) !== planOnce) {
+      issues.push({ kind: 'plan-drift', message: 'plan serialization is not idempotent' });
+    }
+
+    if (reread.changes.length !== module.changes.length) {
+      issues.push({
+        kind: 'change-count',
+        message: `change count drifted: ${module.changes.length} -> ${reread.changes.length}`
+      });
+    } else {
+      for (let i = 0; i < module.changes.length; i++) {
+        if (reread.changes[i].name !== module.changes[i].name) {
+          issues.push({
+            kind: 'change-identity',
+            change: module.changes[i].name,
+            message: `change at index ${i} drifted to "${reread.changes[i].name}"`
+          });
+        }
+      }
+    }
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+
+  return issues;
+}

--- a/pgpm/core/src/ast/types.ts
+++ b/pgpm/core/src/ast/types.ts
@@ -1,0 +1,77 @@
+import { PgpmHeader } from '../files/sql/header';
+import { Change, ExtendedPlanFile } from '../files/types';
+
+/**
+ * The three script directions a pgpm change is materialized into on disk.
+ */
+export type PgpmScriptKind = 'deploy' | 'revert' | 'verify';
+
+/**
+ * The parsed AST of a single pgpm SQL script (one of deploy/revert/verify for a
+ * change). Carries the structured header (verb/project/change/requires) plus the
+ * body, and retains the byte-exact `raw` source so a read→write cycle is lossless.
+ */
+export interface PgpmScriptAst {
+  kind: PgpmScriptKind;
+  /** Structured header block (see {@link PgpmHeader}). */
+  header: PgpmHeader;
+  /** Everything after the header block, byte-exact. */
+  body: string;
+  /** The original file content, byte-exact. */
+  raw: string;
+}
+
+/**
+ * The AST of a single pgpm change: its plan entry (identity + dependencies +
+ * attribution) together with the deploy/revert/verify scripts that implement it.
+ * A script is `null` when the corresponding file does not exist on disk.
+ */
+export interface PgpmChangeAst {
+  /** Path identity / plan change name (e.g. `schemas/auth/tables/users`). */
+  name: string;
+  /** The plan entry for this change (dependencies, timestamp, planner, ...). */
+  plan: Change;
+  deploy: PgpmScriptAst | null;
+  revert: PgpmScriptAst | null;
+  verify: PgpmScriptAst | null;
+}
+
+/**
+ * The parsed AST of a module's Postgres extension `.control` file.
+ */
+export interface PgpmControlAst {
+  /** The control file name (`<name>.control`). */
+  fileName: string;
+  /** Extension name (control basename, equals the plan project). */
+  name: string;
+  /** Extensions this module requires (from the control `requires =` line). */
+  requires: string[];
+  /** `default_version` from the control file. */
+  version: string;
+  /** The original file content, byte-exact. */
+  raw: string;
+}
+
+/**
+ * The unified in-memory AST for an entire pgpm module ("AST for the migrations").
+ *
+ * It composes the existing file-level parsers — plan parser, control reader, SQL
+ * header parser — into a single typed object addressed by plan-order changes.
+ * Operators (rename, rebundle, slice, transpile) become transforms over this tree
+ * instead of ad-hoc file/plan re-reads. Every leaf keeps its byte-exact `raw`, so
+ * {@link readModule} → {@link writeModule} is a lossless copy.
+ */
+export interface PgpmModuleAst {
+  /** Directory the module was read from. */
+  dir: string;
+  /** Project (extension) name, from the plan `%project=`. */
+  name: string;
+  /** Parsed plan (package/uri/changes/tags). */
+  plan: ExtendedPlanFile;
+  /** The original `pgpm.plan` content, byte-exact. */
+  planRaw: string;
+  /** Parsed `.control`, or `null` when the module has no control file. */
+  control: PgpmControlAst | null;
+  /** Changes in plan order, each with its deploy/revert/verify scripts. */
+  changes: PgpmChangeAst[];
+}

--- a/pgpm/core/src/ast/writer.ts
+++ b/pgpm/core/src/ast/writer.ts
@@ -1,0 +1,70 @@
+import { mkdirSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+
+import { generatePlanFileContent } from '../files/plan/writer';
+import { writePgpmScript } from '../files/sql/header';
+import { PgpmModuleAst, PgpmScriptAst } from './types';
+
+/**
+ * Serialize a script AST back to SQL text from its structured header + body.
+ * Byte-identical to the source for scripts read via {@link readModule} (the SQL
+ * header parser is lossless), and reflects any structural header edits.
+ */
+export function serializeScript(script: PgpmScriptAst): string {
+  return writePgpmScript({ header: script.header, body: script.body });
+}
+
+/**
+ * Serialize a module's plan back to `pgpm.plan` text from its structured model.
+ */
+export function serializePlan(module: PgpmModuleAst): string {
+  return generatePlanFileContent(module.plan);
+}
+
+export interface WriteModuleOptions {
+  /** Target directory. Defaults to the module's own `dir`. */
+  outDir?: string;
+  /**
+   * When true (default), write each file from its byte-exact `raw`, producing a
+   * lossless copy of the source module. Set false to write from the structured
+   * model instead (`serializePlan` / `serializeScript`), e.g. after transforms.
+   */
+  fromRaw?: boolean;
+}
+
+/**
+ * Materialize a {@link PgpmModuleAst} back to disk: `pgpm.plan`, the `.control`
+ * file (when present), and every change's deploy/revert/verify script.
+ *
+ * With the default `fromRaw: true` this is a lossless copy of what
+ * {@link readModule} loaded; with `fromRaw: false` it emits the structured
+ * serialization (used by operators that mutate the AST before writing).
+ */
+export function writeModule(
+  module: PgpmModuleAst,
+  options: WriteModuleOptions = {}
+): void {
+  const outDir = options.outDir ?? module.dir;
+  const fromRaw = options.fromRaw ?? true;
+
+  mkdirSync(outDir, { recursive: true });
+
+  writeFileSync(
+    join(outDir, 'pgpm.plan'),
+    fromRaw ? module.planRaw : serializePlan(module)
+  );
+
+  if (module.control) {
+    writeFileSync(join(outDir, module.control.fileName), module.control.raw);
+  }
+
+  for (const change of module.changes) {
+    const scripts = [change.deploy, change.revert, change.verify];
+    for (const script of scripts) {
+      if (!script) continue;
+      const file = join(outDir, script.kind, `${change.name}.sql`);
+      mkdirSync(dirname(file), { recursive: true });
+      writeFileSync(file, fromRaw ? script.raw : serializeScript(script));
+    }
+  }
+}

--- a/pgpm/core/src/index.ts
+++ b/pgpm/core/src/index.ts
@@ -1,27 +1,25 @@
+export * from './core/boilerplate-scanner';
+export * from './core/boilerplate-types';
 export * from './core/class/pgpm';
-export * from './slice';
-export * from './rebundle';
+export * from './core/template-scaffold';
 export * from './extensions/extensions';
 export * from './modules/modules';
 export * from './packaging/package';
 export * from './packaging/transform';
+export * from './rebundle';
 export * from './resolution/deps';
 export * from './resolution/resolve';
+export * from './slice';
+export * from './workspace/minimal';
 export * from './workspace/paths';
 export * from './workspace/utils';
-export * from './workspace/minimal';
-export * from './core/template-scaffold';
-export * from './core/boilerplate-types';
-export * from './core/boilerplate-scanner';
 
 // Export package-files functionality (now integrated into core)
+export * from './ast';
 export * from './files';
-export * from './refactor';
+export { PgpmInit } from './init/client';
 export { cleanSql } from './migrate/clean';
 export { PgpmMigrate } from './migrate/client';
-export { PgpmInit } from './init/client';
-export * from './roles';
-export { parseAuthor } from './utils/author';
 export {
   DeployOptions, 
   DeployResult, 
@@ -34,3 +32,6 @@ export {
   VerifyResult} from './migrate/types';
 export { hashFile, hashString } from './migrate/utils/hash';
 export { executeQuery,TransactionContext, TransactionOptions, withTransaction } from './migrate/utils/transaction';
+export * from './refactor';
+export * from './roles';
+export { parseAuthor } from './utils/author';

--- a/pgpm/core/src/index.ts
+++ b/pgpm/core/src/index.ts
@@ -1,25 +1,28 @@
-export * from './core/boilerplate-scanner';
-export * from './core/boilerplate-types';
 export * from './core/class/pgpm';
-export * from './core/template-scaffold';
+export * from './slice';
+export * from './rebundle';
 export * from './extensions/extensions';
 export * from './modules/modules';
 export * from './packaging/package';
 export * from './packaging/transform';
-export * from './rebundle';
 export * from './resolution/deps';
 export * from './resolution/resolve';
-export * from './slice';
-export * from './workspace/minimal';
 export * from './workspace/paths';
 export * from './workspace/utils';
+export * from './workspace/minimal';
+export * from './core/template-scaffold';
+export * from './core/boilerplate-types';
+export * from './core/boilerplate-scanner';
 
 // Export package-files functionality (now integrated into core)
-export * from './ast';
 export * from './files';
-export { PgpmInit } from './init/client';
+export * from './ast';
+export * from './refactor';
 export { cleanSql } from './migrate/clean';
 export { PgpmMigrate } from './migrate/client';
+export { PgpmInit } from './init/client';
+export * from './roles';
+export { parseAuthor } from './utils/author';
 export {
   DeployOptions, 
   DeployResult, 
@@ -32,6 +35,3 @@ export {
   VerifyResult} from './migrate/types';
 export { hashFile, hashString } from './migrate/utils/hash';
 export { executeQuery,TransactionContext, TransactionOptions, withTransaction } from './migrate/utils/transaction';
-export * from './refactor';
-export * from './roles';
-export { parseAuthor } from './utils/author';


### PR DESCRIPTION
## Summary

The "AST for the migrations." Today every operator (rename, rebundle, slice, and the coming transpile/bundle/apply functions) re-reads a module's files ad-hoc: parse `pgpm.plan`, glob `deploy/*.sql`, re-parse headers, read `.control`. This adds one typed in-memory object so those operators transform a tree instead of re-deriving it from disk each time.

Purely additive — a new `pgpm/core/src/ast/` module (namespaced so it can later be lifted into a standalone leaf `pgpm/ast` package as a pure file move) plus one export line. Nothing existing is touched; it **composes** the existing parsers rather than reimplementing any:

```
readModule(dir) ─ parsePlanFile        (files/plan/parser)
                ├ parseControlFile      (files/extension/reader)
                └ parsePgpmHeader       (files/sql/header)   per deploy/revert/verify
```

Shape (each leaf keeps byte-exact `raw`, so read→write is a lossless copy):

```ts
interface PgpmModuleAst {
  dir: string; name: string;
  plan: ExtendedPlanFile; planRaw: string;
  control: PgpmControlAst | null;
  changes: PgpmChangeAst[];        // in plan order
}
interface PgpmChangeAst { name; plan: Change; deploy/revert/verify: PgpmScriptAst | null }
interface PgpmScriptAst { kind; header: PgpmHeader; body: string; raw: string }
```

API:

```ts
readModule(dir): PgpmModuleAst
writeModule(module, { outDir?, fromRaw? })   // fromRaw=true (default) => lossless copy
serializeScript(script) / serializePlan(module)
verifyModuleRoundTrip(dir): RoundTripIssue[] // read→serialize→re-read invariant
```

`writeModule` defaults to writing each leaf from its `raw` (byte-identical copy); `fromRaw: false` emits the structured serialization for operators that mutate the AST first. `verifyModuleRoundTrip` proves scripts serialize byte-identically (the SQL header parser is lossless) and the plan serialize is idempotent with a stable change set.

## Testing
- `npx tsc --noEmit` clean; new files lint clean.
- 8 new unit tests (`__tests__/ast/module.test.ts`): plan-ordered read, header/dependency parse, null scripts, byte-for-byte `writeModule` copy, serialize helpers, round-trip invariant.
- Full `@pgpmjs/core` suite green with Postgres up: **68 suites / 447 tests** (+8, no regressions).

First in a stacked series building the control-plane/data-plane cloud-function plumbing; subsequent PRs (bundle artifact + manifest, fixture-closure, namespace transpiler) build on this AST.


Link to Devin session: https://app.devin.ai/sessions/ad40d16f38a349b48eb7ce9375e27e6e
Requested by: @pyramation