### PR TITLE
feat(pgpm-core): parseModule/deparseModule — parse()/deparse() aliases for the module AST

### DIFF
--- a/pgpm/core/__tests__/ast/parse.test.ts
+++ b/pgpm/core/__tests__/ast/parse.test.ts
@@ -1,0 +1,61 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+
+import { deparseModule, parseModule, readModule } from '../../src/ast';
+
+let sourceDir: string;
+
+const PLAN = `%syntax-version=1.0.0
+%project=my-module
+%uri=my-module
+
+schemas/auth/schema 2024-01-01T00:00:00Z Dev <dev@example.com> # add schema
+schemas/auth/tables/users [schemas/auth/schema] 2024-01-01T00:00:01Z Dev <dev@example.com> # add users
+`;
+
+const DEPLOY: Record<string, string> = {
+  'schemas/auth/schema': 'CREATE SCHEMA auth;',
+  'schemas/auth/tables/users': 'CREATE TABLE auth.users (id int PRIMARY KEY);'
+};
+
+function write(rel: string, content: string): void {
+  const file = join(sourceDir, rel);
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, content);
+}
+
+beforeEach(() => {
+  sourceDir = mkdtempSync(join(tmpdir(), 'pgpm-parse-src-'));
+  writeFileSync(join(sourceDir, 'pgpm.plan'), PLAN);
+  for (const [change, sql] of Object.entries(DEPLOY)) {
+    write(`deploy/${change}.sql`, `-- Deploy ${change}\nBEGIN;\n${sql}\nCOMMIT;\n`);
+    write(`revert/${change}.sql`, `-- Revert ${change}\nBEGIN;\nDROP THING;\nCOMMIT;\n`);
+  }
+});
+
+afterEach(() => rmSync(sourceDir, { recursive: true, force: true }));
+
+describe('parseModule / deparseModule', () => {
+  it('parseModule is readModule', () => {
+    expect(parseModule(sourceDir)).toEqual(readModule(sourceDir));
+  });
+
+  it('parse → deparse round-trips a module byte-for-byte', () => {
+    const mod = parseModule(sourceDir);
+    const outDir = mkdtempSync(join(tmpdir(), 'pgpm-parse-out-'));
+    try {
+      deparseModule(mod, { outDir });
+      expect(readFileSync(join(outDir, 'pgpm.plan'), 'utf-8')).toBe(PLAN);
+      for (const change of Object.keys(DEPLOY)) {
+        expect(readFileSync(join(outDir, 'deploy', `${change}.sql`), 'utf-8')).toBe(
+          `-- Deploy ${change}\nBEGIN;\n${DEPLOY[change]}\nCOMMIT;\n`
+        );
+      }
+      // re-parsing the deparsed module yields an equal AST (modulo dir)
+      expect(parseModule(outDir).changes).toEqual(mod.changes);
+    } finally {
+      rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/pgpm/core/src/ast/index.ts
+++ b/pgpm/core/src/ast/index.ts
@@ -6,6 +6,7 @@
  * it back losslessly. Lives under `pgpm/core/src/ast` so it can later be lifted
  * into a standalone leaf `pgpm/ast` package as a pure file move.
  */
+export * from './parse';
 export * from './reader';
 export * from './roundtrip';
 export * from './types';

--- a/pgpm/core/src/ast/parse.ts
+++ b/pgpm/core/src/ast/parse.ts
@@ -1,0 +1,30 @@
+import { readModule } from './reader';
+import { PgpmModuleAst } from './types';
+import { writeModule, WriteModuleOptions } from './writer';
+
+/**
+ * Parse a pgpm module directory into a {@link PgpmModuleAst}.
+ *
+ * The module-level analog of `pgsql-parser`'s `parse()`: where that turns SQL
+ * text into a PostgreSQL AST, this turns an on-disk pgpm module (plan + control
+ * + deploy/revert/verify scripts) into a single typed tree. Alias of
+ * {@link readModule}; the inverse of {@link deparseModule}.
+ */
+export function parseModule(dir: string): PgpmModuleAst {
+  return readModule(dir);
+}
+
+/**
+ * Deparse a {@link PgpmModuleAst} back to an on-disk pgpm module.
+ *
+ * The module-level analog of `pgsql-deparser`'s `deparse()`. With the default
+ * `fromRaw: true` it is lossless (byte-exact round-trip of {@link parseModule});
+ * with `fromRaw: false` it re-serializes the structured model, for operators
+ * that mutate the AST first. Alias of {@link writeModule}.
+ *
+ * For in-memory deparse-to-string of individual parts, use `serializePlan` /
+ * `serializeScript`.
+ */
+export function deparseModule(module: PgpmModuleAst, options: WriteModuleOptions = {}): void {
+  writeModule(module, options);
+}


### PR DESCRIPTION
## Summary

Names the pgpm-ast round-trip after the parser stack it mirrors, per Dan's framing ("#1418 — like parse() and deparse()"). Thin, additive aliases; no behavior change.

```ts
parseModule(dir)            = readModule(dir)   // module dir  -> PgpmModuleAst   (like pgsql-parser parse())
deparseModule(ast, opts?)   = writeModule(...)  // PgpmModuleAst -> module dir    (like pgsql-deparser deparse())
```

Where `pgsql-parser.parse()` turns SQL text into a PostgreSQL AST, `parseModule` turns a whole on-disk pgpm module (plan + control + deploy/revert/verify) into one typed tree; `deparseModule` writes it back (lossless by default, structured with `fromRaw: false`). The SQL bodies inside scripts stay text — the literal SQL parse/deparse remains `pgsql-parser`/`pgsql-deparser`, applied by callers via `transpileBundle`'s `transformScript`. In-memory deparse-to-string of parts is still `serializePlan`/`serializeScript`.

Easy to rename if you'd prefer bare `parse`/`deparse` — I namespaced them as `parseModule`/`deparseModule` to avoid colliding at the `@pgpmjs/core` root (which re-exports `./ast`).

## Testing
- New `parse.test.ts`: 2/2 — `parseModule` equals `readModule`; `parse → deparse` byte-for-byte round-trip + equal re-parsed AST.
- `tsc --noEmit` and `eslint` clean.


Link to Devin session: https://app.devin.ai/sessions/ad40d16f38a349b48eb7ce9375e27e6e
Requested by: @pyramation