### PR TITLE
feat(safegres): first-class exposure surface, direction-aware rules, density scoring

### DIFF
--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -28,24 +28,48 @@ Per-field overrides (`--host`, `--port`, `--user`, `--password`, `--database`) a
 
 ## What it checks
 
-| Code | Severity | Category | Check |
-| --- | --- | --- | --- |
-| A1 | critical | flags | RLS enabled but **0 policies** (effectively deny-all) |
-| A2 | high | flags | Grants exist on a table with **RLS disabled** |
-| A3 | medium | flags | RLS enabled but **`FORCE ROW LEVEL SECURITY` not set** (table owner bypass) |
-| A4 | high | coverage | INSERT / UPDATE / DELETE grant with **no covering policy** for that verb |
-| A5 | medium | coverage | SELECT grant with **no policy** (silent empty result) |
-| A6 | info | coverage | UPDATE has `USING` but **no `WITH CHECK`** (row-smuggling surface) |
-| A7 | high | anti-pattern | Trivially-permissive policy (`USING (true)` / `WITH CHECK (true)`) |
-| P1 | high | anti-pattern | Policy body calls a **VOLATILE function** (per-row evaluation) |
-| P5 | high | anti-pattern | Policy body references **`session_user`** / `current_user` / `pg_has_role(...)` |
-| R1 | critical | anti-pattern | An **untrusted role** (options: `{ roles: [...] }`) holds a write privilege |
-| R2 | high | anti-pattern | A permissive write policy applies to an untrusted role or PUBLIC |
-| R3 | medium | anti-pattern | An RLS table has grants **TO PUBLIC** (includes all current/future roles) |
+| Code | Severity | Direction | Category | Check |
+| --- | --- | --- | --- | --- |
+| A1 | low | fail-closed | flags | RLS enabled but **0 policies** (deny-all — confirm the lock is intended) |
+| A2 | high | fail-open | flags | Grants exist on a table with **RLS disabled** |
+| A3 | low | fail-open | flags | RLS enabled but **`FORCE ROW LEVEL SECURITY` not set** (table owner bypass) |
+| A4 | low | fail-closed | coverage | INSERT / UPDATE / DELETE grant with **no covering policy** — writes are denied at runtime |
+| A5 | low | fail-closed | coverage | SELECT grant with **no policy** — queries silently return 0 rows |
+| A6 | info | fail-closed | coverage | UPDATE has `USING` but **no `WITH CHECK`** (row-smuggling surface) |
+| A7 | critical | fail-open | anti-pattern | Trivially-permissive **WRITE** policy (INSERT/UPDATE/DELETE/ALL with literal `true`) |
+| A8 | low | fail-open | anti-pattern | Trivially-permissive **SELECT** policy (`USING (true)` — confirm public-read is intended) |
+| P1 | high | neutral | anti-pattern | Policy body calls a **VOLATILE function** (per-row evaluation) |
+| P5 | high | fail-open | anti-pattern | Policy body references **`session_user`** / `current_user` / `pg_has_role(...)` |
+| R1 | critical | fail-open | anti-pattern | An **untrusted role** (options: `{ roles: [...] }`) holds a write privilege |
+| R2 | high | fail-open | anti-pattern | A permissive write policy applies to an untrusted role or PUBLIC |
+| R3 | medium | fail-open | anti-pattern | An RLS table has grants **TO PUBLIC** (includes all current/future roles) |
+| W1 | medium | — | meta | No exposure surface configured — whole database assumed reachable, score capped |
+
+**Direction matters**: `fail-open` findings are actual exposure (the untrusted side can reach more than intended). `fail-closed` findings are denied at runtime — an availability/hygiene concern, not a leak — and contribute **nothing to the score** by default (tune with `scoring.failClosedWeight`).
 
 Coverage is aggregated `(table, role) → { hasUsing, hasWithCheck }` across every applicable permissive policy (FOR ALL + PUBLIC-role policies considered). Roles with `BYPASSRLS` are suppressed.
 
 R1/R2 are no-ops until a role list is configured — e.g. `"R1": ["critical", { "roles": ["anonymous"] }]` — so they cost nothing on databases without an untrusted-role model. The `safegres:constructive` preset configures them for `anonymous`.
+
+## Exposure surface
+
+A database-wide score is meaningless if most of the database isn't reachable through the app's APIs. Declare (or auto-resolve) the **exposure surface** and safegres partitions findings:
+
+- **Exposed** findings (on API-reachable schemas) drive the score.
+- **Internal** findings are reported as unscored *internal advisories* (hide entirely with `--exposed-only`).
+- **No exposure configured** → a `W1` warning is emitted and the score is capped at 80/B (`scoring.unknownExposureCap`).
+
+```jsonc
+{
+  "exposure": {
+    "schemas": ["app_public", "app_hidden"]      // static surface
+    // or, on a Constructive database:
+    // "resolver": "constructive"                 // introspects routing_public.apis → api_schemas
+  }
+}
+```
+
+CLI: `--exposure-schemas <csv>`, `--exposed-only`. The `safegres:constructive` preset sets `exposure.resolver: "constructive"` so the surface is discovered automatically from the routing plane (including API roles from `role_name`/`anon_role`).
 
 ## Configuration
 
