### PR TITLE
feat(safegres): eval loop + fix R3 PUBLIC-grant false negative

### DIFF
--- a/packages/safegres/__tests__/audit.test.ts
+++ b/packages/safegres/__tests__/audit.test.ts
@@ -111,6 +111,18 @@ describe('audit — Script A', () => {
     expect(p5?.severity).toBe('high');
   });
 
+  it('R3: flags PUBLIC grant on an RLS table through the resolved role filter', async () => {
+    await applyFixture('r3-public-grant-rls.sql');
+    // Default audit path resolves a concrete named-role set for introspection;
+    // PUBLIC must still be retained so R3 can fire.
+    const report = await audit(pg.client as never, { schemas: ['fx_r3'] });
+    const found = findingsFor(report.findings, 'fx_r3');
+    const r3 = found.find((f) => f.code === 'R3');
+    expect(r3).toBeDefined();
+    expect(r3?.role).toBe('PUBLIC');
+    expect(r3?.severity).toBe('medium');
+  });
+
   it('clean table produces no findings', async () => {
     await applyFixture('clean-table.sql');
     const report = await audit(pg.client as never, { schemas: ['fx_clean'] });

--- a/packages/safegres/__tests__/fixtures/r3-public-grant-rls.sql
+++ b/packages/safegres/__tests__/fixtures/r3-public-grant-rls.sql
@@ -1,0 +1,15 @@
+-- R3 seed: an RLS-enabled table with a grant TO PUBLIC. This must surface even
+-- though `audit` always resolves a concrete (named) role set for introspection
+-- — PUBLIC is not a named role, so a naive role filter would drop it and R3
+-- could never fire (regression guard for the introspection role filter).
+
+CREATE SCHEMA IF NOT EXISTS fx_r3;
+
+CREATE TABLE fx_r3.docs (
+  id bigserial PRIMARY KEY,
+  body text
+);
+
+ALTER TABLE fx_r3.docs ENABLE ROW LEVEL SECURITY;
+
+GRANT SELECT ON fx_r3.docs TO PUBLIC;

--- a/packages/safegres/evals/README.md
+++ b/packages/safegres/evals/README.md
@@ -1,0 +1,57 @@
+# safegres evals
+
+A repeatable eval loop for safegres: known SQL scenarios audited under every
+preset, with committed goldens so scoring changes and rule regressions show up
+as diffs.
+
+## Running
+
+```bash
+pnpm eval          # audit every fixture under every preset, compare to goldens
+pnpm eval:update   # re-record goldens from current tool behavior
+```
+
+Requires a reachable Postgres (`PGHOST`/`PGUSER`/`PGPASSWORD`, default
+`localhost`/`postgres`/`password`); each fixture is deployed into an isolated
+database via `pgsql-test`. The loop also runs as part of `pnpm test`, so CI
+guards against drift.
+
+## Layout
+
+- `fixtures/*.sql` — self-contained scenarios. Each creates its own schema
+  (`eval_<name>`) so the audit can be scoped to it. Role creation is guarded
+  with `IF NOT EXISTS` (roles are cluster-global).
+- `cases.ts` — the case list (name → schema → fixture) and the preset set.
+- `golden/<name>.json` — recorded `{ score, grade, byCode }` per preset. The
+  finding-count histogram (keyed by rule code) is stable across finding order
+  and message wording, so goldens stay legible and only move on real behavior
+  changes.
+- `evals.test.ts` — the jest-driven runner (prints a scoreboard, asserts
+  against goldens, or re-records them under `UPDATE_GOLDENS=1`).
+
+## Current scoreboard
+
+| case         | recommended | strict    | constructive | minimal   |
+|--------------|-------------|-----------|--------------|-----------|
+| secure-app   | 100/A+ (0)  | 100/A+ (0)| 100/A+ (0)   | 100/A+ (0)|
+| leaky-app    | 13/F (10)   | 0/F (10)  | 0/F (10)     | 57/D (4)  |
+| anon-exposed | 56/D (5)    | 56/D (5)  | 0/F (11)     | 100/A+ (0)|
+
+`anon-exposed` is the case that shows the `constructive` preset's value: the
+pure-Postgres presets can only see the PUBLIC-grant (R3) and permissive-policy
+(A7) problems, while `constructive` additionally flags the untrusted
+`anonymous` role's write grants (R1) and write policies (R2).
+
+## Adding a case
+
+1. Write `fixtures/<name>.sql` creating schema `eval_<name>`.
+2. Add an entry to `CASES` in `cases.ts`.
+3. `pnpm eval:update` and review the recorded golden before committing.
+
+## Adding real-schema snapshots
+
+Beyond hand-written fixtures, the loop is meant to consume schema snapshots
+dumped from real apps (Diligence, Constructive). Deploy the app schema into a
+database, `pg_dump --schema-only` the relevant schemas into
+`fixtures/<app>-snapshot.sql`, and add a case. This turns dogfooding into a
+regression signal instead of a one-off.

--- a/packages/safegres/evals/cases.ts
+++ b/packages/safegres/evals/cases.ts
@@ -1,0 +1,47 @@
+/**
+ * Eval cases: each is a self-contained SQL fixture deployed into its own
+ * schema, audited under every preset. Goldens live in `evals/golden/` and
+ * capture the resolved score/grade plus a finding-count histogram per preset
+ * — enough to catch scoring drift and rule regressions without being brittle
+ * about finding ordering or messages.
+ */
+
+export interface EvalCase {
+  /** Stable id; also the golden filename. */
+  name: string;
+  /** Schema the fixture creates (audit is scoped to it). */
+  schema: string;
+  /** SQL fixture filename under evals/fixtures/. */
+  file: string;
+  description: string;
+}
+
+export const PRESETS = [
+  'safegres:recommended',
+  'safegres:strict',
+  'safegres:constructive',
+  'safegres:minimal'
+] as const;
+
+export type PresetName = (typeof PRESETS)[number];
+
+export const CASES: EvalCase[] = [
+  {
+    name: 'secure-app',
+    schema: 'eval_secure',
+    file: 'secure-app.sql',
+    description: 'Well-designed RLS app — should score near-perfect everywhere.'
+  },
+  {
+    name: 'leaky-app',
+    schema: 'eval_leaky',
+    file: 'leaky-app.sql',
+    description: 'Common RLS mistakes across several tables — should score poorly.'
+  },
+  {
+    name: 'anon-exposed',
+    schema: 'eval_anon',
+    file: 'anon-exposed.sql',
+    description: 'Untrusted anonymous role wired into a table — only constructive catches it.'
+  }
+];

--- a/packages/safegres/evals/evals.test.ts
+++ b/packages/safegres/evals/evals.test.ts
@@ -1,0 +1,104 @@
+/**
+ * safegres eval loop (jest-driven).
+ *
+ *   pnpm eval          run all cases against goldens (fails on drift)
+ *   pnpm eval:update   re-record goldens from current tool behavior
+ *
+ * Each case's SQL fixture is deployed into an isolated database (pgsql-test)
+ * and audited under every preset. The recorded signal per (case, preset) is
+ * `{ score, grade, byCode }` — a finding-count histogram keyed by rule code,
+ * stable enough to catch scoring changes and rule regressions without
+ * depending on finding order or message wording. A scoreboard is printed on
+ * every run.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { getConnections, type PgTestClient } from 'pgsql-test';
+
+import { audit } from '../src/commands/audit';
+import { loadConfig } from '../src/config/loader';
+import { CASES, type PresetName,PRESETS } from './cases';
+
+jest.setTimeout(180000);
+
+const GOLDEN_DIR = path.join(__dirname, 'golden');
+const FIXTURE_DIR = path.join(__dirname, 'fixtures');
+const UPDATE = process.env.UPDATE_GOLDENS === '1';
+
+interface PresetResult {
+  score: number;
+  grade: string;
+  byCode: Record<string, number>;
+}
+type CaseGolden = Record<PresetName, PresetResult>;
+
+function histogram(codes: string[]): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const c of [...codes].sort()) out[c] = (out[c] ?? 0) + 1;
+  return out;
+}
+
+function goldenPath(name: string): string {
+  return path.join(GOLDEN_DIR, `${name}.json`);
+}
+
+let pg: PgTestClient;
+let teardown: () => Promise<void>;
+const results: Record<string, CaseGolden> = {};
+
+beforeAll(async () => {
+  ({ pg, teardown } = await getConnections());
+  for (const c of CASES) {
+    await pg.any(fs.readFileSync(path.join(FIXTURE_DIR, c.file), 'utf8'));
+    const g = {} as CaseGolden;
+    for (const preset of PRESETS) {
+      const { config } = loadConfig({ preset });
+      const report = await audit(pg.client as never, { schemas: [c.schema], config });
+      g[preset] = {
+        score: report.score?.value ?? -1,
+        grade: report.score?.grade ?? '?',
+        byCode: histogram(report.findings.map((f) => f.code))
+      };
+    }
+    results[c.name] = g;
+  }
+});
+
+afterAll(async () => {
+  // Scoreboard.
+  const pad = (s: string, n: number) => s.padEnd(n);
+  const head = pad('case', 16) + PRESETS.map((p) => pad(p.replace('safegres:', ''), 16)).join('');
+  const lines = ['', head, '-'.repeat(head.length)];
+  for (const c of CASES) {
+    const row = PRESETS.map((p) => {
+      const r = results[c.name][p];
+      const n = Object.values(r.byCode).reduce((a, b) => a + b, 0);
+      return pad(`${r.score}/${r.grade} (${n})`, 16);
+    }).join('');
+    lines.push(pad(c.name, 16) + row);
+  }
+  lines.push('', '(score/grade (findings) per preset)', '');
+  console.log(lines.join('\n'));
+
+  if (UPDATE) {
+    fs.mkdirSync(GOLDEN_DIR, { recursive: true });
+    for (const c of CASES) {
+      fs.writeFileSync(goldenPath(c.name), JSON.stringify(results[c.name], null, 2) + '\n');
+    }
+    console.log(`Updated ${CASES.length} goldens in ${GOLDEN_DIR}`);
+  }
+  if (teardown) await teardown();
+});
+
+describe('safegres evals', () => {
+  for (const c of CASES) {
+    it(`${c.name}: ${c.description}`, () => {
+      if (UPDATE) return; // recording pass — assertions skipped
+      const p = goldenPath(c.name);
+      expect(fs.existsSync(p)).toBe(true);
+      const expected = JSON.parse(fs.readFileSync(p, 'utf8')) as CaseGolden;
+      expect(results[c.name]).toEqual(expected);
+    });
+  }
+});

--- a/packages/safegres/evals/fixtures/anon-exposed.sql
+++ b/packages/safegres/evals/fixtures/anon-exposed.sql
@@ -1,0 +1,37 @@
+-- Scenario: an untrusted `anonymous` role wired directly into a table. This is
+-- the case the `safegres:constructive` preset is built to catch — R1/R2/R3
+-- fire here but are silent under the pure-Postgres presets (which do not know
+-- which role is untrusted).
+
+CREATE SCHEMA IF NOT EXISTS eval_anon;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anonymous') THEN
+    CREATE ROLE anonymous NOLOGIN;
+  END IF;
+END $$;
+
+CREATE TABLE eval_anon.submissions (
+  id bigserial PRIMARY KEY,
+  email text,
+  payload text
+);
+
+ALTER TABLE eval_anon.submissions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE eval_anon.submissions FORCE ROW LEVEL SECURITY;
+
+-- R1: anonymous holds write grants.
+GRANT SELECT, INSERT, UPDATE, DELETE ON eval_anon.submissions TO anonymous;
+
+-- R3: RLS table also granted TO PUBLIC.
+GRANT SELECT ON eval_anon.submissions TO PUBLIC;
+
+-- R2: permissive write policies that apply to anonymous / PUBLIC.
+CREATE POLICY anon_ins ON eval_anon.submissions FOR INSERT TO anonymous
+  WITH CHECK (true);
+CREATE POLICY anon_del ON eval_anon.submissions FOR DELETE TO anonymous
+  USING (true);
+CREATE POLICY public_upd ON eval_anon.submissions FOR UPDATE TO PUBLIC
+  USING (true) WITH CHECK (true);
+CREATE POLICY sel ON eval_anon.submissions FOR SELECT TO anonymous
+  USING (true);

--- a/packages/safegres/evals/fixtures/leaky-app.sql
+++ b/packages/safegres/evals/fixtures/leaky-app.sql
@@ -1,0 +1,35 @@
+-- Scenario: a mix of common RLS mistakes across several tables. Exercises the
+-- coverage + anti-pattern rules and should score poorly, with the grade
+-- dropping further under `strict`.
+
+CREATE SCHEMA IF NOT EXISTS eval_leaky;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'eval_leaky_user') THEN
+    CREATE ROLE eval_leaky_user NOLOGIN;
+  END IF;
+END $$;
+
+-- A1: RLS on, no policies at all (rows invisible / locked).
+CREATE TABLE eval_leaky.secrets (id bigserial PRIMARY KEY, val text);
+ALTER TABLE eval_leaky.secrets ENABLE ROW LEVEL SECURITY;
+GRANT SELECT ON eval_leaky.secrets TO eval_leaky_user;
+
+-- A2: grants but RLS never enabled (wide open).
+CREATE TABLE eval_leaky.audit_log (id bigserial PRIMARY KEY, msg text);
+GRANT SELECT, INSERT ON eval_leaky.audit_log TO eval_leaky_user;
+
+-- A3 + A4 + A6: RLS on but not forced; INSERT/UPDATE granted, only a SELECT
+-- policy exists, and the UPDATE path has no WITH CHECK.
+CREATE TABLE eval_leaky.notes (id bigserial PRIMARY KEY, owner text, body text);
+ALTER TABLE eval_leaky.notes ENABLE ROW LEVEL SECURITY;
+GRANT SELECT, INSERT, UPDATE ON eval_leaky.notes TO eval_leaky_user;
+CREATE POLICY sel ON eval_leaky.notes FOR SELECT TO eval_leaky_user USING (true);
+CREATE POLICY upd ON eval_leaky.notes FOR UPDATE TO eval_leaky_user USING (true);
+
+-- A7: trivially permissive policy on a table that otherwise looks locked down.
+CREATE TABLE eval_leaky.reports (id bigserial PRIMARY KEY, owner text);
+ALTER TABLE eval_leaky.reports ENABLE ROW LEVEL SECURITY;
+ALTER TABLE eval_leaky.reports FORCE ROW LEVEL SECURITY;
+GRANT SELECT ON eval_leaky.reports TO eval_leaky_user;
+CREATE POLICY sel ON eval_leaky.reports FOR SELECT TO eval_leaky_user USING (true);

--- a/packages/safegres/evals/fixtures/secure-app.sql
+++ b/packages/safegres/evals/fixtures/secure-app.sql
@@ -1,0 +1,34 @@
+-- Scenario: a well-designed RLS app schema. Should score near-perfect under
+-- every preset. Each table has RLS enabled + forced, permissive policies
+-- scoped to a trusted role covering exactly the granted verbs, WITH CHECK on
+-- writes, and no untrusted-role or PUBLIC grants. Policies use a JWT claim
+-- (not current_user/session_user) so P5 stays quiet.
+
+CREATE SCHEMA IF NOT EXISTS eval_secure;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'eval_secure_user') THEN
+    CREATE ROLE eval_secure_user NOLOGIN;
+  END IF;
+END $$;
+
+CREATE TABLE eval_secure.documents (
+  id bigserial PRIMARY KEY,
+  owner text NOT NULL,
+  body text
+);
+
+ALTER TABLE eval_secure.documents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE eval_secure.documents FORCE ROW LEVEL SECURITY;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON eval_secure.documents TO eval_secure_user;
+
+CREATE POLICY sel ON eval_secure.documents FOR SELECT TO eval_secure_user
+  USING (owner = current_setting('jwt.claims.user_id', true));
+CREATE POLICY ins ON eval_secure.documents FOR INSERT TO eval_secure_user
+  WITH CHECK (owner = current_setting('jwt.claims.user_id', true));
+CREATE POLICY upd ON eval_secure.documents FOR UPDATE TO eval_secure_user
+  USING (owner = current_setting('jwt.claims.user_id', true))
+  WITH CHECK (owner = current_setting('jwt.claims.user_id', true));
+CREATE POLICY del ON eval_secure.documents FOR DELETE TO eval_secure_user
+  USING (owner = current_setting('jwt.claims.user_id', true));

--- a/packages/safegres/evals/golden/anon-exposed.json
+++ b/packages/safegres/evals/golden/anon-exposed.json
@@ -1,0 +1,33 @@
+{
+  "safegres:recommended": {
+    "score": 56,
+    "grade": "D",
+    "byCode": {
+      "A7": 4,
+      "R3": 1
+    }
+  },
+  "safegres:strict": {
+    "score": 56,
+    "grade": "D",
+    "byCode": {
+      "A7": 4,
+      "R3": 1
+    }
+  },
+  "safegres:constructive": {
+    "score": 0,
+    "grade": "F",
+    "byCode": {
+      "A7": 4,
+      "R1": 3,
+      "R2": 3,
+      "R3": 1
+    }
+  },
+  "safegres:minimal": {
+    "score": 100,
+    "grade": "A+",
+    "byCode": {}
+  }
+}

--- a/packages/safegres/evals/golden/leaky-app.json
+++ b/packages/safegres/evals/golden/leaky-app.json
@@ -1,0 +1,50 @@
+{
+  "safegres:recommended": {
+    "score": 13,
+    "grade": "F",
+    "byCode": {
+      "A1": 1,
+      "A2": 1,
+      "A3": 2,
+      "A4": 1,
+      "A5": 1,
+      "A6": 1,
+      "A7": 3
+    }
+  },
+  "safegres:strict": {
+    "score": 0,
+    "grade": "F",
+    "byCode": {
+      "A1": 1,
+      "A2": 1,
+      "A3": 2,
+      "A4": 1,
+      "A5": 1,
+      "A6": 1,
+      "A7": 3
+    }
+  },
+  "safegres:constructive": {
+    "score": 0,
+    "grade": "F",
+    "byCode": {
+      "A1": 1,
+      "A2": 1,
+      "A3": 2,
+      "A4": 1,
+      "A5": 1,
+      "A6": 1,
+      "A7": 3
+    }
+  },
+  "safegres:minimal": {
+    "score": 57,
+    "grade": "D",
+    "byCode": {
+      "A1": 1,
+      "A2": 1,
+      "A3": 2
+    }
+  }
+}

--- a/packages/safegres/evals/golden/secure-app.json
+++ b/packages/safegres/evals/golden/secure-app.json
@@ -1,0 +1,22 @@
+{
+  "safegres:recommended": {
+    "score": 100,
+    "grade": "A+",
+    "byCode": {}
+  },
+  "safegres:strict": {
+    "score": 100,
+    "grade": "A+",
+    "byCode": {}
+  },
+  "safegres:constructive": {
+    "score": 100,
+    "grade": "A+",
+    "byCode": {}
+  },
+  "safegres:minimal": {
+    "score": 100,
+    "grade": "A+",
+    "byCode": {}
+  }
+}

--- a/packages/safegres/package.json
+++ b/packages/safegres/package.json
@@ -29,7 +29,9 @@
     "build:dev": "makage build --dev && chmod +x dist/cli.js",
     "lint": "eslint . --fix",
     "test": "jest --passWithNoTests",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "eval": "jest evals",
+    "eval:update": "UPDATE_GOLDENS=1 jest evals"
   },
   "keywords": [
     "postgres",

--- a/packages/safegres/src/pg/introspect.ts
+++ b/packages/safegres/src/pg/introspect.ts
@@ -105,8 +105,13 @@ export async function introspectTables(
 ): Promise<TableSnapshot[]> {
   const excludes = [...DEFAULT_EXCLUDES, ...(options.excludeSchemas ?? [])];
 
+  // PUBLIC (grantee_oid = 0) is always retained: a grant TO PUBLIC applies to
+  // every current and future role, so it is relevant regardless of which named
+  // roles are being audited. Filtering it out would blind PUBLIC-grant checks
+  // (R3) whenever a role list is in effect — which, since audit always resolves
+  // a concrete role set, is effectively always.
   const roleFilter = options.roles && options.roles.length > 0
-    ? `AND (CASE WHEN g.grantee_oid = 0 THEN 'PUBLIC' ELSE rol.rolname END) = ANY($3::text[])`
+    ? `AND (g.grantee_oid = 0 OR rol.rolname = ANY($3::text[]))`
     : '';
   const schemaFilter = options.schemas && options.schemas.length > 0
     ? `AND n.nspname = ANY($1::text[])`


### PR DESCRIPTION
## Summary

Adds a repeatable **eval loop** for safegres and fixes a false negative that dogfooding surfaced.

**Eval loop** (`packages/safegres/evals/`): self-contained SQL fixtures, each deployed into an isolated DB (`pgsql-test`) and audited under every preset. The recorded signal per `(case, preset)` is `{ score, grade, byCode }` — a finding-count histogram keyed by rule code, stable across finding order/wording — committed as goldens in `evals/golden/`.

```
pnpm eval          # audit every fixture under every preset, diff vs goldens
pnpm eval:update   # re-record goldens (UPDATE_GOLDENS=1 jest evals)
```

It also runs under `pnpm test`, so CI guards against scoring/rule drift. Current scoreboard:

| case         | recommended | strict     | constructive | minimal    |
|--------------|-------------|------------|--------------|------------|
| secure-app   | 100/A+ (0)  | 100/A+ (0) | 100/A+ (0)   | 100/A+ (0) |
| leaky-app    | 13/F (10)   | 0/F (10)   | 0/F (10)     | 57/D (4)   |
| anon-exposed | 56/D (5)    | 56/D (5)   | 0/F (11)     | 100/A+ (0) |

`anon-exposed` is the case that demonstrates the `constructive` preset's added value: pure-Postgres presets only see the PUBLIC-grant (R3) and permissive-policy (A7) problems, while `constructive` additionally flags the untrusted `anonymous` role's write grants (R1) and write policies (R2).

**Bug fix — R3 could never fire.** `introspectTables` filtered grants by the resolved role set, which is always a list of *named* roles and never `PUBLIC`. Since `audit` always resolves a concrete role set, the PUBLIC grant rows were dropped before `checkPublicGrants` ever saw them — so R3 was effectively dead code (confirmed against Diligence, which has 197 `GRANT ... TO PUBLIC` rows and reported zero R3).

```diff
- AND (CASE WHEN g.grantee_oid = 0 THEN 'PUBLIC' ELSE rol.rolname END) = ANY($3)
+ AND (g.grantee_oid = 0 OR rol.rolname = ANY($3))   -- PUBLIC always retained
```

Adds an introspection-level regression test (`r3-public-grant-rls.sql`) that audits a PUBLIC-granted RLS table through the normal (role-filtered) path and asserts R3 fires.

## Dogfooding notes (Diligence, 305 tables / 125 RLS / 425 policies)

Captured for follow-up, not addressed here:

- **Score saturates to `0/F` under every preset** on a real schema (per-rule cap 40 × 6+ firing rules ≫ 100). The grade has no discriminating power at scale — worth a diminishing-returns or per-schema-normalized model. This is the top UX gap.
- **A3 (FORCE RLS not set): 132** — likely intentional in Constructive (query role ≠ table owner); candidate to demote/opt-in under the `constructive` preset.
- **A2 on private/platform schemas: 112 (100 in `metaschema_*`)** — grants without RLS on internal schemas protected by schema `USAGE`, not RLS; candidate for schema-scoping guidance.
- **P5 (`current_user`) is Constructive-flavored** — `owner = current_user` is a legitimate pure-Postgres pattern; candidate to lower its severity in `recommended`.
- **R1/R2 correctly silent** on Diligence (`anonymous` holds no grants/policies) — good true-negative.

## Test plan

- `pnpm test` — 48 passing (6 suites), including the new eval suite and R3 regression test.
- `pnpm eval` — all fixtures match goldens.
- ESLint clean (only pre-existing `_extends` warnings in `config/loader.ts`).
- `evals/` is excluded from the `dist/` build (tsconfig `include: src/**/*`).


Link to Devin session: https://app.devin.ai/sessions/671aac6e50b04e8caacd3f54c1c63bc6
Requested by: @pyramation