### PR TITLE
refactor(pgpm): collapse materializeBundle onto writeModule; reconcile plan writers

### DIFF
--- a/pgpm/ast/src/files/extension/reader.ts
+++ b/pgpm/ast/src/files/extension/reader.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { basename, dirname, relative } from 'path';
+import { dirname, relative } from 'path';
 
 import { parsePlanFileSimple } from '../plan';
 import { ExtensionInfo } from './writer';
@@ -15,8 +15,20 @@ export interface Module {
  * https://www.postgresql.org/docs/current/extend-extensions.html
  */
 export function parseControlFile(filePath: string, basePath: string): Module {
-  const contents = readFileSync(filePath, 'utf-8');
-  const key = basename(filePath).split('.control')[0];
+  const { requires, version } = parseControlContent(readFileSync(filePath, 'utf-8'));
+  return {
+    path: dirname(relative(basePath, filePath)),
+    requires,
+    version,
+  };
+}
+
+/**
+ * Parse .control file content and extract its metadata. The in-memory core of
+ * {@link parseControlFile}, for control text that does not live on disk (e.g.
+ * inside a migration bundle artifact).
+ */
+export function parseControlContent(contents: string): { requires: string[]; version: string } {
   const requires = contents
     .split('\n')
     .find((line) => /^requires/.test(line))
@@ -31,11 +43,7 @@ export function parseControlFile(filePath: string, basePath: string): Module {
     .replace(/[\']*/g, '')
     .trim() || '';
 
-  return {
-    path: dirname(relative(basePath, filePath)),
-    requires,
-    version,
-  };
+  return { requires, version };
 }
 
 /**

--- a/pgpm/ast/src/files/plan/parser.ts
+++ b/pgpm/ast/src/files/plan/parser.ts
@@ -9,7 +9,15 @@ import { errors } from '@pgpmjs/types';
  * Supports both changes and tags
  */
 export function parsePlanFile(planPath: string): ParseResult<ExtendedPlanFile> {
-  const content = readFileSync(planPath, 'utf-8');
+  return parsePlanContent(readFileSync(planPath, 'utf-8'));
+}
+
+/**
+ * Parse Sqitch plan content (the text of a `pgpm.plan`) with full validation.
+ * The in-memory core of {@link parsePlanFile}, for plan text that does not
+ * live on disk (e.g. inside a migration bundle artifact).
+ */
+export function parsePlanContent(content: string): ParseResult<ExtendedPlanFile> {
   const lines = content.split('\n');
   
   let project = '';

--- a/pgpm/bundle/__tests__/bundle.test.ts
+++ b/pgpm/bundle/__tests__/bundle.test.ts
@@ -7,6 +7,7 @@ import {
   bundleFromModule,
   createBundle,
   materializeBundle,
+  moduleFromBundle,
   readBundleFile,
   verifyBundle,
   writeBundleFile
@@ -128,6 +129,20 @@ describe('bundle file IO', () => {
     const reread = readBundleFile(file);
     expect(reread).toEqual(bundle);
     expect(verifyBundle(reread)).toEqual([]);
+  });
+});
+
+describe('moduleFromBundle', () => {
+  it('hydrates the module AST losslessly (inverse of createBundle)', () => {
+    const source = readModule(sourceDir);
+    const hydrated = moduleFromBundle(bundleFromModule(sourceDir), sourceDir);
+    expect(hydrated).toEqual(source);
+  });
+
+  it('rejects a bundle whose plan does not parse', () => {
+    const bundle = bundleFromModule(sourceDir);
+    bundle.plan = '%project=x\nnot a valid line !!!\n';
+    expect(() => moduleFromBundle(bundle)).toThrow(/Failed to parse bundle plan/);
   });
 });
 

--- a/pgpm/bundle/src/io.ts
+++ b/pgpm/bundle/src/io.ts
@@ -1,9 +1,21 @@
 import { mkdirSync, readFileSync, writeFileSync } from 'fs';
-import { dirname, join } from 'path';
+import { dirname } from 'path';
 
+import { parseControlContent } from '@pgpmjs/ast/files/extension/reader';
+import { parsePlanContent } from '@pgpmjs/ast/files/plan/parser';
+import { parsePgpmHeader } from '@pgpmjs/ast/files/sql/header';
+import { Change } from '@pgpmjs/ast/files/types';
 import { readModule } from '@pgpmjs/ast/module/reader';
+import {
+  PgpmChangeAst,
+  PgpmControlAst,
+  PgpmModuleAst,
+  PgpmScriptAst
+} from '@pgpmjs/ast/module/types';
+import { writeModule } from '@pgpmjs/ast/module/writer';
+import { mapScripts } from '@pgpmjs/traverse';
 import { createBundle, CreateBundleOptions } from './create';
-import { MigrationBundle } from './types';
+import { BundleScript, MigrationBundle } from './types';
 
 /** Default file name for a serialized bundle artifact. */
 export const BUNDLE_FILE_NAME = 'pgpm-bundle.json';
@@ -33,26 +45,67 @@ export function readBundleFile(filePath: string): MigrationBundle {
   return JSON.parse(readFileSync(filePath, 'utf-8')) as MigrationBundle;
 }
 
+function scriptAstFromBundleScript(script: BundleScript): PgpmScriptAst {
+  const { header, body } = parsePgpmHeader(script.sql);
+  return { kind: script.kind, header, body, raw: script.sql };
+}
+
+/**
+ * Hydrate a bundle back into a {@link PgpmModuleAst} — the inverse of
+ * `createBundle`. Composes the existing plan/control/SQL-header parsers over
+ * the bundle's byte-exact contents; every leaf keeps the bundle text as its
+ * `raw`, so `writeModule` reproduces the bundle losslessly.
+ */
+export function moduleFromBundle(bundle: MigrationBundle, dir = ''): PgpmModuleAst {
+  const parsed = parsePlanContent(bundle.plan);
+  if (!parsed.data) {
+    const detail = parsed.errors
+      .map(e => `line ${e.line}: ${e.message}`)
+      .join('; ');
+    throw new Error(`Failed to parse bundle plan for ${bundle.manifest.name}: ${detail}`);
+  }
+  const plan = parsed.data;
+  const planEntries = new Map(plan.changes.map(change => [change.name, change]));
+
+  let control: PgpmControlAst | null = null;
+  if (bundle.control) {
+    const { requires, version } = parseControlContent(bundle.control.content);
+    control = {
+      fileName: bundle.control.fileName,
+      name: bundle.manifest.name,
+      requires,
+      version,
+      raw: bundle.control.content
+    };
+  }
+
+  const changes: PgpmChangeAst[] = bundle.changes.map(change => {
+    const planEntry: Change =
+      planEntries.get(change.name) ?? { name: change.name, dependencies: change.dependencies };
+    const { deploy, revert, verify } = mapScripts(change, scriptAstFromBundleScript);
+    return { name: change.name, plan: planEntry, deploy, revert, verify };
+  });
+
+  return {
+    dir,
+    name: bundle.manifest.name,
+    plan,
+    planRaw: bundle.plan,
+    control,
+    changes
+  };
+}
+
 /**
  * Materialize a bundle back into a real, deployable pgpm module directory:
  * `pgpm.plan`, the `.control` file (when present), and each change's
  * deploy/revert/verify script at its `deploy/<change>.sql` path.
  *
  * The inverse of {@link bundleFromModule}; the emitted directory can be read
- * back with `readModule` or deployed with `PgpmMigrate`.
+ * back with `readModule` or deployed with `PgpmMigrate`. Implemented as
+ * {@link moduleFromBundle} → `writeModule` (byte-exact `raw` leaves), so the
+ * bundle write path is the module AST writer — not a parallel one.
  */
 export function materializeBundle(bundle: MigrationBundle, outDir: string): void {
-  mkdirSync(outDir, { recursive: true });
-  writeFileSync(join(outDir, 'pgpm.plan'), bundle.plan);
-  if (bundle.control) {
-    writeFileSync(join(outDir, bundle.control.fileName), bundle.control.content);
-  }
-  for (const change of bundle.changes) {
-    for (const script of [change.deploy, change.revert, change.verify]) {
-      if (!script) continue;
-      const file = join(outDir, script.kind, `${change.name}.sql`);
-      mkdirSync(dirname(file), { recursive: true });
-      writeFileSync(file, script.sql);
-    }
-  }
+  writeModule(moduleFromBundle(bundle, outDir), { outDir });
 }

--- a/pgpm/core/src/slice/slice.ts
+++ b/pgpm/core/src/slice/slice.ts
@@ -1,5 +1,6 @@
 import { Change, Tag, ExtendedPlanFile } from '@pgpmjs/ast/files/types';
 import { parsePlanFile } from '@pgpmjs/ast/files/plan/parser';
+import { generateChangeLineContent, generateTagLineContent } from '@pgpmjs/ast/files/plan/writer';
 import {
   SliceConfig,
   SliceResult,
@@ -366,46 +367,17 @@ export function generatePlanContent(
   content += `%project=${pkgName}\n`;
   content += `%uri=${pkgName}\n\n`;
 
+  // Dependency brackets keep their original order (empty order map), matching
+  // the source plans this content is sliced from.
+  const originalOrder = new Map<string, number>();
+
   for (const entry of entries) {
-    let line = entry.name;
-
-    if (entry.dependencies && entry.dependencies.length > 0) {
-      line += ` [${entry.dependencies.join(' ')}]`;
-    }
-
-    if (entry.timestamp) {
-      line += ` ${entry.timestamp}`;
-      if (entry.planner) {
-        line += ` ${entry.planner}`;
-        if (entry.email) {
-          line += ` <${entry.email}>`;
-        }
-      }
-    }
-
-    if (entry.comment) {
-      line += ` # ${entry.comment}`;
-    }
-
-    content += line + '\n';
+    content += generateChangeLineContent(entry, originalOrder) + '\n';
 
     // Add tags associated with this change
     const changeTags = tags.filter(t => t.change === entry.name);
     for (const tag of changeTags) {
-      let tagLine = `@${tag.name}`;
-      if (tag.timestamp) {
-        tagLine += ` ${tag.timestamp}`;
-        if (tag.planner) {
-          tagLine += ` ${tag.planner}`;
-          if (tag.email) {
-            tagLine += ` <${tag.email}>`;
-          }
-        }
-      }
-      if (tag.comment) {
-        tagLine += ` # ${tag.comment}`;
-      }
-      content += tagLine + '\n';
+      content += generateTagLineContent(tag) + '\n';
     }
   }
 


### PR DESCRIPTION
## Summary

Phase 3b of the bundle/ast cleanup (constructive-planning#1239): kills the two genuine write-path duplications flagged in the audit, with zero behavior change.

**1. `materializeBundle` no longer has its own `writeFileSync` loop.** New `moduleFromBundle(bundle, dir?): PgpmModuleAst` — the inverse of `createBundle` — hydrates a bundle through the *existing* parsers, keeping every leaf's `raw` byte-exact:

```ts
moduleFromBundle = parsePlanContent(bundle.plan)
                 + parseControlContent(bundle.control.content)
                 + parsePgpmHeader(script.sql) per script (via mapScripts)

materializeBundle(bundle, outDir) = writeModule(moduleFromBundle(bundle, outDir), { outDir })
```

So bundle→disk goes through the one module AST writer (`writeModule`, `fromRaw: true` ⇒ byte-identical output — the existing byte-for-byte + digest round-trip test still passes unchanged). `moduleFromBundle` is also independently useful: it gives operators a typed module AST from a bundle without touching disk.

**2. To enable that, `@pgpmjs/ast` file parsers gained in-memory cores** (pure extractions, path-based functions delegate):
- `parsePlanFile(path)` → `readFileSync` + new `parsePlanContent(content)`
- `parseControlFile(path, base)` → `readFileSync` + new `parseControlContent(contents)`

**3. Plan-writer reconciliation:** `slice/slice.ts`'s `generatePlanContent` had a copy of the change/tag line-formatting logic. It now composes the canonical `generateChangeLineContent`/`generateTagLineContent` from `@pgpmjs/ast/files/plan/writer`, passing an empty order map so dependency brackets keep original order (preserving slice/rebundle byte-identical gates). Remaining writers (`generatePlan` for scaffolding, `writePgpmPlan` for codegen) have genuinely different input shapes/concerns and are left alone.

## Validation
- `@pgpmjs/ast` 10, `@pgpmjs/bundle` 27 (2 new: `moduleFromBundle` deep-equals `readModule` of the source; invalid bundle plan rejected), `@pgpmjs/core` 446 incl. slice/rebundle byte-identical gates — all green.
- Full monorepo build green.

Link to Devin session: https://app.devin.ai/sessions/ad40d16f38a349b48eb7ce9375e27e6e
Requested by: @pyramation