### PR TITLE
feat(server): default the scoped routing plane to logical routing_public

### DIFF
--- a/graphql/env/README.md
+++ b/graphql/env/README.md
@@ -50,7 +50,7 @@ In addition to all environment variables supported by `@pgpmjs/env`, this packag
 - `FEATURES_POSTGIS` - Enable PostGIS support
 
 ### API Configuration
-- `API_SCOPED_ROUTING_SCHEMA` - Schema containing the compiled `resolve_route()` resolver (production routing always resolves through it)
+- `API_ROUTING_SCHEMA` - Schema containing the compiled `resolve_route()` resolver (production routing always resolves through it)
 - `API_IS_PUBLIC` - Whether API is public
 - `API_EXPOSED_SCHEMAS` - Comma-separated list of exposed schemas
 - `API_META_SCHEMAS` - Comma-separated list of meta schemas
@@ -75,7 +75,7 @@ GraphQL defaults are provided by `@constructive-io/graphql-types`:
     roleName: 'administrator',
     isPublic: true,
     metaSchemas: ['routing_public', 'metaschema_public', 'metaschema_modules_public'],
-    scopedRoutingSchema: 'routing_public'
+    routingSchema: 'routing_public'
   }
 }
 ```

--- a/graphql/env/README.md
+++ b/graphql/env/README.md
@@ -74,8 +74,8 @@ GraphQL defaults are provided by `@constructive-io/graphql-types`:
     anonRole: 'administrator',
     roleName: 'administrator',
     isPublic: true,
-    metaSchemas: ['constructive_routing_public', 'metaschema_public', 'metaschema_modules_public'],
-    scopedRoutingSchema: 'constructive_routing_public'
+    metaSchemas: ['routing_public', 'metaschema_public', 'metaschema_modules_public'],
+    scopedRoutingSchema: 'routing_public'
   }
 }
 ```

--- a/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
+++ b/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
@@ -14,7 +14,7 @@ exports[`getEnvOptions merges pgpm defaults, graphql defaults, config, env, and 
       "env_meta2",
     ],
     "roleName": "env_role",
-    "scopedRoutingSchema": "routing_public",
+    "routingSchema": "routing_public",
   },
   "cdn": {
     "awsAccessKey": "minioadmin",

--- a/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
+++ b/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
@@ -14,7 +14,7 @@ exports[`getEnvOptions merges pgpm defaults, graphql defaults, config, env, and 
       "env_meta2",
     ],
     "roleName": "env_role",
