### PR TITLE
fix(pgpm): cascade --no-tty through init template scaffolding

### DIFF
--- a/.agents/skills/pgpm/references/starter-kits.md
+++ b/.agents/skills/pgpm/references/starter-kits.md
@@ -48,7 +48,9 @@ pgpm init workspace --dir pnpm
 
 ## Non-Interactive Mode
 
-For CI/CD pipelines and automation, use `--no-tty` or set `CI=true`:
+For CI/CD pipelines and automation, use `--no-tty` or set `CI=true`. In this
+mode nothing prompts: every required template question must be answered by a
+CLI flag or a resolvable default, otherwise the command errors out.
 
 ```bash
 pgpm init workspace --no-tty \
@@ -56,8 +58,24 @@ pgpm init workspace --no-tty \
   --fullName "Your Name" \
   --email "you@example.com" \
   --username your-github-username \
+  --repoName my-workspace \
   --license MIT
 ```
+
+### Required Parameters for Non-Interactive Workspace
+
+| Parameter | Description | Default when omitted |
+|-----------|-------------|----------------------|
+| `--name` | Workspace name (directory to create) | none — always required |
+| `--fullName` | Author's full name | `git config user.name` |
+| `--email` | Author's email | `git config user.email` |
+| `--repoName` | Repository name | workspace directory name |
+| `--username` | GitHub username | `npm whoami` |
+| `--license` | License (e.g., MIT) | none — always required |
+
+Defaults come from resolvers (git config, npm login, workspace dir name). On a
+machine without a git identity or npm login, pass `--fullName`, `--email`, and
+`--username` explicitly.
 
 ### Required Parameters for Non-Interactive Module
 

--- a/pgpm/cli/src/commands/init/index.ts
+++ b/pgpm/cli/src/commands/init/index.ts
@@ -18,6 +18,7 @@ import { resolveWorkspaceByType } from '@pgpmjs/env';
 import { errors } from '@pgpmjs/types';
 import { CLIOptions, Inquirerer, OptionValue, Question, registerDefaultResolver } from 'inquirerer';
 
+import { isNoTtyRequested } from '../../utils';
 import {
   persistBoilerplateSource,
   readBoilerplateSource,
@@ -100,7 +101,7 @@ async function handleInit(argv: Partial<Record<string, any>>, prompter: Inquirer
     pglite: Boolean(argv.pglite),
   });
   const branch = argv.fromBranch as string | undefined;
-  const noTty = Boolean((argv as any).noTty || argv['no-tty'] || argv.tty === false || process.env.CI === 'true');
+  const noTty = isNoTtyRequested(argv);
   const useBoilerplatePrompt = Boolean(argv.boilerplate);
   const createWorkspace = Boolean(argv.createWorkspace || argv['create-workspace'] || argv.w);
   const useNpxSkills = Boolean(argv.useSkills || argv['use-skills']);
