### PR TITLE
feat(harness): skill dependency tree via frontmatter `requires:`

### DIFF
--- a/agentic/harness/README.md
+++ b/agentic/harness/README.md
@@ -50,7 +50,12 @@ the core owns everything host-neutral.
   - `DirectorySkillSource` — loads the agentskills.io layout
     (`<skill>/SKILL.md` + references/scripts).
   - `resolveSkills()` — last-write-wins merge across layers (hardened base →
-    team overlays → private known-gaps overlay).
+    team overlays → private known-gaps overlay), then transitive frontmatter
+    `requires:` expansion: a skill can declare skills it depends on
+    (`requires: [constructive-security]` or a YAML list) and they are pulled
+    in even when a layer's `include` filter omits them; explicit `exclude`
+    entries still win, and unresolvable requirements surface through
+    `onMissingRequire` instead of throwing.
   - `materializeSkills()` — writes the merged tree with `{{VAR}}`
     substitution (e.g. `HARNESS_TEMPLATES_DIR`).
 

--- a/agentic/harness/__tests__/skills.test.ts
+++ b/agentic/harness/__tests__/skills.test.ts
@@ -8,12 +8,19 @@ import { materializeSkills } from '../src/skills/materialize';
 import { resolveSkills } from '../src/skills/overlay';
 import { DirectorySkillSource } from '../src/skills/source';
 
