### PR TITLE
fix(pgpm): Windows compatibility + windows-latest CI job

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# SQL, plans and control files are content-addressed and compared verbatim in
+# tests, so the working tree must use LF on every platform.
+* text=auto eol=lf

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -139,6 +139,82 @@ jobs:
           done
 
   # =========================================================================
+  # TIER 1b – Windows compatibility (native runner, no Linux containers)
+  #
+  # Windows runners cannot use service containers, so this job uses the
+  # PostgreSQL install that ships with the runner image. It covers the
+  # platform-specific failure modes: path separators in glob patterns,
+  # spaces in paths, and the PG client binaries on PATH.
+  # =========================================================================
+  windows-tests:
+    if: github.event.pull_request.draft != true
+    runs-on: windows-latest
+    timeout-minutes: 25
+
+    env:
+      PGHOST: localhost
+      PGPORT: '5432'
+      PGUSER: postgres
+      PGPASSWORD: root
+      NODE_OPTIONS: '--max-old-space-size=4096'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Configure Git (for tests)
+        run: |
+          git config --global user.name "CI Test User"
+          git config --global user.email "ci@example.com"
+
+      - name: Start PostgreSQL
+        shell: pwsh
+        run: |
+          $service = Get-Service -Name 'postgresql*' | Select-Object -First 1
+          if (-not $service) { throw 'No PostgreSQL service found on the runner image' }
+          Set-Service -Name $service.Name -StartupType Manual
+          Start-Service -Name $service.Name
+          $bin = (Get-ChildItem 'C:\Program Files\PostgreSQL\*\bin' | Select-Object -First 1).FullName
+          if (-not $bin) { throw 'No PostgreSQL bin directory found on the runner image' }
+          Add-Content -Path $env:GITHUB_PATH -Value $bin
+
+      - name: Wait for PostgreSQL
+        shell: pwsh
+        run: |
+          for ($i = 0; $i -lt 30; $i++) {
+            pg_isready -h localhost -p 5432
+            if ($LASTEXITCODE -eq 0) { exit 0 }
+            Start-Sleep -Seconds 2
+          }
+          throw 'PostgreSQL did not become ready'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build pgpm
+        run: pnpm --filter pgpm... build
+
+      # Database-free suites: workspace/module discovery, dependency
+      # resolution, plan parsing. These are the codepaths that regress when
+      # native path separators leak into glob patterns.
+      - name: Test @pgpmjs/core (no database)
+        run: pnpm --filter @pgpmjs/core exec jest __tests__/workspace __tests__/resolution __tests__/core __tests__/files __tests__/roles __tests__/modules
+
+      - name: pgpm end-to-end smoke (deploy → verify → revert)
+        run: node scripts/pgpm-smoke.mjs
+
+  # =========================================================================
   # TIER 2 – PostgreSQL-only tests
   # =========================================================================
   pg-tests:

