### PR TITLE
feat(export): add targetSchema to DataExportTableSpec

### DIFF
--- a/pgpm/export/__tests__/export-data.test.ts
+++ b/pgpm/export/__tests__/export-data.test.ts
@@ -272,6 +272,29 @@ describe('exportTableData', () => {
     expect(none.insert).toBeNull();
   });
 
+  it('reads from the physical schema but emits statements targeting targetSchema', async () => {
+    const result = await exportTableData(
+      pg,
+      {
+        schema: 'app_routing_public',
+        table: 'apis',
+        targetSchema: 'routing_public'
+      },
+      { excludeColumns: ['dbname'] }
+    );
+
+    expect(result.rowCount).toBe(2);
+    expect(result.schema).toBe('routing_public');
+    const insert = result.insert as string;
+    expect(insert).toContain('INSERT INTO routing_public.apis');
+    expect(insert).not.toContain('app_routing_public');
+
+    const revert = buildDataRevertScript([result]);
+    expect(revert).toContain('FROM routing_public.apis');
+    const verify = buildDataVerifyScript([result]);
+    expect(verify).toContain('FROM routing_public.apis');
+  });
+
   it('exports tables without an id column (no ids, ordered by all columns)', async () => {
     const result = await exportTableData(pg, {
       schema: 'app_routing_public',

--- a/pgpm/export/src/export-data.ts
+++ b/pgpm/export/src/export-data.ts
@@ -186,10 +186,18 @@ export const getMetadataExportColumns = async (
 };
 
 export interface DataExportTableSpec {
+  /** Physical schema the rows are read from. */
   schema: string;
   table: string;
   /** Optional equality filter, e.g. { column: 'database_id', value: id }. */
   filter?: { column: string; value: string };
+  /**
+   * Schema the emitted INSERT/DELETE/verify statements target when it
+   * differs from the physical source schema (e.g. rows read from a
+   * prefixed staging schema but replayed into its published logical name).
+   * Defaults to `schema`.
+   */
+  targetSchema?: string;
 }
 
 export interface ExportTableDataOptions {
@@ -204,6 +212,7 @@ export interface ExportTableDataOptions {
 }
 
 export interface TableDataExport {
+  /** Schema the emitted statements target (targetSchema when supplied). */
   schema: string;
   table: string;
   /** Columns included in the INSERT, in table order. */
@@ -234,8 +243,9 @@ export const exportTableData = async (
     c => !excluded.has(c.name) && !isVolatileTimestampColumn(c)
   );
 
+  const targetSchema = spec.targetSchema ?? spec.schema;
   const base: TableDataExport = {
-    schema: spec.schema,
+    schema: targetSchema,
     table: spec.table,
     columns,
     rowCount: 0,
@@ -270,7 +280,7 @@ export const exportTableData = async (
   if (rowsRes.rows.length === 0) return base;
 
   const insertQb = new QueryBuilder()
-    .schema(spec.schema)
+    .schema(targetSchema)
     .table(spec.table)
     .insert(
       rowsRes.rows.map((row: Record<string, string | null>) =>


### PR DESCRIPTION
## Summary

Upstreams a capability constructive-db's static-plane pipeline (constructive-io/constructive-db#2516) currently hand-rolls: exporting table data from one physical schema while emitting scripts that target its published (renamed) schema.

```ts
interface DataExportTableSpec {
  schema: string;          // physical schema rows are read from (unchanged)
  table: string;
  filter?: { column: string; value: string };
  targetSchema?: string;   // NEW: schema the emitted INSERT/DELETE/verify target
}
```

`exportTableData` keeps SELECT + column introspection on `spec.schema`, but builds the INSERT against `targetSchema ?? schema` and reports it as `TableDataExport.schema`, so `buildDataDeployScript`/`buildDataRevertScript`/`buildDataVerifyScript` all target the published name with no post-export `transformSql` retarget needed by callers.

Covered by a new DB-backed test in `export-data.test.ts`; full `@pgpmjs/export` suite green (162/162).

Link to Devin session: https://app.devin.ai/sessions/ef854ab8e37e4fedbb21bfd777608edd
Requested by: @pyramation