### PR TITLE
Retire @pgpm/services: drop pin, module map entry, and required extension

### DIFF
--- a/pgpm.json
+++ b/pgpm.json
@@ -11,6 +11,7 @@
     "@pgpm/jwt-claims": "0.33.0",
     "@pgpm/metaschema-modules": "0.33.0",
     "@pgpm/metaschema-schema": "0.33.0",
+    "@pgpm/services": "0.33.0",
     "@pgpm/stamps": "0.33.0",
     "@pgpm/uuid": "0.33.0"
   }

--- a/pgpm.json
+++ b/pgpm.json
@@ -11,7 +11,6 @@
     "@pgpm/jwt-claims": "0.33.0",
     "@pgpm/metaschema-modules": "0.33.0",
     "@pgpm/metaschema-schema": "0.33.0",
-    "@pgpm/services": "0.33.0",
     "@pgpm/stamps": "0.33.0",
     "@pgpm/uuid": "0.33.0"
   }

--- a/pgpm/core/src/modules/modules.ts
+++ b/pgpm/core/src/modules/modules.ts
@@ -15,7 +15,6 @@ export const PGPM_MODULE_MAP: Record<string, string> = {
   'pgpm-function-resolution': '@pgpm/function-resolution',
   'metaschema-modules': '@pgpm/metaschema-modules',
   'metaschema-schema': '@pgpm/metaschema-schema',
-  'services': '@pgpm/services',
   'pgpm-inflection': '@pgpm/inflection',
   'pgpm-jwt-claims': '@pgpm/jwt-claims',
   'pgpm-stamps': '@pgpm/stamps',

--- a/pgpm/core/src/modules/modules.ts
+++ b/pgpm/core/src/modules/modules.ts
@@ -14,6 +14,9 @@ export const PGPM_MODULE_MAP: Record<string, string> = {
   'pgpm-database-jobs': '@pgpm/database-jobs',
   'pgpm-function-resolution': '@pgpm/function-resolution',
   'metaschema-modules': '@pgpm/metaschema-modules',
+  // TODO(services retirement): remove once @pgpm/metaschema-modules is
+  // republished without its `services` requires and the pin is bumped.
+  'services': '@pgpm/services',
   'metaschema-schema': '@pgpm/metaschema-schema',
   'pgpm-inflection': '@pgpm/inflection',
   'pgpm-jwt-claims': '@pgpm/jwt-claims',

--- a/pgpm/export/__tests__/export-utils.test.ts
+++ b/pgpm/export/__tests__/export-utils.test.ts
@@ -146,7 +146,8 @@ describe('Shared constants', () => {
   it('SERVICE_REQUIRED_EXTENSIONS should include metaschema dependencies', () => {
     expect(SERVICE_REQUIRED_EXTENSIONS).toContain('plpgsql');
     expect(SERVICE_REQUIRED_EXTENSIONS).toContain('metaschema-schema');
-    expect(SERVICE_REQUIRED_EXTENSIONS).toContain('services');
+    expect(SERVICE_REQUIRED_EXTENSIONS).toContain('metaschema-modules');
+    expect(SERVICE_REQUIRED_EXTENSIONS).not.toContain('services');
   });
 
   it('META_COMMON_HEADER should set session_replication_role', () => {

--- a/pgpm/export/src/export-utils.ts
+++ b/pgpm/export/src/export-utils.ts
@@ -111,8 +111,7 @@ export const isTimestampDefaultColumn = (columnDefault: string | null): boolean 
 export const SERVICE_REQUIRED_EXTENSIONS = [
   'plpgsql',
   'metaschema-schema',
-  'metaschema-modules',
-  'services'
+  'metaschema-modules'
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary

Removes what can be removed of the retired `@pgpm/services` module today (item 3 of constructive-planning#1253):

- `pgpm/export/src/export-utils.ts`: `SERVICE_REQUIRED_EXTENSIONS` no longer includes `'services'` (now `plpgsql`, `metaschema-schema`, `metaschema-modules`), so meta exports stop stamping a requires on the dead extension; test updated to assert `services` is absent.

**Deliberately kept (for now):** the `"@pgpm/services": "0.33.0"` pin in `pgpm.json` and the `'services': '@pgpm/services'` module-map entry in `pgpm/core/src/modules/modules.ts` (marked with a TODO). Removing them broke integration CI: the seeds install `@constructive-db/routing@1.0.1` → `@pgpm/metaschema-modules@0.33.0`, whose **published** control still `requires = '...,services,...'`, so deploys fail with `extension "services" is not available` without the pin.

**Remaining follow-up (blocked on npm credentials):** pgpm-modules PR #104 (merged) already drops the `services` requires from `metaschema-modules`. Someone with npm publish rights needs to publish from pgpm-modules main, bump the `@pgpm/metaschema-modules` pin here (and republish/bump `@constructive-db/routing` if it pins the old version), then delete the pin and module-map entry left in this PR.

Verified: workspace build green; `pgpm/core` (367 tests) and `pgpm/export` (157 tests, against `constructiveio/postgres-plus:18`) pass. Root `pnpm lint` fails in 4 unrelated packages (ESLint 9 config discovery) — identical on a clean `origin/main` checkout, pre-existing.

Companion PR: constructive-io/constructive-db#2483 (deletes the `constructive-services` module and folds its metaschema snapshot into the `constructive` module).

Link to Devin session: https://app.devin.ai/sessions/b78c6c47a94045c3ae2791444d25f9fe
Requested by: @pyramation