--- a/pgpm/ast/src/files/extension/reader.ts
+++ b/pgpm/ast/src/files/extension/reader.ts
@@ -17,7 +17,9 @@ export interface Module {
 export function parseControlFile(filePath: string, basePath: string): Module {
   const { requires, version } = parseControlContent(readFileSync(filePath, 'utf-8'));
   return {
-    path: dirname(relative(basePath, filePath)),
+    // posix separators: this path is a portable identifier recorded in
+    // pgpm.json and plan metadata, not a filesystem path
+    path: dirname(relative(basePath, filePath)).replace(/\\/g, '/'),
     requires,
     version,
   };

--- a/pgpm/core/__tests__/modules/module-installation.test.ts
+++ b/pgpm/core/__tests__/modules/module-installation.test.ts
@@ -26,10 +26,12 @@ describe('installModule()', () => {
             'extensions/@pgpm-testing/base32'
     );
 
-    const files = glob.sync('**/*', {
-      cwd: extDir,
-      nodir: true
-    });
+    const files = glob
+      .sync('**/*', {
+        cwd: extDir,
+        nodir: true
+      })
+      .map(f => f.replace(/\\/g, '/'));
 
     expect(files.sort()).toMatchSnapshot();
     expect(fs.existsSync(path.join(extDir, 'pgpm.plan'))).toBe(true);

--- a/pgpm/core/__tests__/modules/module-publishing.test.ts
+++ b/pgpm/core/__tests__/modules/module-publishing.test.ts
@@ -23,10 +23,12 @@ describe('publishToDist()', () => {
   it('copies all required folders and files to dist/', () => {
     mod.publishToDist();
 
-    const structure = glob.sync('**/*', {
-      cwd: distDir,
-      nodir: true
-    });
+    const structure = glob
+      .sync('**/*', {
+        cwd: distDir,
+        nodir: true
+      })
+      .map(p => p.replace(/\\/g, '/'));
 
     expect(structure.sort()).toMatchSnapshot();
   });

--- a/pgpm/core/__tests__/workspace/glob-paths.test.ts
+++ b/pgpm/core/__tests__/workspace/glob-paths.test.ts
@@ -1,0 +1,74 @@
+import fs from 'fs';
+import { sync as globSync } from 'glob';
+import os from 'os';
+import path from 'path';
+
+import { PgpmPackage } from '../../src/core/class/pgpm';
+import { globPattern, toPosixPath } from '../../src/utils/glob';
+
+const writeModule = (workspace: string, name: string) => {
+  const moduleDir = path.join(workspace, 'packages', name);
+  fs.mkdirSync(path.join(moduleDir, 'deploy'), { recursive: true });
+  fs.writeFileSync(
+    path.join(moduleDir, `${name}.control`),
+    `comment = '${name}'\ndefault_version = '0.0.1'\n`
+  );
+  fs.writeFileSync(
+    path.join(moduleDir, 'pgpm.plan'),
+    `%syntax-version=1.0.0\n%project=${name}\n\n`
+  );
+  fs.writeFileSync(
+    path.join(moduleDir, 'package.json'),
+    JSON.stringify({ name, version: '0.0.1' }, null, 2)
+  );
+  return moduleDir;
+};
+
+describe('glob pattern building', () => {
+  it('never emits backslashes, which glob treats as escapes', () => {
+    expect(globPattern('C:\\Users\\dev\\workspace', 'packages/*')).toBe(
+      'C:/Users/dev/workspace/packages/*'
+    );
+    expect(toPosixPath('packages\\my-module')).toBe('packages/my-module');
+  });
+
+  it('documents that a backslash pattern matches nothing', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pgpm-glob-'));
+    fs.mkdirSync(path.join(dir, 'packages', 'mod'), { recursive: true });
+
+    const escaped = `${toPosixPath(dir)}\\packages\\*`;
+    expect(globSync(escaped)).toEqual([]);
+    expect(globSync(globPattern(dir, 'packages/*'))).toHaveLength(1);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe('workspace module discovery', () => {
+  let workspace: string;
+
+  beforeAll(() => {
+    workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'pgpm-workspace-'));
+    fs.writeFileSync(
+      path.join(workspace, 'pgpm.json'),
+      JSON.stringify({ packages: ['packages/*'] }, null, 2)
+    );
+    writeModule(workspace, 'alpha');
+    writeModule(workspace, 'beta');
+  });
+
+  afterAll(() => {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  });
+
+  it('discovers modules from a native workspace path', () => {
+    const pkg = new PgpmPackage(workspace);
+    expect(pkg.allowedDirs).toHaveLength(2);
+    expect(Object.keys(pkg.listModules()).sort()).toEqual(['alpha', 'beta']);
+  });
+
+  it('discovers modules from a nested module cwd', () => {
+    const pkg = new PgpmPackage(path.join(workspace, 'packages', 'alpha'));
+    expect(Object.keys(pkg.listModules()).sort()).toEqual(['alpha', 'beta']);
+  });
+});

--- a/pgpm/core/package.json
+++ b/pgpm/core/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/constructive-io/constructive/issues"
   },
   "scripts": {
-    "copy": "npm run copy:pkg; npm run copy:sql",
+    "copy": "npm run copy:pkg && npm run copy:sql",
     "copy:pkg": "makage assets",
     "copy:sql": "copyfiles -f src/migrate/sql/* dist/migrate/sql && copyfiles -f src/migrate/sql/* dist/esm/migrate/sql",
     "clean": "makage clean",

--- a/pgpm/core/src/core/class/pgpm.ts
+++ b/pgpm/core/src/core/class/pgpm.ts
@@ -37,7 +37,8 @@ import {
 } from '../../modules/modules';
 import { packageModule } from '../../packaging/package';
 import { resolveDependencies,resolveExtensionDependencies } from '../../resolution/deps';
-import { globPaths, globPattern } from '../../utils/glob';
+import { movePath } from '../../utils/fs';
+import { globPaths, globPattern, toPosixPath } from '../../utils/glob';
 import { parseTarget } from '../../utils/target-utils';
 import { DEFAULT_TEMPLATE_REPO, DEFAULT_TEMPLATE_TOOL_NAME, DEFAULT_TEMPLATE_TTL_MS, scaffoldTemplate } from '../template-scaffold';
 
@@ -1052,7 +1053,7 @@ ${dependencies.length > 0 ? dependencies.map(dep => `-- requires: ${dep}`).join(
         const installs = matches.map((conf) => {
           const fullConf = resolve(conf);
           const extDir = dirname(fullConf);
-          const parts = extDir.split('node_modules/');
+          const parts = toPosixPath(extDir).split('node_modules/');
           const relativeDir = parts[parts.length - 1];
           const dstDir = path.join(skitchExtDir, relativeDir);
           return { src: extDir, dst: dstDir, pkg: relativeDir };
@@ -1060,7 +1061,7 @@ ${dependencies.length > 0 ? dependencies.map(dep => `-- requires: ${dep}`).join(
 
         // Sort deepest paths first so nested node_modules deps are
         // extracted before their parent directories are moved.
-        installs.sort((a, b) => b.src.split('/').length - a.src.split('/').length);
+        installs.sort((a, b) => toPosixPath(b.src).split('/').length - toPosixPath(a.src).split('/').length);
 
         for (const { src, dst, pkg } of installs) {
           if (fs.existsSync(dst)) {
@@ -1068,7 +1069,7 @@ ${dependencies.length > 0 ? dependencies.map(dep => `-- requires: ${dep}`).join(
           }
   
           fs.mkdirSync(path.dirname(dst), { recursive: true });
-          execSync(`mv "${src}" "${dst}"`);
+          movePath(src, dst);
           logger.success(`✔ installed ${pkg}`);
   
           const pkgJsonFile = path.join(dst, 'package.json');
@@ -1087,8 +1088,9 @@ ${dependencies.length > 0 ? dependencies.map(dep => `-- requires: ${dep}`).join(
         }
   
       } finally {
-        fs.rmSync(tempDir, { recursive: true, force: true });
+        // chdir out first: Windows locks the process working directory
         process.chdir(originalDir);
+        fs.rmSync(tempDir, { recursive: true, force: true });
       }
     }
   
@@ -2023,7 +2025,8 @@ ${dependencies.length > 0 ? dependencies.map(dep => `-- requires: ${dep}`).join(
       const expected = `${info.extname}.control`;
       if (base !== expected) issues.push({ code: 'control_filename_mismatch', message: `Control filename ${base} != ${expected}`, file: controlPath });
     }
-    return { ok: issues.length === 0, name: info.extname, path: modPath, issues };
+    const reported = issues.map(issue => ({ ...issue, file: toPosixPath(issue.file) }));
+    return { ok: reported.length === 0, name: info.extname, path: toPosixPath(modPath), issues: reported };
   }
 
   renameModule(newName: string, opts?: RenameOptions): { changed: string[]; warnings: string[] } {

--- a/pgpm/core/src/core/class/pgpm.ts
+++ b/pgpm/core/src/core/class/pgpm.ts
@@ -37,6 +37,7 @@ import {
 } from '../../modules/modules';
 import { packageModule } from '../../packaging/package';
 import { resolveDependencies,resolveExtensionDependencies } from '../../resolution/deps';
+import { globPaths, globPattern } from '../../utils/glob';
 import { parseTarget } from '../../utils/target-utils';
 import { DEFAULT_TEMPLATE_REPO, DEFAULT_TEMPLATE_TOOL_NAME, DEFAULT_TEMPLATE_TTL_MS, scaffoldTemplate } from '../template-scaffold';
 
@@ -187,7 +188,7 @@ export class PgpmPackage {
   private loadAllowedDirs(): string[] {
     const globs: string[] = this.config?.packages ?? [];
     const dirs = globs.flatMap(pattern =>
-      glob.sync(path.join(this.workspacePath!, pattern))
+      globPaths(this.workspacePath!, pattern)
     );
     const resolvedDirs = dirs.map(dir => path.resolve(dir));
     // Remove duplicates by converting to Set and back to array
@@ -316,11 +317,11 @@ export class PgpmPackage {
     // nested workspaces (e.g. test fixtures) out of the module map.
     const packageDirs = [
       ...this.allowedDirs,
-      ...glob.sync(path.join(this.workspacePath, this.extensionsDir, '{*,@*/*}'))
+      ...globPaths(this.workspacePath, this.extensionsDir, '{*,@*/*}')
     ];
 
     const moduleFiles = [...new Set(
-      packageDirs.flatMap(dir => glob.sync(`${dir}/**/*.control`))
+      packageDirs.flatMap(dir => glob.sync(globPattern(dir, '**/*.control')))
     )].filter(
       (file: string) => !/node_modules/.test(file)
     ).sort((a, b) => a.localeCompare(b));
@@ -1047,7 +1048,7 @@ ${dependencies.length > 0 ? dependencies.map(dep => `-- requires: ${dep}`).join(
           stdio: 'inherit'
         });
   
-        const matches = glob.sync(`./${this.extensionsDir}/**/pgpm.plan`);
+        const matches = glob.sync(globPattern('.', this.extensionsDir, '**/pgpm.plan'));
         const installs = matches.map((conf) => {
           const fullConf = resolve(conf);
           const extDir = dirname(fullConf);

--- a/pgpm/core/src/resolution/deps.ts
+++ b/pgpm/core/src/resolution/deps.ts
@@ -3,6 +3,7 @@ import { sync as glob } from 'glob';
 import { join,relative } from 'path';
 
 import { PgpmPackage } from '../core/class/pgpm';
+import { globPattern, toPosixPath } from '../utils/glob';
 import { parsePlanFile } from '@pgpmjs/ast/files/plan/parser';
 import { scanDeployScript } from '@pgpmjs/ast/files/sql/header';
 import { ExtendedPlanFile } from '@pgpmjs/ast/files/types';
@@ -473,11 +474,11 @@ export const resolveDependencies = (
   const tagMappings: Record<string, string> = {};
 
   // Process SQL files and build dependency graph
-  const files = glob(`${packageDir}/deploy/**/*.sql`).sort((a, b) => a.localeCompare(b));
+  const files = glob(globPattern(packageDir, 'deploy/**/*.sql')).sort((a, b) => a.localeCompare(b));
 
   for (const file of files) {
     const data = readFileSync(file, 'utf-8');
-    const key = '/' + relative(packageDir, file);
+    const key = '/' + toPosixPath(relative(packageDir, file));
     deps[key] = [];
 
     const { requires } = scanDeployScript(data, { key, extname, makeKey });

--- a/pgpm/core/src/utils/fs.ts
+++ b/pgpm/core/src/utils/fs.ts
@@ -1,0 +1,15 @@
+import fs from 'fs';
+
+/**
+ * Move a file or directory, falling back to copy + remove across devices.
+ * Replaces shelling out to `mv`, which does not exist on Windows.
+ */
+export const movePath = (src: string, dst: string): void => {
+  try {
+    fs.renameSync(src, dst);
+  } catch (e: any) {
+    if (e?.code !== 'EXDEV' && e?.code !== 'EPERM') throw e;
+    fs.cpSync(src, dst, { recursive: true });
+    fs.rmSync(src, { recursive: true, force: true });
+  }
+};

--- a/pgpm/core/src/utils/glob.ts
+++ b/pgpm/core/src/utils/glob.ts
@@ -1,0 +1,24 @@
+import { sync as globSync } from 'glob';
+import path from 'path';
+
+/**
+ * Convert a native filesystem path to a posix-style path.
+ * Windows path separators are not valid inside glob patterns.
+ */
+export const toPosixPath = (p: string): string => p.replace(/\\/g, '/');
+
+/**
+ * Join path segments into a glob pattern.
+ *
+ * `glob` treats `\` as an escape character on every platform, so a Windows
+ * path produced by `path.join` silently matches nothing. Patterns must always
+ * use forward slashes, which Windows accepts as a separator.
+ */
+export const globPattern = (...segments: string[]): string =>
+  toPosixPath(path.join(...segments));
+
+/**
+ * Cross-platform `glob.sync` over path segments joined into a pattern.
+ */
+export const globPaths = (...segments: string[]): string[] =>
+  globSync(globPattern(...segments));

--- a/postgres/constructive-test/package.json
+++ b/postgres/constructive-test/package.json
@@ -39,8 +39,8 @@
     "clean": "makage clean",
     "copy": "makage assets",
     "prepack": "npm run build",
-    "build": "npm run clean; tsc; tsc -p tsconfig.esm.json; npm run copy",
-    "build:dev": "npm run clean; tsc --declarationMap; tsc -p tsconfig.esm.json; npm run copy",
+    "build": "npm run clean && tsc && tsc -p tsconfig.esm.json && npm run copy",
+    "build:dev": "npm run clean && tsc --declarationMap && tsc -p tsconfig.esm.json && npm run copy",
     "lint": "eslint . --fix",
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch"

--- a/postgres/insforge-test/package.json
+++ b/postgres/insforge-test/package.json
@@ -45,8 +45,8 @@
     "clean": "makage clean",
     "copy": "makage assets",
     "prepack": "npm run build",
-    "build": "npm run clean; tsc; tsc -p tsconfig.esm.json; npm run copy",
-    "build:dev": "npm run clean; tsc --declarationMap; tsc -p tsconfig.esm.json; npm run copy",
+    "build": "npm run clean && tsc && tsc -p tsconfig.esm.json && npm run copy",
+    "build:dev": "npm run clean && tsc --declarationMap && tsc -p tsconfig.esm.json && npm run copy",
     "lint": "eslint . --fix",
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch"

--- a/postgres/supabase-test/package.json
+++ b/postgres/supabase-test/package.json
@@ -45,8 +45,8 @@
     "clean": "makage clean",
     "copy": "makage assets",
     "prepack": "npm run build",
-    "build": "npm run clean; tsc; tsc -p tsconfig.esm.json; npm run copy",
-    "build:dev": "npm run clean; tsc --declarationMap; tsc -p tsconfig.esm.json; npm run copy",
+    "build": "npm run clean && tsc && tsc -p tsconfig.esm.json && npm run copy",
+    "build:dev": "npm run clean && tsc --declarationMap && tsc -p tsconfig.esm.json && npm run copy",
     "lint": "eslint . --fix",
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch"

--- a/scripts/pgpm-smoke.mjs
+++ b/scripts/pgpm-smoke.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * Cross-platform pgpm end-to-end smoke test.
+ *
+ * Creates a throwaway workspace (in a directory whose name contains a space),
+ * then runs deploy → verify → revert through the built pgpm CLI. Exercises
+ * workspace/module discovery, plan resolution, and migration execution on the
+ * host platform — the codepaths that silently broke on Windows because glob
+ * patterns were built with native path separators.
+ *
+ * Usage: node scripts/pgpm-smoke.mjs
+ * Requires: pgpm/cli built (pnpm --filter pgpm... build) and a reachable
+ * PostgreSQL (standard PG* env vars).
+ */
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const cli = path.join(repoRoot, 'pgpm', 'cli', 'dist', 'index.js');
+
+if (!fs.existsSync(cli)) {
+  console.error(`pgpm CLI not built at ${cli} — run: pnpm --filter pgpm... build`);
+  process.exit(1);
+}
+
+const MODULE = 'smoke_mod';
+const database = `pgpm_smoke_${Date.now()}`;
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pgpm smoke '));
+const workspace = path.join(root, 'workspace');
+const moduleDir = path.join(workspace, 'packages', MODULE);
+
+const write = (file, contents) => {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, contents);
+};
+
+write(path.join(workspace, 'pgpm.json'), JSON.stringify({ packages: ['packages/*'] }, null, 2));
+write(
+  path.join(moduleDir, `${MODULE}.control`),
+  `# ${MODULE} extension\ncomment = 'pgpm smoke module'\ndefault_version = '0.0.1'\nrequires = 'plpgsql'\nrelocatable = false\nsuperuser = false\n`
+);
+write(
+  path.join(moduleDir, 'pgpm.plan'),
+  `%syntax-version=1.0.0\n%project=${MODULE}\n%uri=${MODULE}\n\n` +
+    `schema 2024-01-01T00:00:00Z smoke <smoke@example.com> # Create schema\n` +
+    `widgets [schema] 2024-01-02T00:00:00Z smoke <smoke@example.com> # Create widgets\n`
+);
+write(
+  path.join(moduleDir, 'deploy', 'schema.sql'),
+  `-- Deploy ${MODULE}:schema to pg\n\nBEGIN;\n\nCREATE SCHEMA ${MODULE};\n\nCOMMIT;\n`
+);
+write(
+  path.join(moduleDir, 'deploy', 'widgets.sql'),
+  `-- Deploy ${MODULE}:widgets to pg\n\n-- requires: schema\n\nBEGIN;\n\nCREATE TABLE ${MODULE}.widgets (\n    id SERIAL PRIMARY KEY,\n    name TEXT NOT NULL\n);\n\nCOMMIT;\n`
+);
+write(path.join(moduleDir, 'revert', 'schema.sql'), `-- Revert ${MODULE}:schema\n\nBEGIN;\n\nDROP SCHEMA ${MODULE};\n\nCOMMIT;\n`);
+write(path.join(moduleDir, 'revert', 'widgets.sql'), `-- Revert ${MODULE}:widgets\n\nBEGIN;\n\nDROP TABLE ${MODULE}.widgets;\n\nCOMMIT;\n`);
+write(
+  path.join(moduleDir, 'verify', 'schema.sql'),
+  `-- Verify ${MODULE}:schema\n\nBEGIN;\n\nSELECT 1 / count(*) FROM information_schema.schemata WHERE schema_name = '${MODULE}';\n\nROLLBACK;\n`
+);
+write(
+  path.join(moduleDir, 'verify', 'widgets.sql'),
+  `-- Verify ${MODULE}:widgets\n\nBEGIN;\n\nSELECT 1 / count(*) FROM information_schema.tables WHERE table_schema = '${MODULE}' AND table_name = 'widgets';\n\nROLLBACK;\n`
+);
+
+const run = (label, args) => {
+  console.log(`\n=== ${label}: pgpm ${args.join(' ')}`);
+  const result = spawnSync(process.execPath, [cli, ...args], {
+    cwd: workspace,
+    stdio: 'inherit',
+    env: { ...process.env, CI: 'true' }
+  });
+  if (result.status !== 0) {
+    console.error(`pgpm ${args.join(' ')} failed with exit code ${result.status}`);
+    process.exit(result.status ?? 1);
+  }
+};
+
+let failed = false;
+try {
+  run('deploy', ['deploy', '--createdb', '--database', database, '--yes', '--package', MODULE, '--cwd', workspace]);
+  run('verify', ['verify', '--database', database, '--yes', '--package', MODULE, '--cwd', workspace]);
+  run('revert', ['revert', '--database', database, '--yes', '--package', MODULE, '--cwd', workspace]);
+  console.log('\npgpm smoke test passed');
+} catch (err) {
+  failed = true;
+  console.error(err);
+} finally {
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
## Summary

Fixes #1444 and adds the Windows CI that would have caught it. The reporter's diagnosis was correct, and the runner turned up three more Windows bugs behind it.

The branch is ordered as evidence: commit 1 adds the CI job only (**103/208 `@pgpmjs/core` tests fail on `windows-latest`, 22 suites, all `MODULE_NOT_FOUND`**), later commits take it to 208/208 plus a green `deploy → verify → revert`.

### 1. glob patterns built from native paths (the reported bug)

`glob` treats `\` as an escape on every platform, so every pattern built with `path.join` silently matches nothing on Windows:

```
path.join('C:\\ws', 'packages/*')  ->  'C:\\ws/packages/*'
glob.sync(that)                    ->  []            // '\w' unescapes to 'w'
glob.sync('C:/ws/packages/*')      ->  ['C:\\ws\\packages\\mod']
```

`loadAllowedDirs()` → `allowedDirs = []` → `listModules()` → `{}` → `MODULE_NOT_FOUND`, which `pgsql-test` swallows as a seed warning and surfaces later as a misleading `schema ... does not exist`.

New `pgpm/core/src/utils/glob.ts`:

```ts
export const toPosixPath = (p: string) => p.replace(/\\/g, '/');
export const globPattern = (...segments: string[]) => toPosixPath(path.join(...segments));
export const globPaths = (...segments: string[]) => globSync(globPattern(...segments));
```

Applied to workspace-package discovery, the extensions dir, the `**/*.control` scan, the install-time `pgpm.plan` scan, and `deps.ts`'s deploy-script scan.

### 2. `;` as a shell separator in npm scripts

`"copy": "npm run copy:pkg; npm run copy:sql"` — cmd.exe has no `;` separator, so it runs `npm run "copy:pkg;"` and `pnpm build` dies in `pgpm/core` before any test runs. Same pattern in three `postgres/*-test` packages. Now `&&`.

### 3. `pgpm install` on Windows

`installModules()` had three platform assumptions:

```diff
-const parts = extDir.split('node_modules/');          // native seps never match
+const parts = toPosixPath(extDir).split('node_modules/');
-execSync(`mv "${src}" "${dst}"`);                     // no `mv` on Windows
+movePath(src, dst);                                   // renameSync + EXDEV/EPERM copy fallback
 } finally {
-  fs.rmSync(tempDir, ...); process.chdir(originalDir); // EBUSY: cwd is locked
+  process.chdir(originalDir); fs.rmSync(tempDir, ...);
 }
```

### 4. Path/EOL values that are identifiers, not filesystem paths

`Module.path` (recorded in `pgpm.json`), `analyzeModule()` issue paths, and `deps.ts` dependency-graph keys are portable identifiers, so they are now posix regardless of platform. A root `.gitattributes` (`* text=auto eol=lf`) stops CRLF checkouts from corrupting the verbatim SQL comparisons — relevant beyond tests, since bundles are content-addressed.

### CI

New `windows-tests` job — one job, no matrix, ~5 min; the Linux tiers are unchanged. Windows runners can't use Linux service containers, so it starts the PostgreSQL that ships with the runner image and puts its `bin` on `PATH` (which also covers the reporter's `spawn psql ENOENT`), runs the DB-free `@pgpmjs/core` suites, then `scripts/pgpm-smoke.mjs`: a generated workspace **in a directory containing a space** taken through `pgpm deploy --createdb` → `verify` → `revert`.

### Not addressed

The reporter's `permission denied for schema` is not a Windows issue — his module emits no `GRANT`s. `teardown({ keepDb: true })` is still supported (`postgres/pgsql-test/src/connect.ts`), so that report is either an older installed version or a cascade from the failing `beforeAll`.


Link to Devin session: https://app.devin.ai/sessions/e3c07fd0df2445b0a1e4d03da2cd2aa8
Requested by: @pyramation