### PR TITLE
feat(pgpm): add `pgpm sync-versions` — realign .control/Makefile/sql with package.json versions

### DIFF
--- a/pgpm/cli/src/commands.ts
+++ b/pgpm/cli/src/commands.ts
@@ -24,6 +24,7 @@ import remove from './commands/remove';
 import renameCmd from './commands/rename';
 import revert from './commands/revert';
 import slice from './commands/slice';
+import syncVersions from './commands/sync-versions';
 import tag from './commands/tag';
 import testPackages from './commands/test-packages';
 import tune from './commands/tune';
@@ -68,6 +69,7 @@ export const createPgpmCommandMap = (skipPgTeardown: boolean = false): Record<st
     analyze: pgt(analyze),
     rename: pgt(renameCmd),
     slice,
+    'sync-versions': syncVersions,
     'test-packages': pgt(testPackages),
     tune: pgt(tune),
     upgrade: pgt(upgrade),

--- a/pgpm/cli/src/commands/sync-versions.ts
+++ b/pgpm/cli/src/commands/sync-versions.ts
@@ -1,0 +1,63 @@
+import { PgpmPackage } from '@pgpmjs/core';
+import { CLIOptions, Inquirerer } from 'inquirerer';
+
+const syncVersionsUsageText = `
+Sync Versions Command:
+
+  pgpm sync-versions [OPTIONS]
+
+  Sync extension metadata (.control default_version, Makefile sql filename,
+  and the sql/<name>--<version>.sql bundle) to each module's package.json
+  version. Inside a module, syncs just that module; at a workspace root,
+  syncs every workspace module.
+
+Options:
+  --help, -h                      Show this help message
+  --check                         Report version skew without writing; exits non-zero if skewed
+  --cwd <directory>               Working directory (default: current directory)
+
+Examples:
+  pgpm sync-versions               Sync all out-of-sync modules
+  pgpm sync-versions --check       Fail if any module's metadata is out of sync (for CI)
+`;
+
+export default async (
+  argv: Partial<Record<string, any>>,
+  _prompter: Inquirerer,
+  _options: CLIOptions
+) => {
+  // Show usage if explicitly requested
+  if (argv.help || argv.h) {
+    console.log(syncVersionsUsageText);
+    process.exit(0);
+  }
+
+  const cwd = argv.cwd ?? process.cwd();
+  const check = Boolean(argv.check);
+
+  const project = new PgpmPackage(cwd);
+  const result = await project.syncVersions({ check });
+
+  if (check) {
+    if (result.skewed.length > 0) {
+      console.log(`${result.skewed.length} module(s) out of sync:`);
+      for (const status of result.skewed) {
+        console.log(
+          `  ${status.name}: package.json ${status.packageVersion} != control ${status.controlVersion}` +
+          (status.sqlFileExists ? '' : ` (missing sql/${status.name}--${status.packageVersion}.sql)`)
+        );
+      }
+      process.exit(1);
+    }
+    console.log(`All ${result.ok.length} module(s) in sync.`);
+    return argv;
+  }
+
+  if (result.synced.length === 0) {
+    console.log(`All ${result.ok.length} module(s) already in sync.`);
+  } else {
+    console.log(`Synced ${result.synced.length} module(s); ${result.ok.length} already in sync.`);
+  }
+
+  return argv;
+};

