### PR TITLE
Remove the default-database concept; require an explicit database id

### DIFF
--- a/graphql/env/README.md
+++ b/graphql/env/README.md
@@ -57,7 +57,6 @@ In addition to all environment variables supported by `@pgpmjs/env`, this packag
 - `API_META_SCHEMAS` - Comma-separated list of meta schemas
 - `API_ANON_ROLE` - Anonymous role name
 - `API_ROLE_NAME` - Default role name
-- `API_DEFAULT_DATABASE_ID` - Default database ID
 
 ## Defaults
 

--- a/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
+++ b/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
@@ -4,7 +4,6 @@ exports[`getEnvOptions merges pgpm defaults, graphql defaults, config, env, and 
 {
   "api": {
     "anonRole": "env_anon",
-    "defaultDatabaseId": "override_db",
     "enableScopedRouting": false,
     "exposedSchemas": [
       "public",

--- a/graphql/env/__tests__/merge.test.ts
+++ b/graphql/env/__tests__/merge.test.ts
@@ -63,7 +63,6 @@ describe('getEnvOptions', () => {
       API_META_SCHEMAS: 'env_meta1,env_meta2',
       API_ANON_ROLE: 'env_anon',
       API_ROLE_NAME: 'env_role',
-      API_DEFAULT_DATABASE_ID: 'env_db',
       SMS_PROVIDER: 'devsms',
       SMS_SENDER_ID: 'EnvSender',
       SMS_REQUEST_TIMEOUT_MS: '4000',
@@ -89,8 +88,7 @@ describe('getEnvOptions', () => {
           oppositeBaseNames: false
         },
         api: {
-          enableScopedRouting: false,
-          defaultDatabaseId: 'override_db'
+          enableScopedRouting: false
         },
         sms: {
           senderId: 'OverrideSender',

--- a/graphql/env/src/env.ts
+++ b/graphql/env/src/env.ts
@@ -19,7 +19,6 @@ export const getGraphQLEnvVars = (env: NodeJS.ProcessEnv = process.env): Partial
     API_META_SCHEMAS,
     API_ANON_ROLE,
     API_ROLE_NAME,
-    API_DEFAULT_DATABASE_ID,
 
     EMBEDDER_PROVIDER,
     EMBEDDER_MODEL,
@@ -68,8 +67,7 @@ export const getGraphQLEnvVars = (env: NodeJS.ProcessEnv = process.env): Partial
       ...(API_EXPOSED_SCHEMAS && { exposedSchemas: API_EXPOSED_SCHEMAS.split(',').map(s => s.trim()) }),
       ...(API_META_SCHEMAS && { metaSchemas: API_META_SCHEMAS.split(',').map(s => s.trim()) }),
       ...(API_ANON_ROLE && { anonRole: API_ANON_ROLE }),
-      ...(API_ROLE_NAME && { roleName: API_ROLE_NAME }),
-      ...(API_DEFAULT_DATABASE_ID && { defaultDatabaseId: API_DEFAULT_DATABASE_ID })
+      ...(API_ROLE_NAME && { roleName: API_ROLE_NAME })
     },
     ...((EMBEDDER_PROVIDER || CHAT_PROVIDER) && {
       llm: {

--- a/graphql/playwright-test/src/get-connections.ts
+++ b/graphql/playwright-test/src/get-connections.ts
@@ -47,7 +47,9 @@ const createConnectionsWithServerBase = async (
     api: {
       enableScopedRouting: false,
       exposedSchemas: input.schemas,
-      defaultDatabaseId: 'test-database',
+      // Static single-tenant mode requires an explicit database id (there is
+      // no default database); the isolated test database uses a stable id.
+      databaseId: 'test-database',
       ...(input.authRole && { anonRole: input.authRole, roleName: input.authRole })
     }
   });

--- a/graphql/playwright-test/src/get-connections.ts
+++ b/graphql/playwright-test/src/get-connections.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'crypto';
+
 import { getEnvOptions } from '@constructive-io/graphql-env';
 import {
   type GraphQLQueryOptions,
@@ -48,8 +50,8 @@ const createConnectionsWithServerBase = async (
       enableScopedRouting: false,
       exposedSchemas: input.schemas,
       // Static single-tenant mode requires an explicit database id (there is
-      // no default database); the isolated test database uses a stable id.
-      databaseId: 'test-database',
+      // no default database); each isolated test database gets a fresh UUID.
+      databaseId: randomUUID(),
       ...(input.authRole && { anonRole: input.authRole, roleName: input.authRole })
     }
   });

--- a/graphql/server-test/README.md
+++ b/graphql/server-test/README.md
@@ -186,7 +186,7 @@ The `server.api` option provides full control over the GraphQL server configurat
 | `exposedSchemas` | `string[]` | from `schemas` | Database schemas to expose (overridden by `schemas`) |
 | `anonRole` | `string` | from `authRole` | Anonymous role name (overridden by `authRole`) |
 | `roleName` | `string` | from `authRole` | Default role name (overridden by `authRole`) |
-| `databaseId` | `string` | `test-database` | Explicit tenant database id for static mode (no default database; requests without one are rejected) |
+| `databaseId` | `string (UUID)` | fresh UUID per test database | Explicit tenant database id for static mode (no default database; requests without one are rejected) |
 | `isPublic` | `boolean` | package default | Whether the API is publicly accessible |
 | `metaSchemas` | `string[]` | package default | Schemas containing metadata tables |
 

--- a/graphql/server-test/README.md
+++ b/graphql/server-test/README.md
@@ -186,7 +186,7 @@ The `server.api` option provides full control over the GraphQL server configurat
 | `exposedSchemas` | `string[]` | from `schemas` | Database schemas to expose (overridden by `schemas`) |
 | `anonRole` | `string` | from `authRole` | Anonymous role name (overridden by `authRole`) |
 | `roleName` | `string` | from `authRole` | Default role name (overridden by `authRole`) |
-| `defaultDatabaseId` | `string` | package default | Default database identifier |
+| `databaseId` | `string` | `test-database` | Explicit tenant database id for static mode (no default database; requests without one are rejected) |
 | `isPublic` | `boolean` | package default | Whether the API is publicly accessible |
 | `metaSchemas` | `string[]` | package default | Schemas containing metadata tables |
 
@@ -219,7 +219,6 @@ const { query } = await getConnections({
     api: {
       enableScopedRouting: false,
       isPublic: false,
-      defaultDatabaseId: 'my-test-db',
       metaSchemas: ['constructive_routing_public', 'metaschema_public']
     }
   }

--- a/graphql/server-test/src/get-connections.ts
+++ b/graphql/server-test/src/get-connections.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import type { GetConnectionOpts, GetConnectionResult } from 'pgsql-test';
 import { getConnections as getPgConnections } from 'pgsql-test';
 import type { SeedAdapter } from 'pgsql-test/seed/types';
@@ -54,9 +55,9 @@ export const getConnections = async (
       // Apply convenience properties (these take precedence)
       exposedSchemas: input.schemas,
       // Static single-tenant mode requires an explicit database id (there is
-      // no default database). Tests run against an isolated database, so use a
-      // stable explicit id unless the caller supplied one.
-      databaseId: input.server?.api?.databaseId ?? 'test-database',
+      // no default database). Each isolated test database gets a fresh UUID
+      // unless the caller supplied one.
+      databaseId: input.server?.api?.databaseId ?? randomUUID(),
       ...(input.authRole && { anonRole: input.authRole, roleName: input.authRole })
     },
     graphile: input.graphile

--- a/graphql/server-test/src/get-connections.ts
+++ b/graphql/server-test/src/get-connections.ts
@@ -53,6 +53,10 @@ export const getConnections = async (
       ...input.server?.api,
       // Apply convenience properties (these take precedence)
       exposedSchemas: input.schemas,
+      // Static single-tenant mode requires an explicit database id (there is
+      // no default database). Tests run against an isolated database, so use a
+      // stable explicit id unless the caller supplied one.
+      databaseId: input.server?.api?.databaseId ?? 'test-database',
       ...(input.authRole && { anonRole: input.authRole, roleName: input.authRole })
     },
     graphile: input.graphile

--- a/graphql/server-test/src/types.ts
+++ b/graphql/server-test/src/types.ts
@@ -24,8 +24,7 @@ export interface ServerOptions {
    *     port: 5555,
    *     api: {
    *       enableScopedRouting: false,
-   *       isPublic: false,
-   *       defaultDatabaseId: 'my-database'
+   *       isPublic: false
    *     }
    *   }
    * });

--- a/graphql/server/README.md
+++ b/graphql/server/README.md
@@ -56,7 +56,7 @@ This starts the server with env defaults from `@constructive-io/graphql-env`.
 
 ## What it does
 
-Runs an Express server that wires CORS, uploads, domain parsing, auth, and PostGraphile into a single GraphQL endpoint. It serves `/graphql` and `/graphiql`, injects per-request `pgSettings`, and flushes cached schemas on demand or via database notifications. When meta API is enabled, it resolves API config (schemas, roles, modules) from the meta schema using the request host and enforces `api.isPublic`, with optional header overrides in private mode; when meta API is disabled, it serves the fixed schemas and roles from `api.exposedSchemas`, `api.anonRole`, `api.roleName`, and `api.defaultDatabaseId`.
+Runs an Express server that wires CORS, uploads, domain parsing, auth, and PostGraphile into a single GraphQL endpoint. It serves `/graphql` and `/graphiql`, injects per-request `pgSettings`, and flushes cached schemas on demand or via database notifications. When meta API is enabled, it resolves API config (schemas, roles, modules) from the meta schema using the request host and enforces `api.isPublic`, with optional header overrides in private mode; when meta API is disabled, it serves the fixed schemas and roles from `api.exposedSchemas`, `api.anonRole`, and `api.roleName`.
 
 ## Key Features
 
@@ -113,7 +113,7 @@ When `API_ENABLE_SCOPED_ROUTING=true` (default):
 When `API_ENABLE_SCOPED_ROUTING=false` (static single-tenant mode):
 
 - The server skips route resolution and serves the fixed schemas in `API_EXPOSED_SCHEMAS`.
-- Roles and database IDs come from `API_ANON_ROLE`, `API_ROLE_NAME`, and `API_DEFAULT_DATABASE_ID`.
+- Roles come from `API_ANON_ROLE` and `API_ROLE_NAME`. A request still requires a resolved database id; there is no default database, so a request with no database id is rejected.
 
 ## Configuration
 
@@ -137,7 +137,6 @@ Configuration is merged from defaults, config files, and env vars via `@construc
 | `API_META_SCHEMAS`             | Meta schemas to query                 | `constructive_routing_public,metaschema_public,metaschema_modules_public` |
 | `API_ANON_ROLE`                | Anonymous role name                   | `administrator`                                               |
 | `API_ROLE_NAME`                | Authenticated role name               | `administrator`                                               |
-| `API_DEFAULT_DATABASE_ID`      | Default database ID                   | unset                                                         |
 | `GRAPHQL_OBSERVABILITY_ENABLED` | Master switch for debug routes and sampler | `false`                                                  |
 | `GRAPHQL_DEBUG_SAMPLER_ENABLED` | Enables periodic NDJSON sampling when observability is on | `true`                                   |
 | `GRAPHQL_DEBUG_SAMPLER_INTERVAL_MS` | Sampler interval in milliseconds | `10000`                                                       |

--- a/graphql/server/src/middleware/__tests__/routing.test.ts
+++ b/graphql/server/src/middleware/__tests__/routing.test.ts
@@ -198,7 +198,12 @@ describe('getApiConfig with scoped routing enabled', () => {
     });
     mockGetPgPool.mockReturnValue(createPool(query) as never);
 
-    await getApiConfig(createOptions(false), createRequest({ host: 'api.example.com' }));
+    // Static single-tenant mode never calls resolve_route. It also has no
+    // database id, and there is no default database, so resolution fails loud
+    // rather than silently proceeding with an undefined tenant.
+    await expect(
+      getApiConfig(createOptions(false), createRequest({ host: 'api.example.com' }))
+    ).rejects.toThrow(/database id/i);
 
     expect(query.mock.calls.some(([sql]) => String(sql).includes('resolve_route'))).toBe(false);
   });

