### PR TITLE
feat(safegres): declared public surface — `public.read` acknowledges intentional open reads

### DIFF
--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -71,6 +71,26 @@ A database-wide score is meaningless if most of the database isn't reachable thr
 
 CLI: `--exposure-schemas <csv>`, `--exposed-only`. The `safegres:constructive` preset sets `exposure.resolver: "constructive"` so the surface is discovered automatically from the routing plane (including API roles from `role_name`/`anon_role`).
 
+## Declared public surface
+
+Some open reads are deliberate — pricing tables, reference data, a public user directory. Declare them and safegres treats them as intent instead of findings:
+
+```jsonc
+{
+  "public": {
+    "read": [
+      "app_public.plans*",        // schema.table globs
+      "app_public.event_types",
+      "app_public.users"          // deliberate public directory
+    ]
+  }
+}
+```
+
+- An open SELECT policy (`USING (true)` — rule A8) on a declared table is **acknowledged**: reported as info, excluded from the score.
+- An open read on any *undeclared* table stays a scored finding — even in a `*_public`-named schema. Naming is never treated as intent; the config declaration is.
+- `safegres doctor` warns about stale `public.read` patterns that no longer match any table.
+
 ## Configuration
 
 safegres is configurable like a linter. Config is discovered by walking up from the current directory: `safegres.config.{ts,js,mjs,cjs}`, `.safegresrc{,.json,.yaml,.yml,.js}`, `safegres.json`, or a `"safegres"` key in package.json (via [confstash](https://github.com/constructive-io/dev-utils/tree/main/packages/confstash)).

--- a/packages/safegres/__tests__/audit.test.ts
+++ b/packages/safegres/__tests__/audit.test.ts
@@ -96,6 +96,30 @@ describe('audit — Script A', () => {
     expect(found.find((f) => f.code === 'A7')).toBeUndefined();
   });
 
+  it('public.read: declared open read is acknowledged (info) and unscored', async () => {
+    // fx_a7 fixture (open SELECT policy) was applied by the A8 test above.
+    const exposure = { schemas: ['fx_a7'] };
+    const undeclared = await audit(pg.client as never, {
+      schemas: ['fx_a7'],
+      config: { exposure }
+    });
+    const declared = await audit(pg.client as never, {
+      schemas: ['fx_a7'],
+      config: { exposure, public: { read: ['fx_a7.*'] } }
+    });
+
+    const a8 = declared.findings.find((f) => f.code === 'A8' && f.schema === 'fx_a7');
+    expect(a8).toBeDefined();
+    expect(a8?.acknowledged).toBe(true);
+    expect(a8?.severity).toBe('info');
+    expect(a8?.message).toContain('declared public read');
+
+    const undeclaredA8 = undeclared.findings.find((f) => f.code === 'A8' && f.schema === 'fx_a7');
+    expect(undeclaredA8?.acknowledged).toBeUndefined();
+    expect(undeclaredA8?.severity).toBe('low');
+    expect(declared.score!.value).toBeGreaterThan(undeclared.score!.value);
+  });
+
   it('A7: flags trivially-permissive WRITE policy as critical (fail-open)', async () => {
     await applyFixture('a7-write-permissive.sql');
     const report = await audit(pg.client as never, { schemas: ['fx_a7w'] });

--- a/packages/safegres/__tests__/config.test.ts
+++ b/packages/safegres/__tests__/config.test.ts
@@ -75,6 +75,14 @@ describe('resolveRules', () => {
       ConfigValidationError
     );
   });
+
+  it('rejects malformed public.read declarations', () => {
+    expect(() => resolveRules({ public: { read: 'app.*' as never } })).toThrow(
+      ConfigValidationError
+    );
+    expect(() => resolveRules({ public: { read: [''] } })).toThrow(ConfigValidationError);
+    expect(() => resolveRules({ public: { read: ['app_public.*'] } })).not.toThrow();
+  });
 });
 
 describe('table overrides', () => {

--- a/packages/safegres/src/commands/audit.ts
+++ b/packages/safegres/src/commands/audit.ts
@@ -26,7 +26,7 @@ import {
   checkUntrustedRoleWrites,
   type RoleTrustOptions
 } from '../checks/role-trust';
-import { allAstRulesDisabled, applyRulesToFindings, resolveRules, rulesForTable } from '../config/resolve';
+import { allAstRulesDisabled, applyRulesToFindings, matchTablePattern, resolveRules, rulesForTable } from '../config/resolve';
 import type { ExposureConfig, SafegresConfig } from '../config/types';
 import { resolveExposure } from '../pg/exposure';
 import { asExecutor, type IntrospectOptions, introspectTables, type QueryExecutor, type TableSnapshot } from '../pg/introspect';
@@ -128,10 +128,24 @@ export async function audit(
   findings = applyRulesToFindings(resolved, findings);
 
   // Stamp direction (from the registry) and exposure on every finding.
+  const publicRead = config.public?.read ?? [];
   for (const f of findings) {
     const meta = RULES_BY_CODE.get(f.code);
     if (meta && f.direction === undefined) f.direction = meta.direction;
     if (exposure.known && f.schema) f.exposed = exposedSchemas.has(f.schema);
+
+    // Declared-public reads: an open SELECT on a table listed in
+    // `public.read` is intent, not a finding — acknowledge it (info,
+    // excluded from the score). Undeclared open reads stay scored.
+    if (
+      f.code === 'A8' && f.schema && f.table
+      && publicRead.some((p) => matchTablePattern(p, `${f.schema}.${f.table}`))
+    ) {
+      f.acknowledged = true;
+      f.severity = 'info';
+      f.message += ' — declared public read (public.read)';
+      f.hint = 'This table is declared in `public.read`, so the open read is treated as intentional and does not affect the score.';
+    }
   }
 
   // W1: no exposure surface — the whole database is assumed reachable.

--- a/packages/safegres/src/commands/doctor.ts
+++ b/packages/safegres/src/commands/doctor.ts
@@ -6,7 +6,7 @@
 
 import { parsePolicyExpression } from '../ast/parse';
 import { loadConfig, type LoadConfigParams } from '../config/loader';
-import { resolveRules } from '../config/resolve';
+import { matchTablePattern, resolveRules } from '../config/resolve';
 import type { ExposureConfig } from '../config/types';
 import { resolveExposure } from '../pg/exposure';
 import { asExecutor, type QueryExecutor } from '../pg/introspect';
@@ -32,11 +32,13 @@ export async function doctor(
 ): Promise<DoctorReport> {
   const checks: DoctorCheck[] = [];
   let exposureConfig: ExposureConfig | undefined;
+  let publicRead: string[] = [];
 
   // --- configuration ---
   try {
     const loaded = loadConfig(options);
     exposureConfig = loaded.config.exposure;
+    publicRead = loaded.config.public?.read ?? [];
     if (loaded.isEmpty) {
       checks.push({
         name: 'config',
@@ -177,6 +179,31 @@ export async function doctor(
     }
   } catch (err) {
     checks.push({ name: 'exposure', status: 'warn', detail: (err as Error).message });
+  }
+
+  // --- declared public surface ---
+  if (publicRead.length > 0) {
+    try {
+      const { rows } = await exec.query<{ qualified: string }>(
+        `SELECT n.nspname || '.' || c.relname AS qualified
+         FROM pg_class c
+         JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE c.relkind IN ('r','p')
+           AND n.nspname NOT IN ('pg_catalog','information_schema')`
+      );
+      const qualified = rows.map((r) => r.qualified);
+      const stale = publicRead.filter((p) => !qualified.some((q) => matchTablePattern(p, q)));
+      checks.push({
+        name: 'public',
+        status: stale.length > 0 ? 'warn' : 'ok',
+        detail:
+          stale.length > 0
+            ? `stale \`public.read\` pattern(s) match no table: ${stale.join(', ')}`
+            : `${publicRead.length} \`public.read\` pattern(s), all match at least one table`
+      });
+    } catch (err) {
+      checks.push({ name: 'public', status: 'warn', detail: (err as Error).message });
+    }
   }
 
   return finish(checks);

--- a/packages/safegres/src/config/resolve.ts
+++ b/packages/safegres/src/config/resolve.ts
@@ -100,6 +100,12 @@ export function resolveRules(config: SafegresConfig): ResolvedRules {
     // Validate override rule settings eagerly.
     applyRulesConfig(rules, o.rules ?? {});
   }
+  const publicRead = config.public?.read;
+  if (publicRead !== undefined) {
+    if (!Array.isArray(publicRead) || publicRead.some((p) => typeof p !== 'string' || p.length === 0)) {
+      throw new ConfigValidationError('"public.read" must be an array of non-empty schema.table glob patterns.');
+    }
+  }
   return { rules, overrides };
 }
 

--- a/packages/safegres/src/config/types.ts
+++ b/packages/safegres/src/config/types.ts
@@ -46,6 +46,22 @@ export interface ExposureConfig {
   roles?: string[];
 }
 
+/**
+ * Declared-public surface: intent, stated in config. Open reads on declared
+ * tables are acknowledged — reported as info and excluded from the score.
+ * Open reads anywhere else stay findings, even in `*_public`-named schemas;
+ * naming is never treated as intent.
+ */
+export interface PublicConfig {
+  /**
+   * Glob patterns matched against the qualified `schema.table` name
+   * (`*` matches any run of characters) for tables whose open SELECT
+   * (`USING (true)`) policies are by design, e.g. reference/pricing tables
+   * or a deliberate public directory.
+   */
+  read?: string[];
+}
+
 export interface ScoringConfig {
   /**
    * Scoring model:
@@ -97,6 +113,8 @@ export interface SafegresConfig {
   extends?: string | string[];
   /** The exposed API surface — what the score is computed against. */
   exposure?: ExposureConfig;
+  /** Tables whose open reads are deliberate (declared public surface). */
+  public?: PublicConfig;
   schemas?: string[];
   excludeSchemas?: string[];
   roles?: string[];

--- a/packages/safegres/src/score/score.ts
+++ b/packages/safegres/src/score/score.ts
@@ -95,7 +95,7 @@ function computeDensityScore(
 
   // Meta findings (e.g. W1) are advisories about the audit itself — the
   // unknown-exposure cap is their penalty, not weighted points.
-  const scorable = findings.filter((f) => f.exposed !== false && f.category !== 'meta');
+  const scorable = findings.filter((f) => f.exposed !== false && !f.acknowledged && f.category !== 'meta');
 
   const byRule = new Map<string, { count: number; points: number }>();
   for (const f of scorable) {
@@ -160,7 +160,7 @@ function computeWeightedScore(
   const bands = { ...DEFAULT_GRADE_BANDS, ...(config.gradeBands ?? {}) };
   const floor = config.floorOnCritical === undefined ? 'C' : config.floorOnCritical;
 
-  const scorable = findings.filter((f) => f.exposed !== false && f.category !== 'meta');
+  const scorable = findings.filter((f) => f.exposed !== false && !f.acknowledged && f.category !== 'meta');
 
   const byRule = new Map<string, { count: number; points: number }>();
   for (const f of scorable) {

--- a/packages/safegres/src/types.ts
+++ b/packages/safegres/src/types.ts
@@ -39,6 +39,12 @@ export interface Finding {
    * reachable).
    */
   exposed?: boolean;
+  /**
+   * The finding is acknowledged by config as intentional (e.g. an open read
+   * on a table declared in `public.read`) — reported, but excluded from the
+   * score.
+   */
+  acknowledged?: boolean;
   /** Schema-qualified location, where applicable. */
   schema?: string;
   table?: string;


### PR DESCRIPTION
## Summary

Open reads that are *by design* (pricing/reference tables, a deliberate public user directory) can now be declared, mirroring the exposure model: intent is stated in config and rewarded, never inferred from schema naming.

```jsonc
// .safegresrc.json
{
  "extends": "safegres:constructive",
  "public": {
    "read": ["constructive_plans_public.*", "constructive_users_public.users"]
  }
}
```

Semantics:
- An A8 finding (`USING (true)` SELECT policy) on a table matching a `public.read` glob is **acknowledged**: new `Finding.acknowledged` flag, severity restamped to `info`, message suffixed `— declared public read`, and excluded from both scoring models (same filter as internal/meta findings).
- Undeclared open reads stay scored — even in `*_public`-named schemas. Naming is never intent.
- `safegres doctor` gains a `public` check that warns about stale `public.read` patterns matching no table.
- `resolveRules` validates `public.read` (array of non-empty `schema.table` globs, reusing `matchTablePattern`).

Dogfood: constructive-db with its 20 intentional public-read tables declared goes **99.3 → 100 (A+)**; the A8 lines remain visible as acknowledged info findings.

Tests: 59 passing (new audit acknowledge/score test + config validation test); lint clean; verified end-to-end against the deployed constructivedb.

Link to Devin session: https://app.devin.ai/sessions/671aac6e50b04e8caacd3f54c1c63bc6
Requested by: @pyramation