@@ -86,15 +110,21 @@ export default defineConfig({
 | Preset | Behavior |
 | --- | --- |
 | `safegres:recommended` | Every rule at its default severity (the no-config behavior) |
-| `safegres:strict` | Coverage gaps escalated (A4 critical, A5 high), `failOn: high` |
-| `safegres:constructive` | Constructive's role model: R1/R2 watch `anonymous`, leak surfaces (A2, A4, A7, P5) critical |
+| `safegres:strict` | Everything escalated; fail-closed findings count 25% toward the score, `failOn: high` |
+| `safegres:constructive` | Auto-resolves exposure from the routing plane; R1/R2 watch `anonymous`; leak surfaces (A2, P5) critical; A3 off (API roles never own tables) |
 | `safegres:minimal` | Structural flags only (A1–A3) — fast CI smoke check |
 
 CLI: `--config <path>`, `--preset <name>`, `--rule CODE=off|severity` (repeatable).
 
 ### Scoring
 
-Every report includes a config-driven score (0–100 + grade): weighted deductions per finding severity (critical 25, high 10, medium 4, low 1, info 0 by default), capped per rule, with any critical finding flooring the grade at C. Tune via `scoring.weights`, `scoring.perRuleWeights`, `scoring.maxDeductionPerRule`, `scoring.gradeBands`, `scoring.floorOnCritical`. Gate CI with `--fail-on-score <n>` / `--fail-on-grade <g>` or `failOn` in config.
+Every report includes a config-driven score (0–100 + grade). The default **density** model normalizes by the exposed surface so large schemas don't saturate to 0/F:
+
+```
+score = 100 · exp(−k · riskPoints / exposedTables)
+```
+
+where `riskPoints` is the severity-weighted sum (critical 25, high 10, medium 4, low 1, info 0) of *exposed, fail-open* findings, and `k` defaults to 0.17 (≈ one critical per 10 exposed tables lands at a C). Non-exposed findings score 0; fail-closed findings score 0 unless `scoring.failClosedWeight` is raised; unknown exposure caps the score (`scoring.unknownExposureCap`, default 80). Any exposed critical floors the grade at C (`scoring.floorOnCritical`). The legacy flat-deduction model is available via `scoring.model: "weighted"`. Tune via `scoring.weights`, `scoring.perRuleWeights`, `scoring.densityK`, `scoring.gradeBands`. Gate CI with `--fail-on-score <n>` / `--fail-on-grade <g>` or `failOn` in config.
 
 ### Other commands
 

--- a/packages/safegres/__tests__/audit.test.ts
+++ b/packages/safegres/__tests__/audit.test.ts
@@ -38,7 +38,9 @@ describe('audit — Script A', () => {
     const report = await audit(pg.client as never, { schemas: ['fx_a1'] });
     const found = findingsFor(report.findings, 'fx_a1');
     expect(codes(found)).toEqual(expect.arrayContaining(['A1']));
-    expect(found.find((f) => f.code === 'A1')?.severity).toBe('critical');
+    const a1 = found.find((f) => f.code === 'A1');
+    expect(a1?.severity).toBe('low');
+    expect(a1?.direction).toBe('fail-closed');
   });
 
   it('A2: flags grants on table with RLS disabled', async () => {
@@ -81,15 +83,28 @@ describe('audit — Script A', () => {
     expect(a6?.privilege).toBe('UPDATE');
   });
 
-  it('A7: flags permissive policy with body = literal true (fail-open)', async () => {
+  it('A8: flags SELECT-only permissive policy with body = literal true (public read)', async () => {
     await applyFixture('a7-trivially-permissive.sql');
     const report = await audit(pg.client as never, { schemas: ['fx_a7'] });
     const found = findingsFor(report.findings, 'fx_a7');
+    const a8 = found.find((f) => f.code === 'A8');
+    expect(a8).toBeDefined();
+    expect(a8?.severity).toBe('low');
+    expect(a8?.policy).toBe('fx_a7_open');
+    expect((a8?.context as { clauses?: string[] } | undefined)?.clauses).toEqual(['USING']);
+    // SELECT-only literal-true is A8, never A7
+    expect(found.find((f) => f.code === 'A7')).toBeUndefined();
+  });
+
+  it('A7: flags trivially-permissive WRITE policy as critical (fail-open)', async () => {
+    await applyFixture('a7-write-permissive.sql');
+    const report = await audit(pg.client as never, { schemas: ['fx_a7w'] });
+    const found = findingsFor(report.findings, 'fx_a7w');
     const a7 = found.find((f) => f.code === 'A7');
     expect(a7).toBeDefined();
-    expect(a7?.severity).toBe('high');
-    expect(a7?.policy).toBe('fx_a7_open');
-    expect((a7?.context as { clauses?: string[] } | undefined)?.clauses).toEqual(['USING']);
+    expect(a7?.severity).toBe('critical');
+    expect(a7?.direction).toBe('fail-open');
+    expect(a7?.policy).toBe('fx_a7w_open_write');
   });
 
   it('P1: flags policy using VOLATILE function', async () => {

--- a/packages/safegres/__tests__/config.test.ts
+++ b/packages/safegres/__tests__/config.test.ts
@@ -41,7 +41,8 @@ describe('rule registry', () => {
 describe('resolveRules', () => {
   it('defaults every rule to enabled at its registry severity', () => {
     const { rules } = resolveRules({});
-    expect(rules.get('A1')).toEqual({ enabled: true, severity: 'critical' });
+    expect(rules.get('A1')).toEqual({ enabled: true, severity: 'low' });
+    expect(rules.get('A7')).toEqual({ enabled: true, severity: 'critical' });
     expect(rules.get('A6')).toEqual({ enabled: true, severity: 'info' });
   });
 
@@ -121,12 +122,12 @@ describe('table overrides', () => {
 describe('allAstRulesDisabled', () => {
   it('detects fully-disabled AST rules', () => {
     expect(allAstRulesDisabled(resolveRules({}))).toBe(false);
-    expect(allAstRulesDisabled(resolveRules({ rules: { 'P*': 'off', A7: 'off' } }))).toBe(true);
+    expect(allAstRulesDisabled(resolveRules({ rules: { 'P*': 'off', A7: 'off', A8: 'off' } }))).toBe(true);
   });
 
   it('stays enabled when an override re-enables an AST rule', () => {
     const resolved = resolveRules({
-      rules: { 'P*': 'off', A7: 'off' },
+      rules: { 'P*': 'off', A7: 'off', A8: 'off' },
       overrides: [{ tables: ['public.payments'], rules: { P5: 'critical' } }]
     });
     expect(allAstRulesDisabled(resolved)).toBe(false);
@@ -178,7 +179,7 @@ describe('loadConfig', () => {
     const { config, filepath } = loadConfig({ cwd });
     expect(filepath).toBe(path.join(cwd, 'safegres.json'));
     const { rules } = resolveRules(config);
-    expect(rules.get('A4')!.severity).toBe('critical'); // from strict
+    expect(rules.get('A4')!.severity).toBe('high'); // from strict
     expect(rules.get('A6')!.enabled).toBe(false); // file wins
     expect(config.failOn?.severity).toBe('high');
   });
@@ -192,7 +193,7 @@ describe('loadConfig', () => {
     });
     const { rules } = resolveRules(config);
     expect(rules.get('A4')!.enabled).toBe(false); // CLI override wins
-    expect(rules.get('A5')!.severity).toBe('high'); // from strict
+    expect(rules.get('A5')!.severity).toBe('medium'); // from strict
   });
 
   it('rejects unknown presets', () => {
@@ -208,31 +209,85 @@ describe('computeScore', () => {
     expect(score.deductions).toEqual([]);
   });
 
-  it('deducts by severity weight and floors the grade on criticals', () => {
-    const score = computeScore([
-      finding({ code: 'A1', severity: 'critical' }),
-      finding({ code: 'A5', severity: 'medium' })
-    ]);
+  it('weighted model: deducts by severity weight and floors the grade on criticals', () => {
+    const score = computeScore(
+      [finding({ code: 'A1', severity: 'critical' }), finding({ code: 'A5', severity: 'medium' })],
+      { model: 'weighted' }
+    );
     expect(score.value).toBe(100 - 25 - 4);
     expect(score.grade).toBe('C'); // 71 would be C anyway; floor also caps at C
     expect(score.deductions[0]).toEqual({ code: 'A1', count: 1, points: 25 });
   });
 
-  it('caps per-rule deductions', () => {
+  it('weighted model: caps per-rule deductions', () => {
     const findings = Array.from({ length: 20 }, () => finding({ code: 'A5', severity: 'medium' }));
-    const score = computeScore(findings, { floorOnCritical: false });
+    const score = computeScore(findings, { model: 'weighted', floorOnCritical: false });
     expect(score.value).toBe(60); // 20*4=80 capped at 40
     expect(score.deductions[0].points).toBe(40);
   });
 
   it('is config-driven: weights, per-rule weights, bands, floor', () => {
     const findings = [finding({ code: 'A3', severity: 'medium' })];
-    expect(computeScore(findings, { weights: { medium: 0 } }).value).toBe(100);
+    expect(computeScore(findings, { model: 'weighted', weights: { medium: 0 } }).value).toBe(100);
     expect(
-      computeScore(findings, { perRuleWeights: { A3: 50 }, maxDeductionPerRule: 100 }).value
+      computeScore(findings, {
+        model: 'weighted',
+        perRuleWeights: { A3: 50 },
+        maxDeductionPerRule: 100
+      }).value
     ).toBe(50);
-    const relaxed = computeScore(findings, { gradeBands: { 'A+': 50 } });
+    const relaxed = computeScore(findings, { model: 'weighted', gradeBands: { 'A+': 50 } });
     expect(relaxed.grade).toBe('A+');
+  });
+
+  it('density model: normalizes by exposed-table count instead of saturating', () => {
+    const findings = Array.from({ length: 20 }, () => finding({ code: 'A2', severity: 'high' }));
+    const small = computeScore(findings, {}, { exposedTables: 20, exposureKnown: true });
+    const large = computeScore(findings, {}, { exposedTables: 400, exposureKnown: true });
+    expect(small.model).toBe('density');
+    expect(large.value).toBeGreaterThan(small.value);
+    expect(small.value).toBeGreaterThan(0); // no 0/F saturation
+    expect(large.exposedTables).toBe(400);
+  });
+
+  it('density model: fail-closed findings contribute nothing by default', () => {
+    const failClosed = Array.from({ length: 50 }, () =>
+      finding({ code: 'A4', severity: 'high', direction: 'fail-closed' })
+    );
+    const score = computeScore(failClosed, {}, { exposedTables: 10, exposureKnown: true });
+    expect(score.value).toBe(100);
+    expect(score.deductions).toEqual([]);
+
+    const strictish = computeScore(
+      failClosed,
+      { failClosedWeight: 0.25 },
+      { exposedTables: 10, exposureKnown: true }
+    );
+    expect(strictish.value).toBeLessThan(100);
+  });
+
+  it('density model: non-exposed findings are excluded from the score', () => {
+    const findings = [
+      finding({ code: 'A7', severity: 'critical', exposed: false }),
+      finding({ code: 'A2', severity: 'high', exposed: true })
+    ];
+    const score = computeScore(findings, {}, { exposedTables: 10, exposureKnown: true });
+    expect(score.deductions).toEqual([{ code: 'A2', count: 1, points: 10 }]);
+    // the internal critical must not floor the grade either
+    expect(score.grade).not.toBe('C');
+  });
+
+  it('density model: caps the score when exposure is unknown', () => {
+    const capped = computeScore([], {}, { exposureKnown: false });
+    expect(capped.value).toBe(80);
+    expect(capped.cappedByUnknownExposure).toBe(true);
+
+    const uncapped = computeScore([], { unknownExposureCap: false }, { exposureKnown: false });
+    expect(uncapped.value).toBe(100);
+
+    const known = computeScore([], {}, { exposureKnown: true });
+    expect(known.value).toBe(100);
+    expect(known.cappedByUnknownExposure).toBeUndefined();
   });
 
   it('compares grades', () => {

--- a/packages/safegres/__tests__/exposure.test.ts
+++ b/packages/safegres/__tests__/exposure.test.ts
@@ -1,0 +1,99 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { getConnections, PgTestClient } from 'pgsql-test';
+
+import { audit } from '../src/commands/audit';
+import { resolveExposure } from '../src/pg/exposure';
+
+jest.setTimeout(120000);
+
+let pg: PgTestClient;
+let teardown: () => Promise<void>;
+
+async function applyFixture(name: string): Promise<void> {
+  const filepath = path.join(__dirname, 'fixtures', name);
+  const sql = fs.readFileSync(filepath, 'utf8');
+  await pg.any(sql);
+}
+
+beforeAll(async () => {
+  ({ pg, teardown } = await getConnections());
+  await applyFixture('a2-grants-no-rls.sql'); // fx_a2 — the "exposed" surface
+  await applyFixture('a7-write-permissive.sql'); // fx_a7w — internal
+});
+
+afterAll(async () => {
+  if (teardown) await teardown();
+});
+
+describe('resolveExposure', () => {
+  it('returns unknown when nothing is configured', async () => {
+    const exposure = await resolveExposure(pg.client as never, undefined);
+    expect(exposure.known).toBe(false);
+    expect(exposure.source).toBe('none');
+  });
+
+  it('resolves a static surface from config', async () => {
+    const exposure = await resolveExposure(pg.client as never, { schemas: ['fx_a2'] });
+    expect(exposure).toMatchObject({ known: true, source: 'config', schemas: ['fx_a2'] });
+  });
+
+  it('falls back to static config when the constructive routing plane is absent', async () => {
+    const exposure = await resolveExposure(pg.client as never, {
+      resolver: 'constructive',
+      schemas: ['fx_a2']
+    });
+    expect(exposure).toMatchObject({ known: true, source: 'config', schemas: ['fx_a2'] });
+  });
+});
+
+describe('audit with exposure', () => {
+  it('emits W1 and caps the score when no exposure surface is configured', async () => {
+    const report = await audit(pg.client as never, { schemas: ['fx_a2', 'fx_a7w'] });
+    expect(report.exposure?.known).toBe(false);
+    expect(report.findings.some((f) => f.code === 'W1')).toBe(true);
+    expect(report.score?.value).toBeLessThanOrEqual(80);
+
+    // a clean surface still can't exceed the unknown-exposure cap
+    const clean = await audit(pg.client as never, { schemas: ['fx_does_not_exist'] });
+    expect(clean.score?.value).toBe(80);
+    expect(clean.score?.cappedByUnknownExposure).toBe(true);
+  });
+
+  it('partitions findings into exposed and internal, scoring only the exposed surface', async () => {
+    const report = await audit(pg.client as never, {
+      schemas: ['fx_a2', 'fx_a7w'],
+      exposure: { schemas: ['fx_a2'] }
+    });
+
+    expect(report.exposure).toMatchObject({
+      known: true,
+      source: 'config',
+      schemas: ['fx_a2'],
+      exposedTables: 1,
+      totalTables: 2
+    });
+    expect(report.findings.some((f) => f.code === 'W1')).toBe(false);
+
+    const a2 = report.findings.find((f) => f.code === 'A2');
+    expect(a2?.exposed).toBe(true);
+
+    // the internal A7 critical must not appear in the score deductions or floor the grade
+    const a7 = report.findings.find((f) => f.code === 'A7');
+    expect(a7?.exposed).toBe(false);
+    expect(report.score?.deductions.every((d) => d.code !== 'A7')).toBe(true);
+    expect(report.score?.cappedByUnknownExposure).toBeUndefined();
+  });
+
+  it('the score improves when the leaky schema is not exposed', async () => {
+    const internalLeak = await audit(pg.client as never, {
+      schemas: ['fx_a2', 'fx_a7w'],
+      exposure: { schemas: ['fx_a2'] }
+    });
+    const exposedLeak = await audit(pg.client as never, {
+      schemas: ['fx_a2', 'fx_a7w'],
+      exposure: { schemas: ['fx_a2', 'fx_a7w'] }
+    });
+    expect(internalLeak.score!.value).toBeGreaterThan(exposedLeak.score!.value);
+  });
+});

--- a/packages/safegres/__tests__/fixtures/a7-write-permissive.sql
+++ b/packages/safegres/__tests__/fixtures/a7-write-permissive.sql
@@ -1,0 +1,25 @@
+-- A7 seed: permissive WRITE policy whose body is the literal `true` —
+-- every applicable role can mutate every row, and because permissive
+-- policies OR together it defeats any scoped policies on the table.
+-- Expected finding: A7 (critical, fail-open)
+
+CREATE SCHEMA IF NOT EXISTS fx_a7w;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'fx_a7w_writer') THEN
+    CREATE ROLE fx_a7w_writer;
+  END IF;
+END $$;
+
+CREATE TABLE fx_a7w.actions (
+  id bigserial PRIMARY KEY,
+  payload text
+);
+
+ALTER TABLE fx_a7w.actions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE fx_a7w.actions FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY fx_a7w_open_write ON fx_a7w.actions FOR INSERT TO fx_a7w_writer WITH CHECK (true);
+
+GRANT USAGE ON SCHEMA fx_a7w TO fx_a7w_writer;
+GRANT INSERT ON fx_a7w.actions TO fx_a7w_writer;

--- a/packages/safegres/src/checks/anti-patterns.ts
+++ b/packages/safegres/src/checks/anti-patterns.ts
@@ -160,16 +160,22 @@ export function checkSessionUserGating(
 }
 
 /**
- * Anti-pattern A7: trivially-permissive policy body.
+ * Anti-patterns A7 / A8: trivially-permissive policy body.
  *
- * A permissive policy whose body is the literal `true` (and has no tightening
- * `WITH CHECK` clause) adds zero security — it's equivalent to not having RLS
- * at all for the covered command. This is different from an intentional
- * *restrictive* `true` (which would require all rows to satisfy it). We only
- * flag `permissive = true` here because Postgres defaults to PERMISSIVE and
- * `USING (true)` is the most common accidental "fail-open" shape.
+ * A permissive policy whose body is the literal `true` adds zero security —
+ * it's equivalent to not having RLS at all for the covered command. This is
+ * different from an intentional *restrictive* `true` (which would require
+ * all rows to satisfy it). We only flag `permissive = true` here because
+ * Postgres defaults to PERMISSIVE and `USING (true)` is the most common
+ * accidental "fail-open" shape.
  *
- * Severity: HIGH — any auditor should see this as RLS-not-actually-enforced.
+ * The verb matters enormously:
+ *   - A7 (critical): a WRITE verb (INSERT/UPDATE/DELETE/ALL) with literal
+ *     `true` lets every applicable role mutate every row — and, because
+ *     permissive policies OR together, it silently defeats any carefully
+ *     scoped policies on the same table.
+ *   - A8 (low): a SELECT-only `USING (true)` is the standard public-read
+ *     reference-table pattern; flag it for confirmation, not alarm.
  *
  * Input: the parsed USING and WITH CHECK ASTs (may be null if empty).
  */
@@ -206,17 +212,30 @@ export function checkTriviallyPermissive(
   if (trivialClauses.length !== presentClauses.length) return null;
 
   const clauseList = trivialClauses.join(' and ');
-  return {
-    code: 'A7',
-    severity: 'high',
-    category: 'anti-pattern',
-    schema: table.schema,
-    table: table.name,
-    policy: policy.name,
-    message: `Policy "${policy.name}" on ${table.schema}.${table.name} is trivially permissive (${clauseList} = true)`,
-    hint: 'A permissive policy whose body is the literal `true` imposes no constraint. Either tighten the predicate (reference the authenticated user / membership) or drop the policy and use a GRANT REVOKE model.',
-    context: { cmd: policy.cmd, clauses: trivialClauses }
-  };
+  const isWrite = policy.cmd !== 'SELECT';
+  return isWrite
+    ? {
+      code: 'A7',
+      severity: 'critical',
+      category: 'anti-pattern',
+      schema: table.schema,
+      table: table.name,
+      policy: policy.name,
+      message: `Policy "${policy.name}" (FOR ${policy.cmd}) on ${table.schema}.${table.name} is trivially permissive (${clauseList} = true) — every applicable role can write every row`,
+      hint: 'Permissive policies OR together, so a literal-true write policy defeats every scoped policy on the table. Tighten the predicate or drop the policy.',
+      context: { cmd: policy.cmd, clauses: trivialClauses }
+    }
+    : {
+      code: 'A8',
+      severity: 'low',
+      category: 'anti-pattern',
+      schema: table.schema,
+      table: table.name,
+      policy: policy.name,
+      message: `Policy "${policy.name}" (FOR SELECT) on ${table.schema}.${table.name} is trivially permissive (${clauseList} = true) — all rows readable by applicable roles`,
+      hint: 'This is the standard public-read reference-table pattern. Confirm the table holds no per-tenant data; otherwise tighten the predicate.',
+      context: { cmd: policy.cmd, clauses: trivialClauses }
+    };
 }
 
 /**

--- a/packages/safegres/src/cli/audit.ts
+++ b/packages/safegres/src/cli/audit.ts
@@ -8,7 +8,7 @@ import { renderJson } from '../report/json';
 import { renderPretty } from '../report/pretty';
 import { meetsGrade } from '../score/score';
 import type { Severity } from '../types';
-import { meetsThreshold, SEVERITY_ORDER } from '../types';
+import { meetsThreshold, SEVERITY_ORDER, summarize } from '../types';
 import { buildClient, configParamsFromArgv, csvList } from './shared';
 
 const log = new Logger('safegres');
@@ -31,6 +31,11 @@ Configuration:
                            .safegresrc{,.json,.yaml,.yml,.js}, safegres.json, package.json "safegres")
   --preset <name>          Apply a built-in preset (recommended|strict|constructive|minimal)
   --rule <CODE=SETTING>    Retune a rule (repeatable), e.g. --rule A3=off --rule A5=high
+
+Exposure (what the score is computed against):
+  --exposure-schemas <csv> Declare the API-exposed schemas; findings outside
+                           them become unscored internal advisories
+  --exposed-only           Hide internal (non-exposed) findings from output
 
 Audit options:
   --schemas <csv>          Limit to these schemas (default: all non-system)
@@ -65,14 +70,23 @@ export default async (
   const client = buildClient(argv);
   await client.connect();
   try {
+    const exposureSchemas = csvList(argv['exposure-schemas']);
     const report = await audit(client, {
       schemas: csvList(argv.schemas),
       excludeSchemas: csvList(argv['exclude-schemas']),
       includeRoles: csvList(argv.roles),
       excludeRoles: csvList(argv['exclude-roles']),
       skipAstChecks: argv['skip-ast'] === true,
+      exposure: exposureSchemas
+        ? { ...config.exposure, schemas: exposureSchemas }
+        : undefined,
       config
     });
+
+    if (argv['exposed-only'] === true) {
+      report.findings = report.findings.filter((f) => f.exposed !== false);
+      report.summary = summarize(report.findings);
+    }
 
     const fmt = typeof argv.format === 'string' ? argv.format : 'pretty';
     let output: string;

--- a/packages/safegres/src/commands/audit.ts
+++ b/packages/safegres/src/commands/audit.ts
@@ -27,12 +27,14 @@ import {
   type RoleTrustOptions
 } from '../checks/role-trust';
 import { allAstRulesDisabled, applyRulesToFindings, resolveRules, rulesForTable } from '../config/resolve';
-import type { SafegresConfig } from '../config/types';
+import type { ExposureConfig, SafegresConfig } from '../config/types';
+import { resolveExposure } from '../pg/exposure';
 import { asExecutor, type IntrospectOptions, introspectTables, type QueryExecutor, type TableSnapshot } from '../pg/introspect';
 import { lookupVolatility, type ProcVolatility } from '../pg/proc';
 import { listAuditableRoles, resolveRoles } from '../pg/roles';
+import { RULES_BY_CODE } from '../rules/registry';
 import { computeScore } from '../score/score';
-import type { Finding, Report } from '../types';
+import type { ExposureReport, Finding, Report } from '../types';
 import { summarize } from '../types';
 import { version as PKG_VERSION } from '../version';
 
@@ -46,6 +48,11 @@ export interface AuditOptions extends IntrospectOptions {
    * that only want grants + RLS-flag + coverage findings.
    */
   skipAstChecks?: boolean;
+  /**
+   * The exposed API surface. Overrides `config.exposure` when provided.
+   * Findings on non-exposed schemas contribute nothing to the score.
+   */
+  exposure?: ExposureConfig;
   /**
    * Merged safegres configuration (rules, overrides, scoring). Rule settings
    * filter and retune findings; scoring settings drive the report score.
@@ -72,11 +79,18 @@ export async function audit(
     options.excludeRoles ?? config.excludeRoles
   );
 
+  const exposure = await resolveExposure(exec, options.exposure ?? config.exposure);
+  const exposedSchemas = new Set(exposure.schemas);
+
   const snapshot = await introspectTables(exec, {
     schemas: options.schemas ?? config.schemas,
     excludeSchemas: options.excludeSchemas ?? config.excludeSchemas,
     roles: resolution.roles
   });
+
+  const exposedTables = exposure.known
+    ? snapshot.filter((t) => exposedSchemas.has(t.schema)).length
+    : snapshot.length;
 
   let findings: Finding[] = [];
 
@@ -112,14 +126,49 @@ export async function audit(
   }
 
   findings = applyRulesToFindings(resolved, findings);
+
+  // Stamp direction (from the registry) and exposure on every finding.
+  for (const f of findings) {
+    const meta = RULES_BY_CODE.get(f.code);
+    if (meta && f.direction === undefined) f.direction = meta.direction;
+    if (exposure.known && f.schema) f.exposed = exposedSchemas.has(f.schema);
+  }
+
+  // W1: no exposure surface — the whole database is assumed reachable.
+  if (!exposure.known && resolved.rules.get('W1')?.enabled !== false) {
+    findings.push({
+      code: 'W1',
+      severity: resolved.rules.get('W1')?.severity ?? 'medium',
+      category: 'meta',
+      direction: 'neutral',
+      message:
+        'No exposure surface configured — the audit assumes the entire database is reachable and the score is capped',
+      hint:
+        'Declare `exposure.schemas` (or use `exposure.resolver: "constructive"` on a Constructive database) so the score reflects what the exposed APIs can actually reach.'
+    });
+  }
+
   findings.sort(compareFindings);
+
+  const exposureReport: ExposureReport = {
+    known: exposure.known,
+    source: exposure.source,
+    schemas: exposure.schemas,
+    ...(exposure.roles ? { roles: exposure.roles } : {}),
+    exposedTables,
+    totalTables: snapshot.length
+  };
 
   return {
     version: PKG_VERSION,
     generatedAt: new Date().toISOString(),
     summary: summarize(findings),
     findings,
-    score: computeScore(findings, config.scoring)
+    score: computeScore(findings, config.scoring, {
+      exposedTables,
+      exposureKnown: exposure.known
+    }),
+    exposure: exposureReport
   };
 }
 

--- a/packages/safegres/src/commands/doctor.ts
+++ b/packages/safegres/src/commands/doctor.ts
@@ -7,6 +7,8 @@
 import { parsePolicyExpression } from '../ast/parse';
 import { loadConfig, type LoadConfigParams } from '../config/loader';
 import { resolveRules } from '../config/resolve';
+import type { ExposureConfig } from '../config/types';
+import { resolveExposure } from '../pg/exposure';
 import { asExecutor, type QueryExecutor } from '../pg/introspect';
 
 export type DoctorStatus = 'ok' | 'warn' | 'fail';
@@ -29,10 +31,12 @@ export async function doctor(
   options: DoctorOptions = {}
 ): Promise<DoctorReport> {
   const checks: DoctorCheck[] = [];
+  let exposureConfig: ExposureConfig | undefined;
 
   // --- configuration ---
   try {
     const loaded = loadConfig(options);
+    exposureConfig = loaded.config.exposure;
     if (loaded.isEmpty) {
       checks.push({
         name: 'config',
@@ -150,6 +154,29 @@ export async function doctor(
     });
   } catch (err) {
     checks.push({ name: 'rls', status: 'warn', detail: (err as Error).message });
+  }
+
+  // --- exposure surface ---
+  try {
+    const exposure = await resolveExposure(exec, exposureConfig);
+    if (exposure.known) {
+      checks.push({
+        name: 'exposure',
+        status: 'ok',
+        detail: `${exposure.schemas.length} exposed schema(s) via ${exposure.source}${
+          exposure.roles && exposure.roles.length > 0 ? ` (api roles: ${exposure.roles.join(', ')})` : ''
+        }`
+      });
+    } else {
+      checks.push({
+        name: 'exposure',
+        status: 'warn',
+        detail:
+          'no exposure surface configured — the audit assumes the whole database is reachable and caps the score. Declare `exposure.schemas` or use `exposure.resolver: "constructive"`.'
+      });
+    }
+  } catch (err) {
+    checks.push({ name: 'exposure', status: 'warn', detail: (err as Error).message });
   }
 
   return finish(checks);

--- a/packages/safegres/src/config/presets.ts
+++ b/packages/safegres/src/config/presets.ts
@@ -11,29 +11,42 @@ export const recommended: SafegresConfig = {
   rules: {}
 };
 
-/** Everything on and escalated; coverage gaps are treated as critical. */
+/**
+ * Everything on and escalated. Fail-closed hygiene findings (dead grants,
+ * locked tables) are re-tuned upward and even contribute a fraction of
+ * their weight to the score.
+ */
 export const strict: SafegresConfig = {
   extends: 'safegres:recommended',
   rules: {
-    A4: 'critical',
-    A5: 'high',
+    A1: 'medium',
+    A3: 'medium',
+    A4: 'high',
+    A5: 'medium',
     A6: 'medium',
+    A8: 'medium',
     P1b: 'high'
   },
+  scoring: { failClosedWeight: 0.25 },
   failOn: { severity: 'high' }
 };
 
 /**
- * Tuned for Constructive's role model (RLS-first, anonymous/authenticated/
- * administrator): untrusted-role rules watch `anonymous`, and anything that
- * can leak rows across the role boundary is critical.
+ * Tuned for Constructive's architecture:
+ * - the exposure surface auto-resolves from the routing plane
+ *   (`routing_public.apis` → `api_schemas` → `metaschema_public.schema`),
+ *   so only what the exposed APIs can reach drives the score;
+ * - untrusted-role rules watch `anonymous`; anything that can leak rows
+ *   across the role boundary is critical;
+ * - A3 is off — API roles never own tables in the Constructive model, so
+ *   non-FORCEd RLS is not an exposure.
  */
 export const constructive: SafegresConfig = {
   extends: 'safegres:recommended',
+  exposure: { resolver: 'constructive' },
   rules: {
     A2: 'critical',
-    A4: 'critical',
-    A7: 'critical',
+    A3: 'off',
     P5: 'critical',
     R1: ['critical', { roles: ['anonymous'] }],
     R2: ['high', { roles: ['anonymous'] }],

--- a/packages/safegres/src/config/types.ts
+++ b/packages/safegres/src/config/types.ts
@@ -24,13 +24,54 @@ export interface OverrideEntry {
 
 export type Grade = 'A+' | 'A' | 'B' | 'C' | 'D' | 'F';
 
+/**
+ * The exposure surface: what is actually reachable through the exposed APIs.
+ * Findings on non-exposed schemas contribute nothing to the score — they are
+ * reported as internal advisories. When no surface is configured or
+ * resolvable, the whole database is assumed reachable, a W1 warning is
+ * emitted, and the score is capped.
+ */
+export interface ExposureConfig {
+  /**
+   * How to resolve the surface:
+   * - `static` (default): use `schemas` / `roles` as given.
+   * - `constructive`: introspect the Constructive routing plane
+   *   (`routing_public.apis` → `api_schemas` → `metaschema_public.schema`,
+   *   plus the platform plane) to discover exposed schemas and API roles.
+   */
+  resolver?: 'static' | 'constructive';
+  /** Schemas reachable from the exposed APIs (static resolver). */
+  schemas?: string[];
+  /** Roles reachable from the API edge (static resolver). */
+  roles?: string[];
+}
+
 export interface ScoringConfig {
+  /**
+   * Scoring model:
+   * - `density` (default): severity-weighted findings per exposed table with
+   *   exponential falloff — does not saturate on large schemas.
+   * - `weighted`: legacy flat deductions with a per-rule cap.
+   */
+  model?: 'density' | 'weighted';
   /** Points deducted per finding of each severity. */
   weights?: Partial<Record<Severity, number>>;
   /** Per-rule weight override — beats the severity weight. */
   perRuleWeights?: Record<string, number>;
-  /** Cap on total deduction any single rule can contribute. */
+  /** Cap on total deduction any single rule can contribute (weighted model). */
   maxDeductionPerRule?: number;
+  /**
+   * Multiplier applied to fail-closed findings' weights (density model).
+   * Default 0 — denied-at-runtime hygiene findings don't reduce the score.
+   */
+  failClosedWeight?: number;
+  /** Density falloff constant (density model). Default 0.17. */
+  densityK?: number;
+  /**
+   * Maximum score when no exposure surface is configured/resolvable.
+   * Default 80. `false` disables the cap.
+   */
+  unknownExposureCap?: number | false;
   /** Any finding at/above this severity caps the grade (e.g. 'critical' -> 'C'). */
   floorOnCritical?: Grade | false;
   /** Minimum score for each grade; anything below the lowest is 'F'. */
@@ -54,6 +95,8 @@ export interface FailOnConfig {
 export interface SafegresConfig {
   /** Presets (`safegres:recommended`, …), relative paths, or npm packages. */
   extends?: string | string[];
+  /** The exposed API surface — what the score is computed against. */
+  exposure?: ExposureConfig;
   schemas?: string[];
   excludeSchemas?: string[];
   roles?: string[];

--- a/packages/safegres/src/index.ts
+++ b/packages/safegres/src/index.ts
@@ -35,6 +35,7 @@ export {
   rulesForTable
 } from './config/resolve';
 export type {
+  ExposureConfig,
   FailOnConfig,
   Grade,
   OverrideEntry,
@@ -43,6 +44,8 @@ export type {
   SafegresConfig,
   ScoringConfig
 } from './config/types';
+export type { ResolvedExposure } from './pg/exposure';
+export { resolveConstructiveExposure, resolveExposure, UNKNOWN_EXPOSURE } from './pg/exposure';
 export {
   type IntrospectOptions,
   introspectTables,
@@ -57,6 +60,6 @@ export { renderJson } from './report/json';
 export { renderPretty } from './report/pretty';
 export type { RuleMeta } from './rules/registry';
 export { expandRuleSelector, isKnownRule, RULES, RULES_BY_CODE } from './rules/registry';
-export type { Score, ScoreDeduction } from './score/score';
+export type { Score, ScoreContext, ScoreDeduction } from './score/score';
 export { computeScore, DEFAULT_GRADE_BANDS, DEFAULT_WEIGHTS, meetsGrade } from './score/score';
 export * from './types';

--- a/packages/safegres/src/pg/exposure.ts
+++ b/packages/safegres/src/pg/exposure.ts
@@ -1,0 +1,123 @@
+/**
+ * Exposure-surface resolution: what is actually reachable through the
+ * exposed APIs. Findings on non-exposed schemas contribute nothing to the
+ * score — they are reported as internal advisories.
+ */
+
+import type { ExposureConfig } from '../config/types';
+import type { QueryExecutor } from './introspect';
+
+export interface ResolvedExposure {
+  /** True when a surface was configured or auto-resolved. */
+  known: boolean;
+  source: 'config' | 'constructive' | 'none';
+  schemas: string[];
+  roles?: string[];
+}
+
+export const UNKNOWN_EXPOSURE: ResolvedExposure = {
+  known: false,
+  source: 'none',
+  schemas: []
+};
+
+/**
+ * Resolve the exposure surface from config, delegating to a resolver when
+ * one is named. Falls back to `UNKNOWN_EXPOSURE` when nothing is configured
+ * or the resolver finds no routing plane.
+ */
+export async function resolveExposure(
+  exec: QueryExecutor,
+  config?: ExposureConfig
+): Promise<ResolvedExposure> {
+  if (!config) return UNKNOWN_EXPOSURE;
+
+  if (config.resolver === 'constructive') {
+    const resolved = await resolveConstructiveExposure(exec);
+    if (resolved) {
+      // Static schemas/roles extend (never replace) what the resolver found.
+      return {
+        known: true,
+        source: 'constructive',
+        schemas: union(resolved.schemas, config.schemas),
+        roles: union(resolved.roles ?? [], config.roles)
+      };
+    }
+    // Routing plane absent — fall through to whatever static surface exists.
+  }
+
+  if (config.schemas && config.schemas.length > 0) {
+    return {
+      known: true,
+      source: 'config',
+      schemas: [...config.schemas].sort(),
+      roles: config.roles
+    };
+  }
+
+  return UNKNOWN_EXPOSURE;
+}
+
+/**
+ * Constructive routing-plane introspection: an API exposes a set of schemas
+ * via `routing_public.apis` → `routing_public.api_schemas` →
+ * `metaschema_public.schema` (and the platform plane via `platform_apis` →
+ * `platform_api_schemas`). API-edge roles come from `apis.role_name` /
+ * `apis.anon_role`.
+ *
+ * Returns `null` when the routing plane isn't present in this database.
+ */
+export async function resolveConstructiveExposure(
+  exec: QueryExecutor
+): Promise<{ schemas: string[]; roles: string[] } | null> {
+  const { rows: present } = await exec.query<{ ok: boolean }>(
+    `SELECT
+       to_regclass('routing_public.apis') IS NOT NULL
+       AND to_regclass('routing_public.api_schemas') IS NOT NULL
+       AND to_regclass('metaschema_public.schema') IS NOT NULL AS ok`
+  );
+  if (!present[0]?.ok) return null;
+
+  const { rows: hasPlatform } = await exec.query<{ ok: boolean }>(
+    `SELECT
+       to_regclass('routing_public.platform_apis') IS NOT NULL
+       AND to_regclass('routing_public.platform_api_schemas') IS NOT NULL AS ok`
+  );
+
+  const planes = [
+    `SELECT s.schema_name, a.role_name, a.anon_role
+       FROM routing_public.apis a
+       JOIN routing_public.api_schemas aps ON aps.api_id = a.id
+       JOIN metaschema_public.schema s ON s.id = aps.schema_id`
+  ];
+  if (hasPlatform[0]?.ok) {
+    planes.push(
+      `SELECT s.schema_name, a.role_name, a.anon_role
+         FROM routing_public.platform_apis a
+         JOIN routing_public.platform_api_schemas aps ON aps.api_id = a.id
+         JOIN metaschema_public.schema s ON s.id = aps.schema_id`
+    );
+  }
+
+  const { rows } = await exec.query<{
+    schema_name: string;
+    role_name: string | null;
+    anon_role: string | null;
+  }>(planes.join(' UNION ALL '));
+
+  const schemas = new Set<string>();
+  const roles = new Set<string>();
+  for (const r of rows) {
+    if (r.schema_name) schemas.add(r.schema_name);
+    if (r.role_name) roles.add(r.role_name);
+    if (r.anon_role) roles.add(r.anon_role);
+  }
+  if (schemas.size === 0) return null;
+
+  return { schemas: [...schemas].sort(), roles: [...roles].sort() };
+}
+
+function union(base: string[], extra?: string[]): string[] {
+  if (!extra || extra.length === 0) return base;
+  return [...new Set([...base, ...extra])].sort();
+}

--- a/packages/safegres/src/report/pretty.ts
+++ b/packages/safegres/src/report/pretty.ts
@@ -25,11 +25,28 @@ export function renderPretty(report: Report, options: { color?: boolean } = {}):
   const colorEnabled = options.color ?? process.stdout.isTTY === true;
   const paint = (sev: Severity, s: string) => (colorEnabled ? SEV_PAINT[sev](s) : noop(s));
 
-  const { summary: s, findings, score } = report;
+  const { summary: s, findings, score, exposure } = report;
   const lines: string[] = [
     `safegres ${report.version}  (${report.generatedAt})`,
     ''
   ];
+
+  if (exposure) {
+    if (exposure.known) {
+      lines.push(
+        `exposure: ${exposure.schemas.length} schema(s) via ${exposure.source}`
+          + `  — ${exposure.exposedTables}/${exposure.totalTables} tables exposed`
+      );
+      if (exposure.roles && exposure.roles.length > 0) {
+        lines.push(`  api roles: ${exposure.roles.join(', ')}`);
+      }
+    } else {
+      lines.push(
+        paint('medium', 'exposure: unknown — entire database assumed reachable (score capped)')
+      );
+    }
+    lines.push('');
+  }
 
   if (score) {
     const gradePaint: (s: string) => string = colorEnabled
@@ -39,7 +56,8 @@ export function renderPretty(report: Report, options: { color?: boolean } = {}):
           ? yanse.yellow
           : yanse.red
       : noop;
-    lines.push(`score: ${gradePaint(`${score.value} (${score.grade})`)}  — model: ${score.model}`);
+    const capNote = score.cappedByUnknownExposure ? '  (capped: exposure unknown)' : '';
+    lines.push(`score: ${gradePaint(`${score.value} (${score.grade})`)}  — model: ${score.model}${capNote}`);
     const top = score.deductions.slice(0, 3);
     if (top.length > 0) {
       lines.push(
@@ -58,8 +76,22 @@ export function renderPretty(report: Report, options: { color?: boolean } = {}):
     ''
   );
 
-  for (const f of findings) {
+  const exposed = findings.filter((f) => f.exposed !== false);
+  const internal = findings.filter((f) => f.exposed === false);
+
+  for (const f of exposed) {
     lines.push(renderFinding(f, paint));
+  }
+
+  if (internal.length > 0) {
+    lines.push(
+      '',
+      `internal advisories (${internal.length}) — not exposed via any API, excluded from the score:`,
+      ''
+    );
+    for (const f of internal) {
+      lines.push(renderFinding(f, paint));
+    }
   }
 
   if (findings.length === 0) {

--- a/packages/safegres/src/rules/registry.ts
+++ b/packages/safegres/src/rules/registry.ts
@@ -1,4 +1,4 @@
-import type { Finding, Severity } from '../types';
+import type { Direction, Finding, Severity } from '../types';
 
 /**
  * Static metadata for every rule safegres can emit. Severity here is the
@@ -10,6 +10,12 @@ export interface RuleMeta {
   code: string;
   category: Finding['category'];
   defaultSeverity: Severity;
+  /**
+   * Leak vs deny vs directionless. `fail-closed` findings are hygiene
+   * concerns — the operation is *denied* at runtime — and contribute nothing
+   * to the score by default. `fail-open` findings are actual exposure.
+   */
+  direction: Direction;
   title: string;
   /**
    * Rules with `scope: 'policy-ast'` require parsing policy expressions.
@@ -22,56 +28,72 @@ export const RULES: RuleMeta[] = [
   {
     code: 'A1',
     category: 'flags',
-    defaultSeverity: 'critical',
-    title: 'RLS enabled but no policies (effectively deny-all)',
+    defaultSeverity: 'low',
+    direction: 'fail-closed',
+    title: 'RLS enabled but no policies (deny-all — confirm the lock is intended)',
     scope: 'table'
   },
   {
     code: 'A2',
     category: 'flags',
     defaultSeverity: 'high',
+    direction: 'fail-open',
     title: 'Grants exist on a table with RLS disabled',
     scope: 'table'
   },
   {
     code: 'A3',
     category: 'flags',
-    defaultSeverity: 'medium',
+    defaultSeverity: 'low',
+    direction: 'fail-open',
     title: 'RLS enabled but FORCE ROW LEVEL SECURITY not set (owner bypass)',
     scope: 'table'
   },
   {
     code: 'A4',
     category: 'coverage',
-    defaultSeverity: 'high',
-    title: 'INSERT/UPDATE/DELETE grant with no covering policy for that verb',
+    defaultSeverity: 'low',
+    direction: 'fail-closed',
+    title: 'INSERT/UPDATE/DELETE grant with no covering policy — writes are denied at runtime',
     scope: 'table'
   },
   {
     code: 'A5',
     category: 'coverage',
-    defaultSeverity: 'medium',
-    title: 'SELECT grant with no covering policy (silent empty result)',
+    defaultSeverity: 'low',
+    direction: 'fail-closed',
+    title: 'SELECT grant with no covering policy — queries silently return 0 rows',
     scope: 'table'
   },
   {
     code: 'A6',
     category: 'coverage',
     defaultSeverity: 'info',
+    direction: 'fail-closed',
     title: 'UPDATE has USING but no WITH CHECK (row-smuggling surface)',
     scope: 'table'
   },
   {
     code: 'A7',
     category: 'anti-pattern',
-    defaultSeverity: 'high',
-    title: 'Trivially-permissive policy (USING (true) / WITH CHECK (true))',
+    defaultSeverity: 'critical',
+    direction: 'fail-open',
+    title: 'Trivially-permissive WRITE policy (INSERT/UPDATE/DELETE/ALL with literal true)',
+    scope: 'policy-ast'
+  },
+  {
+    code: 'A8',
+    category: 'anti-pattern',
+    defaultSeverity: 'low',
+    direction: 'fail-open',
+    title: 'Trivially-permissive SELECT policy (USING (true) — confirm public-read is intended)',
     scope: 'policy-ast'
   },
   {
     code: 'P1',
     category: 'anti-pattern',
     defaultSeverity: 'high',
+    direction: 'neutral',
     title: 'Policy body calls a VOLATILE function (per-row evaluation)',
     scope: 'policy-ast'
   },
@@ -79,6 +101,7 @@ export const RULES: RuleMeta[] = [
     code: 'P1b',
     category: 'anti-pattern',
     defaultSeverity: 'medium',
+    direction: 'neutral',
     title: 'Policy body calls a SECURITY DEFINER wrapper (cannot be inlined)',
     scope: 'policy-ast'
   },
@@ -86,6 +109,7 @@ export const RULES: RuleMeta[] = [
     code: 'P5',
     category: 'anti-pattern',
     defaultSeverity: 'high',
+    direction: 'fail-open',
     title: 'Policy body references session_user / current_user / pg_has_role',
     scope: 'policy-ast'
   },
@@ -93,6 +117,7 @@ export const RULES: RuleMeta[] = [
     code: 'R1',
     category: 'anti-pattern',
     defaultSeverity: 'critical',
+    direction: 'fail-open',
     title: 'Untrusted role holds a write privilege (options: { roles: [...] })',
     scope: 'table'
   },
@@ -100,6 +125,7 @@ export const RULES: RuleMeta[] = [
     code: 'R2',
     category: 'anti-pattern',
     defaultSeverity: 'high',
+    direction: 'fail-open',
     title: 'Permissive write policy applies to an untrusted role or PUBLIC (options: { roles: [...] })',
     scope: 'table'
   },
@@ -107,7 +133,16 @@ export const RULES: RuleMeta[] = [
     code: 'R3',
     category: 'anti-pattern',
     defaultSeverity: 'medium',
+    direction: 'fail-open',
     title: 'RLS table has grants TO PUBLIC (includes all current and future roles)',
+    scope: 'table'
+  },
+  {
+    code: 'W1',
+    category: 'meta',
+    defaultSeverity: 'medium',
+    direction: 'neutral',
+    title: 'No exposure surface configured — the whole database is assumed reachable and the score is capped',
     scope: 'table'
   }
 ];

--- a/packages/safegres/src/score/score.ts
+++ b/packages/safegres/src/score/score.ts
@@ -12,10 +12,24 @@ export interface Score {
   /** 0-100. */
   value: number;
   grade: Grade;
-  /** Scoring model identifier (currently always 'weighted'). */
+  /** Scoring model identifier ('density' or 'weighted'). */
   model: string;
-  /** Per-rule deductions, largest first. */
+  /** Per-rule deductions (weighted) or risk-point contributions (density), largest first. */
   deductions: ScoreDeduction[];
+  /** Density model: risk points per exposed table. */
+  density?: number;
+  /** Density model: the exposed-table denominator. */
+  exposedTables?: number;
+  /** True when the score was capped because no exposure surface was known. */
+  cappedByUnknownExposure?: boolean;
+}
+
+/** Context the audit supplies for exposure-aware scoring. */
+export interface ScoreContext {
+  /** Number of tables on the exposed surface (the density denominator). */
+  exposedTables?: number;
+  /** Whether an exposure surface was configured/resolved. */
+  exposureKnown?: boolean;
 }
 
 export const DEFAULT_WEIGHTS: Record<Severity, number> = {
@@ -35,24 +49,121 @@ export const DEFAULT_GRADE_BANDS: Record<Exclude<Grade, 'F'>, number> = {
 };
 
 const DEFAULT_MAX_DEDUCTION_PER_RULE = 40;
+const DEFAULT_DENSITY_K = 0.17;
+const DEFAULT_UNKNOWN_EXPOSURE_CAP = 80;
+const DEFAULT_FAIL_CLOSED_WEIGHT = 0;
 
 /**
- * Weighted-deduction scoring (Lighthouse-style): each finding deducts points
- * by severity (or per-rule override), capped per rule so one noisy rule can't
- * zero the score alone. Any critical finding floors the grade (default 'C').
- *
- * The score is config-driven by design: disabling or retuning rules changes
- * the findings and therefore the score.
+ * Compute the audit score. The score is config-driven by design: disabling
+ * or retuning rules changes the findings and therefore the score, and only
+ * findings on the exposed surface count (see `Finding.exposed`).
  */
-export function computeScore(findings: Finding[], config: ScoringConfig = {}): Score {
+export function computeScore(
+  findings: Finding[],
+  config: ScoringConfig = {},
+  context: ScoreContext = {}
+): Score {
+  const model = config.model ?? 'density';
+  return model === 'weighted'
+    ? computeWeightedScore(findings, config, context)
+    : computeDensityScore(findings, config, context);
+}
+
+/**
+ * Density scoring: severity-weighted *scorable* findings per exposed table
+ * with exponential falloff — does not saturate on large schemas.
+ *
+ *   score = 100 · exp(−k · riskPoints / exposedTables)
+ *
+ * Scorable findings are those on the exposed surface (`exposed !== false`)
+ * that are not fail-closed (fail-closed weights are multiplied by
+ * `failClosedWeight`, default 0 — denied-at-runtime hygiene doesn't reduce
+ * the score). With the default k, one critical per ~10 exposed tables lands
+ * around a C; one critical per table is an F.
+ */
+function computeDensityScore(
+  findings: Finding[],
+  config: ScoringConfig,
+  context: ScoreContext
+): Score {
+  const weights = { ...DEFAULT_WEIGHTS, ...(config.weights ?? {}) };
+  const perRule = config.perRuleWeights ?? {};
+  const bands = { ...DEFAULT_GRADE_BANDS, ...(config.gradeBands ?? {}) };
+  const floor = config.floorOnCritical === undefined ? 'C' : config.floorOnCritical;
+  const k = config.densityK ?? DEFAULT_DENSITY_K;
+  const failClosedWeight = config.failClosedWeight ?? DEFAULT_FAIL_CLOSED_WEIGHT;
+
+  // Meta findings (e.g. W1) are advisories about the audit itself — the
+  // unknown-exposure cap is their penalty, not weighted points.
+  const scorable = findings.filter((f) => f.exposed !== false && f.category !== 'meta');
+
+  const byRule = new Map<string, { count: number; points: number }>();
+  for (const f of scorable) {
+    let weight = perRule[f.code] ?? weights[f.severity] ?? 0;
+    if (f.direction === 'fail-closed') weight *= failClosedWeight;
+    if (weight <= 0) continue;
+    const entry = byRule.get(f.code) ?? { count: 0, points: 0 };
+    entry.count += 1;
+    entry.points += weight;
+    byRule.set(f.code, entry);
+  }
+
+  const deductions: ScoreDeduction[] = [...byRule.entries()]
+    .map(([code, { count, points }]) => ({ code, count, points }))
+    .sort((a, b) => b.points - a.points || a.code.localeCompare(b.code));
+
+  const riskPoints = deductions.reduce((sum, d) => sum + d.points, 0);
+  const exposedTables = Math.max(1, context.exposedTables ?? 1);
+  const density = riskPoints / exposedTables;
+
+  let value = Math.round(100 * Math.exp(-k * density) * 10) / 10;
+
+  const cap = config.unknownExposureCap ?? DEFAULT_UNKNOWN_EXPOSURE_CAP;
+  const capped = context.exposureKnown === false && cap !== false && value > cap;
+  if (capped) value = cap;
+
+  let grade = gradeFor(value, bands);
+  if (
+    floor
+    && scorable.some(
+      (f) => f.direction !== 'fail-closed' && meetsThreshold(f.severity, 'critical')
+    )
+  ) {
+    grade = worseOf(grade, floor);
+  }
+
+  return {
+    value,
+    grade,
+    model: 'density',
+    deductions,
+    density: Math.round(density * 1000) / 1000,
+    exposedTables,
+    ...(capped ? { cappedByUnknownExposure: true } : {})
+  };
+}
+
+/**
+ * Legacy weighted-deduction scoring (Lighthouse-style): each finding deducts
+ * points by severity (or per-rule override), capped per rule so one noisy
+ * rule can't zero the score alone. Any critical finding floors the grade
+ * (default 'C'). Saturates on large schemas — prefer the density model.
+ */
+function computeWeightedScore(
+  findings: Finding[],
+  config: ScoringConfig,
+  context: ScoreContext
+): Score {
   const weights = { ...DEFAULT_WEIGHTS, ...(config.weights ?? {}) };
   const perRule = config.perRuleWeights ?? {};
   const cap = config.maxDeductionPerRule ?? DEFAULT_MAX_DEDUCTION_PER_RULE;
   const bands = { ...DEFAULT_GRADE_BANDS, ...(config.gradeBands ?? {}) };
   const floor = config.floorOnCritical === undefined ? 'C' : config.floorOnCritical;
 
+  const scorable = findings.filter((f) => f.exposed !== false && f.category !== 'meta');
+
   const byRule = new Map<string, { count: number; points: number }>();
-  for (const f of findings) {
+  for (const f of scorable) {
     const weight = perRule[f.code] ?? weights[f.severity] ?? 0;
     const entry = byRule.get(f.code) ?? { count: 0, points: 0 };
     entry.count += 1;
@@ -66,14 +177,24 @@ export function computeScore(findings: Finding[], config: ScoringConfig = {}): S
     .sort((a, b) => b.points - a.points || a.code.localeCompare(b.code));
 
   const total = deductions.reduce((sum, d) => sum + d.points, 0);
-  const value = Math.max(0, Math.round((100 - total) * 10) / 10);
+  let value = Math.max(0, Math.round((100 - total) * 10) / 10);
+
+  const unknownCap = config.unknownExposureCap ?? DEFAULT_UNKNOWN_EXPOSURE_CAP;
+  const capped = context.exposureKnown === false && unknownCap !== false && value > unknownCap;
+  if (capped) value = unknownCap;
 
   let grade = gradeFor(value, bands);
-  if (floor && findings.some((f) => meetsThreshold(f.severity, 'critical'))) {
+  if (floor && scorable.some((f) => meetsThreshold(f.severity, 'critical'))) {
     grade = worseOf(grade, floor);
   }
 
-  return { value, grade, model: 'weighted', deductions };
+  return {
+    value,
+    grade,
+    model: 'weighted',
+    deductions,
+    ...(capped ? { cappedByUnknownExposure: true } : {})
+  };
 }
 
 const GRADE_ORDER: Grade[] = ['A+', 'A', 'B', 'C', 'D', 'F'];

--- a/packages/safegres/src/types.ts
+++ b/packages/safegres/src/types.ts
@@ -8,6 +8,15 @@
 
 export type Severity = 'critical' | 'high' | 'medium' | 'low' | 'info';
 
+/**
+ * Which way a finding fails:
+ * - `fail-open`   — the untrusted side can read/write more than intended (a leak).
+ * - `fail-closed` — the operation is denied at runtime; an availability/hygiene
+ *                   concern, not an exposure. Excluded from the score by default.
+ * - `neutral`     — directionless (performance, meta).
+ */
+export type Direction = 'fail-open' | 'fail-closed' | 'neutral';
+
 export const SEVERITY_ORDER: Record<Severity, number> = {
   critical: 4,
   high: 3,
@@ -22,6 +31,14 @@ export interface Finding {
   severity: Severity;
   /** High-level bucket — helps renderers group findings. */
   category: 'flags' | 'coverage' | 'anti-pattern' | 'sync' | 'match' | 'meta';
+  /** Leak vs deny vs directionless. Stamped from the rule registry. */
+  direction?: Direction;
+  /**
+   * Whether the finding's table is on the resolved exposure surface.
+   * `undefined` when no exposure surface is known (everything is assumed
+   * reachable).
+   */
+  exposed?: boolean;
   /** Schema-qualified location, where applicable. */
   schema?: string;
   table?: string;
@@ -44,6 +61,22 @@ export interface Summary {
   info: number;
 }
 
+/** The resolved exposure surface an audit was scored against. */
+export interface ExposureReport {
+  /** True when a surface was configured or auto-resolved. */
+  known: boolean;
+  /** Where the surface came from. */
+  source: 'config' | 'constructive' | 'none';
+  /** Schemas reachable from the exposed APIs. Empty when unknown. */
+  schemas: string[];
+  /** API-edge roles, when the resolver can discover them. */
+  roles?: string[];
+  /** Tables on the exposed surface (the score denominator). */
+  exposedTables: number;
+  /** All tables the audit introspected. */
+  totalTables: number;
+}
+
 export interface Report {
   version: string;
   generatedAt: string;
@@ -51,6 +84,8 @@ export interface Report {
   findings: Finding[];
   /** Config-driven audit score (weighted deductions, 0-100 + grade). */
   score?: import('./score/score').Score;
+  /** The exposure surface the score was computed against. */
+  exposure?: ExposureReport;
 }
 
 export function newSummary(): Summary {


### PR DESCRIPTION
## Summary

A database-wide score is meaningless when most of the database isn't API-reachable (planning issue [#1286](https://github.com/constructive-io/constructive-planning/issues/1286)). This makes **exposure** a first-class concept and fixes the two flaws that pinned every real schema at 0/F: score saturation and treating fail-closed (denied at runtime) findings like fail-open leaks.

**Exposure layer** (`src/pg/exposure.ts`, `exposure` config block):
```ts
exposure?: { resolver?: 'static' | 'constructive'; schemas?: string[]; roles?: string[] }
```
- `resolveExposure(exec, config)` → `{ known, source: 'config'|'constructive'|'none', schemas, roles }`
- The `constructive` resolver introspects `routing_public.apis → api_schemas → metaschema_public.schema` (+ platform plane) — the `safegres:constructive` preset enables it, so the surface is discovered with zero config.
- `audit` stamps each finding `exposed: true|false`; non-exposed findings become unscored *internal advisories* (rendered in a separate section; `--exposed-only` hides them). `--exposure-schemas <csv>` declares a static surface.
- Unknown exposure → new `W1` meta finding + score capped at 80 (`scoring.unknownExposureCap`).

**Direction-aware rules**: every rule carries `direction: 'fail-open'|'fail-closed'|'neutral'`. Fail-closed coverage findings (A1 no-policy lock, A4/A5 grant-without-policy = denied at runtime) drop to `low` and contribute 0 to the score by default (`scoring.failClosedWeight`; strict preset uses 0.25). A7 splits: trivially-permissive **write** policies are `critical` (permissive policies OR together, defeating scoped ones); SELECT-only `USING (true)` becomes new low-severity **A8** (intentional public-read pattern).

**Density scoring** (new default; `scoring.model: 'weighted'` keeps the old one):
```
score = 100 · exp(−k · riskPoints / exposedTables)   // k = scoring.densityK, default 0.17
```

Dogfood results (both DBs previously 0/F on every preset):

| DB | preset, no exposure | preset, with exposure |
|---|---|---|
| constructivedb | recommended 79.2/C + W1 | constructive **99.3/A+** (auto-resolved 24 schemas, 486/573 tables; `db_migrate` blanket-write A7×3 + R2×3 now internal advisories) |
| diligence | constructive 21.9/F + W1 | constructive **97.8/A+** (`--exposure-schemas` app schemas, 168/316 tables; 112 A2s all internal metaschema) |

Also: doctor gains an exposure check; README documents direction/exposure/density; 55 tests incl. new `exposure.test.ts` (pgsql-test). No real-schema goldens added.

Link to Devin session: https://app.devin.ai/sessions/671aac6e50b04e8caacd3f54c1c63bc6
Requested by: @pyramation