### PR TITLE
feat: add @agentic-kit/pi — Constructive db tools + confirm gate as a pi extension

### DIFF
--- a/agentic/pi/README.md
+++ b/agentic/pi/README.md
@@ -1,0 +1,53 @@
+# @agentic-kit/pi
+
+<p align="center" width="100%">
+  <img height="250" src="https://raw.githubusercontent.com/constructive-io/constructive/refs/heads/main/assets/outline-logo.svg" />
+</p>
+
+The [pi coding agent](https://github.com/badlogic/pi-mono) adapter for **agentic-kit**: the Constructive typed database tools and the [`@agentic-kit/harness`](https://www.npmjs.com/package/@agentic-kit/harness) confirm gate, packaged as a pi extension any host can register — Constructive Desktop, the [`agent` CLI](https://www.npmjs.com/package/@agentic-kit/cli), or your own pi-based agent.
+
+```bash
+npm install @agentic-kit/pi
+```
+
+## What's inside
+
+- **16 typed db tools** — `provision_database`, `provision_blueprint`, `describe_schema`, `add_relation`, `delete_table`, `create_field` / `update_field` / `delete_field`, `add_policies`, `add_records`, `run_codegen`, and the template suite (`list` / `create` / `apply` / `update` / `delete`). Tool schemas are authored in [zod](https://zod.dev) and emitted as plain JSON Schema at pi's tool boundary.
+- **Confirm gate** — the harness's host-neutral gate wired to pi's `tool_call` events. Hosts with a rich confirm surface (Desktop) expose `confirmTool`/`notifyToolSkipped` on `ctx.ui`; everyone else gets pi's built-in `ui.confirm` dialog.
+- **Host injection** — credentials, backend endpoints, and data-plane tokens come from your host, not from the package:
+
+```ts
+import { Agent } from '@earendil-works/pi-coding-agent';
+import { createDbTools } from '@agentic-kit/pi';
+
+const dbTools = createDbTools({
+  account: () => ({ userId, accessToken }),
+  backendConfig: () => ({ apiEndpoint, modulesEndpoint }),
+  // optional: dataAuthBroker, previewToken(), dataTokenSkewMs
+});
+
+// register like any pi extension
+pi.use(dbTools);
+```
+
+## Host contract
+
+`PiToolsHost` is the only integration surface:
+
+| Member | Purpose |
+| --- | --- |
+| `account()` | signed-in platform account (`userId`, `accessToken`) |
+| `backendConfig()` | env-aware API + modules GraphQL endpoints |
+| `dataAuthBroker?` | remembers per-database end-user tokens across calls |
+| `previewToken?()` | harvest an end-user token from the host's app preview |
+| `dataTokenSkewMs?` | treat tokens expiring within this window as expired |
+
+## Related
+
+- [`@agentic-kit/harness`](https://www.npmjs.com/package/@agentic-kit/harness) — host-neutral skills, gating, and blueprint core
+- [`@agentic-kit/cli`](https://www.npmjs.com/package/@agentic-kit/cli) — `agent`, a local secure-by-default coding agent
+- [`agentic-kit`](https://www.npmjs.com/package/agentic-kit) — the umbrella package
+
+## Credits
+
+Built on the excellent [pi coding agent](https://github.com/badlogic/pi-mono) by Mario Zechner.

--- a/agentic/pi/__tests__/confirm-gate.test.ts
+++ b/agentic/pi/__tests__/confirm-gate.test.ts
@@ -1,0 +1,54 @@
+import type { ExtensionContext, ToolCallEvent } from '@earendil-works/pi-coding-agent';
+
+import { createConfirmGate } from '../src/confirm-gate';
+
+const deps = {
+  resolveProjectContext: async () =>
+    ({ context: { databaseId: 'db1' }, reason: '' }) as never,
+  resolveDataToken: async () => ({ token: 'tok' }) as never,
+  createTemplatePreviewTables: async () => ({ blueprintName: '', tables: [] }) as never,
+};
+
+function fakeCtx(ui: Record<string, unknown>): ExtensionContext {
+  return { hasUI: true, ui, cwd: '/tmp/project' } as unknown as ExtensionContext;
+}
+
+function event(toolName: string, input?: Record<string, unknown>): ToolCallEvent {
+  return { toolName, toolCallId: 'tc-1', input } as unknown as ToolCallEvent;
+}
+
+describe('confirm gate pi adapter', () => {
+  it('uses a rich confirmTool ui when the host provides one', async () => {
+    const calls: unknown[][] = [];
+    const ui = {
+      confirmTool: async (...args: unknown[]) => {
+        calls.push(args);
+        return true;
+      },
+      confirm: async () => {
+        throw new Error('should not fall back');
+      },
+    };
+    const gate = createConfirmGate(deps);
+    gate.onAgentStart();
+    const result = await gate.onToolCall(event('delete_table', { table_name: 't' }), fakeCtx(ui));
+    expect(result).toBeUndefined(); // approved -> tool proceeds
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0]).toBe('tc-1');
+  });
+
+  it("falls back to pi's built-in ui.confirm when no rich surface exists", async () => {
+    const confirms: string[] = [];
+    const ui = {
+      confirm: async (title: string) => {
+        confirms.push(title);
+        return false;
+      },
+    };
+    const gate = createConfirmGate(deps);
+    gate.onAgentStart();
+    const result = await gate.onToolCall(event('delete_table', { table_name: 't' }), fakeCtx(ui));
+    expect(confirms).toHaveLength(1);
+    expect(result).toMatchObject({ block: true });
+  });
+});

--- a/agentic/pi/__tests__/host.test.ts
+++ b/agentic/pi/__tests__/host.test.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+
+import dbTools, { configureHost, createDbTools, getHost, toolSchema } from '../src';
+
+describe('host configuration', () => {
+  it('getHost throws before configureHost', () => {
+    expect(() => getHost()).toThrow(/host not configured/i);
+  });
+
+  it('configureHost + getHost round-trips', () => {
+    const host = {
+      account: () => ({ userId: 'u1', accessToken: 't1' }),
+      backendConfig: () => ({ apiEndpoint: 'http://api.localhost:3000/graphql' }),
+    };
+    configureHost(host);
+    expect(getHost()).toBe(host);
+    expect(getHost().account()?.userId).toBe('u1');
+  });
+
+  it('createDbTools configures the host and returns the extension', () => {
+    const host = {
+      account: (): null => null,
+      backendConfig: (): null => null,
+    };
+    expect(createDbTools(host)).toBe(dbTools);
+    expect(getHost()).toBe(host);
+  });
+});
+
+describe('toolSchema', () => {
+  it('emits plain JSON Schema without a $schema marker', () => {
+    const schema = toolSchema(
+      z.object({
+        table_name: z.string().describe('Table name'),
+        rows: z.array(z.record(z.string(), z.unknown())).optional(),
+      }),
+    ) as unknown as Record<string, unknown>;
+
+    expect(schema.$schema).toBeUndefined();
+    expect(schema.type).toBe('object');
+    const props = schema.properties as Record<string, Record<string, unknown>>;
+    expect(props.table_name).toMatchObject({ type: 'string', description: 'Table name' });
+    expect(schema.required).toEqual(['table_name']);
+  });
+});
+
+describe('dbTools extension', () => {
+  it('registers the 16 tools and both gate events', () => {
+    const registered: string[] = [];
+    const events: string[] = [];
+    const fakePi = {
+      registerTool: (tool: { name: string }) => registered.push(tool.name),
+      on: (event: string) => events.push(event),
+    };
+    (dbTools as (pi: unknown) => void)(fakePi);
+
+    expect(registered).toHaveLength(16);
+    expect(registered).toEqual(
+      expect.arrayContaining([
+        'provision_database',
+        'provision_blueprint',
+        'describe_schema',
+        'add_relation',
+        'delete_table',
+        'create_field',
+        'update_field',
+        'delete_field',
+        'add_policies',
+        'add_records',
+        'run_codegen',
+        'list_templates',
+        'create_template',
+        'apply_template',
+        'update_template',
+        'delete_template',
+      ]),
+    );
+    expect(events).toEqual(['agent_start', 'tool_call']);
+  });
+});

--- a/agentic/pi/jest.config.js
+++ b/agentic/pi/jest.config.js
@@ -1,0 +1,21 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        babelConfig: false,
+        tsconfig: 'tsconfig.json',
+      },
+    ],
+  },
+  transformIgnorePatterns: [`/node_modules/*`],
+  testRegex: '(/__tests__/.*\\.(test|spec))\\.(jsx?|tsx?)$',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  modulePathIgnorePatterns: ['dist/*'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+};

--- a/agentic/pi/package.json
+++ b/agentic/pi/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@agentic-kit/pi",
+  "version": "0.1.0",
+  "author": "Dan Lynch <pyramation@gmail.com>",
+  "description": "Pi adapter for agentic-kit — the Constructive typed db tools (provision, blueprint, codegen, records, policies, templates) and confirm gate as a pi coding-agent extension",
+  "main": "index.js",
+  "module": "esm/index.js",
+  "types": "index.d.ts",
+  "homepage": "https://github.com/constructive-io/constructive",
+  "license": "SEE LICENSE IN LICENSE",
+  "publishConfig": {
+    "access": "public",
+    "directory": "dist"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/constructive-io/constructive"
+  },
+  "bugs": {
+    "url": "https://github.com/constructive-io/constructive/issues"
+  },
+  "scripts": {
+    "clean": "makage clean",
+    "prepack": "npm run build",
+    "build": "makage build",
+    "build:dev": "makage build --dev",
+    "lint": "eslint . --fix",
+    "test": "jest",
+    "test:watch": "jest --watch"
+  },
+  "dependencies": {
+    "@agentic-kit/harness": "workspace:^",
+    "@constructive-io/graphql-query": "^4.5.3",
+    "@constructive-io/sdk": "^1.5.3",
+    "zod": "^4.4.3"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.79.0"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "0.79.6",
+    "typebox": "^1.0.0"
+  },
+  "keywords": [
+    "agentic-kit",
+    "pi",
+    "coding-agent",
+    "constructive"
+  ]
+}