@@ -565,7 +566,7 @@ async function handleModuleInit(
     }
 
     if (!resolvedWorkspacePath) {
-      const noTty = Boolean((argv as any).noTty || argv['no-tty'] || argv.tty === false || process.env.CI === 'true');
+      const noTty = isNoTtyRequested(argv);
 
       // Handle --create-workspace flag: create workspace first, then module
       if (ctx.createWorkspace && (workspaceType === 'pgpm' || workspaceType === 'pnpm')) {

--- a/pgpm/cli/src/commands/init/workspace.ts
+++ b/pgpm/cli/src/commands/init/workspace.ts
@@ -4,6 +4,8 @@ import path from 'path';
 import { DEFAULT_TEMPLATE_REPO, DEFAULT_TEMPLATE_TOOL_NAME, scaffoldTemplate, sluggify } from '@pgpmjs/core';
 import { Inquirerer, Question, registerDefaultResolver } from 'inquirerer';
 
+import { isNoTtyRequested } from '../../utils';
+
 const DEFAULT_MOTD = `
                  |              _   _
      ===         |.===.        '\\-//\`
@@ -53,7 +55,7 @@ export default async function runWorkspaceSetup(
       workspaceName: answers.name
     },
     toolName: DEFAULT_TEMPLATE_TOOL_NAME,
-    noTty: Boolean((argv as any).noTty || argv['no-tty'] || argv.tty === false || process.env.CI === 'true'),
+    noTty: isNoTtyRequested(argv),
     cwd,
     prompter
   });

--- a/pgpm/cli/src/index.ts
+++ b/pgpm/cli/src/index.ts
@@ -2,6 +2,7 @@
 import { CLI, CLIOptions, getPackageJson } from 'inquirerer';
 
 import { commands, createPgpmCommandMap } from './commands';
+import { detectNoTtyFromProcess } from './utils';
 export { createInitUsageText } from './commands/init';
 
 export { createPgpmCommandMap };
@@ -55,7 +56,7 @@ if (require.main === module) {
     process.exit(0);
   }
 
-  const app = new CLI(commands, options);
+  const app = new CLI(commands, { ...options, noTty: detectNoTtyFromProcess() });
 
   app.run().then(() => {
   }).catch(error => {

--- a/pgpm/cli/src/utils/index.ts
+++ b/pgpm/cli/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from './driver';
 export * from './module-utils';
 export * from './npm-version';
 export * from './package-alias';
+export * from './tty';

--- a/pgpm/cli/src/utils/tty.ts
+++ b/pgpm/cli/src/utils/tty.ts
@@ -1,0 +1,20 @@
+/**
+ * Determine whether the CLI should run in non-interactive (noTty) mode from
+ * parsed argv and the environment. Minimist parses `--no-tty` as `tty: false`.
+ */
+export const isNoTtyRequested = (argv: Partial<Record<string, any>>): boolean =>
+  Boolean(
+    argv.noTty ||
+    argv['no-tty'] ||
+    argv.tty === false ||
+    process.env.CI === 'true'
+  );
+
+/**
+ * Detect noTty mode from raw process argv, before minimist parsing. Used at
+ * CLI construction time so the shared prompter itself is non-interactive.
+ */
+export const detectNoTtyFromProcess = (argv: string[] = process.argv): boolean =>
+  argv.includes('--no-tty') ||
+  argv.includes('--noTty') ||
+  process.env.CI === 'true';

--- a/pgpm/core/src/core/template-scaffold.ts
+++ b/pgpm/core/src/core/template-scaffold.ts
@@ -224,7 +224,11 @@ export async function scaffoldTemplate(
     fromPath: effectiveFromPath,
     answers,
     noTty,
-    prompter,
+    // In noTty mode, never reuse a caller prompter: it may have been created
+    // in interactive mode (or already closed), which would route template
+    // questions through the TTY prompt path. Letting the templatizer build
+    // its own prompter guarantees the noTty flag cascades.
+    prompter: noTty ? undefined : prompter,
     // When dir is specified, bypass .boilerplates.json resolution entirely
     useBoilerplatesConfig: !dir,
   });


### PR DESCRIPTION
## Summary
`pgpm init workspace --no-tty ...` crashed with `Error [ERR_USE_AFTER_CLOSE]: readline was closed` whenever any boilerplate question (fullName/email/repoName/username/license) was left to be prompted, because `--no-tty` never reached the prompter that asks the template questions:

1. inquirerer's `CLI` builds the shared prompter with `noTty: options.noTty` (default `false`) and never reads `--no-tty` from argv.
2. `init` computed its own `noTty` flag and passed it to `scaffoldTemplate`, but also passed the shared prompter — and genomic's `promptUser` does `existingPrompter ?? new Inquirerer({ noTty })`, so the flag was ignored and template questions went down the interactive TTY path (crashing on non-TTY/EOF stdin).

Fixes:
- `pgpm/cli/src/index.ts`: `new CLI(commands, { ...options, noTty: detectNoTtyFromProcess() })` — `--no-tty`/`CI=true` now makes the CLI's own prompter non-interactive.
- `@pgpmjs/core` `scaffoldTemplate`: `prompter: noTty ? undefined : prompter` — in noTty mode the templatizer builds its own noTty prompter, guaranteeing the flag cascades to genomic/inquirerer.
- New `isNoTtyRequested(argv)` / `detectNoTtyFromProcess()` helpers in `pgpm/cli/src/utils/tty.ts` replace the three duplicated inline checks in init.
- Doc: `starter-kits.md` now documents the non-interactive workspace flags and their resolver defaults (`git config`, `npm whoami`, workspace dirname).

Behavior after fix (verified locally against built dist):
- missing answers → clean "Missing required arguments" error instead of readline crash
- all flags supplied → scaffolds successfully
- `--fullName/--email/--repoName` omitted with git identity present → resolved from defaults

Follow-ups deferred (per discussion): enumerating the missing flags in the error message lives in inquirerer/genomic.

Link to Devin session: https://app.devin.ai/sessions/d0cd8a9a2bed466d9e89f582346cb826
Requested by: @pyramation