### PR TITLE
test(fixtures): scoped catalog/routing/apps seed + simple-seed-scoped scenario

### DIFF
--- a/__fixtures__/seed/README.md
+++ b/__fixtures__/seed/README.md
@@ -9,6 +9,7 @@ Composable SQL seed layers for integration testing. Each layer builds on the pre
 | **base** | `base/setup.sql` | `uuid-ossp` extension, `stamps` schema + `timestamps()` trigger |
 | **services (real modules)** | `seed.pgpm(repoRoot)` | Real `@pgpm/metaschema-modules` (+ deps: `@pgpm/services`, `@pgpm/metaschema-schema`, ...) installed into the gitignored root `extensions/` — see `.agents/skills/ephemeral-pgpm-fixtures/SKILL.md`; run `pnpm fixtures:install` first |
 | **services data** | `services/test-data.sql` | Example database (`simple-pets`), 3 schemas, 5 APIs, 2 domains, API→schema linkage, animals metaschema entries |
+| **scoped data** | `scoped/resolver.sql`, `scoped/test-data.sql` | Same `simple-pets` tenant expressed on the new schema-only modules (`@constructive-db/{catalog,routing,apps}`): catalog apis/domains, routing apis/api_schemas/domains/routes + compiled hostname/route bindings, apps + app_components — plus the `resolve_route()` resolver the schema-only routing module does not ship |
 | **app-schemas** | `app-schemas/simple-pets/schema.sql` | `simple-pets-*` schemas, animals table with constraints/indexes/triggers |
 | **app data** | `app-schemas/simple-pets/test-data.sql` | 5 test animals (Buddy, Max, Whiskers, Mittens, Tweety) |
 
@@ -53,6 +54,7 @@ Pick only the layers you need:
 - **Metaschema + services only** (no app tables): `seed.pgpm(repoRoot)` + `services/test-data.sql`
 - **Full stack with app data**: `seed.pgpm(repoRoot)` + `app-schemas/*` + `services/test-data.sql` + `app-schemas/*/test-data.sql`
 - **Custom app schema**: `seed.pgpm(repoRoot)` + `services/test-data.sql` + your own schema/data SQL
+- **Scoped routing plane** (catalog/routing/apps instead of services_public): `seed.pgpm(repoRoot)` + `app-schemas/*` + `scoped/resolver.sql` + `scoped/test-data.sql` + `app-schemas/*/test-data.sql`
 
 The installed modules grant `administrator`/`authenticated` — there are no
 `anonymous` grants anywhere (matching production). Server plugins resolve
@@ -66,6 +68,7 @@ These test files use the shared fixtures:
 | Test file | Shared fixtures used |
 |-----------|---------------------|
 | `graphql/server-test/__tests__/server.integration.test.ts` | `base/*` (simple-seed), `services/*` + `app-schemas/*` (services scenarios) |
+| `graphql/server-test/__tests__/scoped-routing.integration.test.ts` | `scoped/*` + `app-schemas/*` (simple-seed-scoped) |
 | `graphql/server-test/__tests__/express-context.integration.test.ts` | `services/*` + `app-schemas/*` |
 | `graphql/server-test/__tests__/upload.integration.test.ts` | `seed.pgpm` modules (storage schemas/data are local) |
 | `graphql/server-test/__tests__/cli-e2e.test.ts` | `base/*` + `app-schemas/*` (animals), `base/*` (search) |

