### PR TITLE
feat(export): hard break off services_public onto scoped planes + surface modules

### DIFF
--- a/pgpm/export/__tests__/__snapshots__/export-flow.test.ts.snap
+++ b/pgpm/export/__tests__/__snapshots__/export-flow.test.ts.snap
@@ -21,11 +21,18 @@ exports[`Export Flow E2E Export to second workspace should match snapshot for se
 [
   "migrate/",
   "migrate/api_schemas.sql",
+  "migrate/api_surface_module.sql",
   "migrate/apis.sql",
+  "migrate/app_module.sql",
+  "migrate/catalog_module.sql",
   "migrate/database.sql",
+  "migrate/database_settings_module.sql",
+  "migrate/domain_module.sql",
   "migrate/domains.sql",
   "migrate/field.sql",
+  "migrate/route_module.sql",
   "migrate/schema.sql",
+  "migrate/site_surface_module.sql",
   "migrate/sites.sql",
   "migrate/table.sql",
 ]

--- a/pgpm/export/__tests__/cross-flow-parity.test.ts
+++ b/pgpm/export/__tests__/cross-flow-parity.test.ts
@@ -20,7 +20,7 @@ import { toCamelCase } from 'inflekt';
 import { exportMeta } from '../src/export-meta';
 import { exportGraphQLMeta } from '../src/export-graphql-meta';
 import { GraphQLClient } from '../src/graphql-client';
-import { META_TABLE_CONFIG, FieldType } from '../src/export-utils';
+import { META_TABLE_CONFIG } from '../src/export-utils';
 import { getGraphQLQueryName, getGraphQLTypeName, GraphQLTypeInfo } from '../src/graphql-naming';
 import { lookupByPgUdt } from '../src/type-map';
 
@@ -47,6 +47,8 @@ const INDEX_ID = 'd0000001-0000-0000-0000-000000000001';
 const POLICY_ID = 'd1000001-0000-0000-0000-000000000001';
 const CORS_SETTINGS_ID = 'd2000001-0000-0000-0000-000000000001';
 const USER_AUTH_MODULE_ID = 'd3000001-0000-0000-0000-000000000001';
+const CATALOG_MODULE_ID = 'd4000001-0000-0000-0000-000000000001';
+const ROUTE_MODULE_ID = 'd5000001-0000-0000-0000-000000000001';
 
 // =============================================================================
 // Helper: build a mock GraphQLClient that reads from the real database
@@ -310,7 +312,7 @@ describe('Cross-flow parity: exportMeta vs exportGraphQLMeta', () => {
         // Create schemas and tables
         await pg.query(`
           CREATE SCHEMA IF NOT EXISTS metaschema_public;
-          CREATE SCHEMA IF NOT EXISTS services_public;
+          CREATE SCHEMA IF NOT EXISTS constructive_routing_public;
           CREATE SCHEMA IF NOT EXISTS metaschema_modules_public;
 
           -- metaschema_public tables
@@ -344,34 +346,37 @@ describe('Cross-flow parity: exportMeta vs exportGraphQLMeta', () => {
             description text
           );
 
-          -- services_public tables
-          CREATE TABLE services_public.domains (
+          -- constructive_routing_public tables
+          CREATE TABLE constructive_routing_public.domains (
             id uuid PRIMARY KEY,
             database_id uuid,
-            site_id uuid,
-            api_id uuid,
-            domain text,
-            subdomain text
+            hostname text,
+            managed boolean,
+            is_wildcard boolean,
+            parent_hostname text,
+            verification_status text,
+            tls_status text,
+            is_published boolean
           );
-          CREATE TABLE services_public.sites (
-            id uuid PRIMARY KEY,
-            database_id uuid,
-            title text,
-            description text,
-            og_image text,
-            favicon text,
-            apple_touch_icon text,
-            logo text
-          );
-          CREATE TABLE services_public.apis (
+          CREATE TABLE constructive_routing_public.sites (
             id uuid PRIMARY KEY,
             database_id uuid,
             name text,
-            is_public boolean,
-            role_name text,
-            anon_role text
+            title text,
+            description text,
+            config jsonb,
+            is_published boolean
           );
-          CREATE TABLE services_public.api_schemas (
+          CREATE TABLE constructive_routing_public.apis (
+            id uuid PRIMARY KEY,
+            database_id uuid,
+            name text,
+            is_published boolean,
+            role_name text,
+            anon_role text,
+            config jsonb
+          );
+          CREATE TABLE constructive_routing_public.api_schemas (
             id uuid PRIMARY KEY,
             database_id uuid,
             schema_id uuid,
@@ -403,13 +408,35 @@ describe('Cross-flow parity: exportMeta vs exportGraphQLMeta', () => {
             force_enabled boolean,
             priority int4
           );
-          CREATE TABLE services_public.cors_settings (
+          CREATE TABLE constructive_routing_public.cors_settings (
             id uuid PRIMARY KEY,
             database_id uuid,
             api_id uuid,
-            allowed_origins text[],
-            allow_credentials boolean,
-            max_age int4
+            allowed_origins text[]
+          );
+          CREATE TABLE metaschema_modules_public.catalog_module (
+            id uuid PRIMARY KEY,
+            database_id uuid,
+            schema_id uuid,
+            public_schema_name text,
+            domains_table_name text,
+            apis_table_name text,
+            sites_table_name text,
+            apps_table_name text,
+            scope text,
+            policies jsonb
+          );
+          CREATE TABLE metaschema_modules_public.route_module (
+            id uuid PRIMARY KEY,
+            database_id uuid,
+            schema_id uuid,
+            catalog_module_id uuid,
+            domain_module_id uuid,
+            routes_table_name text,
+            hostname_bindings_table_name text,
+            route_bindings_table_name text,
+            scope text,
+            prefix text
           );
           CREATE TABLE metaschema_modules_public.user_auth_module (
             id uuid PRIMARY KEY,
@@ -452,22 +479,22 @@ describe('Cross-flow parity: exportMeta vs exportGraphQLMeta', () => {
         `, [FIELD_ID_1, DATABASE_ID, TABLE_ID_USERS, FIELD_ID_2, FIELD_ID_3, TABLE_ID_POSTS]);
 
         await pg.query(`
-          INSERT INTO services_public.apis (id, database_id, name, is_public, role_name, anon_role)
+          INSERT INTO constructive_routing_public.apis (id, database_id, name, is_published, role_name, anon_role)
           VALUES ($1, $2, 'public-api', true, 'authenticated', 'anonymous')
         `, [API_ID, DATABASE_ID]);
 
         await pg.query(`
-          INSERT INTO services_public.sites (id, database_id, title, description)
-          VALUES ($1, $2, 'Test App', 'A test application')
+          INSERT INTO constructive_routing_public.sites (id, database_id, name, title, description)
+          VALUES ($1, $2, 'test-app', 'Test App', 'A test application')
         `, [SITE_ID, DATABASE_ID]);
 
         await pg.query(`
-          INSERT INTO services_public.domains (id, database_id, domain, subdomain)
-          VALUES ($1, $2, 'example.com', 'app')
+          INSERT INTO constructive_routing_public.domains (id, database_id, hostname, managed, is_wildcard, is_published)
+          VALUES ($1, $2, 'app.example.com', false, false, true)
         `, [DOMAIN_ID, DATABASE_ID]);
 
         await pg.query(`
-          INSERT INTO services_public.api_schemas (id, database_id, schema_id, api_id)
+          INSERT INTO constructive_routing_public.api_schemas (id, database_id, schema_id, api_id)
           VALUES ($1, $2, $3, $4)
         `, [API_SCHEMA_ID, DATABASE_ID, SCHEMA_ID_PUB, API_ID]);
 
@@ -486,9 +513,20 @@ describe('Cross-flow parity: exportMeta vs exportGraphQLMeta', () => {
 
         // cors_settings table — tests text[] columns
         await pg.query(`
-          INSERT INTO services_public.cors_settings (id, database_id, api_id, allowed_origins, allow_credentials, max_age)
-          VALUES ($1, $2, $3, ARRAY['http://localhost:3000', 'https://example.com']::text[], true, 3600)
+          INSERT INTO constructive_routing_public.cors_settings (id, database_id, api_id, allowed_origins)
+          VALUES ($1, $2, $3, ARRAY['http://localhost:3000', 'https://example.com']::text[])
         `, [CORS_SETTINGS_ID, DATABASE_ID, API_ID]);
+
+        // surface module config tables (catalog / routing planes)
+        await pg.query(`
+          INSERT INTO metaschema_modules_public.catalog_module (id, database_id, schema_id, public_schema_name, domains_table_name, apis_table_name, sites_table_name, apps_table_name, scope, policies)
+          VALUES ($1, $2, $3, 'constructive_catalog_public', 'domains', 'apis', 'sites', 'apps', 'platform', '{"select": "public"}'::jsonb)
+        `, [CATALOG_MODULE_ID, DATABASE_ID, SCHEMA_ID_PUB]);
+
+        await pg.query(`
+          INSERT INTO metaschema_modules_public.route_module (id, database_id, schema_id, catalog_module_id, routes_table_name, hostname_bindings_table_name, route_bindings_table_name, scope, prefix)
+          VALUES ($1, $2, $3, $4, 'routes', 'hostname_bindings', 'route_bindings', 'platform', '')
+        `, [ROUTE_MODULE_ID, DATABASE_ID, SCHEMA_ID_PUB, CATALOG_MODULE_ID]);
 
         // user_auth_module — tests the renamed field from PR #1172
         await pg.query(`
@@ -591,7 +629,7 @@ describe('Cross-flow parity: exportMeta vs exportGraphQLMeta', () => {
     expect(sqlResult['field']).toContain(FIELD_ID_3);
   });
 
-  it('SQL output for services tables should contain seeded data', async () => {
+  it('SQL output for routing tables should contain seeded data', async () => {
     const sqlResult = await exportMeta({
       opts: { pg: dbConfig },
       dbname: dbConfig.database,

--- a/pgpm/export/__tests__/export-flow.test.ts
+++ b/pgpm/export/__tests__/export-flow.test.ts
@@ -13,14 +13,14 @@
  * - A running PostgreSQL instance accessible via standard PG* env vars
  */
 
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import { PgpmMigrate,PgpmPackage } from '@pgpmjs/core';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync,writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join, relative } from 'path';
-import { getConnections, seed } from 'pgsql-test';
-import type { PgTestClient } from 'pgsql-test';
 import type { PgConfig } from 'pg-env';
+import type { PgTestClient } from 'pgsql-test';
+import { getConnections, seed } from 'pgsql-test';
 
-import { PgpmPackage, PgpmMigrate } from '@pgpmjs/core';
 import { exportMigrations } from '../src/export-migrations';
 
 // Increase timeout for this test as it involves workspace setup and deployment
@@ -62,7 +62,8 @@ function getDirectoryStructure(dir: string, baseDir?: string): string[] {
 const SCHEMA_SHIMS_SQL = `
   CREATE SCHEMA IF NOT EXISTS metaschema_public;
   CREATE SCHEMA IF NOT EXISTS metaschema_modules_public;
-  CREATE SCHEMA IF NOT EXISTS services_public;
+  CREATE SCHEMA IF NOT EXISTS constructive_routing_public;
+  CREATE SCHEMA IF NOT EXISTS constructive_apps_public;
   CREATE SCHEMA IF NOT EXISTS db_migrate;
 
   -- metaschema_public tables
@@ -98,86 +99,108 @@ const SCHEMA_SHIMS_SQL = `
     description text
   );
 
-  -- services_public tables
-  CREATE TABLE IF NOT EXISTS services_public.domains (
+  -- constructive_routing_public tables
+  CREATE TABLE IF NOT EXISTS constructive_routing_public.domains (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     database_id uuid,
-    site_id uuid,
-    api_id uuid,
-    domain text,
-    subdomain text
+    hostname text,
+    managed boolean,
+    is_wildcard boolean,
+    parent_hostname text,
+    verification_status text,
+    tls_status text,
+    tls_secret_name text,
+    is_published boolean,
+    created_at timestamptz DEFAULT now(),
+    updated_at timestamptz DEFAULT now()
   );
 
-  CREATE TABLE IF NOT EXISTS services_public.apis (
+  CREATE TABLE IF NOT EXISTS constructive_routing_public.apis (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     database_id uuid,
     name text,
-    dbname text,
-    is_public boolean,
+    dbname text DEFAULT current_database(),
     role_name text,
-    anon_role text
+    anon_role text,
+    is_published boolean,
+    config jsonb,
+    created_at timestamptz DEFAULT now(),
+    updated_at timestamptz DEFAULT now()
   );
 
-  CREATE TABLE IF NOT EXISTS services_public.sites (
+  CREATE TABLE IF NOT EXISTS constructive_routing_public.sites (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     database_id uuid,
+    name text,
     title text,
     description text,
-    og_image text,
-    favicon text,
-    apple_touch_icon text,
-    logo text,
-    dbname text
+    config jsonb,
+    is_published boolean,
+    created_at timestamptz DEFAULT now(),
+    updated_at timestamptz DEFAULT now()
   );
 
-  CREATE TABLE IF NOT EXISTS services_public.api_schemas (
+  CREATE TABLE IF NOT EXISTS constructive_routing_public.api_schemas (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     database_id uuid,
     schema_id uuid,
-    api_id uuid
+    api_id uuid,
+    created_at timestamptz DEFAULT now(),
+    updated_at timestamptz DEFAULT now()
   );
 
-  -- Additional services_public tables required by exportMeta
-  CREATE TABLE IF NOT EXISTS services_public.apps (
+  -- Additional scoped tables required by exportMeta
+  CREATE TABLE IF NOT EXISTS constructive_apps_public.apps (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    database_id uuid,
+    name text,
+    title text,
+    description text,
+    status text,
+    config jsonb,
+    is_published boolean,
+    created_at timestamptz DEFAULT now(),
+    updated_at timestamptz DEFAULT now()
+  );
+
+  CREATE TABLE IF NOT EXISTS constructive_routing_public.site_modules (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     database_id uuid,
     site_id uuid,
     name text,
-    app_image text,
-    app_store_link text,
-    app_store_id text,
-    app_id_prefix text,
-    play_store_link text
+    data jsonb,
+    created_at timestamptz DEFAULT now(),
+    updated_at timestamptz DEFAULT now()
   );
 
-  CREATE TABLE IF NOT EXISTS services_public.site_modules (
+  CREATE TABLE IF NOT EXISTS constructive_routing_public.site_themes (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     database_id uuid,
     site_id uuid,
-    name text,
-    data jsonb
+    theme jsonb,
+    created_at timestamptz DEFAULT now(),
+    updated_at timestamptz DEFAULT now()
   );
 
-  CREATE TABLE IF NOT EXISTS services_public.site_themes (
+  CREATE TABLE IF NOT EXISTS constructive_routing_public.site_metadata (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     database_id uuid,
     site_id uuid,
-    theme jsonb
+    title text,
+    description text,
+    og_image text,
+    created_at timestamptz DEFAULT now(),
+    updated_at timestamptz DEFAULT now()
   );
 
-  CREATE TABLE IF NOT EXISTS services_public.api_modules (
+  CREATE TABLE IF NOT EXISTS constructive_routing_public.api_modules (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     database_id uuid,
     api_id uuid,
     name text,
-    data jsonb
-  );
-
-  CREATE TABLE IF NOT EXISTS services_public.api_extensions (
-    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    database_id uuid,
-    api_id uuid,
-    schema_name text
+    data jsonb,
+    created_at timestamptz DEFAULT now(),
+    updated_at timestamptz DEFAULT now()
   );
 
   -- metaschema_modules_public tables (module configuration)
@@ -216,6 +239,99 @@ const SCHEMA_SHIMS_SQL = `
     forgot_password_function text,
     send_verification_email_function text,
     verify_email_function text
+  );
+
+  -- metaschema_modules_public surface modules (catalog / routing / apps planes)
+  CREATE TABLE IF NOT EXISTS metaschema_modules_public.catalog_module (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    database_id uuid,
+    schema_id uuid,
+    public_schema_name text,
+    domains_table_name text,
+    apis_table_name text,
+    sites_table_name text,
+    apps_table_name text,
+    api_name text,
+    scope text,
+    policies jsonb
+  );
+
+  CREATE TABLE IF NOT EXISTS metaschema_modules_public.domain_module (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    database_id uuid,
+    schema_id uuid,
+    private_schema_id uuid,
+    catalog_module_id uuid,
+    domains_table_name text,
+    managed_domains_table_name text,
+    scope text,
+    prefix text
+  );
+
+  CREATE TABLE IF NOT EXISTS metaschema_modules_public.api_surface_module (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    database_id uuid,
+    schema_id uuid,
+    catalog_module_id uuid,
+    apis_table_name text,
+    api_schemas_table_name text,
+    api_modules_table_name text,
+    api_settings_table_name text,
+    cors_settings_table_name text,
+    scope text,
+    prefix text
+  );
+
+  CREATE TABLE IF NOT EXISTS metaschema_modules_public.site_surface_module (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    database_id uuid,
+    schema_id uuid,
+    catalog_module_id uuid,
+    sites_table_name text,
+    site_metadata_table_name text,
+    site_modules_table_name text,
+    site_themes_table_name text,
+    scope text,
+    prefix text
+  );
+
+  CREATE TABLE IF NOT EXISTS metaschema_modules_public.app_module (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    database_id uuid,
+    schema_id uuid,
+    private_schema_id uuid,
+    catalog_module_id uuid,
+    apps_table_name text,
+    app_components_table_name text,
+    scope text,
+    prefix text
+  );
+
+  CREATE TABLE IF NOT EXISTS metaschema_modules_public.route_module (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    database_id uuid,
+    schema_id uuid,
+    private_schema_id uuid,
+    catalog_module_id uuid,
+    domain_module_id uuid,
+    routes_table_name text,
+    hostname_bindings_table_name text,
+    route_bindings_table_name text,
+    resolver_function_name text,
+    scope text,
+    prefix text
+  );
+
+  CREATE TABLE IF NOT EXISTS metaschema_modules_public.database_settings_module (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    database_id uuid,
+    schema_id uuid,
+    database_settings_table_name text,
+    rls_settings_table_name text,
+    pubkey_settings_table_name text,
+    webauthn_settings_table_name text,
+    scope text,
+    prefix text
   );
 
 `;
@@ -464,18 +580,40 @@ INSERT INTO metaschema_public.field (id, database_id, table_id, name, type, desc
   ('cccc0020-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'bbbb0003-0000-0000-0000-000000000001', 'id', 'uuid', 'Primary key'),
   ('cccc0021-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'bbbb0003-0000-0000-0000-000000000001', 'name', 'citext', 'Species name');
 
--- Meta public data
-INSERT INTO services_public.apis (id, database_id, name, dbname, is_public, role_name, anon_role) VALUES
+-- Scoped plane data
+INSERT INTO constructive_routing_public.apis (id, database_id, name, dbname, is_published, role_name, anon_role) VALUES
   ('eeee0001-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'public', 'pets-db', true, 'authenticated', 'anonymous');
 
-INSERT INTO services_public.sites (id, database_id, title, description, dbname) VALUES
-  ('ffff0001-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'Pet Clinic', 'A pet management application', 'pets');
+INSERT INTO constructive_routing_public.sites (id, database_id, name, title, description, is_published) VALUES
+  ('ffff0001-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'pet-clinic', 'Pet Clinic', 'A pet management application', true);
 
-INSERT INTO services_public.domains (id, database_id, domain, subdomain) VALUES
-  ('dddd0001-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'localhost', 'pets');
+INSERT INTO constructive_routing_public.domains (id, database_id, hostname, managed, is_wildcard, is_published) VALUES
+  ('dddd0001-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'pets.localhost', false, false, true);
 
-INSERT INTO services_public.api_schemas (id, database_id, schema_id, api_id) VALUES
+INSERT INTO constructive_routing_public.api_schemas (id, database_id, schema_id, api_id) VALUES
   ('1111aaaa-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'aaaa0001-0000-0000-0000-000000000001', 'eeee0001-0000-0000-0000-000000000001');
+
+-- Surface module configuration
+INSERT INTO metaschema_modules_public.catalog_module (id, database_id, schema_id, public_schema_name, domains_table_name, apis_table_name, sites_table_name, apps_table_name, api_name, scope) VALUES
+  ('2222aaaa-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'aaaa0001-0000-0000-0000-000000000001', 'constructive_catalog_public', 'domains', 'apis', 'sites', 'apps', 'public', 'platform');
+
+INSERT INTO metaschema_modules_public.domain_module (id, database_id, schema_id, catalog_module_id, domains_table_name, managed_domains_table_name, scope, prefix) VALUES
+  ('2222bbbb-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'aaaa0001-0000-0000-0000-000000000001', '2222aaaa-0000-0000-0000-000000000001', 'domains', 'managed_domains', 'platform', '');
+
+INSERT INTO metaschema_modules_public.api_surface_module (id, database_id, schema_id, catalog_module_id, apis_table_name, api_schemas_table_name, api_modules_table_name, api_settings_table_name, cors_settings_table_name, scope, prefix) VALUES
+  ('2222cccc-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'aaaa0001-0000-0000-0000-000000000001', '2222aaaa-0000-0000-0000-000000000001', 'apis', 'api_schemas', 'api_modules', 'api_settings', 'cors_settings', 'platform', '');
+
+INSERT INTO metaschema_modules_public.site_surface_module (id, database_id, schema_id, catalog_module_id, sites_table_name, site_metadata_table_name, site_modules_table_name, site_themes_table_name, scope, prefix) VALUES
+  ('2222dddd-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'aaaa0001-0000-0000-0000-000000000001', '2222aaaa-0000-0000-0000-000000000001', 'sites', 'site_metadata', 'site_modules', 'site_themes', 'platform', '');
+
+INSERT INTO metaschema_modules_public.app_module (id, database_id, schema_id, catalog_module_id, apps_table_name, app_components_table_name, scope, prefix) VALUES
+  ('2222eeee-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'aaaa0001-0000-0000-0000-000000000001', '2222aaaa-0000-0000-0000-000000000001', 'apps', 'app_components', 'platform', '');
+
+INSERT INTO metaschema_modules_public.route_module (id, database_id, schema_id, catalog_module_id, domain_module_id, routes_table_name, hostname_bindings_table_name, route_bindings_table_name, scope, prefix) VALUES
+  ('2222ffff-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'aaaa0001-0000-0000-0000-000000000001', '2222aaaa-0000-0000-0000-000000000001', '2222bbbb-0000-0000-0000-000000000001', 'routes', 'hostname_bindings', 'route_bindings', 'platform', '');
+
+INSERT INTO metaschema_modules_public.database_settings_module (id, database_id, schema_id, database_settings_table_name, rls_settings_table_name, pubkey_settings_table_name, webauthn_settings_table_name, scope, prefix) VALUES
+  ('22220000-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'aaaa0001-0000-0000-0000-000000000001', 'database_settings', 'rls_settings', 'pubkey_settings', 'webauthn_settings', 'platform', '');
 `;
   }
 
@@ -500,14 +638,14 @@ INSERT INTO services_public.api_schemas (id, database_id, schema_id, api_id) VAL
     expect(parseInt(fieldResult.rows[0].count)).toBeGreaterThan(0);
   });
 
-  it('should have seeded the database with services_public data', async () => {
-    const apiResult = await pg.query('SELECT COUNT(*) as count FROM services_public.apis');
+  it('should have seeded the database with constructive_routing_public data', async () => {
+    const apiResult = await pg.query('SELECT COUNT(*) as count FROM constructive_routing_public.apis');
     expect(parseInt(apiResult.rows[0].count)).toBeGreaterThan(0);
 
-    const siteResult = await pg.query('SELECT COUNT(*) as count FROM services_public.sites');
+    const siteResult = await pg.query('SELECT COUNT(*) as count FROM constructive_routing_public.sites');
     expect(parseInt(siteResult.rows[0].count)).toBeGreaterThan(0);
 
-    const domainResult = await pg.query('SELECT COUNT(*) as count FROM services_public.domains');
+    const domainResult = await pg.query('SELECT COUNT(*) as count FROM constructive_routing_public.domains');
     expect(parseInt(domainResult.rows[0].count)).toBeGreaterThan(0);
   });
 
@@ -732,10 +870,10 @@ relocatable = false
     });
 
     // Behavioral test: columnDefaults columns must be absent from the generated SQL.
-    // The apis and sites tables have dbname DEFAULT current_database(), which
-    // captures an environment-specific literal during export. columnDefaults
-    // strips the column from the INSERT so the DDL default supplies the correct
-    // value at deploy time (constructive-db commit 348a5b402e).
+    // The apis table has dbname DEFAULT current_database(), which captures an
+    // environment-specific literal during export. columnDefaults strips the
+    // column from the INSERT so the DDL default supplies the correct value at
+    // deploy time (constructive-db commit 348a5b402e).
     it('should exclude dbname from apis and sites INSERTs (columnDefaults)', () => {
       const apisSqlPath = join(exportWorkspaceDir, 'packages', META_EXTENSION_NAME, 'deploy', 'migrate', 'apis.sql');
       const sitesSqlPath = join(exportWorkspaceDir, 'packages', META_EXTENSION_NAME, 'deploy', 'migrate', 'sites.sql');
@@ -746,7 +884,7 @@ relocatable = false
         expect(apisContent).not.toContain('dbname');
         // But other columns should still be present
         expect(apisContent).toContain('name');
-        expect(apisContent).toContain('is_public');
+        expect(apisContent).toContain('is_published');
       }
 
       if (existsSync(sitesSqlPath)) {
@@ -756,6 +894,21 @@ relocatable = false
         // But other columns should still be present
         expect(sitesContent).toContain('title');
         expect(sitesContent).toContain('description');
+      }
+    });
+
+    it('should export the metaschema_modules_public surface module tables', () => {
+      const migrateDir = join(exportWorkspaceDir, 'packages', META_EXTENSION_NAME, 'deploy', 'migrate');
+      const modules = [
+        'catalog_module', 'domain_module', 'api_surface_module',
+        'site_surface_module', 'app_module', 'route_module',
+        'database_settings_module'
+      ];
+
+      for (const moduleTable of modules) {
+        const sqlPath = join(migrateDir, `${moduleTable}.sql`);
+        expect(existsSync(sqlPath)).toBe(true);
+        expect(readFileSync(sqlPath, 'utf-8')).toContain(`INSERT INTO metaschema_modules_public.${moduleTable}`);
       }
     });
   });

--- a/pgpm/export/__tests__/export-meta.test.ts
+++ b/pgpm/export/__tests__/export-meta.test.ts
@@ -3,7 +3,8 @@
  * 
  * These tests validate that META_TABLE_CONFIG uses correct table names,
  * schema groupings, and field definitions for exporting metaschema_public,
- * services_public, and metaschema_modules_public data.
+ * constructive_routing_public, constructive_apps_public, and
+ * metaschema_modules_public data.
  * 
  * Uses actual imports instead of string-matching source files.
  */
@@ -28,18 +29,25 @@ describe('Export Meta Config Validation', () => {
     });
   });
 
-  describe('services_public tables', () => {
+  describe('constructive_routing_public tables', () => {
     const required = [
-      'domains', 'sites', 'apis', 'apps',
+      'domains', 'sites', 'apis',
       'site_modules', 'site_themes', 'site_metadata',
       'api_modules', 'api_schemas'
     ];
 
-    it('should include all required services_public tables in config', () => {
+    it('should include all required constructive_routing_public tables in config', () => {
       for (const table of required) {
         expect(META_TABLE_CONFIG).toHaveProperty(table);
-        expect(META_TABLE_CONFIG[table].schema).toBe('services_public');
+        expect(META_TABLE_CONFIG[table].schema).toBe('constructive_routing_public');
       }
+    });
+  });
+
+  describe('constructive_apps_public tables', () => {
+    it('should include apps in config', () => {
+      expect(META_TABLE_CONFIG).toHaveProperty('apps');
+      expect(META_TABLE_CONFIG.apps.schema).toBe('constructive_apps_public');
     });
   });
 
@@ -70,7 +78,10 @@ describe('Export Meta Config Validation', () => {
       'compute_log_module', 'db_usage_module',
       'storage_log_module', 'transfer_log_module',
       'webauthn_auth_module', 'webauthn_credentials_module',
-      'inference_log_module', 'rate_limit_meters_module'
+      'inference_log_module', 'rate_limit_meters_module',
+      'catalog_module', 'domain_module', 'api_surface_module',
+      'site_surface_module', 'route_module', 'app_module',
+      'database_settings_module'
     ];
 
     it('should include all required metaschema_modules_public tables in config', () => {
@@ -78,6 +89,24 @@ describe('Export Meta Config Validation', () => {
         expect(META_TABLE_CONFIG).toHaveProperty(table);
         expect(META_TABLE_CONFIG[table].schema).toBe('metaschema_modules_public');
       }
+    });
+  });
+
+  describe('surface module dependency order', () => {
+    it('catalog_module should come before the modules that reference it', () => {
+      const order = META_TABLE_ORDER as unknown as string[];
+      const catalogIdx = order.indexOf('catalog_module');
+
+      expect(catalogIdx).toBeGreaterThanOrEqual(0);
+      for (const table of ['domain_module', 'api_surface_module', 'site_surface_module', 'app_module', 'route_module']) {
+        expect(catalogIdx).toBeLessThan(order.indexOf(table));
+      }
+    });
+
+    it('domain_module should come before route_module', () => {
+      const order = META_TABLE_ORDER as unknown as string[];
+
+      expect(order.indexOf('domain_module')).toBeLessThan(order.indexOf('route_module'));
     });
   });
 
@@ -95,7 +124,7 @@ describe('Export Meta Config Validation', () => {
       expect(tableIdx).toBeLessThan(fieldIdx);
     });
 
-    it('metaschema_public tables should come before services_public tables', () => {
+    it('metaschema_public tables should come before scoped plane tables', () => {
       const order = META_TABLE_ORDER as unknown as string[];
       const lastMetaschema = order.indexOf('default_privilege');
       const firstService = order.indexOf('domains');
@@ -103,7 +132,7 @@ describe('Export Meta Config Validation', () => {
       expect(lastMetaschema).toBeLessThan(firstService);
     });
 
-    it('services_public tables should come before metaschema_modules_public tables', () => {
+    it('scoped plane tables should come before metaschema_modules_public tables', () => {
       const order = META_TABLE_ORDER as unknown as string[];
       const lastService = order.indexOf('api_schemas');
       const firstModule = order.indexOf('rls_module');

--- a/pgpm/export/__tests__/export-parity.test.ts
+++ b/pgpm/export/__tests__/export-parity.test.ts
@@ -42,17 +42,14 @@ jest.mock('../src/export-graphql-meta', () => ({
   exportGraphQLMeta: jest.fn()
 }));
 
-import { PgpmPackage, PgpmMigrate } from '@pgpmjs/core';
-import { createClient } from '@pgpmjs/migrate-client';
-import { exportGraphQL } from '../src/export-graphql';
-import { exportMigrations } from '../src/export-migrations';
-import { exportMeta } from '../src/export-meta';
-import { GraphQLClient } from '../src/graphql-client';
-import { exportGraphQLMeta } from '../src/export-graphql-meta';
+import { PgpmMigrate,PgpmPackage } from '@pgpmjs/core';
 import { toCamelCase } from 'inflekt';
 import { getConnections, seed } from 'pgsql-test';
 
-import type { PgpmPackage as PgpmPackageType } from '@pgpmjs/core';
+import { exportGraphQL } from '../src/export-graphql';
+import { exportGraphQLMeta } from '../src/export-graphql-meta';
+import { exportMeta } from '../src/export-meta';
+import { exportMigrations } from '../src/export-migrations';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -100,7 +97,8 @@ const pgRowToCamel = (row: Record<string, unknown>): Record<string, unknown> => 
 const SCHEMA_SHIMS_SQL = `
   CREATE SCHEMA IF NOT EXISTS metaschema_public;
   CREATE SCHEMA IF NOT EXISTS metaschema_modules_public;
-  CREATE SCHEMA IF NOT EXISTS services_public;
+  CREATE SCHEMA IF NOT EXISTS constructive_routing_public;
+  CREATE SCHEMA IF NOT EXISTS constructive_apps_public;
   CREATE SCHEMA IF NOT EXISTS db_migrate;
 
   CREATE TABLE IF NOT EXISTS metaschema_public.database (
@@ -119,38 +117,48 @@ const SCHEMA_SHIMS_SQL = `
     table_id uuid REFERENCES metaschema_public.table(id), name text, type text, description text
   );
 
-  CREATE TABLE IF NOT EXISTS services_public.domains (
-    id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, site_id uuid, api_id uuid, domain text, subdomain text
+  CREATE TABLE IF NOT EXISTS constructive_routing_public.domains (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, hostname text, managed boolean,
+    is_wildcard boolean, parent_hostname text, verification_status text, tls_status text,
+    tls_secret_name text, is_published boolean,
+    created_at timestamptz DEFAULT now(), updated_at timestamptz DEFAULT now()
   );
-  CREATE TABLE IF NOT EXISTS services_public.apis (
-    id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, name text, dbname text,
-    is_public boolean, role_name text, anon_role text
+  CREATE TABLE IF NOT EXISTS constructive_routing_public.apis (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, name text,
+    dbname text DEFAULT current_database(), role_name text, anon_role text,
+    is_published boolean, config jsonb,
+    created_at timestamptz DEFAULT now(), updated_at timestamptz DEFAULT now()
   );
-  CREATE TABLE IF NOT EXISTS services_public.sites (
-    id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, title text, description text,
-    og_image text, favicon text, apple_touch_icon text, logo text, dbname text
+  CREATE TABLE IF NOT EXISTS constructive_routing_public.sites (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, name text, title text,
+    description text, config jsonb, is_published boolean,
+    created_at timestamptz DEFAULT now(), updated_at timestamptz DEFAULT now()
   );
-  CREATE TABLE IF NOT EXISTS services_public.api_schemas (
-    id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, schema_id uuid, api_id uuid
+  CREATE TABLE IF NOT EXISTS constructive_routing_public.api_schemas (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, schema_id uuid, api_id uuid,
+    created_at timestamptz DEFAULT now(), updated_at timestamptz DEFAULT now()
   );
-  CREATE TABLE IF NOT EXISTS services_public.apps (
-    id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, site_id uuid, name text,
-    app_image text, app_store_link text, app_store_id text, app_id_prefix text, play_store_link text
+  CREATE TABLE IF NOT EXISTS constructive_apps_public.apps (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, name text, title text,
+    description text, status text, config jsonb, is_published boolean,
+    created_at timestamptz DEFAULT now(), updated_at timestamptz DEFAULT now()
   );
-  CREATE TABLE IF NOT EXISTS services_public.site_modules (
-    id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, site_id uuid, name text, data jsonb
+  CREATE TABLE IF NOT EXISTS constructive_routing_public.site_modules (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, site_id uuid, name text, data jsonb,
+    created_at timestamptz DEFAULT now(), updated_at timestamptz DEFAULT now()
   );
-  CREATE TABLE IF NOT EXISTS services_public.site_themes (
-    id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, site_id uuid, theme jsonb
+  CREATE TABLE IF NOT EXISTS constructive_routing_public.site_themes (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, site_id uuid, theme jsonb,
+    created_at timestamptz DEFAULT now(), updated_at timestamptz DEFAULT now()
   );
-  CREATE TABLE IF NOT EXISTS services_public.site_metadata (
-    id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, site_id uuid, key text, value text
+  CREATE TABLE IF NOT EXISTS constructive_routing_public.site_metadata (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, site_id uuid, title text,
+    description text, og_image text,
+    created_at timestamptz DEFAULT now(), updated_at timestamptz DEFAULT now()
   );
-  CREATE TABLE IF NOT EXISTS services_public.api_modules (
-    id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, api_id uuid, name text, data jsonb
-  );
-  CREATE TABLE IF NOT EXISTS services_public.api_extensions (
-    id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, api_id uuid, schema_name text
+  CREATE TABLE IF NOT EXISTS constructive_routing_public.api_modules (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, api_id uuid, name text, data jsonb,
+    created_at timestamptz DEFAULT now(), updated_at timestamptz DEFAULT now()
   );
 
   CREATE TABLE IF NOT EXISTS db_migrate.sql_actions (
@@ -178,16 +186,16 @@ const SEED_SQL = `
     ('cccc0002-0000-0000-0000-000000000001', '${DATABASE_ID}', 'bbbb0001-0000-0000-0000-000000000001', 'name', 'text', 'Owner name'),
     ('cccc0003-0000-0000-0000-000000000001', '${DATABASE_ID}', 'bbbb0001-0000-0000-0000-000000000001', 'email', 'text', 'Contact email');
 
-  INSERT INTO services_public.apis (id, database_id, name, dbname, is_public, role_name, anon_role) VALUES
+  INSERT INTO constructive_routing_public.apis (id, database_id, name, dbname, is_published, role_name, anon_role) VALUES
     ('eeee0001-0000-0000-0000-000000000001', '${DATABASE_ID}', 'public', 'pets-db', true, 'authenticated', 'anonymous');
 
-  INSERT INTO services_public.sites (id, database_id, title, description, dbname) VALUES
-    ('ffff0001-0000-0000-0000-000000000001', '${DATABASE_ID}', 'Pet Clinic', 'A pet management application', '${DATABASE_NAME}');
+  INSERT INTO constructive_routing_public.sites (id, database_id, name, title, description, is_published) VALUES
+    ('ffff0001-0000-0000-0000-000000000001', '${DATABASE_ID}', 'pet-clinic', 'Pet Clinic', 'A pet management application', true);
 
-  INSERT INTO services_public.domains (id, database_id, domain, subdomain) VALUES
-    ('dddd0001-0000-0000-0000-000000000001', '${DATABASE_ID}', 'localhost', 'pets');
+  INSERT INTO constructive_routing_public.domains (id, database_id, hostname, managed, is_wildcard, is_published) VALUES
+    ('dddd0001-0000-0000-0000-000000000001', '${DATABASE_ID}', 'pets.localhost', false, false, true);
 
-  INSERT INTO services_public.api_schemas (id, database_id, schema_id, api_id) VALUES
+  INSERT INTO constructive_routing_public.api_schemas (id, database_id, schema_id, api_id) VALUES
     ('1111aaaa-0000-0000-0000-000000000001', '${DATABASE_ID}', 'aaaa0001-0000-0000-0000-000000000001', 'eeee0001-0000-0000-0000-000000000001');
 
   INSERT INTO db_migrate.sql_actions (name, database_id, deploy, deps, content, revert, verify) VALUES

--- a/pgpm/export/__tests__/export-utils.test.ts
+++ b/pgpm/export/__tests__/export-utils.test.ts
@@ -11,16 +11,15 @@ import { join } from 'path';
 import path from 'path';
 
 import {
+  DB_REQUIRED_EXTENSIONS,
+  makeReplacer,
+  META_COMMON_FOOTER,
+  META_COMMON_HEADER,
   META_TABLE_CONFIG,
   META_TABLE_ORDER,
   META_TABLE_OVERRIDES,
-  DB_REQUIRED_EXTENSIONS,
-  SERVICE_REQUIRED_EXTENSIONS,
-  META_COMMON_HEADER,
-  META_COMMON_FOOTER,
-  makeReplacer,
-  normalizeOutdir
-} from '../src/export-utils';
+  normalizeOutdir,
+  SERVICE_REQUIRED_EXTENSIONS} from '../src/export-utils';
 
 // =============================================================================
 // Config / Order consistency
@@ -69,7 +68,13 @@ describe('META_TABLE_CONFIG and META_TABLE_ORDER consistency', () => {
   });
 
   it('every config entry should have a valid schema', () => {
-    const validSchemas = ['metaschema_public', 'services_public', 'metaschema_modules_public'];
+    const validSchemas = [
+      'metaschema_public',
+      'metaschema_modules_public',
+      'constructive_catalog_public',
+      'constructive_routing_public',
+      'constructive_apps_public'
+    ];
 
     for (const [key, config] of Object.entries(META_TABLE_CONFIG)) {
       expect(validSchemas).toContain(config.schema);

--- a/pgpm/export/__tests__/graphql-naming.test.ts
+++ b/pgpm/export/__tests__/graphql-naming.test.ts
@@ -7,11 +7,10 @@
  */
 
 import {
+  buildFieldsFragment,
   getGraphQLQueryName,
   graphqlRowToPostgresRow,
-  intervalToPostgres,
-  buildFieldsFragment
-} from '../src/graphql-naming';
+  intervalToPostgres} from '../src/graphql-naming';
 
 describe('getGraphQLQueryName', () => {
   it('should convert simple table names to pluralized camelCase', () => {
@@ -34,7 +33,7 @@ describe('getGraphQLQueryName', () => {
     expect(getGraphQLQueryName('full_text_search')).toBe('fullTextSearches');
   });
 
-  it('should convert services_public table names', () => {
+  it('should convert scoped routing/apps table names', () => {
     expect(getGraphQLQueryName('domains')).toBe('domains');
     expect(getGraphQLQueryName('sites')).toBe('sites');
     expect(getGraphQLQueryName('apis')).toBe('apis');

--- a/pgpm/export/src/export-graphql-meta.ts
+++ b/pgpm/export/src/export-graphql-meta.ts
@@ -1,7 +1,8 @@
 /**
  * GraphQL equivalent of export-meta.ts.
  * 
- * Fetches metadata from metaschema_public, services_public, and metaschema_modules_public
+ * Fetches metadata from metaschema_public, constructive_routing_public,
+ * constructive_apps_public, and metaschema_modules_public
  * via GraphQL queries instead of direct SQL, then uses the same csv-to-pg Parser to
  * generate SQL INSERT statements.
  */

--- a/pgpm/export/src/export-migrations.ts
+++ b/pgpm/export/src/export-migrations.ts
@@ -40,7 +40,7 @@ interface ExportMigrationsToDiskOptions {
   serviceOutdir?: string;
   /**
    * Skip schema name replacement for infrastructure schemas.
-   * When true, schema names like metaschema_public, services_public will not be renamed.
+   * When true, schema names like metaschema_public, constructive_routing_public will not be renamed.
    * Useful for self-referential introspection where you want to apply policies to real schemas.
    */
   skipSchemaRenaming?: boolean;
@@ -77,7 +77,7 @@ interface ExportOptions {
   serviceOutdir?: string;
   /**
    * Skip schema name replacement for infrastructure schemas.
-   * When true, schema names like metaschema_public, services_public will not be renamed.
+   * When true, schema names like metaschema_public, constructive_routing_public will not be renamed.
    * Useful for self-referential introspection where you want to apply policies to real schemas.
    */
   skipSchemaRenaming?: boolean;
@@ -143,7 +143,7 @@ const exportMigrationsToDisk = async ({
 
   // When skipSchemaRenaming is true, pass empty schemas array to avoid renaming
   // This is useful for self-referential introspection where you want to apply
-  // policies to real infrastructure schemas (metaschema_public, services_public, etc.)
+  // policies to real infrastructure schemas (metaschema_public, constructive_routing_public, etc.)
   const schemasForReplacement = skipSchemaRenaming
     ? []
     : schemas.rows.filter((schema: any) => schema_names.includes(schema.schema_name));

--- a/pgpm/export/src/graphql-naming.ts
+++ b/pgpm/export/src/graphql-naming.ts
@@ -9,7 +9,9 @@
  * Examples:
  *   metaschema_public.database -> databases (query), Database (type)
  *   metaschema_public.foreign_key_constraint -> foreignKeyConstraints
- *   services_public.api_schemas -> apiSchemas
+ *   constructive_routing_public.api_schemas -> apiSchemas
+ *   constructive_apps_public.apps -> apps
+ *   metaschema_modules_public.api_surface_module -> apiSurfaceModules
  *   db_migrate.sql_actions -> sqlActions
  *   column database_id -> databaseId
  */

--- a/pgpm/export/src/meta-export-tables.json
+++ b/pgpm/export/src/meta-export-tables.json
@@ -18,22 +18,22 @@
     },
     {
       "key": "apis",
-      "schema": "services_public",
+      "schema": "constructive_routing_public",
       "table": "apis"
     },
     {
       "key": "database_settings",
-      "schema": "services_public",
+      "schema": "constructive_routing_public",
       "table": "database_settings"
     },
     {
       "key": "managed_domains",
-      "schema": "services_public",
+      "schema": "constructive_routing_public",
       "table": "managed_domains"
     },
     {
       "key": "sites",
-      "schema": "services_public",
+      "schema": "constructive_routing_public",
       "table": "sites"
     },
     {
@@ -78,47 +78,47 @@
     },
     {
       "key": "api_modules",
-      "schema": "services_public",
+      "schema": "constructive_routing_public",
       "table": "api_modules"
     },
     {
       "key": "api_schemas",
-      "schema": "services_public",
+      "schema": "constructive_routing_public",
       "table": "api_schemas"
     },
     {
       "key": "api_settings",
-      "schema": "services_public",
+      "schema": "constructive_routing_public",
       "table": "api_settings"
     },
     {
       "key": "apps",
-      "schema": "services_public",
+      "schema": "constructive_apps_public",
       "table": "apps"
     },
     {
       "key": "cors_settings",
-      "schema": "services_public",
+      "schema": "constructive_routing_public",
       "table": "cors_settings"
     },
     {
       "key": "domains",
-      "schema": "services_public",
+      "schema": "constructive_routing_public",
       "table": "domains"
     },
     {
       "key": "site_metadata",
-      "schema": "services_public",
+      "schema": "constructive_routing_public",
       "table": "site_metadata"
     },
     {
       "key": "site_modules",
-      "schema": "services_public",
+      "schema": "constructive_routing_public",
       "table": "site_modules"
     },
     {
       "key": "site_themes",
-      "schema": "services_public",
+      "schema": "constructive_routing_public",
       "table": "site_themes"
     },
     {
@@ -178,17 +178,17 @@
     },
     {
       "key": "http_routes",
-      "schema": "services_public",
+      "schema": "constructive_routing_public",
       "table": "http_routes"
     },
     {
       "key": "pubkey_settings",
-      "schema": "services_public",
+      "schema": "constructive_routing_public",
       "table": "pubkey_settings"
     },
     {
       "key": "rls_settings",
-      "schema": "services_public",
+      "schema": "constructive_routing_public",
       "table": "rls_settings"
     },
     {
@@ -205,6 +205,11 @@
       "key": "billing_provider_module",
       "schema": "metaschema_modules_public",
       "table": "billing_provider_module"
+    },
+    {
+      "key": "catalog_module",
+      "schema": "metaschema_modules_public",
+      "table": "catalog_module"
     },
     {
       "key": "compute_log_module",
@@ -230,6 +235,11 @@
       "key": "crypto_auth_module",
       "schema": "metaschema_modules_public",
       "table": "crypto_auth_module"
+    },
+    {
+      "key": "database_settings_module",
+      "schema": "metaschema_modules_public",
+      "table": "database_settings_module"
     },
     {
       "key": "db_usage_module",
@@ -473,8 +483,18 @@
     },
     {
       "key": "webauthn_settings",
-      "schema": "services_public",
+      "schema": "constructive_routing_public",
       "table": "webauthn_settings"
+    },
+    {
+      "key": "api_surface_module",
+      "schema": "metaschema_modules_public",
+      "table": "api_surface_module"
+    },
+    {
+      "key": "app_module",
+      "schema": "metaschema_modules_public",
+      "table": "app_module"
     },
     {
       "key": "db_preset_module",
@@ -485,6 +505,11 @@
       "key": "denormalized_table_field",
       "schema": "metaschema_modules_public",
       "table": "denormalized_table_field"
+    },
+    {
+      "key": "domain_module",
+      "schema": "metaschema_modules_public",
+      "table": "domain_module"
     },
     {
       "key": "function_deployment_module",
@@ -507,6 +532,11 @@
       "table": "resource_module"
     },
     {
+      "key": "site_surface_module",
+      "schema": "metaschema_modules_public",
+      "table": "site_surface_module"
+    },
+    {
       "key": "webhook_module",
       "schema": "metaschema_modules_public",
       "table": "webhook_module"
@@ -520,9 +550,82 @@
       "key": "http_route_module",
       "schema": "metaschema_modules_public",
       "table": "http_route_module"
+    },
+    {
+      "key": "route_module",
+      "schema": "metaschema_modules_public",
+      "table": "route_module"
     }
   ],
   "timestampDefaultColumns": {
+    "constructive_apps_public.apps": [
+      "created_at",
+      "updated_at"
+    ],
+    "constructive_routing_public.api_modules": [
+      "created_at",
+      "updated_at"
+    ],
+    "constructive_routing_public.api_schemas": [
+      "created_at",
+      "updated_at"
+    ],
+    "constructive_routing_public.api_settings": [
+      "created_at",
+      "updated_at"
+    ],
+    "constructive_routing_public.apis": [
+      "created_at",
+      "updated_at"
+    ],
+    "constructive_routing_public.cors_settings": [
+      "created_at",
+      "updated_at"
+    ],
+    "constructive_routing_public.database_settings": [
+      "created_at",
+      "updated_at"
+    ],
+    "constructive_routing_public.domains": [
+      "created_at",
+      "updated_at"
+    ],
+    "constructive_routing_public.http_routes": [
+      "created_at",
+      "updated_at"
+    ],
+    "constructive_routing_public.managed_domains": [
+      "created_at",
+      "updated_at"
+    ],
+    "constructive_routing_public.pubkey_settings": [
+      "created_at",
+      "updated_at"
+    ],
+    "constructive_routing_public.rls_settings": [
+      "created_at",
+      "updated_at"
+    ],
+    "constructive_routing_public.site_metadata": [
+      "created_at",
+      "updated_at"
+    ],
+    "constructive_routing_public.site_modules": [
+      "created_at",
+      "updated_at"
+    ],
+    "constructive_routing_public.site_themes": [
+      "created_at",
+      "updated_at"
+    ],
+    "constructive_routing_public.sites": [
+      "created_at",
+      "updated_at"
+    ],
+    "constructive_routing_public.webauthn_settings": [
+      "created_at",
+      "updated_at"
+    ],
     "metaschema_modules_public.db_preset_module": [
       "created_at"
     ],
@@ -603,10 +706,6 @@
       "updated_at"
     ],
     "metaschema_public.unique_constraint": [
-      "created_at",
-      "updated_at"
-    ],
-    "services_public.http_routes": [
       "created_at",
       "updated_at"
     ]


### PR DESCRIPTION
## Summary

Hard break: `pgpm/export` no longer references `services_public` anywhere. The meta-export manifest now points at the scoped planes, and the export additionally surfaces the seven new `metaschema_modules_public` surface-module config tables.

Manifest repoint (`src/meta-export-tables.json`):

```
services_public.{apis,api_schemas,api_modules,api_settings,cors_settings,rls_settings,
                 pubkey_settings,webauthn_settings,database_settings,domains,managed_domains,
                 http_routes,sites,site_metadata,site_modules,site_themes}
  -> constructive_routing_public.*
services_public.apps -> constructive_apps_public.apps
```

`timestampDefaultColumns` keys were rekeyed to the scoped schema names for every routing table plus `constructive_apps_public.apps`.

Newly added to the manifest (none existed before; all verified against the deployed DDL in `pgpm-modules/metaschema-modules`, all in `metaschema_modules_public`):
`catalog_module`, `domain_module`, `api_surface_module`, `site_surface_module`, `app_module`, `route_module`, `database_settings_module`. They are inserted in the same topological/alphabetical position the constructive-db generator would emit — `catalog_module` before the modules FK'ing it, `domain_module` before `route_module`. None of them have `created_at`/`updated_at`, so no timestamp-default entries were added.

Source changes beyond the manifest are documentation-only (`export-graphql-meta.ts`, `export-migrations.ts`, `graphql-naming.ts`): the naming transform never special-cased `services_public`, it strips schema prefixes generically, so `metaschema_modules_public.api_surface_module -> apiSurfaceModules` works unchanged.

Tests: the `CREATE SCHEMA services_public` fixtures in `export-parity`, `export-flow`, and `cross-flow-parity` were rebuilt as scoped tables with the real scoped columns (e.g. `domains.domain/subdomain` -> `hostname/managed/is_wildcard/...`, `apis.is_public` -> `is_published`, `sites` loses `dbname`/`og_image`/`favicon`), plus shims/seeds for the new surface modules so they ride through both the SQL and GraphQL flows. `export-flow` gained an assertion that each surface module emits `deploy/migrate/<module>.sql`, and the folder-structure snapshot was updated accordingly.

Note: the manifest header says it is generated by constructive-db's `generate_constructive.ts`; these entries are hand-applied here and will be reproduced on the next regeneration once the new modules are deployed in that repo.


Link to Devin session: https://app.devin.ai/sessions/c0cbbe72a329445fb64609b4ce190560
Requested by: @pyramation