### PR TITLE
feat(harness): fetch skill releases straight from the GitHub repo (tags), no npm publish needed

### DIFF
--- a/agentic/harness/README.md
+++ b/agentic/harness/README.md
@@ -43,6 +43,13 @@ the core owns everything host-neutral.
     releases inside `compatibleSkillsRange`, and flags
     `harnessUpgradeRequired` when newer skills need newer tool code. Never
     throws — falls back to cache or "no update" offline.
+  - `fetchSkillsFromGit()` / `checkForSkillsUpdateFromGit()` — the same fetch
+    and update check straight from the GitHub repo (the skills repo is just a
+    git repository, released by tagging): a pin (tag, semver range against
+    tags, full commit SHA, or branch) resolves via the GitHub API, the
+    codeload tarball unpacks into the same `<skillsRoot>/<version>/` layout,
+    so caching, offline fallback (`latestLocalRelease()`), and
+    `DirectorySkillSource` work identically.
 - Ordered-overlay skill resolution:
   - `SkillsManifest` — ordered source layers, each with its own version pin
     and include/exclude filters, plus `compatibleSkillsRange` so updaters

--- a/agentic/harness/__tests__/git-fetch.test.ts
+++ b/agentic/harness/__tests__/git-fetch.test.ts
@@ -1,0 +1,189 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import * as tar from 'tar';
+
+import { fetchSkillsFromGit, listGitTagVersions } from '../src/skills/git-fetch';
+import { FetchLike } from '../src/skills/registry';
+import { checkForSkillsUpdateFromGit } from '../src/skills/update-check';
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-git-fetch-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+async function makeRepoTarball(label: string): Promise<Buffer> {
+  const repoDir = path.join(tmp, `repo-${label}`);
+  const skillDir = path.join(repoDir, '.agents/skills/alpha');
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(skillDir, 'SKILL.md'),
+    `---\nname: alpha\ndescription: "alpha ${label}"\n---\n\nbody ${label}\n`
+  );
+  const file = path.join(tmp, `repo-${label}.tgz`);
+  // codeload tarballs have a single `<repo>-<ref>/` top-level dir.
+  await tar.create({ gzip: true, file, cwd: repoDir, prefix: `skills-${label}` }, ['.agents']);
+  return fs.readFileSync(file);
+}
+
+interface FakeGitHub {
+  fetchImpl: FetchLike;
+  requests: string[];
+}
+
+function fakeGitHub(
+  tags: Record<string, { sha: string; data: Buffer }>,
+  branches: Record<string, { sha: string; data: Buffer }> = {}
+): FakeGitHub {
+  const requests: string[] = [];
+  const bySha = new Map<string, Buffer>();
+  for (const { sha, data } of [...Object.values(tags), ...Object.values(branches)]) {
+    bySha.set(sha, data);
+  }
+  const fetchImpl: FetchLike = async (url) => {
+    requests.push(url);
+    const ok = (body: unknown, data?: Buffer) => ({
+      ok: true,
+      status: 200,
+      json: async () => body,
+      arrayBuffer: async () => {
+        const buf = data ?? Buffer.alloc(0);
+        const out = new ArrayBuffer(buf.byteLength);
+        new Uint8Array(out).set(buf);
+        return out;
+      },
+    });
+    const notFound = { ok: false, status: 404, json: async () => ({}), arrayBuffer: async () => new ArrayBuffer(0) };
+
+    if (url.includes('/tags')) {
+      return ok(Object.entries(tags).map(([name, { sha }]) => ({ name, commit: { sha } })));
+    }
+    const commitMatch = url.match(/\/commits\/([^/?]+)$/);
+    if (commitMatch) {
+      const branch = branches[decodeURIComponent(commitMatch[1])];
+      return branch ? ok({ sha: branch.sha }) : notFound;
+    }
+    const tarMatch = url.match(/\/tar\.gz\/(.+)$/);
+    if (tarMatch) {
+      const ref = decodeURIComponent(tarMatch[1]);
+      const data = tags[ref]?.data ?? bySha.get(ref);
+      return data ? ok({}, data) : notFound;
+    }
+    return notFound;
+  };
+  return { fetchImpl, requests };
+}
+
+describe('fetchSkillsFromGit', () => {
+  it('resolves a semver range against tags, unpacks, and reuses the cache', async () => {
+    const v1 = await makeRepoTarball('1.0.0');
+    const v11 = await makeRepoTarball('1.1.0');
+    const gh = fakeGitHub({
+      'v1.0.0': { sha: 'a'.repeat(40), data: v1 },
+      'v1.1.0': { sha: 'b'.repeat(40), data: v11 },
+    });
+    const skillsRoot = path.join(tmp, 'skills');
+
+    const fetched = await fetchSkillsFromGit({
+      repo: 'constructive-io/constructive-skills',
+      pin: '^1.0.0',
+      skillsRoot,
+      fetchImpl: gh.fetchImpl,
+    });
+    expect(fetched.version).toBe('1.1.0');
+    expect(fetched.fromCache).toBe(false);
+    expect(fs.readFileSync(path.join(fetched.skillsDir, 'alpha', 'SKILL.md'), 'utf8')).toContain(
+      'body 1.1.0'
+    );
+
+    // Exact pin of a downloaded version is served from disk, no network.
+    const before = gh.requests.length;
+    const cached = await fetchSkillsFromGit({
+      repo: 'constructive-io/constructive-skills',
+      pin: '1.1.0',
+      skillsRoot,
+      fetchImpl: gh.fetchImpl,
+    });
+    expect(cached.fromCache).toBe(true);
+    expect(gh.requests.length).toBe(before);
+  });
+
+  it('resolves a branch pin to its head SHA', async () => {
+    const data = await makeRepoTarball('main');
+    const sha = 'c'.repeat(40);
+    const gh = fakeGitHub({}, { main: { sha, data } });
+
+    const fetched = await fetchSkillsFromGit({
+      repo: 'constructive-io/constructive-skills',
+      pin: 'main',
+      skillsRoot: path.join(tmp, 'skills'),
+      fetchImpl: gh.fetchImpl,
+    });
+    expect(fetched.version).toBe(sha);
+    expect(fs.existsSync(path.join(fetched.skillsDir, 'alpha', 'SKILL.md'))).toBe(true);
+  });
+
+  it('errors when the repo tarball has no skills directory', async () => {
+    const repoDir = path.join(tmp, 'empty-repo');
+    fs.mkdirSync(repoDir, { recursive: true });
+    fs.writeFileSync(path.join(repoDir, 'README.md'), 'no skills');
+    const file = path.join(tmp, 'empty.tgz');
+    await tar.create({ gzip: true, file, cwd: repoDir, prefix: 'skills-x' }, ['README.md']);
+    const gh = fakeGitHub({ 'v1.0.0': { sha: 'd'.repeat(40), data: fs.readFileSync(file) } });
+
+    await expect(
+      fetchSkillsFromGit({
+        repo: 'o/r',
+        pin: 'v1.0.0',
+        skillsRoot: path.join(tmp, 'skills'),
+        fetchImpl: gh.fetchImpl,
+      })
+    ).rejects.toThrow(/no \.agents\/skills/);
+  });
+});
+
+describe('git update check', () => {
+  it('lists tag versions and reports compatible updates with caching', async () => {
+    const gh = fakeGitHub({
+      'v1.0.0': { sha: 'a'.repeat(40), data: Buffer.alloc(0) },
+      'v1.2.0': { sha: 'b'.repeat(40), data: Buffer.alloc(0) },
+      'v2.0.0': { sha: 'c'.repeat(40), data: Buffer.alloc(0) },
+      'not-a-version': { sha: 'd'.repeat(40), data: Buffer.alloc(0) },
+    });
+    expect(await listGitTagVersions({ repo: 'o/r', fetchImpl: gh.fetchImpl })).toEqual([
+      '1.0.0',
+      '1.2.0',
+      '2.0.0',
+    ]);
+
+    const cacheFile = path.join(tmp, 'update-check.json');
+    const result = await checkForSkillsUpdateFromGit({
+      repo: 'o/r',
+      currentVersion: '1.0.0',
+      compatibleRange: '^1.0.0',
+      cacheFile,
+      fetchImpl: gh.fetchImpl,
+    });
+    expect(result.latestVersion).toBe('2.0.0');
+    expect(result.latestCompatible).toBe('1.2.0');
+    expect(result.updateAvailable).toBe(true);
+    expect(result.harnessUpgradeRequired).toBe(true);
+
+    const before = gh.requests.length;
+    const cached = await checkForSkillsUpdateFromGit({
+      repo: 'o/r',
+      currentVersion: '1.0.0',
+      compatibleRange: '^1.0.0',
+      cacheFile,
+      fetchImpl: gh.fetchImpl,
+    });
+    expect(cached.fromCache).toBe(true);
+    expect(gh.requests.length).toBe(before);
+  });
+});

