### PR TITLE
fix(export): hoist partman registry fixtures into service package; graphile-llm collision; X-Api-Name lookup

### DIFF
--- a/graphile/graphile-llm/src/__tests__/graphile-llm.test.ts
+++ b/graphile/graphile-llm/src/__tests__/graphile-llm.test.ts
@@ -314,6 +314,57 @@ describe('graphile-llm schema enrichment', () => {
       expect(textField).toBeDefined();
       expect(textField!.type.name).toBe('String');
     });
+
+    it('does not conflict with a physical embedding_text column (NoteInput)', async () => {
+      const result = await query<{
+        __type: { inputFields: Array<{ name: string; type: { name: string } }> };
+      }>(`
+        query {
+          __type(name: "NoteInput") {
+            inputFields {
+              name
+              type { name }
+            }
+          }
+        }
+      `);
+
+      expect(result.errors).toBeUndefined();
+      const inputType = result.data?.__type;
+      expect(inputType).toBeDefined();
+
+      // Exactly one embeddingText field — the physical column, not a
+      // plugin-synthesized companion.
+      const textFields = inputType!.inputFields.filter(
+        (f) => f.name === 'embeddingText'
+      );
+      expect(textFields).toHaveLength(1);
+      expect(textFields[0].type.name).toBe('String');
+    });
+
+    it('stores raw text in the physical embedding_text column (not consumed as companion)', async () => {
+      const result = await query<{
+        createNote: { note: { id: number; title: string; embeddingText: string; embedding: number[] | null } };
+      }>(`
+        mutation {
+          createNote(input: { note: { title: "Physical column", embeddingText: "keep me as text" } }) {
+            note {
+              id
+              title
+              embeddingText
+              embedding
+            }
+          }
+        }
+      `);
+
+      expect(result.errors).toBeUndefined();
+      const note = result.data?.createNote?.note;
+      expect(note).toBeDefined();
+      expect(note!.embeddingText).toBe('keep me as text');
+      // The vector column must NOT have been populated by the plugin.
+      expect(note!.embedding).toBeNull();
+    });
   });
 });
 

--- a/graphile/graphile-llm/src/__tests__/setup.sql
+++ b/graphile/graphile-llm/src/__tests__/setup.sql
@@ -40,6 +40,18 @@ CREATE INDEX idx_articles_chunks_embedding ON llm_test.articles_chunks
   USING ivfflat(embedding vector_cosine_ops) WITH (lists = 1);
 
 -- ============================================================================
+-- NOTES table — vector column alongside a physical `embedding_text` column,
+-- which inflects to the same `embeddingText` GraphQL name the mutation plugin
+-- would synthesize. The physical field must win (no naming conflict).
+-- ============================================================================
+CREATE TABLE llm_test.notes (
+  id serial PRIMARY KEY,
+  title text NOT NULL,
+  embedding_text text,
+  embedding vector(3)
+);
+
+-- ============================================================================
 -- SEED DATA — articles
 -- ============================================================================
 INSERT INTO llm_test.articles (id, title, body, embedding) VALUES

--- a/graphile/graphile-llm/src/plugins/text-mutation-plugin.ts
+++ b/graphile/graphile-llm/src/plugins/text-mutation-plugin.ts
@@ -60,6 +60,13 @@ function getTextToVectorMapping(
   const mapping: Record<string, string> = {};
   if (!pgCodec?.attributes) return mapping;
 
+  const attributeFieldNames = new Set<string>(
+    Object.keys(pgCodec.attributes as Record<string, any>).map(
+      (attributeName) =>
+        build.inflection.attribute({ codec: pgCodec, attributeName })
+    )
+  );
+
   for (const [attributeName, attribute] of Object.entries(
     pgCodec.attributes as Record<string, any>
   )) {
@@ -68,7 +75,11 @@ function getTextToVectorMapping(
         codec: pgCodec,
         attributeName
       });
-      mapping[`${fieldName}Text`] = fieldName;
+      const textFieldName = `${fieldName}Text`;
+      // Skip when a physical column already inflects to the companion name
+      // (e.g. `embedding_text` next to `embedding`) — the physical field owns it.
+      if (attributeFieldNames.has(textFieldName)) continue;
+      mapping[textFieldName] = fieldName;
     }
   }
   return mapping;
