### PR TITLE
docs: publish requires install+build; document prepack failure recovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,9 +38,13 @@ pnpm test -- --testNamePattern="test name pattern"
 Lerna with independent versioning and conventional commits. Publishing only from `main` branch:
 
 ```bash
+pnpm install         # Required after pulling: new packages need their own node_modules
+pnpm build           # Required: prepack compiles against sibling dist/ folders
 npx lerna version    # Bump versions
-npx lerna publish    # Publish to npm
+npx lerna publish    # Publish to npm (use `from-package` to resume a failed publish)
 ```
+
+See [PUBLISH.md](./PUBLISH.md) for prepack troubleshooting.
 
 ## Project Architecture
 

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -2,5 +2,37 @@
 
 ```
 pnpm install
+pnpm build
 pnpm lerna publish
+```
+
+The build step is not optional. Workspace deps resolve to a sibling `dist/`
+(`link:../env/dist` in the lockfile), and each package's `prepack` runs
+`makage build`, which deletes `dist/` before recompiling. Building everything
+up front, in topological order, means no package's `tsc` runs against a
+dependency whose `dist/` is missing or half-written.
+
+### recovering a half-finished release
+
+`lerna version` bumps versions, writes CHANGELOGs and commits/tags before
+anything is packed, so a `prepack` failure leaves the repo versioned but
+nothing on npm. Do not re-run `lerna version` — publish the already-bumped
+versions:
+
+```
+pnpm install
+pnpm build
+pnpm lerna publish from-package
+```
+
+### `Cannot find module 'express'` (or any other plain dependency) in prepack
+
+The failing package has no `node_modules/` of its own — usually a newly added
+workspace package in a checkout that was installed before it existed. `makage`
+still runs (it is hoisted to the repo root), so the build starts and then fails
+to resolve every single import, workspace and third-party alike.
+
+```
+rm -rf <path/to/package>/node_modules
+pnpm install
 ```


### PR DESCRIPTION
## Summary

Today's release died in `lerna publish`'s pack phase (`@constructive-io/graphql-dev-server` prepack → 14 × TS2307), leaving every package version-bumped to `*.1` locally but nothing on npm. Both places that document publishing (`PUBLISH.md`, `CLAUDE.md`) told you to run `pnpm install && pnpm lerna publish` with no build step, and neither mentioned `from-package` recovery.

The failure mode itself: the failing package had no `node_modules/` of its own (new workspace package, checkout installed before it existed), so *every* import failed — including plain deps like `express`. `makage` still runs because it is hoisted to the repo root, which makes the build look like it started normally. Verified in a fresh clone: without install → the exact 14 errors; after `pnpm install` + `pnpm -r run clean` + `lerna exec --sort -- npm pack --dry-run` → all 104 packages pack clean.

Docs now say:

```
pnpm install
pnpm build
pnpm lerna publish        # ...or `from-package` when versions are already bumped
```

plus a short note on why the build is load-bearing (workspace deps resolve to sibling `dist/`, and each `prepack` deletes `dist/` before recompiling) and a troubleshooting section for the `Cannot find module 'express'` signature.

Docs-only; no code changes.


Link to Devin session: https://app.devin.ai/sessions/305945e8e36c44ac9fe6c38dbc627cb6
Requested by: @pyramation