### PR TITLE
fix(server): set principal_id claim on routes without an rlsModule

### DIFF
--- a/graphql/server/src/middleware/__tests__/auth-no-rls-module.test.ts
+++ b/graphql/server/src/middleware/__tests__/auth-no-rls-module.test.ts
@@ -1,0 +1,132 @@
+import type { NextFunction, Request, Response } from 'express';
+
+const mockPool = { query: jest.fn() };
+const mockPgQueryContext = jest.fn();
+
+jest.mock('pg-cache', () => ({
+  getPgPool: () => mockPool
+}));
+jest.mock('pg-query-context', () => ({
+  __esModule: true,
+  default: (...args: any[]) => mockPgQueryContext(...args)
+}));
+
+import { createAuthenticateMiddleware } from '../auth';
+
+const createRequest = (headers: Record<string, string> = {}): Request => {
+  const lower: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = v;
+  return {
+    api: { dbname: 'testdb' },
+    headers: lower,
+    clientIp: '127.0.0.1',
+    get: (name: string) => lower[name.toLowerCase()]
+  } as unknown as Request;
+};
+
+const createResponse = () => {
+  const res: any = {};
+  res.status = jest.fn(() => res);
+  res.send = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  return res as Response;
+};
+
+describe('auth middleware without rlsModule', () => {
+  const middleware = createAuthenticateMiddleware({} as any);
+
+  beforeEach(() => {
+    mockPool.query.mockReset();
+    mockPgQueryContext.mockReset();
+  });
+
+  it('populates req.token (including principal_id) from a bearer token', async () => {
+    mockPool.query.mockResolvedValue({ rowCount: 1, rows: [{ '?column?': 1 }] });
+    mockPgQueryContext.mockResolvedValue({
+      rowCount: 1,
+      rows: [{ id: 'tok-1', user_id: 'user-1', principal_id: 'principal-1' }]
+    });
+
+    const req = createRequest({ authorization: 'Bearer abc123' });
+    const next = jest.fn() as NextFunction;
+
+    await middleware(req, createResponse(), next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.token).toEqual({
+      id: 'tok-1',
+      user_id: 'user-1',
+      principal_id: 'principal-1'
+    });
+    expect(mockPgQueryContext).toHaveBeenCalledWith(
+      expect.objectContaining({ variables: ['abc123'] })
+    );
+  });
+
+  it('authenticates via the session cookie when no bearer token is present', async () => {
+    mockPool.query.mockResolvedValue({ rowCount: 1, rows: [{ '?column?': 1 }] });
+    mockPgQueryContext.mockResolvedValue({
+      rowCount: 1,
+      rows: [{ user_id: 'user-2' }]
+    });
+
+    const req = createRequest({ cookie: 'constructive_session=cookie-token' });
+    const next = jest.fn() as NextFunction;
+
+    await middleware(req, createResponse(), next);
+
+    expect(mockPgQueryContext).toHaveBeenCalledWith(
+      expect.objectContaining({ variables: ['cookie-token'] })
+    );
+    expect(req.token).toEqual({ user_id: 'user-2' });
+  });
+
+  it('proceeds anonymously when no credential is present', async () => {
+    const req = createRequest();
+    const next = jest.fn() as NextFunction;
+
+    await middleware(req, createResponse(), next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.token).toBeUndefined();
+    expect(mockPgQueryContext).not.toHaveBeenCalled();
+  });
+
+  it('proceeds anonymously when the platform auth function does not exist', async () => {
+    mockPool.query.mockResolvedValue({ rowCount: 0, rows: [] });
+
+    const req = createRequest({ authorization: 'Bearer abc123' });
+    const next = jest.fn() as NextFunction;
+
+    await middleware(req, createResponse(), next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.token).toBeUndefined();
+    expect(mockPgQueryContext).not.toHaveBeenCalled();
+  });
+
+  it('never fails the request when platform auth throws', async () => {
+    mockPool.query.mockRejectedValue(new Error('boom'));
+
+    const req = createRequest({ authorization: 'Bearer abc123' });
+    const res = createResponse();
+    const next = jest.fn() as NextFunction;
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+    expect(req.token).toBeUndefined();
+  });
+
+  it('reads the device token cookie', async () => {
+    const req = createRequest({
+      cookie: 'constructive_device_token=device-1'
+    });
+    const next = jest.fn() as NextFunction;
+
+    await middleware(req, createResponse(), next);
+
+    expect(req.deviceToken).toBe('device-1');
+  });
+});

