### PR TITLE
feat(pgpm): configurable extensions install directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ graphql/server/*.heapsnapshot
 
 # Ephemeral pgpm modules installed by `pnpm fixtures:install` (pgpm install)
 /extensions/
+# Alternate install dirs configured via `extensionsDir` / PGPM_EXTENSIONS_DIR
+/extensions-*/

--- a/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
+++ b/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
@@ -64,6 +64,7 @@ exports[`getEnvOptions merges pgpm defaults, graphql defaults, config, env, and 
     "queryHistoryLimit": 30,
     "verbose": false,
   },
+  "extensionsDir": "extensions",
   "features": {
     "oppositeBaseNames": false,
     "postgis": false,

--- a/pgpm/cli/__tests__/extensions-dir.test.ts
+++ b/pgpm/cli/__tests__/extensions-dir.test.ts
@@ -1,0 +1,150 @@
+jest.setTimeout(120000);
+process.env.PGPM_SKIP_UPDATE_CHECK = 'true';
+
+import { PgpmPackage } from '@pgpmjs/core';
+import * as fs from 'fs';
+import * as path from 'path';
+import { teardownPgPools } from 'pg-cache';
+
+import { CLIDeployTestFixture, TestFixture } from '../test-utils';
+
+const TEST_PKG = '@pgpm-testing/base32@1.0.0';
+const TEST_PKG_NAME = '@pgpm-testing/base32';
+
+const writeWorkspaceConfig = (workspaceDir: string, extra: Record<string, unknown>) => {
+  const configPath = path.join(workspaceDir, 'pgpm.json');
+  const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+  fs.writeFileSync(configPath, JSON.stringify({ ...config, ...extra }, null, 2));
+};
+
+describe('configurable extensions directory', () => {
+  let fixture: TestFixture;
+  let workspaceDir: string;
+  let moduleDir: string;
+
+  beforeEach(async () => {
+    fixture = new TestFixture();
+
+    workspaceDir = path.join(fixture.tempDir, 'my-workspace');
+    moduleDir = path.join(workspaceDir, 'packages', 'my-module');
+
+    await fixture.runCmd({
+      _: ['init', 'workspace'],
+      cwd: fixture.tempDir,
+      name: 'my-workspace',
+      workspace: true
+    });
+
+    await fixture.runCmd({
+      _: ['init'],
+      cwd: workspaceDir,
+      name: 'my-module',
+      moduleName: 'my-module',
+      extensions: ['plpgsql']
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.PGPM_EXTENSIONS_DIR;
+    fixture.cleanup();
+  });
+
+  it('defaults to extensions/', () => {
+    expect(new PgpmPackage(workspaceDir).extensionsDir).toBe('extensions');
+    expect(new PgpmPackage(workspaceDir).getExtensionsPath()).toBe(
+      path.join(workspaceDir, 'extensions')
+    );
+  });
+
+  it('reads extensionsDir from the workspace pgpm.json', () => {
+    writeWorkspaceConfig(workspaceDir, { extensionsDir: 'extensions-test' });
+
+    expect(new PgpmPackage(workspaceDir).extensionsDir).toBe('extensions-test');
+    expect(new PgpmPackage(moduleDir).extensionsDir).toBe('extensions-test');
+  });
+
+  it('lets PGPM_EXTENSIONS_DIR override the config file, and the option override both', () => {
+    writeWorkspaceConfig(workspaceDir, { extensionsDir: 'extensions-config' });
+    process.env.PGPM_EXTENSIONS_DIR = 'extensions-env';
+
+    expect(new PgpmPackage(workspaceDir).extensionsDir).toBe('extensions-env');
+    expect(
+      new PgpmPackage(workspaceDir, { extensionsDir: 'extensions-option' }).extensionsDir
+    ).toBe('extensions-option');
+  });
+
+  it('installs into the configured dir and scans it for installed modules', async () => {
+    writeWorkspaceConfig(workspaceDir, { extensionsDir: 'extensions-test' });
+
+    await fixture.runCmd({
+      _: ['install', TEST_PKG],
+      cwd: moduleDir
+    });
+
+    const configuredDir = path.join(workspaceDir, 'extensions-test', TEST_PKG_NAME);
+    expect(fs.existsSync(configuredDir)).toBe(true);
+    expect(fs.existsSync(path.join(workspaceDir, 'extensions'))).toBe(false);
+
+    const project = new PgpmPackage(workspaceDir);
+    expect(project.getWorkspaceInstalledModules()).toContain(TEST_PKG_NAME);
+    expect(Object.keys(project.getModuleMap())).toContain('launchql-base32');
+
+    const mod = new PgpmPackage(moduleDir);
+    expect(mod.getInstalledModules().installed).toContain(TEST_PKG_NAME);
+  });
+
+  it('honors the --extensions-dir CLI flag', async () => {
+    await fixture.runCmd({
+      _: ['install', TEST_PKG],
+      cwd: moduleDir,
+      'extensions-dir': 'extensions-flag'
+    });
+
+    expect(
+      fs.existsSync(path.join(workspaceDir, 'extensions-flag', TEST_PKG_NAME))
+    ).toBe(true);
+    expect(fs.existsSync(path.join(workspaceDir, 'extensions'))).toBe(false);
+  });
+});
+
+describe('deploy honors the configured extensions directory', () => {
+  let fixture: CLIDeployTestFixture;
+  let testDb: any;
+
+  beforeAll(async () => {
+    fixture = new CLIDeployTestFixture('sqitch', 'simple-w-exts');
+
+    // Move the workspace modules out of `extensions/` into `extensions-test/`
+    // and drop the `extensions/*` package globs, so the modules are only
+    // discoverable through the configured extensions directory.
+    const wsDir = fixture.tempFixtureDir;
+    fs.renameSync(path.join(wsDir, 'extensions'), path.join(wsDir, 'extensions-test'));
+    fs.writeFileSync(
+      path.join(wsDir, 'pgpm.json'),
+      JSON.stringify({ packages: ['packages/*'], extensionsDir: 'extensions-test' }, null, 2)
+    );
+
+    testDb = await fixture.setupTestDatabase();
+  });
+
+  afterAll(async () => {
+    await fixture.cleanup();
+    await teardownPgPools();
+  });
+
+  it('resolves workspace extensions from the configured dir when deploying', async () => {
+    const project = new PgpmPackage(fixture.tempFixtureDir);
+    expect(project.extensionsDir).toBe('extensions-test');
+    expect(Object.keys(project.getModuleMap())).toEqual(
+      expect.arrayContaining(['sample-unique-names', 'pgpm-base32'])
+    );
+
+    const results = await fixture.exec(
+      `pgpm deploy --database ${testDb.name} --yes --usePlan --package sample-unique-names`,
+      { database: testDb.name }
+    );
+
+    expect(results).toHaveLength(1);
+    expect(await testDb.exists('schema', 'base32')).toBe(true);
+  });
+});

--- a/pgpm/cli/src/commands/install.ts
+++ b/pgpm/cli/src/commands/install.ts
@@ -9,7 +9,11 @@ Install Command:
 
   pgpm install [package]...
 
-  Install pgpm modules into the workspace extensions/ directory.
+  Install pgpm modules into the workspace extensions directory (default: extensions/).
+
+  The install directory is configurable: --extensions-dir wins, then the
+  PGPM_EXTENSIONS_DIR env var, then the \`extensionsDir\` field in the workspace
+  pgpm.json, then the \`extensions\` default.
 
   Inside a module, installing without arguments installs any missing modules
   listed in the module's .control file, and explicit installs are recorded in
@@ -26,6 +30,7 @@ Options:
   --help, -h              Show this help message
   --cwd <directory>       Working directory (default: current directory)
   --force                 Reinstall modules even if already installed
+  --extensions-dir <dir>  Directory (relative to workspace root) to install into (default: extensions)
   -W, --workspace-root    Install at the workspace root (pgpm.json dependencies)
 
 Examples:
@@ -35,6 +40,8 @@ Examples:
   pgpm install @pgpm/base32                    Install single package
   pgpm install @pgpm/base32@latest             Install the latest published version
   pgpm install @pgpm/base32 @pgpm/utils        Install multiple packages
+  pgpm install --extensions-dir extensions-test @pgpm/base32
+                                               Install into extensions-test/ instead of extensions/
 `;
 
 export default async (
@@ -49,7 +56,8 @@ export default async (
   }
   const { cwd = process.cwd() } = argv;
 
-  const project = new PgpmPackage(cwd);
+  const extensionsDir = (argv['extensions-dir'] ?? argv.extensionsDir) as string | undefined;
+  const project = new PgpmPackage(cwd, { extensionsDir });
   const force = Boolean(argv.force);
   const workspaceRoot = Boolean(argv.W || argv['workspace-root'] || argv.workspaceRoot);
 

--- a/pgpm/core/src/core/class/pgpm.ts
+++ b/pgpm/core/src/core/class/pgpm.ts
@@ -1,6 +1,6 @@
-import { loadConfigSyncFromDir, resolvePgpmPath,walkUp } from '@pgpmjs/env';
+import { getExtensionsDir, loadConfigSyncFromDir, resolvePgpmPath,walkUp } from '@pgpmjs/env';
 import { Logger } from '@pgpmjs/logger';
-import { errors, PgpmOptions, PgpmWorkspaceConfig } from '@pgpmjs/types';
+import { DEFAULT_EXTENSIONS_DIR,errors, PgpmOptions, PgpmWorkspaceConfig } from '@pgpmjs/types';
 import { execSync } from 'child_process';
 import fs from 'fs';
 import * as glob from 'glob';
@@ -44,10 +44,16 @@ import { DEFAULT_TEMPLATE_REPO, DEFAULT_TEMPLATE_TOOL_NAME, DEFAULT_TEMPLATE_TTL
 const logger = new Logger('pgpm');
 
 /**
- * Directory name for workspace extensions.
- * Extensions are installed globally in the workspace's extensions/ directory.
+ * Options accepted by the {@link PgpmPackage} constructor.
  */
-const EXTENSIONS_DIR = 'extensions';
+export interface PgpmPackageOptions {
+  /**
+   * Directory (relative to the workspace root) where pgpm modules are installed.
+   * Takes precedence over `PGPM_EXTENSIONS_DIR` and the `extensionsDir` config
+   * field. Defaults to `extensions`.
+   */
+  extensionsDir?: string;
+}
 
 function sortObjectByKey<T extends Record<string, any>>(obj: T): T {
   return Object.fromEntries(Object.entries(obj).sort(([a], [b]) => a.localeCompare(b))) as T;
@@ -126,11 +132,19 @@ export class PgpmPackage {
   public config?: PgpmWorkspaceConfig;
   public allowedDirs: string[] = [];
   public allowedParentDirs: string[] = [];
+  /**
+   * Directory name (relative to the workspace root) where pgpm modules are installed.
+   * Resolved from the constructor option, `PGPM_EXTENSIONS_DIR`, the `extensionsDir`
+   * config field, then the `extensions` default.
+   */
+  public extensionsDir: string = DEFAULT_EXTENSIONS_DIR;
 
+  private readonly options: PgpmPackageOptions;
   private _moduleMap?: ModuleMap;
   private _moduleInfo?: ExtensionInfo;
 
-  constructor(cwd: string = process.cwd()) {
+  constructor(cwd: string = process.cwd(), options: PgpmPackageOptions = {}) {
+    this.options = options;
     this.resetCwd(cwd);
   }
 
@@ -138,12 +152,24 @@ export class PgpmPackage {
     this.cwd = cwd;
     this.workspacePath = resolvePgpmPath(this.cwd);
     this.modulePath = this.resolveSqitchPath();
+    this.extensionsDir = getExtensionsDir(
+      this.options.extensionsDir,
+      this.workspacePath ?? this.cwd
+    );
 
     if (this.workspacePath) {
       this.config = this.loadConfigSync();
       this.allowedDirs = this.loadAllowedDirs();
       this.allowedParentDirs = this.loadAllowedParentDirs();
     }
+  }
+
+  /**
+   * Absolute path of the workspace directory where pgpm modules are installed.
+   */
+  getExtensionsPath(): string {
+    this.ensureWorkspace();
+    return path.join(this.workspacePath!, this.extensionsDir);
   }
 
   private resolveSqitchPath(): string | undefined {
@@ -268,7 +294,7 @@ export class PgpmPackage {
     const results: PgpmPackage[] = [];
 
     for (const dir of dirs) {
-      const proj = new PgpmPackage(dir);
+      const proj = new PgpmPackage(dir, this.options);
       if (proj.isInModule()) {
         results.push(proj);
       }
@@ -290,7 +316,7 @@ export class PgpmPackage {
     // nested workspaces (e.g. test fixtures) out of the module map.
     const packageDirs = [
       ...this.allowedDirs,
-      ...glob.sync(path.join(this.workspacePath, EXTENSIONS_DIR, '{*,@*/*}'))
+      ...glob.sync(path.join(this.workspacePath, this.extensionsDir, '{*,@*/*}'))
     ];
 
     const moduleFiles = [...new Set(
@@ -358,7 +384,7 @@ export class PgpmPackage {
     }
     
     const modulePath = path.resolve(this.workspacePath!, modules[name].path);
-    return new PgpmPackage(modulePath);
+    return new PgpmPackage(modulePath, this.options);
   }
 
   // ──────────────── Module-scoped ────────────────
@@ -992,7 +1018,7 @@ ${dependencies.length > 0 ? dependencies.map(dep => `-- requires: ${dep}`).join(
 
     const inModule = this.isInModule();
     const originalDir = process.cwd();
-    const skitchExtDir = path.join(this.workspacePath!, EXTENSIONS_DIR);
+    const skitchExtDir = this.getExtensionsPath();
 
     let pkgJsonPath: string | undefined;
     let pkgData: Record<string, any> | undefined;
@@ -1017,11 +1043,11 @@ ${dependencies.length > 0 ? dependencies.map(dep => `-- requires: ${dep}`).join(
   
       try {
         process.chdir(tempDir);
-        execSync(`npm install ${pkgstr} --production --prefix ./extensions`, {
+        execSync(`npm install ${pkgstr} --production --prefix ./${this.extensionsDir}`, {
           stdio: 'inherit'
         });
   
-        const matches = glob.sync('./extensions/**/pgpm.plan');
+        const matches = glob.sync(`./${this.extensionsDir}/**/pgpm.plan`);
         const installs = matches.map((conf) => {
           const fullConf = resolve(conf);
           const extDir = dirname(fullConf);
@@ -1213,7 +1239,7 @@ ${dependencies.length > 0 ? dependencies.map(dep => `-- requires: ${dep}`).join(
 
     const pkgData = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
     const dependencies = pkgData.dependencies || {};
-    const skitchExtDir = path.join(this.workspacePath!, EXTENSIONS_DIR);
+    const skitchExtDir = this.getExtensionsPath();
 
     const installed: string[] = [];
     const installedVersions: Record<string, string> = {};
@@ -1241,7 +1267,7 @@ ${dependencies.length > 0 ? dependencies.map(dep => `-- requires: ${dep}`).join(
   getWorkspaceInstalledModules(): string[] {
     this.ensureWorkspace();
 
-    const extensionsDir = path.join(this.workspacePath!, EXTENSIONS_DIR);
+    const extensionsDir = this.getExtensionsPath();
     
     if (!fs.existsSync(extensionsDir)) {
       return [];

--- a/pgpm/core/src/projects/deploy.ts
+++ b/pgpm/core/src/projects/deploy.ts
@@ -46,7 +46,7 @@ export const deployProject = async (
   }
 
   const modulePath = path.resolve(pkg.workspacePath!, modules[name].path);
-  const moduleProject = new PgpmPackage(modulePath);
+  const moduleProject = new PgpmPackage(modulePath, { extensionsDir: pkg.extensionsDir });
 
   log.info(`📦 Resolving dependencies for ${name}...`);
   const extensions: Extensions = moduleProject.getModuleExtensions();
@@ -69,7 +69,7 @@ export const deployProject = async (
 
         if (mergedOpts.deployment.fast) {
           // Use fast deployment strategy
-          const localProject = new PgpmPackage(modulePath);
+          const localProject = new PgpmPackage(modulePath, { extensionsDir: pkg.extensionsDir });
           const cacheKey = getCacheKey(mergedOpts.pg as PgConfig, extension, database);
           
           if (mergedOpts.deployment.cache && deployFastCache[cacheKey]) {

--- a/pgpm/core/src/projects/revert.ts
+++ b/pgpm/core/src/projects/revert.ts
@@ -38,7 +38,7 @@ export const revertProject = async (
   }
 
   const modulePath = path.resolve(pkg.workspacePath!, modules[name].path);
-  const moduleProject = new PgpmPackage(modulePath);
+  const moduleProject = new PgpmPackage(modulePath, { extensionsDir: pkg.extensionsDir });
 
   log.info(`📦 Resolving dependencies for ${name}...`);
   const extensions: Extensions = moduleProject.getModuleExtensions();

--- a/pgpm/core/src/projects/verify.ts
+++ b/pgpm/core/src/projects/verify.ts
@@ -32,7 +32,7 @@ export const verifyProject = async (
   }
 
   const modulePath = path.resolve(pkg.workspacePath!, modules[name].path);
-  const moduleProject = new PgpmPackage(modulePath);
+  const moduleProject = new PgpmPackage(modulePath, { extensionsDir: pkg.extensionsDir });
 
   log.info(`📦 Resolving dependencies for ${name}...`);
   const extensions: Extensions = moduleProject.getModuleExtensions();

--- a/pgpm/env/__tests__/__snapshots__/merge.test.ts.snap
+++ b/pgpm/env/__tests__/__snapshots__/merge.test.ts.snap
@@ -47,6 +47,7 @@ exports[`getEnvOptions merges defaults, config, env, and overrides 1`] = `
     "queryHistoryLimit": 30,
     "verbose": false,
   },
+  "extensionsDir": "extensions",
   "jobs": {
     "gateway": {
       "callbackPort": 12345,

--- a/pgpm/env/__tests__/merge.test.ts
+++ b/pgpm/env/__tests__/merge.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-import { getConnEnvOptions, getEnvOptions } from '../src/merge';
+import { getConnEnvOptions, getEnvOptions, getExtensionsDir } from '../src/merge';
 
 const writeConfig = (dir: string, config: Record<string, unknown>): void => {
   fs.writeFileSync(path.join(dir, 'pgpm.json'), JSON.stringify(config, null, 2));
@@ -277,5 +277,41 @@ describe('getEnvOptions', () => {
       };
       expect(() => getEnvOptions({}, emptyCwd(), safeEnv)).not.toThrow();
     });
+  });
+});
+
+describe('getExtensionsDir', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pgpm-env-extdir-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('defaults to extensions', () => {
+    writeConfig(tempDir, {});
+    expect(getExtensionsDir(undefined, tempDir, {})).toBe('extensions');
+  });
+
+  it('reads extensionsDir from the config file', () => {
+    writeConfig(tempDir, { extensionsDir: 'extensions-config' });
+    expect(getExtensionsDir(undefined, tempDir, {})).toBe('extensions-config');
+  });
+
+  it('prefers PGPM_EXTENSIONS_DIR over the config file', () => {
+    writeConfig(tempDir, { extensionsDir: 'extensions-config' });
+    expect(
+      getExtensionsDir(undefined, tempDir, { PGPM_EXTENSIONS_DIR: 'extensions-env' })
+    ).toBe('extensions-env');
+  });
+
+  it('prefers an explicit override over env and config', () => {
+    writeConfig(tempDir, { extensionsDir: 'extensions-config' });
+    expect(
+      getExtensionsDir('extensions-opt', tempDir, { PGPM_EXTENSIONS_DIR: 'extensions-env' })
+    ).toBe('extensions-opt');
   });
 });

--- a/pgpm/env/src/env.ts
+++ b/pgpm/env/src/env.ts
@@ -16,6 +16,7 @@ export const getEnvVars = (env: NodeJS.ProcessEnv = process.env): PgpmOptions =>
       DB_PREFIX,
       DB_EXTENSIONS,
       DB_CWD,
+      PGPM_EXTENSIONS_DIR,
       DB_CONNECTION_USER,
       DB_CONNECTION_PASSWORD,
       DB_CONNECTION_ROLE,
@@ -87,6 +88,7 @@ export const getEnvVars = (env: NodeJS.ProcessEnv = process.env): PgpmOptions =>
   } = env;
 
   return {
+    ...(PGPM_EXTENSIONS_DIR && { extensionsDir: PGPM_EXTENSIONS_DIR }),
     db: {
       ...(PGROOTDATABASE && { rootDb: PGROOTDATABASE }),
       ...(PGTEMPLATE && { template: PGTEMPLATE }),

--- a/pgpm/env/src/index.ts
+++ b/pgpm/env/src/index.ts
@@ -11,6 +11,6 @@ export {
   resolveWorkspaceByType
 } from './config';
 export { getEnvVars, getNodeEnv, parseEnvBoolean, parseEnvList, parseEnvNumber } from './env';
-export { getConnEnvOptions, getDeploymentEnvOptions,getEnvOptions } from './merge';
+export { getConnEnvOptions, getDeploymentEnvOptions,getEnvOptions, getExtensionsDir } from './merge';
 export { replaceArrays,walkUp } from './utils';
 export type { DeploymentOptions,PgpmOptions, PgTestConnectionOptions } from '@pgpmjs/types';

--- a/pgpm/env/src/merge.ts
+++ b/pgpm/env/src/merge.ts
@@ -1,4 +1,4 @@
-import { DeploymentOptions,pgpmDefaults, PgpmOptions, PgTestConnectionOptions } from '@pgpmjs/types';
+import { DEFAULT_EXTENSIONS_DIR,DeploymentOptions,pgpmDefaults, PgpmOptions, PgTestConnectionOptions } from '@pgpmjs/types';
 import deepmerge from 'deepmerge';
 
 import { assertProductionEnvOptions } from './assert';
@@ -65,6 +65,22 @@ export const getConnEnvOptions = (overrides: Partial<PgTestConnectionOptions> = 
       }
     }
   };
+};
+
+/**
+ * Resolve the workspace directory where pgpm modules are installed.
+ *
+ * Precedence: explicit override -> `PGPM_EXTENSIONS_DIR` env var ->
+ * `extensionsDir` in the pgpm config file (pgpm.json / pgpm.config.js) ->
+ * the `extensions` default.
+ */
+export const getExtensionsDir = (
+  override?: string,
+  cwd: string = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env
+): string => {
+  if (override) return override;
+  return getEnvOptions({}, cwd, env).extensionsDir ?? DEFAULT_EXTENSIONS_DIR;
 };
 
 export const getDeploymentEnvOptions = (overrides: Partial<DeploymentOptions> = {}, cwd: string = process.cwd()): DeploymentOptions => {

--- a/pgpm/types/src/pgpm.ts
+++ b/pgpm/types/src/pgpm.ts
@@ -217,6 +217,12 @@ export interface PgpmWorkspaceConfig {
    */
   dependencies?: Record<string, string>;
   /**
+   * Directory (relative to the workspace root) where pgpm modules are installed.
+   * Defaults to `extensions`. Useful for keeping ephemeral test/fixture installs
+   * out of a committed `extensions/` directory.
+   */
+  extensionsDir?: string;
+  /**
    * Template source recorded at scaffold time when the workspace is created
    * from a non-default boilerplate repo (e.g. via `pgpm init workspace --pglite`
    * or `--repo`). `pgpm init` reads this so modules created inside the workspace
@@ -280,12 +286,22 @@ export interface PgpmOptions {
     /** SMTP email configuration */
     smtp?: SmtpOptions;
     /**
+     * Directory (relative to the workspace root) where pgpm modules are installed
+     * by `pgpm install`. Defaults to `extensions`.
+     */
+    extensionsDir?: string;
+    /**
      * Pluggable migration backend. Undefined = built-in `pg` (server) path.
      * Set `driver.plugin` to a package (e.g. `@pgpmjs/pglite-adapter`) resolved
      * from the consumer's `node_modules`.
      */
     driver?: PgpmDriverConfig;
 }
+
+/**
+ * Default directory (relative to the workspace root) where pgpm modules are installed.
+ */
+export const DEFAULT_EXTENSIONS_DIR = 'extensions';
 
 /**
  * Default configuration values for PGPM framework
@@ -355,6 +371,7 @@ export const pgpmDefaults: PgpmOptions = {
     maxLength: 10000,
     verbose: false
   },
+  extensionsDir: DEFAULT_EXTENSIONS_DIR,
   smtp: {
     port: 587,
     secure: false,


### PR DESCRIPTION
## Summary

`pgpm install` hardcoded `extensions/` as the workspace install dir (`const EXTENSIONS_DIR = 'extensions'` in `pgpm/core/src/core/class/pgpm.ts`), so ephemeral test/fixture installs always collided with a committed `extensions/`. The dir is now a first-class config knob resolved through the unified env system.

**Config knob** — `extensionsDir`, resolved by the new `getExtensionsDir()` in `@pgpmjs/env`:

```ts
getExtensionsDir(override?, cwd?, env?)
//  override (PgpmPackage option / --extensions-dir)
//  → PGPM_EXTENSIONS_DIR
//  → `extensionsDir` in pgpm.json / pgpm.config.js
//  → DEFAULT_EXTENSIONS_DIR ('extensions')
```

Note the precedence: env beats config file, matching the repo-wide `getEnvOptions` hierarchy (defaults → config → env → overrides) rather than config-over-env. `extensionsDir` was added to `PgpmOptions` (+ `pgpmDefaults`) and to `PgpmWorkspaceConfig`; `PGPM_EXTENSIONS_DIR` is parsed in `getEnvVars`.

**Resolution point** — `PgpmPackage` gains an options bag and resolves once per `resetCwd`:

```ts
new PgpmPackage(cwd, { extensionsDir: 'extensions-test' })
pkg.extensionsDir      // resolved name
pkg.getExtensionsPath() // <workspace>/<extensionsDir>
```

Sub-projects it constructs (`getModules`, `getModuleProject`) and the ones built by deploy/verify/revert inherit the resolved dir, so an explicit option propagates through a whole deploy. `pgpm/core/src/resolution/deps.ts` still constructs a bare `PgpmPackage(packageDir)` — it has no parent handle, so it picks up config/env but not a programmatic override.

**Call-sites updated** (all in `pgpm/core/src/core/class/pgpm.ts` unless noted):
- `listModules()` glob `join(workspacePath, extensionsDir, '{*,@*/*}')` — this is what makes deploy/verify/revert workspace-extension resolution honor the dir
- `installModules()` staging: `npm install ... --prefix ./${extensionsDir}` and `glob('./${extensionsDir}/**/pgpm.plan')`, plus the destination `getExtensionsPath()`
- `getInstalledModules()`, `getWorkspaceInstalledModules()` scans
- `projects/deploy.ts` (both `moduleProject` and the fast-path `localProject`), `projects/verify.ts`, `projects/revert.ts`
- `pgpm/cli/src/commands/install.ts`: new `--extensions-dir <dir>` flag + help text

Matches for `extensions` in `slice.ts` / `deps.ts` (`change.startsWith('extensions/')`) are change-path prefixes inside a module, not the install dir — intentionally untouched.

**Backward compatible**: with no config, env or flag the resolved dir is `extensions`, and every existing test (incl. snapshots) passes unchanged. The only snapshot churn is `pgpm/env` picking up the new `extensionsDir: 'extensions'` default in the merged-options snapshot.

**Tests** — `pgpm/cli/__tests__/extensions-dir.test.ts` (6 tests): default is `extensions`; `pgpm.json` `extensionsDir` honored from workspace and module cwd; env beats config and option beats both; install of `@pgpm-testing/base32` lands in `extensions-test/` with no `extensions/` created and is then found by `getWorkspaceInstalledModules()` / `getModuleMap()` / `getInstalledModules()`; `--extensions-dir` flag; and an end-to-end deploy against the `simple-w-exts` fixture with `extensions/` renamed to `extensions-test/` and the `extensions/*` package globs removed, so modules are discoverable *only* via the configured dir. `pgpm/env/__tests__/merge.test.ts` adds 4 precedence tests for `getExtensionsDir`.

`.gitignore` also ignores `/extensions-*/` for ephemeral install dirs.


Link to Devin session: https://app.devin.ai/sessions/e60b4374ca3a48ae8c04d573a0f25e64
Requested by: @pyramation