--- a/agentic/harness/src/index.ts
+++ b/agentic/harness/src/index.ts
@@ -8,6 +8,7 @@ export * from './skills/materialize';
 export * from './skills/registry';
 export * from './skills/integrity';
 export * from './skills/fetch';
+export * from './skills/git-fetch';
 export * from './skills/update-check';
 export * from './gating/preview';
 export * from './gating/decline-guard';

--- a/agentic/harness/src/skills/git-fetch.ts
+++ b/agentic/harness/src/skills/git-fetch.ts
@@ -1,0 +1,183 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import * as semver from 'semver';
+import * as tar from 'tar';
+
+import { FetchedRelease } from './fetch';
+import { FetchLike } from './registry';
+
+/**
+ * GitHub-repo skill source: the skills repo is just a git repository
+ * (e.g. `constructive-io/constructive-skills`), released by tagging. Releases
+ * are downloaded as codeload tarballs and unpacked into the same
+ * `<skillsRoot>/<version>/` layout the npm fetcher uses, so
+ * `latestLocalRelease()` and `DirectorySkillSource` work identically for both.
+ */
+export interface GitFetchOptions {
+  /** `owner/repo`, e.g. `constructive-io/constructive-skills`. */
+  repo: string;
+  /**
+   * Ref pin: a tag (`v1.2.0`), a semver range resolved against tags
+   * (`^1.2.0`), a full commit SHA, or a branch name. Tags and SHAs are
+   * reproducible pins; a branch is a moving pointer resolved at fetch time.
+   */
+  pin: string;
+  /** Root directory releases unpack into: `<skillsRoot>/<version>/`. */
+  skillsRoot: string;
+  /** Path of the skills tree inside the repo (default `.agents/skills`). */
+  repoSubdir?: string;
+  /** GitHub API/codeload base overrides (GHES) and injectable HTTP. */
+  apiUrl?: string;
+  codeloadUrl?: string;
+  fetchImpl?: FetchLike;
+  /** Token for private repos; sent as `authorization: Bearer <token>`. */
+  token?: string;
+}
+
+interface GitRef {
+  /** Directory name under skillsRoot: the semver for tags, else the SHA. */
+  version: string;
+  /** Ref to download (tag name, SHA, or branch). */
+  ref: string;
+  /** Commit SHA when known (tags/SHA pins) for integrity verification. */
+  sha?: string;
+}
+
+const DEFAULT_API = 'https://api.github.com';
+const DEFAULT_CODELOAD = 'https://codeload.github.com';
+const FULL_SHA = /^[0-9a-f]{40}$/;
+
+export async function fetchSkillsFromGit(options: GitFetchOptions): Promise<FetchedRelease> {
+  const subdir = options.repoSubdir ?? '.agents/skills';
+  const fetchImpl = options.fetchImpl ?? (fetch as unknown as FetchLike);
+
+  // Reproducible pins already on disk never touch the network.
+  const exact = semver.valid(cleanTag(options.pin)) ?? (FULL_SHA.test(options.pin) ? options.pin : null);
+  if (exact) {
+    const cached = cachedGitRelease(options.skillsRoot, exact, subdir);
+    if (cached) return cached;
+  }
+
+  const resolved = await resolveGitPin(options, fetchImpl);
+  const cached = cachedGitRelease(options.skillsRoot, resolved.version, subdir);
+  if (cached) return cached;
+
+  const codeload = (options.codeloadUrl ?? DEFAULT_CODELOAD).replace(/\/$/, '');
+  const url = `${codeload}/${options.repo}/tar.gz/${resolved.ref}`;
+  const res = await fetchImpl(url, { headers: authHeaders(options.token) });
+  if (!res.ok) {
+    throw new Error(`Git tarball download failed: HTTP ${res.status} (${url})`);
+  }
+  const data = Buffer.from(await res.arrayBuffer());
+
+  const versionDir = path.join(options.skillsRoot, resolved.version);
+  const staging = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-skills-git-'));
+  try {
+    const tarballPath = path.join(staging, 'release.tgz');
+    fs.writeFileSync(tarballPath, data);
+    const unpackDir = path.join(staging, 'repo');
+    fs.mkdirSync(unpackDir);
+    await tar.extract({ file: tarballPath, cwd: unpackDir, strip: 1 });
+    if (!fs.existsSync(path.join(unpackDir, subdir))) {
+      throw new Error(`${options.repo}@${resolved.ref} has no ${subdir} directory`);
+    }
+    fs.mkdirSync(path.dirname(versionDir), { recursive: true });
+    fs.rmSync(versionDir, { recursive: true, force: true });
+    fs.renameSync(unpackDir, versionDir);
+  } finally {
+    fs.rmSync(staging, { recursive: true, force: true });
+  }
+
+  return {
+    version: resolved.version,
+    skillsDir: path.join(versionDir, subdir),
+    fromCache: false,
+  };
+}
+
+/**
+ * Resolve a pin to a downloadable ref:
+ *   1. full commit SHA → itself;
+ *   2. exact tag (with or without `v`) → that tag;
+ *   3. semver range → highest satisfying tag;
+ *   4. anything else → treated as a branch, resolved to its head SHA.
+ */
+async function resolveGitPin(options: GitFetchOptions, fetchImpl: FetchLike): Promise<GitRef> {
+  const { pin } = options;
+  if (FULL_SHA.test(pin)) {
+    return { version: pin, ref: pin, sha: pin };
+  }
+
+  const tags = await listTags(options, fetchImpl);
+  const byVersion = new Map<string, { name: string; sha: string }>();
+  for (const tag of tags) {
+    const version = semver.valid(cleanTag(tag.name));
+    if (version) byVersion.set(version, tag);
+  }
+
+  const exact = semver.valid(cleanTag(pin));
+  if (exact && byVersion.has(exact)) {
+    const tag = byVersion.get(exact)!;
+    return { version: exact, ref: tag.name, sha: tag.sha };
+  }
+
+  const resolved = semver.maxSatisfying([...byVersion.keys()], pin);
+  if (resolved) {
+    const tag = byVersion.get(resolved)!;
+    return { version: resolved, ref: tag.name, sha: tag.sha };
+  }
+
+  // Branch pin: resolve the head SHA so the unpacked dir is content-addressed.
+  const api = (options.apiUrl ?? DEFAULT_API).replace(/\/$/, '');
+  const res = await fetchImpl(`${api}/repos/${options.repo}/commits/${encodeURIComponent(pin)}`, {
+    headers: { accept: 'application/vnd.github+json', ...authHeaders(options.token) },
+  });
+  if (!res.ok) {
+    throw new Error(`No tag satisfies "${pin}" and ref lookup failed: HTTP ${res.status}`);
+  }
+  const commit = (await res.json()) as { sha: string };
+  return { version: commit.sha, ref: commit.sha, sha: commit.sha };
+}
+
+/** Semver versions published as tags on the repo (e.g. `v1.2.0` → `1.2.0`). */
+export async function listGitTagVersions(
+  options: Pick<GitFetchOptions, 'repo' | 'apiUrl' | 'fetchImpl' | 'token'>
+): Promise<string[]> {
+  const fetchImpl = options.fetchImpl ?? (fetch as unknown as FetchLike);
+  const tags = await listTags(options, fetchImpl);
+  return tags.map((t) => semver.valid(cleanTag(t.name))).filter((v): v is string => v !== null);
+}
+
+async function listTags(
+  options: Pick<GitFetchOptions, 'repo' | 'apiUrl' | 'token'>,
+  fetchImpl: FetchLike
+): Promise<Array<{ name: string; sha: string }>> {
+  const api = (options.apiUrl ?? DEFAULT_API).replace(/\/$/, '');
+  const res = await fetchImpl(`${api}/repos/${options.repo}/tags?per_page=100`, {
+    headers: { accept: 'application/vnd.github+json', ...authHeaders(options.token) },
+  });
+  if (!res.ok) {
+    throw new Error(`Tag listing failed for ${options.repo}: HTTP ${res.status}`);
+  }
+  const tags = (await res.json()) as Array<{ name: string; commit: { sha: string } }>;
+  return tags.map((t) => ({ name: t.name, sha: t.commit.sha }));
+}
+
+function cachedGitRelease(
+  skillsRoot: string,
+  version: string,
+  subdir: string
+): FetchedRelease | null {
+  const skillsDir = path.join(skillsRoot, version, subdir);
+  return fs.existsSync(skillsDir) ? { version, skillsDir, fromCache: true } : null;
+}
+
+function cleanTag(tag: string): string {
+  return tag.replace(/^v/, '');
+}
+
+function authHeaders(token?: string): Record<string, string> {
+  return token ? { authorization: `Bearer ${token}` } : {};
+}