--- a/graphql/server/src/middleware/api.ts
+++ b/graphql/server/src/middleware/api.ts
@@ -160,6 +160,21 @@ const resolveModuleSettings = async (
 const isApiError = (result: ApiConfigResult): result is ApiError =>
   !!result && typeof (result as ApiError).errorHtml === 'string';
 
+/**
+ * Every resolved API surface must carry a database id — there is no default
+ * database. A resolved structure without one is a misconfiguration; fail loud
+ * rather than silently proceeding with an undefined tenant.
+ */
+const assertDatabaseId = (result: ApiStructure): void => {
+  if (!result.databaseId) {
+    const error = new Error(
+      'No database id resolved for this request. A database id is required; there is no default database.'
+    ) as Error & { code?: string };
+    error.code = 'NO_DATABASE_ID';
+    throw error;
+  }
+};
+
 const parseCommaSeparatedHeader = (value: string): string[] =>
   value.split(',').map((s) => s.trim()).filter(Boolean);
 
@@ -291,7 +306,7 @@ const resolveStatic = (ctx: ResolveContext): ApiStructure => {
     schema: opts.api?.exposedSchemas ?? [],
     apiModules: [],
     domains: [],
-    databaseId: opts.api?.defaultDatabaseId,
+    databaseId: opts.api?.databaseId,
     isPublic: false
   };
 };