--- a/__fixtures__/seed/scoped/resolver.sql
+++ b/__fixtures__/seed/scoped/resolver.sql
@@ -1,0 +1,79 @@
+-- Shared fixture: scoped-routing resolver (test stand-in)
+--
+-- The published @constructive-db/routing module is SCHEMA + GRANTS ONLY: it
+-- ships the routing tables but no procedures, so
+-- constructive_routing_public.resolve_route() does not exist after
+-- `pnpm fixtures:install`. This file installs the frozen DB<->server resolver
+-- contract verbatim from constructive-db
+-- (application/constructive/deploy/schemas/constructive_routing_public/procedures/resolve_route)
+-- so tests can exercise the scoped-routing path today.
+--
+-- TODO: drop this file once @constructive-db/routing publishes the resolver
+--       procedure and the pinned module provides resolve_route() directly.
+
+CREATE FUNCTION constructive_routing_public.resolve_route(
+  request_host text,
+  request_path text,
+  request_method text,
+  OUT route_binding_id uuid,
+  OUT hostname text,
+  OUT matched_wildcard boolean,
+  OUT matched_path text,
+  OUT method text,
+  OUT priority int,
+  OUT domain_id uuid,
+  OUT target_catalog_id uuid,
+  OUT target_module text,
+  OUT target_source_id uuid,
+  OUT target_owner_scope text,
+  OUT target_owner_key uuid,
+  OUT resolved_config jsonb,
+  OUT verification_status text,
+  OUT tls_status text,
+  OUT tls_secret_name text
+) RETURNS record AS $$
+SELECT
+  rb.id AS route_binding_id,
+  hb.hostname AS hostname,
+  hb.hostname <> split_part(lower(request_host), ':', 1) AS matched_wildcard,
+  rb.path AS matched_path,
+  rb.method AS method,
+  rb.priority AS priority,
+  rb.domain_id AS domain_id,
+  COALESCE(rb.target_api_id, rb.target_site_id, rb.target_function_id) AS target_catalog_id,
+  CASE
+    WHEN rb.target_api_id IS NOT NULL THEN 'api'
+    WHEN rb.target_site_id IS NOT NULL THEN 'site'
+    WHEN rb.target_function_id IS NOT NULL THEN 'function'
+  END AS target_module,
+  COALESCE(a.id, s.id, f.id) AS target_source_id,
+  COALESCE(a.owner_scope, s.owner_scope, f.owner_scope) AS target_owner_scope,
+  nullif(COALESCE(a.owner_key, s.owner_key, f.owner_key), uuid_nil()) AS target_owner_key,
+  CASE
+    WHEN rb.target_api_id IS NOT NULL THEN (COALESCE(a.config, '{}'::jsonb)) || jsonb_strip_nulls(jsonb_build_object('name', a.name, 'dbname', a.dbname, 'role_name', a.role_name, 'anon_role', a.anon_role))
+    WHEN rb.target_site_id IS NOT NULL THEN (COALESCE(s.config, '{}'::jsonb)) || jsonb_strip_nulls(jsonb_build_object('name', s.name))
+    WHEN rb.target_function_id IS NOT NULL THEN jsonb_strip_nulls(jsonb_build_object('task_identifier', f.task_identifier))
+  END AS resolved_config,
+  hb.verification_status AS verification_status,
+  hb.tls_status AS tls_status,
+  hb.tls_secret_name AS tls_secret_name
+FROM "constructive_routing_public".hostname_bindings AS hb
+  INNER JOIN "constructive_routing_public".route_bindings AS rb ON rb.domain_id = hb.domain_id
+  LEFT OUTER JOIN "constructive_catalog_public".apis AS a ON a.id = rb.target_api_id
+  LEFT OUTER JOIN "constructive_catalog_public".sites AS s ON s.id = rb.target_site_id
+  LEFT OUTER JOIN "constructive_catalog_public".functions AS f ON f.id = rb.target_function_id
+WHERE
+  (hb.hostname = split_part(lower(request_host), ':', 1) OR (hb.is_wildcard AND hb.parent_hostname = substr(split_part(lower(request_host), ':', 1), strpos(split_part(lower(request_host), ':', 1), '.') + 1)))
+  AND ((rb.path = '/' OR (concat('/', ltrim(COALESCE(request_path, '/'), '/')) = rb.path OR "left"(concat('/', ltrim(COALESCE(request_path, '/'), '/')), length(rb.path) + 1) = (rb.path || '/')))
+  AND ((rb.method IS NULL OR upper(rb.method) = upper(request_method)) AND rb.is_active))
+ORDER BY
+  hb.hostname = split_part(lower(request_host), ':', 1) DESC,
+  length(rb.path) DESC,
+  rb.method IS NOT NULL DESC,
+  rb.priority DESC,
+  rb.id ASC
+LIMIT 1
+$$ LANGUAGE sql STABLE SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION constructive_routing_public.resolve_route(text, text, text)
+  TO administrator, authenticated, anonymous;

