### PR TITLE
feat(harness): skills release fetcher — registry client, SRI integrity, appstash unpack, cached update check

### DIFF
--- a/agentic/harness/README.md
+++ b/agentic/harness/README.md
@@ -31,6 +31,18 @@ the core owns everything host-neutral.
   (`~/.constructive/{config,cache,data,logs}` with XDG/tmp fallbacks):
   downloaded skill releases under `data/skills/<version>`, the merged tree
   under `cache/skills-materialized`, update-check metadata in `cache/`.
+- Release fetching + freshness:
+  - `fetchSkillsRelease()` — resolves a pin (exact version, semver range, or
+    dist-tag) against the npm registry, downloads the tarball, verifies its
+    SRI integrity, and unpacks it to `data/skills/<version>/`. Already
+    downloaded releases are reused without network (offline fallback;
+    `latestLocalRelease()` picks the newest local one when the registry is
+    unreachable).
+  - `checkForSkillsUpdate()` — registry update check cached in
+    `cache/skills-update-check.json` (TTL, default 24h); only recommends
+    releases inside `compatibleSkillsRange`, and flags
+    `harnessUpgradeRequired` when newer skills need newer tool code. Never
+    throws — falls back to cache or "no update" offline.
 - Ordered-overlay skill resolution:
   - `SkillsManifest` — ordered source layers, each with its own version pin
     and include/exclude filters, plus `compatibleSkillsRange` so updaters
@@ -47,8 +59,6 @@ the core owns everything host-neutral.
 - Typed db-tools (`provision_database`, `provision_blueprint`, `run_codegen`,
   …) and gating extracted from `constructive-desktop` against
   `HarnessContext`.
