### PR TITLE
feat(safegres): role-trust rules (R1–R3) + safegres:constructive preset, drop multi-tenant

### DIFF
--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -39,8 +39,13 @@ Per-field overrides (`--host`, `--port`, `--user`, `--password`, `--database`) a
 | A7 | high | anti-pattern | Trivially-permissive policy (`USING (true)` / `WITH CHECK (true)`) |
 | P1 | high | anti-pattern | Policy body calls a **VOLATILE function** (per-row evaluation) |
 | P5 | high | anti-pattern | Policy body references **`session_user`** / `current_user` / `pg_has_role(...)` |
+| R1 | critical | anti-pattern | An **untrusted role** (options: `{ roles: [...] }`) holds a write privilege |
+| R2 | high | anti-pattern | A permissive write policy applies to an untrusted role or PUBLIC |
+| R3 | medium | anti-pattern | An RLS table has grants **TO PUBLIC** (includes all current/future roles) |
 
 Coverage is aggregated `(table, role) → { hasUsing, hasWithCheck }` across every applicable permissive policy (FOR ALL + PUBLIC-role policies considered). Roles with `BYPASSRLS` are suppressed.
+
+R1/R2 are no-ops until a role list is configured — e.g. `"R1": ["critical", { "roles": ["anonymous"] }]` — so they cost nothing on databases without an untrusted-role model. The `safegres:constructive` preset configures them for `anonymous`.
 
 ## Configuration
 
