### PR TITLE
feat(node-type-registry): emit presets.json + node-types.json data artifacts

### DIFF
--- a/packages/node-type-registry/README.md
+++ b/packages/node-type-registry/README.md
@@ -82,3 +82,20 @@ cd graphql/node-type-registry && pnpm generate:types
 ```
 
 This produces `src/blueprint-types.generated.ts` from the TS node type source of truth.
+
+## JSON artifacts (data distribution)
+
+The build also emits the registry as pure-data JSON alongside the JS, so it can be consumed **as data** rather than as executable code:
+
+- `presets.json` — `{ registryVersion, presets }` (the module presets)
+- `node-types.json` — `{ registryVersion, nodeTypes }`
+
+```typescript
+import presets from 'node-type-registry/presets.json';
+```
+
+**Why two tiers.** Trusted, first-party consumers (the dashboard, `@agentic-kit/pi`) import this package over npm — a pinned, reviewed dependency; drift is controlled by the version bump. Untrusted or distributed consumers (appstash, third-party agents) should **not** install and execute a package just to get a preset — they fetch these JSON files from a pinned + verified source instead. Same content, no code path, no lifecycle scripts.
+
+`registryVersion` lets a consumer range-check the data against the tool code it was built for (mirrors the skills manifest's `compatibleSkillsRange`) and refuse data that runs ahead of its code. The backend's provision resolver remains the final gate on any module set.
+
+Regenerated automatically by `pnpm build`; run standalone with `pnpm generate:json`.

--- a/packages/node-type-registry/__tests__/generate-json.test.ts
+++ b/packages/node-type-registry/__tests__/generate-json.test.ts
@@ -1,0 +1,36 @@
+import { buildJsonArtifacts } from '../src/codegen/generate-json';
+import { allNodeTypes } from '../src/index';
+import { allModulePresets, getModulePreset } from '../src/module-presets';
+
+describe('json artifacts', () => {
+  const artifacts = buildJsonArtifacts('9.9.9');
+
+  it('carries the registry version for range-checking', () => {
+    expect(artifacts['presets.json'].registryVersion).toBe('9.9.9');
+    expect(artifacts['node-types.json'].registryVersion).toBe('9.9.9');
+  });
+
+  it('presets.json is the in-code presets, not a copy', () => {
+    expect(artifacts['presets.json'].presets).toEqual(allModulePresets);
+  });
+
+  it('node-types.json is the in-code node types', () => {
+    expect(artifacts['node-types.json'].nodeTypes).toEqual(allNodeTypes);
+  });
+
+  it('is pure JSON data (round-trips with no loss)', () => {
+    for (const payload of Object.values(artifacts)) {
+      expect(JSON.parse(JSON.stringify(payload))).toEqual(payload);
+    }
+  });
+
+  it('the b2b:storage preset includes config_secrets_module', () => {
+    const preset = getModulePreset('b2b:storage');
+    const names = (preset?.modules ?? []).map((m) => (Array.isArray(m) ? m[0] : m));
+    expect(names).toContain('config_secrets_module');
+    // and the emitted JSON reflects it too
+    const emitted = artifacts['presets.json'].presets.find((p) => p.name === 'b2b:storage');
+    const emittedNames = (emitted?.modules ?? []).map((m) => (Array.isArray(m) ? m[0] : m));
+    expect(emittedNames).toContain('config_secrets_module');
+  });
+});

--- a/packages/node-type-registry/jest.config.js
+++ b/packages/node-type-registry/jest.config.js
@@ -1,0 +1,19 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        babelConfig: false,
+        tsconfig: 'tsconfig.json'
+      }
+    ]
+  },
+  transformIgnorePatterns: [`/node_modules/*`],
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',
+  testPathIgnorePatterns: ['/node_modules/', '/__tests__/fixtures/'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  modulePathIgnorePatterns: ['dist/*']
+};

--- a/packages/node-type-registry/package.json
+++ b/packages/node-type-registry/package.json
@@ -22,12 +22,13 @@
   "scripts": {
     "clean": "makage clean",
     "prepack": "npm run build",
-    "build": "makage build",
-    "build:dev": "makage build --dev",
+    "build": "makage build && npm run generate:json",
+    "build:dev": "makage build --dev && npm run generate:json",
     "lint": "eslint . --fix",
     "test": "jest",
     "test:watch": "jest --watch",
-    "generate:types": "ts-node src/codegen/generate-types.ts"
+    "generate:types": "ts-node src/codegen/generate-types.ts",
+    "generate:json": "ts-node src/codegen/generate-json.ts --outdir dist"
   },
   "dependencies": {
     "@babel/generator": "^7.29.0",

--- a/packages/node-type-registry/src/codegen/generate-json.ts
+++ b/packages/node-type-registry/src/codegen/generate-json.ts
@@ -1,0 +1,56 @@
+/**
+ * Emit the registry as pure-data JSON artifacts.
+ *
+ * First-party, trusted consumers (the dashboard, `@agentic-kit/pi`) import this
+ * package over npm and get the presets/node types as pinned code. Untrusted or
+ * distributed consumers (appstash, third-party agents) should NOT execute an
+ * installed package — they consume these JSON files as DATA instead, fetched
+ * from a pinned + verified source. Same content, no code path.
+ *
+ * The files carry `registryVersion` so a consumer can range-check the data
+ * against the tool code it was built for (mirrors the skills manifest's
+ * `compatibleSkillsRange`) and refuse data that runs ahead of its code.
+ *
+ * Usage:
+ *   ts-node src/codegen/generate-json.ts [--outdir <dir>]   (default: dist)
+ */
+import { mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+import { allNodeTypes } from '../index';
+import { allModulePresets } from '../module-presets';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { version } = require('../../package.json') as { version: string };
+
+export interface JsonArtifacts {
+  'presets.json': { registryVersion: string; presets: typeof allModulePresets };
+  'node-types.json': { registryVersion: string; nodeTypes: typeof allNodeTypes };
+}
+
+/** Pure: assemble the JSON payloads from the in-code registry. No I/O. */
+export function buildJsonArtifacts(registryVersion: string = version): JsonArtifacts {
+  return {
+    'presets.json': { registryVersion, presets: allModulePresets },
+    'node-types.json': { registryVersion, nodeTypes: allNodeTypes },
+  };
+}
+
+function outdirFromArgs(argv: string[]): string {
+  const i = argv.indexOf('--outdir');
+  return i !== -1 && argv[i + 1] ? argv[i + 1] : 'dist';
+}
+
+function main(): void {
+  const outdir = outdirFromArgs(process.argv.slice(2));
+  mkdirSync(outdir, { recursive: true });
+  const artifacts = buildJsonArtifacts();
+  for (const [file, payload] of Object.entries(artifacts)) {
+    const path = join(outdir, file);
+    writeFileSync(path, `${JSON.stringify(payload, null, 2)}\n`);
+    // eslint-disable-next-line no-console
+    console.log(`[node-type-registry] wrote ${path}`);
+  }
+}
+
+if (require.main === module) main();


### PR DESCRIPTION
## Summary

Follow-up to #1496. To keep provisioning "in sync" across consumers without everyone importing (and executing) the package, `node-type-registry` now emits itself as **pure-data JSON** at build time, alongside the existing JS/types.

```
dist/presets.json     { registryVersion, presets: ModulePreset[] }
dist/node-types.json  { registryVersion, nodeTypes: NodeTypeDefinition[] }
```

**Two-tier trust model** (matches how skills are distributed):
- **First-party / trusted** (dashboard, `@agentic-kit/pi`) — keep importing over npm; a pinned, reviewed dependency, drift controlled by the version bump. Unchanged.
- **Untrusted / distributed** (appstash, third-party agents) — consume the JSON **as data** from a pinned + verified source instead of `npm install`-ing a package to get a preset. No code path, no lifecycle scripts, no RCE surface. `registryVersion` lets them range-check the data against the tool code it was built for (the skills manifest's `compatibleSkillsRange` pattern); the backend's provision resolver stays the final gate.

**Implementation:**
```ts
// src/codegen/generate-json.ts — pure builder, no I/O, testable
export function buildJsonArtifacts(registryVersion?): {
  'presets.json': { registryVersion; presets: allModulePresets };
  'node-types.json': { registryVersion; nodeTypes: allNodeTypes };
}
// main() writes them to --outdir (default dist); wired into `build` + `build:dev`
```
No `exports` field added (would break existing deep imports); JSON resolves as a subpath against the published `dist` root, e.g. `import presets from 'node-type-registry/presets.json'`.

## Testing
- New `__tests__/generate-json.test.ts` (5 cases): version stamping, artifacts equal the in-code arrays (not a hand-copy), pure-JSON round-trip, and `b2b:storage` includes `config_secrets_module` in both source and emitted JSON. Added `jest.config.js` (package had none). `pnpm build` emits both files (verified) and does not leak tests into `dist`.
- Lint (`eslint .`) is broken repo-wide on `main` (ESLint 9 flat-config vs `.eslintrc.json`) — pre-existing, untouched here.


Link to Devin session: https://app.devin.ai/sessions/93aed4dac17243818e6c3bda66be587a
Requested by: @pyramation