-    "scopedRoutingSchema": "constructive_routing_public",
+    "scopedRoutingSchema": "routing_public",
   },
   "cdn": {
     "awsAccessKey": "minioadmin",

--- a/graphql/env/src/env.ts
+++ b/graphql/env/src/env.ts
@@ -12,7 +12,7 @@ export const getGraphQLEnvVars = (env: NodeJS.ProcessEnv = process.env): Partial
     FEATURES_OPPOSITE_BASE_NAMES,
     FEATURES_POSTGIS,
 
-    API_SCOPED_ROUTING_SCHEMA,
+    API_ROUTING_SCHEMA,
     API_IS_PUBLIC,
     API_EXPOSED_SCHEMAS,
     API_META_SCHEMAS,
@@ -60,7 +60,7 @@ export const getGraphQLEnvVars = (env: NodeJS.ProcessEnv = process.env): Partial
       ...(FEATURES_POSTGIS && { postgis: parseEnvBoolean(FEATURES_POSTGIS) })
     },
     api: {
-      ...(API_SCOPED_ROUTING_SCHEMA && { scopedRoutingSchema: API_SCOPED_ROUTING_SCHEMA }),
+      ...(API_ROUTING_SCHEMA && { routingSchema: API_ROUTING_SCHEMA }),
       ...(API_IS_PUBLIC && { isPublic: parseEnvBoolean(API_IS_PUBLIC) }),
       ...(API_EXPOSED_SCHEMAS && { exposedSchemas: API_EXPOSED_SCHEMAS.split(',').map(s => s.trim()) }),
       ...(API_META_SCHEMAS && { metaSchemas: API_META_SCHEMAS.split(',').map(s => s.trim()) }),

--- a/graphql/playwright-test/README.md
+++ b/graphql/playwright-test/README.md
@@ -16,10 +16,10 @@ Constructive Playwright Testing with HTTP server support for end-to-end testing.
 
 This package extends `@constructive-io/graphql-test` to provide an actual HTTP server for Playwright and other E2E testing frameworks. It creates isolated test databases and starts a GraphQL server for your suite to hit over HTTP.
 
-It can run either server, selected per-suite with `server.scopedRouting`:
+It can run either server, selected per-suite with `server.useRouting`:
 
-- `server.scopedRouting: false` (default) — the single-tenant `@constructive-io/graphql-dev-server` (pure PostGraphile). No host route resolution and no database id; the configured schemas are exposed directly. Best for UI/local suites.
-- `server.scopedRouting: true` — the production `@constructive-io/graphql-server`. Every request is resolved through the scoped-routing plane (`constructive_routing_public.resolve_route()`), so the suite must seed real routing/database records and reach the api surface via its seeded host (`Host` header).
+- `server.useRouting: false` (default) — the single-tenant `@constructive-io/graphql-dev-server` (pure PostGraphile). No host route resolution and no database id; the configured schemas are exposed directly. Best for UI/local suites.
+- `server.useRouting: true` — the production `@constructive-io/graphql-server`. Every request is resolved through the scoped-routing plane (`constructive_routing_public.resolve_route()`), so the suite must seed real routing/database records and reach the api surface via its seeded host (`Host` header).
 
 ## Installation
 
@@ -61,7 +61,7 @@ describe('E2E Tests', () => {
 
 ### Against the real (scoped-routing) server
 
-Set `server.scopedRouting: true` to run the production `@constructive-io/graphql-server`. Seed real routing/database records and address the api surface by its seeded host:
+Set `server.useRouting: true` to run the production `@constructive-io/graphql-server`. Seed real routing/database records and address the api surface by its seeded host:
 
 ```typescript
 import { test, expect } from '@playwright/test';
@@ -73,9 +73,9 @@ test('resolves through the scoped routing plane', async ({ request }) => {
       schemas: ['simple-pets-public'],
       authRole: 'anonymous',
       server: {
-        scopedRouting: true,
+        useRouting: true,
         api: {
-          scopedRoutingSchema: 'constructive_routing_public',
+          routingSchema: 'constructive_routing_public',
           isPublic: true,
           metaSchemas: ['constructive_routing_public', 'metaschema_public']
         }
@@ -166,8 +166,8 @@ Creates database connections and starts an HTTP server for testing.
 - `input.authRole` - Default authentication role (e.g., 'anonymous', 'authenticated')
 - `input.server.port` - Port to run the server on (defaults to random available port)
 - `input.server.host` - Host to bind to (defaults to 'localhost')
-- `input.server.scopedRouting` - `false` (default) runs the dev server; `true` runs the production scoped-routing server
-- `input.server.api` - API options forwarded to the production scoped server (e.g. `metaSchemas`, `isPublic`); only used when `scopedRouting` is `true`
+- `input.server.useRouting` - `false` (default) runs the dev server; `true` runs the production scoped-routing server
+- `input.server.api` - API options forwarded to the production scoped server (e.g. `metaSchemas`, `isPublic`); only used when `useRouting` is `true`
 - `input.graphile` - Optional Graphile configuration overrides
 - `seedAdapters` - Optional array of seed adapters for database setup
 
@@ -197,18 +197,18 @@ Low-level function to create just the production `@constructive-io/graphql-serve
 ## How It Works
 
 1. Creates an isolated test database using `pgsql-test`
-2. Starts either the dev server or the production scoped-routing server (see `server.scopedRouting`)
+2. Starts either the dev server or the production scoped-routing server (see `server.useRouting`)
 3. Exposes the GraphQL endpoint for your suite to hit over HTTP
 4. Returns the server URL for Playwright to connect to
 5. Provides a teardown function that stops the server and cleans up the database
 
 ## Configuration
 
-By default (`scopedRouting: false`) the server runs `@constructive-io/graphql-dev-server`, which means:
+By default (`useRouting: false`) the server runs `@constructive-io/graphql-dev-server`, which means:
 - No host route resolution (`resolve_route()`) is required and no database id is needed
 - Schemas are exposed directly based on the `schemas` parameter
 - Perfect for isolated testing without complex domain setup
 
-With `scopedRouting: true` the server runs the production `@constructive-io/graphql-server`:
+With `useRouting: true` the server runs the production `@constructive-io/graphql-server`:
 - Every request is resolved through `constructive_routing_public.resolve_route()`
 - The suite must seed real routing/database records and address the api surface by its seeded host

--- a/graphql/playwright-test/__tests__/scoped-server.playwright.test.ts
+++ b/graphql/playwright-test/__tests__/scoped-server.playwright.test.ts
@@ -8,7 +8,7 @@
  * routing/database records and reaches the api surface via its seeded host.
  *
  * Contrast with `server.playwright.test.ts`, which uses the single-tenant dev
- * server (`scopedRouting` defaults to `false`).
+ * server (`useRouting` defaults to `false`).
  */
 import { expect, test } from '@playwright/test';
 import path from 'path';
@@ -46,9 +46,9 @@ test.describe('playwright-test scoped server (real graphql-server)', () => {
         schemas,
         authRole: 'anonymous',
         server: {
-          scopedRouting: true,
+          useRouting: true,
           api: {
-            scopedRoutingSchema: 'constructive_routing_public',
+            routingSchema: 'constructive_routing_public',
             isPublic: true,
             metaSchemas: scopedMetaSchemas
           }

--- a/graphql/playwright-test/src/get-connections.ts
+++ b/graphql/playwright-test/src/get-connections.ts
@@ -55,9 +55,9 @@ const createConnectionsWithServerBase = async (
 
   // Start the HTTP server. Suites default to the single-tenant dev server;
   // suites exercising the real routing plane opt into the production
-  // scoped-routing server with `server.scopedRouting: true`.
-  const scopedRouting = input.server?.scopedRouting ?? false;
-  const server = scopedRouting
+  // scoped-routing server with `server.useRouting: true`.
+  const useRouting = input.server?.useRouting ?? false;
+  const server = useRouting
     ? await createScopedTestServer(serverOpts, input.server)
     : await createTestServer(serverOpts, input.server);
 

--- a/graphql/playwright-test/src/types.ts
+++ b/graphql/playwright-test/src/types.ts
@@ -20,10 +20,10 @@ export interface PlaywrightServerOptions {
    *   every request through the scoped-routing plane. Suites must seed real
    *   routing/database records so `resolve_route()` returns a real database id.
    */
-  scopedRouting?: boolean;
+  useRouting?: boolean;
   /**
    * API configuration forwarded to the production scoped server (e.g.
-   * `metaSchemas`, `isPublic`). Only used when `scopedRouting` is `true`.
+   * `metaSchemas`, `isPublic`). Only used when `useRouting` is `true`.
    */
   api?: Partial<ApiOptions>;
 }

--- a/graphql/server-test/README.md
+++ b/graphql/server-test/README.md
@@ -181,7 +181,7 @@ The `server.api` option provides full control over the GraphQL server configurat
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `scopedRoutingSchema` | `string` | `constructive_routing_public` | Schema that owns `resolve_route()` and the routing tables |
+| `scopedRoutingSchema` | `string` | `routing_public` | Schema that owns `resolve_route()` and the routing tables |
 | `exposedSchemas` | `string[]` | from `schemas` | Database schemas to expose (overridden by `schemas`) |
 | `anonRole` | `string` | from `authRole` | Anonymous role name (overridden by `authRole`) |
 | `roleName` | `string` | from `authRole` | Default role name (overridden by `authRole`) |

--- a/graphql/server-test/README.md
+++ b/graphql/server-test/README.md
@@ -181,7 +181,7 @@ The `server.api` option provides full control over the GraphQL server configurat
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `scopedRoutingSchema` | `string` | `routing_public` | Schema that owns `resolve_route()` and the routing tables |
+| `routingSchema` | `string` | `routing_public` | Schema that owns `resolve_route()` and the routing tables |
 | `exposedSchemas` | `string[]` | from `schemas` | Database schemas to expose (overridden by `schemas`) |
 | `anonRole` | `string` | from `authRole` | Anonymous role name (overridden by `authRole`) |
 | `roleName` | `string` | from `authRole` | Default role name (overridden by `authRole`) |
@@ -190,12 +190,12 @@ The `server.api` option provides full control over the GraphQL server configurat
 
 The convenience properties (`schemas`, `authRole`) take precedence over corresponding values in `server.api`.
 
-### Choosing the server (`server.scopedRouting`)
+### Choosing the server (`server.useRouting`)
 
 The harness runs suites against one of two servers:
 
-- `server.scopedRouting: true` (default) — the production `@constructive-io/graphql-server`. Every request resolves through the scoped-routing plane, so the suite must seed real routing/database records and use a real database id.
-- `server.scopedRouting: false` — the single-tenant `@constructive-io/graphql-dev-server` (pure PostGraphile, no routing, no database id). It exposes the configured schemas directly and is for local/static suites only.
+- `server.useRouting: true` (default) — the production `@constructive-io/graphql-server`. Every request resolves through the scoped-routing plane, so the suite must seed real routing/database records and use a real database id.
+- `server.useRouting: false` — the single-tenant `@constructive-io/graphql-dev-server` (pure PostGraphile, no routing, no database id). It exposes the configured schemas directly and is for local/static suites only.
 
 ```typescript
 // Basic usage with convenience properties
@@ -208,7 +208,7 @@ const { query } = await getConnections({
 const { query } = await getConnections({
   schemas: ['app_public'],
   server: {
-    scopedRouting: false
+    useRouting: false
   }
 });
 
@@ -219,7 +219,7 @@ const { query } = await getConnections({
   server: {
     port: 5555,
     host: 'localhost',
-    scopedRouting: true,
+    useRouting: true,
     api: {
       isPublic: false,
       metaSchemas: ['constructive_routing_public', 'metaschema_public']

--- a/graphql/server-test/__tests__/cli-e2e.test.ts
+++ b/graphql/server-test/__tests__/cli-e2e.test.ts
@@ -394,7 +394,7 @@ describe('CLI E2E — generated CLI against real DB', () => {
       {
         schemas: ['simple-pets-pets-public'],
         authRole: 'anonymous',
-        server: { scopedRouting: false, api: { isPublic: false } }
+        server: { useRouting: false, api: { isPublic: false } }
       },
       [
         seed.sqlfile([
@@ -782,7 +782,7 @@ describe('CLI E2E — search commands against real DB', () => {
       {
         schemas: ['search_public'],
         authRole: 'anonymous',
-        server: { scopedRouting: false, api: { isPublic: false } }
+        server: { useRouting: false, api: { isPublic: false } }
       },
       [
         seed.sqlfile([
@@ -1126,7 +1126,7 @@ describe('CLI E2E — embedder / --auto-embed', () => {
       {
         schemas: ['search_public'],
         authRole: 'anonymous',
-        server: { scopedRouting: false, api: { isPublic: false } }
+        server: { useRouting: false, api: { isPublic: false } }
       },
       [
         seed.sqlfile([

--- a/graphql/server-test/__tests__/express-context.integration.test.ts
+++ b/graphql/server-test/__tests__/express-context.integration.test.ts
@@ -58,7 +58,8 @@ beforeAll(async () => {
         scopedRouting: true,
         api: {
           isPublic: true,
-          metaSchemas
+          metaSchemas,
+          scopedRoutingSchema: 'constructive_routing_public'
         }
       }
     },

--- a/graphql/server-test/__tests__/express-context.integration.test.ts
+++ b/graphql/server-test/__tests__/express-context.integration.test.ts
@@ -55,11 +55,11 @@ beforeAll(async () => {
       schemas,
       authRole: 'anonymous',
       server: {
-        scopedRouting: true,
+        useRouting: true,
         api: {
           isPublic: true,
           metaSchemas,
-          scopedRoutingSchema: 'constructive_routing_public'
+          routingSchema: 'constructive_routing_public'
         }
       }
     },

--- a/graphql/server-test/__tests__/fn-routes.integration.test.ts
+++ b/graphql/server-test/__tests__/fn-routes.integration.test.ts
@@ -59,11 +59,11 @@ beforeAll(async () => {
       schemas,
       authRole: 'anonymous',
       server: {
-        scopedRouting: true,
+        useRouting: true,
         api: {
           isPublic: true,
           metaSchemas,
-          scopedRoutingSchema: 'constructive_routing_public'
+          routingSchema: 'constructive_routing_public'
         }
       }
     },

--- a/graphql/server-test/__tests__/fn-routes.integration.test.ts
+++ b/graphql/server-test/__tests__/fn-routes.integration.test.ts
@@ -62,7 +62,8 @@ beforeAll(async () => {
         scopedRouting: true,
         api: {
           isPublic: true,
-          metaSchemas
+          metaSchemas,
+          scopedRoutingSchema: 'constructive_routing_public'
         }
       }
     },

--- a/graphql/server-test/__tests__/schema-snapshot.test.ts
+++ b/graphql/server-test/__tests__/schema-snapshot.test.ts
@@ -48,7 +48,7 @@ describe('Schema Snapshot', () => {
         schemas,
         authRole: 'anonymous',
         server: {
-          scopedRouting: false,
+          useRouting: false,
           api: { isPublic: false }
         }
       },

--- a/graphql/server-test/__tests__/scoped-routing.integration.test.ts
+++ b/graphql/server-test/__tests__/scoped-routing.integration.test.ts
@@ -75,7 +75,7 @@ describe('simple-seed-scoped: resolve_route (SQL level)', () => {
       {
         schemas,
         authRole: 'anonymous',
-        server: { scopedRouting: false, api: { isPublic: false } }
+        server: { useRouting: false, api: { isPublic: false } }
       },
       scopedSeedAdapters()
     ));
@@ -174,9 +174,9 @@ describe('simple-seed-scoped: GraphQL over scoped routing (e2e)', () => {
         schemas,
         authRole: 'anonymous',
         server: {
-          scopedRouting: true,
+          useRouting: true,
           api: {
-            scopedRoutingSchema: 'constructive_routing_public',
+            routingSchema: 'constructive_routing_public',
             isPublic: true,
             metaSchemas: scopedMetaSchemas
           }

--- a/graphql/server-test/__tests__/search.integration.test.ts
+++ b/graphql/server-test/__tests__/search.integration.test.ts
@@ -47,7 +47,7 @@ describe('Unified Search — server integration', () => {
         schemas,
         authRole: 'anonymous',
         server: {
-          scopedRouting: false,
+          useRouting: false,
           api: { isPublic: false }
         }
       },

--- a/graphql/server-test/__tests__/server-test.test.ts
+++ b/graphql/server-test/__tests__/server-test.test.ts
@@ -22,7 +22,7 @@ describe('graphql-server-test', () => {
           schemas: ['app_public'],
           authRole: 'anonymous',
           server: {
-            scopedRouting: false
+            useRouting: false
           }
         },
         [seed.sqlfile([sql('test.sql')])]
@@ -111,7 +111,7 @@ describe('graphql-server-test', () => {
           schemas: ['app_public'],
           authRole: 'authenticated',
           server: {
-            scopedRouting: false
+            useRouting: false
           }
         },
         [seed.sqlfile([sql('test.sql')])]

--- a/graphql/server-test/__tests__/server.integration.test.ts
+++ b/graphql/server-test/__tests__/server.integration.test.ts
@@ -4,7 +4,7 @@
  * All host routing resolves through the scoped routing plane
  * (constructive_routing_public.resolve_route); there is no legacy fallback.
  * The single-tenant scenario runs against the dev server
- * (server.scopedRouting: false), which exposes the configured schemas
+ * (server.useRouting: false), which exposes the configured schemas
  * directly with no route resolution.
  *
  * Run tests:
@@ -46,11 +46,11 @@ const teardowns: Array<() => Promise<void>> = [];
 type Scenario = {
   name: string;
   seedDir: 'simple-seed' | 'simple-seed-scoped';
-  scopedRouting: boolean;
+  useRouting: boolean;
   api: {
     isPublic: boolean;
     metaSchemas?: string[];
-    scopedRoutingSchema?: string;
+    routingSchema?: string;
   };
   headers?: Record<string, string>;
 };
@@ -59,14 +59,14 @@ const scenarios: Scenario[] = [
   {
     name: 'static single-tenant (dev server)',
     seedDir: 'simple-seed',
-    scopedRouting: false,
+    useRouting: false,
     api: { isPublic: false }
   },
   {
     name: 'scoped public via domain',
     seedDir: 'simple-seed-scoped',
-    scopedRouting: true,
-    api: { isPublic: true, metaSchemas: scopedMetaSchemas, scopedRoutingSchema: 'constructive_routing_public' },
+    useRouting: true,
+    api: { isPublic: true, metaSchemas: scopedMetaSchemas, routingSchema: 'constructive_routing_public' },
     headers: {
       Host: 'app.test.constructive.io'
     }
@@ -74,8 +74,8 @@ const scenarios: Scenario[] = [
   {
     name: 'scoped private via domain',
     seedDir: 'simple-seed-scoped',
-    scopedRouting: true,
-    api: { isPublic: false, metaSchemas: scopedMetaSchemas, scopedRoutingSchema: 'constructive_routing_public' },
+    useRouting: true,
+    api: { isPublic: false, metaSchemas: scopedMetaSchemas, routingSchema: 'constructive_routing_public' },
     headers: {
       Host: 'private.test.constructive.io'
     }
@@ -83,8 +83,8 @@ const scenarios: Scenario[] = [
   {
     name: 'scoped private via X-Api-Name',
     seedDir: 'simple-seed-scoped',
-    scopedRouting: true,
-    api: { isPublic: false, metaSchemas: scopedMetaSchemas, scopedRoutingSchema: 'constructive_routing_public' },
+    useRouting: true,
+    api: { isPublic: false, metaSchemas: scopedMetaSchemas, routingSchema: 'constructive_routing_public' },
     headers: {
       'X-Database-Id': scopedDatabaseId,
       'X-Api-Name': 'private'
@@ -93,8 +93,8 @@ const scenarios: Scenario[] = [
   {
     name: 'scoped private via X-Schemata',
     seedDir: 'simple-seed-scoped',
-    scopedRouting: true,
-    api: { isPublic: false, metaSchemas: scopedMetaSchemas, scopedRoutingSchema: 'constructive_routing_public' },
+    useRouting: true,
+    api: { isPublic: false, metaSchemas: scopedMetaSchemas, routingSchema: 'constructive_routing_public' },
     headers: {
       'X-Database-Id': scopedDatabaseId,
       'X-Schemata': schemas.join(',')
@@ -149,7 +149,7 @@ describe.each(scenarios)('$name', (scenario) => {
         schemas,
         authRole: 'anonymous',
         server: {
-          scopedRouting: scenario.scopedRouting,
+          useRouting: scenario.useRouting,
           api: scenario.api
         }
       },
@@ -281,11 +281,11 @@ describe('scoped private via X-Meta-Schema', () => {
         schemas: metaApiSchemas,
         authRole: 'anonymous',
         server: {
-          scopedRouting: true,
+          useRouting: true,
           api: {
             isPublic: false,
             metaSchemas: metaApiSchemas,
-            scopedRoutingSchema: 'constructive_routing_public'
+            routingSchema: 'constructive_routing_public'
           }
         }
       },
@@ -357,11 +357,11 @@ describe('Error paths', () => {
         schemas,
         authRole: 'anonymous',
         server: {
-          scopedRouting: true,
+          useRouting: true,
           api: {
             isPublic: false,
             metaSchemas: scopedMetaSchemas,
-            scopedRoutingSchema: 'constructive_routing_public'
+            routingSchema: 'constructive_routing_public'
           }
         }
       },
@@ -407,11 +407,11 @@ describe('Error paths', () => {
           schemas,
           authRole: 'anonymous',
           server: {
-            scopedRouting: true,
+            useRouting: true,
             api: {
               isPublic: false,
               metaSchemas: scopedMetaSchemas,
-              scopedRoutingSchema: 'constructive_routing_public'
+              routingSchema: 'constructive_routing_public'
             }
           }
         },
@@ -442,11 +442,11 @@ describe('Error paths', () => {
           schemas,
           authRole: 'anonymous',
           server: {
-            scopedRouting: true,
+            useRouting: true,
             api: {
               isPublic: true,
               metaSchemas: scopedMetaSchemas,
-              scopedRoutingSchema: 'constructive_routing_public'
+              routingSchema: 'constructive_routing_public'
             }
           }
         },

--- a/graphql/server-test/__tests__/server.integration.test.ts
+++ b/graphql/server-test/__tests__/server.integration.test.ts
@@ -50,6 +50,7 @@ type Scenario = {
   api: {
     isPublic: boolean;
     metaSchemas?: string[];
+    scopedRoutingSchema?: string;
   };
   headers?: Record<string, string>;
 };
@@ -65,7 +66,7 @@ const scenarios: Scenario[] = [
     name: 'scoped public via domain',
     seedDir: 'simple-seed-scoped',
     scopedRouting: true,
-    api: { isPublic: true, metaSchemas: scopedMetaSchemas },
+    api: { isPublic: true, metaSchemas: scopedMetaSchemas, scopedRoutingSchema: 'constructive_routing_public' },
     headers: {
       Host: 'app.test.constructive.io'
     }
@@ -74,7 +75,7 @@ const scenarios: Scenario[] = [
     name: 'scoped private via domain',
     seedDir: 'simple-seed-scoped',
     scopedRouting: true,
-    api: { isPublic: false, metaSchemas: scopedMetaSchemas },
+    api: { isPublic: false, metaSchemas: scopedMetaSchemas, scopedRoutingSchema: 'constructive_routing_public' },
     headers: {
       Host: 'private.test.constructive.io'
     }
@@ -83,7 +84,7 @@ const scenarios: Scenario[] = [
     name: 'scoped private via X-Api-Name',
     seedDir: 'simple-seed-scoped',
     scopedRouting: true,
-    api: { isPublic: false, metaSchemas: scopedMetaSchemas },
+    api: { isPublic: false, metaSchemas: scopedMetaSchemas, scopedRoutingSchema: 'constructive_routing_public' },
     headers: {
       'X-Database-Id': scopedDatabaseId,
       'X-Api-Name': 'private'
@@ -93,7 +94,7 @@ const scenarios: Scenario[] = [
     name: 'scoped private via X-Schemata',
     seedDir: 'simple-seed-scoped',
     scopedRouting: true,
-    api: { isPublic: false, metaSchemas: scopedMetaSchemas },
+    api: { isPublic: false, metaSchemas: scopedMetaSchemas, scopedRoutingSchema: 'constructive_routing_public' },
     headers: {
       'X-Database-Id': scopedDatabaseId,
       'X-Schemata': schemas.join(',')
@@ -283,7 +284,8 @@ describe('scoped private via X-Meta-Schema', () => {
           scopedRouting: true,
           api: {
             isPublic: false,
-            metaSchemas: metaApiSchemas
+            metaSchemas: metaApiSchemas,
+            scopedRoutingSchema: 'constructive_routing_public'
           }
         }
       },
@@ -358,7 +360,8 @@ describe('Error paths', () => {
           scopedRouting: true,
           api: {
             isPublic: false,
-            metaSchemas: scopedMetaSchemas
+            metaSchemas: scopedMetaSchemas,
+            scopedRoutingSchema: 'constructive_routing_public'
           }
         }
       },
@@ -407,7 +410,8 @@ describe('Error paths', () => {
             scopedRouting: true,
             api: {
               isPublic: false,
-              metaSchemas: scopedMetaSchemas
+              metaSchemas: scopedMetaSchemas,
+              scopedRoutingSchema: 'constructive_routing_public'
             }
           }
         },
@@ -441,7 +445,8 @@ describe('Error paths', () => {
             scopedRouting: true,
             api: {
               isPublic: true,
-              metaSchemas: scopedMetaSchemas
+              metaSchemas: scopedMetaSchemas,
+              scopedRoutingSchema: 'constructive_routing_public'
             }
           }
         },

--- a/graphql/server-test/__tests__/upload.integration.test.ts
+++ b/graphql/server-test/__tests__/upload.integration.test.ts
@@ -318,7 +318,8 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
           scopedRouting: true,
           api: {
             isPublic: false,
-            metaSchemas
+            metaSchemas,
+            scopedRoutingSchema: 'constructive_routing_public'
           }
         }
       },

--- a/graphql/server-test/__tests__/upload.integration.test.ts
+++ b/graphql/server-test/__tests__/upload.integration.test.ts
@@ -315,11 +315,11 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
         schemas: [...aliceSchemas, ...bobSchemas, ...mallorySchemas],
         authRole: 'anonymous',
         server: {
-          scopedRouting: true,
+          useRouting: true,
           api: {
             isPublic: false,
             metaSchemas,
-            scopedRoutingSchema: 'constructive_routing_public'
+            routingSchema: 'constructive_routing_public'
           }
         }
       },

--- a/graphql/server-test/src/get-connections.ts
+++ b/graphql/server-test/src/get-connections.ts
@@ -60,9 +60,9 @@ export const getConnections = async (
 
   // Start the HTTP server. Suites default to the production scoped-routing
   // server; static/single-tenant suites opt into the dev server with
-  // `server.scopedRouting: false`.
-  const scopedRouting = input.server?.scopedRouting ?? true;
-  const server = scopedRouting
+  // `server.useRouting: false`.
+  const useRouting = input.server?.useRouting ?? true;
+  const server = useRouting
     ? await createTestServer(serverOpts, input.server)
     : await createDevTestServer(serverOpts, input.server);
 

--- a/graphql/server-test/src/types.ts
+++ b/graphql/server-test/src/types.ts
@@ -22,7 +22,7 @@ export interface ServerOptions {
    *   (pure PostGraphile, no routing, no database id) exposing the configured
    *   schemas directly. For local/static suites only.
    */
-  scopedRouting?: boolean;
+  useRouting?: boolean;
   /**
    * API configuration options for the GraphQL server.
    * These options control how the server handles requests and which features are enabled.
@@ -33,7 +33,7 @@ export interface ServerOptions {
    *   schemas: ['app_public'],
    *   server: {
    *     port: 5555,
-   *     scopedRouting: false
+   *     useRouting: false
    *   }
    * });
    * ```

--- a/graphql/server/README.md
+++ b/graphql/server/README.md
@@ -103,7 +103,7 @@ For the operational workflow, sampler output, and heap snapshot usage, see [docs
 
 This is a production-only server: every request is resolved through the scoped-routing plane. There is no static single-tenant mode and no flag to disable routing. For single-database local development without route resolution or a database id, use [`@constructive-io/graphql-dev-server`](../dev-server/README.md).
 
-- The server resolves the request host with a single `resolve_route()` call against the compiled route bindings in the scoped routing schema (`API_SCOPED_ROUTING_SCHEMA`, default `constructive_routing_public`), mapping host → tenant/api/database/role.
+- The server resolves the request host with a single `resolve_route()` call against the compiled route bindings in the scoped routing schema (`API_SCOPED_ROUTING_SCHEMA`, default `routing_public`), mapping host → tenant/api/database/role.
 - Only APIs where `api.is_public` matches `API_IS_PUBLIC` are served.
 - In private mode (`API_IS_PUBLIC=false`), you can override with headers:
   - `X-Api-Name` + `X-Database-Id`
@@ -126,10 +126,10 @@ Configuration is merged from defaults, config files, and env vars via `@construc
 | `FEATURES_SIMPLE_INFLECTION`   | Enable simple inflection              | `true`                                                        |
 | `FEATURES_OPPOSITE_BASE_NAMES` | Enable opposite base names            | `true`                                                        |
 | `FEATURES_POSTGIS`             | Enable PostGIS support                | `true`                                                        |
-| `API_SCOPED_ROUTING_SCHEMA`    | Schema containing `resolve_route()`   | `constructive_routing_public`                                 |
+| `API_SCOPED_ROUTING_SCHEMA`    | Schema containing `resolve_route()`   | `routing_public`                                 |
 | `API_IS_PUBLIC`                | Serve public APIs only                | `true`                                                        |
 | `API_EXPOSED_SCHEMAS`          | Additional schemas to expose          | empty                                                         |
-| `API_META_SCHEMAS`             | Meta schemas to query                 | `constructive_routing_public,metaschema_public,metaschema_modules_public` |
+| `API_META_SCHEMAS`             | Meta schemas to query                 | `routing_public,metaschema_public,metaschema_modules_public` |
 | `API_ANON_ROLE`                | Anonymous role name                   | `administrator`                                               |
 | `API_ROLE_NAME`                | Authenticated role name               | `administrator`                                               |
 | `GRAPHQL_OBSERVABILITY_ENABLED` | Master switch for debug routes and sampler | `false`                                                  |

--- a/graphql/server/README.md
+++ b/graphql/server/README.md
@@ -103,7 +103,7 @@ For the operational workflow, sampler output, and heap snapshot usage, see [docs
 
 This is a production-only server: every request is resolved through the scoped-routing plane. There is no static single-tenant mode and no flag to disable routing. For single-database local development without route resolution or a database id, use [`@constructive-io/graphql-dev-server`](../dev-server/README.md).
 
-- The server resolves the request host with a single `resolve_route()` call against the compiled route bindings in the scoped routing schema (`API_SCOPED_ROUTING_SCHEMA`, default `routing_public`), mapping host → tenant/api/database/role.
+- The server resolves the request host with a single `resolve_route()` call against the compiled route bindings in the scoped routing schema (`API_ROUTING_SCHEMA`, default `routing_public`), mapping host → tenant/api/database/role.
 - Only APIs where `api.is_public` matches `API_IS_PUBLIC` are served.
 - In private mode (`API_IS_PUBLIC=false`), you can override with headers:
   - `X-Api-Name` + `X-Database-Id`
@@ -126,7 +126,7 @@ Configuration is merged from defaults, config files, and env vars via `@construc
 | `FEATURES_SIMPLE_INFLECTION`   | Enable simple inflection              | `true`                                                        |
 | `FEATURES_OPPOSITE_BASE_NAMES` | Enable opposite base names            | `true`                                                        |
 | `FEATURES_POSTGIS`             | Enable PostGIS support                | `true`                                                        |
-| `API_SCOPED_ROUTING_SCHEMA`    | Schema containing `resolve_route()`   | `routing_public`                                 |
+| `API_ROUTING_SCHEMA`    | Schema containing `resolve_route()`   | `routing_public`                                 |
 | `API_IS_PUBLIC`                | Serve public APIs only                | `true`                                                        |
 | `API_EXPOSED_SCHEMAS`          | Additional schemas to expose          | empty                                                         |
 | `API_META_SCHEMAS`             | Meta schemas to query                 | `routing_public,metaschema_public,metaschema_modules_public` |

--- a/graphql/server/src/middleware/__tests__/api.test.ts
+++ b/graphql/server/src/middleware/__tests__/api.test.ts
@@ -111,7 +111,7 @@ describe('api middleware routing priority', () => {
     });
     expect(svcCache.get('api:db-123:customer-api')).toBe(result);
     expect(query.mock.calls).toEqual(expect.arrayContaining([
-      [expect.stringContaining('FROM constructive_routing_public.apis'), ['db-123', 'customer-api', false]]
+      [expect.stringContaining('FROM "routing_public".apis'), ['db-123', 'customer-api', false]]
     ]));
   });
 });

--- a/graphql/server/src/middleware/api.ts
+++ b/graphql/server/src/middleware/api.ts
@@ -15,7 +15,7 @@ import { getPgPool } from 'pg-cache';
 import errorPage50x from '../errors/50x';
 import errorPage404Message from '../errors/404-message';
 import { ApiConfigResult, ApiError, ApiOptions, ApiStructure, AuthSettings, DatabaseSettings, PubkeyChallengeSettings, RlsModule, WebauthnSettings } from '../types';
-import { getScopedRoutingSchema, isValidSchemaName, resolveRoute, routeToApiStructure } from './routing';
+import { getRoutingSchema, isValidSchemaName, resolveRoute, routeToApiStructure } from './routing';
 
 const log = new Logger('api');
 
@@ -112,7 +112,7 @@ const buildLoaderContext = (
   row: ApiRow
 ): LoaderContext => ({
   routingPool,
-  routingSchema: getScopedRoutingSchema(opts),
+  routingSchema: getRoutingSchema(opts),
   tenantPool: getPgPool({ ...opts.pg, database: row.dbname }),
   databaseId: row.database_id,
   apiId: row.api_id,
@@ -276,7 +276,7 @@ const queryByApiName = async (
   name: string,
   isPublic: boolean
 ): Promise<ApiRow | null> => {
-  const routingSchema = getScopedRoutingSchema(opts);
+  const routingSchema = getRoutingSchema(opts);
   if (!isValidSchemaName(routingSchema)) {
     log.warn(`[api-name-lookup] invalid routing schema name: ${routingSchema}`);
     return null;
@@ -350,7 +350,7 @@ const resolveMetaSchemaHeader = (
 const resolveScopedRoute = async (ctx: ResolveContext): Promise<ApiStructure | null> => {
   const { opts, pool, host } = ctx;
 
-  const schema = getScopedRoutingSchema(opts);
+  const schema = getRoutingSchema(opts);
   const route = await resolveRoute(pool, schema, host);
   if (!route) return null;
 

--- a/graphql/server/src/middleware/api.ts
+++ b/graphql/server/src/middleware/api.ts
@@ -15,7 +15,7 @@ import { getPgPool } from 'pg-cache';
 import errorPage50x from '../errors/50x';
 import errorPage404Message from '../errors/404-message';
 import { ApiConfigResult, ApiError, ApiOptions, ApiStructure, AuthSettings, DatabaseSettings, PubkeyChallengeSettings, RlsModule, WebauthnSettings } from '../types';
-import { resolveRoute, routeToApiStructure } from './routing';
+import { getScopedRoutingSchema, isValidSchemaName, resolveRoute, routeToApiStructure } from './routing';
 
 const log = new Logger('api');
 
@@ -31,7 +31,7 @@ const defaultRegistry: LoaderRegistry = createDefaultRegistry();
 
 // Private-header X-Api-Name lookup against the scoped routing plane.
 // `is_published` is the routing-plane analog of the legacy `is_public` column.
-const SCOPED_API_NAME_LOOKUP_SQL = `
+const scopedApiNameLookupSql = (routingSchema: string): string => `
   SELECT 
     a.id as api_id,
     a.database_id,
@@ -40,8 +40,8 @@ const SCOPED_API_NAME_LOOKUP_SQL = `
     a.anon_role,
     a.is_published as is_public,
     COALESCE(array_agg(s.schema_name) FILTER (WHERE s.schema_name IS NOT NULL), '{}') as schemas
-  FROM constructive_routing_public.apis a
-  LEFT JOIN constructive_routing_public.api_schemas aps ON a.id = aps.api_id
+  FROM "${routingSchema}".apis a
+  LEFT JOIN "${routingSchema}".api_schemas aps ON a.id = aps.api_id
   LEFT JOIN metaschema_public.schema s ON aps.schema_id = s.id
   WHERE a.database_id = $1 
     AND a.name = $2
@@ -112,6 +112,7 @@ const buildLoaderContext = (
   row: ApiRow
 ): LoaderContext => ({
   routingPool,
+  routingSchema: getScopedRoutingSchema(opts),
   tenantPool: getPgPool({ ...opts.pg, database: row.dbname }),
   databaseId: row.database_id,
   apiId: row.api_id,
@@ -270,11 +271,17 @@ const validateSchemata = async (pool: Pool, schemas: string[]): Promise<string[]
 
 const queryByApiName = async (
   pool: Pool,
+  opts: ApiOptions,
   databaseId: string,
   name: string,
   isPublic: boolean
 ): Promise<ApiRow | null> => {
-  const result = await pool.query<ApiRow>(SCOPED_API_NAME_LOOKUP_SQL, [databaseId, name, isPublic]);
+  const routingSchema = getScopedRoutingSchema(opts);
+  if (!isValidSchemaName(routingSchema)) {
+    log.warn(`[api-name-lookup] invalid routing schema name: ${routingSchema}`);
+    return null;
+  }
+  const result = await pool.query<ApiRow>(scopedApiNameLookupSql(routingSchema), [databaseId, name, isPublic]);
   return result.rows[0] ?? null;
 };
 
@@ -312,7 +319,7 @@ const resolveApiNameHeader = async (ctx: ResolveContext): Promise<ApiStructure |
   if (!headers.databaseId) return null;
 
   const isPublic = opts.api?.isPublic ?? false;
-  const row = await queryByApiName(pool, headers.databaseId, headers.apiName!, isPublic);
+  const row = await queryByApiName(pool, opts, headers.databaseId, headers.apiName!, isPublic);
   
   if (!row) {
     log.debug(`[api-name-lookup] No API found for databaseId=${headers.databaseId} name=${headers.apiName}`);
@@ -343,7 +350,7 @@ const resolveMetaSchemaHeader = (
 const resolveScopedRoute = async (ctx: ResolveContext): Promise<ApiStructure | null> => {
   const { opts, pool, host } = ctx;
 
-  const schema = opts.api?.scopedRoutingSchema || 'constructive_routing_public';
+  const schema = getScopedRoutingSchema(opts);
   const route = await resolveRoute(pool, schema, host);
   if (!route) return null;
 

--- a/graphql/server/src/middleware/flush.ts
+++ b/graphql/server/src/middleware/flush.ts
@@ -7,7 +7,7 @@ import { NextFunction, Request, Response } from 'express';
 import { graphileCache } from 'graphile-cache';
 import { getPgPool } from 'pg-cache';
 
-import { getScopedRoutingSchema, isValidSchemaName } from './routing';
+import { getRoutingSchema, isValidSchemaName } from './routing';
 
 const log = new Logger('flush');
 
@@ -46,7 +46,7 @@ export const flushService = async (
     });
   }
 
-  const routingSchema = getScopedRoutingSchema(opts);
+  const routingSchema = getRoutingSchema(opts);
   if (!isValidSchemaName(routingSchema)) {
     log.warn(`[flush] invalid routing schema name: ${routingSchema}`);
     return;

--- a/graphql/server/src/middleware/flush.ts
+++ b/graphql/server/src/middleware/flush.ts
@@ -7,6 +7,8 @@ import { NextFunction, Request, Response } from 'express';
 import { graphileCache } from 'graphile-cache';
 import { getPgPool } from 'pg-cache';
 
+import { getScopedRoutingSchema, isValidSchemaName } from './routing';
+
 const log = new Logger('flush');
 
 export const flush = async (
@@ -44,9 +46,14 @@ export const flushService = async (
     });
   }
 
+  const routingSchema = getScopedRoutingSchema(opts);
+  if (!isValidSchemaName(routingSchema)) {
+    log.warn(`[flush] invalid routing schema name: ${routingSchema}`);
+    return;
+  }
   const svc = await pgPool.query(
     `SELECT hostname
-     FROM constructive_routing_public.domains
+     FROM "${routingSchema}".domains
      WHERE database_id = $1`,
     [databaseId]
   );

--- a/graphql/server/src/middleware/routing.ts
+++ b/graphql/server/src/middleware/routing.ts
@@ -42,13 +42,13 @@ export interface ResolvedRoute {
 const RESOLVER_FUNCTION = 'resolve_route';
 
 /** Published logical name of the database-scope routing plane. */
-export const DEFAULT_SCOPED_ROUTING_SCHEMA = 'routing_public';
+export const DEFAULT_ROUTING_SCHEMA = 'routing_public';
 
 /** The routing-plane schema in effect: configured override or the published default. */
-export const getScopedRoutingSchema = (opts: {
-  api?: { scopedRoutingSchema?: string };
+export const getRoutingSchema = (opts: {
+  api?: { routingSchema?: string };
 }): string =>
-  opts.api?.scopedRoutingSchema || DEFAULT_SCOPED_ROUTING_SCHEMA;
+  opts.api?.routingSchema || DEFAULT_ROUTING_SCHEMA;
 
 export const isValidSchemaName = (name: string): boolean =>
   /^[a-z_][a-z0-9_]*$/.test(name);

--- a/graphql/server/src/middleware/routing.ts
+++ b/graphql/server/src/middleware/routing.ts
@@ -41,7 +41,16 @@ export interface ResolvedRoute {
 
 const RESOLVER_FUNCTION = 'resolve_route';
 
-const isValidSchemaName = (name: string): boolean =>
+/** Published logical name of the database-scope routing plane. */
+export const DEFAULT_SCOPED_ROUTING_SCHEMA = 'routing_public';
+
+/** The routing-plane schema in effect: configured override or the published default. */
+export const getScopedRoutingSchema = (opts: {
+  api?: { scopedRoutingSchema?: string };
+}): string =>
+  opts.api?.scopedRoutingSchema || DEFAULT_SCOPED_ROUTING_SCHEMA;
+
+export const isValidSchemaName = (name: string): boolean =>
   /^[a-z_][a-z0-9_]*$/.test(name);
 
 /**

--- a/graphql/server/src/server.ts
+++ b/graphql/server/src/server.ts
@@ -41,7 +41,7 @@ import { createDebugDatabaseMiddleware } from './middleware/observability/debug-
 import { debugMemory } from './middleware/observability/debug-memory';
 import { localObservabilityOnly } from './middleware/observability/guard';
 import { createRequestLogger } from './middleware/observability/request-logger';
-import { getScopedRoutingSchema } from './middleware/routing';
+import { getRoutingSchema } from './middleware/routing';
 
 const log = new Logger('server');
 
@@ -103,7 +103,7 @@ class Server {
       serverHost: effectiveOpts.server?.host,
       serverPort: effectiveOpts.server?.port,
       apiIsPublic: apiOpts.isPublic,
-      scopedRoutingSchema: apiOpts.scopedRoutingSchema,
+      routingSchema: apiOpts.routingSchema,
       metaSchemas: apiOpts.metaSchemas?.join(',') || 'default',
       observabilityEnabled
     });
@@ -166,7 +166,7 @@ class Server {
     app.use(createContextMiddleware({
       pg: effectiveOpts.pg,
       loaders: createDefaultRegistry(),
-      routingSchema: getScopedRoutingSchema(effectiveOpts)
+      routingSchema: getRoutingSchema(effectiveOpts)
     }));
     app.use(createCaptchaMiddleware());
 

--- a/graphql/server/src/server.ts
+++ b/graphql/server/src/server.ts
@@ -41,6 +41,7 @@ import { createDebugDatabaseMiddleware } from './middleware/observability/debug-
 import { debugMemory } from './middleware/observability/debug-memory';
 import { localObservabilityOnly } from './middleware/observability/guard';
 import { createRequestLogger } from './middleware/observability/request-logger';
+import { getScopedRoutingSchema } from './middleware/routing';
 
 const log = new Logger('server');
 
@@ -162,7 +163,11 @@ class Server {
     app.use(requestLogger);
     app.use(api);
     app.use(authenticate);
-    app.use(createContextMiddleware({ pg: effectiveOpts.pg, loaders: createDefaultRegistry() }));
+    app.use(createContextMiddleware({
+      pg: effectiveOpts.pg,
+      loaders: createDefaultRegistry(),
+      routingSchema: getScopedRoutingSchema(effectiveOpts)
+    }));
     app.use(createCaptchaMiddleware());
 
     // CSRF protection for cookie-authenticated requests

--- a/graphql/types/README.md
+++ b/graphql/types/README.md
@@ -40,7 +40,7 @@ const config: ConstructiveOptions = {
     appendPlugins: [],
   },
   api: {
-    scopedRoutingSchema: 'routing_public',
+    routingSchema: 'routing_public',
     exposedSchemas: ['public'],
   },
   features: {

--- a/graphql/types/README.md
+++ b/graphql/types/README.md
@@ -40,7 +40,7 @@ const config: ConstructiveOptions = {
     appendPlugins: [],
   },
   api: {
-    scopedRoutingSchema: 'constructive_routing_public',
+    scopedRoutingSchema: 'routing_public',
     exposedSchemas: ['public'],
   },
   features: {

--- a/graphql/types/src/graphile.ts
+++ b/graphql/types/src/graphile.ts
@@ -73,9 +73,9 @@ export const apiDefaults: ApiOptions = {
   roleName: 'administrator',
   isPublic: true,
   metaSchemas: [
-    'constructive_routing_public',
+    'routing_public',
     'metaschema_public',
     'metaschema_modules_public'
   ],
-  scopedRoutingSchema: 'constructive_routing_public'
+  scopedRoutingSchema: 'routing_public'
 };

--- a/graphql/types/src/graphile.ts
+++ b/graphql/types/src/graphile.ts
@@ -43,7 +43,7 @@ export interface ApiOptions {
    * always resolved through the scoped-routing plane via
    * <schema>.resolve_route() (host → tenant/api/db/role).
    */
-  scopedRoutingSchema?: string;
+  routingSchema?: string;
 }
 
 /**
@@ -77,5 +77,5 @@ export const apiDefaults: ApiOptions = {
     'metaschema_public',
     'metaschema_modules_public'
   ],
-  scopedRoutingSchema: 'routing_public'
+  routingSchema: 'routing_public'
 };

--- a/packages/cli/src/commands/server.ts
+++ b/packages/cli/src/commands/server.ts
@@ -151,7 +151,7 @@ export default async (
 
   // Debug: Log API routing configuration
   const apiOpts = (options as any).api || {};
-  log.debug(`📡 API Routing: isPublic=${apiOpts.isPublic}, scopedRoutingSchema=${apiOpts.scopedRoutingSchema}`);
+  log.debug(`📡 API Routing: isPublic=${apiOpts.isPublic}, routingSchema=${apiOpts.routingSchema}`);
   if (apiOpts.isPublic === false) {
     log.debug(`   Header-based routing enabled (X-Api-Name, X-Database-Id, X-Meta-Schema)`);
   }

--- a/packages/express-context/README.md
+++ b/packages/express-context/README.md
@@ -63,11 +63,11 @@ Each loader encapsulates a SQL query + type transform + per-databaseId LRU cache
 
 | Loader | Source | Description |
 |--------|--------|-------------|
-| `rlsLoader` | `constructive_routing_public.rls_settings` | RLS module (authenticate functions, schema refs) |
-| `corsLoader` | `constructive_routing_public.cors_settings` | CORS allowed origins |
-| `databaseSettingsLoader` | `constructive_routing_public.database_settings` | Feature flags (aggregates, search, uploads, etc.) |
-| `pubkeyLoader` | `constructive_routing_public.pubkey_settings` | Public key challenge auth settings |
-| `webauthnLoader` | `constructive_routing_public.webauthn_settings` | WebAuthn/passkey configuration |
+| `rlsLoader` | `routing_public.rls_settings` | RLS module (authenticate functions, schema refs) |
+| `corsLoader` | `routing_public.cors_settings` | CORS allowed origins |
+| `databaseSettingsLoader` | `routing_public.database_settings` | Feature flags (aggregates, search, uploads, etc.) |
+| `pubkeyLoader` | `routing_public.pubkey_settings` | Public key challenge auth settings |
+| `webauthnLoader` | `routing_public.webauthn_settings` | WebAuthn/passkey configuration |
 | `authSettingsLoader` | `metaschema_modules_public.sessions_module` | Cookie/captcha settings (two-step tenant DB discovery) |
 
 ### Custom loaders

--- a/packages/express-context/src/context.ts
+++ b/packages/express-context/src/context.ts
@@ -32,6 +32,8 @@ export interface ContextMiddlewareOptions {
   pg?: PgpmOptions['pg'];
   /** Module loader registry for per-database cached lookups */
   loaders?: LoaderRegistry;
+  /** Routing-plane schema loaders query (defaults to routing_public) */
+  routingSchema?: string;
 }
 
 /**
@@ -89,6 +91,7 @@ export function buildContext(
     const routingPool: Pool = getPgPool(opts.pg);
     loaderCtx = {
       routingPool,
+      routingSchema: opts.routingSchema,
       tenantPool,
       databaseId: api.databaseId,
       apiId: api.apiId,

--- a/packages/express-context/src/loaders/cors.ts
+++ b/packages/express-context/src/loaders/cors.ts
@@ -8,19 +8,20 @@
 
 import { createModuleLoader } from './create-loader';
 import type { LoaderContext, ModuleLoader } from './types';
+import { routingSchemaOf } from './types';
 
 // ─── SQL ────────────────────────────────────────────────────────────────────
 
-const CORS_SETTINGS_SQL = `
+const corsSettingsSql = (schema: string): string => `
   SELECT allowed_origins
-  FROM constructive_routing_public.cors_settings
+  FROM "${schema}".cors_settings
   WHERE database_id = $1 AND api_id = $2
   LIMIT 1
 `;
 
-const CORS_SETTINGS_DB_DEFAULT_SQL = `
+const corsSettingsDbDefaultSql = (schema: string): string => `
   SELECT allowed_origins
-  FROM constructive_routing_public.cors_settings
+  FROM "${schema}".cors_settings
   WHERE database_id = $1 AND api_id IS NULL
   LIMIT 1
 `;
@@ -38,12 +39,13 @@ export const corsLoader: ModuleLoader<string[]> = createModuleLoader<string[]>({
   ttlMs: 5 * 60_000,
   async resolve(ctx: LoaderContext) {
     const { routingPool, databaseId, apiId } = ctx;
+    const schema = routingSchemaOf(ctx);
 
     if (apiId) {
-      const perApi = await routingPool.query<CorsSettingsRow>(CORS_SETTINGS_SQL, [databaseId, apiId]);
+      const perApi = await routingPool.query<CorsSettingsRow>(corsSettingsSql(schema), [databaseId, apiId]);
       if (perApi.rows[0]) return perApi.rows[0].allowed_origins;
     }
-    const dbDefault = await routingPool.query<CorsSettingsRow>(CORS_SETTINGS_DB_DEFAULT_SQL, [databaseId]);
+    const dbDefault = await routingPool.query<CorsSettingsRow>(corsSettingsDbDefaultSql(schema), [databaseId]);
     if (dbDefault.rows[0]) return dbDefault.rows[0].allowed_origins;
 
     return undefined;

--- a/packages/express-context/src/loaders/database-settings.ts
+++ b/packages/express-context/src/loaders/database-settings.ts
@@ -9,10 +9,11 @@
 import type { DatabaseSettings } from '../types';
 import { createModuleLoader } from './create-loader';
 import type { LoaderContext, ModuleLoader } from './types';
+import { routingSchemaOf } from './types';
 
 // ─── SQL ────────────────────────────────────────────────────────────────────
 
-const DATABASE_SETTINGS_SQL = `
+const databaseSettingsSql = (schema: string): string => `
   SELECT
     COALESCE(aps.enable_aggregates, ds.enable_aggregates) AS resolved_enable_aggregates,
     COALESCE(aps.enable_postgis, ds.enable_postgis) AS resolved_enable_postgis,
@@ -26,8 +27,8 @@ const DATABASE_SETTINGS_SQL = `
     COALESCE(aps.enable_realtime, ds.enable_realtime) AS resolved_enable_realtime,
     COALESCE(aps.enable_bulk, ds.enable_bulk) AS resolved_enable_bulk,
     COALESCE(aps.enable_i18n, ds.enable_i18n) AS resolved_enable_i18n
-  FROM constructive_routing_public.database_settings ds
-  LEFT JOIN constructive_routing_public.api_settings aps ON ds.database_id = aps.database_id AND aps.api_id = $2
+  FROM "${schema}".database_settings ds
+  LEFT JOIN "${schema}".api_settings aps ON ds.database_id = aps.database_id AND aps.api_id = $2
   WHERE ds.database_id = $1
   LIMIT 1
 `;
@@ -58,7 +59,7 @@ export const databaseSettingsLoader: ModuleLoader<DatabaseSettings> = createModu
     const { routingPool, databaseId, apiId } = ctx;
 
     const result = await routingPool.query<DatabaseSettingsRow>(
-      DATABASE_SETTINGS_SQL,
+      databaseSettingsSql(routingSchemaOf(ctx)),
       [databaseId, apiId ?? null]
     );
     const row = result.rows[0];

--- a/packages/express-context/src/loaders/index.ts
+++ b/packages/express-context/src/loaders/index.ts
@@ -6,11 +6,11 @@
  * a LoaderRegistry and pass it to createContextMiddleware().
  *
  * Built-in loaders cover the standard Constructive modules:
- *   - rlsModule       (constructive_routing_public.rls_settings)
- *   - corsOrigins     (constructive_routing_public.cors_settings)
- *   - databaseSettings(constructive_routing_public.database_settings)
- *   - pubkeyChallengeSettings (constructive_routing_public.pubkey_settings)
- *   - webauthnSettings(constructive_routing_public.webauthn_settings)
+ *   - rlsModule       (routing-plane rls_settings)
+ *   - corsOrigins     (routing-plane cors_settings)
+ *   - databaseSettings(routing-plane database_settings)
+ *   - pubkeyChallengeSettings (routing-plane pubkey_settings)
+ *   - webauthnSettings(routing-plane webauthn_settings)
  *   - authSettings    (metaschema_modules_public.sessions_module → tenant DB)
  *
  * To add a new per-db lookup, implement a ModuleLoader and register it:

--- a/packages/express-context/src/loaders/pubkey.ts
+++ b/packages/express-context/src/loaders/pubkey.ts
@@ -9,10 +9,11 @@
 import type { PubkeyChallengeSettings } from '../types';
 import { createModuleLoader } from './create-loader';
 import type { LoaderContext, ModuleLoader } from './types';
+import { routingSchemaOf } from './types';
 
 // ─── SQL ────────────────────────────────────────────────────────────────────
 
-const PUBKEY_SETTINGS_SQL = `
+const pubkeySettingsSql = (schema: string): string => `
   SELECT
     s.schema_name AS schema,
     ps.crypto_network,
@@ -20,7 +21,7 @@ const PUBKEY_SETTINGS_SQL = `
     sign_in_req_fn.name AS sign_in_request_challenge,
     sign_in_fail_fn.name AS sign_in_record_failure,
     sign_in_fn.name AS sign_in_with_challenge
-  FROM constructive_routing_public.pubkey_settings ps
+  FROM "${schema}".pubkey_settings ps
   LEFT JOIN metaschema_public.schema s ON ps.schema_id = s.id
   LEFT JOIN metaschema_public.function sign_up_fn ON ps.sign_up_with_key_function_id = sign_up_fn.id
   LEFT JOIN metaschema_public.function sign_in_req_fn ON ps.sign_in_request_challenge_function_id = sign_in_req_fn.id
@@ -62,7 +63,7 @@ export const pubkeyLoader: ModuleLoader<PubkeyChallengeSettings> = createModuleL
   ttlMs: 5 * 60_000,
   async resolve(ctx: LoaderContext) {
     const { routingPool, databaseId } = ctx;
-    const result = await routingPool.query<PubkeySettingsRow>(PUBKEY_SETTINGS_SQL, [databaseId]);
+    const result = await routingPool.query<PubkeySettingsRow>(pubkeySettingsSql(routingSchemaOf(ctx)), [databaseId]);
     return fromRow(result.rows[0] ?? null);
   }
 });

--- a/packages/express-context/src/loaders/rls.ts
+++ b/packages/express-context/src/loaders/rls.ts
@@ -9,10 +9,11 @@
 import type { RlsModule } from '../types';
 import { createModuleLoader } from './create-loader';
 import type { LoaderContext, ModuleLoader } from './types';
+import { routingSchemaOf } from './types';
 
 // ─── SQL ────────────────────────────────────────────────────────────────────
 
-const RLS_SETTINGS_SQL = `
+const rlsSettingsSql = (schema: string): string => `
   SELECT
     auth_schema.schema_name AS authenticate_schema,
     role_schema.schema_name AS role_schema,
@@ -22,7 +23,7 @@ const RLS_SETTINGS_SQL = `
     role_id_fn.name AS current_role_id,
     ua_fn.name AS current_user_agent,
     ip_fn.name AS current_ip_address
-  FROM constructive_routing_public.rls_settings rs
+  FROM "${schema}".rls_settings rs
   LEFT JOIN metaschema_public.schema auth_schema ON rs.authenticate_schema_id = auth_schema.id
   LEFT JOIN metaschema_public.schema role_schema ON rs.role_schema_id = role_schema.id
   LEFT JOIN metaschema_public.function auth_fn ON rs.authenticate_function_id = auth_fn.id
@@ -72,7 +73,7 @@ export const rlsLoader: ModuleLoader<RlsModule> = createModuleLoader<RlsModule>(
   ttlMs: 5 * 60_000,
   async resolve(ctx: LoaderContext) {
     const { routingPool, databaseId } = ctx;
-    const result = await routingPool.query<RlsSettingsRow>(RLS_SETTINGS_SQL, [databaseId]);
+    const result = await routingPool.query<RlsSettingsRow>(rlsSettingsSql(routingSchemaOf(ctx)), [databaseId]);
     return fromSettings(result.rows[0] ?? null);
   }
 });

--- a/packages/express-context/src/loaders/types.ts
+++ b/packages/express-context/src/loaders/types.ts
@@ -12,14 +12,34 @@
 
 import type { Pool } from 'pg';
 
+/** Published logical name of the scoped routing plane. */
+export const DEFAULT_ROUTING_SCHEMA = 'routing_public';
+
+/**
+ * The routing-plane schema a loader should query: the context override or
+ * the published default. Throws on names unsafe to interpolate as an
+ * identifier.
+ */
+export const routingSchemaOf = (
+  ctx: Pick<LoaderContext, 'routingSchema'>
+): string => {
+  const schema = ctx.routingSchema ?? DEFAULT_ROUTING_SCHEMA;
+  if (!/^[a-z_][a-z0-9_]*$/.test(schema)) {
+    throw new Error(`invalid routing schema name: ${schema}`);
+  }
+  return schema;
+};
+
 /**
  * Context passed to every loader's resolve function.
  * Provides both pool references so the loader can query whichever
  * database tier it needs.
  */
 export interface LoaderContext {
-  /** Routing/configuration database pool (for constructive_routing_public.* lookups) */
+  /** Routing/configuration database pool (for routing-plane lookups) */
   routingPool: Pool;
+  /** Routing-plane schema to query (defaults to the published routing_public) */
+  routingSchema?: string;
   /** Tenant database pool (for metaschema_modules_public.* lookups) */
   tenantPool: Pool;
   /** UUID of the database being resolved */

--- a/packages/express-context/src/loaders/webauthn.ts
+++ b/packages/express-context/src/loaders/webauthn.ts
@@ -8,10 +8,11 @@
 import type { WebauthnSettings } from '../types';
 import { createModuleLoader } from './create-loader';
 import type { LoaderContext, ModuleLoader } from './types';
+import { routingSchemaOf } from './types';
 
 // ─── SQL ────────────────────────────────────────────────────────────────────
 
-const WEBAUTHN_SETTINGS_SQL = `
+const webauthnSettingsSql = (schema: string): string => `
   SELECT
     s.schema_name AS schema,
     cred_s.schema_name AS credentials_schema,
@@ -24,7 +25,7 @@ const WEBAUTHN_SETTINGS_SQL = `
     ws.require_user_verification,
     ws.resident_key,
     ws.challenge_expiry_seconds
-  FROM constructive_routing_public.webauthn_settings ws
+  FROM "${schema}".webauthn_settings ws
   LEFT JOIN metaschema_public.schema s ON ws.schema_id = s.id
   LEFT JOIN metaschema_public.schema cred_s ON ws.credentials_schema_id = cred_s.id
   LEFT JOIN metaschema_public.schema sess_s ON ws.sessions_schema_id = sess_s.id
@@ -57,7 +58,7 @@ export const webauthnLoader: ModuleLoader<WebauthnSettings> = createModuleLoader
   async resolve(ctx: LoaderContext) {
     const { routingPool, databaseId } = ctx;
 
-    const result = await routingPool.query<WebauthnSettingsRow>(WEBAUTHN_SETTINGS_SQL, [databaseId]);
+    const result = await routingPool.query<WebauthnSettingsRow>(webauthnSettingsSql(routingSchemaOf(ctx)), [databaseId]);
     const row = result.rows[0];
     if (!row?.schema) return undefined;
 

--- a/pgpm.json
+++ b/pgpm.json
@@ -6,7 +6,7 @@
     "@constructive-db/apps": "1.0.1",
     "@constructive-db/catalog": "1.0.1",
     "@constructive-db/routing": "1.0.1",
-    "@constructive-db/routing-functions": "1.0.1",
+    "@constructive-db/routing-functions": "1.1.0",
     "@pgpm/database-jobs": "0.33.1",
     "@pgpm/function-resolution": "0.33.1",
     "@pgpm/jwt-claims": "0.33.0",

--- a/pgpm.json
+++ b/pgpm.json
@@ -6,7 +6,7 @@
     "@constructive-db/apps": "1.0.1",
     "@constructive-db/catalog": "1.0.1",
     "@constructive-db/routing": "1.0.1",
-    "@constructive-db/routing-functions": "1.1.0",
+    "@constructive-db/routing-functions": "1.0.1",
     "@pgpm/database-jobs": "0.33.1",
     "@pgpm/function-resolution": "0.33.1",
     "@pgpm/jwt-claims": "0.33.0",


### PR DESCRIPTION
## Summary

Server-side wiring for constructive-io/constructive-planning#1268 / #1264 items 3–4: constructive-db#2516 renamed the published routing plane to its logical name, so the platform DB now carries `routing_public` — but the server still hardcoded `constructive_routing_public` in places that ignored the configurable routing-schema option.

- Default flips: `apiDefaults.routingSchema` (and the `metaSchemas` default entry) → `routing_public`. `API_ROUTING_SCHEMA` still overrides.
- `graphql/server` no longer hardcodes the schema: the X-Api-Name lookup (`queryByApiName`) and the `/flush` domain query now build their SQL from `getRoutingSchema(opts)` (new helper in `middleware/routing.ts`, identifier-validated, interpolated as a quoted identifier).
- `express-context` loaders (rls/cors/database-settings/pubkey/webauthn) previously hardcoded `constructive_routing_public.*`; `LoaderContext` gains `routingSchema?` (default `routing_public` via `routingSchemaOf(ctx)`), threaded from `buildLoaderContext` and `createContextMiddleware({ routingSchema })`.
- Option rename (per review): `scopedRouting` → `useRouting`, `scopedRoutingSchema` → `routingSchema`, `API_SCOPED_ROUTING_SCHEMA` → `API_ROUTING_SCHEMA`, and matching helper/constant names — "scoped routing" naming no longer leaks into config surfaces.

Integration fixtures (`@constructive-db/routing@1.0.1` in `pgpm.json`) still publish the pre-rename prefixed schema, so the server-test suites pin `routingSchema: 'constructive_routing_public'` explicitly — they can drop that once the renamed plane packages are published.

Tests: graphql/server 120/120, express-context 4/4, graphql/env 9/9 (snapshot updated), server-test scoped suites 86/86 locally (upload/S3 suite requires MinIO, absent locally — verified on CI).

Link to Devin session: https://app.devin.ai/sessions/ef854ab8e37e4fedbb21bfd777608edd
Requested by: @pyramation