### PR TITLE
docs: fix agentic README badges + add pglite-test to FOOTER.md

### DIFF
--- a/FOOTER.md
+++ b/FOOTER.md
@@ -30,6 +30,7 @@ Common issues and solutions for pgpm, PostgreSQL, and testing.
 ### 🧪 Testing
 
 * [pgsql-test](https://github.com/constructive-io/constructive/tree/main/postgres/pgsql-test): **📊 Isolated testing environments** with per-test transaction rollbacks—ideal for integration tests, complex migrations, and RLS simulation.
+* [pglite-test](https://github.com/constructive-io/constructive/tree/main/postgres/pglite-test): **🪶 Drop-in pgsql-test replacement backed by PGlite** — in-process Postgres, no server required, instance-per-suite isolation.
 * [pgsql-seed](https://github.com/constructive-io/constructive/tree/main/postgres/pgsql-seed): **🌱 PostgreSQL seeding utilities** for CSV, JSON, SQL data loading, and pgpm deployment.
 * [supabase-test](https://github.com/constructive-io/constructive/tree/main/postgres/supabase-test): **🧪 Supabase-native test harness** preconfigured for the local Supabase stack—per-test rollbacks, JWT/role context helpers, and CI/GitHub Actions ready.
 * [graphile-test](https://github.com/constructive-io/constructive/tree/main/graphile/graphile-test): **🔐 Authentication mocking** for Graphile-focused test helpers and emulating row-level security contexts.

--- a/agentic/agent/README.md
+++ b/agentic/agent/README.md
@@ -5,11 +5,11 @@
 </p>
 
 <p align="center" width="100%">
-  <a href="https://github.com/constructive-io/agentic-kit/actions/workflows/run-tests.yaml">
-    <img height="20" src="https://github.com/constructive-io/agentic-kit/actions/workflows/run-tests.yaml/badge.svg" />
+  <a href="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml">
+    <img height="20" src="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml/badge.svg" />
   </a>
-   <a href="https://github.com/constructive-io/agentic-kit/blob/main/LICENSE"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
-   <a href="https://www.npmjs.com/package/@agentic-kit/agent"><img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/agentic-kit?filename=packages%2Fagent%2Fpackage.json"/></a>
+   <a href="https://github.com/constructive-io/constructive/blob/main/LICENSE"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
+   <a href="https://www.npmjs.com/package/@agentic-kit/agent"><img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/constructive?filename=agentic%2Fagent%2Fpackage.json"/></a>
 </p>
 
 Minimal stateful agent runtime built on `agentic-kit`. The `Agent` class drives

--- a/agentic/agentic-kit/README.md
+++ b/agentic/agentic-kit/README.md
@@ -4,6 +4,14 @@
   <img height="250" src="https://raw.githubusercontent.com/constructive-io/constructive/refs/heads/main/assets/outline-logo.svg" />
 </p>
 
+<p align="center" width="100%">
+  <a href="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml">
+    <img height="20" src="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml/badge.svg" />
+  </a>
+   <a href="https://github.com/constructive-io/constructive/blob/main/LICENSE"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
+   <a href="https://www.npmjs.com/package/agentic-kit"><img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/constructive?filename=agentic%2Fagentic-kit%2Fpackage.json"/></a>
+</p>
+
 Umbrella package for the agentic-kit family — build your own custom agents with a provider-agnostic chat layer, a stateful agent runtime, and the Constructive harness.
 
 ## Usage

--- a/agentic/anthropic/README.md
+++ b/agentic/anthropic/README.md
@@ -5,11 +5,11 @@
 </p>
 
 <p align="center" width="100%">
-  <a href="https://github.com/constructive-io/agentic-kit/actions/workflows/run-tests.yaml">
-    <img height="20" src="https://github.com/constructive-io/agentic-kit/actions/workflows/run-tests.yaml/badge.svg" />
+  <a href="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml">
+    <img height="20" src="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml/badge.svg" />
   </a>
-   <a href="https://github.com/constructive-io/agentic-kit/blob/main/LICENSE"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
-   <a href="https://www.npmjs.com/package/@agentic-kit/anthropic"><img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/agentic-kit?filename=packages%2Fanthropic%2Fpackage.json"/></a>
+   <a href="https://github.com/constructive-io/constructive/blob/main/LICENSE"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
+   <a href="https://www.npmjs.com/package/@agentic-kit/anthropic"><img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/constructive?filename=agentic%2Fanthropic%2Fpackage.json"/></a>
 </p>
 
 Anthropic (Claude) adapter for `agentic-kit`. Speaks the Messages API over

--- a/agentic/chat/README.md
+++ b/agentic/chat/README.md
@@ -5,11 +5,11 @@
 </p>
 
 <p align="center" width="100%">
-  <a href="https://github.com/constructive-io/agentic-kit/actions/workflows/run-tests.yaml">
-    <img height="20" src="https://github.com/constructive-io/agentic-kit/actions/workflows/run-tests.yaml/badge.svg" />
+  <a href="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml">
+    <img height="20" src="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml/badge.svg" />
   </a>
-   <a href="https://github.com/constructive-io/agentic-kit/blob/main/LICENSE"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
-   <a href="https://www.npmjs.com/package/agentic-kit"><img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/agentic-kit?filename=packages%2Fagentic-kit%2Fpackage.json"/></a>
+   <a href="https://github.com/constructive-io/constructive/blob/main/LICENSE"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
+   <a href="https://www.npmjs.com/package/agentic-kit"><img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/constructive?filename=agentic%2Fchat%2Fpackage.json"/></a>
 </p>
 
 A low-level provider portability layer for LLM applications. `agentic-kit`

--- a/agentic/cli/README.md
+++ b/agentic/cli/README.md
@@ -4,6 +4,14 @@
   <img height="250" src="https://raw.githubusercontent.com/constructive-io/constructive/refs/heads/main/assets/outline-logo.svg" />
 </p>
 
+<p align="center" width="100%">
+  <a href="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml">
+    <img height="20" src="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml/badge.svg" />
+  </a>
+   <a href="https://github.com/constructive-io/constructive/blob/main/LICENSE"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
+   <a href="https://www.npmjs.com/package/@agentic-kit/cli"><img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/constructive?filename=agentic%2Fcli%2Fpackage.json"/></a>
+</p>
+
 `agent` — a local, secure-by-default coding agent that builds your frontend and your backend. Skills, a backend harness, and offline-capable skill releases, batteries included.
 
 ```bash

--- a/agentic/harness/README.md
+++ b/agentic/harness/README.md
@@ -4,6 +4,14 @@
   <img height="250" src="https://raw.githubusercontent.com/constructive-io/constructive/refs/heads/main/assets/outline-logo.svg" />
 </p>
 
+<p align="center" width="100%">
+  <a href="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml">
+    <img height="20" src="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml/badge.svg" />
+  </a>
+   <a href="https://github.com/constructive-io/constructive/blob/main/LICENSE"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
+   <a href="https://www.npmjs.com/package/@agentic-kit/harness"><img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/constructive?filename=agentic%2Fharness%2Fpackage.json"/></a>
+</p>
+
 Give your coding agent a backend. `@agentic-kit/harness` is the host-neutral core of the **Constructive harness** — skills releases, confirm gating, and blueprint logic that turn a generic coding agent into a secure, full-stack app builder.
 
 ```bash

--- a/agentic/ollama/README.md
+++ b/agentic/ollama/README.md
@@ -5,11 +5,11 @@
 </p>
 
 <p align="center" width="100%">
-  <a href="https://github.com/constructive-io/agentic-kit/actions/workflows/run-tests.yaml">
-    <img height="20" src="https://github.com/constructive-io/agentic-kit/actions/workflows/run-tests.yaml/badge.svg" />
+  <a href="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml">
+    <img height="20" src="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml/badge.svg" />
   </a>
-   <a href="https://github.com/constructive-io/agentic-kit/blob/main/LICENSE"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
-   <a href="https://www.npmjs.com/package/@agentic-kit/ollama"><img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/agentic-kit?filename=packages%2Follama%2Fpackage.json"/></a>
+   <a href="https://github.com/constructive-io/constructive/blob/main/LICENSE"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
+   <a href="https://www.npmjs.com/package/@agentic-kit/ollama"><img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/constructive?filename=agentic%2Follama%2Fpackage.json"/></a>
 </p>
 
 A JavaScript/TypeScript client and provider adapter for the Ollama API,
@@ -126,4 +126,4 @@ Either `prompt` (single-turn) or `messages` (multi-turn) must be set.
 
 ## Contributing
 
-Please open issues or pull requests on [GitHub](https://github.com/constructive-io/agentic-kit).
+Please open issues or pull requests on [GitHub](https://github.com/constructive-io/constructive).

--- a/agentic/openai/README.md
+++ b/agentic/openai/README.md
@@ -5,11 +5,11 @@
 </p>
 
 <p align="center" width="100%">
-  <a href="https://github.com/constructive-io/agentic-kit/actions/workflows/run-tests.yaml">
-    <img height="20" src="https://github.com/constructive-io/agentic-kit/actions/workflows/run-tests.yaml/badge.svg" />
+  <a href="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml">
+    <img height="20" src="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml/badge.svg" />
   </a>
-   <a href="https://github.com/constructive-io/agentic-kit/blob/main/LICENSE"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
-   <a href="https://www.npmjs.com/package/@agentic-kit/openai"><img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/agentic-kit?filename=packages%2Fopenai%2Fpackage.json"/></a>
+   <a href="https://github.com/constructive-io/constructive/blob/main/LICENSE"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
+   <a href="https://www.npmjs.com/package/@agentic-kit/openai"><img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/constructive?filename=agentic%2Fopenai%2Fpackage.json"/></a>
 </p>
 
 OpenAI and OpenAI-compatible adapter for `agentic-kit`. Works with GPT models,

--- a/agentic/pi/README.md
+++ b/agentic/pi/README.md
@@ -4,6 +4,14 @@
   <img height="250" src="https://raw.githubusercontent.com/constructive-io/constructive/refs/heads/main/assets/outline-logo.svg" />
 </p>
 
+<p align="center" width="100%">
+  <a href="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml">
+    <img height="20" src="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml/badge.svg" />
+  </a>
+   <a href="https://github.com/constructive-io/constructive/blob/main/LICENSE"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
+   <a href="https://www.npmjs.com/package/@agentic-kit/pi"><img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/constructive?filename=agentic%2Fpi%2Fpackage.json"/></a>
+</p>
+
 The [pi coding agent](https://github.com/badlogic/pi-mono) adapter for **agentic-kit**: the Constructive typed database tools and the [`@agentic-kit/harness`](https://www.npmjs.com/package/@agentic-kit/harness) confirm gate, packaged as a pi extension any host can register — Constructive Desktop, the [`agent` CLI](https://www.npmjs.com/package/@agentic-kit/cli), or your own pi-based agent.
 
 ```bash

--- a/agentic/protocol/README.md
+++ b/agentic/protocol/README.md
@@ -4,7 +4,15 @@
   <img height="250" src="https://raw.githubusercontent.com/constructive-io/constructive/refs/heads/main/assets/outline-logo.svg" />
 </p>
 
-The shared protocol kernel for [agentic-kit](https://github.com/constructive-io/agentic-kit).
+<p align="center" width="100%">
+  <a href="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml">
+    <img height="20" src="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml/badge.svg" />
+  </a>
+   <a href="https://github.com/constructive-io/constructive/blob/main/LICENSE"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
+   <a href="https://www.npmjs.com/package/@agentic-kit/protocol"><img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/constructive?filename=agentic%2Fprotocol%2Fpackage.json"/></a>
+</p>
+
+The shared protocol kernel for [agentic-kit](https://github.com/constructive-io/constructive).
 
 This package holds the provider-agnostic contracts and helpers that every adapter
 and the top-level `agentic-kit` package build on:

--- a/agentic/react/README.md
+++ b/agentic/react/README.md
@@ -5,11 +5,11 @@
 </p>
 
 <p align="center" width="100%">
-  <a href="https://github.com/constructive-io/agentic-kit/actions/workflows/run-tests.yaml">
-    <img height="20" src="https://github.com/constructive-io/agentic-kit/actions/workflows/run-tests.yaml/badge.svg" />
+  <a href="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml">
+    <img height="20" src="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml/badge.svg" />
   </a>
-   <a href="https://github.com/constructive-io/agentic-kit/blob/main/LICENSE"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
-   <a href="https://www.npmjs.com/package/@agentic-kit/react"><img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/agentic-kit?filename=packages%2Freact%2Fpackage.json"/></a>
+   <a href="https://github.com/constructive-io/constructive/blob/main/LICENSE"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
+   <a href="https://www.npmjs.com/package/@agentic-kit/react"><img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/constructive?filename=agentic%2Freact%2Fpackage.json"/></a>
 </p>
 
 Headless React bindings for `@agentic-kit/agent`. Exposes a single hook —


### PR DESCRIPTION
## Summary

Docs-only sweep of the agentic-kit family READMEs:

- **Old GitHub links repointed** — agent, anthropic, chat, ollama, openai, react (and protocol's prose link) still pointed badges/links at the pre-monorepo `constructive-io/agentic-kit` repo. All now point at `constructive-io/constructive` (actions workflow, LICENSE, and the version badge's `filename=agentic%2F<pkg>%2Fpackage.json`).
- **Missing badges added** — agentic-kit (umbrella), cli, harness, pi, protocol had no badge row; each now gets the standard block (run-tests badge, license, npm version) under the logo header.
- **FOOTER.md** — added `pglite-test` to the Testing section (drop-in pgsql-test replacement backed by in-process PGlite). This footer is appended to every published package README by makage.

No code changes.

Link to Devin session: https://app.devin.ai/sessions/93aed4dac17243818e6c3bda66be587a
Requested by: @pyramation