### PR TITLE
docs(pgpm): document bundle envelope, applyEnvelope, and table-data export in package READMEs

### DIFF
--- a/pgpm/bundle/README.md
+++ b/pgpm/bundle/README.md
@@ -24,6 +24,48 @@ provenance: the "shipping container" for a database migration.
 - `transpileBundle` — produce a namespaced bundle (caller supplies the SQL AST rewrite).
 - `diffBundles` / `reconcilePlan` — structural diff and ordered revert/deploy plan.
 
+## The bundle envelope
+
+The **bundle envelope** is how you ship a database the way you ship a product: the
+whole thing — its structure (a `MigrationBundle`), its row data, its fixtures — as one
+sealed, versioned, tamper-evident package. Like a shipping container: standardized,
+stackable, verifiable at every port. The bundle is the schema; the envelope is the
+whole shipment.
+
+```ts
+import { bundleFromModule, createEnvelope, verifyEnvelope, materializeEnvelope } from '@pgpmjs/bundle';
+
+const envelope = createEnvelope({
+  version: '1.0.0',                        // caller-assigned artifact version
+  schema: bundleFromModule(moduleDir),     // required: the MigrationBundle
+  data: [{ name: 'source-plane-data', deploy, revert, verify }],   // e.g. from @pgpmjs/export
+  fixtures: [{ name: 'seed-roles', deploy }],
+  provenance: { sourceDatabase, sliceSpec }  // lineage; recorded but excluded from the digest
+});
+
+verifyEnvelope(envelope);                  // { issues: [], schemaIssues: [] }
+materializeEnvelope(envelope, outDir);     // deterministic, tar-friendly directory layout
+```
+
+- **Manifest** — identity (`name`, `version`), a contents inventory with per-part
+  sha256 digests, and source lineage (`provenance`).
+- **Merkle content digest** — the envelope digest covers the ordered part digests; the
+  schema part's digest is the bundle's own manifest digest, so the chain extends down
+  through every change and script. Flip one byte anywhere and `verifyEnvelope`
+  localizes it.
+- **Payload-agnostic parts** — each data/fixtures part is a named deploy/revert/verify
+  SQL triplet produced by the caller (e.g. the `@pgpmjs/export` data-dump builders);
+  the envelope never generates SQL, it digests, ships, and verifies it.
+- **Serialization** — one JSON artifact (`writeEnvelopeFile` / `readEnvelopeFile`) or a
+  deterministic directory (`materializeEnvelope` / `envelopeFromDirectory`):
+
+  ```
+  envelope.json                 # manifest only
+  schema/pgpm-bundle.json       # the schema MigrationBundle artifact
+  data/<name>/{deploy,revert,verify}.sql
+  fixtures/<name>/{deploy,revert,verify}.sql
+  ```
+
 This package is pure (no database, no deploy engine). The deployment glue —
-`applyBundle`, which drives `PgpmMigrate` — lives in `@pgpmjs/core`. See the
-`pgpm-migration-bundle` skill for the full model.
+`applyBundle` and `applyEnvelope`, which drive `PgpmMigrate` — lives in
+`@pgpmjs/core`. See the `pgpm-migration-bundle` skill for the full model.

--- a/pgpm/core/README.md
+++ b/pgpm/core/README.md
@@ -22,6 +22,28 @@ pgpm Core is the main package for pgpm, providing tools for database migrations,
 - Reading and writing SQL scripts
 - Resolving dependencies between migrations
 
+## Migration bundles and envelopes
+
+`@pgpmjs/core` is the deployment half of the portable artifact layer defined in
+`@pgpmjs/bundle` (the pure layer: `MigrationBundle` — a content-addressed snapshot of a
+pgpm module — and `BundleEnvelope` — the versioned shipping container wrapping a schema
+bundle plus data/fixtures SQL parts):
+
+- `applyBundle(bundle, { config, dryRun?, verify?, timeoutMs?, validateReferences? })` —
+  safety-first apply of a `MigrationBundle` via `PgpmMigrate`: artifact-integrity and
+  optional namespace gating, dry-run preview, atomic single-transaction deploy,
+  timeout, and an explicit result including the rollback plan.
+- `applyEnvelope(envelope, { config, dryRun?, verifyParts?, transformPartSql?, ... })` —
+  the generic `applyMigrationBundle` primitive: digest-gates the whole envelope
+  (`verifyEnvelope`), applies the schema via `applyBundle`, then replays each data and
+  fixtures part's deploy SQL in manifest order inside one transaction (a failing part
+  rolls back all part data; the schema stays applied). `previewEnvelopeApply` gives the
+  pure pre-flight: envelope issues, part replay order, and a layered rollback plan.
+  `transformPartSql` is the seam for pre-apply rewriting of part SQL (e.g.
+  deterministic ID remap).
+
+See `pgpm/bundle/README.md` and the `pgpm-migration-bundle` skill for the artifact model.
+
 ## Configuration
 
 ### Error Output Configuration

--- a/pgpm/export/README.md
+++ b/pgpm/export/README.md
@@ -20,6 +20,13 @@ Export tools for extracting database migrations from existing PostgreSQL databas
 - **GraphQL Export** — Extract migrations via a PostGraphile GraphQL endpoint
 - **Cross-flow parity** — Both flows produce identical output for the same source data
 - **Metadata export** — Export metaschema, services, and module metadata tables
+- **Table-data export** — Generic deterministic row-data dumps (`exportTablesData`,
+  `buildDataDeployScript` / `buildDataRevertScript` / `buildDataVerifyScript`): one
+  INSERT per table in stable order, volatile-default columns excluded via pg_catalog
+  volatility (no regex on default text), replayed under
+  `session_replication_role = replica`, with ID-precise reverts and divide-by-zero
+  verify checks. These scripts are the data/fixtures parts a `@pgpmjs/bundle`
+  envelope ships. All SQL is emitted through `@constructive-io/query-builder`.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Human-facing README docs for the artifact structures landed in #1433/#1435/#1436 — previously only the `pgpm-migration-bundle` agent skill covered them:

- `pgpm/bundle/README.md`: new "The bundle envelope" section — the shipping-container framing (schema + data + fixtures as one sealed, versioned, tamper-evident package), `createEnvelope`/`verifyEnvelope` example, manifest/Merkle-digest model, payload-agnostic parts, JSON + directory serialization layout.
- `pgpm/core/README.md`: "Migration bundles and envelopes" section — `applyBundle` and `applyEnvelope`/`previewEnvelopeApply` semantics (digest gate, one-transaction part replay, layered rollback plan, `transformPartSql` ID-remap seam).
- `pgpm/export/README.md`: feature entry for the generic table-data export (`exportTablesData` + deploy/revert/verify builders) and its role as the envelope's data/fixtures payload producer.

Docs-only; no code changes.

Link to Devin session: https://app.devin.ai/sessions/ad40d16f38a349b48eb7ce9375e27e6e
Requested by: @pyramation