--- a/graphql/server/src/middleware/auth.ts
+++ b/graphql/server/src/middleware/auth.ts
@@ -5,6 +5,7 @@ import { NextFunction, Request, RequestHandler, Response } from 'express';
 import { getPgPool } from 'pg-cache';
 import pgQueryContext from 'pg-query-context';
 import './types'; // for Request type
+import type { ConstructiveAPIToken } from './types';
 
 const log = new Logger('auth');
 const isDev = () => getNodeEnv() === 'development';
@@ -16,6 +17,13 @@ const SESSION_COOKIE_NAME = 'constructive_session';
 const DEVICE_TOKEN_COOKIE_NAME = 'constructive_device_token';
 
 /**
+ * Platform-level authentication function used for API surfaces that do not
+ * declare an RLS module (meta-schema routes, provisioning endpoints, ...).
+ */
+const PLATFORM_AUTH_SCHEMA = 'constructive_auth_private';
+const PLATFORM_AUTH_FUNCTION = 'authenticate';
+
+/**
  * Extract a named cookie value from the raw Cookie header.
  * Avoids pulling in cookie-parser as a dependency.
  */
@@ -24,6 +32,82 @@ const parseCookieToken = (req: Request, cookieName: string): string | undefined 
   if (!header) return undefined;
   const match = header.split(';').find((c) => c.trim().startsWith(`${cookieName}=`));
   return match ? decodeURIComponent(match.split('=')[1].trim()) : undefined;
