### PR TITLE
Finish @pgpm/services retirement: drop pin/module-map entry, bump @pgpm/* pins to 0.33.1

### DIFF
--- a/graphql/server-test/__fixtures__/seed/simple-seed-storage/test-data.sql
+++ b/graphql/server-test/__fixtures__/seed/simple-seed-storage/test-data.sql
@@ -70,7 +70,8 @@ INSERT INTO metaschema_modules_public.storage_module (
   endpoint,
   public_url_prefix,
   provider,
-  allowed_origins
+  allowed_origins,
+  scope
 )
 VALUES (
   'c0000001-0000-0000-0000-000000000001',
@@ -81,7 +82,8 @@ VALUES (
   NULL,  -- use global CDN_ENDPOINT
   NULL,  -- use global CDN_PUBLIC_URL_PREFIX
   'minio',
-  ARRAY['*']
+  ARRAY['*'],
+  'app'
 ) ON CONFLICT (id) DO NOTHING;
 
 -- =====================================================
@@ -162,7 +164,8 @@ INSERT INTO metaschema_modules_public.storage_module (
   endpoint,
   public_url_prefix,
   provider,
-  allowed_origins
+  allowed_origins,
+  scope
 )
 VALUES (
   'c1c1c1c1-0000-0000-0000-000000000001',
@@ -173,7 +176,8 @@ VALUES (
   NULL,
   NULL,
   'minio',
-  ARRAY['*']
+  ARRAY['*'],
+  'app'
 ) ON CONFLICT (id) DO NOTHING;
 
 -- =====================================================
@@ -284,7 +288,8 @@ INSERT INTO metaschema_modules_public.storage_module (
   endpoint,
   public_url_prefix,
   provider,
-  allowed_origins
+  allowed_origins,
+  scope
 )
 VALUES (
   'fa66fa66-0000-0000-0000-000000000001',
@@ -295,7 +300,8 @@ VALUES (
   NULL,
   NULL,
   'minio',
-  ARRAY['*']
+  ARRAY['*'],
+  'app'
 ) ON CONFLICT (id) DO NOTHING;
 
 -- =====================================================

--- a/pgpm.json
+++ b/pgpm.json
@@ -7,12 +7,11 @@
     "@constructive-db/catalog": "1.0.1",
     "@constructive-db/routing": "1.0.1",
     "@constructive-db/routing-functions": "1.1.0",
-    "@pgpm/database-jobs": "0.33.0",
-    "@pgpm/function-resolution": "0.33.0",
+    "@pgpm/database-jobs": "0.33.1",
+    "@pgpm/function-resolution": "0.33.1",
     "@pgpm/jwt-claims": "0.33.0",
-    "@pgpm/metaschema-modules": "0.33.0",
-    "@pgpm/metaschema-schema": "0.33.0",
-    "@pgpm/services": "0.33.0",
+    "@pgpm/metaschema-modules": "0.33.1",
+    "@pgpm/metaschema-schema": "0.33.1",
     "@pgpm/stamps": "0.33.0",
     "@pgpm/uuid": "0.33.0"
   }

--- a/pgpm/core/src/modules/modules.ts
+++ b/pgpm/core/src/modules/modules.ts
@@ -14,9 +14,6 @@ export const PGPM_MODULE_MAP: Record<string, string> = {
   'pgpm-database-jobs': '@pgpm/database-jobs',
   'pgpm-function-resolution': '@pgpm/function-resolution',
   'metaschema-modules': '@pgpm/metaschema-modules',
-  // TODO(services retirement): remove once @pgpm/metaschema-modules is
-  // republished without its `services` requires and the pin is bumped.
-  'services': '@pgpm/services',
   'metaschema-schema': '@pgpm/metaschema-schema',
   'pgpm-inflection': '@pgpm/inflection',
   'pgpm-jwt-claims': '@pgpm/jwt-claims',


### PR DESCRIPTION
## Summary
Completes the services retirement started in #1455, now that `@pgpm/metaschema-modules@0.33.1` (pgpm-modules #104) is published without its `services` requires.

- `pgpm.json`: remove the temporary `"@pgpm/services": "0.33.0"` pin; bump `@pgpm/metaschema-modules`, `@pgpm/metaschema-schema`, `@pgpm/database-jobs`, `@pgpm/function-resolution` to `0.33.1`.
- `pgpm/core/src/modules/modules.ts`: remove the TODO'd `'services': '@pgpm/services'` module-map entry.
- `graphql/server-test/__fixtures__/seed/simple-seed-storage/test-data.sql`: pass `scope => 'app'` explicitly in the three `storage_module` inserts — 0.33.1 (synced from constructive-db) drops the `DEFAULT 'app'` on `scope`, so the seed inserts otherwise fail and upload tests error with `STORAGE_MODULE_NOT_FOUND`.

Note: `pgpm install -W` / `pnpm fixtures:install` rewrites the `@constructive-db/routing-functions` pin from `1.1.0` to `1.0.1` in `pgpm.json` even though it installs `1.1.0`; the pin is kept at `1.1.0` here (looks like a pgpm recording bug, not addressed in this PR).

Verified locally against postgres-plus:18 + MinIO: `pgpm/core` 367 tests, `pgpm/export` 157 tests, `graphql/server-test` 140 tests, `graphile/graphile-function-bindings` 22 tests all pass. `rg -i 'constructive-services|@pgpm/services'` is clean (excluding `node_modules`/`extensions`).

Link to Devin session: https://app.devin.ai/sessions/b78c6c47a94045c3ae2791444d25f9fe
Requested by: @pyramation