--- a/__fixtures__/seed/scoped/test-data.sql
+++ b/__fixtures__/seed/scoped/test-data.sql
@@ -1,0 +1,239 @@
+-- Shared fixture: metaschema + scoped catalog/routing/apps test data
+--
+-- Scoped-plane equivalent of `services/test-data.sql`: it models the SAME
+-- "simple-pets" tenant (same database id, same APIs, same domains, same
+-- api -> schema linkage) but expressed as rows in the new schema-only modules
+--   - @constructive-db/catalog  -> constructive_catalog_public
+--   - @constructive-db/routing  -> constructive_routing_public
+--   - @constructive-db/apps     -> constructive_apps_public
+-- instead of services_public.
+--
+-- The metaschema block below is identical to `services/test-data.sql` so this
+-- file can be composed standalone (routing.api_schemas.schema_id FKs
+-- metaschema_public.schema).
+--
+-- `constructive_routing_public.{hostname_bindings,route_bindings}` are the
+-- compiled indexes read by resolve_route(). In production they are maintained
+-- by domain/route sync triggers, which the schema-only modules do not ship, so
+-- this fixture writes both the source rows (domains/routes) and the compiled
+-- rows explicitly.
+--
+-- NOTE: does NOT include app-level schemas/tables or row data.
+--       Compose with app-schemas/* seeds and `scoped/resolver.sql` for that.
+
+SET session_replication_role TO replica;
+
+-- =====================================================
+-- METASCHEMA DATA
+-- =====================================================
+
+-- Database entry (ID matches servicesDatabaseId in test files)
+INSERT INTO metaschema_public.database (id, owner_id, name, hash)
+VALUES (
+  '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9',
+  NULL,
+  'simple-pets',
+  '425a0f10-0170-5760-85df-2a980c378224'
+) ON CONFLICT (id) DO NOTHING;
+
+-- Schema entries
+INSERT INTO metaschema_public.schema (id, database_id, name, schema_name, description, is_public)
+VALUES
+  ('6dbae92a-5450-401b-1ed5-d69e7754940d', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', 'public', 'simple-pets-public', NULL, true),
+  ('6dba9876-043f-48ee-399d-ddc991ad978d', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', 'private', 'simple-pets-private', NULL, false),
+  ('6dba6f21-0193-43f4-3bdb-61b4b956b6b6', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', 'pets_public', 'simple-pets-pets-public', NULL, true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Table entry for animals
+INSERT INTO metaschema_public.table (id, database_id, schema_id, name, description)
+VALUES (
+  '6dba36e9-b098-4157-1b4c-e5b6e3a885de',
+  '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9',
+  '6dba6f21-0193-43f4-3bdb-61b4b956b6b6',
+  'animals',
+  NULL
+) ON CONFLICT (id) DO NOTHING;
+
+-- Field entries for animals table
+INSERT INTO metaschema_public.field (id, database_id, table_id, name, type, description)
+VALUES
+  ('6dbace4d-bcf9-4d55-e363-6b24623f0d8a', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', '6dba36e9-b098-4157-1b4c-e5b6e3a885de', 'id', 'uuid', NULL),
+  ('6dbae9c7-3460-4f65-8290-b2a8e05eb714', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', '6dba36e9-b098-4157-1b4c-e5b6e3a885de', 'name', 'text', NULL),
+  ('6dbacc68-876e-4ece-b190-706819ae4f00', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', '6dba36e9-b098-4157-1b4c-e5b6e3a885de', 'species', 'text', NULL),
+  ('6dba080e-bb3f-4556-8ca7-425ceb98a519', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', '6dba36e9-b098-4157-1b4c-e5b6e3a885de', 'owner_id', 'uuid', NULL)
+ON CONFLICT (id) DO NOTHING;
+
+-- Primary key constraint
+INSERT INTO metaschema_public.primary_key_constraint (id, database_id, table_id, name, type, field_ids)
+VALUES (
+  '6dbaeb74-b5cf-46d5-4724-6ab26c27da2d',
+  '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9',
+  '6dba36e9-b098-4157-1b4c-e5b6e3a885de',
+  'animals_pkey',
+  'p',
+  '{6dbace4d-bcf9-4d55-e363-6b24623f0d8a}'
+) ON CONFLICT (id) DO NOTHING;
+
+-- =====================================================
+-- CATALOG DATA (constructive_catalog_public)
+-- =====================================================
+--
+-- `apis.config` carries the api surface projection the server folds into
+-- ApiStructure via resolve_route().resolved_config (api_id, database_id,
+-- is_public, schemas); name/dbname/role_name/anon_role are merged in by the
+-- resolver from the columns below.
+
+INSERT INTO constructive_catalog_public.apis
+  (id, owner_scope, owner_key, is_visible, database_id, name, dbname, role_name, anon_role, config)
+VALUES
+  (
+    '6c9997a4-591b-4cb3-9313-4ef45d6f134e', 'database', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', true,
+    '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', 'app', current_database(), 'authenticated', 'anonymous',
+    jsonb_build_object(
+      'api_id', '6c9997a4-591b-4cb3-9313-4ef45d6f134e',
+      'database_id', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9',
+      'is_public', true,
+      'schemas', jsonb_build_array('simple-pets-public', 'simple-pets-pets-public')
+    )
+  ),
+  (
+    'e257c53d-6ba6-40de-b679-61b37188a316', 'database', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', false,
+    '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', 'private', current_database(), 'administrator', 'administrator',
+    jsonb_build_object(
+      'api_id', 'e257c53d-6ba6-40de-b679-61b37188a316',
+      'database_id', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9',
+      'is_public', false,
+      'schemas', jsonb_build_array('simple-pets-public', 'simple-pets-private', 'simple-pets-pets-public')
+    )
+  ),
+  (
+    '28199444-da40-40b1-8a4c-53edbf91c738', 'database', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', true,
+    '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', 'public', current_database(), 'authenticated', 'anonymous',
+    jsonb_build_object(
+      'api_id', '28199444-da40-40b1-8a4c-53edbf91c738',
+      'database_id', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9',
+      'is_public', true,
+      'schemas', jsonb_build_array('simple-pets-public')
+    )
+  ),
+  (
+    'cc1e8389-e69d-4e12-9089-a98bf11fc75f', 'database', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', true,
+    '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', 'admin', current_database(), 'authenticated', 'anonymous',
+    jsonb_build_object(
+      'api_id', 'cc1e8389-e69d-4e12-9089-a98bf11fc75f',
+      'database_id', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9',
+      'is_public', true,
+      'schemas', jsonb_build_array('simple-pets-public')
+    )
+  ),
+  (
+    'a2e6098f-2c11-4f2a-b481-c19175bc62ef', 'database', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', true,
+    '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', 'auth', current_database(), 'authenticated', 'anonymous',
+    jsonb_build_object(
+      'api_id', 'a2e6098f-2c11-4f2a-b481-c19175bc62ef',
+      'database_id', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9',
+      'is_public', true,
+      'schemas', jsonb_build_array('simple-pets-public')
+    )
+  )
+ON CONFLICT (id) DO NOTHING;
+
+-- Catalog domains: globally-claimed hostnames (same ids as services domains)
+INSERT INTO constructive_catalog_public.domains
+  (id, owner_scope, owner_key, is_visible, database_id, hostname, is_wildcard, parent_hostname, managed, verification_status, tls_status)
+VALUES
+  (
+    '41181146-890e-4991-9da7-3dddf87d9e78', 'database', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', true,
+    '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', 'app.test.constructive.io', false, NULL, false, 'verified', 'ready'
+  ),
+  (
+    '51181146-890e-4991-9da7-3dddf87d9e79', 'database', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', false,
+    '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', 'private.test.constructive.io', false, NULL, false, 'verified', 'ready'
+  )
+ON CONFLICT (id) DO NOTHING;
+
+-- =====================================================
+-- ROUTING DATA (constructive_routing_public)
+-- =====================================================
+
+-- Routing-side api surfaces (own the api_schemas / settings joins)
+INSERT INTO constructive_routing_public.apis
+  (id, database_id, name, dbname, role_name, anon_role, is_published)
+VALUES
+  ('6c9997a4-591b-4cb3-9313-4ef45d6f134e', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', 'app', current_database(), 'authenticated', 'anonymous', true),
+  ('e257c53d-6ba6-40de-b679-61b37188a316', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', 'private', current_database(), 'administrator', 'administrator', false),
+  ('28199444-da40-40b1-8a4c-53edbf91c738', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', 'public', current_database(), 'authenticated', 'anonymous', true),
+  ('cc1e8389-e69d-4e12-9089-a98bf11fc75f', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', 'admin', current_database(), 'authenticated', 'anonymous', true),
+  ('a2e6098f-2c11-4f2a-b481-c19175bc62ef', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', 'auth', current_database(), 'authenticated', 'anonymous', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- API -> schema linkage (mirrors services_public.api_schemas)
+INSERT INTO constructive_routing_public.api_schemas (id, database_id, schema_id, api_id)
+VALUES
+  -- app API schemas (public + pets_public)
+  ('71181146-890e-4991-9da7-3dddf87d9e01', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', '6dbae92a-5450-401b-1ed5-d69e7754940d', '6c9997a4-591b-4cb3-9313-4ef45d6f134e'),
+  ('71181146-890e-4991-9da7-3dddf87d9e02', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', '6dba6f21-0193-43f4-3bdb-61b4b956b6b6', '6c9997a4-591b-4cb3-9313-4ef45d6f134e'),
+  -- private API schemas (public + private + pets_public)
+  ('71181146-890e-4991-9da7-3dddf87d9e03', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', '6dbae92a-5450-401b-1ed5-d69e7754940d', 'e257c53d-6ba6-40de-b679-61b37188a316'),
+  ('71181146-890e-4991-9da7-3dddf87d9e04', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', '6dba9876-043f-48ee-399d-ddc991ad978d', 'e257c53d-6ba6-40de-b679-61b37188a316'),
+  ('71181146-890e-4991-9da7-3dddf87d9e05', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', '6dba6f21-0193-43f4-3bdb-61b4b956b6b6', 'e257c53d-6ba6-40de-b679-61b37188a316')
+ON CONFLICT (id) DO NOTHING;
+
+-- Routing-side domains (source rows for the compiled hostname index)
+INSERT INTO constructive_routing_public.domains
+  (id, database_id, hostname, managed, is_wildcard, parent_hostname, verification_status, tls_status, tls_secret_name, is_published)
+VALUES
+  ('41181146-890e-4991-9da7-3dddf87d9e78', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', 'app.test.constructive.io', false, false, NULL, 'verified', 'ready', NULL, true),
+  ('51181146-890e-4991-9da7-3dddf87d9e79', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', 'private.test.constructive.io', false, false, NULL, 'verified', 'ready', NULL, false)
+ON CONFLICT (id) DO NOTHING;
+
+-- Routes: hostname root path -> api surface (source rows)
+INSERT INTO constructive_routing_public.routes
+  (id, database_id, domain_id, target_api_id, path, method, priority, is_active)
+VALUES
+  ('91181146-890e-4991-9da7-3dddf87d9e01', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', '41181146-890e-4991-9da7-3dddf87d9e78', '6c9997a4-591b-4cb3-9313-4ef45d6f134e', '/', NULL, 0, true),
+  ('91181146-890e-4991-9da7-3dddf87d9e02', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', '51181146-890e-4991-9da7-3dddf87d9e79', 'e257c53d-6ba6-40de-b679-61b37188a316', '/', NULL, 0, true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Compiled hostname index (normally maintained by domain sync triggers)
+INSERT INTO constructive_routing_public.hostname_bindings
+  (id, hostname, domain_id, is_wildcard, parent_hostname, managed, verification_status, tls_status, tls_secret_name)
+VALUES
+  ('a1181146-890e-4991-9da7-3dddf87d9e01', 'app.test.constructive.io', '41181146-890e-4991-9da7-3dddf87d9e78', false, NULL, false, 'verified', 'ready', NULL),
+  ('a1181146-890e-4991-9da7-3dddf87d9e02', 'private.test.constructive.io', '51181146-890e-4991-9da7-3dddf87d9e79', false, NULL, false, 'verified', 'ready', NULL)
+ON CONFLICT (id) DO NOTHING;
+
+-- Compiled route precedence index (normally maintained by route sync triggers)
+INSERT INTO constructive_routing_public.route_bindings
+  (id, domain_id, target_api_id, target_site_id, target_function_id, path, method, priority, is_active)
+VALUES
+  ('b1181146-890e-4991-9da7-3dddf87d9e01', '41181146-890e-4991-9da7-3dddf87d9e78', '6c9997a4-591b-4cb3-9313-4ef45d6f134e', NULL, NULL, '/', NULL, 0, true),
+  ('b1181146-890e-4991-9da7-3dddf87d9e02', '51181146-890e-4991-9da7-3dddf87d9e79', 'e257c53d-6ba6-40de-b679-61b37188a316', NULL, NULL, '/', NULL, 0, true)
+ON CONFLICT (id) DO NOTHING;
+
+-- =====================================================
+-- APPS DATA (constructive_apps_public)
+-- =====================================================
+
+INSERT INTO constructive_apps_public.apps
+  (id, database_id, name, title, description, status, is_published)
+VALUES (
+  'c1181146-890e-4991-9da7-3dddf87d9e01',
+  '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9',
+  'simple-pets',
+  'Simple Pets',
+  'Scoped-plane fixture app for the simple-pets tenant',
+  'active',
+  true
+) ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO constructive_apps_public.app_components
+  (id, database_id, app_id, component_api_id, component_domain_id, component_type)
+VALUES
+  ('d1181146-890e-4991-9da7-3dddf87d9e01', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', 'c1181146-890e-4991-9da7-3dddf87d9e01', '6c9997a4-591b-4cb3-9313-4ef45d6f134e', NULL, 'api'),
+  ('d1181146-890e-4991-9da7-3dddf87d9e02', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', 'c1181146-890e-4991-9da7-3dddf87d9e01', 'e257c53d-6ba6-40de-b679-61b37188a316', NULL, 'api'),
+  ('d1181146-890e-4991-9da7-3dddf87d9e03', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', 'c1181146-890e-4991-9da7-3dddf87d9e01', NULL, '41181146-890e-4991-9da7-3dddf87d9e78', 'domain'),
+  ('d1181146-890e-4991-9da7-3dddf87d9e04', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', 'c1181146-890e-4991-9da7-3dddf87d9e01', NULL, '51181146-890e-4991-9da7-3dddf87d9e79', 'domain')
+ON CONFLICT (id) DO NOTHING;
+
+SET session_replication_role TO DEFAULT;

--- a/graphql/server-test/__tests__/scoped-routing.integration.test.ts
+++ b/graphql/server-test/__tests__/scoped-routing.integration.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Scoped Routing Integration Tests (simple-seed-scoped)
+ *
+ * Exercises the new schema-only pgpm modules
+ *   @constructive-db/catalog → constructive_catalog_public
+ *   @constructive-db/routing → constructive_routing_public
+ *   @constructive-db/apps    → constructive_apps_public
+ * seeded from `__fixtures__/seed/scoped/*` for the same "simple-pets" tenant
+ * that `__fixtures__/seed/services/test-data.sql` models on services_public.
+ *
+ * Run tests:
+ *   pnpm test -- --testPathPattern=scoped-routing.integration
+ */
+
+import path from 'path';
+import type { PgTestClient } from 'pgsql-test/test-client';
+import type supertest from 'supertest';
+
+import { getConnections, seed } from '../src';
+
+jest.setTimeout(60000);
+
+const sharedSeedRoot = path.join(__dirname, '..', '..', '..', '__fixtures__', 'seed');
+const shared = (...segments: string[]) =>
+  path.join(sharedSeedRoot, ...segments);
+const pgpmWorkspace = path.join(sharedSeedRoot, '..', '..');
+const schemas = ['simple-pets-public', 'simple-pets-pets-public'];
+const scopedDatabaseId = '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9';
+const appApiId = '6c9997a4-591b-4cb3-9313-4ef45d6f134e';
+const privateApiId = 'e257c53d-6ba6-40de-b679-61b37188a316';
+const scopedMetaSchemas = [
+  'constructive_catalog_public',
+  'constructive_routing_public',
+  'constructive_apps_public',
+  'metaschema_public',
+  'metaschema_modules_public'
+];
+
+/** Row shape returned by constructive_routing_public.resolve_route(). */
+interface ResolvedRouteRow {
+  route_binding_id: string | null;
+  hostname: string | null;
+  matched_wildcard: boolean | null;
+  matched_path: string | null;
+  target_module: string | null;
+  target_source_id: string | null;
+  target_owner_scope: string | null;
+  target_owner_key: string | null;
+  resolved_config: Record<string, unknown> | null;
+  verification_status: string | null;
+  tls_status: string | null;
+}
+
+const scopedSeedAdapters = () => [
+  seed.pgpm(pgpmWorkspace),
+  seed.sqlfile([
+    shared('app-schemas', 'simple-pets', 'schema.sql'),
+    shared('scoped', 'resolver.sql'),
+    shared('scoped', 'test-data.sql'),
+    shared('app-schemas', 'simple-pets', 'test-data.sql')
+  ])
+];
+
+describe('simple-seed-scoped: resolve_route (SQL level)', () => {
+  let pg: PgTestClient;
+  let teardown: () => Promise<void>;
+
+  const resolveRoute = (host: string) =>
+    pg.oneOrNone<ResolvedRouteRow>(
+      `SELECT * FROM constructive_routing_public.resolve_route($1, '/', NULL)`,
+      [host]
+    );
+
+  beforeAll(async () => {
+    ({ pg, teardown } = await getConnections(
+      {
+        schemas,
+        authRole: 'anonymous',
+        server: { api: { enableServicesApi: false, isPublic: false } }
+      },
+      scopedSeedAdapters()
+    ));
+  });
+
+  afterAll(async () => {
+    await teardown();
+  });
+
+  it('deploys the scoped catalog/routing/apps schemas', async () => {
+    const rows = await pg.any<{ nspname: string }>(
+      `SELECT nspname FROM pg_namespace WHERE nspname LIKE 'constructive_%' ORDER BY nspname`
+    );
+    expect(rows.map((r) => r.nspname)).toEqual([
+      'constructive_apps_public',
+      'constructive_catalog_public',
+      'constructive_routing_public'
+    ]);
+  });
+
+  it('resolves the public app host to the app api surface', async () => {
+    const route = await resolveRoute('app.test.constructive.io');
+
+    expect(route).not.toBeNull();
+    expect(route!.route_binding_id).not.toBeNull();
+    expect(route!.hostname).toBe('app.test.constructive.io');
+    expect(route!.matched_wildcard).toBe(false);
+    expect(route!.matched_path).toBe('/');
+    expect(route!.target_module).toBe('api');
+    expect(route!.target_source_id).toBe(appApiId);
+    expect(route!.target_owner_scope).toBe('database');
+    expect(route!.target_owner_key).toBe(scopedDatabaseId);
+    expect(route!.verification_status).toBe('verified');
+    expect(route!.tls_status).toBe('ready');
+    expect(route!.resolved_config).toMatchObject({
+      name: 'app',
+      api_id: appApiId,
+      database_id: scopedDatabaseId,
+      is_public: true,
+      role_name: 'authenticated',
+      anon_role: 'anonymous',
+      schemas
+    });
+    // The server needs dbname + schemas to build an ApiStructure.
+    expect(typeof route!.resolved_config!.dbname).toBe('string');
+  });
+
+  it('resolves the private host to the private api surface', async () => {
+    const route = await resolveRoute('private.test.constructive.io');
+
+    expect(route).not.toBeNull();
+    expect(route!.target_source_id).toBe(privateApiId);
+    expect(route!.resolved_config).toMatchObject({
+      name: 'private',
+      is_public: false,
+      role_name: 'administrator',
+      anon_role: 'administrator',
+      schemas: [
+        'simple-pets-public',
+        'simple-pets-private',
+        'simple-pets-pets-public'
+      ]
+    });
+  });
+
+  it('returns a null binding for an unknown host', async () => {
+    const route = await resolveRoute('nope.test.constructive.io');
+    expect(route!.route_binding_id).toBeNull();
+  });
+
+  it('ignores port suffixes on the request host', async () => {
+    const route = await resolveRoute('app.test.constructive.io:5678');
+    expect(route!.target_source_id).toBe(appApiId);
+  });
+});
+
+/**
+ * End-to-end scoped plane: the request is resolved by
+ * constructive_routing_public.resolve_route() (enableScopedRouting), and the
+ * legacy services_public domain lookup is only the fallback — the scoped seed
+ * has no services_public rows, so a successful request proves the scoped path.
+ */
+describe('simple-seed-scoped: GraphQL over scoped routing (e2e)', () => {
+  let request: supertest.Agent;
+  let teardown: () => Promise<void>;
+
+  const postGraphQL = (payload: { query: string }) =>
+    request
+      .post('/graphql')
+      .set('Host', 'app.test.constructive.io')
+      .send(payload);
+
+  beforeAll(async () => {
+    ({ request, teardown } = await getConnections(
+      {
+        schemas,
+        authRole: 'anonymous',
+        server: {
+          api: {
+            enableServicesApi: true,
+            enableScopedRouting: true,
+            scopedRoutingSchema: 'constructive_routing_public',
+            isPublic: true,
+            metaSchemas: scopedMetaSchemas
+          }
+        }
+      },
+      scopedSeedAdapters()
+    ));
+  });
+
+  afterAll(async () => {
+    await teardown();
+  });
+
+  it('resolves the host through the scoped plane and mutates', async () => {
+    const createRes = await postGraphQL({
+      query: `mutation {
+        createAnimal(input: { animal: { name: "ScopedHamster", species: "Hamster" } }) {
+          animal { id name species }
+        }
+      }`
+    });
+
+    expect(createRes.status).toBe(200);
+    expect(createRes.body.data.createAnimal.animal.name).toBe('ScopedHamster');
+  });
+
+  // TODO: connection (list) queries currently fail for EVERY server integration
+  // scenario on main — `{ animals { nodes { ... } } }` throws
+  // `TypeError: Cannot read properties of undefined (reading 'items')` inside
+  // grafast's ConnectionStep, including the legacy simple-seed/services
+  // scenarios in server.integration.test.ts. Unskip once that regression is
+  // fixed; scoped resolution itself already works (see the mutation above).
+  it.skip('should query all animals', async () => {
+    const res = await postGraphQL({
+      query: '{ animals { nodes { name species } } }'
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.animals.nodes).toHaveLength(5);
+  });
+});

--- a/pgpm.json
+++ b/pgpm.json
@@ -3,6 +3,9 @@
     "testing/*"
   ],
   "dependencies": {
+    "@constructive-db/apps": "1.0.1",
+    "@constructive-db/catalog": "1.0.1",
+    "@constructive-db/routing": "1.0.1",
     "@pgpm/database-jobs": "0.33.0",
     "@pgpm/function-resolution": "0.33.0",
     "@pgpm/jwt-claims": "0.33.0",


### PR DESCRIPTION
## Summary

Groundwork for migrating tests off `services_public` onto the new scoped plane. Pins the three published schema-only modules and adds a `simple-seed-scoped` fixture + test that models the **same** `simple-pets` tenant (same database id, APIs, domains, api→schema linkage) as `__fixtures__/seed/services/test-data.sql`, but as catalog/routing/apps rows.

`pgpm.json` gains exact pins `@constructive-db/{catalog,apps,routing}@1.0.1`; `pnpm fixtures:install` vendors them into the gitignored `extensions/` and they deploy cleanly alongside metaschema (`constructive_{catalog,routing,apps}_public`).

New fixtures:

- `__fixtures__/seed/scoped/test-data.sql` — metaschema block (same as the services fixture, needed for `routing.api_schemas.schema_id`) + catalog `apis`/`domains`, routing `apis`/`api_schemas`/`domains`/`routes`, apps `apps`/`app_components`. `hostname_bindings` / `route_bindings` are the compiled indexes `resolve_route()` reads; production maintains them via sync triggers that the schema-only modules don't ship, so the fixture writes them explicitly.
- `__fixtures__/seed/scoped/resolver.sql` — **stand-in**: `@constructive-db/routing@1.0.1` is schema + grants only, so `constructive_routing_public.resolve_route()` does not exist after install. This installs the frozen resolver verbatim from `constructive-db@application/constructive/.../resolve_route/procedure.sql`, with a TODO to delete it once the module publishes the procedure.

Because the resolver folds `apis.config` into `resolved_config`, the catalog api rows carry the server-side projection the middleware needs:

```sql
config = {"api_id", "database_id", "is_public",
          "schemas": ["simple-pets-public", "simple-pets-pets-public"]}
-- resolve_route() merges in name/dbname/role_name/anon_role from columns
```

New `graphql/server-test/__tests__/scoped-routing.integration.test.ts`:

- **SQL level (green)** — `resolve_route(host, '/', NULL)` returns the app/private api surfaces with `dbname` + `schemas`, `target_module = 'api'`, owner scope/key, null binding for unknown hosts, port-suffix stripping.
- **e2e over scoped routing (green mutation)** — server configured with `enableScopedRouting: true` + `scopedRoutingSchema: 'constructive_routing_public'` and scoped-only seed data (no `services_public` rows), so a successful request proves resolution went through the scoped plane; the log confirms `key=app.test.constructive.io schemas=simple-pets-public,simple-pets-pets-public role=authenticated`.
- The golden `{ animals { nodes { name species } } }` assertion is `it.skip` with a TODO: connection/list queries currently fail in **every** server integration scenario on `main` (`TypeError: Cannot read properties of undefined (reading 'items')` in grafast `ConnectionStep`) — `server.integration.test.ts` is 29 failed / 11 passed on a clean checkout, mutations pass.

No server / express-context / codegen changes; `@pgpm/services` pin and services scenarios are untouched. `extensions/` stays uncommitted.

Note: scoped routing is only consulted in `domain-lookup` mode, so the e2e scenario keeps `enableServicesApi: true` — `enableServicesApi: false` short-circuits the api middleware before `resolveScopedRoute()`.


Link to Devin session: https://app.devin.ai/sessions/f7e23e0e1bd345f7a624c1b719ed9ef9
Requested by: @pyramation