### PR TITLE
feat(safegres): pgpm autodetect audit — `audit --pgpm` + `safegres/pgpm-test` helper

### DIFF
--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -151,4 +151,38 @@ console.log(renderPretty(report));
 console.log(`${report.findings.length} findings`);
 ```
 
+## pgpm projects
+
+For pgpm workspaces, safegres can deploy the workspace into an ephemeral test
+database and audit it — no running database or connection flags required
+(needs the optional peer dependency `pgsql-test`):
+
+```bash
+safegres audit --pgpm            # nearest pgpm module/workspace from cwd
+safegres audit --pgpm ./packages/my-db
+```
+
+Or as a jest test via the `safegres/pgpm-test` entrypoint:
+
+```ts
+import { auditPgpmWorkspace } from 'safegres/pgpm-test';
+
+it('passes the security audit', async () => {
+  const report = await auditPgpmWorkspace();
+  expect(report.score.grade).toBe('A+');
+});
+```
+
+Both discover the project's safegres config (`safegres.config.js`,
+`.safegresrc*`, …) by walking up from the workspace directory. pgpm projects
+usually don't have Constructive routing metadata, so declare the exposed
+surface statically:
+
+```json
+{
+  "extends": "safegres:recommended",
+  "exposure": { "schemas": ["app_public"] }
+}
+```
+
 

--- a/packages/safegres/__tests__/pgpm-test.test.ts
+++ b/packages/safegres/__tests__/pgpm-test.test.ts
@@ -1,0 +1,34 @@
+import { resolve } from 'path';
+
+import { auditPgpmWorkspace } from '../src/pgpm-test';
+
+jest.setTimeout(120000);
+
+const fixture = resolve(
+  __dirname,
+  '../../../__fixtures__/sqitch/simple/packages/my-third'
+);
+
+describe('auditPgpmWorkspace', () => {
+  it('deploys the pgpm module into an ephemeral db and audits it', async () => {
+    const report = await auditPgpmWorkspace({
+      cwd: fixture,
+      exposure: { schemas: ['mythirdapp'] }
+    });
+    expect(report.score).toBeDefined();
+    expect(report.exposure).toMatchObject({
+      known: true,
+      source: 'config',
+      schemas: ['mythirdapp']
+    });
+    expect(report.findings.some((f) => f.code === 'W1')).toBe(false);
+    // mythirdapp.customers has no grants and no RLS → nothing exposed leaks.
+    expect(report.score!.grade).toBe('A+');
+  });
+
+  it('reports unknown exposure (W1 + cap) when none is configured', async () => {
+    const report = await auditPgpmWorkspace({ cwd: fixture });
+    expect(report.exposure).toMatchObject({ known: false, source: 'none' });
+    expect(report.findings.some((f) => f.code === 'W1')).toBe(true);
+  });
+});

--- a/packages/safegres/package.json
+++ b/packages/safegres/package.json
@@ -53,6 +53,14 @@
     "pgsql-parser": "^18.1.1",
     "yanse": "^0.2.1"
   },
+  "peerDependencies": {
+    "pgsql-test": "*"
+  },
+  "peerDependenciesMeta": {
+    "pgsql-test": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/pg": "^8.20.0",

--- a/packages/safegres/src/cli/audit.ts
+++ b/packages/safegres/src/cli/audit.ts
@@ -1,17 +1,34 @@
 import { Logger } from '@pgpmjs/logger';
 import { CLIOptions, Inquirerer, ParsedArgs } from 'inquirerer';
 
-import { audit } from '../commands/audit';
+import { audit, type AuditOptions } from '../commands/audit';
 import { loadConfig } from '../config/loader';
 import type { Grade } from '../config/types';
 import { renderJson } from '../report/json';
 import { renderPretty } from '../report/pretty';
 import { meetsGrade } from '../score/score';
-import type { Severity } from '../types';
+import type { Report, Severity } from '../types';
 import { meetsThreshold, SEVERITY_ORDER, summarize } from '../types';
 import { buildClient, configParamsFromArgv, csvList } from './shared';
 
 const log = new Logger('safegres');
+
+/**
+ * `--pgpm` mode needs the optional peer dependency `pgsql-test`, so the
+ * helper module is loaded lazily with a friendly error when it's missing.
+ */
+function importPgpmTest(): typeof import('../pgpm-test') {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require('../pgpm-test');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND') {
+      log.error('--pgpm requires the optional peer dependency "pgsql-test" — install it (e.g. `npm i -D pgsql-test`) and retry');
+      process.exit(2);
+    }
+    throw err;
+  }
+}
 
 const usage = `
 safegres audit — pure-PostgreSQL RLS auditor
@@ -19,6 +36,9 @@ safegres audit — pure-PostgreSQL RLS auditor
   safegres audit [OPTIONS]
 
 Connection (priority order, top wins):
