### PR TITLE
fix(core): record the requested package's own version during install

### DIFF
--- a/pgpm/core/__tests__/modules/module-installation.test.ts
+++ b/pgpm/core/__tests__/modules/module-installation.test.ts
@@ -92,6 +92,17 @@ describe('workspace-level install', () => {
     expect(workspace.getWorkspaceDependencies()['@pgpm-testing/base32']).toBe('1.2.0');
   });
 
+  it('records the requested package version, not a dependency version', async () => {
+    // routing@5.0.0 depends on catalog@4.0.0 and routing-platform@4.0.0;
+    // the recorded pin must be the requested package's own version.
+    await workspace.installModules('@constructive-db/routing@5.0.0');
+
+    const config = JSON.parse(
+      fs.readFileSync(path.join(workspace.getWorkspacePath()!, 'pgpm.json'), 'utf-8')
+    );
+    expect(config.dependencies['@constructive-db/routing']).toBe('5.0.0');
+  });
+
   it('installWorkspaceDependencies installs pinned deps and skips installed ones', async () => {
     const configPath = path.join(workspace.getWorkspacePath()!, 'pgpm.json');
     const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));

--- a/pgpm/core/src/core/class/pgpm.ts
+++ b/pgpm/core/src/core/class/pgpm.ts
@@ -1077,10 +1077,12 @@ ${dependencies.length > 0 ? dependencies.map(dep => `-- requires: ${dep}`).join(
             throw new Error(`Missing package.json in installed extension: ${dst}`);
           }
   
-          const { version } = JSON.parse(fs.readFileSync(pkgJsonFile, 'utf-8'));
-          installedVersions[name] = `${version}`;
-          if (pkgData) {
-            pkgData.dependencies[name] = `${version}`;
+          const { name: installedName, version } = JSON.parse(fs.readFileSync(pkgJsonFile, 'utf-8'));
+          if (installedName === name) {
+            installedVersions[name] = `${version}`;
+            if (pkgData) {
+              pkgData.dependencies[name] = `${version}`;
+            }
           }
   
           const extensionName = getExtensionName(dst);


### PR DESCRIPTION
## Summary

`pgpm install` (module and `-W` workspace-root modes) corrupted the recorded version pin whenever the installed package's transitive dependencies had different versions. `installModules` extracts every module found in the npm install tree (the package **and** its deps), and inside that extraction loop recorded *each* extracted module's version under the *requested* package's name — so the last-extracted dependency's version won the write-back:

```
pgpm.json: "@constructive-db/routing": "5.0.0"
pgpm install -W
  → installs routing@5.0.0 correctly into extensions/
  → but rewrites the pin to "4.0.0" (the version of its dep catalog/routing-platform)
```

Fix in `installModules`:

```diff
- const { version } = JSON.parse(fs.readFileSync(pkgJsonFile, 'utf-8'));
- installedVersions[name] = `${version}`;
+ const { name: installedName, version } = JSON.parse(fs.readFileSync(pkgJsonFile, 'utf-8'));
+ if (installedName === name) {
+   installedVersions[name] = `${version}`;
+   ...
```

The existing `@pgpm-testing/*` fixtures never caught this because their dependency versions are always identical to the requested package's. Added a regression test using `@constructive-db/routing@5.0.0` (deps pinned at 4.0.0), which fails without the fix.

Link to Devin session: https://app.devin.ai/sessions/ef854ab8e37e4fedbb21bfd777608edd
Requested by: @pyramation