-function makeSkillDir(root: string, name: string, body: string, extra?: Record<string, string>) {
+function makeSkillDir(
+  root: string,
+  name: string,
+  body: string,
+  extra?: Record<string, string>,
+  requires?: string[]
+) {
   const dir = path.join(root, name);
   fs.mkdirSync(dir, { recursive: true });
+  const requiresLine = requires ? `requires: [${requires.join(', ')}]\n` : '';
   fs.writeFileSync(
     path.join(dir, 'SKILL.md'),
-    `---\nname: ${name}\ndescription: "${name} description"\n---\n\n${body}\n`
+    `---\nname: ${name}\ndescription: "${name} description"\n${requiresLine}---\n\n${body}\n`
   );
   for (const [rel, contents] of Object.entries(extra ?? {})) {
     const dest = path.join(dir, rel);
@@ -32,6 +39,17 @@ describe('frontmatter', () => {
 
   it('rejects files without frontmatter', () => {
     expect(() => parseFrontmatter('# no frontmatter')).toThrow(/frontmatter/);
+  });
+
+  it('parses requires as inline list, block list, or absent', () => {
+    expect(
+      parseFrontmatter('---\nname: a\ndescription: d\nrequires: [x, "y"]\n---\nbody').requires
+    ).toEqual(['x', 'y']);
+    expect(
+      parseFrontmatter('---\nname: a\ndescription: d\nrequires:\n  - x\n  - y\n---\nbody')
+        .requires
+    ).toEqual(['x', 'y']);
+    expect(parseFrontmatter('---\nname: a\ndescription: d\n---\nbody').requires).toEqual([]);
   });
 });
 
@@ -109,6 +127,38 @@ describe('overlay resolution + materialization', () => {
     fs.mkdirSync(path.join(target, 'stale-skill'), { recursive: true });
     materializeSkills(target, skills, {});
     expect(fs.existsSync(path.join(target, 'stale-skill'))).toBe(false);
+  });
+
+  it('pulls in `requires:` dependencies past include filters, transitively', async () => {
+    const base = path.join(tmp, 'base');
+    makeSkillDir(base, 'workflow', 'workflow body', undefined, ['security']);
+    makeSkillDir(base, 'security', 'security body', undefined, ['access-control']);
+    makeSkillDir(base, 'access-control', 'ac body');
+    makeSkillDir(base, 'unrelated', 'unrelated body');
+
+    const skills = await resolveSkills(
+      { sources: [{ name: 'base', include: ['workflow'] }] },
+      [new DirectorySkillSource('base', base)]
+    );
+    expect(skills.map((s) => s.name).sort()).toEqual(['access-control', 'security', 'workflow']);
+  });
+
+  it('never resurrects excluded skills and reports missing requires', async () => {
+    const base = path.join(tmp, 'base');
+    makeSkillDir(base, 'workflow', 'workflow body', undefined, ['security', 'not-shipped']);
+    makeSkillDir(base, 'security', 'security body');
+
+    const missing: Array<[string, string]> = [];
+    const skills = await resolveSkills(
+      { sources: [{ name: 'base', exclude: ['security'] }] },
+      [new DirectorySkillSource('base', base)],
+      { onMissingRequire: (skill, required) => missing.push([skill, required]) }
+    );
+    expect(skills.map((s) => s.name)).toEqual(['workflow']);
+    expect(missing.sort()).toEqual([
+      ['workflow', 'not-shipped'],
+      ['workflow', 'security'],
+    ]);
   });
 
   it('errors on unknown manifest source and missing directory', async () => {

--- a/agentic/harness/src/skills/frontmatter.ts
+++ b/agentic/harness/src/skills/frontmatter.ts
@@ -1,7 +1,28 @@
 export interface ParsedSkillFrontmatter {
   name: string;
   description: string;
+  /** Skill names this skill depends on (frontmatter `requires:`). */
+  requires: string[];
   body: string;
+}
+
+function parseRequires(fm: string): string[] {
+  const inline = fm.match(/(?:^|\n)requires:\s*\[([^\]]*)\]/);
+  if (inline) {
+    return inline[1]
+      .split(',')
+      .map((s) => unquoteScalar(s.trim()) ?? '')
+      .filter(Boolean);
+  }
+  const block = fm.match(/(?:^|\n)requires:\s*\n((?:[ \t]+-[^\n]*\n?)+)/);
+  if (block) {
+    return block[1]
+      .split('\n')
+      .map((line) => line.replace(/^[ \t]+-\s*/, '').trim())
+      .map((s) => unquoteScalar(s) ?? '')
+      .filter(Boolean);
+  }
+  return [];
 }
 
 function unquoteScalar(value: string | undefined): string | undefined {
@@ -15,7 +36,7 @@ function unquoteScalar(value: string | undefined): string | undefined {
   return value;
 }
 
-/** Parse the minimal YAML frontmatter (`name`, `description`) of a SKILL.md. */
+/** Parse the minimal YAML frontmatter (`name`, `description`, optional `requires`) of a SKILL.md. */
 export function parseFrontmatter(raw: string): ParsedSkillFrontmatter {
   const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/);
   if (!match) {
@@ -28,5 +49,5 @@ export function parseFrontmatter(raw: string): ParsedSkillFrontmatter {
   const description = unquoteScalar(descMatch?.[1]?.trim());
   if (!name) throw new Error('Skill frontmatter missing `name`');
   if (!description) throw new Error('Skill frontmatter missing `description`');
-  return { name, description, body };
+  return { name, description, requires: parseRequires(fm), body };
 }

--- a/agentic/harness/src/skills/overlay.ts
+++ b/agentic/harness/src/skills/overlay.ts
@@ -2,28 +2,62 @@ import { HarnessSkill } from '../types';
 import { layerAllowsSkill, SkillsManifest, validateManifest } from './manifest';
 import { SkillSource } from './source';
 
+export interface ResolveSkillsOptions {
+  /**
+   * Called for every `requires:` entry that names a skill not present in any
+   * layer (or explicitly excluded everywhere). Missing requirements never
+   * throw — a skill may legitimately depend on one the host bundles itself.
+   */
+  onMissingRequire?: (skillName: string, requiredName: string) => void;
+}
+
 /**
  * Resolve the effective skill set from ordered source layers.
  *
  * Sources are applied in manifest order; a later layer replaces an
  * earlier layer's skill of the same name wholesale (all files), and may add
  * new skills. Include/exclude filters apply per layer.
+ *
+ * After merging, frontmatter `requires:` dependencies are followed
+ * transitively: a required skill is pulled in even when a layer's `include`
+ * list omits it. Explicit `exclude` entries still win — an excluded skill is
+ * never pulled back in by a dependency.
  */
 export async function resolveSkills(
   manifest: SkillsManifest,
-  sources: SkillSource[]
+  sources: SkillSource[],
+  options: ResolveSkillsOptions = {}
 ): Promise<HarnessSkill[]> {
   validateManifest(manifest);
   const byName = new Map(sources.map((s) => [s.name, s]));
   const resolved = new Map<string, HarnessSkill>();
+  /** Merged pool ignoring `include` filters (but honoring `exclude`) — the
+   * candidates a `requires:` may pull in. */
+  const requirePool = new Map<string, HarnessSkill>();
   for (const ref of manifest.sources) {
     const source = byName.get(ref.name);
     if (!source) {
       throw new Error(`Manifest source ${ref.name} has no registered SkillSource`);
     }
     for (const skill of await source.load()) {
+      if (ref.exclude?.includes(skill.name)) continue;
+      requirePool.set(skill.name, skill);
       if (!layerAllowsSkill(ref, skill.name)) continue;
       resolved.set(skill.name, skill);
+    }
+  }
+  const queue = [...resolved.values()];
+  while (queue.length > 0) {
+    const skill = queue.pop()!;
+    for (const requiredName of skill.requires) {
+      if (resolved.has(requiredName)) continue;
+      const required = requirePool.get(requiredName);
+      if (!required) {
+        options.onMissingRequire?.(skill.name, requiredName);
+        continue;
+      }
+      resolved.set(requiredName, required);
+      queue.push(required);
     }
   }
   return [...resolved.values()];

--- a/agentic/harness/src/skills/source.ts
+++ b/agentic/harness/src/skills/source.ts
@@ -36,10 +36,10 @@ export class DirectorySkillSource implements SkillSource {
       const skillMd = path.join(skillDir, 'SKILL.md');
       if (!fs.existsSync(skillMd)) continue;
       const raw = fs.readFileSync(skillMd, 'utf8');
-      const { name, description } = parseFrontmatter(raw);
+      const { name, description, requires } = parseFrontmatter(raw);
       const files: SkillFile[] = [{ relPath: 'SKILL.md', contents: raw }];
       collectExtraFiles(skillDir, '', files);
-      skills.push({ name, description, files, sourceName: this.name });
+      skills.push({ name, description, requires, files, sourceName: this.name });
     }
     return skills;
   }

--- a/agentic/harness/src/types.ts
+++ b/agentic/harness/src/types.ts
@@ -17,6 +17,8 @@ export interface SkillFile {
 export interface HarnessSkill {
   name: string;
   description: string;
+  /** Skill names this skill depends on (frontmatter `requires:`). */
+  requires: string[];
   files: SkillFile[];
   /** Name of the manifest source layer this skill was resolved from. */
   sourceName: string;


### PR DESCRIPTION
## Summary

Adds the skill dependency tree to `@agentic-kit/harness` skill resolution: a skill can declare the skills it depends on in its SKILL.md frontmatter, and the overlay resolver pulls them in transitively — so a harness manifest can pin just the entrypoint skills (e.g. `include: [constructive-harness]`) and the domain skills they reference (`constructive-security`, `constructive-blueprints`, …) come along automatically.

```yaml
---
name: constructive-harness
description: ...
requires: [constructive-security, constructive-blueprints]   # or a YAML block list
---
```

- `parseFrontmatter()` now returns `requires: string[]` (inline `[a, b]` and block-list forms; absent → `[]`); `HarnessSkill` carries it.
- `resolveSkills(manifest, sources, options?)`: after the existing last-write-wins layer merge, BFS over `requires` pulls dependencies from a pool that ignores `include` filters but honors `exclude` — an explicitly excluded skill is never resurrected by a dependency. Requirements that exist in no layer don't throw (a host may bundle them itself); they surface via the new `options.onMissingRequire(skillName, requiredName)` callback.

3 new tests: frontmatter forms, transitive include-bypass pull-in, exclude-wins + missing-require reporting.

Link to Devin session: https://app.devin.ai/sessions/e5484fbd179546fdaebc9576e2346963
Requested by: @pyramation