### PR TITLE
feat(pgpm-traverse): add @pgpmjs/traverse walker; refactor bundle ops onto it

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -154,7 +154,7 @@ jobs:
       matrix:
         include:
           - batch: pg-core
-            packages: 'pgpm/ast pgpm/bundle pgpm/core pgpm/cli jobs/knative-job-service packages/client packages/safegres postgres/pg-codegen'
+            packages: 'pgpm/ast pgpm/traverse pgpm/bundle pgpm/core pgpm/cli jobs/knative-job-service packages/client packages/safegres postgres/pg-codegen'
           - batch: pg-postgres
             packages: 'postgres/pgsql-test postgres/drizzle-orm-test postgres/introspectron graphile/graphile-test graphile/graphile-connection-filter graphile/graphile-postgis'
           - batch: pg-graphql

--- a/pgpm/bundle/src/create.ts
+++ b/pgpm/bundle/src/create.ts
@@ -1,5 +1,6 @@
 import { PgpmModuleAst, PgpmScriptAst } from '@pgpmjs/ast/module/types';
 import { hashString } from '@pgpmjs/ast';
+import { mapScripts } from '@pgpmjs/traverse';
 import {
   BUNDLE_FORMAT_VERSION,
   BundleChange,
@@ -57,9 +58,7 @@ export function createBundle(
   options: CreateBundleOptions = {}
 ): MigrationBundle {
   const changes: BundleChange[] = module.changes.map(change => {
-    const deploy = toBundleScript(change.deploy);
-    const revert = toBundleScript(change.revert);
-    const verify = toBundleScript(change.verify);
+    const { deploy, revert, verify } = mapScripts(change, toBundleScript);
     const digest = computeChangeDigest(change.name, {
       deploy: deploy?.digest,
       revert: revert?.digest,

--- a/pgpm/bundle/src/diff.ts
+++ b/pgpm/bundle/src/diff.ts
@@ -1,4 +1,5 @@
 import { PgpmScriptKind } from '@pgpmjs/ast/module/types';
+import { zipScripts } from '@pgpmjs/traverse';
 import { BundleChange, BundleScript, MigrationBundle } from './types';
 
 /** Per-script disposition between two revisions of the same change. */
@@ -40,11 +41,11 @@ function scriptDiff(from: BundleScript | null, to: BundleScript | null): ScriptD
 }
 
 function changeScriptDiffs(from: BundleChange, to: BundleChange): Record<PgpmScriptKind, ScriptDiff> {
-  return {
-    deploy: scriptDiff(from.deploy, to.deploy),
-    revert: scriptDiff(from.revert, to.revert),
-    verify: scriptDiff(from.verify, to.verify)
-  };
+  const diffs = {} as Record<PgpmScriptKind, ScriptDiff>;
+  zipScripts(from, to, (kind, a, b) => {
+    diffs[kind] = scriptDiff(a, b);
+  });
+  return diffs;
 }
 
 /**

--- a/pgpm/bundle/src/transpile.ts
+++ b/pgpm/bundle/src/transpile.ts
@@ -2,6 +2,7 @@ import { PgpmScriptKind } from '@pgpmjs/ast/module/types';
 import { parsePgpmHeader, renameInHeader, writePgpmScript } from '@pgpmjs/ast/files/sql/header';
 import { hashString } from '@pgpmjs/ast';
 import { renameInPlanContent } from '@pgpmjs/ast';
+import { mapScripts } from '@pgpmjs/traverse';
 import {
   computeBundleDigest,
   computeChangeDigest,
@@ -73,13 +74,11 @@ function buildRenames(
 }
 
 function transpileScriptSql(
-  script: BundleScript | null,
+  script: BundleScript,
   changeName: string,
   renames: Map<string, string>,
   options: TranspileBundleOptions
-): BundleScript | null {
-  if (!script) return null;
-
+): BundleScript {
   let sql = script.sql;
   if (renames.size > 0) {
     const parsed = parsePgpmHeader(sql);
@@ -114,9 +113,9 @@ export function transpileBundle(
   const changes: BundleChange[] = bundle.changes.map(change => {
     const name = renames.get(change.name) ?? change.name;
     const dependencies = change.dependencies.map(dep => renames.get(dep) ?? dep);
-    const deploy = transpileScriptSql(change.deploy, change.name, renames, options);
-    const revert = transpileScriptSql(change.revert, change.name, renames, options);
-    const verify = transpileScriptSql(change.verify, change.name, renames, options);
+    const { deploy, revert, verify } = mapScripts(change, script =>
+      transpileScriptSql(script, change.name, renames, options)
+    );
     const digest = computeChangeDigest(name, {
       deploy: deploy?.digest,
       revert: revert?.digest,

--- a/pgpm/bundle/src/verify.ts
+++ b/pgpm/bundle/src/verify.ts
@@ -1,4 +1,5 @@
 import { hashString } from '@pgpmjs/ast';
+import { forEachScript } from '@pgpmjs/traverse';
 import { computeBundleDigest, computeChangeDigest } from './create';
 import { MigrationBundle } from './types';
 
@@ -44,8 +45,7 @@ export function verifyBundle(bundle: MigrationBundle): BundleIssue[] {
   }
 
   for (const change of bundle.changes) {
-    for (const script of [change.deploy, change.revert, change.verify]) {
-      if (!script) continue;
+    forEachScript(change, script => {
       if (hashString(script.sql) !== script.digest) {
         issues.push({
           kind: 'script-digest',
@@ -54,7 +54,7 @@ export function verifyBundle(bundle: MigrationBundle): BundleIssue[] {
           message: 'script digest does not match its sql'
         });
       }
-    }
+    });
     const expected = computeChangeDigest(change.name, {
       deploy: change.deploy?.digest,
       revert: change.revert?.digest,

--- a/pgpm/traverse/README.md
+++ b/pgpm/traverse/README.md
@@ -1,0 +1,33 @@
+# @pgpmjs/traverse
+
+<p align="center" width="100%">
+  <img height="250" src="https://raw.githubusercontent.com/constructive-io/constructive/refs/heads/main/assets/outline-logo.svg" />
+</p>
+
+<p align="center" width="100%">
+  <a href="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml">
+    <img height="20" src="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml/badge.svg" />
+  </a>
+   <a href="https://github.com/constructive-io/constructive/blob/main/LICENSE"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
+   <a href="https://www.npmjs.com/package/@pgpmjs/traverse"><img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/constructive?filename=pgpm%2Ftraverse%2Fpackage.json"/></a>
+</p>
+
+Traversal primitives for the pgpm AST — the shared, dependency-free way to walk a
+change's three script slots (`deploy` / `revert` / `verify`). Both the module AST's
+`PgpmChangeAst` (`@pgpmjs/ast`) and the bundle's `BundleChange` (`@pgpmjs/bundle`)
+structurally satisfy `ScriptSlots<S>`, so the same helpers walk either without
+re-implementing the per-slot loop everywhere.
+
+```ts
+const SCRIPT_KINDS = ['deploy', 'revert', 'verify'] as const;
+
+interface ScriptSlots<S> { deploy: S | null; revert: S | null; verify: S | null; }
+
+forEachScript(change, (script, kind) => { /* visit present scripts */ });
+const next = mapScripts(change, (script, kind) => transform(script)); // null-preserving
+zipScripts(from, to, (kind, a, b) => { /* pair two revisions for diffing */ });
+```
+
+Pure leaf (depends only on `@pgpmjs/ast` for the `PgpmScriptKind` type). Used by
+`@pgpmjs/bundle` (`createBundle` / `verifyBundle` / `diffBundles` / `transpileBundle`)
+to replace hand-rolled `[deploy, revert, verify]` walks with one canonical primitive.

--- a/pgpm/traverse/__tests__/traverse.test.ts
+++ b/pgpm/traverse/__tests__/traverse.test.ts
@@ -1,0 +1,66 @@
+import { forEachScript, mapScripts, SCRIPT_KINDS, ScriptSlots, zipScripts } from '../src';
+
+interface Script {
+  kind: string;
+  value: number;
+}
+
+const slots = (deploy: number | null, revert: number | null, verify: number | null): ScriptSlots<Script> => ({
+  deploy: deploy == null ? null : { kind: 'deploy', value: deploy },
+  revert: revert == null ? null : { kind: 'revert', value: revert },
+  verify: verify == null ? null : { kind: 'verify', value: verify }
+});
+
+describe('SCRIPT_KINDS', () => {
+  it('is deploy/revert/verify in canonical order', () => {
+    expect(SCRIPT_KINDS).toEqual(['deploy', 'revert', 'verify']);
+  });
+});
+
+describe('forEachScript', () => {
+  it('visits present slots in deploy→revert→verify order, skipping nulls', () => {
+    const seen: Array<[string, number]> = [];
+    forEachScript(slots(1, null, 3), (s, kind) => seen.push([kind, s.value]));
+    expect(seen).toEqual([
+      ['deploy', 1],
+      ['verify', 3]
+    ]);
+  });
+
+  it('visits nothing when all slots are absent', () => {
+    const seen: string[] = [];
+    forEachScript(slots(null, null, null), (_s, kind) => seen.push(kind));
+    expect(seen).toEqual([]);
+  });
+});
+
+describe('mapScripts', () => {
+  it('maps present slots and preserves nulls', () => {
+    const out = mapScripts(slots(1, null, 3), s => s.value * 10);
+    expect(out).toEqual({ deploy: 10, revert: null, verify: 30 });
+  });
+
+  it('clears a slot when the mapper returns null', () => {
+    const out = mapScripts(slots(1, 2, 3), (s, kind) => (kind === 'revert' ? null : s.value));
+    expect(out).toEqual({ deploy: 1, revert: null, verify: 3 });
+  });
+
+  it('passes the kind to the mapper', () => {
+    const out = mapScripts(slots(1, 2, 3), (_s, kind) => kind);
+    expect(out).toEqual({ deploy: 'deploy', revert: 'revert', verify: 'verify' });
+  });
+});
+
+describe('zipScripts', () => {
+  it('visits every kind with both sides (nullable)', () => {
+    const seen: Array<[string, number | null, number | null]> = [];
+    zipScripts(slots(1, 2, null), slots(1, null, 5), (kind, a, b) =>
+      seen.push([kind, a?.value ?? null, b?.value ?? null])
+    );
+    expect(seen).toEqual([
+      ['deploy', 1, 1],
+      ['revert', 2, null],
+      ['verify', null, 5]
+    ]);
+  });
+});

--- a/pgpm/traverse/jest.config.js
+++ b/pgpm/traverse/jest.config.js
@@ -1,0 +1,18 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        babelConfig: false,
+        tsconfig: 'tsconfig.json',
+      },
+    ],
+  },
+  transformIgnorePatterns: [`/node_modules/*`],
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  modulePathIgnorePatterns: ['dist/*']
+};

--- a/pgpm/traverse/package.json
+++ b/pgpm/traverse/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@pgpmjs/bundle",
+  "name": "@pgpmjs/traverse",
   "version": "0.0.1",
   "author": "Constructive <developers@constructive.io>",
-  "description": "PGPM migration bundle — the portable, content-addressed artifact layer (create/io/verify/transpile/diff/reconcile)",
+  "description": "Traversal primitives for the pgpm module AST / migration bundle — walk a change's deploy/revert/verify scripts",
   "main": "index.js",
   "module": "esm/index.js",
   "types": "index.d.ts",
@@ -29,18 +29,18 @@
     "test:watch": "jest --watch"
   },
   "keywords": [
-    "bundle",
-    "migration",
+    "traverse",
+    "ast",
     "typescript",
     "pgpm",
     "pgpmjs",
-    "postgresql"
+    "postgresql",
+    "migrations"
   ],
   "devDependencies": {
     "makage": "^0.3.0"
   },
   "dependencies": {
-    "@pgpmjs/ast": "workspace:^",
-    "@pgpmjs/traverse": "workspace:^"
+    "@pgpmjs/ast": "workspace:^"
   }
 }

--- a/pgpm/traverse/src/index.ts
+++ b/pgpm/traverse/src/index.ts
@@ -1,0 +1,75 @@
+/**
+ * @pgpmjs/traverse — traversal primitives for the pgpm AST / migration bundle.
+ *
+ * A pgpm change is materialized into exactly three script slots — `deploy`,
+ * `revert`, `verify` — each of which may be absent. Every operator (create,
+ * verify, diff, transpile) walks those slots; this package is the one canonical
+ * place that loop lives, so it is not re-rolled (and subtly diverged) in each op.
+ *
+ * The helpers are generic over the script type `S` and work structurally: both
+ * `PgpmChangeAst`/`PgpmScriptAst` (`@pgpmjs/ast`) and `BundleChange`/`BundleScript`
+ * (`@pgpmjs/bundle`) satisfy {@link ScriptSlots}, so the same functions traverse
+ * a module AST or a bundle. Pure leaf: depends only on `@pgpmjs/ast` for the
+ * `PgpmScriptKind` type.
+ */
+import { PgpmScriptKind } from '@pgpmjs/ast/module/types';
+
+export type { PgpmScriptKind };
+
+/** The three script directions of a pgpm change, in canonical deploy order. */
+export const SCRIPT_KINDS: readonly PgpmScriptKind[] = ['deploy', 'revert', 'verify'];
+
+/**
+ * A node carrying the three pgpm script slots. `null` means the script is absent
+ * (the file does not exist / the bundle change omits it). Both the module AST's
+ * change node and the bundle's change node satisfy this shape structurally.
+ */
+export interface ScriptSlots<S> {
+  deploy: S | null;
+  revert: S | null;
+  verify: S | null;
+}
+
+/**
+ * Visit each present (non-null) script slot in fixed `deploy → revert → verify`
+ * order. Absent slots are skipped.
+ */
+export function forEachScript<S>(
+  slots: ScriptSlots<S>,
+  visit: (script: S, kind: PgpmScriptKind) => void
+): void {
+  for (const kind of SCRIPT_KINDS) {
+    const script = slots[kind];
+    if (script != null) visit(script, kind);
+  }
+}
+
+/**
+ * Map each present script slot to a new value, preserving nulls and slot order.
+ * A slot that is absent stays absent; a mapper that returns `null` also clears
+ * the slot.
+ */
+export function mapScripts<S, T>(
+  slots: ScriptSlots<S>,
+  map: (script: S, kind: PgpmScriptKind) => T | null
+): ScriptSlots<T> {
+  return {
+    deploy: slots.deploy == null ? null : map(slots.deploy, 'deploy'),
+    revert: slots.revert == null ? null : map(slots.revert, 'revert'),
+    verify: slots.verify == null ? null : map(slots.verify, 'verify')
+  };
+}
+
+/**
+ * Pair the corresponding script slots of two nodes and visit every kind (either
+ * side may be `null`) — the primitive for diffing two revisions of a change.
+ */
+export function zipScripts<S>(
+  a: ScriptSlots<S>,
+  b: ScriptSlots<S>,
+  visit: (kind: PgpmScriptKind, a: S | null, b: S | null) => void
+): void {
+  for (const kind of SCRIPT_KINDS) {
+    visit(kind, a[kind], b[kind]);
+  }
+}

--- a/pgpm/traverse/tsconfig.esm.json
+++ b/pgpm/traverse/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/esm",
+    "module": "es2022",
+    "rootDir": "src/",
+    "declaration": false
+  }
+}

--- a/pgpm/traverse/tsconfig.json
+++ b/pgpm/traverse/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src/"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules", "**/*.spec.*", "**/*.test.*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2850,6 +2850,9 @@ importers:
       '@pgpmjs/ast':
         specifier: workspace:^
         version: link:../ast/dist
+      '@pgpmjs/traverse':
+        specifier: workspace:^
+        version: link:../traverse/dist
     devDependencies:
       makage:
         specifier: ^0.3.0
@@ -3085,6 +3088,17 @@ importers:
       yanse:
         specifier: ^0.2.1
         version: 0.2.1
+    devDependencies:
+      makage:
+        specifier: ^0.3.0
+        version: 0.3.0
+    publishDirectory: dist
+
+  pgpm/traverse:
+    dependencies:
+      '@pgpmjs/ast':
+        specifier: workspace:^
+        version: link:../ast/dist
     devDependencies:
       makage:
         specifier: ^0.3.0


### PR DESCRIPTION
## Summary

Phase 3a of the pgpm package split (after `@pgpmjs/ast` #1426 and `@pgpmjs/bundle` #1427). A pgpm change is materialized into exactly three script slots — `deploy`/`revert`/`verify` — and `createBundle`/`verifyBundle`/`diffBundles`/`transpileBundle` each hand-rolled the `[deploy, revert, verify]` walk. This extracts that single primitive into a new pure leaf package **`@pgpmjs/traverse`** and refactors the bundle ops onto it. No behavior change; digests unchanged.

This is the shared traversal seam Dan asked for ("a `pgpmjs/traverse` — traversing a pgpm AST migration bundle") — it's where the per-script SQL transform and the structural rewrite both hang off one walk instead of ad-hoc loops.

**New package `@pgpmjs/traverse`** (depends only on `@pgpmjs/ast` for the `PgpmScriptKind` type):

```ts
const SCRIPT_KINDS = ['deploy', 'revert', 'verify'] as const;
interface ScriptSlots<S> { deploy: S | null; revert: S | null; verify: S | null; }

forEachScript(slots, (script, kind) => void)          // visit present slots, in order
mapScripts(slots, (script, kind) => T | null): Slots<T> // map, null-preserving
zipScripts(a, b, (kind, a|null, b|null) => void)       // pair two revisions for diffing
```

Generic over the script type and **structural**, so both `PgpmChangeAst`/`PgpmScriptAst` (`@pgpmjs/ast`) and `BundleChange`/`BundleScript` (`@pgpmjs/bundle`) satisfy `ScriptSlots<S>` — the same helpers walk a module AST or a bundle.

**No cycle:** `@pgpmjs/bundle` → `@pgpmjs/traverse` → `@pgpmjs/ast`.

**Refactored `@pgpmjs/bundle` consumers:**
```diff
-const deploy = toBundleScript(change.deploy); const revert = ...; const verify = ...;
+const { deploy, revert, verify } = mapScripts(change, toBundleScript);           // create

-for (const script of [change.deploy, change.revert, change.verify]) { if (!script) continue; ... }
+forEachScript(change, script => { ... });                                        // verify

-return { deploy: scriptDiff(from.deploy, to.deploy), revert: ..., verify: ... };
+zipScripts(from, to, (kind, a, b) => { diffs[kind] = scriptDiff(a, b); });        // diff

-const deploy = transpileScriptSql(change.deploy, ...); ... (each handled null)
+const { deploy, revert, verify } = mapScripts(change, s => transpileScriptSql(s, ...)); // transpile
```
(`transpileScriptSql` now takes a non-null `BundleScript` since `mapScripts` skips absent slots.)

Every export has a real consumer — no built-ahead surface.

## Validation
- `@pgpmjs/traverse`: 7 tests pass.
- `@pgpmjs/bundle`: 25 tests pass (digests/round-trip unchanged).
- `@pgpmjs/core`: 446 tests pass.
- `pnpm run build` (full monorepo) green. Added `pgpm/traverse` to the CI `pg-core` batch.

## Follow-ups (tracked in constructive-planning#1239)
Phase 3b: `materializeBundle` → `writeModule`/`serializePlan` and reconcile the two plan writers. Phase 3c: relocate the file-parser tests into `@pgpmjs/ast`. Then update the `pgpm-migration-bundle` skill and merge #1425. The real typed SQL transform (rewrite `RangeVar.schemaname`, function/RLS/FK/grant nodes by AST node type, not text) is the constructive-db driver that plugs into this seam.

Link to Devin session: https://app.devin.ai/sessions/ad40d16f38a349b48eb7ce9375e27e6e
Requested by: @pyramation