-- npm/git release fetchers (download + integrity check into
-  `data/skills/<version>`, offline fallback to the last good release).
 - pi adapter, terminal CLI, and `.claude`/MCP export surfaces.
 
 ```ts

--- a/agentic/harness/__tests__/fetch.test.ts
+++ b/agentic/harness/__tests__/fetch.test.ts
@@ -1,0 +1,240 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import * as tar from 'tar';
+
+import { fetchSkillsRelease, latestLocalRelease, resolvePin } from '../src/skills/fetch';
+import { verifyIntegrity } from '../src/skills/integrity';
+import { FetchLike, Packument } from '../src/skills/registry';
+import { checkForSkillsUpdate } from '../src/skills/update-check';
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-fetch-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+async function makeTarball(version: string): Promise<Buffer> {
+  const pkgDir = path.join(tmp, `pkg-${version}`);
+  const skillDir = path.join(pkgDir, '.agents/skills/alpha');
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(skillDir, 'SKILL.md'),
+    `---\nname: alpha\ndescription: "alpha ${version}"\n---\n\nbody ${version}\n`
+  );
+  const file = path.join(tmp, `pkg-${version}.tgz`);
+  await tar.create({ gzip: true, file, cwd: pkgDir, prefix: 'package' }, ['.agents']);
+  return fs.readFileSync(file);
+}
+
+function sri(data: Buffer): string {
+  return `sha512-${crypto.createHash('sha512').update(data).digest('base64')}`;
+}
+
+interface FakeRegistry {
+  fetchImpl: FetchLike;
+  requests: string[];
+}
+
+function fakeRegistry(
+  versions: Record<string, { data: Buffer; integrity?: string }>,
+  distTags: Record<string, string> = {}
+): FakeRegistry {
+  const requests: string[] = [];
+  const packument: Packument = {
+    name: '@constructive-io/skills',
+    'dist-tags': { latest: Object.keys(versions).sort().pop()!, ...distTags },
+    versions: Object.fromEntries(
+      Object.entries(versions).map(([version, { data, integrity }]) => [
+        version,
+        {
+          version,
+          dist: { tarball: `https://reg.test/tarball/${version}`, integrity: integrity ?? sri(data) },
+        },
+      ])
+    ),
+  };
+  const fetchImpl: FetchLike = async (url) => {
+    requests.push(url);
+    const tarballMatch = url.match(/\/tarball\/(.+)$/);
+    if (tarballMatch) {
+      const entry = versions[tarballMatch[1]];
+      return {
+        ok: !!entry,
+        status: entry ? 200 : 404,
+        json: async () => ({}),
+        arrayBuffer: async () => {
+          const buf = entry.data;
+          const out = new ArrayBuffer(buf.byteLength);
+          new Uint8Array(out).set(buf);
+          return out;
+        },
+      };
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => packument,
+      arrayBuffer: async () => new ArrayBuffer(0),
+    };
+  };
+  return { fetchImpl, requests };
+}
+
+describe('verifyIntegrity', () => {
+  it('accepts matching sha512 SRI and rejects tampered data', () => {
+    const data = Buffer.from('hello');
+    const integrity = sri(data);
+    expect(() => verifyIntegrity(data, { integrity })).not.toThrow();
+    expect(() => verifyIntegrity(Buffer.from('tampered'), { integrity })).toThrow(/Integrity/);
+    expect(() => verifyIntegrity(data, {})).toThrow(/no integrity metadata/);
+  });
+});
+
+describe('fetchSkillsRelease', () => {
+  it('downloads, verifies, and unpacks a release, then reuses it offline', async () => {
+    const data = await makeTarball('1.0.0');
+    const registry = fakeRegistry({ '1.0.0': { data } });
+    const skillsRoot = path.join(tmp, 'skills');
+
+    const first = await fetchSkillsRelease({
+      pkg: '@constructive-io/skills',
+      pin: '1.0.0',
+      skillsRoot,
+      fetchImpl: registry.fetchImpl,
+    });
+    expect(first.fromCache).toBe(false);
+    expect(fs.existsSync(path.join(first.skillsDir, 'alpha/SKILL.md'))).toBe(true);
+
+    const requestsAfterFirst = registry.requests.length;
+    const second = await fetchSkillsRelease({
+      pkg: '@constructive-io/skills',
+      pin: '1.0.0',
+      skillsRoot,
+      fetchImpl: registry.fetchImpl,
+    });
+    expect(second.fromCache).toBe(true);
+    expect(registry.requests.length).toBe(requestsAfterFirst); // no network for exact cached pin
+  });
+
+  it('resolves ranges and dist-tags', async () => {
+    const v110 = await makeTarball('1.1.0');
+    const v120 = await makeTarball('1.2.0');
+    const registry = fakeRegistry(
+      { '1.1.0': { data: v110 }, '1.2.0': { data: v120 } },
+      { stable: '1.1.0' }
+    );
+    const skillsRoot = path.join(tmp, 'skills');
+
+    const ranged = await fetchSkillsRelease({
+      pkg: '@constructive-io/skills',
+      pin: '^1.1.0',
+      skillsRoot,
+      fetchImpl: registry.fetchImpl,
+    });
+    expect(ranged.version).toBe('1.2.0');
+
+    const tagged = await fetchSkillsRelease({
+      pkg: '@constructive-io/skills',
+      pin: 'stable',
+      skillsRoot,
+      fetchImpl: registry.fetchImpl,
+    });
+    expect(tagged.version).toBe('1.1.0');
+  });
+
+  it('rejects tampered tarballs and leaves nothing behind', async () => {
+    const data = await makeTarball('1.0.0');
+    const registry = fakeRegistry({
+      '1.0.0': { data, integrity: sri(Buffer.from('other bytes')) },
+    });
+    const skillsRoot = path.join(tmp, 'skills');
+    await expect(
+      fetchSkillsRelease({
+        pkg: '@constructive-io/skills',
+        pin: '1.0.0',
+        skillsRoot,
+        fetchImpl: registry.fetchImpl,
+      })
+    ).rejects.toThrow(/Integrity/);
+    expect(latestLocalRelease(skillsRoot)).toBeNull();
+  });
+
+  it('resolvePin errors when nothing satisfies', () => {
+    const packument: Packument = { name: 'x', 'dist-tags': {}, versions: {} };
+    expect(() => resolvePin(packument, '^2.0.0')).toThrow(/satisfies/);
+  });
+
+  it('latestLocalRelease returns newest downloaded version for offline fallback', async () => {
+    const skillsRoot = path.join(tmp, 'skills');
+    for (const version of ['1.0.0', '1.2.0', '1.10.0']) {
+      const dir = path.join(skillsRoot, version, '.agents/skills/alpha');
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'SKILL.md'), 'x');
+    }
+    expect(latestLocalRelease(skillsRoot)?.version).toBe('1.10.0');
+  });
+});
+
+describe('checkForSkillsUpdate', () => {
+  const versions = { '1.0.0': {}, '1.1.0': {}, '2.0.0': {} };
+  const packument: Packument = {
+    name: '@constructive-io/skills',
+    'dist-tags': { latest: '2.0.0' },
+    versions: Object.fromEntries(
+      Object.keys(versions).map((v) => [v, { version: v, dist: { tarball: '' } }])
+    ),
+  };
+  const fetchImpl: FetchLike = async () => ({
+    ok: true,
+    status: 200,
+    json: async () => packument,
+    arrayBuffer: async () => new ArrayBuffer(0),
+  });
+
+  it('reports compatible updates and harness-upgrade-required, and caches', async () => {
+    const cacheFile = path.join(tmp, 'cache/update-check.json');
+    const result = await checkForSkillsUpdate({
+      pkg: '@constructive-io/skills',
+      currentVersion: '1.0.0',
+      compatibleRange: '^1.0.0',
+      cacheFile,
+      fetchImpl,
+    });
+    expect(result.latestCompatible).toBe('1.1.0');
+    expect(result.updateAvailable).toBe(true);
+    expect(result.harnessUpgradeRequired).toBe(true); // 2.0.0 exists outside range
+
+    const failingFetch: FetchLike = async () => {
+      throw new Error('offline');
+    };
+    const cached = await checkForSkillsUpdate({
+      pkg: '@constructive-io/skills',
+      currentVersion: '1.0.0',
+      compatibleRange: '^1.0.0',
+      cacheFile,
+      fetchImpl: failingFetch,
+    });
+    expect(cached.fromCache).toBe(true);
+    expect(cached.latestCompatible).toBe('1.1.0');
+  });
+
+  it('never throws with no cache and a dead registry', async () => {
+    const failingFetch: FetchLike = async () => {
+      throw new Error('offline');
+    };
+    const result = await checkForSkillsUpdate({
+      pkg: '@constructive-io/skills',
+      currentVersion: '1.0.0',
+      cacheFile: path.join(tmp, 'none.json'),
+      fetchImpl: failingFetch,
+    });
+    expect(result.updateAvailable).toBe(false);
+  });
+});