--- a/pgpm/cli/src/utils/display.ts
+++ b/pgpm/cli/src/utils/display.ts
@@ -12,6 +12,7 @@ export const usageText = `
     extension          Manage module dependencies
     plan               Generate module deployment plans
     package            Package module for distribution
+    sync-versions      Sync .control/Makefile/sql metadata to package.json versions
     export             Export database migrations from existing databases
     update             Update pgpm to the latest version
     cache              Manage cached templates (clean)

--- a/pgpm/core/__tests__/modules/sync-versions.test.ts
+++ b/pgpm/core/__tests__/modules/sync-versions.test.ts
@@ -1,0 +1,101 @@
+import fs from 'fs';
+import path from 'path';
+
+import { PgpmPackage } from '../../src';
+import { getModuleVersionStatus } from '../../src/packaging/sync-versions';
+import { TestFixture } from '../../test-utils';
+
+let fixture: TestFixture;
+
+beforeEach(() => {
+  fixture = new TestFixture('sqitch', 'constructive');
+});
+
+afterEach(() => {
+  fixture.cleanup();
+});
+
+const modulePath = (name: string) => fixture.fixturePath('packages', name);
+
+const skewModule = (name: string, version: string) => {
+  const pkgPath = path.join(modulePath(name), 'package.json');
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+  pkg.version = version;
+  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+};
+
+describe('syncVersions', () => {
+  it('is a no-op when all modules are already in sync', async () => {
+    const workspace = new PgpmPackage(fixture.tempFixtureDir);
+    const result = await workspace.syncVersions();
+
+    expect(result.synced).toHaveLength(0);
+    expect(result.skewed).toHaveLength(0);
+    expect(result.ok.length).toBeGreaterThan(0);
+    expect(result.ok.every(s => s.inSync)).toBe(true);
+  });
+
+  it('syncs a skewed module: control, Makefile, and sql filename', async () => {
+    skewModule('totp', '1.2.3');
+
+    const workspace = new PgpmPackage(fixture.tempFixtureDir);
+    const result = await workspace.syncVersions();
+
+    expect(result.synced.map(s => s.name)).toEqual(['totp']);
+
+    const dir = modulePath('totp');
+    const control = fs.readFileSync(path.join(dir, 'totp.control'), 'utf-8');
+    expect(control).toContain(`default_version = '1.2.3'`);
+
+    const makefile = fs.readFileSync(path.join(dir, 'Makefile'), 'utf-8');
+    expect(makefile).toContain('sql/totp--1.2.3.sql');
+    expect(makefile).not.toContain('sql/totp--0.0.1.sql');
+
+    expect(fs.existsSync(path.join(dir, 'sql', 'totp--1.2.3.sql'))).toBe(true);
+    expect(fs.existsSync(path.join(dir, 'sql', 'totp--0.0.1.sql'))).toBe(false);
+
+    expect(getModuleVersionStatus(dir).inSync).toBe(true);
+  });
+
+  it('reports skew without writing in check mode', async () => {
+    skewModule('totp', '9.9.9');
+
+    const dir = modulePath('totp');
+    const controlBefore = fs.readFileSync(path.join(dir, 'totp.control'), 'utf-8');
+
+    const workspace = new PgpmPackage(fixture.tempFixtureDir);
+    const result = await workspace.syncVersions({ check: true });
+
+    expect(result.synced).toHaveLength(0);
+    expect(result.skewed.map(s => s.name)).toEqual(['totp']);
+    expect(result.skewed[0].packageVersion).toBe('9.9.9');
+    expect(result.skewed[0].controlVersion).toBe('0.0.1');
+
+    expect(fs.readFileSync(path.join(dir, 'totp.control'), 'utf-8')).toBe(controlBefore);
+    expect(fs.existsSync(path.join(dir, 'sql', 'totp--9.9.9.sql'))).toBe(false);
+  });
+
+  it('passes check mode when everything is in sync', async () => {
+    const workspace = new PgpmPackage(fixture.tempFixtureDir);
+    const result = await workspace.syncVersions({ check: true });
+
+    expect(result.skewed).toHaveLength(0);
+    expect(result.ok.length).toBeGreaterThan(0);
+  });
+
+  it('syncs only the current module when run inside a module', async () => {
+    skewModule('totp', '2.0.0');
+    skewModule('secrets', '2.0.0');
+
+    const project = new PgpmPackage(modulePath('totp'));
+    const result = await project.syncVersions();
+
+    expect(result.synced.map(s => s.name)).toEqual(['totp']);
+
+    const secretsControl = fs.readFileSync(
+      path.join(modulePath('secrets'), 'secrets.control'),
+      'utf-8'
+    );
+    expect(secretsControl).toContain(`default_version = '0.0.1'`);
+  });
+});

--- a/pgpm/core/src/core/class/pgpm.ts
+++ b/pgpm/core/src/core/class/pgpm.ts
@@ -36,6 +36,7 @@ import {
   ModuleMap
 } from '../../modules/modules';
 import { packageModule } from '../../packaging/package';
+import { syncModuleVersions, SyncVersionsOptions, SyncVersionsResult } from '../../packaging/sync-versions';
 import { resolveDependencies,resolveExtensionDependencies } from '../../resolution/deps';
 import { movePath } from '../../utils/fs';
 import { globPaths, globPattern, toPosixPath } from '../../utils/glob';
@@ -1466,6 +1467,25 @@ ${dependencies.length > 0 ? dependencies.map(dep => `-- requires: ${dep}`).join(
   }
 
   // ──────────────── Package Operations ────────────────
+
+  /**
+   * Sync extension metadata (.control default_version, Makefile sql filename,
+   * and the sql/<name>--<version>.sql bundle) to the package.json version.
+   * Inside a module, syncs just that module; at a workspace root, syncs every
+   * workspace module. With `check: true`, reports skew without writing.
+   */
+  async syncVersions(options: SyncVersionsOptions = {}): Promise<SyncVersionsResult> {
+    if (this.isInModule()) {
+      return syncModuleVersions([this.modulePath!], options);
+    }
+
+    this.ensureWorkspace();
+    const moduleMap = this.getModuleMap();
+    const packageDirs = Object.values(moduleMap).map(mod =>
+      path.resolve(this.workspacePath!, mod.path)
+    );
+    return syncModuleVersions(packageDirs, options);
+  }
 
   /**
    * Get the set of modules that have been deployed to the database

--- a/pgpm/core/src/index.ts
+++ b/pgpm/core/src/index.ts
@@ -3,6 +3,7 @@ export * from './rebundle';
 export * from './extensions/extensions';
 export * from './modules/modules';
 export * from './packaging/package';
+export * from './packaging/sync-versions';
 export * from './packaging/transform';
 export * from './resolution/deps';
 export * from './resolution/resolve';

--- a/pgpm/core/src/packaging/package.ts
+++ b/pgpm/core/src/packaging/package.ts
@@ -161,7 +161,7 @@ export const writePackage = async ({
     );
 
     pkg.version = version;
-    writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+    writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
 
     const regex = new RegExp(`${extname}--[0-9.]+.sql`);
     writeFileSync(makePath, Makefile.replace(regex, sqlFileName));

--- a/pgpm/core/src/packaging/sync-versions.ts
+++ b/pgpm/core/src/packaging/sync-versions.ts
@@ -1,0 +1,99 @@
+import { Logger } from '@pgpmjs/logger';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+import { getExtensionName, parseControlContent } from '@pgpmjs/ast/files';
+import { writePackage } from './package';
+
+const log = new Logger('sync-versions');
+
+export interface ModuleVersionStatus {
+  /** Extension name from pgpm.plan */
+  name: string;
+  packageDir: string;
+  /** Version from package.json (source of truth) */
+  packageVersion: string;
+  /** default_version from the .control file */
+  controlVersion: string;
+  /** Whether sql/<name>--<packageVersion>.sql exists */
+  sqlFileExists: boolean;
+  inSync: boolean;
+}
+
+export interface SyncVersionsOptions {
+  /** Report skew without writing anything */
+  check?: boolean;
+  usePlan?: boolean;
+}
+
+export interface SyncVersionsResult {
+  /** Modules that were regenerated (empty in check mode) */
+  synced: ModuleVersionStatus[];
+  /** Modules found out of sync (populated in check mode) */
+  skewed: ModuleVersionStatus[];
+  /** Modules already in sync */
+  ok: ModuleVersionStatus[];
+}
+
+/**
+ * Inspect a module directory and report whether its extension metadata
+ * (.control default_version + sql bundle) matches the package.json version.
+ */
+export const getModuleVersionStatus = (packageDir: string): ModuleVersionStatus => {
+  const name = getExtensionName(packageDir);
+  const pkg = JSON.parse(readFileSync(join(packageDir, 'package.json'), 'utf-8'));
+  const control = readFileSync(join(packageDir, `${name}.control`), 'utf-8');
+  const { version: controlVersion } = parseControlContent(control);
+  const packageVersion = pkg.version;
+  const sqlFileExists = existsSync(join(packageDir, 'sql', `${name}--${packageVersion}.sql`));
+
+  return {
+    name,
+    packageDir,
+    packageVersion,
+    controlVersion,
+    sqlFileExists,
+    inSync: packageVersion === controlVersion && sqlFileExists
+  };
+};
+
+/**
+ * Bring a set of module directories back in sync with their package.json
+ * versions by re-running the packaging flow (control file, Makefile, and
+ * sql/<name>--<version>.sql regenerate from the package.json version).
+ */
+export const syncModuleVersions = async (
+  packageDirs: string[],
+  { check = false, usePlan = true }: SyncVersionsOptions = {}
+): Promise<SyncVersionsResult> => {
+  const result: SyncVersionsResult = { synced: [], skewed: [], ok: [] };
+
+  for (const packageDir of packageDirs) {
+    const status = getModuleVersionStatus(packageDir);
+
+    if (status.inSync) {
+      result.ok.push(status);
+      continue;
+    }
+
+    if (check) {
+      result.skewed.push(status);
+      log.warn(
+        `✗ ${status.name}: package.json ${status.packageVersion} != control ${status.controlVersion}` +
+        (status.sqlFileExists ? '' : ` (missing sql/${status.name}--${status.packageVersion}.sql)`)
+      );
+      continue;
+    }
+
+    await writePackage({
+      version: status.packageVersion,
+      extension: true,
+      usePlan,
+      packageDir
+    });
+    result.synced.push(status);
+    log.success(`✓ ${status.name}: synced to ${status.packageVersion}`);
+  }
+
+  return result;
+};

--- a/pgpm/core/src/packaging/sync-versions.ts
+++ b/pgpm/core/src/packaging/sync-versions.ts
@@ -2,7 +2,7 @@ import { Logger } from '@pgpmjs/logger';
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 
-import { getExtensionName, parseControlContent } from '@pgpmjs/ast/files';
+import { getExtensionInfo, parseControlContent } from '@pgpmjs/ast/files';
 import { writePackage } from './package';
 
 const log = new Logger('sync-versions');
@@ -40,20 +40,17 @@ export interface SyncVersionsResult {
  * (.control default_version + sql bundle) matches the package.json version.
  */
 export const getModuleVersionStatus = (packageDir: string): ModuleVersionStatus => {
-  const name = getExtensionName(packageDir);
-  const pkg = JSON.parse(readFileSync(join(packageDir, 'package.json'), 'utf-8'));
-  const control = readFileSync(join(packageDir, `${name}.control`), 'utf-8');
-  const { version: controlVersion } = parseControlContent(control);
-  const packageVersion = pkg.version;
-  const sqlFileExists = existsSync(join(packageDir, 'sql', `${name}--${packageVersion}.sql`));
+  const { extname, version, controlFile, sqlFile } = getExtensionInfo(packageDir);
+  const { version: controlVersion } = parseControlContent(readFileSync(controlFile, 'utf-8'));
+  const sqlFileExists = existsSync(join(packageDir, sqlFile));
 
   return {
-    name,
+    name: extname,
     packageDir,
-    packageVersion,
+    packageVersion: version,
     controlVersion,
     sqlFileExists,
-    inSync: packageVersion === controlVersion && sqlFileExists
+    inSync: version === controlVersion && sqlFileExists
   };
 };
 


### PR DESCRIPTION
## Summary
Published pgpm packages can skew: `lerna version` bumps package.json at publish time but nobody re-runs `pgpm package`, so `.control` `default_version`, the Makefile `DATA` line, and the `sql/<name>--<version>.sql` bundle go stale (e.g. `@constructive-db/routing@5.0.0` shipping `routing--4.0.0.sql`; caused the `install -W` pin corruption fixed in #1472).

New `pgpm sync-versions` command reuses the existing `writePackage` packaging flow rather than reinventing it:

- `pgpm/core/src/packaging/sync-versions.ts`
  - `getModuleVersionStatus(packageDir)` — compares package.json `version` vs `.control` `default_version` (via `parseControlContent`) and checks `sql/<name>--<version>.sql` exists
  - `syncModuleVersions(packageDirs, { check, usePlan })` — for each skewed module runs `writePackage({ version: pkg.version, ... })` (regenerates control + Makefile + sql bundle); `check: true` only reports
- `PgpmPackage.syncVersions({ check })` — inside a module syncs just that module; at a workspace root iterates `getModuleMap()` and syncs every module
- CLI: `pgpm/cli/src/commands/sync-versions.ts`, registered in the command router; `--check` exits non-zero on skew (for CI)
- Boilerplate wiring is in constructive-io/pgpm-boilerplates (root `"scripts": { "version": "pgpm sync-versions" }` for the lerna-based pgpm workspace template) — lerna runs the root `version` lifecycle after bumps but before its commit, so synced files land in the version commit

Tests: `pgpm/core/__tests__/modules/sync-versions.test.ts` (TestFixture pattern) — skewed module gets control/Makefile/sql regenerated, check mode failure/success, no-op when in sync, module-scoped run leaves sibling modules untouched. Verified the built CLI end-to-end on a fixture workspace (`--check` exit 1 → sync → `--check` exit 0). `pgpm/core` suite: 120 passed. Repo-wide lint is known-broken (ESLint 9 vs legacy .eslintrc) and untouched.

Link to Devin session: https://app.devin.ai/sessions/94734f31443e41cba17460746a31711d
Requested by: @pyramation