### PR TITLE
fix(routing): fall back to server database when scoped route config lacks dbname

### DIFF
--- a/graphql/server/src/middleware/routing.ts
+++ b/graphql/server/src/middleware/routing.ts
@@ -121,13 +121,15 @@ export const routeToApiStructure = (
   }
 
   const config = (route.resolved_config ?? {}) as ApiSurfaceConfig;
-  if (!config.dbname || !config.schemas?.length) {
-    log.debug('[resolve-route] api target missing dbname/schemas in resolved_config; no match');
+  if (!config.schemas?.length) {
+    log.debug('[resolve-route] api target missing schemas in resolved_config; no match');
     return null;
   }
 
   return {
     apiId: config.api_id ?? route.target_source_id ?? undefined,
+    // Scoped APIs leave dbname NULL when their schemas live in the serving
+    // database; fall back to the server's own database in that case.
     dbname: config.dbname || opts.pg?.database || '',
     anonRole: config.anon_role || 'anon',
     roleName: config.role_name || 'authenticated',


### PR DESCRIPTION
## Summary

Database-scoped route targets can resolve with `resolved_config.schemas` populated but `dbname` null (the plane lives in the same physical database as the server). `convertRouteToApi` previously required both, so scoped endpoints (e.g. tenant `admin-*`/`auth-*` hostnames) 404'd with "API service not found".

```diff
- if (!config.dbname || !config.schemas?.length) return null;
+ if (!config.schemas?.length) return null;
  return {
    apiId: config.api_id ?? route.target_source_id ?? undefined,
-   dbname: config.dbname,
+   dbname: config.dbname || opts.pg?.database || '',
  };
```

Verified via constructive-hub: tenant database-scoped admin/auth endpoints resolve and the dashboard Playwright core suite passes (6 passed, 11 skipped, 0 failed) with constructive-io/constructive-db#2528 and constructive-io/dashboard#246.

Link to Devin session: https://app.devin.ai/sessions/497b48aa78b845d39127371f6bf9d6de
Requested by: @pyramation