+};
+
+/** Build the JWT claim context propagated to the authentication function. */
+const buildAuthContext = (req: Request): Record<string, any> => {
+  const context: Record<string, any> = {
+    'jwt.claims.ip_address': req.clientIp
+  };
+  if (req.get('origin')) {
+    context['jwt.claims.origin'] = req.get('origin');
+  }
+  if (req.get('User-Agent')) {
+    context['jwt.claims.user_agent'] = req.get('User-Agent');
+  }
+  return context;
+};
+
+/** Resolve the request credential: Bearer header first, session cookie second. */
+export const resolveCredential = (
+  req: Request
+): { token?: string; source: 'bearer' | 'cookie' | 'none' } => {
+  const { authorization = '' } = req.headers;
+  const [authType, authToken] = authorization.split(' ');
+  if (authType?.toLowerCase() === 'bearer' && authToken) {
+    return { token: authToken, source: 'bearer' };
+  }
+  const cookieToken = parseCookieToken(req, SESSION_COOKIE_NAME);
+  if (cookieToken) return { token: cookieToken, source: 'cookie' };
+  return { source: 'none' };
+};
+
+/**
+ * Authenticate a request hitting a route without an RLS module.
+ *
+ * These routes still need `jwt.claims.principal_id` (and the rest of the token
+ * claims) to be populated, so the credential is resolved against the platform
+ * authentication function when it exists. Failures are non-fatal: the request
+ * simply proceeds anonymously.
+ */
+export const authenticatePlatform = async (
+  req: Request,
+  pool: any
+): Promise<ConstructiveAPIToken | undefined> => {
+  const { token: credential, source } = resolveCredential(req);
+  if (!credential) return undefined;
+
+  try {
+    const exists = await pool.query(
+      `SELECT 1 FROM pg_proc p
+         JOIN pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = $1 AND p.proname = $2
+        LIMIT 1`,
+      [PLATFORM_AUTH_SCHEMA, PLATFORM_AUTH_FUNCTION]
+    );
+    if (!exists?.rowCount) {
+      log.info('[auth] No platform authenticate function available');
+      return undefined;
+    }
+
+    const result = await pgQueryContext({
+      client: pool,
+      context: buildAuthContext(req),
+      query: `SELECT * FROM "${PLATFORM_AUTH_SCHEMA}"."${PLATFORM_AUTH_FUNCTION}"($1)`,
+      variables: [credential]
+    });
+
+    if (!result?.rowCount) {
+      log.info('[auth] Platform auth returned no rows');
+      return undefined;
+    }
+
+    log.info(`[auth] Platform auth success via ${source}`);
+    return result.rows[0];
+  } catch (e: any) {
+    log.warn(`[auth] Platform auth failed: ${e.message}`);
+    return undefined;
+  }
 };
 
 export const createAuthenticateMiddleware = (
@@ -55,7 +139,17 @@ export const createAuthenticateMiddleware = (
     );
 
     if (!rlsModule) {
-      log.info('[auth] No RLS module configured, skipping auth');
+      // No RLS module, but the token claims (notably principal_id) must still
+      // be populated when a credential is present.
+      log.info('[auth] No RLS module configured, attempting platform auth');
+      const platformToken = await authenticatePlatform(req, pool);
+      if (platformToken) {
+        req.token = platformToken;
+      }
+      const noRlsDeviceToken = parseCookieToken(req, DEVICE_TOKEN_COOKIE_NAME);
+      if (noRlsDeviceToken) {
+        req.deviceToken = noRlsDeviceToken;
+      }
       return next();
     }
 
@@ -68,34 +162,13 @@ export const createAuthenticateMiddleware = (
     );
 
     if (authFn && rlsModule.privateSchema.schemaName) {
-      const { authorization = '' } = req.headers;
-      const [authType, authToken] = authorization.split(' ');
       let token: any = {};
 
-      log.info(
-        `[auth] authorization header present=${!!authorization}, ` +
-          `authType=${authType ?? 'none'}, hasToken=${!!authToken}`
-      );
-
-      // Resolve the credential: prefer Bearer header, fall back to session cookie
-      const cookieToken = parseCookieToken(req, SESSION_COOKIE_NAME);
-      const effectiveToken = (authType?.toLowerCase() === 'bearer' && authToken)
-        ? authToken
-        : cookieToken;
-      const tokenSource = (authType?.toLowerCase() === 'bearer' && authToken) ? 'bearer' : (cookieToken ? 'cookie' : 'none');
+      const { token: effectiveToken, source: tokenSource } = resolveCredential(req);
 
       if (effectiveToken) {
         log.info(`[auth] Processing ${tokenSource} authentication`);
-        const context: Record<string, any> = {
-          'jwt.claims.ip_address': req.clientIp,
-        };
-
-        if (req.get('origin')) {
-          context['jwt.claims.origin'] = req.get('origin');
-        }
-        if (req.get('User-Agent')) {
-          context['jwt.claims.user_agent'] = req.get('User-Agent');
-        }
+        const context = buildAuthContext(req);
 
         const authQuery = `SELECT * FROM "${rlsModule.privateSchema.schemaName}"."${authFn}"($1)`;
         log.info(`[auth] Executing auth query: ${authQuery}`);


### PR DESCRIPTION
## Summary

Fixes #1439. API surfaces with no `rlsModule` (meta-schema routes, provisioning endpoints) returned early from the auth middleware, so `req.token` was never set and `graphile.ts` fell back to `anonSettings` — leaving `jwt.claims.principal_id` unset and breaking any SPRT policy that reads `current_principal_id()`.

The no-rlsModule branch now attempts platform-level authentication before `next()`:

```diff
 if (!rlsModule) {
-  return next();
+  const platformToken = await authenticatePlatform(req, pool); // constructive_auth_private.authenticate($1)
+  if (platformToken) req.token = platformToken;
+  // device-token cookie is also read on this path now
+  return next();
 }
```

`authenticatePlatform` is deliberately best-effort and never fails the request: it first probes `pg_proc`/`pg_namespace` for `constructive_auth_private.authenticate` (databases without the platform auth module simply proceed anonymously), then runs it through `pgQueryContext` with the same ip/origin/user-agent claims as the RLS path. Errors are logged at `warn` and the request continues anonymously rather than returning `BAD_TOKEN_DEFINITION` — this path must not turn provisioning traffic into 200-with-errors responses.

Credential resolution (Bearer header, falling back to the `constructive_session` cookie) and JWT-claim context building were extracted into `resolveCredential` / `buildAuthContext` and are shared by both paths, so cookie sessions work identically on rlsModule-less routes.

Once `req.token.user_id` is present, the existing `graphile.ts` logic sets `jwt.claims.principal_id = req.token.principal_id || req.token.user_id`, so no change was needed there.

Tests: `graphql/server/src/middleware/__tests__/auth-no-rls-module.test.ts` covers bearer + cookie population of `principal_id`, no-credential, missing-function, and throwing-pool cases. The first two fail on `main` (`req.token` undefined).


Link to Devin session: https://app.devin.ai/sessions/cb8b3fdcce6c4af3abb50d3401450620
Requested by: @pyramation