--- a/agentic/harness/src/skills/update-check.ts
+++ b/agentic/harness/src/skills/update-check.ts
@@ -3,10 +3,10 @@ import * as path from 'path';
 
 import * as semver from 'semver';
 
+import { GitFetchOptions, listGitTagVersions } from './git-fetch';
 import { RegistryClient, RegistryOptions } from './registry';
 
-export interface UpdateCheckOptions extends RegistryOptions {
-  pkg: string;
+interface UpdateCheckCommonOptions {
   /** Version currently in use. */
   currentVersion: string;
   /**
@@ -20,6 +20,14 @@ export interface UpdateCheckOptions extends RegistryOptions {
   ttlMs?: number;
   now?: () => number;
 }
+
+export interface UpdateCheckOptions extends RegistryOptions, UpdateCheckCommonOptions {
+  pkg: string;
+}
+
+export interface GitUpdateCheckOptions
+  extends Pick<GitFetchOptions, 'repo' | 'apiUrl' | 'fetchImpl' | 'token'>,
+    UpdateCheckCommonOptions {}
 
 export interface UpdateCheckResult {
   checkedAt: number;
@@ -46,6 +54,26 @@ const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
 export async function checkForSkillsUpdate(
   options: UpdateCheckOptions
 ): Promise<UpdateCheckResult> {
+  return checkWithLister(options, async () => {
+    const packument = await new RegistryClient(options).packument(options.pkg);
+    return Object.keys(packument.versions);
+  });
+}
+
+/**
+ * Same update check against a GitHub repo's semver tags instead of an npm
+ * registry (the skills repo is just a git repository, released by tagging).
+ */
+export async function checkForSkillsUpdateFromGit(
+  options: GitUpdateCheckOptions
+): Promise<UpdateCheckResult> {
+  return checkWithLister(options, () => listGitTagVersions(options));
+}
+
+async function checkWithLister(
+  options: UpdateCheckCommonOptions,
+  listVersions: () => Promise<string[]>
+): Promise<UpdateCheckResult> {
   const now = options.now ?? Date.now;
   const ttl = options.ttlMs ?? DEFAULT_TTL_MS;
 
@@ -56,8 +84,7 @@ export async function checkForSkillsUpdate(
 
   let versions: string[];
   try {
-    const packument = await new RegistryClient(options).packument(options.pkg);
-    versions = Object.keys(packument.versions).filter((v) => semver.valid(v));
+    versions = (await listVersions()).filter((v) => semver.valid(v));
   } catch {
     if (cached) return { ...cached, fromCache: true };
     return noUpdate(options.currentVersion, now());


### PR DESCRIPTION
## Summary

Dan's call: constructive-skills is just a GitHub repository — so the harness shouldn't require an npm publish to pull skills. This adds a git-based release source alongside the existing npm fetcher, following the pgpm/appstash pattern (appstash dirs + injectable HTTP, releases = tags).

New `src/skills/git-fetch.ts`:

```ts
fetchSkillsFromGit({ repo: 'constructive-io/constructive-skills', pin, skillsRoot, token? })
  // pin resolution:
  //   full 40-char SHA           → downloaded as-is (content-addressed dir)
  //   exact tag `v1.2.0`/`1.2.0` → that tag
  //   semver range `^1.0.0`      → highest satisfying tag (GitHub API tag list)
  //   anything else              → branch, resolved to its head SHA
```

Downloads the codeload tarball and unpacks to the same `<skillsRoot>/<version>/` layout as the npm fetcher, so exact-pin cache reuse (no network), `latestLocalRelease()` offline fallback, and `DirectorySkillSource` all work identically for both sources. `token` supports private repos.

`update-check.ts` refactored around a shared `checkWithLister()` core; `checkForSkillsUpdate` (npm packument) unchanged in behavior, new `checkForSkillsUpdateFromGit` runs the same TTL-cached, `compatibleSkillsRange`-aware check against the repo's semver tags via `listGitTagVersions()`.

4 new tests (fake GitHub API/codeload): range→tag resolution + cache reuse, branch→head-SHA pin, missing `.agents/skills` error, tag-based update check with caching.

Link to Devin session: https://app.devin.ai/sessions/e5484fbd179546fdaebc9576e2346963
Requested by: @pyramation