### PR TITLE
refactor(errors): registry message is the untagged default; drop built-in en catalog

### DIFF
--- a/packages/errors/__tests__/parse.test.ts
+++ b/packages/errors/__tests__/parse.test.ts
@@ -174,11 +174,15 @@ describe('format / i18n', () => {
     expect(format('MODULE_NOT_FOUND', { name: 'auth' })).toBe('Module "auth" not found in modules list.');
   });
 
-  it('uses a registered locale catalog with fallback to en', () => {
+  it('uses a registered locale overlay, falling back to the registry default', () => {
     registerCatalog('es', { ACCOUNT_EXISTS: 'Ya existe una cuenta con este correo.' });
     expect(format('ACCOUNT_EXISTS', {}, 'es')).toBe('Ya existe una cuenta con este correo.');
-    // falls back to en for codes not in the es catalog
+    // codes without an overlay entry fall back to the untagged registry default
     expect(format('FORBIDDEN', {}, 'es')).toBe('You do not have permission to do that.');
+  });
+
+  it('renders the registry default when no locale is given', () => {
+    expect(format('FORBIDDEN')).toBe('You do not have permission to do that.');
   });
 
   it('humanizes unknown codes as a last resort', () => {

--- a/packages/errors/src/format.ts
+++ b/packages/errors/src/format.ts
@@ -1,32 +1,28 @@
 import { interpolate } from './interpolate';
-import { allCodes, getDefinition } from './registry';
+import { getDefinition } from './registry';
 import type { ErrorContext } from './types';
 
 /** A locale catalog maps `code` → message template (with `{{var}}`). */
 export type MessageCatalog = Record<string, string>;
 
+/**
+ * Locale to use when `format` is called without one. This is a plain fallback
+ * label, not a special catalog: the untagged default copy lives in the registry
+ * itself, so there is no built-in `'en'` catalog to keep in sync.
+ */
 export const DEFAULT_LOCALE = 'en';
 
 /**
- * Built-in `en` catalog derived from every registered code's string message
- * (curated + generated). Entries whose message is a function are omitted (they
- * are computed, not templated) and fall back to the registry function at
- * format time.
+ * Registered locale overlays. Empty by default — the base/default message for
+ * every code is the registry entry, so a locale only needs entries for the
+ * codes it actually translates.
  */
-const defaultEnCatalog: MessageCatalog = Object.fromEntries(
-  allCodes()
-    .map((code) => getDefinition(code))
-    .filter((def): def is NonNullable<typeof def> => !!def && typeof def.message === 'string')
-    .map((def) => [def.code, def.message as string])
-);
-
-const catalogs: Record<string, MessageCatalog> = {
-  [DEFAULT_LOCALE]: { ...defaultEnCatalog }
-};
+const catalogs: Record<string, MessageCatalog> = {};
 
 /**
  * Register or extend a locale catalog. Merges with any existing entries for
- * that locale (new entries win), so hosts can override individual codes.
+ * that locale (new entries win), so hosts can override individual codes — pass
+ * the default locale to override the base copy.
  */
 export function registerCatalog(locale: string, catalog: MessageCatalog): void {
   catalogs[locale] = { ...catalogs[locale], ...catalog };
@@ -38,25 +34,30 @@ function humanize(code: string): string {
   return lower.charAt(0).toUpperCase() + lower.slice(1);
 }
 
+/** The registry's default message for a code (string template or function). */
+function defaultMessage(code: string, context: ErrorContext): string {
+  const def = getDefinition(code);
+  if (def) {
+    if (typeof def.message === 'string') return interpolate(def.message, context);
+    if (typeof def.message === 'function') {
+      return (def.message as (ctx: ErrorContext) => string)(context);
+    }
+  }
+  return humanize(code);
+}
+
 /**
  * Render a localized message for a code.
  *
  * Resolution order:
- * 1. requested-locale catalog entry (template) → interpolate
- * 2. default-locale catalog entry (template) → interpolate
- * 3. registry function message → call with context
- * 4. humanized code
+ * 1. requested-locale overlay entry (template) → interpolate
+ * 2. registry default message (template → interpolate, or function → call)
+ * 3. humanized code
  */
 export function format(code: string, context: ErrorContext = {}, locale: string = DEFAULT_LOCALE): string {
-  const template = catalogs[locale]?.[code] ?? catalogs[DEFAULT_LOCALE]?.[code];
-  if (typeof template === 'string') {
-    return interpolate(template, context);
+  const overlay = catalogs[locale]?.[code];
+  if (typeof overlay === 'string') {
+    return interpolate(overlay, context);
   }
-
-  const def = getDefinition(code);
-  if (def && typeof def.message === 'function') {
-    return (def.message as (ctx: ErrorContext) => string)(context);
-  }
-
-  return humanize(code);
+  return defaultMessage(code, context);
 }


### PR DESCRIPTION
## Summary

Simplifies message resolution in `@constructive-io/errors` so **English is just "the default," not a named locale**. The registry already holds the default copy for every code, so the built-in `'en'` catalog (a duplicate of those messages) was redundant and had to be kept in sync.

Now `format()` resolves a requested-locale **overlay** first, then falls back **directly to the registry message**:

```diff
-const defaultEnCatalog = Object.fromEntries(allCodes()...);   // duplicate of registry copy
-const catalogs = { en: { ...defaultEnCatalog } };
+const catalogs = {};   // only real locale overlays (es, fr, ...) ever get added

 function format(code, ctx, locale = DEFAULT_LOCALE) {
-  const t = catalogs[locale]?.[code] ?? catalogs['en']?.[code];
-  if (typeof t === 'string') return interpolate(t, ctx);
-  const def = getDefinition(code);
-  if (def && typeof def.message === 'function') return def.message(ctx);
-  return humanize(code);
+  const overlay = catalogs[locale]?.[code];
+  if (typeof overlay === 'string') return interpolate(overlay, ctx);
+  return defaultMessage(code, ctx);   // registry string→interpolate | fn→call | humanize
 }
```

**Public API is unchanged** — `format(code, ctx, locale?)`, `registerCatalog(locale, catalog)`, `DEFAULT_LOCALE`, the `errors.*` factories, and `ConstructiveError` keep identical signatures and outputs. `format('ACCOUNT_EXISTS', { email })` returns the same string as before. A locale still overlays only the codes it translates and falls back to the registry default; hosts can still override the base copy via `registerCatalog(DEFAULT_LOCALE, { ... })`.

Removes ~15 lines and the duplicated catalog. Tests updated (29 pass).

## Notes
- No `exports`/`sideEffects` polish included: no package in the monorepo uses an `exports` map (all rely on `main`/`module`/`types`), so adding one only here would be an inconsistent outlier; and the package already has no import-time side effects, so the `sideEffects` flag is unnecessary.
- Follow-up (not in this PR): first npm publish of `@constructive-io/errors` so out-of-repo frontends (dashboard, desktop) can consume it.


Link to Devin session: https://app.devin.ai/sessions/f4d3ce9225894883ba9cfc9ed2f0ba7e
Requested by: @pyramation