### PR TITLE
[review-only] Scoped-routing doc updates + non-generated pgpm/export changes from #1450

### DIFF
--- a/.agents/skills/pgpm/references/pgpm-tables.md
+++ b/.agents/skills/pgpm/references/pgpm-tables.md
@@ -1,6 +1,6 @@
 # pgpm Table Creation Rules
 
-When creating a new table in `metaschema_modules_public`, `metaschema_public`, or `services_public` schemas in the constructive-db repository, follow these steps.
+When creating a new table in `metaschema_modules_public`, `metaschema_public`, or `constructive_routing_public` schemas in the constructive-db repository, follow these steps.
 
 ## Required: Deterministic ID Trigger
 

--- a/graphql/env/README.md
+++ b/graphql/env/README.md
@@ -50,7 +50,8 @@ In addition to all environment variables supported by `@pgpmjs/env`, this packag
 - `FEATURES_POSTGIS` - Enable PostGIS support
 
 ### API Configuration
-- `API_ENABLE_SERVICES` - Enable services API (domain/subdomain routing)
+- `API_ENABLE_SCOPED_ROUTING` - Enable scoped routing (host resolution via `resolve_route()`)
+- `API_SCOPED_ROUTING_SCHEMA` - Schema containing the compiled `resolve_route()` resolver
 - `API_IS_PUBLIC` - Whether API is public
 - `API_EXPOSED_SCHEMAS` - Comma-separated list of exposed schemas
 - `API_META_SCHEMAS` - Comma-separated list of meta schemas
@@ -71,13 +72,13 @@ GraphQL defaults are provided by `@constructive-io/graphql-types`:
     postgis: true
   },
   api: {
-    enableServicesApi: true,
     exposedSchemas: [],
     anonRole: 'administrator',
     roleName: 'administrator',
-    defaultDatabaseId: 'hard-coded',
     isPublic: true,
-    metaSchemas: ['services_public', 'metaschema_public', 'metaschema_modules_public']
+    metaSchemas: ['constructive_routing_public', 'metaschema_public', 'metaschema_modules_public'],
+    enableScopedRouting: true,
+    scopedRoutingSchema: 'constructive_routing_public'
   }
 }
 ```

--- a/graphql/playwright-test/README.md
+++ b/graphql/playwright-test/README.md
@@ -64,7 +64,7 @@ let connections: Awaited<ReturnType<typeof getConnectionsWithServer>>;
 
 test.beforeAll(async () => {
   connections = await getConnectionsWithServer({
-    schemas: ['services_public', 'app_public'],
+    schemas: ['app_public'],
     authRole: 'anonymous',
     server: {
       port: 5555,
@@ -150,14 +150,14 @@ Low-level function to create just the HTTP server without database setup.
 
 1. Creates an isolated test database using `pgsql-test`
 2. Starts an Express server with Constructive GraphQL middleware
-3. Configures `enableServicesApi: false` to bypass domain/subdomain routing
+3. Configures `enableScopedRouting: false` (static mode) to bypass host route resolution
 4. Exposes the specified schemas directly via the GraphQL endpoint
 5. Returns the server URL for Playwright to connect to
 6. Provides a teardown function that stops the server and cleans up the database
 
 ## Configuration
 
-The server is configured with `enableServicesApi: false`, which means:
-- No domain/subdomain routing is required
+The server is configured with `enableScopedRouting: false`, which means:
+- No host route resolution (`resolve_route()`) is required
 - Schemas are exposed directly based on the `schemas` parameter
 - Perfect for isolated testing without complex domain setup

--- a/graphql/server/README.md
+++ b/graphql/server/README.md
@@ -99,20 +99,20 @@ For the operational workflow, sampler output, and heap snapshot usage, see [docs
 - `GET /debug/memory` -> memory/process/Graphile debug snapshot when observability is enabled
 - `GET /debug/db` -> PostgreSQL activity/locks/pool debug snapshot when observability is enabled
 
-## Meta API routing
+## Scoped routing
 
-When `API_ENABLE_META=true` (default):
+When `API_ENABLE_SCOPED_ROUTING=true` (default):
 
-- The server resolves APIs from `services_public.domains` using the request host.
+- The server resolves the request host with a single `resolve_route()` call against the compiled route bindings in the scoped routing schema (`API_SCOPED_ROUTING_SCHEMA`, default `constructive_routing_public`), mapping host → tenant/api/database/role.
 - Only APIs where `api.is_public` matches `API_IS_PUBLIC` are served.
 - In private mode (`API_IS_PUBLIC=false`), you can override with headers:
   - `X-Api-Name` + `X-Database-Id`
   - `X-Schemata` + `X-Database-Id`
   - `X-Meta-Schema` + `X-Database-Id`
 
-When `API_ENABLE_META=false`:
+When `API_ENABLE_SCOPED_ROUTING=false` (static single-tenant mode):
 
-- The server skips meta lookups and serves the fixed schemas in `API_EXPOSED_SCHEMAS`.
+- The server skips route resolution and serves the fixed schemas in `API_EXPOSED_SCHEMAS`.
 - Roles and database IDs come from `API_ANON_ROLE`, `API_ROLE_NAME`, and `API_DEFAULT_DATABASE_ID`.
 
 ## Configuration
@@ -130,13 +130,14 @@ Configuration is merged from defaults, config files, and env vars via `@construc
 | `FEATURES_SIMPLE_INFLECTION`   | Enable simple inflection              | `true`                                                        |
 | `FEATURES_OPPOSITE_BASE_NAMES` | Enable opposite base names            | `true`                                                        |
 | `FEATURES_POSTGIS`             | Enable PostGIS support                | `true`                                                        |