--- a/agentic/harness/package.json
+++ b/agentic/harness/package.json
@@ -29,7 +29,12 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "appstash": "^0.7.0"
+    "appstash": "^0.7.0",
+    "semver": "^7.7.2",
+    "tar": "^7.4.3"
+  },
+  "devDependencies": {
+    "@types/semver": "^7.7.0"
   },
   "keywords": []
 }

--- a/agentic/harness/src/index.ts
+++ b/agentic/harness/src/index.ts
@@ -5,3 +5,7 @@ export * from './skills/manifest';
 export * from './skills/source';
 export * from './skills/overlay';
 export * from './skills/materialize';
+export * from './skills/registry';
+export * from './skills/integrity';
+export * from './skills/fetch';
+export * from './skills/update-check';

--- a/agentic/harness/src/skills/fetch.ts
+++ b/agentic/harness/src/skills/fetch.ts
@@ -1,0 +1,114 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import * as semver from 'semver';
+import * as tar from 'tar';
+
+import { verifyIntegrity } from './integrity';
+import { Packument, RegistryClient, RegistryOptions } from './registry';
+
+export interface FetchReleaseOptions extends RegistryOptions {
+  /** npm package that ships the skills, e.g. `@constructive-io/skills`. */
+  pkg: string;
+  /**
+   * Version pin: exact version, semver range, or dist-tag. Ranges resolve to
+   * the highest satisfying published version.
+   */
+  pin: string;
+  /** Root directory releases unpack into: `<skillsRoot>/<version>/`. */
+  skillsRoot: string;
+  /** Path of the skills tree inside the package (default `.agents/skills`). */
+  packageSubdir?: string;
+}
+
+export interface FetchedRelease {
+  version: string;
+  /** Directory containing `<skill>/SKILL.md` folders, ready for DirectorySkillSource. */
+  skillsDir: string;
+  /** True when the release was already on disk and no download happened. */
+  fromCache: boolean;
+}
+
+export function resolvePin(packument: Packument, pin: string): string {
+  const distTag = packument['dist-tags'][pin];
+  if (distTag) return distTag;
+  if (packument.versions[pin]) return pin;
+  const versions = Object.keys(packument.versions);
+  const resolved = semver.maxSatisfying(versions, pin);
+  if (!resolved) {
+    throw new Error(`No published version of ${packument.name} satisfies pin "${pin}"`);
+  }
+  return resolved;
+}
+
+/**
+ * Ensure a skills release is unpacked under `<skillsRoot>/<version>/` and
+ * return its skills directory. Downloads at most once per version: an already
+ * unpacked release is reused without touching the network, so a previously
+ * fetched version keeps working offline.
+ */
+export async function fetchSkillsRelease(options: FetchReleaseOptions): Promise<FetchedRelease> {
+  const subdir = options.packageSubdir ?? '.agents/skills';
+  const client = new RegistryClient(options);
+
+  const exactPin = semver.valid(options.pin);
+  if (exactPin) {
+    const cached = cachedRelease(options.skillsRoot, exactPin, subdir);
+    if (cached) return cached;
+  }
+
+  const packument = await client.packument(options.pkg);
+  const version = resolvePin(packument, options.pin);
+  const cached = cachedRelease(options.skillsRoot, version, subdir);
+  if (cached) return cached;
+
+  const release = packument.versions[version];
+  const data = await client.tarball(release.dist.tarball);
+  verifyIntegrity(data, release.dist);
+
+  const versionDir = path.join(options.skillsRoot, version);
+  const staging = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-skills-'));
+  try {
+    const tarballPath = path.join(staging, 'release.tgz');
+    fs.writeFileSync(tarballPath, data);
+    const unpackDir = path.join(staging, 'package');
+    fs.mkdirSync(unpackDir);
+    await tar.extract({ file: tarballPath, cwd: unpackDir, strip: 1 });
+    fs.mkdirSync(path.dirname(versionDir), { recursive: true });
+    fs.rmSync(versionDir, { recursive: true, force: true });
+    fs.renameSync(unpackDir, versionDir);
+  } finally {
+    fs.rmSync(staging, { recursive: true, force: true });
+  }
+
+  const skillsDir = path.join(versionDir, subdir);
+  if (!fs.existsSync(skillsDir)) {
+    throw new Error(`Release ${options.pkg}@${version} has no ${subdir} directory`);
+  }
+  return { version, skillsDir, fromCache: false };
+}
+
+/** Newest already-downloaded version under `skillsRoot`, or null. */
+export function latestLocalRelease(skillsRoot: string, subdir = '.agents/skills'): FetchedRelease | null {
+  if (!fs.existsSync(skillsRoot)) return null;
+  const versions = fs
+    .readdirSync(skillsRoot)
+    .filter((name) => semver.valid(name) && fs.existsSync(path.join(skillsRoot, name, subdir)))
+    .sort(semver.rcompare);
+  if (versions.length === 0) return null;
+  return {
+    version: versions[0],
+    skillsDir: path.join(skillsRoot, versions[0], subdir),
+    fromCache: true,
+  };
+}
+
+function cachedRelease(
+  skillsRoot: string,
+  version: string,
+  subdir: string
+): FetchedRelease | null {
+  const skillsDir = path.join(skillsRoot, version, subdir);
+  return fs.existsSync(skillsDir) ? { version, skillsDir, fromCache: true } : null;
+}

