### PR TITLE
feat(safegres): output verbosity — --summary, --verbose, collapse internal advisories by default

### DIFF
--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -26,6 +26,15 @@ safegres audit
 
 Per-field overrides (`--host`, `--port`, `--user`, `--password`, `--database`) and a full `--connection <url>` flag are also supported. See `safegres audit --help`.
 
+### Output & verbosity
+
+Pretty output prints the exposure line, score, and the exposed findings. Internal (non-exposed) advisories are collapsed to a one-line count by default so a large database's report stays readable.
+
+- `--summary`, `-q` — print only the exposure line, score/grade, and severity counts (no per-finding lines). Ideal for CI job summaries.
+- `--verbose` — expand the internal advisories instead of collapsing them to a count.
+- `--exposed-only` — drop internal findings entirely.
+- `--format json` / `--format json-pretty` — machine-readable output (always carries every finding).
+
 ## What it checks
 
 | Code | Severity | Direction | Category | Check |

--- a/packages/safegres/__tests__/pretty.test.ts
+++ b/packages/safegres/__tests__/pretty.test.ts
@@ -1,0 +1,69 @@
+import { renderPretty } from '../src/report/pretty';
+import type { Finding, Report } from '../src/types';
+import { summarize } from '../src/types';
+
+function makeReport(): Report {
+  const findings: Finding[] = [
+    {
+      code: 'A2',
+      severity: 'high',
+      category: 'flags',
+      exposed: true,
+      schema: 'app_public',
+      table: 'widgets',
+      message: 'grants exist on a table with RLS disabled'
+    },
+    {
+      code: 'A2',
+      severity: 'high',
+      category: 'flags',
+      exposed: false,
+      schema: 'db_migrate',
+      table: 'sql_actions',
+      message: 'grants exist on a table with RLS disabled'
+    },
+    {
+      code: 'A2',
+      severity: 'high',
+      category: 'flags',
+      exposed: false,
+      schema: 'db_migrate',
+      table: 'log',
+      message: 'grants exist on a table with RLS disabled'
+    }
+  ];
+  return {
+    version: '1.0.0',
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    summary: summarize(findings),
+    findings
+  };
+}
+
+describe('renderPretty verbosity', () => {
+  it('collapses internal advisories to a count by default', () => {
+    const out = renderPretty(makeReport(), { color: false });
+    expect(out).toContain('app_public.widgets');
+    expect(out).toContain('internal advisories (2)');
+    expect(out).toContain('--verbose');
+    // internal findings are not listed individually
+    expect(out).not.toContain('db_migrate.sql_actions');
+    expect(out).not.toContain('db_migrate.log');
+  });
+
+  it('--verbose expands the internal advisories', () => {
+    const out = renderPretty(makeReport(), { color: false, verbose: true });
+    expect(out).toContain('app_public.widgets');
+    expect(out).toContain('db_migrate.sql_actions');
+    expect(out).toContain('db_migrate.log');
+    expect(out).not.toContain('--verbose to list');
+  });
+
+  it('--summary prints counts only, no findings', () => {
+    const out = renderPretty(makeReport(), { color: false, summary: true });
+    expect(out).toContain('summary:');
+    expect(out).toContain('3 high');
+    expect(out).not.toContain('app_public.widgets');
+    expect(out).not.toContain('internal advisories');
+  });
+});