@@ -161,6 +172,13 @@ export function createLlmTextMutationPlugin(): GraphileConfig.Plugin {
               attributeName: columnName
             });
             const textFieldName = `${fieldName}Text`;
+
+            // Skip when the input type already has a field with the companion
+            // name (e.g. a physical `embedding_text` column inflected to
+            // `embeddingText`) — extending would be a naming conflict.
+            if (textFieldName in newFields) {
+              continue;
+            }
 
             newFields = build.extend(
               newFields,

--- a/graphql/server/src/middleware/__tests__/api.test.ts
+++ b/graphql/server/src/middleware/__tests__/api.test.ts
@@ -111,7 +111,7 @@ describe('api middleware routing priority', () => {
     });
     expect(svcCache.get('api:db-123:customer-api')).toBe(result);
     expect(query.mock.calls).toEqual(expect.arrayContaining([
-      [expect.stringContaining('FROM "routing_public".apis'), ['db-123', 'customer-api', false]]
+      [expect.stringContaining('FROM "routing_public".apis'), ['db-123', 'customer-api']]
     ]));
   });
 });

--- a/graphql/server/src/middleware/api.ts
+++ b/graphql/server/src/middleware/api.ts
@@ -30,7 +30,10 @@ const defaultRegistry: LoaderRegistry = createDefaultRegistry();
 // =============================================================================
 
 // Private-header X-Api-Name lookup against the scoped routing plane.
-// `is_published` is the routing-plane analog of the legacy `is_public` column.
+// X-Api-Name is a trusted internal selector (only honored when the server
+// runs with isPublic=false): it addresses a database's API surface by name.
+// `is_published` governs cross-scope route visibility, not internal
+// addressability, so it does not filter this lookup.
 const scopedApiNameLookupSql = (routingSchema: string): string => `
   SELECT 
     a.id as api_id,
@@ -45,7 +48,6 @@ const scopedApiNameLookupSql = (routingSchema: string): string => `
   LEFT JOIN metaschema_public.schema s ON aps.schema_id = s.id
   WHERE a.database_id = $1 
     AND a.name = $2