--- a/agentic/harness/src/skills/integrity.ts
+++ b/agentic/harness/src/skills/integrity.ts
@@ -1,0 +1,32 @@
+import * as crypto from 'crypto';
+
+/**
+ * Verify an npm SRI `integrity` string (`sha512-<base64>`, `sha256-…`) or a
+ * legacy hex `shasum` (sha1) against tarball bytes. Throws on mismatch.
+ */
+export function verifyIntegrity(
+  data: Buffer,
+  { integrity, shasum }: { integrity?: string; shasum?: string }
+): void {
+  if (integrity) {
+    const dash = integrity.indexOf('-');
+    if (dash === -1) {
+      throw new Error(`Malformed integrity string: ${integrity}`);
+    }
+    const algorithm = integrity.slice(0, dash);
+    const expected = integrity.slice(dash + 1);
+    const actual = crypto.createHash(algorithm).update(data).digest('base64');
+    if (actual !== expected) {
+      throw new Error(`Integrity check failed (${algorithm}): expected ${expected}, got ${actual}`);
+    }
+    return;
+  }
+  if (shasum) {
+    const actual = crypto.createHash('sha1').update(data).digest('hex');
+    if (actual !== shasum) {
+      throw new Error(`Integrity check failed (sha1): expected ${shasum}, got ${actual}`);
+    }
+    return;
+  }
+  throw new Error('Release has no integrity metadata to verify');
+}