@@ -460,6 +475,7 @@ export const getApiConfig = async (
 
   // Cache successful results
   if (result && !isApiError(result)) {
+    assertDatabaseId(result);
     svcCache.set(cacheKey, result);
   }
 
@@ -474,24 +490,27 @@ export const createApiMiddleware = (opts: ApiOptions) => {
   return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     log.debug(`[api-middleware] ${req.method} ${req.path}`);
 
-    // Fast path: static single-tenant mode (scoped routing disabled) — no
-    // route resolution, expose the configured schemas directly.
-    if (!opts.api?.enableScopedRouting) {
-      req.api = resolveStatic({
-        opts,
-        pool: null as unknown as Pool,
-        domain: '',
-        subdomain: null,
-        cacheKey: 'static',
-        headers: {},
-        host: ''
-      });
-      req.databaseId = req.api.databaseId;
-      req.svc_key = 'static';
-      return next();
-    }
-
     try {
+      // Fast path: static single-tenant mode (scoped routing disabled) — no
+      // route resolution, expose the configured schemas directly. A database
+      // id is still required; assertDatabaseId throws when it is absent.
+      if (!opts.api?.enableScopedRouting) {
+        const staticApi = resolveStatic({
+          opts,
+          pool: null as unknown as Pool,
+          domain: '',
+          subdomain: null,
+          cacheKey: 'static',
+          headers: {},
+          host: ''
+        });
+        assertDatabaseId(staticApi);
+        req.api = staticApi;
+        req.databaseId = staticApi.databaseId;
+        req.svc_key = 'static';
+        return next();
+      }
+
       const apiConfig = await getApiConfig(opts, req);
 
       if (isApiError(apiConfig)) {
@@ -513,6 +532,12 @@ export const createApiMiddleware = (opts: ApiOptions) => {
 
       if (err.code === 'NO_VALID_SCHEMAS') {
         res.status(404).send(errorPage404Message(err.message));
+        return;
+      }
+
+      if (err.code === 'NO_DATABASE_ID') {
+        log.error('[api-middleware] no database id resolved:', err.message);
+        res.status(500).send(errorPage50x);
         return;
       }
 

--- a/graphql/types/src/graphile.ts
+++ b/graphql/types/src/graphile.ts
@@ -34,8 +34,12 @@ export interface ApiOptions {
   anonRole?: string;
   /** Default role name for authenticated requests */
   roleName?: string;
-  /** Default database identifier to use */
-  defaultDatabaseId?: string;
+  /**
+   * Explicit tenant database id for static single-tenant mode. There is no
+   * default database and this is never populated from env; a request that
+   * resolves without a database id is rejected.
+   */
+  databaseId?: string;
   /** Whether the API is publicly accessible */
   isPublic?: boolean;
   /** Schemas containing metadata tables */


### PR DESCRIPTION
## Summary

There is no more "default database." The `defaultDatabaseId` / `API_DEFAULT_DATABASE_ID` fallback is deleted, and request resolution now **fails loud** when it produces no database id instead of silently proceeding with an undefined tenant.

Follow-up to the routing cleanup discussion — kills the config knob that let a request run against an implicit/undefined database.

### Behavior change
- `ApiOptions.defaultDatabaseId` and the `API_DEFAULT_DATABASE_ID` env var are removed (env parser, type, defaults, docs).
- `graphql/server` middleware: after any resolver mode (static, scoped-route, header modes) produces a structure, `assertDatabaseId()` throws `NO_DATABASE_ID` when `databaseId` is falsy. The middleware maps that to a 500.
  ```ts
  const assertDatabaseId = (result: ApiStructure) => {
    if (!result.databaseId) throw Object.assign(new Error('No database id resolved ...'), { code: 'NO_DATABASE_ID' });
  };
  ```
  Static single-tenant mode used to tolerate an undefined db id silently — it no longer does.

### Explicit (non-default) db id
Static single-tenant mode still needs *a* tenant id; it must now be provided **explicitly** (there is no default and it is never sourced from env). `ApiOptions` gains `databaseId?: string` for that, read by `resolveStatic`. The two test harnesses (`graphql/server-test`, `graphql/playwright-test`) mint a fresh per-database `randomUUID()` for each isolated test database (callers may pass their own) — no literal/shared default anywhere.

### Tests
- `routing.test.ts` "does not call resolve_route when scoped routing is disabled" now asserts `getApiConfig(...)` rejects with a db-id error (while still asserting `resolve_route` is never called). The services_public negative assertion is untouched.
- env `merge.test.ts` + snapshot updated to drop `defaultDatabaseId`.

### Verification
- Builds (tsc) pass: `graphql/types`, `graphql/env`, `graphql/server`, `graphql/server-test`, `graphql/playwright-test`.
- `graphql/server` (120), `graphql/env` (9), `graphql/types`, `graphql/playwright-test` (1) suites pass.
- `graphql/server-test` integration failures are **pre-existing/environment** (need infra not on this VM): main fails 108, this branch fails 72, and every test failing here also fails on main (0 new regressions). CI's `integration-graphql` job (with proper infra) passes.
- `pnpm lint` fails repo-wide due to a pre-existing ESLint 9 vs `.eslintrc.json` mismatch, unrelated to this change; lint config left untouched.
- `rg 'defaultDatabaseId|API_DEFAULT_DATABASE_ID'` is clean outside CHANGELOGs.

Link to Devin session: https://app.devin.ai/sessions/7d5c2bf9f4314e8782556e3255edf39b
Requested by: @pyramation