--- a/agentic/pi/src/app-workspace.ts
+++ b/agentic/pi/src/app-workspace.ts
@@ -1,0 +1,154 @@
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+// pnpm 11.8 no longer reads the `pnpm` field from a non-root package.json, so the
+// template's `pnpm.overrides.graphql` (in packages/app/package.json) is silently
+// ignored. Without that override two graphql versions (16.13.0 + 16.14.0) get
+// installed, which instantiates two copies of `grafast` under DIFFERENT
+// peer-dependency hash contexts. graphile-search then resolves in one context
+// while graphile-connection-filter was linked under the other, so codegen dies
+// with `Cannot find module 'graphile-connection-filter'`. Hoisting the override
+// to the ROOT pnpm-workspace.yaml (which pnpm 11.8 DOES read) collapses graphql —
+// and therefore grafast — to a single version, and the missing module resolves
+// (PNPM-GRAPHQL-OVERRIDE-001). We also strip the nested packages/app
+// pnpm-workspace.yaml the template ships, and keep onlyBuiltDependencies so the
+// native deps build where honored (PNPM-BUILDS-001).
+export const NATIVE_BUILD_DEPS = ['esbuild', 'sharp', 'unrs-resolver'];
+export const IGNORED_BUILDS_RE = /ERR_PNPM_IGNORED_BUILDS|Ignored build scripts/;
+const DEFAULT_GRAPHQL_OVERRIDE = '16.14.0';
+
+const TEMPLATE_REPO = 'https://github.com/constructive-io/sandbox-templates';
+const TEMPLATE_SUBDIR = path.join('nextjs', 'constructive-app');
+
+export async function run(
+  cmd: string,
+  args: string[],
+  cwd: string,
+  env?: Record<string, string>,
+): Promise<{ ok: boolean; out: string }> {
+  try {
+    const { stdout, stderr } = await execFileAsync(cmd, args, {
+      cwd,
+      timeout: 5 * 60_000,
+      encoding: 'utf-8',
+      maxBuffer: 32 * 1024 * 1024,
+      env: env ? { ...process.env, ...env } : process.env,
+    });
+    return { ok: true, out: `${stdout}${stderr}`.trim() };
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; message?: string };
+    return { ok: false, out: `${e.stdout ?? ''}${e.stderr ?? ''}`.trim() || e.message || 'failed' };
+  }
+}
+
+// Read the graphql pin the template wants from its (now-ignored) pnpm.overrides
+// so we propagate the template's own value instead of hardcoding ours.
+async function templateGraphqlOverride(cwd: string): Promise<string> {
+  try {
+    const pkg = JSON.parse(
+      await readFile(path.join(cwd, 'packages', 'app', 'package.json'), 'utf8'),
+    );
+    const v = pkg?.pnpm?.overrides?.graphql;
+    return typeof v === 'string' && v.length > 0 ? v : DEFAULT_GRAPHQL_OVERRIDE;
+  } catch {
+    return DEFAULT_GRAPHQL_OVERRIDE;
+  }
+}
+
+export async function ensureWorkspaceConfig(cwd: string): Promise<void> {
+  const nested = path.join(cwd, 'packages', 'app', 'pnpm-workspace.yaml');
+  if (existsSync(nested)) {
+    await rm(nested, { force: true });
+  }
+
+  const graphqlPin = await templateGraphqlOverride(cwd);
+  const builds = NATIVE_BUILD_DEPS.map((d) => `  - ${d}`).join('\n');
+  const text =
+    `packages:\n  - "packages/*"\n\n` +
+    `overrides:\n  graphql: ${graphqlPin}\n\n` +
+    `onlyBuiltDependencies:\n${builds}\n`;
+
+  await writeFile(path.join(cwd, 'pnpm-workspace.yaml'), text);
+}
+
+// Force @constructive-io/graphql-codegen to `latest` in the app package.json
+// before the single install — older 4.9.x throws on PostGraphile `filter` inputs
+// (TS-001).
+export async function pinCodegenLatest(appDir: string): Promise<void> {
+  const pkgPath = path.join(appDir, 'package.json');
+  const pkg = JSON.parse(await readFile(pkgPath, 'utf8'));
+  for (const field of ['devDependencies', 'dependencies'] as const) {
+    if (pkg[field]?.['@constructive-io/graphql-codegen']) {
+      pkg[field]['@constructive-io/graphql-codegen'] = 'latest';
+    }
+  }
+  await writeFile(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+}
+
+// The Constructive Next.js app is just the `nextjs/constructive-app` tree from
+// the sandbox-templates repo — it ships no `____VAR____` placeholders, so there
+// is nothing to templatize. `pgpm init` only fetches and copies that tree, but
+// its CLI is unreliable in the non-TTY agent shell, which made the agent thrash
+// for minutes. Materialize `packages/app` deterministically by shallow-cloning
+// the template instead (PGPM-001).
+export async function ensureAppScaffold(cwd: string): Promise<{ ok: boolean; out: string }> {
+  const appDir = path.join(cwd, 'packages', 'app');
+  if (existsSync(path.join(appDir, 'package.json'))) {
+    return { ok: true, out: 'packages/app already scaffolded' };
+  }
+
+  const tmp = path.join(os.tmpdir(), `airpage-app-template-${process.pid}`);
+  await rm(tmp, { recursive: true, force: true });
+  const clone = await run('git', ['clone', '--depth', '1', TEMPLATE_REPO, tmp], cwd);
+  if (!clone.ok) {
+    await rm(tmp, { recursive: true, force: true });
+    return { ok: false, out: `Template clone failed:\n${clone.out}` };
+  }
+
+  const src = path.join(tmp, TEMPLATE_SUBDIR);
+  if (!existsSync(src)) {
+    await rm(tmp, { recursive: true, force: true });
+    return { ok: false, out: `Template subdir ${TEMPLATE_SUBDIR} missing in ${TEMPLATE_REPO}` };
+  }
+
+  try {
+    await mkdir(path.dirname(appDir), { recursive: true });
+    await cp(src, appDir, { recursive: true });
+  } catch (err) {
+    await rm(tmp, { recursive: true, force: true });
+    return {
+      ok: false,
+      out: `Copying template into packages/app failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  await rm(tmp, { recursive: true, force: true });
+  return { ok: true, out: 'Scaffolded packages/app from the constructive-app template.' };
+}
+
+// Scaffold packages/app, hoist the workspace config, pin codegen, and run the one
+// clean install. All of this is database-INDEPENDENT, so it can be prewarmed
+// concurrently with the ~90s provision_database backend mutation to keep clone +
+// install off run_codegen's critical path. Best-effort and fully idempotent:
+// run_codegen re-runs the same steps, finding the scaffold present and the install
+// already satisfied (a fast no-op). Errors are swallowed by callers that prewarm —
+// run_codegen surfaces any real failure later.
+export async function prewarmAppWorkspace(cwd: string): Promise<{ ok: boolean; out: string }> {
+  const scaffold = await ensureAppScaffold(cwd);
+  if (!scaffold.ok) return scaffold;
+
+  const appDir = path.join(cwd, 'packages', 'app');
+  await ensureWorkspaceConfig(cwd);
+  await pinCodegenLatest(appDir);
+
+  const install = await run('pnpm', ['install', '--no-frozen-lockfile'], cwd);
+  if (!install.ok && !IGNORED_BUILDS_RE.test(install.out)) {
+    return { ok: false, out: `pnpm install failed:\n${install.out}` };
+  }
+  return { ok: true, out: 'Prewarmed packages/app scaffold + install.' };
+}

--- a/agentic/pi/src/confirm-gate.ts
+++ b/agentic/pi/src/confirm-gate.ts
@@ -1,0 +1,98 @@
+import {
+  type ConfirmGate as HarnessConfirmGate,
+  createConfirmGate as createHarnessConfirmGate,
+  type GateHost,
+} from '@agentic-kit/harness';
+import type {
+  ExtensionContext,
+  ToolCallEvent,
+  ToolCallEventResult,
+} from '@earendil-works/pi-coding-agent';
+import type { ConfirmPreview } from '@agentic-kit/harness';
+
+import type { resolveDataToken, resolveProjectContext } from './context';
+import type { createTemplatePreviewTables } from './tools/templates';
+
+// Hosts with a rich confirm surface (e.g. Constructive Desktop's extension-ui)
+// extend pi's ExtensionUIContext with these members; when present they take
+// precedence over pi's built-in ui.confirm dialog.
+type RichConfirmUi = {
+  confirmTool?: (
+    toolCallId: string,
+    title: string,
+    message: string,
+    preview?: ConfirmPreview,
+  ) => Promise<boolean>;
+  notifyToolSkipped?: (toolCallId: string) => void;
+};
+
+// Thin pi adapter over the host-neutral gate in @agentic-kit/harness: pi's
+// ToolCallEvent/ExtensionContext are mapped onto the package's
+// GateToolCallEvent/GateHost, and the host-backed resolvers below are
+// wrapped into its ConfirmGateDeps. index.ts wires the real resolvers, tests
+// substitute fakes.
+export type ConfirmGateDeps = {
+  resolveProjectContext: typeof resolveProjectContext;
+  resolveDataToken: typeof resolveDataToken;
+  createTemplatePreviewTables: typeof createTemplatePreviewTables;
+};
+
+export type ConfirmGate = {
+  onAgentStart: () => void;
+  onToolCall: (
+    event: ToolCallEvent,
+    ctx: ExtensionContext,
+  ) => Promise<ToolCallEventResult | undefined>;
+};
+
+export function createConfirmGate(deps: ConfirmGateDeps): ConfirmGate {
+  const gate: HarnessConfirmGate = createHarnessConfirmGate({
+    isProjectRunnable: async (cwd) => {
+      const resolved = await deps.resolveProjectContext(cwd);
+      return resolved.context !== null;
+    },
+    hasDataToken: async (cwd) => {
+      const resolved = await deps.resolveProjectContext(cwd);
+      if (!resolved.context) return false;
+      const token = await deps.resolveDataToken(resolved.context);
+      return Boolean(token.token);
+    },
+    resolveTemplatePreview: async (cwd, blueprintName, displayName) => {
+      const resolved = await deps.resolveProjectContext(cwd);
+      if (!resolved.context) return undefined;
+      const result = await deps.createTemplatePreviewTables(resolved.context, blueprintName);
+      if (result.tables.length === 0) return undefined;
+      return {
+        kind: 'template',
+        displayName,
+        blueprintName: result.blueprintName || undefined,
+        tables: result.tables,
+      };
+    },
+  });
+
+  return {
+    onAgentStart: gate.onAgentStart,
+
+    onToolCall: async (event, ctx) => {
+      const ui = ctx.ui as ExtensionContext['ui'] & RichConfirmUi;
+      const host: GateHost = {
+        hasUI: ctx.hasUI,
+        confirmTool: (toolCallId, title, message, preview) =>
+          ui.confirmTool
+            ? ui.confirmTool(toolCallId, title, message, preview)
+            : ui.confirm(title, message),
+        notifyToolSkipped: (toolCallId) => ui.notifyToolSkipped?.(toolCallId),
+      };
+      return gate.onToolCall(
+        {
+          toolName: event.toolName,
+          toolCallId: event.toolCallId,
+          input: event.input as Record<string, unknown> | undefined,
+        },
+        host,
+        ctx.cwd,
+      );
+    },
+  };
+}

--- a/agentic/pi/src/context.ts
+++ b/agentic/pi/src/context.ts
@@ -1,0 +1,315 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { api, auth, modules } from '@constructive-io/sdk';
+
+import { probeDatabase } from './db-probe';
+import { DEFAULT_DATA_TOKEN_SKEW_MS, getHost } from './host';
+
+const DEFAULT_API_ENDPOINT = 'http://api.localhost:3000/graphql';
+const DEFAULT_MODULES_ENDPOINT = 'http://modules.localhost:3000/graphql';
+
+export type ApiClient = ReturnType<typeof api.createClient>;
+export type ModulesClient = ReturnType<typeof modules.createClient>;
+
+export type ProjectContext = {
+  api: ApiClient;
+  modules: ModulesClient;
+  databaseId: string;
+  schemaId: string;
+  ownerId: string | undefined;
+  apiEndpoint: string;
+  modulesEndpoint: string;
+  databaseName: string;
+  accessToken: string;
+  // Per-DB data/CRUD endpoint (api-<db>.localhost). Empty when DATABASE_NAME is
+  // absent — record tools need it; schema tools use `api` and ignore it.
+  dataEndpoint: string;
+};
+
+export type ProjectContextFailureCode =
+  | 'no-env'
+  | 'missing-credentials'
+  | 'db-missing'
+  | 'account-mismatch'
+  | 'backend-unreachable'
+  | 'schema-unresolved';
+
+export type ResolveResult = {
+  context: ProjectContext | null;
+  reason: string;
+  code?: ProjectContextFailureCode;
+};
+
+function parseEnv(source: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const rawLine of source.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    env[key] = value;
+  }
+  return env;
+}
+
+export type ResolveOptions = {
+  /** Which plane the context is for. Ownership gates the control plane only:
+   *  schema editing and provisioning act under the signed-in account, so a
+   *  foreign-owned binding is blocked ('account-mismatch'). The data plane
+   *  (real rows via app end-user tokens) never checks desktop-account
+   *  ownership — a live foreign-owned database serves data fine, exactly as
+   *  the app itself does in the Preview. */
+  plane?: 'control' | 'data';
+};
+
+export async function resolveProjectContext(
+  cwd: string,
+  options: ResolveOptions = {},
+): Promise<ResolveResult> {
+  let source: string;
+  try {
+    source = await readFile(path.join(cwd, '.env'), 'utf8');
+  } catch {
+    return {
+      context: null,
+      reason:
+        'No .env found in the project. Provision a Constructive database first (scaffold the project), then retry.',
+      code: 'no-env',
+    };
+  }
+
+  const env = parseEnv(source);
+  const accessToken = env.ACCESS_TOKEN;
+  const databaseId = env.DATABASE_ID;
+
+  if (!accessToken || !databaseId) {
+    return {
+      context: null,
+      reason:
+        'Project is not connected to a Constructive database yet (missing ACCESS_TOKEN/DATABASE_ID in .env). Provision the database first, then retry.',
+      code: 'missing-credentials',
+    };
+  }
+
+  // A per-project .env pin wins for the DATA plane (the .env key belongs to
+  // whatever backend wrote it); otherwise fall back to the app's backend-config
+  // store (environment-aware) so app + harness share one endpoint source.
+  const host = getHost();
+  const backend = host.backendConfig();
+  const apiEndpoint = env.API_ENDPOINT || backend?.apiEndpoint || DEFAULT_API_ENDPOINT;
+  const modulesEndpoint = env.MODULES_ENDPOINT || backend?.modulesEndpoint || DEFAULT_MODULES_ENDPOINT;
+
+  // The whole control plane (binding probe, schema resolution, blueprint/schema
+  // tools) authenticates with the ACCOUNT bearer: the platform api rejects
+  // per-database keys, so the project ACCESS_TOKEN can never act on metaschema
+  // surfaces. The .env key stays in the context for the data plane only. The
+  // bearer is only ever sent to the app-configured backend — never a
+  // .env-pinned endpoint, which an untrusted cloned project controls.
+  const controlApiEndpoint = backend?.apiEndpoint || DEFAULT_API_ENDPOINT;
+  const controlModulesEndpoint = backend?.modulesEndpoint || DEFAULT_MODULES_ENDPOINT;
+  const account = host.account();
+  const accountBearer = account?.apiKey ?? account?.accessToken;
+  if (!accountBearer) {
+    return {
+      context: null,
+      reason:
+        'No usable account credential to reach the Constructive control plane. Sign in to the app, then retry.',
+      code: 'missing-credentials',
+    };
+  }
+  const controlHeaders = { Authorization: `Bearer ${accountBearer}` };
+
+  const apiClient = api.createClient({ endpoint: controlApiEndpoint, headers: controlHeaders });
+
+  // Always probe the bound database — the .env stamp proves the project WAS
+  // bound, never that the database still exists (backend refresh, deletion,
+  // revoked key). The probe is the single source of binding health.
+  const probe = await probeDatabase({
+    endpoint: controlApiEndpoint,
+    bearer: accountBearer,
+    databaseId,
+  });
+  if (probe.outcome === 'unreachable') {
+    return {
+      context: null,
+      reason: `Could not reach the Constructive backend at ${controlApiEndpoint} (${probe.detail}). Check it is running, then retry.`,
+      code: 'backend-unreachable',
+    };
+  }
+  if (probe.outcome === 'missing') {
+    return {
+      context: null,
+      reason: `The bound database (DATABASE_ID=${databaseId}) no longer exists on this backend. Re-provision with provision_database (reprovision: true) — the schema is rebuilt from the project; records do not carry over.`,
+      code: 'db-missing',
+    };
+  }
+
+  // Schemas are account-scoped: a live binding under a different account is
+  // never shown in the Schemas tab or written to by the agent. The project's
+  // local blueprint survives account changes, so recovery is a reprovision
+  // under the signed-in account. Owner truth comes from the probe (backend),
+  // not the .env stamp. Data-plane resolution skips this gate — see
+  // ResolveOptions.
+  const sessionUserId = account?.userId;
+  if (
+    options.plane !== 'data' &&
+    probe.ownerId &&
+    sessionUserId &&
+    probe.ownerId !== sessionUserId
+  ) {
+    return {
+      context: null,
+      reason: `The bound database (DATABASE_ID=${databaseId}) was provisioned under a different account than the one signed in. Re-provision with provision_database (reprovision: true) to rebuild it under this account — the schema is rebuilt from the project; records do not carry over.`,
+      code: 'account-mismatch',
+    };
+  }
+
+  const databaseName = env.DATABASE_NAME || probe.name || '';
+  const ownerId = probe.ownerId || env.OWNER_ID || undefined;
+  const dataEndpoint = databaseName
+    ? deriveSubdomainEndpoint(apiEndpoint, `api-${databaseName}`)
+    : '';
+
+  const schemaId = await resolveSchemaId(apiClient, databaseId);
+  if (!schemaId) {
+    return {
+      context: null,
+      reason:
+        'Could not resolve a schema (app_public/public) for this database. The database may not be fully provisioned yet.',
+      code: 'schema-unresolved',
+    };
+  }
+
+  return {
+    context: {
+      api: apiClient,
+      modules: modules.createClient({ endpoint: controlModulesEndpoint, headers: controlHeaders }),
+      databaseId,
+      schemaId,
+      ownerId,
+      apiEndpoint,
+      modulesEndpoint,
+      databaseName,
+      accessToken,
+      dataEndpoint,
+    },
+    reason: '',
+  };
+}
+
+const NEEDS_AUTH_REASON =
+  'Not signed in to the app database yet. Sign in from the Sheets tab, or open the Preview and sign in to your app, then try again.';
+
+export type DataTokenResult = { token?: string; userId?: string; reason?: string };
+
+// Resolve a data-plane token for record operations: serve the broker's active
+// account while valid, otherwise harvest the token the user created by signing
+// into their app in the Preview and adopt it into the broker. Also returns the
+// signed-in user's id (used to scope rows by entityId). Returns a reason (no
+// token) when neither source has a valid token — the caller surfaces a sign-in
+// prompt.
+export async function resolveDataToken(context: ProjectContext): Promise<DataTokenResult> {
+  const host = getHost();
+  const broker = host.dataAuthBroker;
+  const active = broker?.getActiveToken(context.databaseId);
+  if (active) return { token: active.token, userId: active.userId };
+
+  const preview = host.previewToken ? await host.previewToken() : null;
+  if (!preview) return { reason: NEEDS_AUTH_REASON };
+  if (broker?.isInvalidToken(context.databaseId, preview.accessToken)) {
+    return { reason: NEEDS_AUTH_REASON };
+  }
+
+  const parsed = preview.accessTokenExpiresAt ? Date.parse(preview.accessTokenExpiresAt) : NaN;
+  const expiresAt = Number.isNaN(parsed) ? Date.now() + 60 * 60 * 1000 : parsed;
+  const skewMs = host.dataTokenSkewMs ?? DEFAULT_DATA_TOKEN_SKEW_MS;
+  if (expiresAt <= Date.now() + skewMs) return { reason: NEEDS_AUTH_REASON };
+
+  broker?.adoptToken(context.databaseId, {
+    userId: preview.userId,
+    token: preview.accessToken,
+    expiresAt,
+    origin: 'harvest',
+  });
+  return { token: preview.accessToken, userId: preview.userId };
+}
+
+// Per-DB endpoints are deterministic on the provisioning subdomain (= DATABASE_NAME):
+// each plane swaps the first host label of its control-plane endpoint
+// (e.g. api.localhost -> api-myapp.localhost, auth.localhost -> auth-myapp.localhost).
+export function deriveSubdomainEndpoint(baseEndpoint: string, firstLabel: string): string {
+  try {
+    const url = new URL(baseEndpoint);
+    const labels = url.hostname.split('.');
+    labels[0] = firstLabel;
+    url.hostname = labels.join('.');
+    return url.toString();
+  } catch {
+    return '';
+  }
+}
+
+// The backend hierarchy is org -> db -> tables; the owning org is the auth-plane
+// user the database's ownerId points at. Best-effort display lookup only —
+// binding health never depends on it. Authenticates with the account bearer
+// against the app-configured auth endpoint (the platform rejects per-database
+// keys, and the bearer never goes to a .env-pinned endpoint).
+export async function resolveOrgName(ownerId: string): Promise<string | undefined> {
+  try {
+    const host = getHost();
+    const account = host.account();
+    const bearer = account?.apiKey ?? account?.accessToken;
+    if (!bearer) return undefined;
+    const backend = host.backendConfig();
+    const authEndpoint = deriveSubdomainEndpoint(
+      backend?.apiEndpoint || DEFAULT_API_ENDPOINT,
+      'auth',
+    );
+    if (!authEndpoint) return undefined;
+    const client = auth.createClient({
+      endpoint: authEndpoint,
+      headers: { Authorization: `Bearer ${bearer}` },
+    });
+    const result = await client.user
+      .findMany({
+        select: { displayName: true, username: true },
+        where: { id: { equalTo: ownerId } },
+      })
+      .execute();
+    if (!result.ok) return undefined;
+    const node = (result.data.users?.nodes ?? [])[0];
+    return node?.displayName || node?.username || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function resolveSchemaId(
+  apiClient: ApiClient,
+  databaseId: string,
+): Promise<string | undefined> {
+  const result = await apiClient.schema
+    .findMany({
+      select: { id: true, name: true },
+      where: { databaseId: { equalTo: databaseId } },
+    })
+    .execute();
+
+  if (!result.ok) return undefined;
+
+  const nodes = (result.data.schemas?.nodes ?? []).filter((s) => Boolean(s && s.id));
+  const appPublic = nodes.find((s) => s.name === 'app_public');
+  if (appPublic) return appPublic.id;
+  const pub = nodes.find((s) => s.name === 'public');
+  if (pub) return pub.id;
+  return nodes[0]?.id;
+}

--- a/agentic/pi/src/db-probe.ts
+++ b/agentic/pi/src/db-probe.ts
@@ -1,0 +1,73 @@
+import { api } from '@constructive-io/sdk';
+
+export type DatabaseProbe =
+  | { outcome: 'found'; name?: string; ownerId?: string }
+  | { outcome: 'missing' }
+  | { outcome: 'unreachable'; detail: string };
+
+type ProbePayload = {
+  databases: {
+    nodes: { id: string; name: string | null; ownerId: string | null }[];
+  } | null;
+};
+
+export type ProbeExecutor = {
+  execute<T>(
+    document: string,
+    variables?: Record<string, unknown>,
+  ): Promise<
+    | { ok: true; data: T; errors: undefined }
+    | { ok: false; data: null; errors: { message: string }[] }
+  >;
+};
+
+const AUTH_ERROR_RE = /unauthenticated|unauthorized|permission denied|jwt|http 401|http 403/i;
+
+// Liveness probe for a bound database. The split drives recovery: 'missing'
+// means the backend answered and the binding is dead (database deleted,
+// backend refreshed) — recovery is reprovision. 'unreachable' means no usable
+// answer (backend down, network error, rejected credential) — recovery is
+// retry/re-sign-in, never reprovision.
+//
+// The probe authenticates with the ACCOUNT bearer, not the project's .env key:
+// the platform api rejects per-database keys, and the singular `database(id:)`
+// field is gone from the current contract, so the lookup goes through the
+// `databases` collection filter via the SDK's raw FetchAdapter.
+export async function probeDatabase(args: {
+  endpoint: string;
+  bearer: string;
+  databaseId: string;
+  executor?: ProbeExecutor;
+}): Promise<DatabaseProbe> {
+  const executor =
+    args.executor ??
+    new api.FetchAdapter(args.endpoint, { Authorization: `Bearer ${args.bearer}` });
+  const document = `
+    query ProbeDatabase {
+      databases(where: { id: { equalTo: ${JSON.stringify(args.databaseId)} } }) {
+        nodes { id name ownerId }
+      }
+    }`;
+  try {
+    const result = await executor.execute<ProbePayload>(document);
+    if (result.ok) {
+      const node = result.data.databases?.nodes?.[0];
+      if (!node) return { outcome: 'missing' };
+      return { outcome: 'found', name: node.name ?? undefined, ownerId: node.ownerId ?? undefined };
+    }
+    const detail = result.errors?.[0]?.message ?? 'unknown error';
+    // A 5xx is the backend failing, not an answer about this database. An auth
+    // rejection is a dead ACCOUNT credential — never evidence the binding is
+    // dead, so it must not push toward reprovision.
+    if (/^HTTP 5\d\d/i.test(detail)) return { outcome: 'unreachable', detail };
+    if (AUTH_ERROR_RE.test(detail)) {
+      return {
+        outcome: 'unreachable',
+        detail: `${detail} — the account credential was rejected; sign in again, then retry`,
+      };
+    }
+    return { outcome: 'missing' };
+  } catch (err) {
+    return { outcome: 'unreachable', detail: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/agentic/pi/src/host.ts
+++ b/agentic/pi/src/host.ts
@@ -1,0 +1,75 @@
+/**
+ * Host contract for the pi-hosted Constructive tools.
+ *
+ * The typed db tools were extracted from Constructive Desktop, where they read
+ * an Electron-side `runtime` singleton (account store, backend config, data-auth
+ * broker, preview token). Hosts now inject the same surface here once at
+ * startup (`configureHost`); the tool modules stay module-level `ToolDefinition`
+ * consts and read it lazily via `getHost()`.
+ */
+
+export type HostAccount = {
+  userId: string;
+  accessToken: string;
+  apiKey?: string;
+};
+
+export type HostBackendConfig = {
+  apiEndpoint?: string;
+  modulesEndpoint?: string;
+};
+
+export type ActiveDataToken = {
+  token: string;
+  userId?: string;
+  expiresAt: number;
+  origin?: string;
+};
+
+/**
+ * Optional data-plane token broker: remembers per-database end-user tokens
+ * across tool calls and invalidates declined/expired ones. Hosts without a
+ * broker fall back to the preview-token harvest on every call.
+ */
+export interface DataAuthBroker {
+  getActiveToken(databaseId: string): ActiveDataToken | undefined | null;
+  isInvalidToken(databaseId: string, token: string): boolean;
+  adoptToken(databaseId: string, token: ActiveDataToken): void;
+}
+
+/** Token harvested from the host's app preview (end-user sign-in). */
+export type PreviewToken = {
+  accessToken: string;
+  accessTokenExpiresAt?: string;
+  userId?: string;
+};
+
+export interface PiToolsHost {
+  /** Signed-in platform account, or null/undefined when signed out. */
+  account(): HostAccount | null | undefined;
+  /** Host-configured backend endpoints (env-aware). */
+  backendConfig(): HostBackendConfig | null | undefined;
+  /** Optional data-plane token broker (see DataAuthBroker). */
+  dataAuthBroker?: DataAuthBroker;
+  /** Harvest an end-user token from the host's app preview, if it has one. */
+  previewToken?(): Promise<PreviewToken | null>;
+  /** Treat tokens expiring within this window as already expired. Default 30s. */
+  dataTokenSkewMs?: number;
+}
+
+export const DEFAULT_DATA_TOKEN_SKEW_MS = 30_000;
+
+let currentHost: PiToolsHost | null = null;
+
+export function configureHost(host: PiToolsHost): void {
+  currentHost = host;
+}
+
+export function getHost(): PiToolsHost {
+  if (!currentHost) {
+    throw new Error(
+      '@agentic-kit/pi host not configured. Call configureHost() (or createDbTools(host)) before using the db tools.'
+    );
+  }
+  return currentHost;
+}

--- a/agentic/pi/src/index.ts
+++ b/agentic/pi/src/index.ts
@@ -1,0 +1,76 @@
+import type { ExtensionFactory } from '@earendil-works/pi-coding-agent';
+
+import { createConfirmGate } from './confirm-gate';
+import { resolveDataToken, resolveProjectContext } from './context';
+import { configureHost, type PiToolsHost } from './host';
+import { addPoliciesTool } from './tools/add-policies';
+import { addRecordsTool } from './tools/add-records';
+import { addRelationTool } from './tools/add-relation';
+import { describeSchemaTool } from './tools/describe-schema';
+import { createFieldTool, deleteFieldTool, deleteTableTool, updateFieldTool } from './tools/mutations';
+import { provisionBlueprintTool } from './tools/provision-blueprint';
+import { provisionDatabaseTool } from './tools/provision-database';
+import { runCodegenTool } from './tools/run-codegen';
+import {
+  applyTemplateTool,
+  createTemplatePreviewTables,
+  createTemplateTool,
+  deleteTemplateTool,
+  listTemplatesTool,
+  updateTemplateTool,
+} from './tools/templates';
+
+export const dbTools: ExtensionFactory = (pi) => {
+  pi.registerTool(provisionDatabaseTool);
+  pi.registerTool(describeSchemaTool);
+  pi.registerTool(listTemplatesTool);
+  pi.registerTool(provisionBlueprintTool);
+  pi.registerTool(addRelationTool);
+  pi.registerTool(deleteTableTool);
+  pi.registerTool(createFieldTool);
+  pi.registerTool(updateFieldTool);
+  pi.registerTool(deleteFieldTool);
+  pi.registerTool(addPoliciesTool);
+  pi.registerTool(applyTemplateTool);
+  pi.registerTool(createTemplateTool);
+  pi.registerTool(updateTemplateTool);
+  pi.registerTool(deleteTemplateTool);
+  pi.registerTool(addRecordsTool);
+  pi.registerTool(runCodegenTool);
+
+  const gate = createConfirmGate({
+    resolveProjectContext,
+    resolveDataToken,
+    createTemplatePreviewTables,
+  });
+  pi.on('agent_start', gate.onAgentStart);
+  pi.on('tool_call', gate.onToolCall);
+};
+
+/** Configure the host and get the extension in one call. */
+export function createDbTools(host: PiToolsHost): ExtensionFactory {
+  configureHost(host);
+  return dbTools;
+}
+
+export { type ConfirmGate, type ConfirmGateDeps, createConfirmGate } from './confirm-gate';
+export {
+  type ModulesClient,
+  type ProjectContext,
+  resolveDataToken,
+  resolveProjectContext,
+} from './context';
+export {
+  type ActiveDataToken,
+  configureHost,
+  type DataAuthBroker,
+  getHost,
+  type HostAccount,
+  type HostBackendConfig,
+  type PiToolsHost,
+  type PreviewToken,
+} from './host';
+export { toolSchema } from './tool-schema';
+export { createTemplatePreviewTables } from './tools/templates';
+
+export default dbTools;

--- a/agentic/pi/src/policy/add-policies-to-table.ts
+++ b/agentic/pi/src/policy/add-policies-to-table.ts
@@ -1,0 +1,113 @@
+import { getPolicyCategory, type PolicyProvisioningCategory } from '@agentic-kit/harness';
+
+import type { ModulesClient } from '../context';
+import {
+  buildGrants,
+  buildPolicyEntry,
+  CRUD_OPERATIONS,
+  type CrudOperation,
+  type CrudPolicyConfigs,
+  groupOperationsByConfig,
+  type PolicyEntry,
+} from './provision-helpers';
+
+const SUPPORTED_CATEGORIES: ReadonlySet<PolicyProvisioningCategory> = new Set([
+  'has-module',
+  'no-fields',
+  'needs-table',
+]);
+
+export interface AddPoliciesToTablePolicyEntry {
+  policyType: string;
+  dataNodeType?: string;
+  nodeData?: Record<string, unknown>;
+  sharedPolicyData: Record<string, unknown>;
+  operations: CrudPolicyConfigs;
+  enabledOperations?: CrudOperation[];
+}
+
+export interface AddPoliciesToTableInput {
+  client: ModulesClient;
+  databaseId: string;
+  schemaId: string;
+  tableId: string;
+  policies: AddPoliciesToTablePolicyEntry[];
+}
+
+export class UnsupportedPolicyCategoryError extends Error {
+  constructor(
+    public readonly policyType: string,
+    public readonly category: PolicyProvisioningCategory,
+  ) {
+    super(
+      `Policy type "${policyType}" has category "${category}" which requires column creation or composite handling — use the policies UI instead.`,
+    );
+    this.name = 'UnsupportedPolicyCategoryError';
+  }
+}
+
+export async function addPoliciesToExistingTable(
+  input: AddPoliciesToTableInput,
+): Promise<{ success: true }> {
+  const { client } = input;
+
+  for (const entry of input.policies) {
+    const category = getPolicyCategory(entry.policyType);
+    if (!SUPPORTED_CATEGORIES.has(category)) {
+      throw new UnsupportedPolicyCategoryError(entry.policyType, category);
+    }
+  }
+
+  const policiesArray: PolicyEntry[] = [];
+  const nodesByType = new Map<string, { $type: string; data?: Record<string, unknown> }>();
+
+  for (const entry of input.policies) {
+    const groups = groupOperationsByConfig(
+      entry.enabledOperations ?? CRUD_OPERATIONS,
+      entry.operations,
+    );
+
+    for (const group of groups) {
+      const ops = group.privileges.join('_');
+      const rand = Math.random().toString(36).slice(2, 8);
+      policiesArray.push(
+        buildPolicyEntry(entry.policyType, {
+          privileges: group.privileges,
+          policy_role: group.roleName,
+          permissive: group.isPermissive,
+          data: entry.sharedPolicyData,
+          policy_name: `${ops}_${rand}`,
+        }),
+      );
+    }
+
+    if (entry.dataNodeType && !nodesByType.has(entry.dataNodeType)) {
+      const nodeData = entry.nodeData ?? {};
+      nodesByType.set(entry.dataNodeType, {
+        $type: entry.dataNodeType,
+        ...(Object.keys(nodeData).length > 0 ? { data: nodeData } : {}),
+      });
+    }
+  }
+
+  const provisionInput: Record<string, unknown> = {
+    databaseId: input.databaseId,
+    schemaId: input.schemaId,
+    tableId: input.tableId,
+    grants: buildGrants(),
+    policies: policiesArray,
+  };
+
+  if (nodesByType.size > 0) {
+    provisionInput.nodes = [...nodesByType.values()];
+  }
+
+  await client.secureTableProvision
+    .create({
+      data: provisionInput as Parameters<typeof client.secureTableProvision.create>[0]['data'],
+      select: { id: true, tableId: true, tableName: true },
+    })
+    .unwrap();
+
+  return { success: true };
+}

--- a/agentic/pi/src/policy/provision-helpers.ts
+++ b/agentic/pi/src/policy/provision-helpers.ts
@@ -1,0 +1,102 @@
+export type CrudOperation = 'create' | 'read' | 'update' | 'delete';
+
+export interface OperationPolicyConfig {
+  roleName: string;
+  isPermissive: boolean;
+  policyData: Record<string, unknown>;
+  isCustomized: boolean;
+}
+
+export interface CrudPolicyConfigs {
+  create: OperationPolicyConfig;
+  read: OperationPolicyConfig;
+  update: OperationPolicyConfig;
+  delete: OperationPolicyConfig;
+}
+
+export const CRUD_OPERATIONS: CrudOperation[] = ['create', 'read', 'update', 'delete'];
+
+export type GrantPrivilege = [string, string | string[]];
+
+export interface GrantEntry {
+  roles: string[];
+  privileges: GrantPrivilege[];
+}
+
+export interface PolicyEntry {
+  $type: string;
+  data?: Record<string, unknown>;
+  privileges?: string[];
+  policy_role?: string;
+  permissive?: boolean;
+  policy_name?: string;
+}
+
+export const ALL_CRUD_PRIVILEGES: GrantPrivilege[] = [
+  ['select', '*'],
+  ['insert', '*'],
+  ['update', '*'],
+  ['delete', '*'],
+];
+
+const CRUD_OP_TO_LOWER_PRIVILEGE: Record<CrudOperation, string> = {
+  create: 'insert',
+  read: 'select',
+  update: 'update',
+  delete: 'delete',
+};
+
+export function crudOpToPrivilege(op: CrudOperation): string {
+  return CRUD_OP_TO_LOWER_PRIVILEGE[op];
+}
+
+export function crudOpsToPrivileges(ops: readonly CrudOperation[]): string[] {
+  return ops.map(crudOpToPrivilege);
+}
+
+export function buildGrants(
+  roles: string[] = ['authenticated'],
+  privileges: GrantPrivilege[] = ALL_CRUD_PRIVILEGES,
+): GrantEntry[] {
+  return [{ roles, privileges }];
+}
+
+export function buildPolicyEntry(
+  type: string,
+  opts: Partial<Omit<PolicyEntry, '$type'>> = {},
+): PolicyEntry {
+  const entry: PolicyEntry = { $type: type };
+  if (opts.data && Object.keys(opts.data).length > 0) entry.data = opts.data;
+  if (opts.privileges && opts.privileges.length > 0) entry.privileges = opts.privileges;
+  if (opts.policy_role) entry.policy_role = opts.policy_role;
+  if (opts.permissive !== undefined) entry.permissive = opts.permissive;
+  if (opts.policy_name) entry.policy_name = opts.policy_name;
+  return entry;
+}
+
+export interface OperationGroup {
+  roleName: string;
+  isPermissive: boolean;
+  privileges: string[];
+}
+
+export function groupOperationsByConfig(
+  enabledOperations: readonly CrudOperation[],
+  operations: CrudPolicyConfigs,
+): OperationGroup[] {
+  const groupMap = new Map<string, OperationGroup>();
+
+  for (const op of enabledOperations) {
+    const config = operations[op];
+    const key = `${config.roleName}:${config.isPermissive}`;
+
+    let group = groupMap.get(key);
+    if (!group) {
+      group = { roleName: config.roleName, isPermissive: config.isPermissive, privileges: [] };
+      groupMap.set(key, group);
+    }
+    group.privileges.push(...crudOpsToPrivileges([op]));
+  }
+
+  return [...groupMap.values()];
+}

--- a/agentic/pi/src/provision-database/create-database-provision.ts
+++ b/agentic/pi/src/provision-database/create-database-provision.ts
@@ -1,0 +1,61 @@
+// Provision a database through the modules endpoint's createDatabaseProvisionModule
+// mutation — an insert into database_provision_modules whose BEFORE INSERT trigger
+// creates the database, domain, API, and module set before the row returns (the
+// same contract constructive-client's admin app uses). The retired requestDatabase
+// mutation only ever existed on dev builds of the api endpoint; production
+// deployments (modules.launchql.dev) expose this one. bootstrapUser: true copies
+// the owner into the new database so its per-DB API recognizes the account user.
+// The generated ORM's default adapter is plain fetch, so the SDK's FetchAdapter is
+// injected to keep *.localhost DNS/Host routing working in Node.
+
+import { api, modules } from '@constructive-io/sdk';
+
+import type { ProvisionModule } from './modules';
+
+type ProvisionInput = Parameters<modules.DatabaseProvisionModuleModel['create']>[0]['data'];
+
+export async function createDatabaseProvision(args: {
+  endpoint: string;
+  bearer: string;
+  databaseName: string;
+  domain: string;
+  ownerId: string;
+  modules: ProvisionModule[];
+}): Promise<{ databaseId: string }> {
+  const db = modules.createClient({
+    adapter: new api.FetchAdapter(args.endpoint, {
+      Authorization: `Bearer ${args.bearer}`,
+    }),
+  });
+  const result = await db.databaseProvisionModule
+    .create({
+      data: {
+        databaseName: args.databaseName,
+        subdomain: args.databaseName,
+        domain: args.domain,
+        ownerId: args.ownerId,
+        modules: args.modules as unknown as ProvisionInput['modules'],
+        bootstrapUser: true,
+      },
+      select: {
+        id: true,
+        databaseId: true,
+        status: true,
+        errorMessage: true,
+        completedAt: true,
+      },
+    })
+    .unwrap();
+  const record = result.createDatabaseProvisionModule?.databaseProvisionModule;
+  if (!record) throw new Error('createDatabaseProvisionModule returned no provision record.');
+  if (record.status === 'failed') {
+    throw new Error(record.errorMessage ?? 'provisioning failed');
+  }
+  if (record.status !== 'completed') {
+    throw new Error(
+      record.errorMessage ?? `provisioning did not complete (status: ${record.status ?? 'unknown'})`,
+    );
+  }
+  if (!record.databaseId) throw new Error('provisioning completed but returned no databaseId.');
+  return { databaseId: record.databaseId };
+}

--- a/agentic/pi/src/provision-database/credential.ts
+++ b/agentic/pi/src/provision-database/credential.ts
@@ -1,0 +1,33 @@
+// Pure: decide which credential authenticates a project's provisioning. Under the
+// account gate a signed-in session is guaranteed, so every new project provisions
+// UNDER the account (account-owned + enumerable): the database's owner_id is the
+// account's own userId, and the account's API key (falling back to its session
+// token) is the bearer that authenticates the provision mutation and lands in the
+// project .env as ACCESS_TOKEN (refreshed on every provision run, including the
+// skip path). A signed-in session with no usable bearer (keychain locked) is an
+// explicit error, never a silent throwaway owner.
+// Side-effect-free so the branch is unit-testable without runtime/network.
+
+export type AccountCredential = {
+  userId: string;
+  accessToken: string;
+  apiKey?: string;
+};
+
+export type ProvisionCredential =
+  | { mode: 'account'; ownerId: string; bearer: string }
+  | { mode: 'error'; reason: string };
+
+export function selectProvisionCredential(
+  account: AccountCredential | null | undefined,
+): ProvisionCredential {
+  const bearer = account?.apiKey ?? account?.accessToken;
+  if (account?.userId && bearer) {
+    return { mode: 'account', ownerId: account.userId, bearer };
+  }
+  return {
+    mode: 'error',
+    reason:
+      'No usable account credential. Sign in (or unlock your session) before provisioning a database.',
+  };
+}

--- a/agentic/pi/src/provision-database/env-file.ts
+++ b/agentic/pi/src/provision-database/env-file.ts
@@ -1,0 +1,99 @@
+// Pure .env merge — used by provision_database to persist provisioning
+// credentials without clobbering existing keys: replace a key in place if
+// present, else append.
+// Kept side-effect-free so it is unit-testable (the tool does the fs write).
+
+export type EnvVars = Record<string, string>;
+
+/**
+ * Upsert `vars` into the existing `.env` `content`. Existing keys are replaced
+ * in place (preserving surrounding lines/comments); new keys are appended.
+ * Returns the new file body, trailing-newline-terminated.
+ */
+export function mergeEnv(content: string, vars: EnvVars): string {
+  let out = content;
+  for (const [key, val] of Object.entries(vars)) {
+    // Escape the key for the regex, and use a replacement function so `$`
+    // sequences in the value are never treated as replacement specials.
+    const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = new RegExp(`^${escapedKey}=.*`, 'm');
+    if (regex.test(out)) out = out.replace(regex, () => `${key}=${val}`);
+    else out += `\n${key}=${val}`;
+  }
+  return out.trim() + '\n';
+}
+
+/** The credential keys provision_database owns in a project's .env. */
+export const PROVISION_ENV_KEYS = [
+  'DATABASE_ID',
+  'DATABASE_NAME',
+  'OWNER_ID',
+  'ACCESS_TOKEN',
+  'PGDATABASE',
+  'API_ENDPOINT',
+  'MODULES_ENDPOINT',
+] as const;
+
+/**
+ * Keys archived as comments on reprovision — the binding identity: which
+ * database, under whom, on which backend. ACCESS_TOKEN is the account login
+ * token, identical across bindings, so it is overwritten in place rather than
+ * archived.
+ */
+export const ARCHIVED_BINDING_KEYS = [
+  'DATABASE_ID',
+  'DATABASE_NAME',
+  'OWNER_ID',
+  'PGDATABASE',
+  'API_ENDPOINT',
+  'MODULES_ENDPOINT',
+] as const;
+
+/**
+ * Build the provisioning credential block written to a project's .env. The
+ * endpoint pins record which backend owns this binding — outside-app consumers
+ * (verify-feature.sh, skill scripts, dev-server shells) resolve them instead of
+ * falling back to localhost defaults when the app targets a hosted backend.
+ */
+export function provisionEnvVars(args: {
+  databaseId: string;
+  databaseName: string;
+  ownerId: string;
+  accessToken: string;
+  apiEndpoint: string;
+  modulesEndpoint: string;
+}): EnvVars {
+  return {
+    DATABASE_ID: args.databaseId,
+    DATABASE_NAME: args.databaseName,
+    OWNER_ID: args.ownerId,
+    ACCESS_TOKEN: args.accessToken,
+    PGDATABASE: args.databaseName,
+    API_ENDPOINT: args.apiEndpoint,
+    MODULES_ENDPOINT: args.modulesEndpoint,
+  };
+}
+
+/**
+ * Comment out the given keys in place (`# archived <date>: KEY=value`) so a
+ * reprovision keeps the previous binding readable in the file instead of
+ * silently overwriting it. Every other line — including existing comments and
+ * already-archived entries — passes through untouched.
+ */
+export function archiveBindingKeys(
+  content: string,
+  keys: readonly string[],
+  archivedOn: string,
+): string {
+  const keySet = new Set(keys);
+  return content
+    .split('\n')
+    .map((line) => {
+      if (line.trimStart().startsWith('#')) return line;
+      const eq = line.indexOf('=');
+      if (eq === -1) return line;
+      const key = line.slice(0, eq).trim();
+      return keySet.has(key) ? `# archived ${archivedOn}: ${line.trim()}` : line;
+    })
+    .join('\n');
+}

--- a/agentic/pi/src/provision-database/modules.ts
+++ b/agentic/pi/src/provision-database/modules.ts
@@ -1,0 +1,48 @@
+// Explicit module list for database provisioning.
+//
+// The backend SILENTLY DROPS the `['all']` sentinel (constructive-db #1273),
+// provisioning ZERO modules and leaving downstream tables (e.g. limits_table_id)
+// NULL. We mirror constructive-client's DEFAULT_PROVISION_MODULES exactly.
+// Scoped/configured modules are `[name, options]` tuples. See PROVISION-API-001.
+export type ProvisionModule = string | [string, Record<string, unknown>];
+
+export const DEFAULT_PROVISION_MODULES: ProvisionModule[] = [
+  'users_module',
+  'membership_types_module',
+  ['permissions_module', { scope: 'app' }],
+  ['permissions_module', { scope: 'org' }],
+  ['limits_module', { scope: 'app' }],
+  ['limits_module', { scope: 'org' }],
+  ['levels_module', { scope: 'app' }],
+  ['levels_module', { scope: 'org' }],
+  ['memberships_module', { scope: 'app' }],
+  ['memberships_module', { scope: 'org' }],
+  'sessions_module',
+  'user_state_module',
+  'user_credentials_module',
+  ['internal_secrets_module', { scope: 'app' }],
+  'emails_module',
+  'rls_module',
+  'user_auth_module',
+  'session_secrets_module',
+  'rate_limits_module',
+  'connected_accounts_module',
+  ['identity_providers_module', { scope: 'app' }],
+  'webauthn_credentials_module',
+  'webauthn_auth_module',
+  'phone_numbers_module',
+  ['profiles_module', { scope: 'app' }],
+  ['profiles_module', { scope: 'org' }],
+  ['hierarchy_module', { scope: 'org' }],
+  ['invites_module', { scope: 'app' }],
+  ['invites_module', { scope: 'org' }],
+  // Mirrors constructive-client: api_name links storage to the same api-<slug>
+  // endpoint the generated SDK targets (without it uploads fail with "not
+  // enabled for this endpoint"), prefix keeps app_buckets/app_files names off
+  // user tables, and buckets seeds the public bucket row uploads need.
+  [
+    'storage_module',
+    { scope: 'app', api_name: 'api', prefix: 'app', buckets: [{ key: 'public', is_public: true }] },
+  ],
+  'devices_module',
+];

--- a/agentic/pi/src/provision-database/pg-fixups.ts
+++ b/agentic/pi/src/provision-database/pg-fixups.ts
@@ -1,0 +1,158 @@
+// Post-provision SQL fixups for a freshly provisioned database.
+//
+// Two things must happen at the Postgres level that the provisioning GraphQL API
+// does not do for us:
+//
+//  1. Naming settings — `constructive.simple_schema_names` and
+//     `schema_use_underscores` make later `provision_blueprint` calls create an
+//     `app_public` schema (which resolveSchemaId looks for) instead of a
+//     hyphenated `<db>-<hex>-app-public` one. These ALTER DATABASE settings
+//     PERSIST, so we set them once here, before any blueprint construction.
+//
+//  2. Membership defaults — new sign-ups otherwise land with
+//     is_approved=false/is_verified=false, the AuthzEntityMembership policy then
+//     denies every insert/select, and CRUD rows silently never persist
+//     (BLUEPRINT-PENDING-001). We flip the defaults (future sign-ups) AND any
+//     memberships already created during provisioning.
+//
+// All SQL targets the PHYSICAL control-plane database (`constructive`), NOT the
+// app's database name — that name is only a schema prefix (MEMBERSHIP-DB-001).
+//
+// Connection creds come from the ambient PG* env vars, falling back to sourcing
+// `pgpm env` (the same mechanism the old `eval "$(pgpm env)"` shell step used).
+// If neither yields a connection, provisioning still succeeded — we return a
+// note so the tool can warn the user that sign-in/CRUD may need a manual fixup.
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export type FixupResult = { applied: boolean; note: string };
+
+export type PgEnv = {
+  host?: string;
+  port?: string;
+  user?: string;
+  password?: string;
+};
+
+// Parse `pgpm env` output. It prints shell assignments (optionally `export`-
+// prefixed), one per line: `export PGHOST=localhost`. Quotes are stripped.
+export function parsePgpmEnv(stdout: string): PgEnv {
+  const env: Record<string, string> = {};
+  for (const rawLine of stdout.split('\n')) {
+    const line = rawLine.trim().replace(/^export\s+/, '');
+    const eq = line.indexOf('=');
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    env[key] = value;
+  }
+  return {
+    host: env.PGHOST,
+    port: env.PGPORT,
+    user: env.PGUSER,
+    password: env.PGPASSWORD,
+  };
+}
+
+export async function resolvePgEnv(): Promise<PgEnv | null> {
+  if (process.env.PGHOST) {
+    return {
+      host: process.env.PGHOST,
+      port: process.env.PGPORT,
+      user: process.env.PGUSER,
+      password: process.env.PGPASSWORD,
+    };
+  }
+  try {
+    const { stdout } = await execFileAsync('pgpm', ['env'], { timeout: 15_000 });
+    const parsed = parsePgpmEnv(stdout);
+    return parsed.host ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+// Find the memberships schema for this app. Schema names use hyphens locally
+// (`<db>-<hex>-memberships-public`) but may use underscores when the naming
+// settings are active — match both, scoped to this app's name prefix.
+const MEMBERSHIPS_SCHEMA_QUERY = `
+  SELECT schema_name FROM information_schema.schemata
+   WHERE (schema_name LIKE '%memberships-public' OR schema_name LIKE '%memberships_public')
+         AND (schema_name LIKE $1 OR schema_name LIKE $2)
+   ORDER BY schema_name DESC LIMIT 1`;
+
+export async function applySqlFixups(args: {
+  databaseName: string;
+  physicalDb: string;
+}): Promise<FixupResult> {
+  const pgEnv = await resolvePgEnv();
+  if (!pgEnv) {
+    return {
+      applied: false,
+      note: 'Could not reach Postgres (no PGHOST and `pgpm env` unavailable). Database provisioned, but membership defaults were not enabled — sign-in/CRUD may fail until the constructive DB is fixed up manually.',
+    };
+  }
+
+  // pg is dynamically imported so the main bundle never loads it unless a
+  // provision actually runs with Postgres access. The import lives inside the
+  // try: fixups are best-effort, so even a broken pg module must degrade to a
+  // note instead of failing the tool after the database is already provisioned.
+  let pool: import('pg').Pool | undefined;
+  try {
+    const { Pool } = await import('pg');
+    pool = new Pool({
+      host: pgEnv.host,
+      port: pgEnv.port ? Number(pgEnv.port) : undefined,
+      user: pgEnv.user,
+      password: pgEnv.password,
+      database: args.physicalDb,
+    });
+
+    const db = args.physicalDb;
+    // Persistent naming settings — so future provision_blueprint calls land an
+    // `app_public` schema resolveSchemaId can find.
+    await pool.query(`ALTER DATABASE "${db}" SET constructive.simple_schema_names = 'true'`);
+    await pool.query(`ALTER DATABASE "${db}" SET constructive.schema_use_underscores = 'true'`);
+
+    const schemaResult = await pool.query(MEMBERSHIPS_SCHEMA_QUERY, [
+      `${args.databaseName}-%`,
+      `${args.databaseName}\\_%`,
+    ]);
+
+    if (schemaResult.rows.length === 0) {
+      return {
+        applied: true,
+        note: `Naming settings applied, but no memberships schema was found for "${args.databaseName}" — sign-in may need a manual membership fixup.`,
+      };
+    }
+
+    const membershipsSchema = schemaResult.rows[0].schema_name as string;
+    await pool.query(
+      `UPDATE "${membershipsSchema}".app_membership_defaults SET is_approved = TRUE, is_verified = TRUE`,
+    );
+    await pool.query(
+      `UPDATE "${membershipsSchema}".app_memberships
+         SET is_approved = TRUE, is_verified = TRUE
+       WHERE is_approved = FALSE OR is_verified = FALSE`,
+    );
+
+    return { applied: true, note: `Membership defaults enabled (schema: ${membershipsSchema}).` };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      applied: false,
+      note: `Database provisioned, but SQL fixups failed (${message}). Sign-in/CRUD may fail until membership defaults are enabled manually.`,
+    };
+  } finally {
+    await pool?.end().catch(() => {});
+  }
+}

--- a/agentic/pi/src/records/meta.ts
+++ b/agentic/pi/src/records/meta.ts
@@ -1,0 +1,211 @@
+import type { Table, TableInflection, TableQueryNames } from '@constructive-io/graphql-query/types/schema';
+
+// Vendored from constructive-client's `@constructive-io/data` (not published to
+// the registry). We query the per-DB data endpoint's `_meta` introspection and
+// reshape each table into the `Table` shape `buildPostGraphileCreate` expects.
+// Relations are intentionally left empty: the create-mutation builder only reads
+// them to skip relational fields in the return selection, and every `_meta` field
+// is a real scalar column, so selecting them all is valid.
+//
+// Only fields the live backend's `_meta` actually exposes are selected here —
+// over-selecting (e.g. MetaType.modifier or MetaInflection.createField) fails
+// GraphQL validation. The reshapers below tolerate the omitted fields.
+
+export const META_QUERY = `
+  query DbToolsMeta {
+    _meta {
+      tables {
+        name
+        query { all one create update delete }
+        inflection {
+          allRows
+          conditionType
+          connection
+          createInputType
+          createPayloadType
+          deletePayloadType
+          edge
+          filterType
+          orderByType
+          patchType
+          tableType
+          updatePayloadType
+        }
+        fields {
+          name
+          isNotNull
+          hasDefault
+          type {
+            gqlType
+            isArray
+            pgType
+            subtype
+            isNotNull
+            hasDefault
+          }
+        }
+      }
+    }
+  }
+`;
+
+type RawType = {
+  gqlType: string;
+  isArray: boolean;
+  modifier?: string | number | null;
+  pgAlias?: string | null;
+  pgType?: string | null;
+  subtype?: string | null;
+  typmod?: number | null;
+  isNotNull?: boolean | null;
+  hasDefault?: boolean | null;
+};
+
+type RawField = {
+  name: string;
+  isNotNull?: boolean | null;
+  hasDefault?: boolean | null;
+  type: RawType;
+};
+
+type RawInflection = Partial<Record<keyof TableInflection, string | null>>;
+
+type RawQuery = {
+  all: string;
+  one?: string | null;
+  create?: string | null;
+  update?: string | null;
+  delete?: string | null;
+};
+
+export type RawMetaTable = {
+  name: string;
+  query?: RawQuery | null;
+  inflection?: RawInflection | null;
+  fields?: (RawField | null)[] | null;
+};
+
+export type MetaResponse = {
+  _meta?: { tables?: (RawMetaTable | null)[] | null } | null;
+};
+
+function pgFieldToCamelCase(name: string): string {
+  return name.replace(/_([a-z0-9])/g, (_, c: string) => c.toUpperCase());
+}
+
+function convertInflection(inflection: RawInflection | null | undefined): TableInflection | undefined {
+  if (!inflection) return undefined;
+  const s = (key: keyof TableInflection): string => inflection[key] ?? '';
+  const n = (key: keyof TableInflection): string | null => inflection[key] ?? null;
+  return {
+    allRows: s('allRows'),
+    allRowsSimple: s('allRowsSimple'),
+    conditionType: s('conditionType'),
+    connection: s('connection'),
+    createField: s('createField'),
+    createInputType: s('createInputType'),
+    createPayloadType: s('createPayloadType'),
+    deleteByPrimaryKey: n('deleteByPrimaryKey'),
+    deletePayloadType: s('deletePayloadType'),
+    edge: s('edge'),
+    edgeField: s('edgeField'),
+    enumType: s('enumType'),
+    filterType: n('filterType'),
+    inputType: s('inputType'),
+    orderByType: s('orderByType'),
+    patchField: s('patchField'),
+    patchType: n('patchType'),
+    tableFieldName: s('tableFieldName'),
+    tableType: s('tableType'),
+    typeName: s('typeName'),
+    updateByPrimaryKey: n('updateByPrimaryKey'),
+    updatePayloadType: n('updatePayloadType'),
+  };
+}
+
+function convertQuery(query: RawQuery | null | undefined): TableQueryNames | undefined {
+  if (!query) return undefined;
+  return {
+    all: query.all,
+    one: query.one ?? null,
+    create: query.create ?? '',
+    update: query.update ?? null,
+    delete: query.delete ?? null,
+  };
+}
+
+export function cleanTable(meta: RawMetaTable): Table {
+  return {
+    name: meta.name,
+    inflection: convertInflection(meta.inflection),
+    query: convertQuery(meta.query),
+    fields: (meta.fields ?? [])
+      .filter((f): f is RawField => Boolean(f))
+      .map((field) => ({
+        name: pgFieldToCamelCase(field.name),
+        type: {
+          gqlType: field.type.gqlType,
+          isArray: field.type.isArray,
+          modifier: field.type.modifier,
+          pgAlias: field.type.pgAlias,
+          pgType: field.type.pgType,
+          subtype: field.type.subtype,
+          typmod: field.type.typmod,
+        },
+        isNotNull: field.isNotNull ?? field.type.isNotNull ?? null,
+        hasDefault: field.hasDefault ?? field.type.hasDefault ?? null,
+      })),
+    relations: { belongsTo: [], hasOne: [], hasMany: [], manyToMany: [] },
+  };
+}
+
+function normalizeTableLookupKey(value: string | null | undefined): string {
+  return (value ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '');
+}
+
+function getTableLookupVariants(value: string | null | undefined): string[] {
+  const normalized = normalizeTableLookupKey(value);
+  if (!normalized) return [];
+  const variants = new Set<string>([normalized]);
+  if (normalized.endsWith('y')) {
+    variants.add(`${normalized}s`);
+    variants.add(`${normalized.slice(0, -1)}ies`);
+  }
+  if (normalized.endsWith('ies')) {
+    variants.add(`${normalized.slice(0, -3)}y`);
+  }
+  if (/(s|x|z|ch|sh)$/.test(normalized)) variants.add(`${normalized}es`);
+  if (normalized.endsWith('es')) variants.add(normalized.slice(0, -2));
+  if (!normalized.endsWith('s')) variants.add(`${normalized}s`);
+  if (normalized.endsWith('s')) variants.add(normalized.slice(0, -1));
+  return [...variants].filter(Boolean);
+}
+
+// Resolve a user-supplied table name (snake_case singular or plural) against the
+// PascalCase-singular `_meta` table names, tolerating pluralization differences.
+export function findMetaTable(tables: RawMetaTable[], requested: string): RawMetaTable | undefined {
+  const index = new Map<string, RawMetaTable>();
+  for (const table of tables) {
+    const keys = [
+      table.name,
+      table.query?.all,
+      table.query?.one,
+      table.inflection?.tableType,
+      table.inflection?.tableFieldName,
+      table.inflection?.allRows,
+    ];
+    for (const key of keys) {
+      for (const variant of getTableLookupVariants(key)) {
+        if (!index.has(variant)) index.set(variant, table);
+      }
+    }
+  }
+  for (const variant of getTableLookupVariants(requested)) {
+    const match = index.get(variant);
+    if (match) return match;
+  }
+  return undefined;
+}

--- a/agentic/pi/src/run-codegen/barrels.ts
+++ b/agentic/pi/src/run-codegen/barrels.ts
@@ -1,0 +1,50 @@
+// Turbopack barrel normalization (TURBOPACK-BARREL-001).
+//
+// Codegen emits directory barrel re-exports like `export * from './hooks'` where
+// `./hooks` is a directory with an index.ts. Next.js 16's Turbopack cannot
+// resolve directory specifiers — it needs an explicit `./hooks/index`. This pass
+// rewrites `./X` -> `./X/index` only when X resolves to a sibling DIRECTORY,
+// leaving file specifiers (and ones already ending in /index) untouched.
+//
+// Pure-ish: operates on a real directory tree (so it's exercised with a temp
+// fixture in tests) and is idempotent — safe to re-run.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SPEC_RE = /((?:export|import)[^\n]*?from\s*["'])(\.\.?\/[^"']+?)(["'])/g;
+const FILE_EXT_RE = /\.(tsx?|jsx?|json|css)$/;
+
+/** Rewrite directory barrel specifiers under `root` in place. Returns the count
+ * of files changed. No-op (returns 0) when `root` does not exist. */
+export function normalizeSdkBarrels(root: string): number {
+  if (!fs.existsSync(root)) return 0;
+  let changed = 0;
+
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(p);
+        continue;
+      }
+      if (!/\.tsx?$/.test(entry.name)) continue;
+      const orig = fs.readFileSync(p, 'utf8');
+      const next = orig.replace(SPEC_RE, (match, pre: string, spec: string, post: string) => {
+        if (FILE_EXT_RE.test(spec)) return match; // already a file
+        const abs = path.resolve(path.dirname(p), spec);
+        if (fs.existsSync(abs) && fs.statSync(abs).isDirectory()) {
+          return pre + spec.replace(/\/$/, '') + '/index' + post;
+        }
+        return match;
+      });
+      if (next !== orig) {
+        fs.writeFileSync(p, next);
+        changed++;
+      }
+    }
+  };
+
+  walk(root);
+  return changed;
+}

--- a/agentic/pi/src/run-codegen/endpoints.ts
+++ b/agentic/pi/src/run-codegen/endpoints.ts
@@ -1,0 +1,59 @@
+export type PlaneEndpoints = { admin: string; auth: string; app: string };
+
+// Codegen and the Next.js dev server default every per-DB vhost to
+// *-<db>.localhost:3000, which only exists on a local backend. Derive the real
+// vhosts from the api endpoint the binding belongs to by swapping its first
+// host label (api.launchql.dev -> admin-<db>.launchql.dev) — the same scheme
+// context.ts uses for the data plane. The app DATA plane is `api-<db>`, not
+// `app-<db>` (SUBDOMAIN-001).
+export function derivePlaneEndpoints(
+  apiEndpoint: string,
+  databaseName: string,
+): PlaneEndpoints | undefined {
+  const derive = (label: string): string | undefined => {
+    try {
+      const url = new URL(apiEndpoint);
+      const labels = url.hostname.split('.');
+      labels[0] = `${label}-${databaseName}`;
+      url.hostname = labels.join('.');
+      return url.toString();
+    } catch {
+      return undefined;
+    }
+  };
+  const admin = derive('admin');
+  const auth = derive('auth');
+  const app = derive('api');
+  return admin && auth && app ? { admin, auth, app } : undefined;
+}
+
+// The template's graphql-codegen.config.ts honors CODEGEN_*_ENDPOINT for the
+// URL and CODEGEN_*_HOST for the Host header; set both so scheme and routing
+// stay in sync on any backend.
+export function codegenEndpointEnv(planes: PlaneEndpoints): Record<string, string> {
+  return {
+    CODEGEN_ADMIN_ENDPOINT: planes.admin,
+    CODEGEN_ADMIN_HOST: new URL(planes.admin).host,
+    CODEGEN_AUTH_ENDPOINT: planes.auth,
+    CODEGEN_AUTH_HOST: new URL(planes.auth).host,
+    CODEGEN_APP_ENDPOINT: planes.app,
+    CODEGEN_APP_HOST: new URL(planes.app).host,
+  };
+}
+
+// .env.local for the dev server: the template's runtime config falls back to
+// localhost vhosts unless NEXT_PUBLIC_*_ENDPOINT overrides are present.
+export function envLocalContent(
+  databaseName: string,
+  planes: PlaneEndpoints | undefined,
+): string {
+  const lines = [`NEXT_PUBLIC_DB_NAME=${databaseName}`];
+  if (planes) {
+    lines.push(
+      `NEXT_PUBLIC_ADMIN_ENDPOINT=${planes.admin}`,
+      `NEXT_PUBLIC_AUTH_ENDPOINT=${planes.auth}`,
+      `NEXT_PUBLIC_APP_ENDPOINT=${planes.app}`,
+    );
+  }
+  return `${lines.join('\n')}\n`;
+}

--- a/agentic/pi/src/schema-resolve.ts
+++ b/agentic/pi/src/schema-resolve.ts
@@ -1,0 +1,105 @@
+import type { ProjectContext } from './context';
+
+export type ResolvedField = {
+  id: string;
+  name: string;
+  tableId: string;
+};
+
+export type ResolvedUniqueConstraint = {
+  id: string;
+  fieldIds: string[];
+};
+
+export type ResolvedTable = {
+  id: string;
+  name: string;
+  fields: ResolvedField[];
+  uniqueConstraints: ResolvedUniqueConstraint[];
+};
+
+export type ResolvedSchema = {
+  tables: ResolvedTable[];
+};
+
+export async function resolveSchema(context: ProjectContext): Promise<ResolvedSchema> {
+  const { api, databaseId } = context;
+
+  const tablesResult = await api.table
+    .findMany({
+      select: { id: true, name: true },
+      where: { databaseId: { equalTo: databaseId } },
+    })
+    .execute();
+
+  if (!tablesResult.ok) {
+    const message = tablesResult.errors.map((e) => e.message).join('; ');
+    throw new Error(`Failed to read tables: ${message}`);
+  }
+
+  const tableNodes = tablesResult.data.tables?.nodes ?? [];
+  const tableIds = tableNodes.map((t) => t.id);
+
+  const fieldsByTable = new Map<string, ResolvedField[]>();
+  const constraintsByTable = new Map<string, ResolvedUniqueConstraint[]>();
+
+  if (tableIds.length > 0) {
+    const fieldsResult = await api.field
+      .findMany({
+        select: { id: true, name: true, tableId: true },
+        where: { tableId: { in: tableIds } },
+      })
+      .execute();
+
+    if (!fieldsResult.ok) {
+      const message = fieldsResult.errors.map((e) => e.message).join('; ');
+      throw new Error(`Failed to read fields: ${message}`);
+    }
+
+    for (const field of fieldsResult.data.fields?.nodes ?? []) {
+      const list = fieldsByTable.get(field.tableId) ?? [];
+      list.push({ id: field.id, name: field.name, tableId: field.tableId });
+      fieldsByTable.set(field.tableId, list);
+    }
+
+    const constraintsResult = await api.uniqueConstraint
+      .findMany({
+        select: { id: true, tableId: true, fieldIds: true },
+        where: { tableId: { in: tableIds } },
+      })
+      .execute();
+
+    if (constraintsResult.ok) {
+      for (const c of constraintsResult.data.uniqueConstraints?.nodes ?? []) {
+        const list = constraintsByTable.get(c.tableId) ?? [];
+        list.push({ id: c.id, fieldIds: Array.isArray(c.fieldIds) ? c.fieldIds : [] });
+        constraintsByTable.set(c.tableId, list);
+      }
+    }
+  }
+
+  const tables: ResolvedTable[] = tableNodes.map((table) => ({
+    id: table.id,
+    name: table.name,
+    fields: fieldsByTable.get(table.id) ?? [],
+    uniqueConstraints: constraintsByTable.get(table.id) ?? [],
+  }));
+
+  return { tables };
+}
+
+export function resolveTable(schema: ResolvedSchema, tableName: string): ResolvedTable {
+  const table = schema.tables.find((t) => t.name === tableName);
+  if (!table) throw new Error(`Table "${tableName}" not found in current schema`);
+  return table;
+}
+
+export function resolveField(table: ResolvedTable, fieldName: string): ResolvedField {
+  const field = table.fields.find((f) => f.name === fieldName);
+  if (!field) throw new Error(`Field "${fieldName}" not found in table "${table.name}"`);
+  return field;
+}
+
+export function findUniqueConstraintId(table: ResolvedTable, fieldId: string): string | undefined {
+  return table.uniqueConstraints.find((c) => c.fieldIds.includes(fieldId))?.id;
+}

--- a/agentic/pi/src/tool-schema.ts
+++ b/agentic/pi/src/tool-schema.ts
@@ -1,0 +1,12 @@
+import type { TSchema } from 'typebox';
+import { z } from 'zod';
+
+// Tool parameter schemas are authored in zod; pi's ToolDefinition wants a
+// typebox TSchema. Structurally a TSchema is just a JSON Schema object, so the
+// draft-7 output of z.toJSONSchema (minus the $schema marker, matching what
+// typebox emits) is cast across the boundary. typebox itself is a type-only
+// import — it never appears in the runtime bundle.
+export function toolSchema(schema: z.ZodType): TSchema {
+  const { $schema: _$schema, ...rest } = z.toJSONSchema(schema, { target: 'draft-7' });
+  return rest as unknown as TSchema;
+}

--- a/agentic/pi/src/tools/add-policies.ts
+++ b/agentic/pi/src/tools/add-policies.ts
@@ -1,0 +1,124 @@
+import { buildNodeData, getPolicyFieldDefaults, getPolicyProvisioningConfig } from '@agentic-kit/harness';
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
+import { z } from 'zod';
+
+import { resolveProjectContext } from '../context';
+import { addPoliciesToExistingTable } from '../policy/add-policies-to-table';
+import type { CrudOperation, CrudPolicyConfigs } from '../policy/provision-helpers';
+import { resolveSchema, resolveTable } from '../schema-resolve';
+import { toolSchema } from '../tool-schema';
+
+const DEFAULT_ROLE = 'authenticated';
+
+const CrudOperationSchema = z.enum(['create', 'read', 'update', 'delete']);
+
+const PolicyEntrySchema = z.object({
+  policy_type: z
+    .string()
+    .describe(
+      'Policy type id. Supported: AuthzAllowAll, AuthzDenyAll, AuthzAppMembership, AuthzDirectOwner, AuthzEntityMembership, AuthzOrgHierarchy, AuthzPublishable (these auto-create columns via their Data* node), AuthzRelatedMemberList, AuthzRelatedEntityMembership. Not supported (use the policies UI): AuthzDirectOwnerAny, AuthzMemberList, AuthzTemporal, AuthzComposite.',
+    ),
+  operations: z
+    .array(CrudOperationSchema)
+    .min(1)
+    .describe(
+      'CRUD operations the policy applies to: any subset of ["create","read","update","delete"].',
+    ),
+  role_name: z
+    .string()
+    .describe('PostgreSQL role the policy applies to. Defaults to "authenticated".')
+    .optional(),
+  is_permissive: z
+    .boolean()
+    .describe('PERMISSIVE (default true) vs RESTRICTIVE — most policies should be permissive.')
+    .optional(),
+  data: z
+    .record(z.string(), z.unknown())
+    .describe(
+      'Type-specific shared data. AuthzDirectOwner: { entity_field: "owner_id" }. AuthzAppMembership: { permission?, is_admin?, is_owner? }. Empty object {} for AuthzAllowAll / AuthzDenyAll.',
+    )
+    .optional(),
+  node_data: z
+    .record(z.string(), z.unknown())
+    .describe('Optional data for the underlying Data* node (has-module policies only).')
+    .optional(),
+});
+
+const AddPoliciesZod = z.object({
+  table_name: z
+    .string()
+    .describe(
+      'Name of the existing table to attach the policies to. Use describe_schema first to verify it exists.',
+    ),
+  policies: z
+    .array(PolicyEntrySchema)
+    .min(1)
+    .describe('One or more policies to add. Each entry becomes one secure_table_provision call.'),
+});
+const AddPoliciesSchema = toolSchema(AddPoliciesZod);
+
+export type AddPoliciesDetails = {
+  success: boolean;
+  message: string;
+};
+
+function buildOperations(roleName: string, isPermissive: boolean): CrudPolicyConfigs {
+  const config = { roleName, isPermissive, policyData: {}, isCustomized: false };
+  return { create: config, read: config, update: config, delete: config };
+}
+
+export const addPoliciesTool: ToolDefinition<typeof AddPoliciesSchema, AddPoliciesDetails> = {
+  name: 'add_policies',
+  label: 'Add policies',
+  description:
+    'Add one or more RLS policies to an existing table. Has-module policies (AuthzDirectOwner, AuthzEntityMembership, AuthzOrgHierarchy, AuthzPublishable) auto-create the columns they need — call directly, do not add columns first.',
+  promptSnippet:
+    'add_policies: attach RLS policies to an existing table (one call can add many). Gated.',
+  parameters: AddPoliciesSchema,
+  async execute(_id, params: z.infer<typeof AddPoliciesZod>, _signal, _onUpdate, ctx) {
+    const resolved = await resolveProjectContext(ctx.cwd);
+    if (!resolved.context) {
+      return {
+        content: [{ type: 'text', text: resolved.reason }],
+        details: { success: false, message: resolved.reason },
+      };
+    }
+
+    const { modules, databaseId, schemaId } = resolved.context;
+
+    try {
+      const schema = await resolveSchema(resolved.context);
+      const table = resolveTable(schema, params.table_name);
+
+      const policies = params.policies.map((entry) => {
+        const config = getPolicyProvisioningConfig(entry.policy_type);
+        const defaults = getPolicyFieldDefaults(entry.policy_type);
+        const mergedData = { ...defaults, ...(entry.data ?? {}) };
+        const nodeData = entry.node_data ?? buildNodeData(entry.policy_type, mergedData);
+        return {
+          policyType: entry.policy_type,
+          dataNodeType: config?.dataNodeType,
+          nodeData,
+          sharedPolicyData: mergedData,
+          operations: buildOperations(entry.role_name ?? DEFAULT_ROLE, entry.is_permissive ?? true),
+          enabledOperations: entry.operations as CrudOperation[],
+        };
+      });
+
+      await addPoliciesToExistingTable({
+        client: modules,
+        databaseId,
+        schemaId,
+        tableId: table.id,
+        policies,
+      });
+
+      const count = params.policies.length;
+      const message = `Added ${count} ${count === 1 ? 'policy' : 'policies'} to ${params.table_name}`;
+      return { content: [{ type: 'text', text: message }], details: { success: true, message } };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to add policies';
+      return { content: [{ type: 'text', text: message }], details: { success: false, message } };
+    }
+  },
+};

--- a/agentic/pi/src/tools/add-records.ts
+++ b/agentic/pi/src/tools/add-records.ts
@@ -1,0 +1,163 @@
+import {
+  buildPostGraphileCreate,
+  toCamelCaseSingular,
+  toCreateMutationName,
+} from '@constructive-io/graphql-query/generators';
+import { objects } from '@constructive-io/sdk';
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
+import { z } from 'zod';
+
+import { resolveDataToken, resolveProjectContext } from '../context';
+import { cleanTable, findMetaTable, META_QUERY, type MetaResponse } from '../records/meta';
+import { toolSchema } from '../tool-schema';
+
+export type AddRecordsDetails = {
+  success: boolean;
+  message: string;
+  tableName?: string;
+  columns?: string[];
+  rows?: Record<string, unknown>[];
+  createdCount?: number;
+  asOf?: string;
+  // Set when there's no valid data-plane token: the user hasn't signed into their
+  // app in the Preview (or the session token expired). The renderer shows a
+  // text prompt to sign in there.
+  needsAuth?: boolean;
+};
+
+type ToolResult = { content: { type: 'text'; text: string }[]; details: AddRecordsDetails };
+
+function fail(message: string): ToolResult {
+  return { content: [{ type: 'text', text: message }], details: { success: false, message } };
+}
+
+function needsAuth(message: string): ToolResult {
+  return {
+    content: [{ type: 'text', text: message }],
+    details: { success: false, message, needsAuth: true },
+  };
+}
+
+// Mirror @constructive-io/data's prepareCreateInput (create semantics): drop
+// undefined/null/empty-string so server defaults apply; keep false/0/[]/objects.
+function stripForCreate(record: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (value === undefined || value === null || value === '') continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+const AddRecordsZod = z.object({
+  table_name: z
+    .string()
+    .describe('Name of the table to insert rows into (snake_case, singular or plural).'),
+  records: z
+    .array(z.record(z.string(), z.unknown()))
+    .describe(
+      'Rows to insert. Each is an object of column → value (camelCase or snake_case column names).',
+    ),
+});
+const AddRecordsSchema = toolSchema(AddRecordsZod);
+
+export const addRecordsTool: ToolDefinition<typeof AddRecordsSchema, AddRecordsDetails> = {
+  name: 'add_records',
+  label: 'Add records',
+  description: "Insert one or more rows into a table in the project's app database.",
+  promptSnippet: 'add_records: insert rows into an existing table. Gated.',
+  parameters: AddRecordsSchema,
+  async execute(_id, params: z.infer<typeof AddRecordsZod>, _signal, _onUpdate, ctx) {
+    const resolved = await resolveProjectContext(ctx.cwd);
+    if (!resolved.context) return fail(resolved.reason);
+    const { dataEndpoint } = resolved.context;
+
+    if (!dataEndpoint) {
+      return fail(
+        'Cannot resolve the app data endpoint (DATABASE_NAME missing from .env). Re-provision the database, then retry.',
+      );
+    }
+    if (params.records.length === 0) return fail('No records provided.');
+
+    const token = await resolveDataToken(resolved.context);
+    if (!token.token) return needsAuth(token.reason ?? 'Sign in to the database to insert records.');
+
+    const adapter = new objects.FetchAdapter(dataEndpoint, {
+      Authorization: `Bearer ${token.token}`,
+    });
+
+    let tables;
+    try {
+      const meta = await adapter.execute<MetaResponse>(META_QUERY);
+      if (!meta.ok) {
+        return fail(`Failed to read schema from the app database: ${meta.errors.map((e) => e.message).join('; ')}`);
+      }
+      tables = (meta.data._meta?.tables ?? []).filter((t): t is NonNullable<typeof t> => Boolean(t));
+    } catch (err) {
+      return fail(err instanceof Error ? err.message : 'Failed to query the app database schema.');
+    }
+
+    const rawTable = findMetaTable(tables, params.table_name);
+    if (!rawTable) {
+      return fail(`Table "${params.table_name}" was not found in the app database.`);
+    }
+
+    const table = cleanTable(rawTable);
+    const allTables = tables.map(cleanTable);
+    const mutation = buildPostGraphileCreate(table, allTables).toString();
+    const mutationName = toCreateMutationName(table.name, table);
+    const singularName = toCamelCaseSingular(table.name, table);
+
+    // Constructive app tables scope rows by entityId (the owning user's id). The
+    // create input requires it, but callers won't know it — backfill it with the
+    // signed-in user's id from the Preview session when the table has the column
+    // and the record omits it.
+    const hasEntityId = table.fields.some((f) => f.name === 'entityId');
+
+    const created: Record<string, unknown>[] = [];
+    const errors: string[] = [];
+
+    for (const record of params.records) {
+      const prepared =
+        hasEntityId && token.userId && record.entityId == null && record.entity_id == null
+          ? { ...record, entityId: token.userId }
+          : record;
+      const variables = { input: { [singularName]: stripForCreate(prepared) } };
+      try {
+        const result = await adapter.execute<Record<string, unknown>>(mutation, variables);
+        if (!result.ok) {
+          errors.push(result.errors.map((e) => e.message).join('; '));
+          continue;
+        }
+        const payload = result.data[mutationName] as Record<string, unknown> | undefined;
+        const row = (payload?.[singularName] as Record<string, unknown> | undefined) ?? {};
+        created.push(row);
+      } catch (err) {
+        errors.push(err instanceof Error ? err.message : 'Unknown error');
+      }
+    }
+
+    if (created.length === 0) {
+      return fail(`Failed to insert into "${params.table_name}": ${errors.join('; ') || 'unknown error'}`);
+    }
+
+    const columns = table.fields.map((f) => f.name);
+    const message =
+      errors.length > 0
+        ? `Inserted ${created.length} of ${params.records.length} row(s) into ${params.table_name} (${errors.length} failed).`
+        : `Inserted ${created.length} row(s) into ${params.table_name}.`;
+
+    return {
+      content: [{ type: 'text', text: message }],
+      details: {
+        success: true,
+        message,
+        tableName: rawTable.name,
+        columns,
+        rows: created,
+        createdCount: created.length,
+        asOf: new Date().toISOString(),
+      },
+    };
+  },
+};

--- a/agentic/pi/src/tools/add-relation-schema.ts
+++ b/agentic/pi/src/tools/add-relation-schema.ts
@@ -1,0 +1,72 @@
+import type { BlueprintDefinition } from '@agentic-kit/harness';
+import { z } from 'zod';
+
+import { toolSchema } from '../tool-schema';
+
+// delete_action is intentionally always sent: the backend REJECTS a
+// RelationBelongsTo whose delete_action is absent ("PROVISION_RELATION:
+// delete_action is required"). We default it to 'a' (NO ACTION) so the model
+// never has to supply it.
+export const DeleteAction = z
+  .enum(['c', 'r', 'n', 'a', 'd'])
+  .describe(
+    'FK delete action: c=CASCADE, r=RESTRICT, n=SET NULL, a=NO ACTION (default), d=SET DEFAULT',
+  );
+
+export const AddRelationZod = z.object({
+  relation_type: z
+    .enum(['belongs_to', 'many_to_many'])
+    .describe(
+      'belongs_to adds an FK column on the source table; many_to_many adds a junction table. Defaults to belongs_to.',
+    )
+    .optional(),
+  source_table: z.string().describe('Existing source table name (snake_case).'),
+  target_table: z.string().describe('Existing target table name (snake_case).'),
+  field_name: z
+    .string()
+    .describe('belongs_to only: FK column name to add on the source table, e.g. "author_id".')
+    .optional(),
+  junction_table_name: z
+    .string()
+    .describe('many_to_many only: name of the junction table to create, e.g. "post_tags".')
+    .optional(),
+  delete_action: DeleteAction.optional(),
+  is_required: z
+    .boolean()
+    .describe(
+      'belongs_to only: make the FK NOT NULL. Defaults to false — a NOT NULL FK fails if the source table already has rows.',
+    )
+    .optional(),
+});
+
+export const AddRelationSchema = toolSchema(AddRelationZod);
+
+export type AddRelationParams = z.infer<typeof AddRelationZod>;
+
+// Build a relation-only blueprint definition (no tables): the spike proved
+// constructBlueprint applies relations to PRE-EXISTING tables without recreating
+// them, as long as delete_action is supplied.
+export function buildRelation(params: AddRelationParams): BlueprintDefinition['relations'] {
+  const deleteAction = params.delete_action ?? 'a';
+  if ((params.relation_type ?? 'belongs_to') === 'many_to_many') {
+    return [
+      {
+        $type: 'RelationManyToMany',
+        source_table: params.source_table,
+        target_table: params.target_table,
+        junction_table_name: params.junction_table_name as string,
+        delete_action: deleteAction,
+      },
+    ];
+  }
+  return [
+    {
+      $type: 'RelationBelongsTo',
+      source_table: params.source_table,
+      target_table: params.target_table,
+      field_name: params.field_name as string,
+      delete_action: deleteAction,
+      is_required: params.is_required ?? false,
+    },
+  ];
+}

--- a/agentic/pi/src/tools/add-relation.ts
+++ b/agentic/pi/src/tools/add-relation.ts
@@ -1,0 +1,114 @@
+import { expandBlueprintDefaults } from '@agentic-kit/harness';
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
+
+import { resolveProjectContext } from '../context';
+import { resolveSchema, resolveTable } from '../schema-resolve';
+import { type AddRelationParams as Params, AddRelationSchema, buildRelation } from './add-relation-schema';
+
+export type AddRelationDetails = {
+  success: boolean;
+  message: string;
+  sourceTable?: string;
+  targetTable?: string;
+  fieldName?: string;
+};
+
+type ToolResult = { content: { type: 'text'; text: string }[]; details: AddRelationDetails };
+
+function fail(message: string): ToolResult {
+  return { content: [{ type: 'text', text: message }], details: { success: false, message } };
+}
+
+export const addRelationTool: ToolDefinition<typeof AddRelationSchema, AddRelationDetails> = {
+  name: 'add_relation',
+  label: 'Add relation',
+  description:
+    'Add a relation between two EXISTING tables without recreating them: belongs_to adds a foreign-key column on the source table; many_to_many creates a junction table. Use this for relations discovered after the tables were provisioned. For brand-new related tables, prefer a single provision_blueprint call.',
+  promptSnippet:
+    'add_relation: link two existing tables (belongs_to FK column, or many_to_many junction). Gated.',
+  parameters: AddRelationSchema,
+  async execute(_id, params: Params, _signal, _onUpdate, ctx): Promise<ToolResult> {
+    const type = params.relation_type ?? 'belongs_to';
+    if (type === 'belongs_to' && !params.field_name) {
+      return fail('field_name is required for a belongs_to relation (the FK column name on the source table).');
+    }
+    if (type === 'many_to_many' && !params.junction_table_name) {
+      return fail('junction_table_name is required for a many_to_many relation.');
+    }
+
+    const resolved = await resolveProjectContext(ctx.cwd);
+    if (!resolved.context) return fail(resolved.reason);
+    const { modules, databaseId, schemaId, ownerId } = resolved.context;
+    if (!ownerId) return fail('Not authenticated (missing OWNER_ID in .env).');
+
+    // Validate both tables exist before constructing — a clearer error than the
+    // backend's, and avoids a no-op blueprint.
+    let schema;
+    try {
+      schema = await resolveSchema(resolved.context);
+      resolveTable(schema, params.source_table);
+      resolveTable(schema, params.target_table);
+    } catch (err) {
+      return fail(err instanceof Error ? err.message : 'Failed to resolve schema.');
+    }
+
+    const definition = expandBlueprintDefaults({ tables: [], relations: buildRelation(params) });
+    const uniqueName = `add_relation_${Date.now()}`;
+
+    try {
+      const created = await modules.blueprint
+        .create({
+          data: {
+            ownerId,
+            databaseId,
+            name: uniqueName,
+            displayName: `${params.source_table} → ${params.target_table}`,
+            description: `Add ${type} relation`,
+            definition,
+          },
+          select: { id: true },
+        })
+        .unwrap();
+
+      const blueprintId = created.createBlueprint?.blueprint?.id;
+      if (!blueprintId) throw new Error('Failed to create relation blueprint');
+
+      const constructResult = await modules.mutation
+        .constructBlueprint({ input: { blueprintId, schemaId } }, { select: { result: true } })
+        .unwrap();
+
+      if (!constructResult.constructBlueprint?.result) {
+        const constructions = await modules.blueprintConstruction
+          .findMany({
+            where: { blueprintId: { equalTo: blueprintId } },
+            orderBy: ['ID_DESC'],
+            first: 1,
+            select: { status: true, errorDetails: true },
+          })
+          .unwrap();
+        const error =
+          constructions?.blueprintConstructions?.nodes?.[0]?.errorDetails ?? 'Unknown error';
+        return fail(
+          `Failed to add relation: ${typeof error === 'string' ? error : JSON.stringify(error)}`,
+        );
+      }
+    } catch (err) {
+      return fail(`Failed to add relation: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    const message =
+      type === 'many_to_many'
+        ? `Created junction table "${params.junction_table_name}" linking ${params.source_table} ↔ ${params.target_table}.`
+        : `Added FK "${params.field_name}" on ${params.source_table} → ${params.target_table}.`;
+    return {
+      content: [{ type: 'text', text: message }],
+      details: {
+        success: true,
+        message,
+        sourceTable: params.source_table,
+        targetTable: params.target_table,
+        fieldName: params.field_name,
+      },
+    };
+  },
+};

--- a/agentic/pi/src/tools/describe-schema.ts
+++ b/agentic/pi/src/tools/describe-schema.ts
@@ -1,0 +1,164 @@
+import { fieldTypeToTypeName, isInternalPolicy } from '@agentic-kit/harness';
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
+import { z } from 'zod';
+
+import { resolveProjectContext } from '../context';
+import { toolSchema } from '../tool-schema';
+
+const ParamZod = z.object({});
+const ParamSchema = toolSchema(ParamZod);
+
+type Params = z.infer<typeof ParamZod>;
+
+type SchemaField = {
+  name: string;
+  type: string;
+  isRequired: boolean;
+  defaultValue: string | null;
+};
+
+type SchemaTable = {
+  name: string;
+  fields: SchemaField[];
+  policies: string[];
+};
+
+export type DescribeSchemaDetails = {
+  tables: SchemaTable[];
+};
+
+function toDefaultValueString(value: unknown): string | null {
+  if (value == null) return null;
+  if (typeof value === 'string') return value;
+  return JSON.stringify(value);
+}
+
+function formatText(details: DescribeSchemaDetails): string {
+  const lines: string[] = [];
+  if (details.tables.length === 0) {
+    lines.push('No application tables yet.');
+  } else {
+    lines.push(`Tables (${details.tables.length}):`);
+    for (const table of details.tables) {
+      lines.push(`  ${table.name}`);
+      for (const field of table.fields) {
+        const req = field.isRequired ? ' required' : '';
+        const def = field.defaultValue != null ? ` default=${field.defaultValue}` : '';
+        lines.push(`    - ${field.name}: ${field.type}${req}${def}`);
+      }
+      if (table.policies.length > 0) {
+        lines.push(`    policies: ${table.policies.join(', ')}`);
+      }
+    }
+  }
+  return lines.join('\n');
+}
+
+export const describeSchemaTool: ToolDefinition<typeof ParamSchema, DescribeSchemaDetails> = {
+  name: 'describe_schema',
+  label: 'Describe schema',
+  description:
+    'Inspect the current Constructive database schema for this project: application tables with their fields (name, type, required, default). Read-only.',
+  promptSnippet:
+    'describe_schema: list the project database tables and their fields. Read-only — call before modifying schema.',
+  parameters: ParamSchema,
+  async execute(_toolCallId, _params: Params, _signal, _onUpdate, ctx) {
+    const resolved = await resolveProjectContext(ctx.cwd);
+    if (!resolved.context) {
+      return {
+        content: [{ type: 'text', text: resolved.reason }],
+        details: { tables: [] },
+      };
+    }
+
+    const { api, databaseId } = resolved.context;
+
+    const tablesResult = await api.table
+      .findMany({
+        select: { id: true, name: true, category: true },
+        where: {
+          databaseId: { equalTo: databaseId },
+          or: [{ category: { equalTo: 'APP' } }, { name: { equalTo: 'users' } }],
+        },
+        orderBy: ['NAME_ASC'],
+      })
+      .execute();
+
+    if (!tablesResult.ok) {
+      const message = tablesResult.errors.map((e) => e.message).join('; ');
+      return {
+        content: [{ type: 'text', text: `Failed to read schema: ${message}` }],
+        details: { tables: [] },
+      };
+    }
+
+    const tableNodes = tablesResult.data.tables?.nodes ?? [];
+    const tableIds = tableNodes.map((t) => t.id);
+
+    const fieldsByTable = new Map<string, SchemaField[]>();
+    const policiesByTable = new Map<string, string[]>();
+    if (tableIds.length > 0) {
+      const [fieldsResult, policiesResult] = await Promise.all([
+        api.field
+          .findMany({
+            select: {
+              name: true,
+              type: true,
+              isRequired: true,
+              defaultValue: true,
+              tableId: true,
+            },
+            where: { tableId: { in: tableIds } },
+          })
+          .execute(),
+        api.policy
+          .findMany({
+            select: { tableId: true, policyType: true },
+            where: { tableId: { in: tableIds } },
+          })
+          .execute(),
+      ]);
+
+      if (!fieldsResult.ok) {
+        const message = fieldsResult.errors.map((e) => e.message).join('; ');
+        return {
+          content: [{ type: 'text', text: `Failed to read fields: ${message}` }],
+          details: { tables: [] },
+        };
+      }
+
+      for (const field of fieldsResult.data.fields?.nodes ?? []) {
+        const list = fieldsByTable.get(field.tableId) ?? [];
+        list.push({
+          name: field.name,
+          type: fieldTypeToTypeName(field.type),
+          isRequired: Boolean(field.isRequired),
+          defaultValue: toDefaultValueString(field.defaultValue),
+        });
+        fieldsByTable.set(field.tableId, list);
+      }
+
+      // One policy spans CRUD as several rows; collapse to distinct types per table.
+      if (policiesResult.ok) {
+        for (const policy of policiesResult.data.policies?.nodes ?? []) {
+          if (isInternalPolicy(policy.policyType)) continue;
+          const list = policiesByTable.get(policy.tableId) ?? [];
+          if (!list.includes(policy.policyType)) list.push(policy.policyType);
+          policiesByTable.set(policy.tableId, list);
+        }
+      }
+    }
+
+    const tables: SchemaTable[] = tableNodes.map((table) => ({
+      name: table.name,
+      fields: fieldsByTable.get(table.id) ?? [],
+      policies: policiesByTable.get(table.id) ?? [],
+    }));
+
+    const details: DescribeSchemaDetails = { tables };
+    return {
+      content: [{ type: 'text', text: formatText(details) }],
+      details,
+    };
+  },
+};

--- a/agentic/pi/src/tools/mutations.ts
+++ b/agentic/pi/src/tools/mutations.ts
@@ -1,0 +1,253 @@
+import { toFieldDefault, toFieldType } from '@agentic-kit/harness';
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
+import { z } from 'zod';
+
+import { resolveProjectContext } from '../context';
+import { findUniqueConstraintId, resolveField, resolveSchema, resolveTable } from '../schema-resolve';
+import { toolSchema } from '../tool-schema';
+
+export type MutationDetails = {
+  success: boolean;
+  message: string;
+};
+
+function ok(message: string) {
+  return {
+    content: [{ type: 'text' as const, text: message }],
+    details: { success: true, message },
+  };
+}
+
+function fail(message: string) {
+  return {
+    content: [{ type: 'text' as const, text: message }],
+    details: { success: false, message },
+  };
+}
+
+// ── delete_table ──────────────────────────────────────────────────────────
+
+const DeleteTableZod = z.object({
+  table_name: z.string().describe('Name of the table to delete (snake_case)'),
+});
+const DeleteTableSchema = toolSchema(DeleteTableZod);
+
+export const deleteTableTool: ToolDefinition<typeof DeleteTableSchema, MutationDetails> = {
+  name: 'delete_table',
+  label: 'Delete table',
+  description: 'Permanently delete a table and its data from the project database.',
+  promptSnippet: 'delete_table: drop an existing table by name. Destructive — gated.',
+  parameters: DeleteTableSchema,
+  async execute(_id, params: z.infer<typeof DeleteTableZod>, _signal, _onUpdate, ctx) {
+    const resolved = await resolveProjectContext(ctx.cwd);
+    if (!resolved.context) return fail(resolved.reason);
+    try {
+      const schema = await resolveSchema(resolved.context);
+      const table = resolveTable(schema, params.table_name);
+      await resolved.context.api.table
+        .delete({ where: { id: table.id }, select: { id: true } })
+        .unwrap();
+      return ok(`Deleted table ${params.table_name}`);
+    } catch (err) {
+      return fail(err instanceof Error ? err.message : 'Failed to delete table');
+    }
+  },
+};
+
+// ── create_field ──────────────────────────────────────────────────────────
+
+const CreateFieldZod = z.object({
+  table_name: z.string().describe('Name of the table to add the field to'),
+  field_name: z.string().describe('Field name in snake_case'),
+  type: z
+    .string()
+    .describe(
+      'PostgreSQL type: text, integer, smallint, numeric, boolean, date, timestamp, timestamptz, time, json, jsonb, inet, email, url, image, upload',
+    ),
+  is_required: z.boolean().describe('Whether the field is NOT NULL. Defaults to false.').optional(),
+  default_value: z
+    .union([z.string(), z.null()])
+    .describe('SQL default expression, e.g. "now()", "\'draft\'"')
+    .optional(),
+  is_unique: z
+    .boolean()
+    .describe('Whether the field has a unique constraint. Defaults to false.')
+    .optional(),
+});
+const CreateFieldSchema = toolSchema(CreateFieldZod);
+
+export const createFieldTool: ToolDefinition<typeof CreateFieldSchema, MutationDetails> = {
+  name: 'create_field',
+  label: 'Create field',
+  description: 'Add a new field (column) to an existing table in the project database.',
+  promptSnippet: 'create_field: add a column to an existing table. Gated.',
+  parameters: CreateFieldSchema,
+  async execute(_id, params: z.infer<typeof CreateFieldZod>, _signal, _onUpdate, ctx) {
+    const resolved = await resolveProjectContext(ctx.cwd);
+    if (!resolved.context) return fail(resolved.reason);
+    const { api, databaseId } = resolved.context;
+    try {
+      const schema = await resolveSchema(resolved.context);
+      const table = resolveTable(schema, params.table_name);
+
+      const result = await api.field
+        .create({
+          data: {
+            name: params.field_name,
+            type: toFieldType(params.type) as unknown as Record<string, unknown>,
+            tableId: table.id,
+            databaseId,
+            isRequired: params.is_required ?? false,
+            defaultValue: toFieldDefault(params.default_value) as unknown as
+              | Record<string, unknown>
+              | undefined,
+          },
+          select: { id: true, name: true, type: true },
+        })
+        .unwrap();
+
+      const createdId = result.createField?.field?.id;
+
+      if (params.is_unique && createdId) {
+        try {
+          await api.uniqueConstraint
+            .create({
+              data: {
+                tableId: table.id,
+                databaseId,
+                fieldIds: [createdId],
+                name: `${table.name}_${params.field_name}_key`,
+                type: 'u',
+              },
+              select: { id: true },
+            })
+            .unwrap();
+        } catch (err) {
+          console.warn('Failed to create unique constraint:', err);
+        }
+      }
+
+      return ok(`Added field ${params.table_name}.${params.field_name}`);
+    } catch (err) {
+      return fail(err instanceof Error ? err.message : 'Failed to create field');
+    }
+  },
+};
+
+// ── update_field ──────────────────────────────────────────────────────────
+
+const UpdateFieldZod = z.object({
+  table_name: z.string().describe('Name of the table containing the field'),
+  field_name: z.string().describe('Current field name'),
+  new_name: z.string().describe('New field name in snake_case (if renaming)').optional(),
+  new_type: z.string().describe('New PostgreSQL type (if changing type)').optional(),
+  is_required: z.boolean().describe('Set NOT NULL constraint').optional(),
+  default_value: z
+    .union([z.string(), z.null()])
+    .describe('New SQL default expression, or null to remove')
+    .optional(),
+  is_unique: z.boolean().describe('Set or remove unique constraint').optional(),
+});
+const UpdateFieldSchema = toolSchema(UpdateFieldZod);
+
+export const updateFieldTool: ToolDefinition<typeof UpdateFieldSchema, MutationDetails> = {
+  name: 'update_field',
+  label: 'Update field',
+  description: 'Modify an existing field: rename, change type, toggle required/unique, or set default.',
+  promptSnippet: 'update_field: rename/retype/toggle an existing column. Gated.',
+  parameters: UpdateFieldSchema,
+  async execute(_id, params: z.infer<typeof UpdateFieldZod>, _signal, _onUpdate, ctx) {
+    const resolved = await resolveProjectContext(ctx.cwd);
+    if (!resolved.context) return fail(resolved.reason);
+    const { api, databaseId } = resolved.context;
+    try {
+      const schema = await resolveSchema(resolved.context);
+      const table = resolveTable(schema, params.table_name);
+      const field = resolveField(table, params.field_name);
+
+      const patch: Record<string, unknown> = {};
+      if (params.new_name) patch.name = params.new_name;
+      if (params.new_type) patch.type = toFieldType(params.new_type) as unknown as Record<string, unknown>;
+      if (params.is_required !== undefined) patch.isRequired = params.is_required;
+      if (params.default_value !== undefined) {
+        patch.defaultValue =
+          params.default_value === null ? null : (toFieldDefault(params.default_value) ?? null);
+      }
+
+      if (Object.keys(patch).length > 0) {
+        await api.field
+          .update({
+            where: { id: field.id },
+            data: patch,
+            select: { id: true, name: true, type: true },
+          })
+          .unwrap();
+      }
+
+      if (params.is_unique !== undefined) {
+        const existingUniqueId = findUniqueConstraintId(table, field.id);
+        if (params.is_unique && !existingUniqueId) {
+          try {
+            await api.uniqueConstraint
+              .create({
+                data: {
+                  tableId: table.id,
+                  databaseId,
+                  fieldIds: [field.id],
+                  name: `${table.name}_${params.new_name ?? field.name}_key`,
+                  type: 'u',
+                },
+                select: { id: true },
+              })
+              .unwrap();
+          } catch (err) {
+            console.warn('Failed to create unique constraint:', err);
+          }
+        } else if (!params.is_unique && existingUniqueId) {
+          try {
+            await api.uniqueConstraint
+              .delete({ where: { id: existingUniqueId }, select: { id: true } })
+              .unwrap();
+          } catch (err) {
+            console.warn('Failed to delete unique constraint:', err);
+          }
+        }
+      }
+
+      return ok(`Updated field ${params.table_name}.${params.field_name}`);
+    } catch (err) {
+      return fail(err instanceof Error ? err.message : 'Failed to update field');
+    }
+  },
+};
+
+// ── delete_field ──────────────────────────────────────────────────────────
+
+const DeleteFieldZod = z.object({
+  table_name: z.string().describe('Name of the table containing the field'),
+  field_name: z.string().describe('Name of the field to delete'),
+});
+const DeleteFieldSchema = toolSchema(DeleteFieldZod);
+
+export const deleteFieldTool: ToolDefinition<typeof DeleteFieldSchema, MutationDetails> = {
+  name: 'delete_field',
+  label: 'Delete field',
+  description: 'Permanently delete a field (column) from an existing table.',
+  promptSnippet: 'delete_field: drop a column from a table by name. Destructive — gated.',
+  parameters: DeleteFieldSchema,
+  async execute(_id, params: z.infer<typeof DeleteFieldZod>, _signal, _onUpdate, ctx) {
+    const resolved = await resolveProjectContext(ctx.cwd);
+    if (!resolved.context) return fail(resolved.reason);
+    try {
+      const schema = await resolveSchema(resolved.context);
+      const table = resolveTable(schema, params.table_name);
+      const field = resolveField(table, params.field_name);
+      await resolved.context.api.field
+        .delete({ where: { id: field.id }, select: { id: true } })
+        .unwrap();
+      return ok(`Deleted field ${params.table_name}.${params.field_name}`);
+    } catch (err) {
+      return fail(err instanceof Error ? err.message : 'Failed to delete field');
+    }
+  },
+};

--- a/agentic/pi/src/tools/provision-blueprint.ts
+++ b/agentic/pi/src/tools/provision-blueprint.ts
@@ -1,0 +1,158 @@
+import {
+  type Blueprint,
+  BlueprintZod,
+  expandBlueprintDefaults,
+  filterInternalPolicies,
+} from '@agentic-kit/harness';
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
+
+import { resolveProjectContext } from '../context';
+import { toolSchema } from '../tool-schema';
+
+const BlueprintSchema = toolSchema(BlueprintZod);
+
+type Params = Blueprint;
+
+type ProvisionedField = {
+  name: string;
+  type: string;
+  isRequired: boolean;
+  defaultValue: string | null;
+};
+
+type ProvisionedTable = {
+  name: string;
+  fields: ProvisionedField[];
+  policies: string[];
+  relationCount: number;
+};
+
+export type ProvisionBlueprintDetails = {
+  created: number;
+  total: number;
+  tables: ProvisionedTable[];
+  error: string | null;
+};
+
+function formatText(name: string, details: ProvisionBlueprintDetails): string {
+  if (details.error) return `Failed to provision "${name}": ${details.error}`;
+  const lines = [`Created ${details.created} table${details.created === 1 ? '' : 's'} from "${name}":`];
+  for (const table of details.tables) {
+    const parts = [`${table.fields.length} field${table.fields.length === 1 ? '' : 's'}`];
+    if (table.relationCount > 0) {
+      parts.push(`${table.relationCount} relation${table.relationCount === 1 ? '' : 's'}`);
+    }
+    if (table.policies.length > 0) {
+      parts.push(`policies: ${table.policies.map((policy) => policy.replace(/^Authz/, '')).join(', ')}`);
+    }
+    lines.push(`  - ${table.name} (${parts.join(', ')})`);
+  }
+  return lines.join('\n');
+}
+
+export const provisionBlueprintTool: ToolDefinition<typeof BlueprintSchema, ProvisionBlueprintDetails> =
+  {
+    name: 'provision_blueprint',
+    label: 'Provision blueprint',
+    description:
+      'Create one or more related tables (with fields, RLS policies, and relations) in the project database from a blueprint definition. Always put related tables in a SINGLE call so relations are created together.',
+    promptSnippet:
+      'provision_blueprint: create new tables from scratch in a single call (fields + policies + relations). Call describe_schema first.',
+    parameters: BlueprintSchema,
+    async execute(_toolCallId, params: Params, _signal, _onUpdate, ctx) {
+      const empty: ProvisionBlueprintDetails = { created: 0, total: 0, tables: [], error: null };
+
+      const resolved = await resolveProjectContext(ctx.cwd);
+      if (!resolved.context) {
+        return { content: [{ type: 'text', text: resolved.reason }], details: empty };
+      }
+
+      const { modules, databaseId, schemaId, ownerId } = resolved.context;
+      if (!ownerId) {
+        return {
+          content: [{ type: 'text', text: 'Not authenticated (missing OWNER_ID in .env).' }],
+          details: empty,
+        };
+      }
+
+      const definition = expandBlueprintDefaults(params.definition);
+      const uniqueName = `${params.name}_${Date.now()}`;
+
+      try {
+        const createResult = await modules.blueprint
+          .create({
+            data: {
+              ownerId,
+              databaseId,
+              name: uniqueName,
+              displayName: params.name,
+              description: params.description,
+              definition,
+            },
+            select: { id: true, name: true },
+          })
+          .unwrap();
+
+        const blueprintId = createResult.createBlueprint?.blueprint?.id;
+        if (!blueprintId) throw new Error('Failed to create blueprint');
+
+        const constructResult = await modules.mutation
+          .constructBlueprint(
+            { input: { blueprintId, schemaId } },
+            { select: { result: true } },
+          )
+          .unwrap();
+
+        const result = constructResult.constructBlueprint?.result;
+
+        if (!result) {
+          const constructions = await modules.blueprintConstruction
+            .findMany({
+              where: { blueprintId: { equalTo: blueprintId } },
+              orderBy: ['ID_DESC'],
+              first: 1,
+              select: { status: true, errorDetails: true },
+            })
+            .unwrap();
+
+          const error =
+            constructions?.blueprintConstructions?.nodes?.[0]?.errorDetails ?? 'Unknown error';
+          const details: ProvisionBlueprintDetails = {
+            created: 0,
+            total: params.definition.tables.length,
+            tables: [],
+            error: typeof error === 'string' ? error : JSON.stringify(error),
+          };
+          return { content: [{ type: 'text', text: formatText(params.name, details) }], details };
+        }
+
+        const relations = params.definition.relations ?? [];
+        const details: ProvisionBlueprintDetails = {
+          created: params.definition.tables.length,
+          total: params.definition.tables.length,
+          tables: params.definition.tables.map((t) => ({
+            name: t.table_name,
+            fields: (t.fields ?? []).map((f) => ({
+              name: f.name,
+              type: f.type,
+              isRequired: f.is_required ?? false,
+              defaultValue: f.default ?? null,
+            })),
+            policies: filterInternalPolicies(t.policies.map((p) => p.$type)),
+            relationCount: relations.filter((r) => r.source_table === t.table_name).length,
+          })),
+          error: null,
+        };
+        return { content: [{ type: 'text', text: formatText(params.name, details) }], details };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Failed to provision blueprint';
+        const details: ProvisionBlueprintDetails = {
+          created: 0,
+          total: params.definition.tables.length,
+          tables: [],
+          error: message,
+        };
+        return { content: [{ type: 'text', text: formatText(params.name, details) }], details };
+      }
+    },
+  };

--- a/agentic/pi/src/tools/provision-database.ts
+++ b/agentic/pi/src/tools/provision-database.ts
@@ -1,0 +1,309 @@
+import { writeFile } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
+import { z } from 'zod';
+
+import { getHost } from '../host';
+import { toolSchema } from '../tool-schema';
+
+import { prewarmAppWorkspace } from '../app-workspace';
+import { probeDatabase } from '../db-probe';
+import { createDatabaseProvision } from '../provision-database/create-database-provision';
+import { selectProvisionCredential } from '../provision-database/credential';
+import {
+  archiveBindingKeys,
+  ARCHIVED_BINDING_KEYS,
+  mergeEnv,
+  provisionEnvVars,
+} from '../provision-database/env-file';
+import { DEFAULT_PROVISION_MODULES } from '../provision-database/modules';
+import { applySqlFixups } from '../provision-database/pg-fixups';
+
+const DEFAULT_API_ENDPOINT = 'http://api.localhost:3000/graphql';
+const DEFAULT_MODULES_ENDPOINT = 'http://modules.localhost:3000/graphql';
+
+// The per-DB endpoints are subdomain.<domain>; the provisioning domain is the api
+// endpoint's host minus its first label (api.localhost -> localhost,
+// api.launchql.dev -> launchql.dev), so dev and devnet both provision correctly.
+function provisionDomain(apiEndpoint: string): string {
+  try {
+    const { hostname } = new URL(apiEndpoint);
+    // A bare IP host has no domain hierarchy to strip: dropping its first label
+    // ('192.168.1.10' -> '168.1.10') would yield a garbage domain. Use it verbatim.
+    if (hostname.includes(':') || /^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)) return hostname;
+    const parts = hostname.split('.');
+    return parts.length > 1 ? parts.slice(1).join('.') : parts.join('.');
+  } catch {
+    return 'localhost';
+  }
+}
+
+const ProvisionDatabaseZod = z.object({
+  database_name: z
+    .string()
+    .describe(
+      'Name for the app database (lowercase, alphanumeric + underscores). Doubles as the deterministic provisioning subdomain (api-<name>/auth-<name>/app-<name>.localhost), so keep it short and URL-safe.',
+    ),
+  reprovision: z
+    .boolean()
+    .describe(
+      'Mint a fresh database even though the project already carries a binding — use when the bound database no longer exists on this backend (refreshed backend, deleted database), when it belongs to a different account than the one signed in, or when the user asks for a clean rebuild. The old .env keys are archived as comments and the old database is never deleted server-side. The schema must be rebuilt afterwards (provision_blueprint + run_codegen); records do not carry over.',
+    )
+    .optional(),
+});
+const ProvisionDatabaseSchema = toolSchema(ProvisionDatabaseZod);
+
+type Params = z.infer<typeof ProvisionDatabaseZod>;
+
+export type ProvisionDatabaseDetails = {
+  success: boolean;
+  message: string;
+  databaseId?: string;
+  databaseName?: string;
+  ownerId?: string;
+  fixupNote?: string;
+  /** True when an existing live binding was kept — nothing changed. */
+  skipped?: boolean;
+};
+
+type ToolResult = { content: { type: 'text'; text: string }[]; details: ProvisionDatabaseDetails };
+
+function fail(message: string): ToolResult {
+  return { content: [{ type: 'text', text: message }], details: { success: false, message } };
+}
+
+// Minimal .env reader for the idempotency check (full parsing lives in context.ts).
+function parseEnvKeys(source: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const rawLine of source.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq === -1) continue;
+    env[line.slice(0, eq).trim()] = line.slice(eq + 1).trim();
+  }
+  return env;
+}
+
+async function withRetry<T>(fn: () => Promise<T>, maxRetries = 5, delayMs = 2000): Promise<T> {
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('already exists') || msg.includes('exists')) throw err;
+      if (attempt === maxRetries) throw err;
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+  }
+  throw new Error('unreachable');
+}
+
+export const provisionDatabaseTool: ToolDefinition<
+  typeof ProvisionDatabaseSchema,
+  ProvisionDatabaseDetails
+> = {
+  name: 'provision_database',
+  label: 'Provision database',
+  description:
+    'Bootstrap a new Constructive database for the project under your account: provision the standard module set, enable membership defaults, and write credentials (DATABASE_ID, ACCESS_TOKEN, etc.) to the project .env. Run this ONCE before any schema/record tools. If the project is already bound to a live database under the signed-in account it skips; if the bound database no longer exists on this backend (refreshed/deleted) or belongs to a different account, pass reprovision: true to mint a fresh one (old keys archived in .env, old database kept; rebuild the schema afterwards).',
+  promptSnippet:
+    'provision_database: one-time bootstrap of the project database (owner + modules + .env). Run before describe_schema/provision_blueprint. Skips when the existing binding is live under the signed-in account; reprovision: true replaces a dead or foreign-account binding (archives old keys, never deletes the old db). Gated.',
+  parameters: ProvisionDatabaseSchema,
+  async execute(_id, params: Params, _signal, _onUpdate, ctx): Promise<ToolResult> {
+    const databaseName = params.database_name.trim();
+    if (!databaseName) return fail('database_name is required.');
+
+    const envPath = path.join(ctx.cwd, '.env');
+    let existing = '';
+    try {
+      existing = await readFile(envPath, 'utf8');
+    } catch {
+      /* no existing .env — fine */
+    }
+
+    // Unify endpoints onto the app's backend-config store (environment-aware:
+    // *.localhost:3000 in dev, *.launchql.dev packaged). A process.env override
+    // still wins for ad-hoc dev; the hardcoded default is a last resort if the
+    // store isn't ready.
+    const host = getHost();
+    const backend = host.backendConfig();
+    const apiEndpoint = process.env.API_ENDPOINT || backend?.apiEndpoint || DEFAULT_API_ENDPOINT;
+    const modulesEndpoint =
+      process.env.MODULES_ENDPOINT || backend?.modulesEndpoint || DEFAULT_MODULES_ENDPOINT;
+
+    // Every new project provisions UNDER the account (owner_id = the account user),
+    // so the database is account-owned and enumerable. The account bearer is the
+    // single credential: it authenticates the provision mutation, the idempotency
+    // probe below, and is the ACCESS_TOKEN written to .env for project-local
+    // scripts. It expires with the login session — a relogin plus any provision
+    // run (including the skip path) refreshes the .env copy. A signed-in session
+    // with no usable bearer errors out here rather than silently minting a
+    // throwaway owner. Gate BEFORE prewarm so an error return doesn't leak a
+    // detached background scaffold/install.
+    const credential = selectProvisionCredential(host.account());
+    if (credential.mode === 'error') {
+      return fail(`Cannot provision a database: ${credential.reason}`);
+    }
+    const ownerId = credential.ownerId;
+
+    // Idempotency keyed on binding liveness AND ownership: a binding is done only
+    // when its database still answers and belongs to the signed-in account
+    // (schemas are account-scoped). A dead binding (backend refreshed, database
+    // deleted, key revoked) or a live one under another account points at the
+    // reprovision path; an unreachable backend is a retry, never a reprovision.
+    const existingEnv = parseEnvKeys(existing);
+    const hasBinding = Boolean(existingEnv.DATABASE_ID && existingEnv.ACCESS_TOKEN);
+    if (hasBinding && !params.reprovision) {
+      // The probe carries the account bearer, so it only ever targets the
+      // app-configured backend — never a .env-pinned endpoint, which an
+      // untrusted cloned project controls.
+      const probe = await probeDatabase({
+        endpoint: apiEndpoint,
+        bearer: credential.bearer,
+        databaseId: existingEnv.DATABASE_ID,
+      });
+      if (probe.outcome === 'unreachable') {
+        return fail(
+          `Cannot verify the existing database binding: backend unreachable (${probe.detail}). Check the Constructive backend is running, then retry — do not reprovision on an unreachable backend.`,
+        );
+      }
+      if (probe.outcome === 'missing') {
+        return fail(
+          `Project carries a binding (DATABASE_ID=${existingEnv.DATABASE_ID}) but that database no longer exists on this backend. Re-run with reprovision: true to mint a fresh database (old keys archived in .env, old database untouched), then rebuild the schema (provision_blueprint + run_codegen); records do not carry over.`,
+        );
+      }
+      const sessionUserId = host.account()?.userId;
+      if (probe.ownerId && sessionUserId && probe.ownerId !== sessionUserId) {
+        return fail(
+          `Project carries a binding (DATABASE_ID=${existingEnv.DATABASE_ID}) but that database was provisioned under a different account than the one signed in. Re-run with reprovision: true to mint a fresh database under this account (old keys archived in .env, old database untouched), then rebuild the schema (provision_blueprint + run_codegen); records do not carry over.`,
+        );
+      }
+      // Heal .env on the skip path: a stale token (relogin) or missing/stale
+      // endpoint pins (project provisioned before pins existed, or backend
+      // config changed) refresh to the current session + backend.
+      const refresh: Record<string, string> = {};
+      if (existingEnv.ACCESS_TOKEN !== credential.bearer) refresh.ACCESS_TOKEN = credential.bearer;
+      if (existingEnv.API_ENDPOINT !== apiEndpoint) refresh.API_ENDPOINT = apiEndpoint;
+      if (existingEnv.MODULES_ENDPOINT !== modulesEndpoint) {
+        refresh.MODULES_ENDPOINT = modulesEndpoint;
+      }
+      let tokenNote = '';
+      if (Object.keys(refresh).length > 0) {
+        const keys = Object.keys(refresh).join(', ');
+        try {
+          await writeFile(envPath, mergeEnv(existing, refresh));
+          tokenNote = ` Refreshed in .env from the signed-in session: ${keys}.`;
+        } catch (err) {
+          tokenNote = ` Could not refresh ${keys} in .env: ${err instanceof Error ? err.message : String(err)}.`;
+        }
+      }
+      const message = `Project already provisioned (DATABASE_ID=${existingEnv.DATABASE_ID}) and the database is live under this account. Skipping — pass reprovision: true only for an explicit clean rebuild.${tokenNote}`;
+      return {
+        content: [{ type: 'text', text: message }],
+        details: {
+          success: true,
+          message,
+          databaseId: existingEnv.DATABASE_ID,
+          databaseName: existingEnv.DATABASE_NAME,
+          ownerId: existingEnv.OWNER_ID,
+          skipped: true,
+        },
+      };
+    }
+    if (hasBinding && params.reprovision) {
+      existing = archiveBindingKeys(
+        existing,
+        ARCHIVED_BINDING_KEYS,
+        new Date().toISOString().slice(0, 10),
+      );
+    }
+
+    // The packages/app scaffold + pnpm install are database-INDEPENDENT, so kick
+    // them off now to run concurrently with the ~90s provisioning mutation below.
+    // This keeps clone + install off run_codegen's critical path. Best-effort:
+    // run_codegen re-runs the same idempotent steps, so a prewarm failure is
+    // harmless. Never let it reject (we await it before returning).
+    const prewarm = prewarmAppWorkspace(ctx.cwd).catch(
+      (err: unknown): { ok: boolean; out: string } => ({
+        ok: false,
+        out: err instanceof Error ? err.message : String(err),
+      }),
+    );
+
+    const physicalDb = process.env.CONSTRUCTIVE_DB || 'constructive';
+
+    // Provision on the MODULES endpoint: createDatabaseProvisionModule creates
+    // the database owned by ownerId, provisions the module set, and bootstraps
+    // the owner into it before the row returns. The domain still derives from
+    // the api endpoint's host (per-DB endpoints live under it), and an explicit
+    // subdomain (= databaseName) keeps them deterministic (SUBDOMAIN-001).
+    let databaseId: string;
+    try {
+      ({ databaseId } = await withRetry(() =>
+        createDatabaseProvision({
+          endpoint: modulesEndpoint,
+          bearer: credential.bearer,
+          databaseName,
+          domain: provisionDomain(apiEndpoint),
+          ownerId,
+          modules: DEFAULT_PROVISION_MODULES,
+        }),
+      ));
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      const nameTakenHint = /already exists|already taken|already in use|duplicate/i.test(detail)
+        ? ' The database name is already taken on the backend — re-run with a different database_name.'
+        : '';
+      return fail(`Database provisioning failed: ${detail}.${nameTakenHint}`);
+    }
+
+    // Enable membership defaults + naming settings at the SQL level. Best-effort:
+    // provisioning already succeeded, so a fixup failure is a warning, not an error.
+    const fixup = await applySqlFixups({ databaseName, physicalDb });
+
+    // Persist the binding to the project .env (upsert, preserving other keys).
+    const merged = mergeEnv(
+      existing,
+      provisionEnvVars({
+        databaseId,
+        databaseName,
+        ownerId,
+        accessToken: credential.bearer,
+        apiEndpoint,
+        modulesEndpoint,
+      }),
+    );
+    try {
+      await writeFile(envPath, merged);
+    } catch (err) {
+      return fail(
+        `Database provisioned (ID: ${databaseId}) but writing .env failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    // Settle the concurrent prewarm so the scaffold + install are in place before
+    // run_codegen runs. A failure here is non-fatal — run_codegen redoes the work.
+    const prewarmResult = await prewarm;
+    const prewarmNote = prewarmResult.ok ? ' packages/app prewarmed.' : '';
+
+    const reprovisionNote =
+      hasBinding && params.reprovision
+        ? ' Previous binding archived in .env (old database kept); rebuild the schema with provision_blueprint + run_codegen.'
+        : '';
+    const message = `Provisioned database "${databaseName}" (ID: ${databaseId}). Credentials written to .env. ${fixup.note}${prewarmNote}${reprovisionNote}`;
+    return {
+      content: [{ type: 'text', text: message }],
+      details: {
+        success: true,
+        message,
+        databaseId,
+        databaseName,
+        ownerId,
+        fixupNote: fixup.note,
+      },
+    };
+  },
+};

--- a/agentic/pi/src/tools/run-codegen.ts
+++ b/agentic/pi/src/tools/run-codegen.ts
@@ -1,0 +1,196 @@
+import { existsSync } from 'node:fs';
+import { readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
+import { z } from 'zod';
+
+import { getHost } from '../host';
+import { toolSchema } from '../tool-schema';
+
+import {
+  ensureAppScaffold,
+  ensureWorkspaceConfig,
+  IGNORED_BUILDS_RE,
+  pinCodegenLatest,
+  prewarmAppWorkspace,
+  run,
+} from '../app-workspace';
+import { normalizeSdkBarrels } from '../run-codegen/barrels';
+import { codegenEndpointEnv, derivePlaneEndpoints, envLocalContent } from '../run-codegen/endpoints';
+
+const DEFAULT_API_ENDPOINT = 'http://api.localhost:3000/graphql';
+
+const RunCodegenZod = z.object({});
+const RunCodegenSchema = toolSchema(RunCodegenZod);
+
+type Params = z.infer<typeof RunCodegenZod>;
+
+export type RunCodegenDetails = {
+  success: boolean;
+  message: string;
+  barrelsRewritten?: number;
+  generatedSubmodules?: string[];
+};
+
+type ToolResult = { content: { type: 'text'; text: string }[]; details: RunCodegenDetails };
+
+function fail(message: string): ToolResult {
+  return { content: [{ type: 'text', text: message }], details: { success: false, message } };
+}
+
+const FETCH_RESET_RE = /Failed to fetch schema|Connection reset|ECONNRESET|socket hang up/i;
+
+// Read the binding provision_database wrote to the project .env. The
+// API_ENDPOINT pin identifies which backend owns the binding — it wins over
+// the app's current backend config, matching context.ts data-plane precedence.
+async function readProjectEnv(
+  cwd: string,
+): Promise<{ databaseName?: string; apiEndpoint?: string }> {
+  try {
+    const env = await readFile(path.join(cwd, '.env'), 'utf8');
+    const read = (key: string) => env.match(new RegExp(`^${key}=(.+)$`, 'm'))?.[1]?.trim();
+    return { databaseName: read('DATABASE_NAME'), apiEndpoint: read('API_ENDPOINT') };
+  } catch {
+    return {};
+  }
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// The codegen CLI introspects three live vhosts (admin/auth/app). Under load the
+// Constructive backend intermittently resets a connection mid-introspection
+// ("Failed to fetch schema: Connection reset"), which is transient — a retry
+// almost always clears it. Re-run the whole generate (it rebuilds all targets)
+// up to `attempts` times, only on a fetch/reset failure; any other failure is
+// real and returned immediately (CODEGEN-RETRY-001).
+async function runCodegenWithRetry(
+  appDir: string,
+  env: Record<string, string>,
+  attempts = 4,
+): Promise<{ ok: boolean; out: string }> {
+  const sdk = path.join(appDir, 'src', 'graphql', 'sdk');
+  let last: { ok: boolean; out: string } = { ok: false, out: 'codegen never ran' };
+  for (let i = 1; i <= attempts; i++) {
+    for (const sub of ['admin', 'auth', 'app']) {
+      await rm(path.join(sdk, sub), { recursive: true, force: true });
+    }
+    last = await run(
+      'npx',
+      ['@constructive-io/graphql-codegen', 'generate', '--config', './graphql-codegen.config.ts'],
+      appDir,
+      env,
+    );
+    if (last.ok) return last;
+    if (!FETCH_RESET_RE.test(last.out)) return last;
+    if (i < attempts) await sleep(2000 * i);
+  }
+  return last;
+}
+
+export const runCodegenTool: ToolDefinition<typeof RunCodegenSchema, RunCodegenDetails> = {
+  name: 'run_codegen',
+  label: 'Run codegen',
+  description:
+    "Generate the typed GraphQL SDK for the project's Next.js app (packages/app). Runs the exact deterministic sequence — scaffold packages/app from the constructive-app template if it doesn't exist yet, hoist the graphql override to the root workspace so a single grafast resolves, pin codegen to latest, do one clean install, run codegen (retrying transient backend connection resets), and normalize SDK barrels for Turbopack. Run AFTER provisioning the database and creating schema; it scaffolds packages/app itself, so no separate `pgpm init` step is needed. The scaffold + install are usually prewarmed during provision_database, so this is fast.",
+  promptSnippet:
+    'run_codegen: scaffold packages/app (if missing) + regenerate the typed SDK (workspace-config + clean install + codegen-with-retry + barrel-normalize). Run after schema changes. Gated.',
+  parameters: RunCodegenSchema,
+  async execute(_id, _params: Params, _signal, _onUpdate, ctx): Promise<ToolResult> {
+    const cwd = ctx.cwd;
+    const appDir = path.join(cwd, 'packages', 'app');
+
+    // Materialize packages/app deterministically if it isn't there yet — this
+    // replaces the flaky `pgpm init` scaffold step (PGPM-001). When
+    // provision_database prewarmed it, this no-ops.
+    const scaffold = await ensureAppScaffold(cwd);
+    if (!scaffold.ok) {
+      return fail(scaffold.out);
+    }
+
+    const { databaseName: dbName, apiEndpoint: envApiEndpoint } = await readProjectEnv(cwd);
+    if (!dbName) {
+      return fail('DATABASE_NAME missing from .env — provision the database first, then re-run.');
+    }
+
+    const backend = getHost().backendConfig();
+    const apiEndpoint = envApiEndpoint || backend?.apiEndpoint || DEFAULT_API_ENDPOINT;
+    const planes = derivePlaneEndpoints(apiEndpoint, dbName);
+
+    // The dev server reads .env.local (NEXT_PUBLIC_DB_NAME + per-DB endpoint
+    // overrides so it doesn't fall back to localhost vhosts on a remote
+    // backend); the codegen config reads process.env (passed directly below).
+    try {
+      await writeFile(path.join(appDir, '.env.local'), envLocalContent(dbName, planes));
+    } catch (err) {
+      return fail(
+        `Failed to write packages/app/.env.local: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    // Hoist the graphql override to the root workspace (PNPM-GRAPHQL-OVERRIDE-001)
+    // and pin codegen to latest (TS-001) before the single clean install. When
+    // prewarmed by provision_database these are idempotent and the install is a
+    // fast no-op; otherwise this is the first install (PNPM-BUILDS-001).
+    await ensureWorkspaceConfig(cwd);
+    await pinCodegenLatest(appDir);
+
+    const install = await run('pnpm', ['install', '--no-frozen-lockfile'], cwd);
+    if (!install.ok && !IGNORED_BUILDS_RE.test(install.out)) {
+      return fail(`pnpm install failed:\n${install.out}`);
+    }
+
+    const codegen = await runCodegenWithRetry(appDir, {
+      NEXT_PUBLIC_DB_NAME: dbName,
+      ...(planes ? codegenEndpointEnv(planes) : {}),
+    });
+    if (!codegen.ok) {
+      // A reset that survives every internal retry is a backend OUTAGE, not a code
+      // or install problem — re-running run_codegen cannot fix it. Say so explicitly
+      // so the agent marks sdk-codegen `blocked` instead of looping the tool to the
+      // time cap (CODEGEN-OUTAGE-001 / THRASH-001).
+      if (FETCH_RESET_RE.test(codegen.out)) {
+        return fail(
+          'codegen failed: BACKEND OUTAGE — the Constructive backend reset the connection ' +
+            'during schema introspection, and it stayed down across every internal retry. ' +
+            'This is an EXTERNAL outage, not a code or install problem; re-running run_codegen ' +
+            'will NOT fix it. Call run_preflight once — if the backend is down, mark ' +
+            'sdk-codegen `blocked` (SERVER-001, BLOCKED-PROCEED-001) and hand back to ' +
+            'build-orchestrator. Do NOT loop on run_codegen (THRASH-001).\n\n' +
+            codegen.out,
+        );
+      }
+      return fail(`codegen failed:\n${codegen.out}`);
+    }
+
+    // Normalize directory barrels so Turbopack can resolve them (TURBOPACK-BARREL-001).
+    const sdkRoot = path.join(appDir, 'src', 'graphql', 'sdk');
+    const barrelsRewritten = normalizeSdkBarrels(sdkRoot);
+
+    // Report which app submodules actually generated — a bare scaffold with only
+    // index.ts means codegen had no schema to generate against.
+    const appSdk = path.join(sdkRoot, 'app');
+    const generatedSubmodules = ['hooks', 'orm', 'types'].filter((sub) =>
+      existsSync(path.join(appSdk, sub)),
+    );
+
+    const message =
+      generatedSubmodules.length > 0
+        ? `Codegen complete. Generated app submodules: ${generatedSubmodules.join(', ')}. Normalized ${barrelsRewritten} barrel file(s).`
+        : `Codegen ran, but no app submodules (hooks/orm/types) were generated — the database may have no entity tables yet. Normalized ${barrelsRewritten} barrel file(s).`;
+
+    return {
+      content: [{ type: 'text', text: message }],
+      details: {
+        success: generatedSubmodules.length > 0,
+        message,
+        barrelsRewritten,
+        generatedSubmodules,
+      },
+    };
+  },
+};
+
+// Re-exported so provision_database can prewarm the same deterministic scaffold +
+// install concurrently with its backend mutation (kept off run_codegen's path).
+export { prewarmAppWorkspace };

--- a/agentic/pi/src/tools/templates.ts
+++ b/agentic/pi/src/tools/templates.ts
@@ -1,0 +1,432 @@
+import { type ConfirmPreviewTable, filterInternalPolicies } from '@agentic-kit/harness';
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
+import { z } from 'zod';
+
+import type { ModulesClient, ProjectContext } from '../context';
+import { resolveProjectContext } from '../context';
+import { toolSchema } from '../tool-schema';
+
+export type TemplateDetails = {
+  success: boolean;
+  message: string;
+};
+
+export type CreateTemplateDetails = TemplateDetails & {
+  displayName?: string;
+  blueprintName?: string;
+  tables?: ConfirmPreviewTable[];
+};
+
+type TemplateField = {
+  name: string;
+  type: string;
+  isRequired: boolean;
+  defaultValue: string | null;
+};
+
+type TemplateTable = {
+  name: string;
+  fields: TemplateField[];
+  policies: string[];
+  relationCount: number;
+};
+
+type TemplateInfo = {
+  displayName: string;
+  description: string | null;
+  categories: string[];
+  tables: TemplateTable[];
+};
+
+export type ListTemplatesDetails = { templates: TemplateInfo[] };
+
+// A stored blueprint field's `type` is an expanded object (`{ name: 'text' }`),
+// not the bare string the agent passes to provision_blueprint. Flatten it to the
+// type name so the renderer gets a string, never an object (which React can't
+// render as a child).
+function fieldTypeName(raw: unknown): string {
+  if (typeof raw === 'string') return raw;
+  if (raw && typeof raw === 'object' && typeof (raw as { name?: unknown }).name === 'string') {
+    return (raw as { name: string }).name;
+  }
+  return '';
+}
+
+// A template's definition is a stored blueprint (see BlueprintDefinitionSchema):
+// { tables: [{ table_name, fields, policies }], relations: [{ source_table, … }] }.
+// Parse it into the same table shape provision_blueprint surfaces so the renderer
+// can reuse TableCard. Defensive throughout — it's untyped JSON from the catalog.
+function parseTemplateTables(definition: unknown): TemplateTable[] {
+  if (!definition || typeof definition !== 'object') return [];
+  const def = definition as { tables?: unknown; relations?: unknown };
+  const tables = Array.isArray(def.tables) ? def.tables : [];
+  const relations = Array.isArray(def.relations) ? def.relations : [];
+  return tables.map((raw) => {
+    const table = raw as { table_name?: string; fields?: unknown; policies?: unknown };
+    const fields = Array.isArray(table.fields) ? table.fields : [];
+    const policies = Array.isArray(table.policies) ? table.policies : [];
+    return {
+      name: table.table_name ?? '',
+      fields: fields.map((rawField) => {
+        const field = rawField as {
+          name?: string;
+          type?: unknown;
+          is_required?: boolean;
+          default?: unknown;
+        };
+        return {
+          name: field.name ?? '',
+          type: fieldTypeName(field.type),
+          isRequired: field.is_required ?? false,
+          defaultValue: typeof field.default === 'string' ? field.default : null,
+        };
+      }),
+      policies: filterInternalPolicies(
+        policies.map((policy) => (policy as { $type?: string }).$type ?? '').filter(Boolean),
+      ),
+      relationCount: relations.filter(
+        (relation) => (relation as { source_table?: string }).source_table === table.table_name,
+      ).length,
+    };
+  });
+}
+
+function formatTemplatesText(templates: TemplateInfo[]): string {
+  if (templates.length === 0) return 'No blueprint templates available.';
+  const lines = [`Available blueprint templates (${templates.length}):`];
+  for (const template of templates) {
+    const cats = template.categories.length ? ` [${template.categories.join(', ')}]` : '';
+    lines.push(`  ${template.displayName} — ${template.tables.length} tables${cats}`);
+    for (const table of template.tables) {
+      lines.push(`    - ${table.name} (${table.fields.length} field${table.fields.length === 1 ? '' : 's'})`);
+    }
+  }
+  return lines.join('\n');
+}
+
+// The latest project blueprint (or a named one) — the definition source for
+// create_template, and for the confirm preview of the tables it will template.
+// A blueprintName is a best-effort hint: if it matches nothing (the agent often
+// guesses casing/wording), fall back to the most recent blueprint so the confirm
+// still previews real tables and execute templates the same one it previewed.
+async function fetchLatestBlueprint(
+  context: ProjectContext,
+  blueprintName: string | undefined,
+) {
+  const found = await context.modules.blueprint
+    .findMany({
+      select: { displayName: true, definition: true },
+      where: {
+        databaseId: { equalTo: context.databaseId },
+        ...(blueprintName ? { displayName: { equalTo: blueprintName } } : {}),
+      },
+      orderBy: ['CREATED_AT_DESC'],
+      first: 1,
+    })
+    .unwrap();
+  return found.blueprints?.nodes?.[0];
+}
+
+async function findProjectBlueprint(
+  context: ProjectContext,
+  blueprintName: string | undefined,
+): Promise<{ displayName: string; definition: unknown } | null> {
+  let node = await fetchLatestBlueprint(context, blueprintName);
+  if (!node && blueprintName) node = await fetchLatestBlueprint(context, undefined);
+  return node?.definition ? { displayName: node.displayName ?? '', definition: node.definition } : null;
+}
+
+export type CreateTemplatePreview = {
+  blueprintName: string;
+  tables: ConfirmPreviewTable[];
+};
+
+// The create_template confirm preview — the source blueprint's name and its
+// tables, parsed into the shape the renderer's TableCard reuses. Best-effort: any
+// failure yields no tables rather than blocking the confirm.
+export async function createTemplatePreviewTables(
+  context: ProjectContext,
+  blueprintName: string | undefined,
+): Promise<CreateTemplatePreview> {
+  try {
+    const blueprint = await findProjectBlueprint(context, blueprintName);
+    if (!blueprint) return { blueprintName: '', tables: [] };
+    return {
+      blueprintName: blueprint.displayName,
+      tables: parseTemplateTables(blueprint.definition),
+    };
+  } catch (err) {
+    console.warn('[db-tools] create_template preview lookup failed:', err);
+    return { blueprintName: '', tables: [] };
+  }
+}
+
+async function resolveTemplateId(client: ModulesClient, displayName: string): Promise<string> {
+  const result = await client.blueprintTemplate
+    .findMany({
+      select: { id: true, displayName: true },
+      where: { displayName: { equalTo: displayName } },
+      first: 1,
+    })
+    .unwrap();
+
+  const template = result.blueprintTemplates?.nodes?.[0];
+  if (!template?.id) throw new Error(`Template "${displayName}" not found`);
+  return template.id;
+}
+
+function done(success: boolean, message: string) {
+  return { content: [{ type: 'text' as const, text: message }], details: { success, message } };
+}
+
+// ── list_templates ────────────────────────────────────────────────────────
+
+const ListTemplatesZod = z.object({});
+const ListTemplatesSchema = toolSchema(ListTemplatesZod);
+
+export const listTemplatesTool: ToolDefinition<typeof ListTemplatesSchema, ListTemplatesDetails> = {
+  name: 'list_templates',
+  label: 'List templates',
+  description:
+    'List the blueprint templates available to provision into the project database (display name, description, categories, table count). Read-only — these are a global catalog, not the project schema.',
+  promptSnippet:
+    'list_templates: list the available blueprint templates to apply. Read-only — call before apply_template.',
+  parameters: ListTemplatesSchema,
+  async execute(_id, _params: z.infer<typeof ListTemplatesZod>, _signal, _onUpdate, ctx) {
+    const resolved = await resolveProjectContext(ctx.cwd);
+    if (!resolved.context) {
+      return { content: [{ type: 'text', text: resolved.reason }], details: { templates: [] } };
+    }
+
+    const result = await resolved.context.modules.blueprintTemplate
+      .findMany({
+        select: {
+          displayName: true,
+          description: true,
+          categories: true,
+          definition: true,
+        },
+        orderBy: ['NAME_ASC'],
+      })
+      .execute();
+
+    if (!result.ok) {
+      const message = result.errors.map((e) => e.message).join('; ');
+      return {
+        content: [{ type: 'text', text: `Failed to read templates: ${message}` }],
+        details: { templates: [] },
+      };
+    }
+
+    const templates: TemplateInfo[] = (result.data.blueprintTemplates?.nodes ?? []).map(
+      (template) => ({
+        displayName: template.displayName ?? '',
+        description: template.description ?? null,
+        categories: Array.isArray(template.categories) ? template.categories : [],
+        tables: parseTemplateTables(template.definition),
+      }),
+    );
+
+    return {
+      content: [{ type: 'text', text: formatTemplatesText(templates) }],
+      details: { templates },
+    };
+  },
+};
+
+// ── create_template ───────────────────────────────────────────────────────
+
+const CreateTemplateZod = z.object({
+  displayName: z.string().describe('Display name for the new blueprint template'),
+  blueprintName: z
+    .string()
+    .describe(
+      'Display name of an existing project blueprint to save as the template. Defaults to the most recently provisioned blueprint.',
+    )
+    .optional(),
+  description: z.string().describe('Description shown in the template catalog').optional(),
+  categories: z
+    .array(z.string())
+    .describe('Categories for catalog grouping and discovery')
+    .optional(),
+});
+const CreateTemplateSchema = toolSchema(CreateTemplateZod);
+
+export const createTemplateTool: ToolDefinition<typeof CreateTemplateSchema, CreateTemplateDetails> = {
+  name: 'create_template',
+  label: 'Create template',
+  description:
+    'Save an existing project blueprint into the global template catalog as a reusable blueprint template. Defaults to the most recently provisioned blueprint; pass blueprintName to pick a specific one by display name. Gated.',
+  promptSnippet:
+    'create_template: save a project blueprint to the reusable template catalog. Gated.',
+  parameters: CreateTemplateSchema,
+  async execute(_id, params: z.infer<typeof CreateTemplateZod>, _signal, _onUpdate, ctx) {
+    const resolved = await resolveProjectContext(ctx.cwd);
+    if (!resolved.context) return done(false, resolved.reason);
+    const { modules, ownerId } = resolved.context;
+    if (!ownerId) return done(false, 'Not authenticated (missing OWNER_ID in .env).');
+
+    try {
+      const blueprint = await findProjectBlueprint(resolved.context, params.blueprintName);
+      if (!blueprint) {
+        const which = params.blueprintName ? `"${params.blueprintName}"` : 'any blueprint';
+        return done(false, `No project blueprint found (${which}). Provision a blueprint first.`);
+      }
+
+      const base = params.displayName.toLowerCase().replace(/\s+/g, '_');
+      await modules.blueprintTemplate
+        .create({
+          data: {
+            ownerId,
+            name: `${base}_${Date.now()}`,
+            displayName: params.displayName,
+            description: params.description,
+            categories: params.categories,
+            definition: blueprint.definition as Record<string, unknown>,
+          },
+          select: { id: true, displayName: true },
+        })
+        .unwrap();
+
+      const message = `Created template "${params.displayName}"`;
+      return {
+        content: [{ type: 'text' as const, text: message }],
+        details: {
+          success: true,
+          message,
+          displayName: params.displayName,
+          blueprintName: blueprint.displayName,
+          tables: parseTemplateTables(blueprint.definition),
+        },
+      };
+    } catch (err) {
+      return done(false, err instanceof Error ? err.message : 'Failed to create template');
+    }
+  },
+};
+
+// ── apply_template ────────────────────────────────────────────────────────
+
+const ApplyTemplateZod = z.object({
+  templateName: z.string().describe('The display name of the blueprint template to apply'),
+  nameOverride: z
+    .string()
+    .describe(
+      'Optional name override for the created blueprint (snake_case). Defaults to template name.',
+    )
+    .optional(),
+});
+const ApplyTemplateSchema = toolSchema(ApplyTemplateZod);
+
+export const applyTemplateTool: ToolDefinition<typeof ApplyTemplateSchema, TemplateDetails> = {
+  name: 'apply_template',
+  label: 'Apply template',
+  description:
+    'Apply an existing blueprint template to the project database, creating its tables. Use the template display name (from list_templates).',
+  promptSnippet: 'apply_template: provision a saved blueprint template by display name. Gated.',
+  parameters: ApplyTemplateSchema,
+  async execute(_id, params: z.infer<typeof ApplyTemplateZod>, _signal, _onUpdate, ctx) {
+    const resolved = await resolveProjectContext(ctx.cwd);
+    if (!resolved.context) return done(false, resolved.reason);
+    const { modules, databaseId, schemaId, ownerId } = resolved.context;
+    if (!ownerId) return done(false, 'Not authenticated (missing OWNER_ID in .env).');
+
+    try {
+      const templateId = await resolveTemplateId(modules, params.templateName);
+      const base = params.nameOverride ?? params.templateName.toLowerCase().replace(/\s+/g, '_');
+      const nameOverride = `${base}_${Date.now()}`;
+
+      const copyResult = await modules.mutation
+        .copyTemplateToBlueprint(
+          { input: { templateId, databaseId, ownerId, nameOverride } },
+          { select: { result: true } },
+        )
+        .unwrap();
+
+      const blueprintId = copyResult.copyTemplateToBlueprint?.result;
+      if (!blueprintId) throw new Error('Failed to copy template');
+
+      const constructResult = await modules.mutation
+        .constructBlueprint({ input: { blueprintId, schemaId } }, { select: { result: true } })
+        .unwrap();
+
+      const refMap = constructResult.constructBlueprint?.result;
+      if (!refMap) return done(false, `Construction failed for template "${params.templateName}"`);
+
+      const createdCount = Object.keys(refMap).length;
+      return done(
+        true,
+        `Applied template "${params.templateName}" — created ${createdCount} table${createdCount === 1 ? '' : 's'}`,
+      );
+    } catch (err) {
+      return done(false, err instanceof Error ? err.message : 'Failed to apply template');
+    }
+  },
+};
+
+// ── update_template ───────────────────────────────────────────────────────
+
+const UpdateTemplateZod = z.object({
+  templateName: z.string().describe('The display name of the blueprint template to update'),
+  patch: z.object({
+    displayName: z.string().describe('New display name').optional(),
+    description: z.string().describe('New description').optional(),
+    categories: z.array(z.string()).describe('New categories').optional(),
+    tags: z.array(z.string()).describe('New tags').optional(),
+    visibility: z.enum(['private', 'public']).describe('New visibility').optional(),
+  }),
+});
+const UpdateTemplateSchema = toolSchema(UpdateTemplateZod);
+
+export const updateTemplateTool: ToolDefinition<typeof UpdateTemplateSchema, TemplateDetails> = {
+  name: 'update_template',
+  label: 'Update template',
+  description: 'Update a blueprint template’s metadata (display name, description, categories, tags, visibility).',
+  promptSnippet: 'update_template: edit a saved template’s metadata by display name. Gated.',
+  parameters: UpdateTemplateSchema,
+  async execute(_id, params: z.infer<typeof UpdateTemplateZod>, _signal, _onUpdate, ctx) {
+    const resolved = await resolveProjectContext(ctx.cwd);
+    if (!resolved.context) return done(false, resolved.reason);
+    try {
+      const templateId = await resolveTemplateId(resolved.context.modules, params.templateName);
+      await resolved.context.modules.blueprintTemplate
+        .update({
+          where: { id: templateId },
+          data: params.patch,
+          select: { id: true, displayName: true },
+        })
+        .unwrap();
+      return done(true, `Updated template "${params.templateName}"`);
+    } catch (err) {
+      return done(false, err instanceof Error ? err.message : 'Failed to update template');
+    }
+  },
+};
+
+// ── delete_template ───────────────────────────────────────────────────────
+
+const DeleteTemplateZod = z.object({
+  templateName: z.string().describe('The display name of the blueprint template to delete'),
+});
+const DeleteTemplateSchema = toolSchema(DeleteTemplateZod);
+
+export const deleteTemplateTool: ToolDefinition<typeof DeleteTemplateSchema, TemplateDetails> = {
+  name: 'delete_template',
+  label: 'Delete template',
+  description: 'Permanently delete a blueprint template by its display name.',
+  promptSnippet: 'delete_template: remove a saved template by display name. Destructive — gated.',
+  parameters: DeleteTemplateSchema,
+  async execute(_id, params: z.infer<typeof DeleteTemplateZod>, _signal, _onUpdate, ctx) {
+    const resolved = await resolveProjectContext(ctx.cwd);
+    if (!resolved.context) return done(false, resolved.reason);
+    try {
+      const templateId = await resolveTemplateId(resolved.context.modules, params.templateName);
+      await resolved.context.modules.blueprintTemplate
+        .delete({ where: { id: templateId }, select: { id: true } })
+        .unwrap();
+      return done(true, `Deleted template "${params.templateName}"`);
+    } catch (err) {
+      return done(false, err instanceof Error ? err.message : 'Failed to delete template');
+    }
+  },
+};

--- a/agentic/pi/tsconfig.esm.json
+++ b/agentic/pi/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "es2022",
+    "outDir": "dist/esm"
+  }
+}

--- a/agentic/pi/tsconfig.json
+++ b/agentic/pi/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,29 @@ importers:
         version: link:../protocol/dist
     publishDirectory: dist
 
+  agentic/pi:
+    dependencies:
+      '@agentic-kit/harness':
+        specifier: workspace:^
+        version: link:../harness/dist
+      '@constructive-io/graphql-query':
+        specifier: ^4.5.3
+        version: 4.5.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(grafserv@1.0.0(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))(ws@8.20.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(pg-sql2@5.0.1)(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tamedevil@0.1.1)(use-sync-external-store@1.6.0(react@19.2.5))(ws@8.20.1)
+      '@constructive-io/sdk':
+        specifier: ^1.5.3
+        version: 1.5.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(grafserv@1.0.0(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))(ws@8.20.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(pg-sql2@5.0.1)(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tamedevil@0.1.1)(use-sync-external-store@1.6.0(react@19.2.5))(ws@8.20.1)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@earendil-works/pi-coding-agent':
+        specifier: 0.79.6
+        version: 0.79.6(ws@8.20.1)(zod@4.4.3)
+      typebox:
+        specifier: ^1.0.0
+        version: 1.1.38
+    publishDirectory: dist
+
   agentic/protocol:
     publishDirectory: dist
 
@@ -3712,6 +3735,9 @@ importers:
 
 packages:
 
+  12factor-env@1.21.0:
+    resolution: {integrity: sha512-wWaC+62wfdVW8yqvoVyGkE2s+QztejYvD8IJppVS1yB1ZCOe7H9mJ8U1bJhM0CiHKE02w3tvlFhKKXbFMXmrhw==}
+
   '@0no-co/graphql.web@1.2.0':
     resolution: {integrity: sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw==}
     peerDependencies:
@@ -3719,6 +3745,12 @@ packages:
     peerDependenciesMeta:
       graphql:
         optional: true
+
+  '@agentic-kit/ollama@2.7.0':
+    resolution: {integrity: sha512-y03wXes0SjZh2KbEyNUJxxAqZrcOz+3suUkRYeJNca1/g6icEhZLnNBdgVRoK8q1tStoCvIfGpLJGr/4eWF5Ag==}
+
+  '@agentic-kit/protocol@1.8.0':
+    resolution: {integrity: sha512-yWRkSeph88nego+lmMbczdGY1y9Tol8zsbzA4cvNHVyhEeNyza79zLh9wBYXXlJcqgTeeihSD7XYUhCQHlANKg==}
 
   '@anthropic-ai/sdk@0.91.1':
     resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
@@ -4111,11 +4143,49 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
+  '@constructive-io/bucket-provisioner@0.18.0':
+    resolution: {integrity: sha512-ron3iwQ6Ht130aQx6RgHh7DVY8BnBEUGuqu4p74EacmPUrSn8T9jbzemNZzWJOVUAC09bSrorDvL6uvQePgAZA==}
+
+  '@constructive-io/content-type-stream@2.24.0':
+    resolution: {integrity: sha512-vgY/nFWiq2PUD3Twy85WfwTCCcWBzMeN8BdU+P6244i5s8if6vrtOjIwmQFwDlw5PS/JRvmtw0NjIEqLXgreHg==}
+
+  '@constructive-io/express-context@0.18.0':
+    resolution: {integrity: sha512-apjuKG7031WE4m3WW+6Ap2kDvUtTR0jkBumXrT/1sIoLInYg9sWe17JR7DXse84RAtw5CaWcX/v2vrWYqmqfEg==}
+    peerDependencies:
+      express: ^5.0.0
+
   '@constructive-io/fetch@1.1.1':
     resolution: {integrity: sha512-kpus6sqQwMUTBNpqYvSejG27HJXDucV+BQUNUg3T5U92Qy94Q6of7OhbovICteDMmgcRKCdc5S2e2pXnIY8L5A==}
 
+  '@constructive-io/graphql-env@3.23.0':
+    resolution: {integrity: sha512-jcBZomhnrb+eYA65TlRqzT0sC0ilbCl4z1mwTvkY9XszulvZcjCmSgWMWKxlH6awdgLAE973CrAnGggXVm/how==}
+
+  '@constructive-io/graphql-query@4.5.3':
+    resolution: {integrity: sha512-Ve4l6czmpujUIL3+x6y7uG1TIuuYYBMQspeSx4wwzrFr1r4XeTmXe/38/jtLyKzeMvPMkJ5BbYiIHM1qO3hnWQ==}
+
+  '@constructive-io/graphql-types@3.22.0':
+    resolution: {integrity: sha512-/Ov2D7rQzkzFmKaYzHJrFkPBvs3DszvGISu8Q8kfGC7S/ep0KI2Yw8lYxtLoUzqTkUaotIaJZMcD8bObssmK6A==}
+
+  '@constructive-io/llm-env@0.7.0':
+    resolution: {integrity: sha512-Ef1DNwmWaY/yrI8Du2u9zs5bsg5FZXb00sEoCiyjBptSDvkIrSB88Encq0Derh/yuY+1KGlAhaDSt11ZnacToQ==}
+
   '@constructive-io/noble-hashes@0.2.1':
     resolution: {integrity: sha512-P/C3m4Y9Ywhk7+05aKpg8L7Lkl9Am6AmYMsrMEQ6pRKQA+HIhEutsn9oL99ldsc7gtIt9UEuSHzLRKQvyQCEGQ==}
+
+  '@constructive-io/s3-streamer@2.33.0':
+    resolution: {integrity: sha512-8tj3BOYoBY0h+gHBjdGa8PLdnnZbQUTqK7D2PciaVUseeEe7Okpk95irAoewdGrZko0BL8DZLnefYyHHEf+f3g==}
+
+  '@constructive-io/s3-utils@2.24.0':
+    resolution: {integrity: sha512-qshYjwcUuLEO1DkpYAKOVGEDcQWOBQ9WoPrYXMvxyL344JeYm4UZjHieOLsEWL6IwccnUbXGw8p21d4xCuAgTA==}
+
+  '@constructive-io/sdk@1.5.3':
+    resolution: {integrity: sha512-Lh63Asrjesv77LQ31N8XrXDc6lzdCHDNIBPnRvZkRyS7fiPgiqcX4vT39AoWkshn3vI2gkKlw6uXwxiMEJZCdQ==}
+
+  '@constructive-io/upload-names@2.23.0':
+    resolution: {integrity: sha512-/kh5W//oxeWCJtpUFNIXyUPyKXH6frCwDqU9yflZbySLP7bNtlvPXG6Zs/uEypo1SqE3veco1/+LpIU43+hdtA==}
+
+  '@constructive-io/url-domains@2.23.0':
+    resolution: {integrity: sha512-5yvJWNHB0ztYQXf8lfy6kjGWQUOMaxyNR39xgKWwkLLSVmE/3jLLVymtY1cTLWbQiHa5Ek86B0ArQp48J7P7Ng==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -5335,6 +5405,18 @@ packages:
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
+
+  '@pgpmjs/env@2.33.0':
+    resolution: {integrity: sha512-/NlCXAtMd6mbp8lVsiLHo/ErahpF3Pjfz5KvGENHtFnpWIN2Mi9oQhTo8grzH6n47/qyQ36wZ1hYhY8HSigSEA==}
+
+  '@pgpmjs/logger@2.18.0':
+    resolution: {integrity: sha512-2Crr/s299ahmXv0fxasu8GVrV6VovQhGUtFsM4dVUjHx3mXlW8P+nfkHM2BnQxWeqWV3u25z7aXnRiWDCZ0K/Q==}
+
+  '@pgpmjs/server-utils@3.19.0':
+    resolution: {integrity: sha512-36i7q7+bzbklE1Y7+bdQJbMuBhuTRqcznmnDs5HvfM29B9gFK5TXTVO1h3B4FArpmVpYctr303PkqL/a7T+gzg==}
+
+  '@pgpmjs/types@2.40.0':
+    resolution: {integrity: sha512-rI3DLp94jS9PhWzfAyeW0Gn+L8HrwKvjTQHd8X7uQsc9bCCl0TwxKaPiUFJHdgzYSBJltjCWsxWNZ1wp2R0Org==}
 
   '@pgsql/quotes@18.1.0':
     resolution: {integrity: sha512-wZcMP1QHiQbWWKOw4nfvZ74xUSz/9jqeSUXVnoR1saI5M0D+iYbiuOlfNDyYmziLwgEkCuSJLZK1dZ+eQCwgAA==}
@@ -7486,6 +7568,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag-hash@2.24.0:
+    resolution: {integrity: sha512-3whEZblANp5QeSF3jP/TTz+aalTOoQ+LP6c3TucjwukDvdWG1Hp8lXbn77nldnKWvQNGqaBi/aXTvmik4Hzffg==}
+
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
@@ -7845,6 +7930,9 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
+  gql-ast@3.17.0:
+    resolution: {integrity: sha512-HJqf5oeuWmuRTEEwklYIv/9SQvk9e0lehq/fIYcfdUckBwADAQ39zMRlGL5o3CnoYcyeOV7wbt9EN0YFdMC4Fg==}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -7882,6 +7970,17 @@ packages:
       ws:
         optional: true
 
+  graphile-bucket-provisioner-plugin@1.4.0:
+    resolution: {integrity: sha512-bNgc7a1R0wNiQJQqsNY8Ceapwp4YjU+N5E+RMzDVLnEkap2/suuDysnOQz7GTXFf1WU+iWy0doJyivNbzTADAQ==}
+    peerDependencies:
+      grafast: 1.0.2
+      graphile-build: 5.0.2
+      graphile-build-pg: 5.0.2
+      graphile-config: 1.0.1
+      graphile-utils: 5.0.0
+      graphql: 16.13.0
+      postgraphile: 5.0.3
+
   graphile-build-pg@5.0.2:
     resolution: {integrity: sha512-8vkg1x5UcooFogPCp+3EUt6qqWX8NG01gANoVFUk9yK2c8DW+aQaF37LAaa96r9JR4FE0yeO2zk6WvOOemk2dg==}
     engines: {node: '>=22'}
@@ -7906,6 +8005,21 @@ packages:
       graphile-config: ^1.0.0-rc.5
       graphql: 16.13.0
 
+  graphile-bulk-mutations@1.5.2:
+    resolution: {integrity: sha512-h6C6gnk2kNG0vNasrEhqaA62A/iW+3+HoJZPmGW4kkxF+OyWGQL/5bNXuZE0zf8pHvJM1yzBhoHf7QB3NWq8ug==}
+    peerDependencies:
+      '@dataplan/pg': 1.0.3
+      grafast: 1.0.2
+      graphile-build: 5.0.2
+      graphile-build-pg: 5.0.2
+      graphile-config: 1.0.1
+      graphql: 16.13.0
+      pg-sql2: 5.0.1
+      postgraphile: 5.0.3
+
+  graphile-cache@4.4.0:
+    resolution: {integrity: sha512-1fiiWLpDNBFAEI0OiJtzIhlHeIjCxdQBsP3TT5nI2Ykox98Wnjj/LRVTUMUGKo13+U9wKVbuxRkof+KiA85W3A==}
+
   graphile-config@1.0.1:
     resolution: {integrity: sha512-sVdSWNmetW/WZKVQ0Dii2kCu0Le6X6qwuBRecWg575iOMjbZgxo+b4oVeSOTtR6NTKuLsMYQBkzSaeoAKOPB+A==}
     engines: {node: '>=22'}
@@ -7919,6 +8033,158 @@ packages:
       graphile-config: 1.0.1
       graphql: 16.13.0
       pg-sql2: 5.0.1
+      postgraphile: 5.0.3
+
+  graphile-connection-filter@2.5.2:
+    resolution: {integrity: sha512-o4FVxCOSR5KezoIgjtD8ZB42oeh4zK1EOTYcS6nfm3AzkNvzyAIpSLyT+RjyKhT56ORWc6/qhOEvkq/WJGTwNg==}
+    peerDependencies:
+      '@dataplan/pg': 1.0.3
+      graphile-build: 5.0.2
+      graphile-build-pg: 5.0.2
+      graphile-config: 1.0.1
+      graphql: 16.13.0
+      pg-sql2: 5.0.1
+      postgraphile: 5.0.3
+
+  graphile-i18n@2.5.2:
+    resolution: {integrity: sha512-sq0O2pLHix4+kRN7OIdTDl2yTFLEAF7koAMZRvPoLS0/yutLCMFSxkxLL2BaiYQkPoLCAvmMrn5hUPE36uC5bQ==}
+    peerDependencies:
+      '@dataplan/pg': 1.0.3
+      grafast: 1.0.2
+      graphile-build: 5.0.2
+      graphile-build-pg: 5.0.2
+      graphile-config: 1.0.1
+      graphql: 16.13.0
+      pg-sql2: 5.0.1
+      postgraphile: 5.0.3
+
+  graphile-llm@1.5.2:
+    resolution: {integrity: sha512-9lzWW72Vmrjv5u24HiQgb4KjlfY1Rz+xxrWFEeEqOmduyMyaHBGNfr9W57TVEmG8mG4e45dK+RFb6vfiuAtsxQ==}
+    peerDependencies:
+      '@dataplan/pg': 1.0.3
+      grafast: 1.0.2
+      graphile-build: 5.0.2
+      graphile-build-pg: 5.0.2
+      graphile-config: 1.0.1
+      graphile-search: ^1.18.0
+      graphile-utils: 5.0.0
+      graphql: 16.13.0
+      pg-sql2: 5.0.1
+      postgraphile: 5.0.3
+    peerDependenciesMeta:
+      graphile-search:
+        optional: true
+      graphile-utils:
+        optional: true
+
+  graphile-ltree@2.5.2:
+    resolution: {integrity: sha512-jDbiJP8FdXX3Y3Batr8qhX0e8nlUbi0Lakt3a4LxEyZS/Mky5nVGcuKWaII9ayw4P6i9ooFMTlzavQ6XOxK5fA==}
+    peerDependencies:
+      '@dataplan/pg': 1.0.3
+      grafast: 1.0.2
+      graphile-build: 5.0.2
+      graphile-build-pg: 5.0.2
+      graphile-config: 1.0.1
+      graphile-connection-filter: ^1.13.0
+      graphql: 16.13.0
+      pg-sql2: 5.0.1
+      postgraphile: 5.0.3
+    peerDependenciesMeta:
+      graphile-connection-filter:
+        optional: true
+
+  graphile-meta@1.1.1:
+    resolution: {integrity: sha512-2TkIudmP/ut6Hj6EoKSmcyIVfmDkasa4IWiqrTWzX/I/6/6EsNrSkG2IPuCQ/5A2udxHC2BSfTd7FgGBaHjveQ==}
+    peerDependencies:
+      graphile-build: 5.0.2
+      graphile-build-pg: 5.0.2
+      graphile-config: 1.0.1
+      graphql: 16.13.0
+      postgraphile: 5.0.3
+
+  graphile-pg-aggregates@2.5.2:
+    resolution: {integrity: sha512-IMql0qpltxR+oqbzU9Luk7LJIi6UnUuk4189UIqbdzjlNwu2KZh2KIxCrs81tYteYQDpEZQCUkwL4VaXe6vdpQ==}
+    peerDependencies:
+      '@dataplan/pg': 1.0.3
+      grafast: 1.0.2
+      graphile-build: 5.0.2
+      graphile-build-pg: 5.0.2
+      graphile-config: 1.0.1
+      graphile-connection-filter: ^1.13.0
+      graphql: 16.13.0
+      pg-sql2: 5.0.1
+      postgraphile: 5.0.3
+
+  graphile-plugin-utils@1.4.0:
+    resolution: {integrity: sha512-8NEefFFkO7DbriRVptJkUfWPmuIXNG73+H2eKwLDwYuwPzoqJjmiugzo2r7sw14dPVvBXdj/eXlc/PrQRQrsqQ==}
+    peerDependencies:
+      '@dataplan/pg': 1.0.3
+      graphile-build: 5.0.2
+      graphile-build-pg: 5.0.2
+      graphile-config: 1.0.1
+      graphql: 16.13.0
+      pg-sql2: 5.0.1
+      postgraphile: 5.0.3
+
+  graphile-postgis@3.5.2:
+    resolution: {integrity: sha512-XwpWDWG7HoJIWgsqt5YEpRgrzr0nP3SNZkVWVOYtEg4iK03IDtK2Q3eD2z7h9QRMjqrC2bxIH58VocwU3EDWjg==}
+    peerDependencies:
+      '@dataplan/pg': 1.0.3
+      grafast: 1.0.2
+      graphile-build: 5.0.2
+      graphile-build-pg: 5.0.2
+      graphile-config: 1.0.1
+      graphile-connection-filter: ^1.13.0
+      graphql: 16.13.0
+      pg-sql2: 5.0.1
+      postgraphile: 5.0.3
+    peerDependenciesMeta:
+      graphile-connection-filter:
+        optional: true
+
+  graphile-presigned-url-plugin@1.4.0:
+    resolution: {integrity: sha512-sNVduSqJSFCHwUu+B+IrI9VlV80LNzxEH2oyX3wIYoF1AJvf00m6l6sH93XpswLXvXLRqeQHVjdsUofx7QYMpQ==}
+    peerDependencies:
+      grafast: 1.0.2
+      graphile-build: 5.0.2
+      graphile-build-pg: 5.0.2
+      graphile-config: 1.0.1
+      graphile-utils: 5.0.0
+      graphql: 16.13.0
+      postgraphile: 5.0.3
+
+  graphile-realtime-subscriptions@1.4.0:
+    resolution: {integrity: sha512-W8Jzz+2axchlJSGmbtB000MI1bM59VUvY6ovcKat0JalkPlPRm6Z0OeEPEGi4CbWBdoUrKM4In1IJ0RWl2vOpw==}
+    peerDependencies:
+      grafast: 1.0.2
+      graphile-build: 5.0.2
+      graphile-build-pg: 5.0.2
+      graphile-config: 1.0.1
+      graphile-utils: 5.0.0
+      graphql: 16.13.0
+      postgraphile: 5.0.3
+
+  graphile-search@2.5.2:
+    resolution: {integrity: sha512-ex7EeLKXSVThmEpx6vJ42f6Lw4cTdoE8Y/juqVwObMT1K4qmLbZ+7bgoR+hAFwRc1RN+z4U/AXVzzb+4lo2jJQ==}
+    peerDependencies:
+      '@dataplan/pg': 1.0.3
+      graphile-build: 5.0.2
+      graphile-build-pg: 5.0.2
+      graphile-config: 1.0.1
+      graphql: 16.13.0
+      pg-sql2: 5.0.1
+      postgraphile: 5.0.3
+
+  graphile-settings@6.5.3:
+    resolution: {integrity: sha512-sccwlpaXs3mAJZSH/5B85uigqKAlBT8HyMv25LEgL6mYDh83v8KbhU863IvV1Pf9qwDVnSGYoynGx484uQba0A==}
+
+  graphile-upload-plugin@2.18.0:
+    resolution: {integrity: sha512-0nh0RrnKg3woKc2Inh1GZP6jo835tTg2Su+qq4y5NYV5V3o+RTcUJqmNOVr6ZYUmfBeI0dz+uXkVhVVVyoVjcw==}
+    peerDependencies:
+      graphile-build: 5.0.2
+      graphile-build-pg: 5.0.2
+      graphile-config: 1.0.1
+      graphql: 16.13.0
       postgraphile: 5.0.3
 
   graphile-utils@5.0.0:
@@ -8819,6 +9085,9 @@ packages:
   microseconds@0.2.0:
     resolution: {integrity: sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==}
 
+  mime-bytes@0.24.0:
+    resolution: {integrity: sha512-G3VvG9nluHSND6IfCQuT9UieXCINL75LQXlh4a4u6igpapa09crROtlC4xmFsTph55TTVc/8e1qY7OEnTT96VA==}
+
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
@@ -9335,6 +9604,9 @@ packages:
     resolution: {integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==}
     engines: {node: '>=4'}
 
+  pg-cache@3.19.0:
+    resolution: {integrity: sha512-dFM0p6iCS2zTJWiiAdcNsJUCU07yJopd1tG0shxUjEG6URJJ0y0NTsgc7f8yfmVP09QJXGLi4dvnP7DRXWWh1Q==}
+
   pg-cloudflare@1.3.0:
     resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
 
@@ -9349,6 +9621,9 @@ packages:
 
   pg-copy-streams@7.0.0:
     resolution: {integrity: sha512-zBvnY6wtaBRE2ae2xXWOOGMaNVPkXh1vhypAkNSKgMdciJeTyIQAHZaEeRAxUjs/p1El5jgzYmwG5u871Zj3dQ==}
+
+  pg-env@1.22.0:
+    resolution: {integrity: sha512-IH4VI5cAs6UGCqkw2sjaBbghoK5L++lPUsVkRxzCh+NJFR947VV8BmkDS5De1QIeX4NFaEadwvo9U+Bouz5hpg==}
 
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
@@ -9379,6 +9654,9 @@ packages:
 
   pg-protocol@1.14.0:
     resolution: {integrity: sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==}
+
+  pg-query-context@2.23.0:
+    resolution: {integrity: sha512-ZlGHx1S1BXIqSq+s4vVmMOWoU4YKTlFF/cgcDEhFbUe1udOtB0Q5z55eIifA0FRKyADFttYvHxH/KePLKaCRzQ==}
 
   pg-sql2@5.0.1:
     resolution: {integrity: sha512-DdOZNUBhuBuGcq3UgUNsYE9FPdPzw9YA1K/WQxutNhC17DA/CImapyamv6lliVvdAVNZ+CWB1z+p7SmSJmkezw==}
@@ -10505,6 +10783,9 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  uuid-hash@2.23.0:
+    resolution: {integrity: sha512-CugWIHeOKrHDMh18vQS1nMh1VGycs99b4ljQFvaQ+w4uVgR4rxnAT3RBlZ1K4SX6m2t5U8pSbHRMScoFqH8GpA==}
+
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
@@ -10767,9 +11048,19 @@ packages:
 
 snapshots:
 
+  12factor-env@1.21.0:
+    dependencies:
+      envalid: 8.1.1
+
   '@0no-co/graphql.web@1.2.0(graphql@16.13.0)':
     optionalDependencies:
       graphql: 16.13.0
+
+  '@agentic-kit/ollama@2.7.0':
+    dependencies:
+      '@agentic-kit/protocol': 1.8.0
+
+  '@agentic-kit/protocol@1.8.0': {}
 
   '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
     dependencies:
@@ -10836,17 +11127,17 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/core': 3.977.1
       '@aws-sdk/credential-provider-node': 3.972.44
       '@aws-sdk/eventstream-handler-node': 3.972.30
       '@aws-sdk/middleware-eventstream': 3.972.25
       '@aws-sdk/middleware-websocket': 3.972.44
       '@aws-sdk/token-providers': 3.1048.0
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/fetch-http-handler': 5.4.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/fetch-http-handler': 5.6.12
       '@smithy/node-http-handler': 4.4.16
-      '@smithy/types': 4.14.2
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/client-s3@3.1052.0':
@@ -11096,11 +11387,11 @@ snapshots:
 
   '@aws-sdk/token-providers@3.1048.0':
     dependencies:
-      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/core': 3.977.1
       '@aws-sdk/nested-clients': 3.997.11
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1052.0':
@@ -11414,9 +11705,155 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
+  '@constructive-io/bucket-provisioner@0.18.0':
+    dependencies:
+      '@aws-sdk/client-s3': 3.1052.0
+      '@constructive-io/s3-utils': 2.24.0
+
+  '@constructive-io/content-type-stream@2.24.0':
+    dependencies:
+      etag-hash: 2.24.0
+      mime-bytes: 0.24.0
+      uuid-hash: 2.23.0
+
+  '@constructive-io/express-context@0.18.0(express@5.2.1)':
+    dependencies:
+      '@constructive-io/url-domains': 2.23.0
+      '@pgpmjs/env': 2.33.0
+      '@pgpmjs/logger': 2.18.0
+      '@pgpmjs/server-utils': 3.19.0
+      '@pgpmjs/types': 2.40.0
+      express: 5.2.1
+      lru-cache: 11.2.7
+      pg: 8.21.0
+      pg-cache: 3.19.0
+      pg-query-context: 2.23.0
+    transitivePeerDependencies:
+      - pg-native
+      - supports-color
+
   '@constructive-io/fetch@1.1.1': {}
 
+  '@constructive-io/graphql-env@3.23.0':
+    dependencies:
+      12factor-env: 1.21.0
+      '@constructive-io/graphql-types': 3.22.0
+      '@pgpmjs/env': 2.33.0
+      deepmerge: 4.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@constructive-io/graphql-query@4.5.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(grafserv@1.0.0(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))(ws@8.20.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(pg-sql2@5.0.1)(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tamedevil@0.1.1)(use-sync-external-store@1.6.0(react@19.2.5))(ws@8.20.1)':
+    dependencies:
+      '@0no-co/graphql.web': 1.2.0(graphql@16.13.0)
+      '@constructive-io/fetch': 1.1.1
+      '@constructive-io/graphql-types': 3.22.0
+      ajv: 8.20.0
+      gql-ast: 3.17.0
+      grafast: 1.0.2(graphql@16.13.0)
+      graphile-build-pg: 5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-config: 1.0.1
+      graphile-settings: 6.5.3(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))(ws@8.20.1)
+      graphql: 16.13.0
+      inflection: 3.0.2
+      inflekt: 0.7.1
+      lru-cache: 11.2.7
+      postgraphile: 5.0.3(02c18e7c6179c4ae54031f8cdca16ab5)
+    transitivePeerDependencies:
+      - '@dataplan/json'
+      - '@dataplan/pg'
+      - '@envelop/core'
+      - '@fastify/websocket'
+      - '@types/node'
+      - '@types/react'
+      - '@types/react-dom'
+      - '@whatwg-node/server'
+      - bufferutil
+      - crossws
+      - grafserv
+      - graphile-build
+      - h3
+      - hono
+      - immer
+      - pg
+      - pg-native
+      - pg-sql2
+      - react
+      - react-dom
+      - supports-color
+      - tamedevil
+      - use-sync-external-store
+      - utf-8-validate
+      - ws
+
+  '@constructive-io/graphql-types@3.22.0':
+    dependencies:
+      '@pgpmjs/types': 2.40.0
+      deepmerge: 4.3.1
+      graphile-config: 1.0.1
+      pg-env: 1.22.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@constructive-io/llm-env@0.7.0': {}
+
   '@constructive-io/noble-hashes@0.2.1': {}
+
+  '@constructive-io/s3-streamer@2.33.0':
+    dependencies:
+      '@aws-sdk/client-s3': 3.1052.0
+      '@aws-sdk/lib-storage': 3.1052.0(@aws-sdk/client-s3@3.1052.0)
+      '@constructive-io/content-type-stream': 2.24.0
+      '@constructive-io/s3-utils': 2.24.0
+      '@pgpmjs/types': 2.40.0
+
+  '@constructive-io/s3-utils@2.24.0':
+    dependencies:
+      '@aws-sdk/client-s3': 3.1052.0
+      '@aws-sdk/lib-storage': 3.1052.0(@aws-sdk/client-s3@3.1052.0)
+      '@aws-sdk/s3-request-presigner': 3.1052.0
+
+  '@constructive-io/sdk@1.5.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(grafserv@1.0.0(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))(ws@8.20.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(pg-sql2@5.0.1)(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tamedevil@0.1.1)(use-sync-external-store@1.6.0(react@19.2.5))(ws@8.20.1)':
+    dependencies:
+      '@0no-co/graphql.web': 1.2.0(graphql@16.13.0)
+      '@constructive-io/graphql-query': 4.5.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(grafserv@1.0.0(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))(ws@8.20.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(pg-sql2@5.0.1)(pg@8.21.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tamedevil@0.1.1)(use-sync-external-store@1.6.0(react@19.2.5))(ws@8.20.1)
+      '@constructive-io/graphql-types': 3.22.0
+      gql-ast: 3.17.0
+      graphql: 16.13.0
+    transitivePeerDependencies:
+      - '@dataplan/json'
+      - '@dataplan/pg'
+      - '@envelop/core'
+      - '@fastify/websocket'
+      - '@types/node'
+      - '@types/react'
+      - '@types/react-dom'
+      - '@whatwg-node/server'
+      - bufferutil
+      - crossws
+      - grafserv
+      - graphile-build
+      - h3
+      - hono
+      - immer
+      - pg
+      - pg-native
+      - pg-sql2
+      - react
+      - react-dom
+      - supports-color
+      - tamedevil
+      - use-sync-external-store
+      - utf-8-validate
+      - ws
+
+  '@constructive-io/upload-names@2.23.0': {}
+
+  '@constructive-io/url-domains@2.23.0':
+    dependencies:
+      express: 5.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -12976,6 +13413,30 @@ snapshots:
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
       '@noble/hashes': 1.8.0
+
+  '@pgpmjs/env@2.33.0':
+    dependencies:
+      12factor-env: 1.21.0
+      '@pgpmjs/types': 2.40.0
+      deepmerge: 4.3.1
+
+  '@pgpmjs/logger@2.18.0':
+    dependencies:
+      yanse: 0.2.1
+
+  '@pgpmjs/server-utils@3.19.0':
+    dependencies:
+      '@pgpmjs/logger': 2.18.0
+      '@pgpmjs/types': 2.40.0
+      cors: 2.8.6
+      express: 5.2.1
+      lru-cache: 11.2.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@pgpmjs/types@2.40.0':
+    dependencies:
+      pg-env: 1.22.0
 
   '@pgsql/quotes@18.1.0': {}
 
@@ -15062,6 +15523,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag-hash@2.24.0: {}
+
   etag@1.8.1: {}
 
   eventemitter3@4.0.7: {}
@@ -15493,6 +15956,10 @@ snapshots:
 
   gopd@1.2.0: {}
 
+  gql-ast@3.17.0:
+    dependencies:
+      graphql: 16.13.0
+
   graceful-fs@4.2.11: {}
 
   grafast@1.0.2(graphql@16.13.0):
@@ -15608,6 +16075,19 @@ snapshots:
       - supports-color
       - use-sync-external-store
 
+  graphile-bucket-provisioner-plugin@1.4.0(c173c9f37f056a802829fa20e1098874):
+    dependencies:
+      '@constructive-io/bucket-provisioner': 0.18.0
+      '@pgpmjs/logger': 2.18.0
+      '@pgsql/quotes': 18.1.0
+      grafast: 1.0.2(graphql@16.13.0)
+      graphile-build: 5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)
+      graphile-build-pg: 5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-config: 1.0.1
+      graphile-utils: 5.0.1(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(tamedevil@0.1.1)
+      graphql: 16.13.0
+      postgraphile: 5.0.3(02c18e7c6179c4ae54031f8cdca16ab5)
+
   graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1):
     dependencies:
       '@dataplan/pg': 1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)
@@ -15665,6 +16145,58 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  graphile-bulk-mutations@1.5.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(postgraphile@5.0.3(02c18e7c6179c4ae54031f8cdca16ab5)):
+    dependencies:
+      '@dataplan/pg': 1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      grafast: 1.0.2(graphql@16.13.0)
+      graphile-build: 5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)
+      graphile-build-pg: 5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-config: 1.0.1
+      graphql: 16.13.0
+      pg-sql2: 5.0.1
+      postgraphile: 5.0.3(02c18e7c6179c4ae54031f8cdca16ab5)
+
+  graphile-cache@4.4.0(2e92867bd5e9d5c071d0c985feeef641):
+    dependencies:
+      12factor-env: 1.21.0
+      '@pgpmjs/logger': 2.18.0
+      express: 5.2.1
+      grafserv: 1.0.0(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))(ws@8.20.1)
+      graphile-realtime-subscriptions: 1.4.0(c173c9f37f056a802829fa20e1098874)
+      lru-cache: 11.2.7
+      pg-cache: 3.19.0
+      postgraphile: 5.0.3(02c18e7c6179c4ae54031f8cdca16ab5)
+    transitivePeerDependencies:
+      - '@dataplan/json'
+      - '@dataplan/pg'
+      - '@envelop/core'
+      - '@fastify/websocket'
+      - '@types/node'
+      - '@types/react'
+      - '@types/react-dom'
+      - '@whatwg-node/server'
+      - bufferutil
+      - crossws
+      - grafast
+      - graphile-build
+      - graphile-build-pg
+      - graphile-config
+      - graphile-utils
+      - graphql
+      - h3
+      - hono
+      - immer
+      - pg
+      - pg-native
+      - pg-sql2
+      - react
+      - react-dom
+      - supports-color
+      - tamedevil
+      - use-sync-external-store
+      - utf-8-validate
+      - ws
+
   graphile-config@1.0.1:
     dependencies:
       chalk: 4.1.2
@@ -15695,6 +16227,238 @@ snapshots:
       graphql: 16.13.0
       pg-sql2: 5.0.1
       postgraphile: 5.0.3(f0ca433f04a3f28b00a29892b7510c70)
+
+  graphile-connection-filter@2.5.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(postgraphile@5.0.3(02c18e7c6179c4ae54031f8cdca16ab5)):
+    dependencies:
+      '@dataplan/pg': 1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      graphile-build: 5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)
+      graphile-build-pg: 5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-config: 1.0.1
+      graphile-plugin-utils: 1.4.0(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(postgraphile@5.0.3(02c18e7c6179c4ae54031f8cdca16ab5))
+      graphql: 16.13.0
+      pg-sql2: 5.0.1
+      postgraphile: 5.0.3(02c18e7c6179c4ae54031f8cdca16ab5)
+
+  graphile-i18n@2.5.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(postgraphile@5.0.3(02c18e7c6179c4ae54031f8cdca16ab5)):
+    dependencies:
+      '@dataplan/pg': 1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      accept-language-parser: 1.5.0
+      grafast: 1.0.2(graphql@16.13.0)
+      graphile-build: 5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)
+      graphile-build-pg: 5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-config: 1.0.1
+      graphql: 16.13.0
+      pg-sql2: 5.0.1
+      postgraphile: 5.0.3(02c18e7c6179c4ae54031f8cdca16ab5)
+
+  graphile-llm@1.5.2(e7103b85f4a330e782ad9f626d4b47b1):
+    dependencies:
+      '@agentic-kit/ollama': 2.7.0
+      '@constructive-io/express-context': 0.18.0(express@5.2.1)
+      '@constructive-io/llm-env': 0.7.0
+      '@dataplan/pg': 1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      grafast: 1.0.2(graphql@16.13.0)
+      graphile-build: 5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)
+      graphile-build-pg: 5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-cache: 4.4.0(2e92867bd5e9d5c071d0c985feeef641)
+      graphile-config: 1.0.1
+      graphql: 16.13.0
+      pg-sql2: 5.0.1
+      postgraphile: 5.0.3(02c18e7c6179c4ae54031f8cdca16ab5)
+    optionalDependencies:
+      graphile-search: 2.5.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(postgraphile@5.0.3(02c18e7c6179c4ae54031f8cdca16ab5))
+      graphile-utils: 5.0.1(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(tamedevil@0.1.1)
+    transitivePeerDependencies:
+      - '@dataplan/json'
+      - '@envelop/core'
+      - '@fastify/websocket'
+      - '@types/node'
+      - '@types/react'
+      - '@types/react-dom'
+      - '@whatwg-node/server'
+      - bufferutil
+      - crossws
+      - express
+      - h3
+      - hono
+      - immer
+      - pg
+      - pg-native
+      - react
+      - react-dom
+      - supports-color
+      - tamedevil
+      - use-sync-external-store
+      - utf-8-validate
+      - ws
+
+  graphile-ltree@2.5.2(3389f019113bb43c95737d21f1d1a397):
+    dependencies:
+      '@dataplan/pg': 1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      grafast: 1.0.2(graphql@16.13.0)
+      graphile-build: 5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)
+      graphile-build-pg: 5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-config: 1.0.1
+      graphql: 16.13.0
+      pg-sql2: 5.0.1
+      postgraphile: 5.0.3(02c18e7c6179c4ae54031f8cdca16ab5)
+    optionalDependencies:
+      graphile-connection-filter: 2.5.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(postgraphile@5.0.3(02c18e7c6179c4ae54031f8cdca16ab5))
+
+  graphile-meta@1.1.1(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(postgraphile@5.0.3(02c18e7c6179c4ae54031f8cdca16ab5)):
+    dependencies:
+      graphile-build: 5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)
+      graphile-build-pg: 5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-config: 1.0.1
+      graphql: 16.13.0
+      postgraphile: 5.0.3(02c18e7c6179c4ae54031f8cdca16ab5)
+
+  graphile-pg-aggregates@2.5.2(3389f019113bb43c95737d21f1d1a397):
+    dependencies:
+      '@dataplan/pg': 1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      grafast: 1.0.2(graphql@16.13.0)
+      graphile-build: 5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)
+      graphile-build-pg: 5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-config: 1.0.1
+      graphile-connection-filter: 2.5.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(postgraphile@5.0.3(02c18e7c6179c4ae54031f8cdca16ab5))
+      graphile-plugin-utils: 1.4.0(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(postgraphile@5.0.3(02c18e7c6179c4ae54031f8cdca16ab5))
+      graphql: 16.13.0
+      pg-sql2: 5.0.1
+      postgraphile: 5.0.3(02c18e7c6179c4ae54031f8cdca16ab5)
+
+  graphile-plugin-utils@1.4.0(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(postgraphile@5.0.3(02c18e7c6179c4ae54031f8cdca16ab5)):
+    dependencies:
+      '@dataplan/pg': 1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      graphile-build: 5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)
+      graphile-build-pg: 5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-config: 1.0.1
+      graphql: 16.13.0
+      pg-sql2: 5.0.1
+      postgraphile: 5.0.3(02c18e7c6179c4ae54031f8cdca16ab5)
+
+  graphile-postgis@3.5.2(3389f019113bb43c95737d21f1d1a397):
+    dependencies:
+      '@dataplan/pg': 1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      grafast: 1.0.2(graphql@16.13.0)
+      graphile-build: 5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)
+      graphile-build-pg: 5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-config: 1.0.1
+      graphql: 16.13.0
+      pg-sql2: 5.0.1
+      postgraphile: 5.0.3(02c18e7c6179c4ae54031f8cdca16ab5)
+    optionalDependencies:
+      graphile-connection-filter: 2.5.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(postgraphile@5.0.3(02c18e7c6179c4ae54031f8cdca16ab5))
+
+  graphile-presigned-url-plugin@1.4.0(c173c9f37f056a802829fa20e1098874):
+    dependencies:
+      '@aws-sdk/client-s3': 3.1052.0
+      '@aws-sdk/s3-request-presigner': 3.1052.0
+      '@pgpmjs/logger': 2.18.0
+      '@pgsql/quotes': 18.1.0
+      grafast: 1.0.2(graphql@16.13.0)
+      graphile-build: 5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)
+      graphile-build-pg: 5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-config: 1.0.1
+      graphile-utils: 5.0.1(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(tamedevil@0.1.1)
+      graphql: 16.13.0
+      lru-cache: 11.2.7
+      postgraphile: 5.0.3(02c18e7c6179c4ae54031f8cdca16ab5)
+
+  graphile-realtime-subscriptions@1.4.0(c173c9f37f056a802829fa20e1098874):
+    dependencies:
+      '@pgpmjs/logger': 2.18.0
+      '@pgsql/quotes': 18.1.0
+      grafast: 1.0.2(graphql@16.13.0)
+      graphile-build: 5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)
+      graphile-build-pg: 5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-config: 1.0.1
+      graphile-utils: 5.0.1(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(tamedevil@0.1.1)
+      graphql: 16.13.0
+      postgraphile: 5.0.3(02c18e7c6179c4ae54031f8cdca16ab5)
+
+  graphile-search@2.5.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(postgraphile@5.0.3(02c18e7c6179c4ae54031f8cdca16ab5)):
+    dependencies:
+      '@dataplan/pg': 1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      graphile-build: 5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)
+      graphile-build-pg: 5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-config: 1.0.1
+      graphile-plugin-utils: 1.4.0(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(postgraphile@5.0.3(02c18e7c6179c4ae54031f8cdca16ab5))
+      graphql: 16.13.0
+      pg-sql2: 5.0.1
+      postgraphile: 5.0.3(02c18e7c6179c4ae54031f8cdca16ab5)
+
+  graphile-settings@6.5.3(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))(ws@8.20.1):
+    dependencies:
+      '@aws-sdk/client-s3': 3.1052.0
+      '@constructive-io/bucket-provisioner': 0.18.0
+      '@constructive-io/graphql-env': 3.23.0
+      '@constructive-io/graphql-types': 3.22.0
+      '@constructive-io/s3-streamer': 2.33.0
+      '@constructive-io/s3-utils': 2.24.0
+      '@constructive-io/upload-names': 2.23.0
+      '@dataplan/json': 1.0.0(grafast@1.0.2(graphql@16.13.0))
+      '@dataplan/pg': 1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      '@graphile-contrib/pg-many-to-many': 2.0.0-rc.2
+      '@pgpmjs/logger': 2.18.0
+      '@pgpmjs/types': 2.40.0
+      '@pgsql/quotes': 18.1.0
+      cors: 2.8.6
+      express: 5.2.1
+      grafast: 1.0.2(graphql@16.13.0)
+      grafserv: 1.0.0(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))(ws@8.20.1)
+      graphile-bucket-provisioner-plugin: 1.4.0(c173c9f37f056a802829fa20e1098874)
+      graphile-build: 5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)
+      graphile-build-pg: 5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-bulk-mutations: 1.5.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(postgraphile@5.0.3(02c18e7c6179c4ae54031f8cdca16ab5))
+      graphile-config: 1.0.1
+      graphile-connection-filter: 2.5.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(postgraphile@5.0.3(02c18e7c6179c4ae54031f8cdca16ab5))
+      graphile-i18n: 2.5.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(postgraphile@5.0.3(02c18e7c6179c4ae54031f8cdca16ab5))
+      graphile-llm: 1.5.2(e7103b85f4a330e782ad9f626d4b47b1)
+      graphile-ltree: 2.5.2(3389f019113bb43c95737d21f1d1a397)
+      graphile-meta: 1.1.1(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(postgraphile@5.0.3(02c18e7c6179c4ae54031f8cdca16ab5))
+      graphile-pg-aggregates: 2.5.2(3389f019113bb43c95737d21f1d1a397)
+      graphile-postgis: 3.5.2(3389f019113bb43c95737d21f1d1a397)
+      graphile-presigned-url-plugin: 1.4.0(c173c9f37f056a802829fa20e1098874)
+      graphile-realtime-subscriptions: 1.4.0(c173c9f37f056a802829fa20e1098874)
+      graphile-search: 2.5.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(postgraphile@5.0.3(02c18e7c6179c4ae54031f8cdca16ab5))
+      graphile-upload-plugin: 2.18.0(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(postgraphile@5.0.3(02c18e7c6179c4ae54031f8cdca16ab5))
+      graphile-utils: 5.0.1(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(tamedevil@0.1.1)
+      graphql: 16.13.0
+      inflekt: 0.7.1
+      lru-cache: 11.2.7
+      pg: 8.21.0
+      pg-query-context: 2.23.0
+      pg-sql2: 5.0.1
+      postgraphile: 5.0.3(02c18e7c6179c4ae54031f8cdca16ab5)
+      request-ip: 3.3.0
+      tamedevil: 0.1.1
+    transitivePeerDependencies:
+      - '@envelop/core'
+      - '@fastify/websocket'
+      - '@types/node'
+      - '@types/react'
+      - '@types/react-dom'
+      - '@whatwg-node/server'
+      - bufferutil
+      - crossws
+      - h3
+      - hono
+      - immer
+      - pg-native
+      - react
+      - react-dom
+      - supports-color
+      - use-sync-external-store
+      - utf-8-validate
+      - ws
+
+  graphile-upload-plugin@2.18.0(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(postgraphile@5.0.3(02c18e7c6179c4ae54031f8cdca16ab5)):
+    dependencies:
+      graphile-build: 5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)
+      graphile-build-pg: 5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-config: 1.0.1
+      graphql: 16.13.0
+      postgraphile: 5.0.3(02c18e7c6179c4ae54031f8cdca16ab5)
 
   graphile-utils@5.0.0(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build-pg@5.0.2(@dataplan/pg@1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.0.2(graphql@16.13.0))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(tamedevil@0.1.1):
     dependencies:
@@ -17018,6 +17782,8 @@ snapshots:
 
   microseconds@0.2.0: {}
 
+  mime-bytes@0.24.0: {}
+
   mime-db@1.52.0: {}
 
   mime-db@1.54.0: {}
@@ -17342,7 +18108,7 @@ snapshots:
       tmp: 0.2.5
       tsconfig-paths: 4.2.0
       tslib: 2.8.1
-      yaml: 2.8.4
+      yaml: 2.9.0
       yargs: 17.7.2
       yargs-parser: 21.1.1
     optionalDependencies:
@@ -17597,6 +18363,17 @@ snapshots:
     dependencies:
       pify: 3.0.0
 
+  pg-cache@3.19.0:
+    dependencies:
+      12factor-env: 1.21.0
+      '@pgpmjs/logger': 2.18.0
+      '@pgpmjs/types': 2.40.0
+      lru-cache: 11.2.7
+      pg: 8.21.0
+      pg-env: 1.22.0
+    transitivePeerDependencies:
+      - pg-native
+
   pg-cloudflare@1.3.0:
     optional: true
 
@@ -17608,6 +18385,10 @@ snapshots:
   pg-connection-string@2.13.0: {}
 
   pg-copy-streams@7.0.0: {}
+
+  pg-env@1.22.0:
+    dependencies:
+      12factor-env: 1.21.0
 
   pg-int8@1.0.1: {}
 
@@ -17654,6 +18435,12 @@ snapshots:
   pg-protocol@1.13.0: {}
 
   pg-protocol@1.14.0: {}
+
+  pg-query-context@2.23.0:
+    dependencies:
+      pg: 8.21.0
+    transitivePeerDependencies:
+      - pg-native
 
   pg-sql2@5.0.1:
     dependencies:
@@ -19047,6 +19834,8 @@ snapshots:
       react: 19.2.5
 
   util-deprecate@1.0.2: {}
+
+  uuid-hash@2.23.0: {}
 
   uuid@10.0.0: {}
 


### PR DESCRIPTION
## Summary

New package `agentic/pi` (`@agentic-kit/pi@0.1.0`): the 16 typed db tools (provision_database, provision_blueprint, describe_schema, add_relation, delete/create/update field+table mutations, add_policies, add_records, run_codegen, and the 5-tool template suite) extracted from Constructive Desktop's `src/main/harness/extensions/db-tools/`, plus the confirm gate, packaged as a reusable pi extension for Desktop, the `agent` CLI, and third-party pi hosts.

**Host injection replaces Electron singletons.** Everywhere the Desktop code read `runtime.accountStore` / `runtime.backendConfigStore` / `runtime.dataAuthBroker` / `readPreviewToken()`, the tools now read an injected `PiToolsHost`:

```ts
interface PiToolsHost {
  account(): HostAccount | null | undefined;          // { userId, accessToken }
  backendConfig(): HostBackendConfig | null | undefined; // { apiEndpoint, modulesEndpoint }
  dataAuthBroker?: DataAuthBroker;    // per-database end-user token memory
  previewToken?(): Promise<PreviewToken | null>;
  dataTokenSkewMs?: number;           // default 30s
}
configureHost(host);            // or: pi.use(createDbTools(host))
```

**No typebox, ESM-safe.** Per the "I don't want to use typebox" direction: tool parameter schemas are authored in zod and cast to pi's `TSchema` at the boundary via `toolSchema(zodSchema)` (`z.toJSONSchema(..., { target: 'draft-7' })` minus `$schema` — structurally identical to what typebox emitted). `typebox` and `@earendil-works/pi-coding-agent` are **type-only imports** (typebox is a devDep; pi is a peer + devDep), so the CJS build never `require()`s pi's ESM-only runtime — verified: loading `dist/index.js` pulls zero earendil/typebox modules. Dual CJS/ESM via makage like the rest of the family. `provision_blueprint` reuses the harness's `BlueprintZod`.

**Confirm gate generalized for terminal hosts.** The pi adapter now detects a rich confirm surface (`ctx.ui.confirmTool`/`notifyToolSkipped`, i.e. Desktop's extension-ui) and otherwise falls back to pi's built-in `ui.confirm(title, message)` dialog — so the CLI gets gating for free with the TUI y/n prompt.

**Generated ORM dependency.** Desktop's `@/generated/modules/orm` import is replaced with the published `@constructive-io/sdk` `modules` namespace (`modules.createClient`, input type derived from `modules.DatabaseProvisionModuleModel['create']`), so no generated code is vendored.

Behavior of the tool implementations is otherwise preserved verbatim from Desktop.

## Testing

- `pnpm build` — clean dual CJS/ESM build; CJS smoke-load confirms no pi/typebox in the require graph
- `pnpm test` — 7 tests: host configure/error paths, `toolSchema` JSON-Schema output, all-16-tool registration + gate event wiring, and confirm-gate rich-UI vs `ui.confirm` fallback
- `tsc --noEmit` clean; repo-wide `pnpm lint` remains broken on main (ESLint 9 vs legacy .eslintrc) — untouched

Follow-ups (separate PRs): point Desktop at this package and delete its vendored db-tools; wire `@agentic-kit/cli` to `createDbTools`.

Link to Devin session: https://app.devin.ai/sessions/93aed4dac17243818e6c3bda66be587a
Requested by: @pyramation