--- a/agentic/harness/src/skills/registry.ts
+++ b/agentic/harness/src/skills/registry.ts
@@ -1,0 +1,61 @@
+/**
+ * Minimal npm registry client for skill releases. HTTP is injectable so
+ * hosts can add proxies/auth and tests can run offline.
+ */
+
+export type FetchLike = (
+  url: string,
+  init?: { headers?: Record<string, string> }
+) => Promise<{
+  ok: boolean;
+  status: number;
+  json(): Promise<unknown>;
+  arrayBuffer(): Promise<ArrayBuffer>;
+}>;
+
+export interface RegistryOptions {
+  registryUrl?: string;
+  fetchImpl?: FetchLike;
+}
+
+export interface PackumentVersion {
+  version: string;
+  dist: { tarball: string; integrity?: string; shasum?: string };
+}
+
+export interface Packument {
+  name: string;
+  'dist-tags': Record<string, string>;
+  versions: Record<string, PackumentVersion>;
+}
+
+const DEFAULT_REGISTRY = 'https://registry.npmjs.org';
+
+export class RegistryClient {
+  private readonly registryUrl: string;
+  private readonly fetchImpl: FetchLike;
+
+  constructor(options: RegistryOptions = {}) {
+    this.registryUrl = (options.registryUrl ?? DEFAULT_REGISTRY).replace(/\/$/, '');
+    this.fetchImpl = options.fetchImpl ?? (fetch as unknown as FetchLike);
+  }
+
+  async packument(pkg: string): Promise<Packument> {
+    const url = `${this.registryUrl}/${pkg.replace('/', '%2f')}`;
+    const res = await this.fetchImpl(url, {
+      headers: { accept: 'application/vnd.npm.install-v1+json' },
+    });
+    if (!res.ok) {
+      throw new Error(`Registry request failed for ${pkg}: HTTP ${res.status}`);
+    }
+    return (await res.json()) as Packument;
+  }
+
+  async tarball(url: string): Promise<Buffer> {
+    const res = await this.fetchImpl(url);
+    if (!res.ok) {
+      throw new Error(`Tarball download failed: HTTP ${res.status} (${url})`);
+    }
+    return Buffer.from(await res.arrayBuffer());
+  }
+}