-| `API_ENABLE_META`              | Enable meta API routing               | `true`                                                        |
+| `API_ENABLE_SCOPED_ROUTING`    | Enable scoped routing                 | `true`                                                        |
+| `API_SCOPED_ROUTING_SCHEMA`    | Schema containing `resolve_route()`   | `constructive_routing_public`                                 |
 | `API_IS_PUBLIC`                | Serve public APIs only                | `true`                                                        |
-| `API_EXPOSED_SCHEMAS`          | Schemas when meta routing is disabled | empty                                                         |
-| `API_META_SCHEMAS`             | Meta schemas to query                 | `services_public,metaschema_public,metaschema_modules_public` |
+| `API_EXPOSED_SCHEMAS`          | Schemas when scoped routing is disabled | empty                                                       |
+| `API_META_SCHEMAS`             | Meta schemas to query                 | `constructive_routing_public,metaschema_public,metaschema_modules_public` |
 | `API_ANON_ROLE`                | Anonymous role name                   | `administrator`                                               |
 | `API_ROLE_NAME`                | Authenticated role name               | `administrator`                                               |
-| `API_DEFAULT_DATABASE_ID`      | Default database ID                   | `hard-coded`                                                  |
+| `API_DEFAULT_DATABASE_ID`      | Default database ID                   | unset                                                         |
 | `GRAPHQL_OBSERVABILITY_ENABLED` | Master switch for debug routes and sampler | `false`                                                  |
 | `GRAPHQL_DEBUG_SAMPLER_ENABLED` | Enables periodic NDJSON sampling when observability is on | `true`                                   |
 | `GRAPHQL_DEBUG_SAMPLER_INTERVAL_MS` | Sampler interval in milliseconds | `10000`                                                       |

--- a/graphql/types/README.md
+++ b/graphql/types/README.md
@@ -40,7 +40,8 @@ const config: ConstructiveOptions = {
     appendPlugins: [],
   },
   api: {
-    enableServicesApi: true,
+    enableScopedRouting: true,
+    scopedRoutingSchema: 'constructive_routing_public',
     exposedSchemas: ['public'],
   },
   features: {

--- a/packages/express-context/README.md
+++ b/packages/express-context/README.md
@@ -63,11 +63,11 @@ Each loader encapsulates a SQL query + type transform + per-databaseId LRU cache
 
 | Loader | Source | Description |
 |--------|--------|-------------|
-| `rlsLoader` | `services_public.rls_settings` | RLS module (authenticate functions, schema refs) |
-| `corsLoader` | `services_public.cors_settings` | CORS allowed origins |
-| `databaseSettingsLoader` | `services_public.database_settings` | Feature flags (aggregates, search, uploads, etc.) |
-| `pubkeyLoader` | `services_public.pubkey_settings` | Public key challenge auth settings |
-| `webauthnLoader` | `services_public.webauthn_settings` | WebAuthn/passkey configuration |
+| `rlsLoader` | `constructive_routing_public.rls_settings` | RLS module (authenticate functions, schema refs) |
+| `corsLoader` | `constructive_routing_public.cors_settings` | CORS allowed origins |
+| `databaseSettingsLoader` | `constructive_routing_public.database_settings` | Feature flags (aggregates, search, uploads, etc.) |
+| `pubkeyLoader` | `constructive_routing_public.pubkey_settings` | Public key challenge auth settings |
+| `webauthnLoader` | `constructive_routing_public.webauthn_settings` | WebAuthn/passkey configuration |
 | `authSettingsLoader` | `metaschema_modules_public.sessions_module` | Cookie/captcha settings (two-step tenant DB discovery) |
 
 ### Custom loaders

--- a/pgpm/export/__tests__/export-meta.test.ts
+++ b/pgpm/export/__tests__/export-meta.test.ts
@@ -132,12 +132,12 @@ describe('Export Meta Config Validation', () => {
       expect(lastMetaschema).toBeLessThan(firstService);
     });
 
-    it('scoped plane tables should come before metaschema_modules_public tables', () => {
+    it('metaschema_modules_public tables should come before scoped plane tables', () => {
       const order = META_TABLE_ORDER as unknown as string[];
-      const lastService = order.indexOf('api_schemas');
-      const firstModule = order.indexOf('rls_module');
+      const lastModule = order.indexOf('rls_module');
+      const firstScoped = order.indexOf('apis');
 
-      expect(lastService).toBeLessThan(firstModule);
+      expect(lastModule).toBeLessThan(firstScoped);
     });
   });
 });

