### PR TITLE
feat(pgpm-core): migration bundle artifact — content-addressed, verifiable, provenance manifest

### DIFF
--- a/pgpm/core/__tests__/ast/module.test.ts
+++ b/pgpm/core/__tests__/ast/module.test.ts
@@ -1,0 +1,161 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+
+import {
+  readModule,
+  serializePlan,
+  serializeScript,
+  verifyModuleRoundTrip,
+  writeModule
+} from '../../src/ast';
+
+let sourceDir: string;
+
+const PLAN = `%syntax-version=1.0.0
+%project=my-module
+%uri=my-module
+
+schemas/auth/schema 2024-01-01T00:00:00Z Dev <dev@example.com> # add schema
+schemas/auth/tables/users [schemas/auth/schema] 2024-01-01T00:00:01Z Dev <dev@example.com> # add users
+schemas/billing/schema [schemas/auth/schema] 2024-01-01T00:00:02Z Dev <dev@example.com> # add billing
+`;
+
+const CONTROL = `# my-module extension
+comment = 'my-module extension'
+default_version = '0.0.1'
+module_pathname = '$libdir/my-module'
+requires = 'citext,plpgsql'
+relocatable = false
+superuser = false
+`;
+
+const DEPLOY: Record<string, string> = {
+  'schemas/auth/schema': 'CREATE SCHEMA auth;',
+  'schemas/auth/tables/users': 'CREATE TABLE auth.users (id int PRIMARY KEY);',
+  'schemas/billing/schema': 'CREATE SCHEMA billing;'
+};
+
+function write(rel: string, content: string): void {
+  const file = join(sourceDir, rel);
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, content);
+}
+
+beforeEach(() => {
+  sourceDir = mkdtempSync(join(tmpdir(), 'pgpm-ast-src-'));
+  writeFileSync(join(sourceDir, 'pgpm.plan'), PLAN);
+  writeFileSync(join(sourceDir, 'my-module.control'), CONTROL);
+  for (const [change, sql] of Object.entries(DEPLOY)) {
+    write(`deploy/${change}.sql`, `-- Deploy ${change}\nBEGIN;\n${sql}\nCOMMIT;\n`);
+    write(`revert/${change}.sql`, `-- Revert ${change}\nBEGIN;\nDROP THING;\nCOMMIT;\n`);
+    // verify intentionally omitted for one change to exercise null scripts
+    if (change !== 'schemas/billing/schema') {
+      write(`verify/${change}.sql`, `-- Verify ${change}\nBEGIN;\nSELECT 1;\nROLLBACK;\n`);
+    }
+  }
+});
+
+afterEach(() => {
+  rmSync(sourceDir, { recursive: true, force: true });
+});
+
+describe('readModule', () => {
+  it('builds a plan-ordered module AST with parsed control + scripts', () => {
+    const mod = readModule(sourceDir);
+
+    expect(mod.name).toBe('my-module');
+    expect(mod.dir).toBe(sourceDir);
+    expect(mod.changes.map(c => c.name)).toEqual([
+      'schemas/auth/schema',
+      'schemas/auth/tables/users',
+      'schemas/billing/schema'
+    ]);
+
+    expect(mod.control).not.toBeNull();
+    expect(mod.control!.fileName).toBe('my-module.control');
+    expect(mod.control!.version).toBe('0.0.1');
+    expect(mod.control!.requires).toEqual(['citext', 'plpgsql']);
+  });
+
+  it('parses each change header and preserves dependencies', () => {
+    const mod = readModule(sourceDir);
+    const users = mod.changes.find(c => c.name === 'schemas/auth/tables/users')!;
+
+    expect(users.plan.dependencies).toEqual(['schemas/auth/schema']);
+    expect(users.deploy).not.toBeNull();
+    expect(users.deploy!.header.verb).toBe('Deploy');
+    expect(users.deploy!.header.change).toBe('schemas/auth/tables/users');
+    expect(users.deploy!.body).toContain('CREATE TABLE auth.users');
+  });
+
+  it('marks a missing script as null', () => {
+    const mod = readModule(sourceDir);
+    const billing = mod.changes.find(c => c.name === 'schemas/billing/schema')!;
+    expect(billing.deploy).not.toBeNull();
+    expect(billing.verify).toBeNull();
+  });
+
+  it('throws when there is no pgpm.plan', () => {
+    const empty = mkdtempSync(join(tmpdir(), 'pgpm-ast-empty-'));
+    try {
+      expect(() => readModule(empty)).toThrow(/No pgpm\.plan/);
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('writeModule (lossless copy)', () => {
+  it('reproduces plan, control, and scripts byte-for-byte', () => {
+    const mod = readModule(sourceDir);
+    const outDir = mkdtempSync(join(tmpdir(), 'pgpm-ast-out-'));
+    try {
+      writeModule(mod, { outDir });
+
+      expect(readFileSync(join(outDir, 'pgpm.plan'), 'utf-8')).toBe(PLAN);
+      expect(readFileSync(join(outDir, 'my-module.control'), 'utf-8')).toBe(CONTROL);
+      for (const [change, sql] of Object.entries(DEPLOY)) {
+        expect(readFileSync(join(outDir, 'deploy', `${change}.sql`), 'utf-8')).toBe(
+          `-- Deploy ${change}\nBEGIN;\n${sql}\nCOMMIT;\n`
+        );
+      }
+      // omitted verify stays omitted
+      const rereadMod = readModule(outDir);
+      expect(rereadMod.changes.find(c => c.name === 'schemas/billing/schema')!.verify).toBeNull();
+    } finally {
+      rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('serialize helpers', () => {
+  it('serializeScript is byte-identical to source header+body', () => {
+    const mod = readModule(sourceDir);
+    for (const change of mod.changes) {
+      for (const script of [change.deploy, change.revert, change.verify]) {
+        if (!script) continue;
+        expect(serializeScript(script)).toBe(script.raw);
+      }
+    }
+  });
+
+  it('serializePlan round-trips the plan structurally', () => {
+    const mod = readModule(sourceDir);
+    const once = serializePlan(mod);
+    // re-parsing the serialized plan and serializing again is stable
+    const outDir = mkdtempSync(join(tmpdir(), 'pgpm-ast-plan-'));
+    try {
+      writeModule(mod, { outDir, fromRaw: false });
+      expect(serializePlan(readModule(outDir))).toBe(once);
+    } finally {
+      rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('verifyModuleRoundTrip', () => {
+  it('reports no drift for a well-formed module', () => {
+    expect(verifyModuleRoundTrip(sourceDir)).toEqual([]);
+  });
+});

--- a/pgpm/core/__tests__/bundle/bundle.test.ts
+++ b/pgpm/core/__tests__/bundle/bundle.test.ts
@@ -1,0 +1,154 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+
+import { readModule } from '../../src/ast';
+import {
+  bundleFromModule,
+  createBundle,
+  materializeBundle,
+  readBundleFile,
+  verifyBundle,
+  writeBundleFile
+} from '../../src/bundle';
+
+let sourceDir: string;
+
+const PLAN = `%syntax-version=1.0.0
+%project=my-module
+%uri=my-module
+
+schemas/auth/schema 2024-01-01T00:00:00Z Dev <dev@example.com> # add schema
+schemas/auth/tables/users [schemas/auth/schema] 2024-01-01T00:00:01Z Dev <dev@example.com> # add users
+schemas/billing/schema [schemas/auth/schema] 2024-01-01T00:00:02Z Dev <dev@example.com> # add billing
+`;
+
+const CONTROL = `# my-module extension
+comment = 'my-module extension'
+default_version = '0.0.1'
+requires = 'plpgsql'
+relocatable = false
+superuser = false
+`;
+
+const DEPLOY: Record<string, string> = {
+  'schemas/auth/schema': 'CREATE SCHEMA auth;',
+  'schemas/auth/tables/users': 'CREATE TABLE auth.users (id int PRIMARY KEY);',
+  'schemas/billing/schema': 'CREATE SCHEMA billing;'
+};
+
+function write(rel: string, content: string): void {
+  const file = join(sourceDir, rel);
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, content);
+}
+
+beforeEach(() => {
+  sourceDir = mkdtempSync(join(tmpdir(), 'pgpm-bundle-src-'));
+  writeFileSync(join(sourceDir, 'pgpm.plan'), PLAN);
+  writeFileSync(join(sourceDir, 'my-module.control'), CONTROL);
+  for (const [change, sql] of Object.entries(DEPLOY)) {
+    write(`deploy/${change}.sql`, `-- Deploy ${change}\nBEGIN;\n${sql}\nCOMMIT;\n`);
+    write(`revert/${change}.sql`, `-- Revert ${change}\nBEGIN;\nDROP THING;\nCOMMIT;\n`);
+    if (change !== 'schemas/billing/schema') {
+      write(`verify/${change}.sql`, `-- Verify ${change}\nBEGIN;\nSELECT 1;\nROLLBACK;\n`);
+    }
+  }
+});
+
+afterEach(() => {
+  rmSync(sourceDir, { recursive: true, force: true });
+});
+
+describe('createBundle', () => {
+  it('captures ordered changes, control, and digests', () => {
+    const bundle = createBundle(readModule(sourceDir));
+
+    expect(bundle.manifest.name).toBe('my-module');
+    expect(bundle.manifest.formatVersion).toBe('1');
+    expect(bundle.manifest.changeCount).toBe(3);
+    expect(bundle.manifest.deployOrder).toEqual([
+      'schemas/auth/schema',
+      'schemas/auth/tables/users',
+      'schemas/billing/schema'
+    ]);
+    expect(bundle.manifest.digest).toMatch(/^[0-9a-f]{64}$/);
+    expect(bundle.control).not.toBeNull();
+
+    const users = bundle.changes.find(c => c.name === 'schemas/auth/tables/users')!;
+    expect(users.dependencies).toEqual(['schemas/auth/schema']);
+    expect(users.deploy!.digest).toMatch(/^[0-9a-f]{64}$/);
+
+    const billing = bundle.changes.find(c => c.name === 'schemas/billing/schema')!;
+    expect(billing.verify).toBeNull();
+  });
+
+  it('is deterministic; provenance and createdWith do not affect the digest', () => {
+    const a = createBundle(readModule(sourceDir));
+    const b = createBundle(readModule(sourceDir), {
+      createdWith: 'other-tool@9.9.9',
+      provenance: { metaschemaRevision: 'abc123', profile: 'tier' }
+    });
+
+    expect(b.manifest.digest).toBe(a.manifest.digest);
+    expect(b.manifest.provenance).toEqual({ metaschemaRevision: 'abc123', profile: 'tier' });
+    expect(b.manifest.createdWith).toBe('other-tool@9.9.9');
+  });
+});
+
+describe('verifyBundle', () => {
+  it('passes for a freshly created bundle', () => {
+    expect(verifyBundle(createBundle(readModule(sourceDir)))).toEqual([]);
+  });
+
+  it('detects tampered SQL via the script digest', () => {
+    const bundle = createBundle(readModule(sourceDir));
+    bundle.changes[0].deploy!.sql = 'DROP DATABASE prod;';
+    expect(verifyBundle(bundle).map(i => i.kind)).toContain('script-digest');
+  });
+
+  it('detects a tampered plan via the bundle digest', () => {
+    const bundle = createBundle(readModule(sourceDir));
+    bundle.plan = bundle.plan + '\nsneaky/change 2024-01-01T00:00:09Z Dev <dev@example.com> # x\n';
+    expect(verifyBundle(bundle).map(i => i.kind)).toContain('bundle-digest');
+  });
+
+  it('detects reordered changes', () => {
+    const bundle = createBundle(readModule(sourceDir));
+    bundle.changes.reverse();
+    expect(verifyBundle(bundle).map(i => i.kind)).toContain('order-mismatch');
+  });
+});
+
+describe('bundle file IO', () => {
+  it('round-trips through JSON', () => {
+    const bundle = bundleFromModule(sourceDir);
+    const file = join(mkdtempSync(join(tmpdir(), 'pgpm-bundle-io-')), 'pgpm-bundle.json');
+    writeBundleFile(bundle, file);
+    const reread = readBundleFile(file);
+    expect(reread).toEqual(bundle);
+    expect(verifyBundle(reread)).toEqual([]);
+  });
+});
+
+describe('materializeBundle', () => {
+  it('reproduces a deployable module byte-for-byte and preserves the digest', () => {
+    const bundle = bundleFromModule(sourceDir);
+    const outDir = mkdtempSync(join(tmpdir(), 'pgpm-bundle-mat-'));
+    try {
+      materializeBundle(bundle, outDir);
+
+      expect(readFileSync(join(outDir, 'pgpm.plan'), 'utf-8')).toBe(PLAN);
+      expect(readFileSync(join(outDir, 'my-module.control'), 'utf-8')).toBe(CONTROL);
+      for (const [change, sql] of Object.entries(DEPLOY)) {
+        expect(readFileSync(join(outDir, 'deploy', `${change}.sql`), 'utf-8')).toBe(
+          `-- Deploy ${change}\nBEGIN;\n${sql}\nCOMMIT;\n`
+        );
+      }
+      // round-trip: re-bundling the materialized module yields the same digest
+      expect(bundleFromModule(outDir).manifest.digest).toBe(bundle.manifest.digest);
+    } finally {
+      rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/pgpm/core/src/ast/index.ts
+++ b/pgpm/core/src/ast/index.ts
@@ -1,0 +1,12 @@
+/**
+ * pgpm-ast: the unified in-memory AST for pgpm modules ("AST for the migrations").
+ *
+ * Composes the existing file-level parsers (plan, control, SQL header) into a
+ * single typed {@link PgpmModuleAst} object that operators transform, then writes
+ * it back losslessly. Lives under `pgpm/core/src/ast` so it can later be lifted
+ * into a standalone leaf `pgpm/ast` package as a pure file move.
+ */
+export * from './reader';
+export * from './roundtrip';
+export * from './types';
+export * from './writer';

--- a/pgpm/core/src/ast/reader.ts
+++ b/pgpm/core/src/ast/reader.ts
@@ -1,0 +1,82 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+import { parseControlFile } from '../files/extension/reader';
+import { parsePlanFile } from '../files/plan/parser';
+import { parsePgpmHeader } from '../files/sql/header';
+import { readScript, scriptExists } from '../files/sql-scripts/reader';
+import {
+  PgpmChangeAst,
+  PgpmControlAst,
+  PgpmModuleAst,
+  PgpmScriptAst,
+  PgpmScriptKind
+} from './types';
+
+function readScriptAst(
+  dir: string,
+  kind: PgpmScriptKind,
+  change: string
+): PgpmScriptAst | null {
+  if (!scriptExists(dir, kind, change)) return null;
+  const raw = readScript(dir, kind, change);
+  const { header, body } = parsePgpmHeader(raw);
+  return { kind, header, body, raw };
+}
+
+/**
+ * Read a pgpm module directory into the unified {@link PgpmModuleAst}.
+ *
+ * Composes the existing plan parser, control reader, and SQL header parser — it
+ * does not re-implement any parsing. The module is addressed by plan order: the
+ * `changes` array follows `pgpm.plan`, and each change eagerly parses its
+ * deploy/revert/verify scripts (missing ones are `null`). Every leaf retains its
+ * byte-exact source so {@link writeModule} can reproduce the module losslessly.
+ *
+ * @throws when `dir` has no `pgpm.plan`, or the plan fails to parse.
+ */
+export function readModule(dir: string): PgpmModuleAst {
+  const planPath = join(dir, 'pgpm.plan');
+  if (!existsSync(planPath)) {
+    throw new Error(`No pgpm.plan found in module directory: ${dir}`);
+  }
+
+  const planRaw = readFileSync(planPath, 'utf-8');
+  const parsed = parsePlanFile(planPath);
+  if (!parsed.data) {
+    const detail = parsed.errors
+      .map(e => `line ${e.line}: ${e.message}`)
+      .join('; ');
+    throw new Error(`Failed to parse plan file ${planPath}: ${detail}`);
+  }
+
+  const plan = parsed.data;
+  const name = plan.package;
+
+  let control: PgpmControlAst | null = null;
+  if (name) {
+    const fileName = `${name}.control`;
+    const controlPath = join(dir, fileName);
+    if (existsSync(controlPath)) {
+      const raw = readFileSync(controlPath, 'utf-8');
+      const info = parseControlFile(controlPath, dir);
+      control = {
+        fileName,
+        name,
+        requires: info.requires,
+        version: info.version,
+        raw
+      };
+    }
+  }
+
+  const changes: PgpmChangeAst[] = plan.changes.map(planChange => ({
+    name: planChange.name,
+    plan: planChange,
+    deploy: readScriptAst(dir, 'deploy', planChange.name),
+    revert: readScriptAst(dir, 'revert', planChange.name),
+    verify: readScriptAst(dir, 'verify', planChange.name)
+  }));
+
+  return { dir, name, plan, planRaw, control, changes };
+}

--- a/pgpm/core/src/ast/roundtrip.ts
+++ b/pgpm/core/src/ast/roundtrip.ts
@@ -1,0 +1,79 @@
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { readModule } from './reader';
+import { serializePlan, serializeScript, writeModule } from './writer';
+
+/**
+ * A single discrepancy found by {@link verifyModuleRoundTrip}.
+ */
+export interface RoundTripIssue {
+  kind: 'script-drift' | 'plan-drift' | 'change-count' | 'change-identity';
+  change?: string;
+  script?: string;
+  message: string;
+}
+
+/**
+ * Read-only invariant check for the module AST: proves a module survives a
+ * read → serialize → re-read cycle without drifting.
+ *
+ * Guarantees checked:
+ *   - every script serializes byte-identically to its source (the SQL header
+ *     parser is lossless), and
+ *   - the plan serialization is idempotent and the structured change set is
+ *     stable across a serialize → re-read round trip.
+ *
+ * Returns the issues found rather than throwing.
+ */
+export function verifyModuleRoundTrip(dir: string): RoundTripIssue[] {
+  const issues: RoundTripIssue[] = [];
+  const module = readModule(dir);
+
+  for (const change of module.changes) {
+    for (const script of [change.deploy, change.revert, change.verify]) {
+      if (!script) continue;
+      if (serializeScript(script) !== script.raw) {
+        issues.push({
+          kind: 'script-drift',
+          change: change.name,
+          script: script.kind,
+          message: 'header serialize is not byte-identical to source'
+        });
+      }
+    }
+  }
+
+  const planOnce = serializePlan(module);
+  const tmp = mkdtempSync(join(tmpdir(), 'pgpm-ast-rt-'));
+  try {
+    writeModule(module, { outDir: tmp, fromRaw: false });
+    const reread = readModule(tmp);
+
+    if (serializePlan(reread) !== planOnce) {
+      issues.push({ kind: 'plan-drift', message: 'plan serialization is not idempotent' });
+    }
+
+    if (reread.changes.length !== module.changes.length) {
+      issues.push({
+        kind: 'change-count',
+        message: `change count drifted: ${module.changes.length} -> ${reread.changes.length}`
+      });
+    } else {
+      for (let i = 0; i < module.changes.length; i++) {
+        if (reread.changes[i].name !== module.changes[i].name) {
+          issues.push({
+            kind: 'change-identity',
+            change: module.changes[i].name,
+            message: `change at index ${i} drifted to "${reread.changes[i].name}"`
+          });
+        }
+      }
+    }
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+
+  return issues;
+}

--- a/pgpm/core/src/ast/types.ts
+++ b/pgpm/core/src/ast/types.ts
@@ -1,0 +1,77 @@
+import { PgpmHeader } from '../files/sql/header';
+import { Change, ExtendedPlanFile } from '../files/types';
+
+/**
+ * The three script directions a pgpm change is materialized into on disk.
+ */
+export type PgpmScriptKind = 'deploy' | 'revert' | 'verify';
+
+/**
+ * The parsed AST of a single pgpm SQL script (one of deploy/revert/verify for a
+ * change). Carries the structured header (verb/project/change/requires) plus the
+ * body, and retains the byte-exact `raw` source so a read→write cycle is lossless.
+ */
+export interface PgpmScriptAst {
+  kind: PgpmScriptKind;
+  /** Structured header block (see {@link PgpmHeader}). */
+  header: PgpmHeader;
+  /** Everything after the header block, byte-exact. */
+  body: string;
+  /** The original file content, byte-exact. */
+  raw: string;
+}
+
+/**
+ * The AST of a single pgpm change: its plan entry (identity + dependencies +
+ * attribution) together with the deploy/revert/verify scripts that implement it.
+ * A script is `null` when the corresponding file does not exist on disk.
+ */
+export interface PgpmChangeAst {
+  /** Path identity / plan change name (e.g. `schemas/auth/tables/users`). */
+  name: string;
+  /** The plan entry for this change (dependencies, timestamp, planner, ...). */
+  plan: Change;
+  deploy: PgpmScriptAst | null;
+  revert: PgpmScriptAst | null;
+  verify: PgpmScriptAst | null;
+}
+
+/**
+ * The parsed AST of a module's Postgres extension `.control` file.
+ */
+export interface PgpmControlAst {
+  /** The control file name (`<name>.control`). */
+  fileName: string;
+  /** Extension name (control basename, equals the plan project). */
+  name: string;
+  /** Extensions this module requires (from the control `requires =` line). */
+  requires: string[];
+  /** `default_version` from the control file. */
+  version: string;
+  /** The original file content, byte-exact. */
+  raw: string;
+}
+
+/**
+ * The unified in-memory AST for an entire pgpm module ("AST for the migrations").
+ *
+ * It composes the existing file-level parsers — plan parser, control reader, SQL
+ * header parser — into a single typed object addressed by plan-order changes.
+ * Operators (rename, rebundle, slice, transpile) become transforms over this tree
+ * instead of ad-hoc file/plan re-reads. Every leaf keeps its byte-exact `raw`, so
+ * {@link readModule} → {@link writeModule} is a lossless copy.
+ */
+export interface PgpmModuleAst {
+  /** Directory the module was read from. */
+  dir: string;
+  /** Project (extension) name, from the plan `%project=`. */
+  name: string;
+  /** Parsed plan (package/uri/changes/tags). */
+  plan: ExtendedPlanFile;
+  /** The original `pgpm.plan` content, byte-exact. */
+  planRaw: string;
+  /** Parsed `.control`, or `null` when the module has no control file. */
+  control: PgpmControlAst | null;
+  /** Changes in plan order, each with its deploy/revert/verify scripts. */
+  changes: PgpmChangeAst[];
+}

--- a/pgpm/core/src/ast/writer.ts
+++ b/pgpm/core/src/ast/writer.ts
@@ -1,0 +1,70 @@
+import { mkdirSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+
+import { generatePlanFileContent } from '../files/plan/writer';
+import { writePgpmScript } from '../files/sql/header';
+import { PgpmModuleAst, PgpmScriptAst } from './types';
+
+/**
+ * Serialize a script AST back to SQL text from its structured header + body.
+ * Byte-identical to the source for scripts read via {@link readModule} (the SQL
+ * header parser is lossless), and reflects any structural header edits.
+ */
+export function serializeScript(script: PgpmScriptAst): string {
+  return writePgpmScript({ header: script.header, body: script.body });
+}
+
+/**
+ * Serialize a module's plan back to `pgpm.plan` text from its structured model.
+ */
+export function serializePlan(module: PgpmModuleAst): string {
+  return generatePlanFileContent(module.plan);
+}
+
+export interface WriteModuleOptions {
+  /** Target directory. Defaults to the module's own `dir`. */
+  outDir?: string;
+  /**
+   * When true (default), write each file from its byte-exact `raw`, producing a
+   * lossless copy of the source module. Set false to write from the structured
+   * model instead (`serializePlan` / `serializeScript`), e.g. after transforms.
+   */
+  fromRaw?: boolean;
+}
+
+/**
+ * Materialize a {@link PgpmModuleAst} back to disk: `pgpm.plan`, the `.control`
+ * file (when present), and every change's deploy/revert/verify script.
+ *
+ * With the default `fromRaw: true` this is a lossless copy of what
+ * {@link readModule} loaded; with `fromRaw: false` it emits the structured
+ * serialization (used by operators that mutate the AST before writing).
+ */
+export function writeModule(
+  module: PgpmModuleAst,
+  options: WriteModuleOptions = {}
+): void {
+  const outDir = options.outDir ?? module.dir;
+  const fromRaw = options.fromRaw ?? true;
+
+  mkdirSync(outDir, { recursive: true });
+
+  writeFileSync(
+    join(outDir, 'pgpm.plan'),
+    fromRaw ? module.planRaw : serializePlan(module)
+  );
+
+  if (module.control) {
+    writeFileSync(join(outDir, module.control.fileName), module.control.raw);
+  }
+
+  for (const change of module.changes) {
+    const scripts = [change.deploy, change.revert, change.verify];
+    for (const script of scripts) {
+      if (!script) continue;
+      const file = join(outDir, script.kind, `${change.name}.sql`);
+      mkdirSync(dirname(file), { recursive: true });
+      writeFileSync(file, fromRaw ? script.raw : serializeScript(script));
+    }
+  }
+}

--- a/pgpm/core/src/bundle/create.ts
+++ b/pgpm/core/src/bundle/create.ts
@@ -1,0 +1,102 @@
+import { PgpmModuleAst, PgpmScriptAst } from '../ast/types';
+import { hashString } from '../migrate/utils/hash';
+import {
+  BUNDLE_FORMAT_VERSION,
+  BundleChange,
+  BundleScript,
+  MigrationBundle
+} from './types';
+
+/**
+ * Digest for a single change: its name plus the digests of its scripts, in a
+ * fixed deploy/revert/verify order. A missing script contributes an empty slot
+ * so presence/absence changes the digest.
+ */
+export function computeChangeDigest(
+  name: string,
+  scripts: { deploy?: string | null; revert?: string | null; verify?: string | null }
+): string {
+  return hashString(
+    [name, scripts.deploy ?? '', scripts.revert ?? '', scripts.verify ?? ''].join('\n')
+  );
+}
+
+/**
+ * Top-level bundle digest: the plan, the control content, and the ordered change
+ * digests. Deterministic and independent of tool version / provenance.
+ */
+export function computeBundleDigest(
+  plan: string,
+  controlContent: string | null,
+  changeDigests: string[]
+): string {
+  return hashString([plan, controlContent ?? '', ...changeDigests].join('\n'));
+}
+
+function toBundleScript(script: PgpmScriptAst | null): BundleScript | null {
+  if (!script) return null;
+  return { kind: script.kind, sql: script.raw, digest: hashString(script.raw) };
+}
+
+export interface CreateBundleOptions {
+  /** Tool identifier recorded in the manifest (default `@pgpmjs/core`). */
+  createdWith?: string;
+  /** Lineage recorded in the manifest (excluded from the digest). */
+  provenance?: Record<string, string>;
+}
+
+/**
+ * Build a content-addressed {@link MigrationBundle} from a module AST.
+ *
+ * Pure and deterministic: no disk I/O, no clock, no version noise in the digest.
+ * The change order follows the module's plan order, which the AST already
+ * preserves, so the bundle's `deployOrder` is dependency-safe by construction.
+ */
+export function createBundle(
+  module: PgpmModuleAst,
+  options: CreateBundleOptions = {}
+): MigrationBundle {
+  const changes: BundleChange[] = module.changes.map(change => {
+    const deploy = toBundleScript(change.deploy);
+    const revert = toBundleScript(change.revert);
+    const verify = toBundleScript(change.verify);
+    const digest = computeChangeDigest(change.name, {
+      deploy: deploy?.digest,
+      revert: revert?.digest,
+      verify: verify?.digest
+    });
+    return {
+      name: change.name,
+      dependencies: change.plan.dependencies ?? [],
+      deploy,
+      revert,
+      verify,
+      digest
+    };
+  });
+
+  const controlContent = module.control?.raw ?? null;
+  const deployOrder = changes.map(c => c.name);
+  const digest = computeBundleDigest(
+    module.planRaw,
+    controlContent,
+    changes.map(c => c.digest)
+  );
+
+  return {
+    manifest: {
+      formatVersion: BUNDLE_FORMAT_VERSION,
+      name: module.name,
+      createdWith: options.createdWith ?? '@pgpmjs/core',
+      changeCount: changes.length,
+      deployOrder,
+      digest,
+      ...(options.provenance ? { provenance: options.provenance } : {})
+    },
+    plan: module.planRaw,
+    control: module.control
+      ? { fileName: module.control.fileName, content: module.control.raw }
+      : null,
+    changes
+  };
+}

--- a/pgpm/core/src/bundle/index.ts
+++ b/pgpm/core/src/bundle/index.ts
@@ -1,0 +1,14 @@
+/**
+ * pgpm migration bundles: the portable, content-addressed artifact layer.
+ *
+ * A {@link MigrationBundle} is a deterministic snapshot of a pgpm module — plan,
+ * control, ordered changes, and per-change/whole-bundle sha256 digests — with an
+ * optional provenance manifest. It is the substrate for the `exportMigrationBundle`
+ * / `applyMigrationBundle` / `transpileMigrationBundle` cloud functions: build one
+ * from a module AST, transport or transform it, verify its digests, then
+ * materialize it back into a deployable module.
+ */
+export * from './create';
+export * from './io';
+export * from './types';
+export * from './verify';

--- a/pgpm/core/src/bundle/io.ts
+++ b/pgpm/core/src/bundle/io.ts
@@ -1,0 +1,58 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+
+import { readModule } from '../ast/reader';
+import { createBundle, CreateBundleOptions } from './create';
+import { MigrationBundle } from './types';
+
+/** Default file name for a serialized bundle artifact. */
+export const BUNDLE_FILE_NAME = 'pgpm-bundle.json';
+
+/**
+ * Build a bundle straight from a module directory on disk (readModule → createBundle).
+ */
+export function bundleFromModule(
+  moduleDir: string,
+  options?: CreateBundleOptions
+): MigrationBundle {
+  return createBundle(readModule(moduleDir), options);
+}
+
+/**
+ * Serialize a bundle to a single JSON artifact file (stable 2-space formatting).
+ */
+export function writeBundleFile(bundle: MigrationBundle, filePath: string): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, JSON.stringify(bundle, null, 2) + '\n');
+}
+
+/**
+ * Read a bundle artifact JSON file back into memory.
+ */
+export function readBundleFile(filePath: string): MigrationBundle {
+  return JSON.parse(readFileSync(filePath, 'utf-8')) as MigrationBundle;
+}
+
+/**
+ * Materialize a bundle back into a real, deployable pgpm module directory:
+ * `pgpm.plan`, the `.control` file (when present), and each change's
+ * deploy/revert/verify script at its `deploy/<change>.sql` path.
+ *
+ * The inverse of {@link bundleFromModule}; the emitted directory can be read
+ * back with `readModule` or deployed with `PgpmMigrate`.
+ */
+export function materializeBundle(bundle: MigrationBundle, outDir: string): void {
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(join(outDir, 'pgpm.plan'), bundle.plan);
+  if (bundle.control) {
+    writeFileSync(join(outDir, bundle.control.fileName), bundle.control.content);
+  }
+  for (const change of bundle.changes) {
+    for (const script of [change.deploy, change.revert, change.verify]) {
+      if (!script) continue;
+      const file = join(outDir, script.kind, `${change.name}.sql`);
+      mkdirSync(dirname(file), { recursive: true });
+      writeFileSync(file, script.sql);
+    }
+  }
+}

--- a/pgpm/core/src/bundle/types.ts
+++ b/pgpm/core/src/bundle/types.ts
@@ -1,0 +1,72 @@
+import { PgpmScriptKind } from '../ast/types';
+
+/** Current bundle format version. Bumped only on breaking artifact changes. */
+export const BUNDLE_FORMAT_VERSION = '1';
+
+/**
+ * One script (deploy/revert/verify) inside a bundled change: the SQL text plus a
+ * content digest so integrity can be re-verified after transport/transpile.
+ */
+export interface BundleScript {
+  kind: PgpmScriptKind;
+  /** SQL text, byte-exact from source. */
+  sql: string;
+  /** sha256 of {@link sql}. */
+  digest: string;
+}
+
+/**
+ * One change inside a bundle: identity + plan dependencies + its scripts.
+ */
+export interface BundleChange {
+  name: string;
+  dependencies: string[];
+  deploy: BundleScript | null;
+  revert: BundleScript | null;
+  verify: BundleScript | null;
+  /** sha256 over the change's identity + script digests (see `computeChangeDigest`). */
+  digest: string;
+}
+
+/**
+ * The bundle's self-describing header: what it is, how it was ordered, and where
+ * it came from. Digests make the artifact content-addressable and reproducible.
+ */
+export interface BundleManifest {
+  formatVersion: string;
+  /** Module / extension name (plan `%project=`). */
+  name: string;
+  /** Tool that produced the bundle (informational; excluded from {@link digest}). */
+  createdWith: string;
+  changeCount: number;
+  /** Change names in deploy (plan) order. */
+  deployOrder: string[];
+  /**
+   * sha256 over the plan, control, and ordered change digests. Deterministic and
+   * independent of `createdWith`/provenance so identical inputs hash identically.
+   */
+  digest: string;
+  /**
+   * Optional caller-supplied lineage — e.g. source metaschema revision, the
+   * classifier profile used, or a source→target namespace mapping. Recorded in
+   * the manifest but excluded from {@link digest} so provenance never perturbs
+   * content addressing.
+   */
+  provenance?: Record<string, string>;
+}
+
+/**
+ * A portable, content-addressed PGPM migration bundle: the deterministic,
+ * ordered artifact that `exportMigrationBundle` emits and `applyMigrationBundle`
+ * / `transpileMigrationBundle` consume. Built from a {@link PgpmModuleAst} and
+ * round-trippable back into a real pgpm module on disk.
+ */
+export interface MigrationBundle {
+  manifest: BundleManifest;
+  /** `pgpm.plan` content, byte-exact. */
+  plan: string;
+  /** `.control` file, or null when the source module had none. */
+  control: { fileName: string; content: string } | null;
+  /** Changes in deploy order. */
+  changes: BundleChange[];
+}

--- a/pgpm/core/src/bundle/verify.ts
+++ b/pgpm/core/src/bundle/verify.ts
@@ -1,0 +1,85 @@
+import { hashString } from '../migrate/utils/hash';
+import { computeBundleDigest, computeChangeDigest } from './create';
+import { MigrationBundle } from './types';
+
+/**
+ * A single bundle integrity discrepancy found by {@link verifyBundle}.
+ */
+export interface BundleIssue {
+  kind:
+    | 'script-digest'
+    | 'change-digest'
+    | 'bundle-digest'
+    | 'order-mismatch'
+    | 'change-count';
+  change?: string;
+  script?: string;
+  message: string;
+}
+
+/**
+ * Recompute every digest in a bundle and confirm it matches the recorded values.
+ *
+ * This is the integrity gate `applyMigrationBundle` / `transpileMigrationBundle`
+ * run before trusting a transported artifact: it proves the SQL bytes, per-change
+ * digests, deploy order, and top-level digest are internally consistent. Read-only;
+ * returns the issues rather than throwing.
+ */
+export function verifyBundle(bundle: MigrationBundle): BundleIssue[] {
+  const issues: BundleIssue[] = [];
+
+  if (bundle.changes.length !== bundle.manifest.changeCount) {
+    issues.push({
+      kind: 'change-count',
+      message: `manifest.changeCount=${bundle.manifest.changeCount} but ${bundle.changes.length} changes present`
+    });
+  }
+
+  const order = bundle.changes.map(c => c.name);
+  if (order.join('\n') !== bundle.manifest.deployOrder.join('\n')) {
+    issues.push({
+      kind: 'order-mismatch',
+      message: 'changes order does not match manifest.deployOrder'
+    });
+  }
+
+  for (const change of bundle.changes) {
+    for (const script of [change.deploy, change.revert, change.verify]) {
+      if (!script) continue;
+      if (hashString(script.sql) !== script.digest) {
+        issues.push({
+          kind: 'script-digest',
+          change: change.name,
+          script: script.kind,
+          message: 'script digest does not match its sql'
+        });
+      }
+    }
+    const expected = computeChangeDigest(change.name, {
+      deploy: change.deploy?.digest,
+      revert: change.revert?.digest,
+      verify: change.verify?.digest
+    });
+    if (expected !== change.digest) {
+      issues.push({
+        kind: 'change-digest',
+        change: change.name,
+        message: 'change digest does not match its scripts'
+      });
+    }
+  }
+
+  const expectedBundle = computeBundleDigest(
+    bundle.plan,
+    bundle.control?.content ?? null,
+    bundle.changes.map(c => c.digest)
+  );
+  if (expectedBundle !== bundle.manifest.digest) {
+    issues.push({
+      kind: 'bundle-digest',
+      message: 'manifest.digest does not match bundle content'
+    });
+  }
+
+  return issues;
+}

--- a/pgpm/core/src/index.ts
+++ b/pgpm/core/src/index.ts
@@ -17,6 +17,7 @@ export * from './core/boilerplate-scanner';
 // Export package-files functionality (now integrated into core)
 export * from './files';
 export * from './ast';
+export * from './bundle';
 export * from './refactor';
 export { cleanSql } from './migrate/clean';
 export { PgpmMigrate } from './migrate/client';

--- a/pgpm/core/src/index.ts
+++ b/pgpm/core/src/index.ts
@@ -1,27 +1,25 @@
+export * from './core/boilerplate-scanner';
+export * from './core/boilerplate-types';
 export * from './core/class/pgpm';
-export * from './slice';
-export * from './rebundle';
+export * from './core/template-scaffold';
 export * from './extensions/extensions';
 export * from './modules/modules';
 export * from './packaging/package';
 export * from './packaging/transform';
+export * from './rebundle';
 export * from './resolution/deps';
 export * from './resolution/resolve';
+export * from './slice';
+export * from './workspace/minimal';
 export * from './workspace/paths';
 export * from './workspace/utils';
-export * from './workspace/minimal';
-export * from './core/template-scaffold';
-export * from './core/boilerplate-types';
-export * from './core/boilerplate-scanner';
 
 // Export package-files functionality (now integrated into core)
+export * from './ast';
 export * from './files';
-export * from './refactor';
+export { PgpmInit } from './init/client';
 export { cleanSql } from './migrate/clean';
 export { PgpmMigrate } from './migrate/client';
-export { PgpmInit } from './init/client';
-export * from './roles';
-export { parseAuthor } from './utils/author';
 export {
   DeployOptions, 
   DeployResult, 
@@ -34,3 +32,6 @@ export {
   VerifyResult} from './migrate/types';
 export { hashFile, hashString } from './migrate/utils/hash';
 export { executeQuery,TransactionContext, TransactionOptions, withTransaction } from './migrate/utils/transaction';
+export * from './refactor';
+export * from './roles';
+export { parseAuthor } from './utils/author';

--- a/pgpm/core/src/index.ts
+++ b/pgpm/core/src/index.ts
@@ -1,25 +1,28 @@
-export * from './core/boilerplate-scanner';
-export * from './core/boilerplate-types';
 export * from './core/class/pgpm';
-export * from './core/template-scaffold';
+export * from './slice';
+export * from './rebundle';
 export * from './extensions/extensions';
 export * from './modules/modules';
 export * from './packaging/package';
 export * from './packaging/transform';
-export * from './rebundle';
 export * from './resolution/deps';
 export * from './resolution/resolve';
-export * from './slice';
-export * from './workspace/minimal';
 export * from './workspace/paths';
 export * from './workspace/utils';
+export * from './workspace/minimal';
+export * from './core/template-scaffold';
+export * from './core/boilerplate-types';
+export * from './core/boilerplate-scanner';
 
 // Export package-files functionality (now integrated into core)
-export * from './ast';
 export * from './files';
-export { PgpmInit } from './init/client';
+export * from './ast';
+export * from './refactor';
 export { cleanSql } from './migrate/clean';
 export { PgpmMigrate } from './migrate/client';
+export { PgpmInit } from './init/client';
+export * from './roles';
+export { parseAuthor } from './utils/author';
 export {
   DeployOptions, 
   DeployResult, 
@@ -32,6 +35,3 @@ export {
   VerifyResult} from './migrate/types';
 export { hashFile, hashString } from './migrate/utils/hash';
 export { executeQuery,TransactionContext, TransactionOptions, withTransaction } from './migrate/utils/transaction';
-export * from './refactor';
-export * from './roles';
-export { parseAuthor } from './utils/author';


### PR DESCRIPTION
## Summary

The portable artifact layer for the migration cloud functions. `exportMigrationBundle` / `applyMigrationBundle` / `transpileMigrationBundle` all need one thing to pass a module between databases: a deterministic, self-describing, integrity-checkable snapshot. This adds it on top of pgpm-ast.

A `MigrationBundle` is a module AST reduced to transportable data + sha256 digests + a provenance manifest:

```ts
interface MigrationBundle {
  manifest: { formatVersion; name; createdWith; changeCount; deployOrder[]; digest; provenance? };
  plan: string;                                   // pgpm.plan, byte-exact
  control: { fileName; content } | null;
  changes: { name; dependencies[]; deploy/revert/verify: {sql;digest}|null; digest }[];  // deploy order
}
```

API:

```ts
createBundle(moduleAst, { createdWith?, provenance? }): MigrationBundle   // pure, deterministic
bundleFromModule(dir, opts?)                                             // readModule → createBundle
verifyBundle(bundle): BundleIssue[]                                      // recompute every digest
writeBundleFile / readBundleFile                                        // JSON artifact
materializeBundle(bundle, outDir)                                       // back to a deployable module
```

Design points worth calling out:
- **Digests are reproducible.** `manifest.digest` = `sha256(plan + control + orderedChangeDigests)`; each change digest folds in its script digests; each script digest = `sha256(sql)`. `createdWith` and `provenance` are recorded but **excluded from the digest**, so identical inputs hash identically regardless of who built the bundle or what lineage was attached — required for caching/verification across transpiles.
- **Provenance is first-class but out-of-band.** Callers attach `{ metaschemaRevision, profile, sourceNamespace → targetNamespace, ... }` without perturbing content addressing.
- **Order is dependency-safe by construction** — it inherits the module's plan order via the AST; `verifyBundle` re-checks it.
- `createBundle` is pure (no I/O, no clock); `materializeBundle` is the exact inverse of `bundleFromModule` (proven byte-for-byte + digest-stable in tests).

Additive only: new `pgpm/core/src/bundle/` + one export line; nothing existing is touched.

## Testing
- `tsc --noEmit` clean; new files lint clean.
- 8 new unit tests (`__tests__/bundle/bundle.test.ts`): ordered capture + digests, determinism (provenance/tool-version don't move the digest), integrity detection (tampered sql → `script-digest`, tampered plan → `bundle-digest`, reorder → `order-mismatch`), JSON round-trip, and byte-for-byte + digest-stable `materializeBundle`.
- Full `@pgpmjs/core` suite green with Postgres up: **69 suites / 455 tests** (no regressions).

**Stacked on #1418 (pgpm-ast)** — this branch includes that commit, so review #1418 first; the bundle layer is the `pgpm/core/src/bundle/` files here. Targeting `main` so CI runs the full suite.


Link to Devin session: https://app.devin.ai/sessions/ad40d16f38a349b48eb7ce9375e27e6e
Requested by: @pyramation