--- a/packages/safegres/src/cli.ts
+++ b/packages/safegres/src/cli.ts
@@ -14,8 +14,8 @@ if (process.argv.includes('--version') || process.argv.includes('-v')) {
 
 const options: Partial<CLIOptions> = {
   minimistOpts: {
-    alias: { v: 'version', h: 'help' },
-    boolean: ['skip-ast', 'color', 'help', 'version'],
+    alias: { v: 'version', h: 'help', q: 'summary' },
+    boolean: ['skip-ast', 'color', 'help', 'version', 'summary', 'verbose'],
     string: [
       'connection',
       'host',

--- a/packages/safegres/src/cli/audit.ts
+++ b/packages/safegres/src/cli/audit.ts
@@ -63,6 +63,8 @@ Audit options:
   --roles <csv>            Audit grants only for these roles (default: all)
   --exclude-roles <csv>    Skip grants for these roles
   --format <fmt>           "pretty" (default) | "json" | "json-pretty"
+  --summary, -q            Print only exposure, score, and severity counts (no findings)
+  --verbose                Expand internal (non-exposed) advisories (listed as a count otherwise)
   --fail-on <severity>     Exit non-zero if any finding >= severity
                            (critical|high|medium|low|info; default: none)
   --fail-on-score <n>      Exit non-zero if the score is below n (0-100)
@@ -130,7 +132,11 @@ export default async (
     output = renderJson(report, { pretty: true });
     break;
   case 'pretty':
-    output = renderPretty(report, { color: colorEnabled });
+    output = renderPretty(report, {
+      color: colorEnabled,
+      summary: argv.summary === true,
+      verbose: argv.verbose === true
+    });
     break;
   default:
     log.error(`Unknown --format: ${fmt}`);

--- a/packages/safegres/src/report/pretty.ts
+++ b/packages/safegres/src/report/pretty.ts
@@ -21,7 +21,15 @@ const SEV_PAINT: Record<Severity, Painter> = {
 
 const noop: Painter = (s) => s;
 
-export function renderPretty(report: Report, options: { color?: boolean } = {}): string {
+export interface RenderPrettyOptions {
+  color?: boolean;
+  /** Only render the exposure line, score, and severity summary — no per-finding lines. */
+  summary?: boolean;
+  /** Expand the internal (non-exposed) advisories instead of collapsing them to a count. */
+  verbose?: boolean;
+}
+
+export function renderPretty(report: Report, options: RenderPrettyOptions = {}): string {
   const colorEnabled = options.color ?? process.stdout.isTTY === true;
   const paint = (sev: Severity, s: string) => (colorEnabled ? SEV_PAINT[sev](s) : noop(s));
 
@@ -72,9 +80,14 @@ export function renderPretty(report: Report, options: { color?: boolean } = {}):
       + `${paint('high', String(s.high))} high  `
       + `${paint('medium', String(s.medium))} medium  `
       + `${paint('low', String(s.low))} low  `
-      + `${paint('info', String(s.info))} info`,
-    ''
+      + `${paint('info', String(s.info))} info`
   );
+
+  // --summary: score + counts only, no per-finding lines.
+  if (options.summary) {
+    return lines.join('\n');
+  }
+  lines.push('');
 
   const exposed = findings.filter((f) => f.exposed !== false);
   const internal = findings.filter((f) => f.exposed === false);
@@ -84,13 +97,25 @@ export function renderPretty(report: Report, options: { color?: boolean } = {}):
   }
 
   if (internal.length > 0) {
-    lines.push(
-      '',
-      `internal advisories (${internal.length}) — not exposed via any API, excluded from the score:`,
-      ''
-    );
-    for (const f of internal) {
-      lines.push(renderFinding(f, paint));
+    // Collapse internal advisories to a count by default; --verbose lists them.
+    if (options.verbose) {
+      lines.push(
+        '',
+        `internal advisories (${internal.length}) — not exposed via any API, excluded from the score:`,
+        ''
+      );
+      for (const f of internal) {
+        lines.push(renderFinding(f, paint));
+      }
+    } else {
+      lines.push(
+        '',
+        paint(
+          'info',
+          `internal advisories (${internal.length}) — not exposed via any API, `
+            + 'excluded from the score; run with --verbose to list.'
+        )
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

The pretty report printed **every** finding, so on a large DB (e.g. constructivedb: ~700 findings, ~200 internal advisories) the CLI/CI output was a wall of text. This adds verbosity control so you can "just see the score."

Changes to `renderPretty` + the `audit` CLI:

- **Internal (non-exposed) advisories now collapse to a one-line count by default** — exposed findings still print in full:
  ```
  internal advisories (200) — not exposed via any API, excluded from the score; run with --verbose to list.
  ```
- **`--verbose`** — expands the internal advisories back into individual lines (old behavior).
- **`--summary` / `-q`** — prints only the exposure line, score/grade, and severity counts; no per-finding lines. Ideal for CI job summaries.
- `--exposed-only` (unchanged) still drops internal findings entirely; JSON output always carries every finding.

```ts
renderPretty(report, { color, summary, verbose })
// summary  -> return after the "summary:" counts line
// verbose  -> list internal advisories individually
// default  -> exposed findings + one-line internal count
```

`-v` is already `--version`, so verbose is `--summary`/`-q` + long-form `--verbose` only.

## Test plan
- New `__tests__/pretty.test.ts`: default collapses internal to a count, `--verbose` expands them, `--summary` emits counts only (no findings).
- Full package suite green (62 tests), Postgres up.


Link to Devin session: https://app.devin.ai/sessions/671aac6e50b04e8caacd3f54c1c63bc6
Requested by: @pyramation