@@ -71,7 +76,7 @@ Or typed:
 import { defineConfig } from 'confstash';
 
 export default defineConfig({
-  extends: 'safegres:multi-tenant',
+  extends: 'safegres:constructive',
   rules: { A6: 'low' }
 });
 ```
@@ -82,7 +87,7 @@ export default defineConfig({
 | --- | --- |
 | `safegres:recommended` | Every rule at its default severity (the no-config behavior) |
 | `safegres:strict` | Coverage gaps escalated (A4 critical, A5 high), `failOn: high` |
-| `safegres:multi-tenant` | Cross-tenant leak surfaces (A2, A4, A7, P5) critical |
+| `safegres:constructive` | Constructive's role model: R1/R2 watch `anonymous`, leak surfaces (A2, A4, A7, P5) critical |
 | `safegres:minimal` | Structural flags only (A1–A3) — fast CI smoke check |
 
 CLI: `--config <path>`, `--preset <name>`, `--rule CODE=off|severity` (repeatable).

--- a/packages/safegres/__tests__/config.test.ts
+++ b/packages/safegres/__tests__/config.test.ts
@@ -31,6 +31,7 @@ function finding(partial: Partial<Finding> & { code: string }): Finding {
 describe('rule registry', () => {
   it('expands prefix wildcards', () => {
     expect(expandRuleSelector('P*').sort()).toEqual(['P1', 'P1b', 'P5']);
+    expect(expandRuleSelector('R*').sort()).toEqual(['R1', 'R2', 'R3']);
     expect(expandRuleSelector('*')).toHaveLength(RULES.length);
     expect(expandRuleSelector('A1')).toEqual(['A1']);
     expect(expandRuleSelector('ZZ')).toEqual([]);
@@ -140,16 +141,22 @@ describe('presets', () => {
     expect(rules.get('P1')!.enabled).toBe(false);
   });
 
-  it('multi-tenant escalates leak-prone rules to critical', () => {
+  it('constructive escalates leak-prone rules and watches anonymous', () => {
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'safegres-'));
     fs.writeFileSync(
       path.join(cwd, '.safegresrc.json'),
-      JSON.stringify({ extends: 'safegres:multi-tenant' })
+      JSON.stringify({ extends: 'safegres:constructive' })
     );
     const { config } = loadConfig({ cwd });
     const { rules } = resolveRules(config);
     expect(rules.get('A2')!.severity).toBe('critical');
     expect(rules.get('P5')!.severity).toBe('critical');
+    expect(rules.get('R1')).toEqual({
+      enabled: true,
+      severity: 'critical',
+      options: { roles: ['anonymous'] }
+    });
+    expect(rules.get('R2')!.options).toEqual({ roles: ['anonymous'] });
     expect(config.scoring?.floorOnCritical).toBe('C');
   });
 });

--- a/packages/safegres/__tests__/role-trust.test.ts
+++ b/packages/safegres/__tests__/role-trust.test.ts
@@ -1,0 +1,110 @@
+import {
+  checkPublicGrants,
+  checkUntrustedRolePolicies,
+  checkUntrustedRoleWrites
+} from '../src/checks/role-trust';
+import type { GrantInfo, PolicyInfo, TableSnapshot } from '../src/pg/introspect';
+
+function table(partial: Partial<TableSnapshot> = {}): TableSnapshot {
+  return {
+    schema: 'public',
+    name: 'users',
+    oid: 1,
+    rlsEnabled: true,
+    rlsForced: true,
+    isPartitioned: false,
+    owner: 'app_owner',
+    grants: [],
+    policies: [],
+    ...partial
+  };
+}
+
+function grant(role: string, privilege: GrantInfo['privilege']): GrantInfo {
+  return { role, privilege, grantable: false, bypassRls: false };
+}
+
+function policy(partial: Partial<PolicyInfo> = {}): PolicyInfo {
+  return {
+    name: 'p',
+    cmd: 'ALL',
+    permissive: true,
+    roles: ['authenticated'],
+    using: 'true',
+    withCheck: null,
+    ...partial
+  };
+}
+
+describe('R1 checkUntrustedRoleWrites', () => {
+  it('is a no-op with no roles configured', () => {
+    const t = table({ grants: [grant('anonymous', 'INSERT')] });
+    expect(checkUntrustedRoleWrites(t)).toEqual([]);
+    expect(checkUntrustedRoleWrites(t, { roles: [] })).toEqual([]);
+  });
+
+  it('flags write grants to untrusted roles, not reads', () => {
+    const t = table({
+      grants: [
+        grant('anonymous', 'SELECT'),
+        grant('anonymous', 'INSERT'),
+        grant('anonymous', 'DELETE'),
+        grant('authenticated', 'INSERT')
+      ]
+    });
+    const out = checkUntrustedRoleWrites(t, { roles: ['anonymous'] });
+    expect(out).toHaveLength(2);
+    expect(out.map((f) => f.privilege).sort()).toEqual(['DELETE', 'INSERT']);
+    expect(out[0].code).toBe('R1');
+    expect(out[0].severity).toBe('critical');
+    expect(out[0].role).toBe('anonymous');
+  });
+});
+
+describe('R2 checkUntrustedRolePolicies', () => {
+  it('flags permissive write policies applying to untrusted roles', () => {
+    const t = table({
+      policies: [
+        policy({ name: 'anon_insert', cmd: 'INSERT', roles: ['anonymous'] }),
+        policy({ name: 'anon_select', cmd: 'SELECT', roles: ['anonymous'] }),
+        policy({ name: 'auth_all', cmd: 'ALL', roles: ['authenticated'] })
+      ]
+    });
+    const out = checkUntrustedRolePolicies(t, { roles: ['anonymous'] });
+    expect(out).toHaveLength(1);
+    expect(out[0].code).toBe('R2');
+    expect(out[0].policy).toBe('anon_insert');
+  });
+
+  it('flags PUBLIC policies (they include untrusted roles)', () => {
+    const t = table({ policies: [policy({ name: 'open_all', roles: ['PUBLIC'] })] });
+    const out = checkUntrustedRolePolicies(t, { roles: ['anonymous'] });
+    expect(out).toHaveLength(1);
+    expect(out[0].message).toContain('PUBLIC (all roles)');
+  });
+
+  it('ignores restrictive policies and RLS-disabled tables', () => {
+    const restrictive = table({
+      policies: [policy({ roles: ['anonymous'], permissive: false })]
+    });
+    expect(checkUntrustedRolePolicies(restrictive, { roles: ['anonymous'] })).toEqual([]);
+
+    const noRls = table({ rlsEnabled: false, policies: [policy({ roles: ['anonymous'] })] });
+    expect(checkUntrustedRolePolicies(noRls, { roles: ['anonymous'] })).toEqual([]);
+  });
+});
+
+describe('R3 checkPublicGrants', () => {
+  it('flags PUBLIC grants on RLS tables', () => {
+    const t = table({ grants: [grant('PUBLIC', 'SELECT'), grant('PUBLIC', 'INSERT')] });
+    const out = checkPublicGrants(t);
+    expect(out).toHaveLength(1);
+    expect(out[0].code).toBe('R3');
+    expect(out[0].message).toContain('SELECT, INSERT');
+  });
+
+  it('ignores tables without RLS or without PUBLIC grants', () => {
+    expect(checkPublicGrants(table({ rlsEnabled: false, grants: [grant('PUBLIC', 'SELECT')] }))).toEqual([]);
+    expect(checkPublicGrants(table({ grants: [grant('authenticated', 'SELECT')] }))).toEqual([]);
+  });
+});

--- a/packages/safegres/src/checks/role-trust.ts
+++ b/packages/safegres/src/checks/role-trust.ts
@@ -1,0 +1,104 @@
+import type { PgPrivilege, TableSnapshot } from '../pg/introspect';
+import type { Finding } from '../types';
+
+/**
+ * Role-trust rules (R-series): findings driven by *who* is granted access,
+ * not just whether coverage exists. R1/R2 take a configurable list of
+ * untrusted roles (e.g. `anonymous`) via rule options; with no roles
+ * configured they are no-ops, so they cost nothing on databases without
+ * such a role model.
+ */
+
+export interface RoleTrustOptions {
+  /** Role names considered untrusted (exact match). */
+  roles?: string[];
+}
+
+const WRITE_PRIVILEGES: PgPrivilege[] = ['INSERT', 'UPDATE', 'DELETE', 'TRUNCATE'];
+
+/**
+ * R1: an untrusted role holds a write privilege on a table. Even with
+ * airtight policies, write access for e.g. `anonymous` is almost always a
+ * grant mistake — unauthenticated actors can INSERT/UPDATE/DELETE.
+ */
+export function checkUntrustedRoleWrites(
+  table: TableSnapshot,
+  options: RoleTrustOptions = {}
+): Finding[] {
+  const untrusted = new Set(options.roles ?? []);
+  if (untrusted.size === 0) return [];
+
+  const out: Finding[] = [];
+  for (const grant of table.grants) {
+    if (!untrusted.has(grant.role)) continue;
+    if (!WRITE_PRIVILEGES.includes(grant.privilege)) continue;
+    out.push({
+      code: 'R1',
+      severity: 'critical',
+      category: 'anti-pattern',
+      schema: table.schema,
+      table: table.name,
+      role: grant.role,
+      privilege: grant.privilege,
+      message: `Untrusted role ${grant.role} has ${grant.privilege} grant on ${table.schema}.${table.name}`,
+      hint: `Revoke ${grant.privilege} from ${grant.role} unless unauthenticated writes to this table are intentional (e.g. a public signup or event-ingest table).`
+    });
+  }
+  return out;
+}
+
+/**
+ * R2: a permissive policy makes write operations pass RLS for an untrusted
+ * role (directly or via PUBLIC). Pairs with R1: the grant is the door, the
+ * policy is the unlocked latch.
+ */
+export function checkUntrustedRolePolicies(
+  table: TableSnapshot,
+  options: RoleTrustOptions = {}
+): Finding[] {
+  const untrusted = new Set(options.roles ?? []);
+  if (untrusted.size === 0 || !table.rlsEnabled) return [];
+
+  const out: Finding[] = [];
+  for (const policy of table.policies) {
+    if (!policy.permissive) continue;
+    if (policy.cmd === 'SELECT') continue;
+    const applies = policy.roles.filter((r) => r === 'PUBLIC' || untrusted.has(r));
+    if (applies.length === 0) continue;
+    const via = policy.roles.includes('PUBLIC') ? 'PUBLIC (all roles)' : applies.join(', ');
+    out.push({
+      code: 'R2',
+      severity: 'high',
+      category: 'anti-pattern',
+      schema: table.schema,
+      table: table.name,
+      policy: policy.name,
+      message: `Permissive ${policy.cmd} policy ${policy.name} on ${table.schema}.${table.name} applies to untrusted role via ${via}`,
+      hint: 'Scope the policy TO specific trusted roles instead of PUBLIC/untrusted roles, or verify unauthenticated writes are intended.'
+    });
+  }
+  return out;
+}
+
+/**
+ * R3: a table with RLS enabled has grants TO PUBLIC. PUBLIC includes every
+ * present and future role, which silently widens access as roles are added
+ * and defeats role-scoped policy reasoning.
+ */
+export function checkPublicGrants(table: TableSnapshot): Finding[] {
+  if (!table.rlsEnabled) return [];
+  const publicPrivs = table.grants.filter((g) => g.role === 'PUBLIC').map((g) => g.privilege);
+  if (publicPrivs.length === 0) return [];
+  return [
+    {
+      code: 'R3',
+      severity: 'medium',
+      category: 'anti-pattern',
+      schema: table.schema,
+      table: table.name,
+      role: 'PUBLIC',
+      message: `Table ${table.schema}.${table.name} has RLS enabled but grants ${publicPrivs.join(', ')} to PUBLIC`,
+      hint: 'Grant to specific roles instead of PUBLIC — PUBLIC includes every current and future role, including untrusted ones.'
+    }
+  ];
+}

--- a/packages/safegres/src/cli/audit.ts
+++ b/packages/safegres/src/cli/audit.ts
@@ -29,7 +29,7 @@ Connection (priority order, top wins):
 Configuration:
   --config <path>          Explicit config file (else discovered: safegres.config.{ts,js,mjs,cjs},
                            .safegresrc{,.json,.yaml,.yml,.js}, safegres.json, package.json "safegres")
-  --preset <name>          Apply a built-in preset (recommended|strict|multi-tenant|minimal)
+  --preset <name>          Apply a built-in preset (recommended|strict|constructive|minimal)
   --rule <CODE=SETTING>    Retune a rule (repeatable), e.g. --rule A3=off --rule A5=high
 
 Audit options:

--- a/packages/safegres/src/commands/audit.ts
+++ b/packages/safegres/src/commands/audit.ts
@@ -20,7 +20,13 @@ import {
   checkRlsEnabledNoPolicies,
   checkRlsNotForced
 } from '../checks/rls-flags';
-import { allAstRulesDisabled, applyRulesToFindings, resolveRules } from '../config/resolve';
+import {
+  checkPublicGrants,
+  checkUntrustedRolePolicies,
+  checkUntrustedRoleWrites,
+  type RoleTrustOptions
+} from '../checks/role-trust';
+import { allAstRulesDisabled, applyRulesToFindings, resolveRules, rulesForTable } from '../config/resolve';
 import type { SafegresConfig } from '../config/types';
 import { asExecutor, type IntrospectOptions, introspectTables, type QueryExecutor, type TableSnapshot } from '../pg/introspect';
 import { lookupVolatility, type ProcVolatility } from '../pg/proc';
@@ -88,6 +94,16 @@ export async function audit(
     // --- Grant-vs-policy coverage ---
     findings.push(...checkCoverageGaps(table));
     findings.push(...checkUpdateWithCheckCoverage(table));
+
+    // --- Role-trust (options-driven; per-table overrides can retune roles) ---
+    const tableRules = rulesForTable(resolved, table.schema, table.name);
+    findings.push(
+      ...checkUntrustedRoleWrites(table, tableRules.get('R1')?.options as RoleTrustOptions)
+    );
+    findings.push(
+      ...checkUntrustedRolePolicies(table, tableRules.get('R2')?.options as RoleTrustOptions)
+    );
+    findings.push(...checkPublicGrants(table));
 
     // --- AST-level anti-patterns ---
     if (!skipAst) {

--- a/packages/safegres/src/config/presets.ts
+++ b/packages/safegres/src/config/presets.ts
@@ -24,16 +24,20 @@ export const strict: SafegresConfig = {
 };
 
 /**
- * Tuned for tenant-isolation apps: anything that can leak rows across
- * tenants is critical.
+ * Tuned for Constructive's role model (RLS-first, anonymous/authenticated/
+ * administrator): untrusted-role rules watch `anonymous`, and anything that
+ * can leak rows across the role boundary is critical.
  */
-export const multiTenant: SafegresConfig = {
+export const constructive: SafegresConfig = {
   extends: 'safegres:recommended',
   rules: {
     A2: 'critical',
     A4: 'critical',
     A7: 'critical',
-    P5: 'critical'
+    P5: 'critical',
+    R1: ['critical', { roles: ['anonymous'] }],
+    R2: ['high', { roles: ['anonymous'] }],
+    R3: 'medium'
   },
   scoring: { floorOnCritical: 'C' }
 };
@@ -51,6 +55,6 @@ export const minimal: SafegresConfig = {
 export const PRESETS: Record<string, SafegresConfig> = {
   'safegres:recommended': recommended,
   'safegres:strict': strict,
-  'safegres:multi-tenant': multiTenant,
+  'safegres:constructive': constructive,
   'safegres:minimal': minimal
 };

--- a/packages/safegres/src/index.ts
+++ b/packages/safegres/src/index.ts
@@ -11,13 +11,19 @@ export {
   type PgAstNode,
   type PolicyExpression,
   PolicyParseError} from './ast/parse';
+export type { RoleTrustOptions } from './checks/role-trust';
+export {
+  checkPublicGrants,
+  checkUntrustedRolePolicies,
+  checkUntrustedRoleWrites
+} from './checks/role-trust';
 export type { AuditOptions } from './commands/audit';
 export { audit } from './commands/audit';
 export type { DoctorCheck, DoctorOptions, DoctorReport, DoctorStatus } from './commands/doctor';
 export { doctor } from './commands/doctor';
 export type { LoadConfigParams } from './config/loader';
 export { loadConfig, safegresConfigLoader } from './config/loader';
-export { minimal, multiTenant, PRESETS, recommended, strict } from './config/presets';
+export { constructive, minimal, PRESETS, recommended, strict } from './config/presets';
 export type { ResolvedRule, ResolvedRules } from './config/resolve';
 export {
   allAstRulesDisabled,

--- a/packages/safegres/src/rules/registry.ts
+++ b/packages/safegres/src/rules/registry.ts
@@ -88,6 +88,27 @@ export const RULES: RuleMeta[] = [
     defaultSeverity: 'high',
     title: 'Policy body references session_user / current_user / pg_has_role',
     scope: 'policy-ast'
+  },
+  {
+    code: 'R1',
+    category: 'anti-pattern',
+    defaultSeverity: 'critical',
+    title: 'Untrusted role holds a write privilege (options: { roles: [...] })',
+    scope: 'table'
+  },
+  {
+    code: 'R2',
+    category: 'anti-pattern',
+    defaultSeverity: 'high',
+    title: 'Permissive write policy applies to an untrusted role or PUBLIC (options: { roles: [...] })',
+    scope: 'table'
+  },
+  {
+    code: 'R3',
+    category: 'anti-pattern',
+    defaultSeverity: 'medium',
+    title: 'RLS table has grants TO PUBLIC (includes all current and future roles)',
+    scope: 'table'
   }
 ];
 


### PR DESCRIPTION
## Summary

Per Dan: minimize presets to what we actually understand — keep `recommended` / `strict` / `minimal`, drop `multi-tenant`, and add a role-aware `safegres:constructive` preset focused on our role model (e.g. `anonymous` being granted table access or covered by an RLS policy).

**New role-trust rules** (`src/checks/role-trust.ts`), options-driven so core stays pure-Postgres:
- `R1` (critical): an untrusted role holds a write grant (INSERT/UPDATE/DELETE/TRUNCATE). No-op unless `options.roles` is configured.
- `R2` (high): a permissive non-SELECT policy applies to an untrusted role — directly or via `PUBLIC` role targeting. No-op without `options.roles`.
- `R3` (medium): an RLS-enabled table has grants `TO PUBLIC` (every current and future role). Always on.

Rule options now flow into checks: the audit loop resolves `rulesForTable(...)` per table and passes `rules.get('R1')?.options` into the check, so per-table `overrides` can retune the watched role list.

**`safegres:constructive`** replaces `multi-tenant` (keeps its A2/A4/A7/P5→critical escalations and `floorOnCritical: 'C'`) and adds:
```jsonc
"R1": ["critical", { "roles": ["anonymous"] }],
"R2": ["high",     { "roles": ["anonymous"] }],
"R3": "medium"
```

Tests: 44 passing (7 new in `__tests__/role-trust.test.ts` + preset/wildcard updates). Smoke-tested `audit --preset constructive` and `print-config --preset constructive` against postgres-plus:18.

Link to Devin session: https://app.devin.ai/sessions/671aac6e50b04e8caacd3f54c1c63bc6
Requested by: @pyramation