--- a/agentic/harness/src/skills/update-check.ts
+++ b/agentic/harness/src/skills/update-check.ts
@@ -1,0 +1,114 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import * as semver from 'semver';
+
+import { RegistryClient, RegistryOptions } from './registry';
+
+export interface UpdateCheckOptions extends RegistryOptions {
+  pkg: string;
+  /** Version currently in use. */
+  currentVersion: string;
+  /**
+   * Semver range the installed harness supports (`compatibleSkillsRange`).
+   * Newer releases outside this range are reported but never recommended.
+   */
+  compatibleRange?: string;
+  /** Cache file (e.g. `harnessDirs().updateCheckFile`). */
+  cacheFile: string;
+  /** Re-query the registry only after this long (default 24h). */
+  ttlMs?: number;
+  now?: () => number;
+}
+
+export interface UpdateCheckResult {
+  checkedAt: number;
+  /** True when this result came from the cache file, not the registry. */
+  fromCache: boolean;
+  currentVersion: string;
+  /** Newest published version overall. */
+  latestVersion: string;
+  /** Newest version inside compatibleRange — the one an updater may adopt. */
+  latestCompatible: string | null;
+  /** True when latestCompatible is newer than currentVersion. */
+  updateAvailable: boolean;
+  /** True when a newer release exists but only outside compatibleRange. */
+  harnessUpgradeRequired: boolean;
+}
+
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Check the registry for newer skill releases, caching results on disk so
+ * repeated sessions don't hit the network. Registry failures fall back to the
+ * cached result (stale ok) or report "no update" — never throw.
+ */
+export async function checkForSkillsUpdate(
+  options: UpdateCheckOptions
+): Promise<UpdateCheckResult> {
+  const now = options.now ?? Date.now;
+  const ttl = options.ttlMs ?? DEFAULT_TTL_MS;
+
+  const cached = readCache(options.cacheFile);
+  if (cached && cached.currentVersion === options.currentVersion && now() - cached.checkedAt < ttl) {
+    return { ...cached, fromCache: true };
+  }
+
+  let versions: string[];
+  try {
+    const packument = await new RegistryClient(options).packument(options.pkg);
+    versions = Object.keys(packument.versions).filter((v) => semver.valid(v));
+  } catch {
+    if (cached) return { ...cached, fromCache: true };
+    return noUpdate(options.currentVersion, now());
+  }
+  if (versions.length === 0) return noUpdate(options.currentVersion, now());
+
+  const latestVersion = versions.sort(semver.rcompare)[0];
+  const latestCompatible = options.compatibleRange
+    ? semver.maxSatisfying(versions, options.compatibleRange)
+    : latestVersion;
+  const result: UpdateCheckResult = {
+    checkedAt: now(),
+    fromCache: false,
+    currentVersion: options.currentVersion,
+    latestVersion,
+    latestCompatible,
+    updateAvailable:
+      latestCompatible !== null && semver.gt(latestCompatible, options.currentVersion),
+    harnessUpgradeRequired:
+      semver.gt(latestVersion, options.currentVersion) &&
+      (latestCompatible === null || semver.gt(latestVersion, latestCompatible)),
+  };
+  writeCache(options.cacheFile, result);
+  return result;
+}
+
+function noUpdate(currentVersion: string, checkedAt: number): UpdateCheckResult {
+  return {
+    checkedAt,
+    fromCache: false,
+    currentVersion,
+    latestVersion: currentVersion,
+    latestCompatible: currentVersion,
+    updateAvailable: false,
+    harnessUpgradeRequired: false,
+  };
+}
+
+function readCache(cacheFile: string): UpdateCheckResult | null {
+  try {
+    return JSON.parse(fs.readFileSync(cacheFile, 'utf8')) as UpdateCheckResult;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(cacheFile: string, result: UpdateCheckResult): void {
+  try {
+    fs.mkdirSync(path.dirname(cacheFile), { recursive: true });
+    fs.writeFileSync(cacheFile, JSON.stringify(result, null, 2));
+  } catch {
+    // Cache write failures are non-fatal.
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,16 @@ importers:
       appstash:
         specifier: ^0.7.0
         version: 0.7.0
+      semver:
+        specifier: ^7.7.2
+        version: 7.8.1
+      tar:
+        specifier: ^7.4.3
+        version: 7.5.22
+    devDependencies:
+      '@types/semver':
+        specifier: ^7.7.0
+        version: 7.7.1
     publishDirectory: dist
 
   agentic/ollama:
@@ -5187,6 +5197,13 @@ packages:
       }
     engines: { node: '>=18' }
 
+  '@isaacs/fs-minipass@4.0.1':
+    resolution:
+      {
+        integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==,
+      }
+    engines: { node: '>=18.0.0' }
+
   '@isaacs/string-locale-compare@1.1.0':
     resolution:
       {
@@ -8398,6 +8415,13 @@ packages:
         integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==,
       }
     engines: { node: '>=10' }
+
+  chownr@3.0.0:
+    resolution:
+      {
+        integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==,
+      }
+    engines: { node: '>=18' }
 
   ci-info@3.9.0:
     resolution:
@@ -11827,6 +11851,13 @@ packages:
       }
     engines: { node: '>= 8' }
 
+  minizlib@3.1.0:
+    resolution:
+      {
+        integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==,
+      }
+    engines: { node: '>= 18' }
+
   mkdirp@1.0.4:
     resolution:
       {
@@ -13479,14 +13510,6 @@ packages:
     engines: { node: '>=10' }
     hasBin: true
 
-  semver@7.7.4:
-    resolution:
-      {
-        integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==,
-      }
-    engines: { node: '>=10' }
-    hasBin: true
-
   semver@7.8.1:
     resolution:
       {
@@ -13959,6 +13982,13 @@ packages:
       }
     engines: { node: '>=10' }
     deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  tar@7.5.22:
+    resolution:
+      {
+        integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==,
+      }
+    engines: { node: '>=18' }
 
   temp-dir@1.0.0:
     resolution:
@@ -14736,6 +14766,13 @@ packages:
       {
         integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==,
       }
+
+  yallist@5.0.0:
+    resolution:
+      {
+        integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==,
+      }
+    engines: { node: '>=18' }
 
   yaml@2.8.4:
     resolution:
@@ -16112,6 +16149,10 @@ snapshots:
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@isaacs/cliui@9.0.0': {}
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
 
   '@isaacs/string-locale-compare@1.1.0': {}
 
@@ -18307,6 +18348,8 @@ snapshots:
       fsevents: 2.3.3
 
   chownr@2.0.0: {}
+
+  chownr@3.0.0: {}
 
   ci-info@3.9.0: {}
 
@@ -20844,6 +20887,10 @@ snapshots:
       minipass: 3.3.6
       yallist: 4.0.0
 
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
   mkdirp@1.0.4: {}
 
   mock-req@0.2.0: {}
@@ -20936,7 +20983,7 @@ snapshots:
       ignore-by-default: 1.0.1
       minimatch: 10.2.4
       pstree.remy: 1.1.8
-      semver: 7.7.4
+      semver: 7.8.1
       simple-update-notifier: 2.0.0
       supports-color: 5.5.0
       touch: 3.1.1
@@ -22133,8 +22180,6 @@ snapshots:
 
   semver@7.7.3: {}
 
-  semver@7.7.4: {}
-
   semver@7.8.1: {}
 
   send@1.2.1:
@@ -22439,6 +22484,14 @@ snapshots:
       minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
+
+  tar@7.5.22:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
 
   temp-dir@1.0.0: {}
 
@@ -22862,6 +22915,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
+
+  yallist@5.0.0: {}
 
   yaml@2.8.4: {}
 


### PR DESCRIPTION
## Summary

Second `@agentic-kit/harness` PR (follows #1478): the runtime pull path that gets constructive-skills releases from the registry into the appstash, completing the "skills always stay fresh, never hard-coded in a host" model from constructive-planning#1274.

Four new modules under `src/skills/`:

- `registry.ts` — minimal npm registry client (`packument()` / `tarball()`) with an injectable `FetchLike` so hosts can add proxies/auth and tests run offline.
- `integrity.ts` — `verifyIntegrity(data, {integrity, shasum})`: verifies npm SRI (`sha512-…`) or legacy sha1 shasum; throws on mismatch, refuses releases with no integrity metadata.
- `fetch.ts` —
  ```ts
  fetchSkillsRelease({ pkg, pin, skillsRoot }): Promise<{ version, skillsDir, fromCache }>
  ```
  Pin resolution order: dist-tag → exact version → `semver.maxSatisfying` range. Download → verify SRI → unpack (tar, strip package/ prefix) via a temp staging dir → atomic rename into `<skillsRoot>/<version>/`. Exact pins already on disk short-circuit with zero network; `latestLocalRelease()` provides the offline fallback (newest local version). The `skillsDir` feeds straight into `DirectorySkillSource` → `resolveSkills()` → `materializeSkills()` from #1478.
- `update-check.ts` — `checkForSkillsUpdate()`: registry check cached in `cache/skills-update-check.json` (default 24h TTL, appstash layout). Only recommends versions inside `compatibleSkillsRange` (`updateAvailable`), and sets `harnessUpgradeRequired` when newer skills exist only outside the range — so docs can't drift ahead of installed tool signatures. Never throws: registry failures fall back to the cached result (stale ok) or "no update".

Deps added: `semver` (already in the monorepo), `tar` (npm's own tarball lib). 8 new tests exercise the full path against an in-memory fake registry with real tarballs: download+unpack+cache reuse, range/dist-tag resolution, tampered-tarball rejection (nothing left on disk), offline fallback, update-check caching and offline behavior.

Next per #1273: extract the typed db-tools + gating from constructive-desktop against `HarnessContext`.

Link to Devin session: https://app.devin.ai/sessions/e5484fbd179546fdaebc9576e2346963
Requested by: @pyramation