--- a/pgpm/export/src/export-graphql-meta.ts
+++ b/pgpm/export/src/export-graphql-meta.ts
@@ -148,6 +148,13 @@ export const exportGraphQLMeta = async ({
     const tableConfig = META_TABLE_CONFIG[key];
     if (!tableConfig) return;
 
+    // Schema-qualified manifest keys (e.g. constructive_catalog_public.apis)
+    // mark tables whose name collides with a table in another plane. GraphQL
+    // type/query names are derived from the bare table name, so these cannot
+    // be addressed unambiguously through the meta API — only the SQL flow
+    // exports them.
+    if (key.includes('.')) return;
+
     // Build fields dynamically: either from hardcoded config or via introspection
     const { fields: configFields, enumFields } = await buildDynamicFieldsFromGraphQL(client, tableConfig);
     if (Object.keys(configFields).length === 0) return;

--- a/pgpm/export/src/export-graphql.ts
+++ b/pgpm/export/src/export-graphql.ts
@@ -72,8 +72,9 @@ export interface ExportGraphQLOptions {
   skipSchemaRenaming?: boolean;
   /**
    * sql_actions categories to exclude from the export (e.g. ['security',
-   * 'permissions']). Rows whose category matches are omitted; rows with a
-   * null category are always kept.
+   * 'permissions']). The migrate API no longer exposes the category column;
+   * exclusion is enforced server-side by the export_category_filter RLS
+   * policy (export.exclude_categories), so this flag is not applied client-side.
    */
   excludeCategories?: string[];
 }
@@ -100,8 +101,7 @@ export const exportGraphQL = async ({
   repoName,
   username,
   serviceOutdir,
-  skipSchemaRenaming = false,
-  excludeCategories
+  skipSchemaRenaming = false
 }: ExportGraphQLOptions): Promise<void> => {
   const normalizedOutdir = normalizeOutdir(outdir);
   const svcOutdir = normalizeOutdir(serviceOutdir || outdir);
@@ -154,19 +154,10 @@ export const exportGraphQL = async ({
             actionName: true,
             actionId: true,
             actorId: true,
-            payload: true,
-            category: true
+            payload: true
           },
           where: {
-            databaseId: { equalTo: databaseId },
-            ...(excludeCategories && excludeCategories.length > 0
-              ? {
-                  or: [
-                    { category: { isNull: true } },
-                    { category: { notIn: excludeCategories } }
-                  ]
-                }
-              : {})
+            databaseId: { equalTo: databaseId }
           },
           orderBy: ['ID_ASC'],
           first: PAGE_SIZE,


### PR DESCRIPTION
## Summary

Draft, source-only review slice of #1450 — just the hand-written files, none of the regenerated SDK/fixture output. Everything here needs human eyes; the rest of #1450 is pure codegen.

### Docs (item 10) — 5 READMEs + 1 skills doc
Rewritten from the removed services mode to the current scoped model:
- `enableServicesApi` → `enableScopedRouting`, plus `scopedRoutingSchema: 'constructive_routing_public'`
- `API_ENABLE_META` / `API_META_SCHEMAS` → `API_ENABLE_SCOPED_ROUTING` / `API_SCOPED_ROUTING_SCHEMA`, meta-schema defaults repointed to `constructive_routing_public`
- express-context loader sources (`rls/cors/databaseSettings/pubkey/webauthn`) → `constructive_routing_public.*`
- playwright-test helper documented as `enableScopedRouting: false` (static mode)
- `.agents/skills/pgpm/references/pgpm-tables.md`: `services_public` → `constructive_routing_public`

### Non-generated `pgpm/export` changes (forced by the regenerated schema)
1. `src/export-graphql.ts` — the migrate API no longer exposes `sql_actions.category` (repointed upstream to `ddl_audit_public`), so the client-side `category` select + `notIn`/`isNull` filter is removed. Exclusion is now enforced server-side by the `export_category_filter` RLS policy (`export.exclude_categories`). `excludeCategories` stays on the options type for the SQL flow.
   ```diff
   - select: { ..., payload: true, category: true },
   - where: { databaseId: { equalTo }, ...(excludeCategories ? { or: [{category:{isNull:true}},{category:{notIn:excludeCategories}}] } : {}) }
   + select: { ..., payload: true },
   + where: { databaseId: { equalTo } }
   ```
2. `src/export-graphql-meta.ts` — the regenerated manifest adds schema-qualified keys (e.g. `constructive_catalog_public.apis`) for tables whose bare name collides across planes. GraphQL type/query names derive from the bare name, so these can't be addressed via the meta API; skip them in the GraphQL flow (SQL flow still exports them).
   ```diff
   + if (key.includes('.')) return;
   ```
3. `__tests__/export-meta.test.ts` — regenerated manifest orders `metaschema_modules_public` tables *before* the scoped-plane tables; the assertion previously asserted the reverse. Updated to `rls_module` before `apis`.

### Verification
`pgpm/export` builds and all 157 tests pass with these changes.

Not for merge — merge #1450. This exists only to make review of the human-authored parts easy.

Link to Devin session: https://app.devin.ai/sessions/7d5c2bf9f4314e8782556e3255edf39b
Requested by: @pyramation