-    AND a.is_published = $3
   GROUP BY a.id, a.database_id, a.dbname, a.role_name, a.anon_role, a.is_published
   LIMIT 1
 `;
@@ -273,15 +275,14 @@ const queryByApiName = async (
   pool: Pool,
   opts: ApiOptions,
   databaseId: string,
-  name: string,
-  isPublic: boolean
+  name: string
 ): Promise<ApiRow | null> => {
   const routingSchema = getRoutingSchema(opts);
   if (!isValidSchemaName(routingSchema)) {
     log.warn(`[api-name-lookup] invalid routing schema name: ${routingSchema}`);
     return null;
   }
-  const result = await pool.query<ApiRow>(scopedApiNameLookupSql(routingSchema), [databaseId, name, isPublic]);
+  const result = await pool.query<ApiRow>(scopedApiNameLookupSql(routingSchema), [databaseId, name]);
   return result.rows[0] ?? null;
 };
 
@@ -318,8 +319,7 @@ const resolveApiNameHeader = async (ctx: ResolveContext): Promise<ApiStructure |
   const { opts, pool, headers } = ctx;
   if (!headers.databaseId) return null;
 
-  const isPublic = opts.api?.isPublic ?? false;
-  const row = await queryByApiName(pool, opts, headers.databaseId, headers.apiName!, isPublic);
+  const row = await queryByApiName(pool, opts, headers.databaseId, headers.apiName!);
   
   if (!row) {
     log.debug(`[api-name-lookup] No API found for databaseId=${headers.databaseId} name=${headers.apiName}`);

--- a/pgpm/export/__tests__/export-flow.test.ts
+++ b/pgpm/export/__tests__/export-flow.test.ts
@@ -1066,5 +1066,88 @@ relocatable = false
       );
       expect(planContent).toContain('schemas/pets_full_public/tables/pets/policies/pets_policy');
     }, 180000);
+
+    it('hoists meta_registration registry fixtures into the service package', async () => {
+      const PART_EXTENSION_NAME = 'pets-part';
+      const PART_META_EXTENSION_NAME = 'pets-part-svc';
+      const PARTMAN_DEPLOY = 'schemas/pets_public/tables/pets/table/partman';
+
+      await pg.query(
+        `INSERT INTO db_migrate.sql_actions (name, database_id, deploy, deps, content, revert, verify, category)
+         VALUES (
+           'register_partman_parent',
+           $1,
+           $2,
+           ARRAY['schemas/pets_public/tables/pets/table']::text[],
+           'INSERT INTO metaschema_public.partition (id, database_id, table_id) VALUES (''00000000-0000-0000-0000-000000000001'', ''${DATABASE_ID}'', ''00000000-0000-0000-0000-000000000002'') ON CONFLICT (table_id) DO NOTHING;',
+           'DELETE FROM metaschema_public.partition WHERE table_id = ''00000000-0000-0000-0000-000000000002'';',
+           'SELECT 1;',
+           'meta_registration'
+         )
+         ON CONFLICT (database_id, deploy) DO NOTHING`,
+        [DATABASE_ID, PARTMAN_DEPLOY]
+      );
+
+      const schemaResult = await pg.query(
+        'SELECT schema_name FROM metaschema_public.schema WHERE database_id = $1',
+        [DATABASE_ID]
+      );
+      const schemaNames = schemaResult.rows.map((r: any) => r.schema_name);
+
+      scaffoldModule(PART_EXTENSION_NAME, 'Exported pets database schema (partman)');
+      scaffoldModule(PART_META_EXTENSION_NAME, 'Exported pets service metadata (partman)');
+
+      const project = new PgpmPackage(exportWorkspaceDir);
+
+      await exportMigrations({
+        project,
+        options: {
+          pg: dbConfig
+        },
+        dbInfo: {
+          dbname: dbConfig.database,
+          databaseName: 'pets',
+          database_ids: [DATABASE_ID]
+        },
+        author: 'test <test@test.local>',
+        outdir: join(exportWorkspaceDir, 'packages'),
+        schema_names: schemaNames,
+        extensionName: PART_EXTENSION_NAME,
+        extensionDesc: 'Exported pets database schema (partman)',
+        metaExtensionName: PART_META_EXTENSION_NAME,
+        metaExtensionDesc: 'Exported pets service metadata (partman)'
+      });
+
+      // The app package must NOT carry the registry fixture — it FK-references
+      // metaschema identity rows that only exist in the service package.
+      const appPlan = readFileSync(
+        join(exportWorkspaceDir, 'packages', PART_EXTENSION_NAME, 'pgpm.plan'),
+        'utf-8'
+      );
+      expect(appPlan).not.toContain('/table/partman');
+
+      // The service package carries it, ordered after the metaschema fixtures,
+      // with its DDL prerequisite expressed as a cross-package require.
+      const svcPlan = readFileSync(
+        join(exportWorkspaceDir, 'packages', PART_META_EXTENSION_NAME, 'pgpm.plan'),
+        'utf-8'
+      );
+      expect(svcPlan).toContain('tables/pets/table/partman');
+      expect(svcPlan).toContain(`${PART_EXTENSION_NAME}:schemas/pets_part_public/tables/pets/table`);
+
+      const svcDeploy = readFileSync(
+        join(exportWorkspaceDir, 'packages', PART_META_EXTENSION_NAME, 'deploy',
+          'schemas/pets_part_public/tables/pets/table/partman.sql'),
+        'utf-8'
+      );
+      expect(svcDeploy).toContain('INSERT INTO metaschema_public.partition');
+
+      // The service control declares the app package as a required extension.
+      const svcControl = readFileSync(
+        join(exportWorkspaceDir, 'packages', PART_META_EXTENSION_NAME, `${PART_META_EXTENSION_NAME}.control`),
+        'utf-8'
+      );
+      expect(svcControl).toContain(PART_EXTENSION_NAME);
+    }, 180000);
   });
 });

--- a/pgpm/export/__tests__/export-flow.test.ts
+++ b/pgpm/export/__tests__/export-flow.test.ts
@@ -1147,7 +1147,7 @@ relocatable = false
         join(exportWorkspaceDir, 'packages', PART_META_EXTENSION_NAME, `${PART_META_EXTENSION_NAME}.control`),
         'utf-8'
       );
-      expect(svcControl).toContain(PART_EXTENSION_NAME);
+      expect(svcControl).toMatch(new RegExp(`^requires = '.*\\b${PART_EXTENSION_NAME}'`, 'm'));
     }, 180000);
   });
 });

--- a/pgpm/export/src/export-migrations.ts
+++ b/pgpm/export/src/export-migrations.ts
@@ -170,6 +170,16 @@ const exportMigrationsToDisk = async ({
         [databaseId]
       );
 
+  // Registry fixtures — meta_registration actions that insert into
+  // metaschema_public.* (e.g. pg_partman partition registration) — FK-reference
+  // the database/schema/table/field identity rows exported into the
+  // meta/service package. Hoist them into that package, after its metaschema
+  // fixtures, so both packages deploy cleanly in app → service order.
+  const isRegistryFixture = (row: { category?: string; content?: string }): boolean =>
+    row.category === 'meta_registration' && /\bmetaschema_public\./.test(row.content ?? '');
+  const registryRows = results.rows.filter(isRegistryFixture);
+  const appRows = results.rows.filter((row: any) => !isRegistryFixture(row));
+
   const opts: SqlWriteOptions = {
     name,
     replacer,
@@ -180,7 +190,7 @@ const exportMigrationsToDisk = async ({
   // Build description for the database extension package
   const dbExtensionDesc = extensionDesc || `${name} database schema for ${databaseName}`;
 
-  if (results?.rows?.length > 0) {
+  if (appRows.length > 0) {
     // Detect missing modules at workspace level and prompt user
     const dbMissingResult = await detectMissingModules(project, [...DB_REQUIRED_EXTENSIONS], prompter, argv);
 
@@ -202,8 +212,8 @@ const exportMigrationsToDisk = async ({
       await installMissingModules(dbModuleDir, dbMissingResult.missingModules);
     }
 
-    writePgpmPlan(results.rows, opts);
-    writePgpmFiles(results.rows, opts);
+    writePgpmPlan(appRows, opts);
+    writePgpmFiles(appRows, opts);
   } else {
     console.log('No sql_actions found — skipping database module. Meta/service module will still be exported.');
   }
@@ -224,6 +234,12 @@ const exportMigrationsToDisk = async ({
   // Detect missing modules at workspace level and prompt user
   const svcMissingResult = await detectMissingModules(project, [...SERVICE_REQUIRED_EXTENSIONS], prompter, argv);
 
+  // Hoisted registry fixtures reference the application package's DDL, so the
+  // service package requires it as an extension when any are present.
+  const svcExtensions = registryRows.length > 0 && appRows.length > 0
+    ? [...SERVICE_REQUIRED_EXTENSIONS, name]
+    : [...SERVICE_REQUIRED_EXTENSIONS];
+
   // Create/prepare the module directory (use serviceOutdir if provided)
   const svcModuleDir = await preparePackage({
     project,
@@ -231,7 +247,7 @@ const exportMigrationsToDisk = async ({
     outdir: svcOutdir,
     name: metaExtensionName,
     description: metaDesc,
-    extensions: [...SERVICE_REQUIRED_EXTENSIONS],
+    extensions: svcExtensions,
     prompter,
     repoName,
     username
@@ -290,6 +306,24 @@ ${META_COMMON_FOOTER}
 
       tablesWithContent.push(tableName);
     }
+  }
+
+  // Append the hoisted registry fixtures after the metaschema identity
+  // fixtures they FK-reference. Their DDL prerequisites live in the
+  // application package, so those deps become cross-package requires.
+  const lastMetaChange = tablesWithContent.length > 0
+    ? `migrate/${tablesWithContent[tablesWithContent.length - 1]}`
+    : null;
+  for (const row of registryRows) {
+    const crossDeps = (row.deps ?? []).map((dep: string) => `${name}:${dep}`);
+    metaPackage.push({
+      name: row.name,
+      deploy: row.deploy,
+      content: row.content,
+      revert: row.revert,
+      verify: row.verify,
+      deps: lastMetaChange ? [...crossDeps, lastMetaChange] : crossDeps
+    });
   }
 
   opts.replacer = metaReplacer.replacer;

--- a/pgpm/export/src/export-utils.ts
+++ b/pgpm/export/src/export-utils.ts
@@ -1,5 +1,5 @@
 import { getMissingInstallableModules, parseAuthor,PgpmPackage } from '@pgpmjs/core';
-import { mkdirSync, rmSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { sync as glob } from 'glob';
 import { toSnakeCase } from 'inflekt';
 import { Inquirerer } from 'inquirerer';
@@ -402,6 +402,27 @@ export const makeReplacer = ({ schemas, name, schemaPrefix }: MakeReplacerOption
 };
 
 /**
+ * Ensures the module's control file `requires` line contains every requested
+ * extension, preserving any extras already listed.
+ */
+const syncControlRequires = (pgpmDir: string, name: string, extensions: string[]): void => {
+  const controlPath = path.join(pgpmDir, `${name}.control`);
+  if (!existsSync(controlPath)) return;
+
+  const content = readFileSync(controlPath, 'utf-8');
+  const match = content.match(/^requires\s*=\s*'([^']*)'\s*$/m);
+  const existing = match ? match[1].split(',').map((s) => s.trim()).filter(Boolean) : [];
+  const merged = [...existing, ...extensions.filter((ext) => !existing.includes(ext))];
+  if (merged.length === existing.length) return;
+
+  const requiresLine = `requires = '${merged.join(',')}'`;
+  const updated = match
+    ? content.replace(match[0], requiresLine)
+    : `${content.trimEnd()}\n${requiresLine}\n`;
+  writeFileSync(controlPath, updated);
+};
+
+/**
  * Creates a PGPM package directory or resets the deploy/revert/verify directories if it exists.
  * If the module already exists and a prompter is provided, prompts the user for confirmation.
  *
@@ -470,6 +491,10 @@ export const preparePackage = async ({
       rmSync(path.resolve(pgpmDir, 'deploy'), { recursive: true, force: true });
       rmSync(path.resolve(pgpmDir, 'revert'), { recursive: true, force: true });
       rmSync(path.resolve(pgpmDir, 'verify'), { recursive: true, force: true });
+
+      // Re-exports over an existing package skip initModule, so sync the
+      // control file's requires with the requested extensions.
+      syncControlRequires(pgpmDir, name, extensions);
     }
   } finally {
     process.chdir(curDir);


### PR DESCRIPTION
## Summary

Three upstream fixes found while testing the export path against diligence-app-demo and agentic-db:

**1. `@pgpmjs/export` — partman FK whack-a-mole, fixed at the root.** Generated `partman.sql` fixtures (`category = 'meta_registration'`) insert into `metaschema_public.partition`, FK-referencing the `database`/`table`/`field` identity rows that only exist in the *meta/service* package — so the app package could never deploy standalone. `exportMigrations` now hoists these registry fixtures out of the app package into the service package:

- `isRegistryFixture(row)`: `category === 'meta_registration' && content matches /\bmetaschema_public\./`
- hoisted rows are appended after the `migrate/*` metaschema identity fixtures, with their original DDL deps rewritten as cross-package requires (`<app-name>:<change>`)
- the service package's control file now requires the app extension when any fixtures were hoisted

Packages now deploy cleanly in the natural app → service order; no more deploy-order workarounds in consumers. Regression test added in `export-flow.test.ts` (`hoists meta_registration registry fixtures into the service package`).

**2. `graphile-llm` — `embeddingText` collision.** `LlmTextMutationPlugin` synthesized a `<field>Text` companion input for every vector column, colliding with tables that have a physical `embedding_text` sibling (inflects to the same GraphQL name), which killed schema build. Synthesis is now skipped when a physical attribute already owns the companion name (checked both at mapping construction and in the input-field hook). Vector-only tables are unchanged; tests cover both shapes (`notes` table with physical `embedding_text` added to setup.sql).

**3. `graphql/server` — X-Api-Name lookup no longer filters `is_published`.** The private-header lookup did `AND a.is_published = $3` with `$3 = opts.api.isPublic` — on the private server this meant *only unpublished* APIs were addressable, a carryover from the legacy `is_public` column. Per the routing-plane definition, `is_published` governs *cross-scope route visibility*, not internal addressability; `X-Api-Name` is a trusted internal selector (only honored when `isPublic === false`). The filter is dropped.

Tests: `pgpm/export` 163 passing (incl. new regression test), `graphile-llm` collision tests passing, `graphql/server` middleware tests passing, tsc clean.

Related: found via export testing in https://github.com/constructive-io/diligence-app-demo/pull/40 and https://github.com/constructive-io/agentic-db/pull/38.

Link to Devin session: https://app.devin.ai/sessions/497b48aa78b845d39127371f6bf9d6de
Requested by: @pyramation