+  --pgpm [dir]             No connection needed: deploy the pgpm workspace at
+                           [dir] (default: nearest from cwd) into an ephemeral
+                           test database and audit it (requires pgsql-test)
   --connection <url>       Full PostgreSQL connection string
   --host <host>            PostgreSQL host        (else PGHOST,    default localhost)
   --port <port>            PostgreSQL port        (else PGPORT,    default 5432)
@@ -65,74 +85,83 @@ export default async (
   // minimist parses `--no-color` as `color: false`.
   const colorEnabled = argv.color !== false;
 
-  const { config } = loadConfig(configParamsFromArgv(argv));
+  const pgpmCwd = typeof argv.pgpm === 'string' ? argv.pgpm : undefined;
+  const { config } = loadConfig({ cwd: pgpmCwd, ...configParamsFromArgv(argv) });
 
-  const client = buildClient(argv);
-  await client.connect();
-  try {
-    const exposureSchemas = csvList(argv['exposure-schemas']);
-    const report = await audit(client, {
-      schemas: csvList(argv.schemas),
-      excludeSchemas: csvList(argv['exclude-schemas']),
-      includeRoles: csvList(argv.roles),
-      excludeRoles: csvList(argv['exclude-roles']),
-      skipAstChecks: argv['skip-ast'] === true,
-      exposure: exposureSchemas
-        ? { ...config.exposure, schemas: exposureSchemas }
-        : undefined,
-      config
-    });
+  const exposureSchemas = csvList(argv['exposure-schemas']);
+  const auditOptions: AuditOptions = {
+    schemas: csvList(argv.schemas),
+    excludeSchemas: csvList(argv['exclude-schemas']),
+    includeRoles: csvList(argv.roles),
+    excludeRoles: csvList(argv['exclude-roles']),
+    skipAstChecks: argv['skip-ast'] === true,
+    exposure: exposureSchemas
+      ? { ...config.exposure, schemas: exposureSchemas }
+      : undefined,
+    config
+  };
 
-    if (argv['exposed-only'] === true) {
-      report.findings = report.findings.filter((f) => f.exposed !== false);
-      report.summary = summarize(report.findings);
+  let report: Report;
+  if (argv.pgpm) {
+    const { auditPgpmWorkspace } = importPgpmTest();
+    report = await auditPgpmWorkspace({ ...auditOptions, cwd: pgpmCwd });
+  } else {
+    const client = buildClient(argv);
+    await client.connect();
+    try {
+      report = await audit(client, auditOptions);
+    } finally {
+      await client.end();
     }
+  }
 
-    const fmt = typeof argv.format === 'string' ? argv.format : 'pretty';
-    let output: string;
-    switch (fmt) {
-    case 'json':
-      output = renderJson(report);
-      break;
-    case 'json-pretty':
-      output = renderJson(report, { pretty: true });
-      break;
-    case 'pretty':
-      output = renderPretty(report, { color: colorEnabled });
-      break;
-    default:
-      log.error(`Unknown --format: ${fmt}`);
+  if (argv['exposed-only'] === true) {
+    report.findings = report.findings.filter((f) => f.exposed !== false);
+    report.summary = summarize(report.findings);
+  }
+
+  const fmt = typeof argv.format === 'string' ? argv.format : 'pretty';
+  let output: string;
+  switch (fmt) {
+  case 'json':
+    output = renderJson(report);
+    break;
+  case 'json-pretty':
+    output = renderJson(report, { pretty: true });
+    break;
+  case 'pretty':
+    output = renderPretty(report, { color: colorEnabled });
+    break;
+  default:
+    log.error(`Unknown --format: ${fmt}`);
+    process.exit(2);
+  }
+  process.stdout.write(output);
+  process.stdout.write('\n');
+
+  const failOnSeverity =
+    typeof argv['fail-on'] === 'string' ? (argv['fail-on'] as Severity) : config.failOn?.severity;
+  if (failOnSeverity) {
+    if (!(failOnSeverity in SEVERITY_ORDER)) {
+      log.error(`Unknown --fail-on severity: ${failOnSeverity}`);
       process.exit(2);
     }
-    process.stdout.write(output);
-    process.stdout.write('\n');
-
-    const failOnSeverity =
-      typeof argv['fail-on'] === 'string' ? (argv['fail-on'] as Severity) : config.failOn?.severity;
-    if (failOnSeverity) {
-      if (!(failOnSeverity in SEVERITY_ORDER)) {
-        log.error(`Unknown --fail-on severity: ${failOnSeverity}`);
-        process.exit(2);
-      }
-      if (report.findings.some((f) => meetsThreshold(f.severity, failOnSeverity))) {
-        process.exit(1);
-      }
-    }
-
-    const failOnScore =
-      typeof argv['fail-on-score'] === 'number' ? argv['fail-on-score'] : config.failOn?.score;
-    if (failOnScore != null && report.score && report.score.value < failOnScore) {
-      log.error(`score ${report.score.value} is below --fail-on-score ${failOnScore}`);
+    if (report.findings.some((f) => meetsThreshold(f.severity, failOnSeverity))) {
       process.exit(1);
     }
+  }
 
-    const failOnGrade =
-      typeof argv['fail-on-grade'] === 'string' ? (argv['fail-on-grade'] as Grade) : config.failOn?.grade;
-    if (failOnGrade && report.score && !meetsGrade(report.score.grade, failOnGrade)) {
-      log.error(`grade ${report.score.grade} is below --fail-on-grade ${failOnGrade}`);
-      process.exit(1);
-    }
-  } finally {
-    await client.end();
+  const failOnScore =
+    typeof argv['fail-on-score'] === 'number' ? argv['fail-on-score'] : config.failOn?.score;
+  if (failOnScore != null && report.score && report.score.value < failOnScore) {
+    log.error(`score ${report.score.value} is below --fail-on-score ${failOnScore}`);
+    process.exit(1);
+  }
+
+  const failOnGrade =
+    typeof argv['fail-on-grade'] === 'string' ? (argv['fail-on-grade'] as Grade) : config.failOn?.grade;
+  if (failOnGrade && report.score && !meetsGrade(report.score.grade, failOnGrade)) {
+    log.error(`grade ${report.score.grade} is below --fail-on-grade ${failOnGrade}`);
+    process.exit(1);
   }
 };

--- a/packages/safegres/src/pgpm-test.ts
+++ b/packages/safegres/src/pgpm-test.ts
@@ -1,0 +1,59 @@
+/**
+ * Test helper for pgpm projects: deploy the workspace into an ephemeral
+ * database (via pgsql-test) and audit it with the project's discovered
+ * safegres config.
+ *
+ * `pgsql-test` is an optional peer dependency — only needed when this
+ * entrypoint is imported.
+ *
+ * ```ts
+ * import { auditPgpmWorkspace } from 'safegres/pgpm-test';
+ *
+ * it('passes the security audit', async () => {
+ *   const report = await auditPgpmWorkspace();
+ *   expect(report.score.grade).toBe('A+');
+ * });
+ * ```
+ */
+import { getConnections, seed } from 'pgsql-test';
+
+import { audit, type AuditOptions } from './commands/audit';
+import { loadConfig } from './config/loader';
+import type { SafegresConfig } from './config/types';
+import type { QueryExecutor } from './pg/introspect';
+import type { Report } from './types';
+
+export interface AuditPgpmWorkspaceOptions extends Omit<AuditOptions, 'config'> {
+  /**
+   * pgpm workspace or module directory to deploy. Defaults to the nearest
+   * pgpm module/workspace discovered from `process.cwd()`.
+   */
+  cwd?: string;
+  /** Explicit safegres config file (else discovered by walk-up from `cwd`). */
+  configFile?: string;
+  /** Built-in preset name (recommended|strict|constructive|minimal). */
+  preset?: string;
+  /** Pre-resolved config — skips discovery entirely. */
+  config?: SafegresConfig;
+}
+
+/**
+ * Deploy the pgpm workspace at `cwd` into an ephemeral test database, run
+ * `safegres audit` against it with the project's safegres config, tear the
+ * database down, and return the report.
+ */
+export async function auditPgpmWorkspace(
+  options: AuditPgpmWorkspaceOptions = {}
+): Promise<Report> {
+  const { cwd, configFile, preset, config: explicitConfig, ...auditOptions } = options;
+  const config = explicitConfig ?? loadConfig({ cwd, configFile, preset }).config;
+  const { pg, teardown } = await getConnections({}, [seed.pgpm(cwd)]);
+  try {
+    return await audit(pg.client as unknown as QueryExecutor, {
+      ...auditOptions,
+      config
+    });
+  } finally {
+    await teardown();
+  }
+}


### PR DESCRIPTION
## Summary

Step 2 of [constructive-planning#1287](https://github.com/constructive-io/constructive-planning/issues/1287): make any pgpm project auditable with one command / one 5-line test, no new packages.

New `src/pgpm-test.ts` (deep import `safegres/pgpm-test`):

```ts
export async function auditPgpmWorkspace(options: AuditPgpmWorkspaceOptions = {}): Promise<Report> {
  const config = options.config ?? loadConfig({ cwd, configFile, preset }).config;   // confstash walk-up from the workspace
  const { pg, teardown } = await getConnections({}, [seed.pgpm(cwd)]);               // ephemeral db + workspace deploy
  try { return await audit(pg.client, { ...auditOptions, config }); }
  finally { await teardown(); }
}
```

CLI twin: `safegres audit --pgpm [dir]` — same path, no connection flags needed; renders/gates identically to a normal audit (the render + `--fail-on*` logic is now shared between both modes).

`pgsql-test` becomes an **optional peer dependency**, loaded lazily (`require` inside `importPgpmTest()` with a friendly install hint) so plain `safegres audit` users pay nothing.

Tested against the shared `__fixtures__/sqitch/simple` workspace: static exposure → `A+`, no config → W1 + unknown-exposure behavior. 57 tests green.

Link to Devin session: https://app.devin.ai/sessions/671aac6e50b04e8caacd3f54c1c63bc6
Requested by: @pyramation