### PR TITLE
feat(safegres): call-graph audit — trust boundaries reachable from the exposed surface (--call-graph)

### DIFF
--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -100,6 +100,36 @@ Some open reads are deliberate — pricing tables, reference data, a public user
 - An open read on any *undeclared* table stays a scored finding — even in a `*_public`-named schema. Naming is never treated as intent; the config declaration is.
 - `safegres doctor` warns about stale `public.read` patterns that no longer match any table.
 
+## Call graph (`--call-graph`)
+
+RLS findings tell you what the *tables* allow. The call graph tells you what the *functions* reach: starting from the exposed entry points (functions the API roles can `EXECUTE`), safegres statically walks each body and lists every **trust boundary** on the way — unscored, because a public `SECURITY DEFINER` calling private functions is the intended pattern (that's how `sign_in` works). The output is a deterministic checklist for human review:
+
+| Code | Boundary |
+|------|----------|
+| CF1 | `SECURITY DEFINER` without a pinned `search_path` (CWE-426) — provable misconfiguration, fix these |
+| CF2 | `SECURITY DEFINER` executable by `anonymous`/PUBLIC — widest blast radius, confirm intent |
+| CG2 | RLS-bypass path — a DEFINER's owner owns (or bypasses RLS on) a table it touches, so RLS does not protect that table on this path |
+| CG3 | Auth-context mutation — a reachable function writes `jwt.claims.*` / `role` |
+| CG1 | Trust hop — execution crosses into a `SECURITY DEFINER` (you are trusting its author's authorization logic) |
+| CG4 | Internal reach — a non-exposed table is reached from a public entry via a DEFINER path |
+| CG5 | Opaque node — dynamic SQL (`EXECUTE`) or an unparseable body; static analysis ends here, audit manually |
+
+```bash
+safegres audit --database mydb --call-graph
+```
+
+```
+call graph — trust boundaries reachable from the exposed surface (unscored; human review)
+  2 entry point(s) → 4 reachable function(s)  |  3 trust hop(s)  1 RLS-bypass  1 auth-context  1 internal-reach  1 opaque
+
+CG2 — RLS-bypass paths (RLS does not protect the table on this path) (1)
+  • fx_cg_private.verify_password → fx_cg_private.users
+      RLS on fx_cg_private.users does not apply on this path — fx_cg_private.verify_password is SECURITY DEFINER running as postgres (BYPASSRLS/superuser)
+      via: fx_cg_public.sign_in → fx_cg_private.verify_password
+```
+
+Bodies are analyzed for `sql` and `plpgsql` functions (via the PL/pgSQL parser); overloads collapse into one node per `schema.name`; unqualified calls resolve to every user function with that name (a conservative over-approximation). JSON output (`--format json`) carries the full graph — nodes, edges, and checklist — sorted stably so it can be snapshotted and diffed in CI.
+
 ## Configuration
 
 safegres is configurable like a linter. Config is discovered by walking up from the current directory: `safegres.config.{ts,js,mjs,cjs}`, `.safegresrc{,.json,.yaml,.yml,.js}`, `safegres.json`, or a `"safegres"` key in package.json (via [confstash](https://github.com/constructive-io/dev-utils/tree/main/packages/confstash)).

--- a/packages/safegres/__tests__/callgraph.test.ts
+++ b/packages/safegres/__tests__/callgraph.test.ts
@@ -1,0 +1,113 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { getConnections, PgTestClient } from 'pgsql-test';
+
+import { buildCallGraph, type CallGraphReport } from '../src/callgraph/graph';
+import { audit } from '../src/commands/audit';
+import { introspectFunctions } from '../src/pg/functions';
+import { introspectTables } from '../src/pg/introspect';
+
+jest.setTimeout(120000);
+
+let pg: PgTestClient;
+let teardown: () => Promise<void>;
+let cg: CallGraphReport;
+
+beforeAll(async () => {
+  ({ pg, teardown } = await getConnections());
+  const sql = fs.readFileSync(path.join(__dirname, 'fixtures', 'callgraph.sql'), 'utf8');
+  await pg.any(sql);
+
+  const functions = await introspectFunctions(pg.client as never, {
+    schemas: ['fx_cg_public', 'fx_cg_private']
+  });
+  const tables = await introspectTables(pg.client as never, {
+    schemas: ['fx_cg_public', 'fx_cg_private']
+  });
+  cg = await buildCallGraph({
+    functions,
+    tables,
+    exposedSchemas: ['fx_cg_public'],
+    apiRoles: ['anonymous', 'authenticated']
+  });
+});
+
+afterAll(async () => {
+  if (teardown) await teardown();
+});
+
+describe('buildCallGraph', () => {
+  it('finds only the API-granted functions in exposed schemas as entry points', () => {
+    expect(cg.entries.map((e) => e.fn)).toEqual([
+      'fx_cg_public.sign_in',
+      'fx_cg_public.widget_report'
+    ]);
+    // Private helpers are reachable but never entries.
+    expect(cg.stats.entryPoints).toBe(2);
+    expect(cg.stats.reachableFunctions).toBeGreaterThanOrEqual(4);
+  });
+
+  it('flags trust hops (CG1) when execution crosses into SECURITY DEFINER', () => {
+    const hops = cg.checklist.filter((i) => i.code === 'CG1').map((i) => i.fn);
+    expect(hops).toContain('fx_cg_public.sign_in'); // the entry itself is DEFINER
+    expect(hops).toContain('fx_cg_private.verify_password');
+    expect(hops).toContain('fx_cg_private.issue_token');
+  });
+
+  it('flags RLS-bypass paths (CG2) when a DEFINER owner bypasses the table RLS', () => {
+    const bypass = cg.checklist.find((i) => i.code === 'CG2');
+    expect(bypass?.fn).toBe('fx_cg_private.verify_password');
+    expect(bypass?.table).toBe('fx_cg_private.users');
+    expect(bypass?.path[0]).toBe('fx_cg_public.sign_in');
+  });
+
+  it('flags auth-context mutations (CG3)', () => {
+    const auth = cg.checklist.find((i) => i.code === 'CG3');
+    expect(auth?.fn).toBe('fx_cg_private.issue_token');
+    expect(auth?.message).toContain('jwt.claims.user_email');
+  });
+
+  it('flags internal tables reached via DEFINER paths (CG4)', () => {
+    const reach = cg.checklist.find((i) => i.code === 'CG4');
+    expect(reach?.table).toBe('fx_cg_private.users');
+  });
+
+  it('flags dynamic SQL as opaque (CG5) instead of silently dropping it', () => {
+    const opaque = cg.checklist.find((i) => i.code === 'CG5');
+    expect(opaque?.fn).toBe('fx_cg_public.run_report');
+    expect(opaque?.message).toContain('dynamic SQL');
+    expect(opaque?.path).toEqual(['fx_cg_public.widget_report', 'fx_cg_public.run_report']);
+  });
+
+  it('flags DEFINERs without a pinned search_path (CF1) but not pinned ones', () => {
+    const cf1 = cg.checklist.filter((i) => i.code === 'CF1').map((i) => i.fn);
+    expect(cf1).toContain('fx_cg_private.verify_password');
+    expect(cf1).not.toContain('fx_cg_public.sign_in');
+    expect(cf1).not.toContain('fx_cg_private.issue_token');
+  });
+
+  it('flags DEFINER entry points executable by anonymous (CF2)', () => {
+    const cf2 = cg.checklist.filter((i) => i.code === 'CF2').map((i) => i.fn);
+    expect(cf2).toContain('fx_cg_public.sign_in');
+  });
+});
+
+describe('audit --call-graph integration', () => {
+  it('attaches an unscored callGraph section to the report', async () => {
+    const report = await audit(pg.client as never, {
+      schemas: ['fx_cg_public', 'fx_cg_private'],
+      exposure: { schemas: ['fx_cg_public'], roles: ['anonymous', 'authenticated'] },
+      callGraph: true
+    });
+    expect(report.callGraph?.stats.entryPoints).toBe(2);
+    expect(report.callGraph?.stats.trustHops).toBeGreaterThanOrEqual(3);
+
+    // The call graph never affects the score: same score without it.
+    const plain = await audit(pg.client as never, {
+      schemas: ['fx_cg_public', 'fx_cg_private'],
+      exposure: { schemas: ['fx_cg_public'], roles: ['anonymous', 'authenticated'] }
+    });
+    expect(report.score?.value).toBe(plain.score?.value);
+    expect(plain.callGraph).toBeUndefined();
+  });
+});

--- a/packages/safegres/__tests__/fixtures/callgraph.sql
+++ b/packages/safegres/__tests__/fixtures/callgraph.sql
@@ -1,0 +1,81 @@
+-- Call-graph fixture: a public sign-in path that crosses into a private
+-- schema through SECURITY DEFINER functions.
+CREATE SCHEMA fx_cg_public;
+CREATE SCHEMA fx_cg_private;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+    CREATE ROLE authenticated;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anonymous') THEN
+    CREATE ROLE anonymous;
+  END IF;
+END $$;
+
+CREATE TABLE fx_cg_private.users (
+  id uuid PRIMARY KEY,
+  email text NOT NULL,
+  password_hash text NOT NULL
+);
+ALTER TABLE fx_cg_private.users ENABLE ROW LEVEL SECURITY;
+
+CREATE TABLE fx_cg_public.widgets (
+  id uuid PRIMARY KEY,
+  name text
+);
+
+-- Private helper: DEFINER, reads the private users table, unpinned search_path.
+CREATE FUNCTION fx_cg_private.verify_password(user_email text, pw text)
+RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE ok boolean;
+BEGIN
+  SELECT (u.password_hash = pw) INTO ok
+  FROM fx_cg_private.users u WHERE u.email = user_email;
+  RETURN COALESCE(ok, false);
+END;
+$$;
+REVOKE EXECUTE ON FUNCTION fx_cg_private.verify_password FROM PUBLIC;
+
+-- Private helper: mutates the auth context.
+CREATE FUNCTION fx_cg_private.issue_token(user_email text)
+RETURNS text LANGUAGE plpgsql SECURITY DEFINER SET search_path = fx_cg_private AS $$
+BEGIN
+  PERFORM set_config('jwt.claims.user_email', user_email, true);
+  RETURN 'token';
+END;
+$$;
+REVOKE EXECUTE ON FUNCTION fx_cg_private.issue_token FROM PUBLIC;
+
+-- Public entry point: DEFINER with pinned search_path, callable by anonymous.
+CREATE FUNCTION fx_cg_public.sign_in(user_email text, pw text)
+RETURNS text LANGUAGE plpgsql SECURITY DEFINER SET search_path = fx_cg_public AS $$
+DECLARE tok text;
+BEGIN
+  IF NOT fx_cg_private.verify_password(user_email, pw) THEN
+    RAISE EXCEPTION 'bad credentials';
+  END IF;
+  tok := fx_cg_private.issue_token(user_email);
+  RETURN tok;
+END;
+$$;
+REVOKE EXECUTE ON FUNCTION fx_cg_public.sign_in FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION fx_cg_public.sign_in TO anonymous;
+
+-- Public INVOKER function: not an entry point (no API grant), dynamic SQL.
+CREATE FUNCTION fx_cg_public.run_report(tbl text)
+RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+  EXECUTE format('SELECT count(*) FROM %I', tbl);
+END;
+$$;
+REVOKE EXECUTE ON FUNCTION fx_cg_public.run_report FROM PUBLIC;
+
+-- Public entry with dynamic SQL, callable by authenticated.
+CREATE FUNCTION fx_cg_public.widget_report()
+RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+  PERFORM fx_cg_public.run_report('widgets');
+END;
+$$;
+REVOKE EXECUTE ON FUNCTION fx_cg_public.widget_report FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION fx_cg_public.widget_report TO authenticated;

--- a/packages/safegres/package.json
+++ b/packages/safegres/package.json
@@ -47,6 +47,7 @@
     "@pgsql/types": "^18.0.0",
     "confstash": "^0.1.0",
     "inquirerer": "^4.9.1",
+    "libpg-query": "^18.1.2",
     "pg": "^8.21.0",
     "pg-env": "workspace:^",
     "pgsql-deparser": "^18.1.1",

--- a/packages/safegres/src/callgraph/extract.ts
+++ b/packages/safegres/src/callgraph/extract.ts
@@ -1,0 +1,204 @@
+/**
+ * Static body extraction for the call graph.
+ *
+ * Given a function's source, extract the function calls, table references
+ * (read vs write), and auth-context mutations it contains. Dynamic SQL
+ * (`EXECUTE format(...)`) and unparseable bodies are surfaced as `opaque`
+ * rather than silently dropped — static analysis ends there.
+ */
+
+import { parsePlPgSQL } from 'libpg-query';
+import { parse } from 'pgsql-parser';
+
+import { findAll, funcNameParts } from '../ast/walk';
+import type { FunctionSnapshot } from '../pg/functions';
+
+export interface NameRef {
+  schema?: string;
+  name: string;
+}
+
+export interface TableRef extends NameRef {
+  write: boolean;
+}
+
+export interface ExtractedBody {
+  calls: NameRef[];
+  tables: TableRef[];
+  /** GUC names written via `set_config(...)` / `SET`, plus `role` for SET ROLE. */
+  settings: string[];
+  /** True when the body contains dynamic SQL we cannot follow statically. */
+  opaque: boolean;
+  /** Why the body is (partially) opaque, when it is. */
+  opaqueReason?: string;
+}
+
+const EMPTY: ExtractedBody = { calls: [], tables: [], settings: [], opaque: false };
+
+/** Languages whose bodies we can statically analyze. */
+const ANALYZABLE = new Set(['sql', 'plpgsql']);
+
+export async function extractBody(fn: FunctionSnapshot): Promise<ExtractedBody> {
+  if (!ANALYZABLE.has(fn.language)) {
+    if (fn.language === 'internal' || fn.language === 'c') return EMPTY;
+    return { ...EMPTY, opaque: true, opaqueReason: `language "${fn.language}" is not statically analyzable` };
+  }
+
+  if (fn.language === 'sql') {
+    if (!fn.source || fn.source.trim() === '') return EMPTY;
+    return extractFromSql(fn.source, 'statement');
+  }
+
+  // plpgsql: parse the full CREATE FUNCTION, then analyze every embedded
+  // SQL expression/statement the PL/pgSQL parser hands back.
+  if (!fn.definition) return { ...EMPTY, opaque: true, opaqueReason: 'no function definition available' };
+
+  let parsed: unknown;
+  try {
+    parsed = await parsePlPgSQL(fn.definition);
+  } catch {
+    return { ...EMPTY, opaque: true, opaqueReason: 'PL/pgSQL body failed to parse' };
+  }
+
+  const out: MutableBody = { calls: [], tables: [], settings: [], opaque: false };
+  const exprs: Array<{ query: string; parseMode: number }> = [];
+  collectPlpgsql(parsed, exprs, out);
+
+  for (const e of exprs) {
+    // parseMode 0 = full statement; 3 = assignment (`target := expr` or
+    // `target = expr`) — strip the anchored target so the RHS parses. The
+    // RHS may itself contain `:=` (named arguments), so only the leading
+    // target is removed. Anything else is a bare expression.
+    let q = e.query;
+    if (e.parseMode === 3) {
+      q = q.replace(/^\s*[a-zA-Z_"][\w$".]*(\[[^\]]*\])*\s*:?=\s*/, '');
+    }
+    const sql = e.parseMode === 0 ? q : `SELECT ${q}`;
+    const part = await extractFromSql(sql, 'statement');
+    mergeBody(out, part);
+  }
+
+  return finalize(out);
+}
+
+interface MutableBody {
+  calls: NameRef[];
+  tables: TableRef[];
+  settings: string[];
+  opaque: boolean;
+  opaqueReason?: string;
+}
+
+/** Walk the PL/pgSQL JSON tree: collect embedded SQL, flag dynamic EXECUTE. */
+function collectPlpgsql(node: unknown, exprs: Array<{ query: string; parseMode: number }>, out: MutableBody): void {
+  if (Array.isArray(node)) {
+    for (const item of node) collectPlpgsql(item, exprs, out);
+    return;
+  }
+  if (!node || typeof node !== 'object') return;
+  const rec = node as Record<string, unknown>;
+
+  if (rec.PLpgSQL_stmt_dynexecute) {
+    out.opaque = true;
+    out.opaqueReason = 'dynamic SQL (EXECUTE) — cannot follow statically';
+    // Still walk it: the format() expression itself may call functions.
+  }
+
+  const expr = rec.PLpgSQL_expr as Record<string, unknown> | undefined;
+  if (expr && typeof expr.query === 'string') {
+    exprs.push({ query: expr.query, parseMode: typeof expr.parseMode === 'number' ? expr.parseMode : 2 });
+  }
+
+  for (const value of Object.values(rec)) collectPlpgsql(value, exprs, out);
+}
+
+async function extractFromSql(sql: string, _mode: 'statement'): Promise<ExtractedBody> {
+  let ast: unknown;
+  try {
+    ast = await parse(sql);
+  } catch {
+    // Individual fragments can legitimately fail (PL/pgSQL variables in
+    // type positions, etc.) — treat as opaque rather than erroring out.
+    return { ...EMPTY, opaque: true, opaqueReason: 'SQL fragment failed to parse' };
+  }
+
+  const out: MutableBody = { calls: [], tables: [], settings: [], opaque: false };
+
+  for (const call of findAll(ast, 'FuncCall')) {
+    const ref = funcNameParts(call);
+    if (ref.name === '<unknown>') continue;
+    out.calls.push(ref);
+
+    if (ref.name === 'set_config' && (!ref.schema || ref.schema === 'pg_catalog')) {
+      const setting = firstStringArg(call);
+      if (setting) out.settings.push(setting);
+    }
+  }
+
+  // Write targets: the relation of INSERT/UPDATE/DELETE statements.
+  const writeOids = new Set<Record<string, unknown>>();
+  for (const tag of ['InsertStmt', 'UpdateStmt', 'DeleteStmt']) {
+    for (const stmt of findAll(ast, tag)) {
+      const rel = stmt.relation as Record<string, unknown> | undefined;
+      if (rel) writeOids.add(rel);
+    }
+  }
+  for (const rv of findAll(ast, 'RangeVar')) {
+    const name = typeof rv.relname === 'string' ? rv.relname : undefined;
+    if (!name) continue;
+    const schema = typeof rv.schemaname === 'string' ? rv.schemaname : undefined;
+    out.tables.push({ schema, name, write: writeOids.has(rv) });
+  }
+
+  // SET role / SET session_authorization / SET request.jwt… inside SQL bodies.
+  for (const set of findAll(ast, 'VariableSetStmt')) {
+    const name = typeof set.name === 'string' ? set.name : undefined;
+    if (name) out.settings.push(name.toLowerCase());
+  }
+
+  return finalize(out);
+}
+
+function firstStringArg(call: Record<string, unknown>): string | null {
+  const args = call.args;
+  if (!Array.isArray(args) || args.length === 0) return null;
+  const first = args[0] as Record<string, unknown>;
+  const aconst = first.A_Const as Record<string, unknown> | undefined;
+  const sval = aconst?.sval as Record<string, unknown> | undefined;
+  const v = sval?.sval;
+  return typeof v === 'string' ? v : null;
+}
+
+function mergeBody(into: MutableBody, from: ExtractedBody): void {
+  into.calls.push(...from.calls);
+  into.tables.push(...from.tables);
+  into.settings.push(...from.settings);
+  if (from.opaque && !into.opaque) {
+    into.opaque = true;
+    into.opaqueReason = from.opaqueReason;
+  }
+}
+
+function finalize(body: MutableBody): ExtractedBody {
+  const callKeys = new Set<string>();
+  const calls = body.calls.filter((c) => {
+    const k = `${c.schema ?? ''}.${c.name}`;
+    if (callKeys.has(k)) return false;
+    callKeys.add(k);
+    return true;
+  });
+  const tableKeys = new Map<string, TableRef>();
+  for (const t of body.tables) {
+    const k = `${t.schema ?? ''}.${t.name}`;
+    const existing = tableKeys.get(k);
+    if (existing) existing.write = existing.write || t.write;
+    else tableKeys.set(k, { ...t });
+  }
+  return {
+    calls,
+    tables: [...tableKeys.values()],
+    settings: [...new Set(body.settings)],
+    opaque: body.opaque,
+    ...(body.opaqueReason ? { opaqueReason: body.opaqueReason } : {})
+  };
+}

--- a/packages/safegres/src/callgraph/graph.ts
+++ b/packages/safegres/src/callgraph/graph.ts
@@ -1,0 +1,356 @@
+/**
+ * Call-graph construction and trust-boundary classification.
+ *
+ * Starting from the exposed entry points (functions the API roles can
+ * EXECUTE), walk what those functions transitively call and touch, and emit
+ * an unscored audit checklist of trust boundaries for human review:
+ *
+ *   CG1  trust hop           — execution crosses into a SECURITY DEFINER
+ *   CG2  RLS-bypass path     — a DEFINER touches a table whose RLS its owner bypasses
+ *   CG3  auth-context change — a reachable function mutates jwt claims / role
+ *   CG4  internal reach      — a non-exposed table is reached via a DEFINER hop
+ *   CG5  opaque node         — dynamic SQL / unparseable body; audit manually
+ *
+ * Plus two provable misconfigurations:
+ *
+ *   CF1  SECURITY DEFINER without a pinned search_path (CWE-426)
+ *   CF2  SECURITY DEFINER executable by anonymous / PUBLIC
+ */
+
+import type { FunctionSnapshot } from '../pg/functions';
+import type { TableSnapshot } from '../pg/introspect';
+import { extractBody,type ExtractedBody } from './extract';
+
+export interface CallGraphOptions {
+  functions: FunctionSnapshot[];
+  tables: TableSnapshot[];
+  /** Exposed schemas; when undefined the exposure surface is unknown. */
+  exposedSchemas?: string[];
+  /** Roles the API connects as. EXECUTE for any of these (or PUBLIC) marks an entry point. */
+  apiRoles: string[];
+}
+
+export interface CallGraphNode {
+  id: string;
+  schema: string;
+  name: string;
+  securityDefiner: boolean;
+  owner: string;
+  ownerBypassesRls: boolean;
+  searchPathPinned: boolean;
+  language: string;
+  opaque: boolean;
+  opaqueReason?: string;
+  /** Auth-context settings this function writes (jwt claims, role, …). */
+  authSettings: string[];
+  /** Entry-point roles when this node is an entry (EXECUTE-granted API roles). */
+  entryRoles?: string[];
+}
+
+export interface CallGraphEdge {
+  from: string;
+  to: string;
+  kind: 'call' | 'read' | 'write';
+}
+
+export type ChecklistCode = 'CG1' | 'CG2' | 'CG3' | 'CG4' | 'CG5' | 'CF1' | 'CF2';
+
+export interface ChecklistItem {
+  code: ChecklistCode;
+  /** Entry point this boundary is reachable from. */
+  entry: string;
+  /** Call path from the entry to the flagged node, entry first. */
+  path: string[];
+  /** The flagged function. */
+  fn: string;
+  /** The touched table, for CG2/CG4. */
+  table?: string;
+  message: string;
+}
+
+export interface CallGraphReport {
+  entries: Array<{ fn: string; roles: string[]; securityDefiner: boolean }>;
+  nodes: CallGraphNode[];
+  edges: CallGraphEdge[];
+  checklist: ChecklistItem[];
+  stats: {
+    entryPoints: number;
+    reachableFunctions: number;
+    trustHops: number;
+    rlsBypassPaths: number;
+    authContextMutations: number;
+    internalReach: number;
+    opaqueNodes: number;
+  };
+}
+
+/** GUC names whose mutation means the function changes who the caller "is". */
+const AUTH_SETTING_PATTERN = /jwt|claims|role|session_authorization|user_id|\bauth\b/i;
+
+export async function buildCallGraph(options: CallGraphOptions): Promise<CallGraphReport> {
+  const exposureKnown = options.exposedSchemas !== undefined;
+  const exposed = new Set(options.exposedSchemas ?? []);
+  const apiRoles = new Set([...options.apiRoles, 'PUBLIC']);
+
+  // Overloads collapse into one node per schema.name — we resolve calls by
+  // name, not by argument types.
+  const nodesById = new Map<string, CallGraphNode>();
+  const fnsById = new Map<string, FunctionSnapshot[]>();
+  const fnsByName = new Map<string, string[]>();
+  for (const fn of options.functions) {
+    const id = `${fn.schema}.${fn.name}`;
+    const group = fnsById.get(id);
+    if (group) group.push(fn);
+    else {
+      fnsById.set(id, [fn]);
+      const byName = fnsByName.get(fn.name);
+      if (byName) byName.push(id);
+      else fnsByName.set(fn.name, [id]);
+    }
+  }
+
+  const tablesById = new Map<string, TableSnapshot>();
+  const tablesByName = new Map<string, string[]>();
+  for (const t of options.tables) {
+    const id = `${t.schema}.${t.name}`;
+    tablesById.set(id, t);
+    const byName = tablesByName.get(t.name);
+    if (byName) byName.push(id);
+    else tablesByName.set(t.name, [id]);
+  }
+
+  // Entry points: functions in an exposed schema (or anywhere, when exposure
+  // is unknown) that an API role can EXECUTE.
+  const entries: Array<{ fn: string; roles: string[]; securityDefiner: boolean }> = [];
+  for (const [id, group] of fnsById) {
+    const fn = group[0];
+    if (exposureKnown && !exposed.has(fn.schema)) continue;
+    const roles = [...new Set(
+      group.flatMap((g) => g.grants.map((gr) => gr.role)).filter((r) => apiRoles.has(r))
+    )].sort();
+    if (roles.length === 0) continue;
+    entries.push({ fn: id, roles, securityDefiner: group.some((g) => g.isSecurityDefiner) });
+  }
+  entries.sort((a, b) => a.fn.localeCompare(b.fn));
+
+  // Extract bodies lazily, memoized per node.
+  const bodies = new Map<string, ExtractedBody>();
+  const getBody = async (id: string): Promise<ExtractedBody> => {
+    const cached = bodies.get(id);
+    if (cached) return cached;
+    const group = fnsById.get(id) ?? [];
+    const merged: ExtractedBody = { calls: [], tables: [], settings: [], opaque: false };
+    for (const fn of group) {
+      const b = await extractBody(fn);
+      merged.calls.push(...b.calls);
+      merged.tables.push(...b.tables);
+      merged.settings.push(...b.settings);
+      if (b.opaque && !merged.opaque) {
+        merged.opaque = true;
+        merged.opaqueReason = b.opaqueReason;
+      }
+    }
+    bodies.set(id, merged);
+    return merged;
+  };
+
+  const resolveCall = (ref: { schema?: string; name: string }): string[] => {
+    if (ref.schema) {
+      return fnsById.has(`${ref.schema}.${ref.name}`) ? [`${ref.schema}.${ref.name}`] : [];
+    }
+    // Unqualified: candidates are every user function with that name. None →
+    // assume a builtin. Multiple → follow all (conservative over-approximation).
+    return fnsByName.get(ref.name) ?? [];
+  };
+
+  const resolveTable = (ref: { schema?: string; name: string }): string[] => {
+    if (ref.schema) {
+      return tablesById.has(`${ref.schema}.${ref.name}`) ? [`${ref.schema}.${ref.name}`] : [];
+    }
+    return tablesByName.get(ref.name) ?? [];
+  };
+
+  const ensureNode = (id: string, body: ExtractedBody): CallGraphNode => {
+    let node = nodesById.get(id);
+    if (node) return node;
+    const group = fnsById.get(id) ?? [];
+    const fn = group[0];
+    node = {
+      id,
+      schema: fn.schema,
+      name: fn.name,
+      securityDefiner: group.some((g) => g.isSecurityDefiner),
+      owner: fn.owner,
+      ownerBypassesRls: fn.ownerBypassesRls,
+      searchPathPinned: group.every((g) => g.searchPathPinned),
+      language: fn.language,
+      opaque: body.opaque,
+      ...(body.opaqueReason ? { opaqueReason: body.opaqueReason } : {}),
+      authSettings: body.settings.filter((s) => AUTH_SETTING_PATTERN.test(s)).sort()
+    };
+    nodesById.set(id, node);
+    return node;
+  };
+
+  const edges: CallGraphEdge[] = [];
+  const edgeKeys = new Set<string>();
+  const addEdge = (edge: CallGraphEdge): void => {
+    const key = `${edge.from}→${edge.to}:${edge.kind}`;
+    if (edgeKeys.has(key)) return;
+    edgeKeys.add(key);
+    edges.push(edge);
+  };
+
+  const checklist: ChecklistItem[] = [];
+  const itemKeys = new Set<string>();
+  const addItem = (item: ChecklistItem): void => {
+    // Dedupe on (code, fn, table) — the shortest path from the first entry
+    // that reaches the boundary is kept as the exemplar.
+    const key = `${item.code}::${item.fn}::${item.table ?? ''}`;
+    if (itemKeys.has(key)) return;
+    itemKeys.add(key);
+    checklist.push(item);
+  };
+
+  // BFS from each entry point; nodes are visited once globally for graph
+  // construction, but per-entry paths drive the checklist exemplars.
+  const globallyVisited = new Set<string>();
+
+  for (const entry of entries) {
+    const queue: Array<{ id: string; path: string[] }> = [{ id: entry.fn, path: [entry.fn] }];
+    const visited = new Set<string>([entry.fn]);
+
+    while (queue.length > 0) {
+      const { id, path } = queue.shift()!;
+      const body = await getBody(id);
+      const node = ensureNode(id, body);
+      if (id === entry.fn) node.entryRoles = entry.roles;
+
+      const firstVisit = !globallyVisited.has(id);
+      globallyVisited.add(id);
+
+      // Does the path so far cross a DEFINER boundary?
+      const pathHasDefiner = path.some((p) => nodesById.get(p)?.securityDefiner);
+
+      if (node.opaque) {
+        addItem({
+          code: 'CG5', entry: entry.fn, path, fn: id,
+          message: node.opaqueReason ?? 'body cannot be followed statically — audit manually'
+        });
+      }
+      if (node.authSettings.length > 0) {
+        addItem({
+          code: 'CG3', entry: entry.fn, path, fn: id,
+          message: `mutates auth context: ${node.authSettings.join(', ')}`
+        });
+      }
+      if (node.securityDefiner && firstVisit) {
+        if (!node.searchPathPinned) {
+          addItem({
+            code: 'CF1', entry: entry.fn, path, fn: id,
+            message: 'SECURITY DEFINER without a pinned search_path (CWE-426) — set `SET search_path` on the function'
+          });
+        }
+        const group = fnsById.get(id) ?? [];
+        const wideRoles = [...new Set(
+          group.flatMap((g) => g.grants.map((gr) => gr.role))
+            .filter((r) => r === 'PUBLIC' || r === 'anonymous')
+        )].sort();
+        if (wideRoles.length > 0) {
+          addItem({
+            code: 'CF2', entry: entry.fn, path, fn: id,
+            message: `SECURITY DEFINER executable by ${wideRoles.join(', ')} — widest blast radius; confirm this is intended`
+          });
+        }
+      }
+
+      // Table edges.
+      for (const t of body.tables) {
+        for (const tableId of resolveTable(t)) {
+          const table = tablesById.get(tableId)!;
+          addEdge({ from: id, to: tableId, kind: t.write ? 'write' : 'read' });
+
+          const effectiveDefiner = node.securityDefiner || pathHasDefiner;
+          if (
+            node.securityDefiner
+            && (node.owner === table.owner || node.ownerBypassesRls)
+            && !table.rlsForced
+          ) {
+            addItem({
+              code: 'CG2', entry: entry.fn, path, fn: id, table: tableId,
+              message: `RLS on ${tableId} does not apply on this path — ${id} is SECURITY DEFINER running as ${node.owner}`
+                + (node.ownerBypassesRls ? ' (BYPASSRLS/superuser)' : ` (owner of ${tableId})`)
+            });
+          }
+          if (exposureKnown && !exposed.has(table.schema) && effectiveDefiner) {
+            addItem({
+              code: 'CG4', entry: entry.fn, path, fn: id, table: tableId,
+              message: `${t.write ? 'writes' : 'reads'} internal table ${tableId} via a SECURITY DEFINER path`
+            });
+          }
+        }
+      }
+
+      // Call edges.
+      for (const c of body.calls) {
+        for (const calleeId of resolveCall(c)) {
+          if (calleeId === id) continue;
+          addEdge({ from: id, to: calleeId, kind: 'call' });
+          const calleeBody = await getBody(calleeId);
+          const callee = ensureNode(calleeId, calleeBody);
+          if (callee.securityDefiner) {
+            addItem({
+              code: 'CG1', entry: entry.fn, path: [...path, calleeId], fn: calleeId,
+              message: `trust hop — execution crosses into SECURITY DEFINER ${calleeId} (runs as ${callee.owner})`
+            });
+          }
+          if (!visited.has(calleeId)) {
+            visited.add(calleeId);
+            queue.push({ id: calleeId, path: [...path, calleeId] });
+          }
+        }
+      }
+    }
+
+    // The entry itself being a DEFINER is the first trust hop.
+    const entryNode = nodesById.get(entry.fn);
+    if (entryNode?.securityDefiner) {
+      addItem({
+        code: 'CG1', entry: entry.fn, path: [entry.fn], fn: entry.fn,
+        message: `trust hop — entry point is SECURITY DEFINER (runs as ${entryNode.owner}; callable by ${entry.roles.join(', ')})`
+      });
+    }
+  }
+
+  checklist.sort(compareItems);
+  const nodes = [...nodesById.values()].sort((a, b) => a.id.localeCompare(b.id));
+  edges.sort((a, b) => a.from.localeCompare(b.from) || a.to.localeCompare(b.to) || a.kind.localeCompare(b.kind));
+
+  const count = (code: ChecklistCode): number => checklist.filter((i) => i.code === code).length;
+
+  return {
+    entries,
+    nodes,
+    edges,
+    checklist,
+    stats: {
+      entryPoints: entries.length,
+      reachableFunctions: globallyVisited.size,
+      trustHops: count('CG1'),
+      rlsBypassPaths: count('CG2'),
+      authContextMutations: count('CG3'),
+      internalReach: count('CG4'),
+      opaqueNodes: count('CG5')
+    }
+  };
+}
+
+const CODE_ORDER: Record<ChecklistCode, number> = {
+  CF1: 0, CF2: 1, CG2: 2, CG3: 3, CG1: 4, CG4: 5, CG5: 6
+};
+
+function compareItems(a: ChecklistItem, b: ChecklistItem): number {
+  if (CODE_ORDER[a.code] !== CODE_ORDER[b.code]) return CODE_ORDER[a.code] - CODE_ORDER[b.code];
+  if (a.fn !== b.fn) return a.fn.localeCompare(b.fn);
+  return (a.table ?? '').localeCompare(b.table ?? '');
+}

--- a/packages/safegres/src/cli.ts
+++ b/packages/safegres/src/cli.ts
@@ -15,7 +15,7 @@ if (process.argv.includes('--version') || process.argv.includes('-v')) {
 const options: Partial<CLIOptions> = {
   minimistOpts: {
     alias: { v: 'version', h: 'help', q: 'summary' },
-    boolean: ['skip-ast', 'color', 'help', 'version', 'summary', 'verbose'],
+    boolean: ['skip-ast', 'color', 'help', 'version', 'summary', 'verbose', 'call-graph'],
     string: [
       'connection',
       'host',

--- a/packages/safegres/src/cli/audit.ts
+++ b/packages/safegres/src/cli/audit.ts
@@ -57,6 +57,12 @@ Exposure (what the score is computed against):
                            them become unscored internal advisories
   --exposed-only           Hide internal (non-exposed) findings from output
 
+Call graph (unscored; human review):
+  --call-graph             Analyze the functions reachable from the exposed entry
+                           points and list trust boundaries: SECURITY DEFINER hops,
+                           RLS-bypass paths, auth-context mutations, internal-table
+                           reach, and opaque (dynamic SQL) nodes
+
 Audit options:
   --schemas <csv>          Limit to these schemas (default: all non-system)
   --exclude-schemas <csv>  Skip these schemas
@@ -97,6 +103,7 @@ export default async (
     includeRoles: csvList(argv.roles),
     excludeRoles: csvList(argv['exclude-roles']),
     skipAstChecks: argv['skip-ast'] === true,
+    callGraph: argv['call-graph'] === true,
     exposure: exposureSchemas
       ? { ...config.exposure, schemas: exposureSchemas }
       : undefined,

--- a/packages/safegres/src/commands/audit.ts
+++ b/packages/safegres/src/commands/audit.ts
@@ -4,6 +4,7 @@
  * Ingests a catalog snapshot, runs every check, and returns a structured report.
  */
 
+import { buildCallGraph } from '../callgraph/graph';
 import {
   checkSessionUserGating,
   checkTriviallyPermissive,
@@ -29,6 +30,7 @@ import {
 import { allAstRulesDisabled, applyRulesToFindings, matchTablePattern, resolveRules, rulesForTable } from '../config/resolve';
 import type { ExposureConfig, SafegresConfig } from '../config/types';
 import { resolveExposure } from '../pg/exposure';
+import { introspectFunctions } from '../pg/functions';
 import { asExecutor, type IntrospectOptions, introspectTables, type QueryExecutor, type TableSnapshot } from '../pg/introspect';
 import { lookupVolatility, type ProcVolatility } from '../pg/proc';
 import { listAuditableRoles, resolveRoles } from '../pg/roles';
@@ -53,6 +55,12 @@ export interface AuditOptions extends IntrospectOptions {
    * Findings on non-exposed schemas contribute nothing to the score.
    */
   exposure?: ExposureConfig;
+  /**
+   * Build the unscored call-graph audit: trust boundaries (SECURITY DEFINER
+   * hops, RLS-bypass paths, auth-context mutations) reachable from the
+   * exposed entry points. Adds `report.callGraph`.
+   */
+  callGraph?: boolean;
   /**
    * Merged safegres configuration (rules, overrides, scoring). Rule settings
    * filter and retune findings; scoring settings drive the report score.
@@ -173,7 +181,7 @@ export async function audit(
     totalTables: snapshot.length
   };
 
-  return {
+  const report: Report = {
     version: PKG_VERSION,
     generatedAt: new Date().toISOString(),
     summary: summarize(findings),
@@ -184,6 +192,23 @@ export async function audit(
     }),
     exposure: exposureReport
   };
+
+  if (options.callGraph) {
+    const functions = await introspectFunctions(exec, {
+      schemas: options.schemas ?? config.schemas,
+      excludeSchemas: options.excludeSchemas ?? config.excludeSchemas
+    });
+    report.callGraph = await buildCallGraph({
+      functions,
+      tables: snapshot,
+      exposedSchemas: exposure.known ? exposure.schemas : undefined,
+      apiRoles: exposure.roles && exposure.roles.length > 0
+        ? exposure.roles
+        : ['anonymous', 'authenticated']
+    });
+  }
+
+  return report;
 }
 
 async function auditTableAst(

--- a/packages/safegres/src/index.ts
+++ b/packages/safegres/src/index.ts
@@ -11,6 +11,15 @@ export {
   type PgAstNode,
   type PolicyExpression,
   PolicyParseError} from './ast/parse';
+export type {
+  CallGraphEdge,
+  CallGraphNode,
+  CallGraphOptions,
+  CallGraphReport,
+  ChecklistCode,
+  ChecklistItem
+} from './callgraph/graph';
+export { buildCallGraph } from './callgraph/graph';
 export type { RoleTrustOptions } from './checks/role-trust';
 export {
   checkPublicGrants,
@@ -46,6 +55,8 @@ export type {
 } from './config/types';
 export type { ResolvedExposure } from './pg/exposure';
 export { resolveConstructiveExposure, resolveExposure, UNKNOWN_EXPOSURE } from './pg/exposure';
+export type { FunctionGrant, FunctionSnapshot, IntrospectFunctionOptions } from './pg/functions';
+export { introspectFunctions } from './pg/functions';
 export {
   type IntrospectOptions,
   introspectTables,
@@ -56,6 +67,7 @@ export {
   type TableSnapshot
 } from './pg/introspect';
 export { listAuditableRoles, resolveRoles } from './pg/roles';
+export { renderCallGraph } from './report/callgraph';
 export { renderJson } from './report/json';
 export { renderPretty } from './report/pretty';
 export type { RuleMeta } from './rules/registry';

--- a/packages/safegres/src/pg/functions.ts
+++ b/packages/safegres/src/pg/functions.ts
@@ -1,0 +1,157 @@
+/**
+ * Function catalog introspection for the call-graph audit.
+ *
+ * One query over `pg_proc` returns every user-defined function with the
+ * attributes the trust-boundary analysis needs: SECURITY DEFINER vs INVOKER,
+ * the owner role (what a DEFINER actually runs as), whether `search_path`
+ * is pinned, the language, the body source, and EXECUTE grants per role.
+ */
+
+import type { QueryExecutor } from './introspect';
+
+export interface FunctionGrant {
+  role: string;
+  /** Was the grant delegated (`WITH GRANT OPTION`). */
+  grantable: boolean;
+}
+
+export interface FunctionSnapshot {
+  oid: number;
+  schema: string;
+  name: string;
+  /** Argument type signature, e.g. `text, uuid` — disambiguates overloads. */
+  args: string;
+  owner: string;
+  /** Owner is a superuser or has BYPASSRLS — RLS never applies to it. */
+  ownerBypassesRls: boolean;
+  isSecurityDefiner: boolean;
+  /** True when `proconfig` pins `search_path` (CWE-426 mitigation for DEFINERs). */
+  searchPathPinned: boolean;
+  language: string;
+  /** Raw body (`prosrc`); null for C/internal functions. */
+  source: string | null;
+  /** Full `CREATE FUNCTION` statement — what `parsePlPgSQL` consumes. */
+  definition: string | null;
+  /**
+   * EXECUTE grants. `PUBLIC` appears as the role name `PUBLIC`.
+   * When `proacl` is NULL Postgres applies the default function ACL, which
+   * includes EXECUTE to PUBLIC — represented here as a synthetic PUBLIC grant.
+   */
+  grants: FunctionGrant[];
+  /** True when the grants came from the default ACL (no explicit GRANT/REVOKE). */
+  defaultAcl: boolean;
+}
+
+const DEFAULT_EXCLUDES = ['pg_catalog', 'information_schema', 'pg_toast'];
+
+export interface IntrospectFunctionOptions {
+  schemas?: string[];
+  excludeSchemas?: string[];
+}
+
+export async function introspectFunctions(
+  exec: QueryExecutor,
+  options: IntrospectFunctionOptions = {}
+): Promise<FunctionSnapshot[]> {
+  const excludes = [...DEFAULT_EXCLUDES, ...(options.excludeSchemas ?? [])];
+  const schemaFilter = options.schemas && options.schemas.length > 0
+    ? `AND n.nspname = ANY($1::text[])`
+    : `AND NOT (n.nspname = ANY($2::text[]))`;
+
+  const sql = `
+    WITH _params AS (
+      SELECT $1::text[] AS include_schemas, $2::text[] AS exclude_schemas
+    ),
+    procs AS (
+      SELECT
+        p.oid,
+        n.nspname                                    AS schema_name,
+        p.proname                                    AS name,
+        pg_get_function_identity_arguments(p.oid)    AS args,
+        pg_get_userbyid(p.proowner)                  AS owner,
+        COALESCE(o.rolsuper OR o.rolbypassrls, false) AS owner_bypasses_rls,
+        p.prosecdef                                  AS security_definer,
+        EXISTS (
+          SELECT 1 FROM unnest(COALESCE(p.proconfig, ARRAY[]::text[])) cfg
+          WHERE cfg LIKE 'search_path=%'
+        )                                            AS search_path_pinned,
+        l.lanname                                    AS language,
+        p.prosrc                                     AS source,
+        CASE WHEN l.lanname IN ('sql', 'plpgsql')
+             THEN pg_get_functiondef(p.oid)
+             ELSE NULL END                           AS definition,
+        p.proacl                                     AS proacl
+      FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+      JOIN pg_language l  ON l.oid = p.prolang
+      LEFT JOIN pg_roles o ON o.oid = p.proowner
+      WHERE p.prokind IN ('f', 'p')
+        ${schemaFilter}
+    ),
+    grants AS (
+      SELECT
+        pr.oid,
+        CASE WHEN a.grantee = 0 THEN 'PUBLIC' ELSE rol.rolname END AS grantee,
+        a.is_grantable
+      FROM procs pr,
+           LATERAL aclexplode(pr.proacl) a
+      LEFT JOIN pg_roles rol ON rol.oid = a.grantee
+      WHERE pr.proacl IS NOT NULL
+        AND a.privilege_type = 'EXECUTE'
+    )
+    SELECT
+      p.oid::int            AS oid,
+      p.schema_name,
+      p.name,
+      p.args,
+      p.owner,
+      p.owner_bypasses_rls,
+      p.security_definer,
+      p.search_path_pinned,
+      p.language,
+      p.source,
+      p.definition,
+      COALESCE(
+        (SELECT jsonb_agg(jsonb_build_object('role', g.grantee, 'grantable', g.is_grantable))
+         FROM grants g WHERE g.oid = p.oid),
+        '[]'::jsonb
+      )                     AS grants,
+      (p.proacl IS NULL)    AS default_acl
+    FROM procs p
+    ORDER BY p.schema_name, p.name, p.args
+  `;
+
+  const { rows } = await exec.query<{
+    oid: number;
+    schema_name: string;
+    name: string;
+    args: string;
+    owner: string;
+    owner_bypasses_rls: boolean;
+    security_definer: boolean;
+    search_path_pinned: boolean;
+    language: string;
+    source: string | null;
+    definition: string | null;
+    grants: Array<{ role: string; grantable: boolean }>;
+    default_acl: boolean;
+  }>(sql, [options.schemas ?? [], excludes]);
+
+  return rows.map((r) => ({
+    oid: r.oid,
+    schema: r.schema_name,
+    name: r.name,
+    args: r.args,
+    owner: r.owner,
+    ownerBypassesRls: r.owner_bypasses_rls,
+    isSecurityDefiner: r.security_definer,
+    searchPathPinned: r.search_path_pinned,
+    language: r.language,
+    source: r.source,
+    definition: r.definition,
+    grants: r.default_acl
+      ? [{ role: 'PUBLIC', grantable: false }]
+      : r.grants.map((g) => ({ role: g.role, grantable: g.grantable })),
+    defaultAcl: r.default_acl
+  }));
+}

--- a/packages/safegres/src/report/callgraph.ts
+++ b/packages/safegres/src/report/callgraph.ts
@@ -1,0 +1,64 @@
+import yanse from 'yanse';
+
+import type { CallGraphReport, ChecklistCode, ChecklistItem } from '../callgraph/graph';
+
+type Painter = (s: string) => string;
+
+const CODE_META: Record<ChecklistCode, { title: string; paint: Painter }> = {
+  CF1: { title: 'DEFINER without pinned search_path (provable — fix these)', paint: yanse.red },
+  CF2: { title: 'DEFINER executable by anonymous/PUBLIC (provable — confirm intent)', paint: yanse.red },
+  CG2: { title: 'RLS-bypass paths (RLS does not protect the table on this path)', paint: yanse.yellow },
+  CG3: { title: 'auth-context mutations (functions that change who you are)', paint: yanse.yellow },
+  CG1: { title: 'trust hops (execution crosses into SECURITY DEFINER)', paint: yanse.cyan },
+  CG4: { title: 'internal tables reached via DEFINER paths', paint: yanse.cyan },
+  CG5: { title: 'opaque nodes (static analysis ends here — audit manually)', paint: yanse.gray }
+};
+
+const CODE_ORDER: ChecklistCode[] = ['CF1', 'CF2', 'CG2', 'CG3', 'CG1', 'CG4', 'CG5'];
+
+export interface RenderCallGraphOptions {
+  color?: boolean;
+  /** Only the stats line — no checklist items. */
+  summary?: boolean;
+}
+
+export function renderCallGraph(cg: CallGraphReport, options: RenderCallGraphOptions = {}): string {
+  const color = options.color === true;
+  const paint = (p: Painter, s: string) => (color ? p(s) : s);
+
+  const s = cg.stats;
+  const lines: string[] = [
+    paint(yanse.bold, 'call graph — trust boundaries reachable from the exposed surface (unscored; human review)'),
+    `  ${s.entryPoints} entry point(s) → ${s.reachableFunctions} reachable function(s)`
+      + `  |  ${s.trustHops} trust hop(s)  ${s.rlsBypassPaths} RLS-bypass  `
+      + `${s.authContextMutations} auth-context  ${s.internalReach} internal-reach  ${s.opaqueNodes} opaque`
+  ];
+
+  if (options.summary || cg.checklist.length === 0) {
+    if (cg.checklist.length === 0) lines.push('  no trust boundaries found.');
+    return lines.join('\n');
+  }
+
+  for (const code of CODE_ORDER) {
+    const items = cg.checklist.filter((i) => i.code === code);
+    if (items.length === 0) continue;
+    const meta = CODE_META[code];
+    lines.push('', paint(meta.paint, `${code} — ${meta.title} (${items.length})`));
+    for (const item of items) {
+      lines.push(...renderItem(item));
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function renderItem(item: ChecklistItem): string[] {
+  const subject = item.table ? `${item.fn} → ${item.table}` : item.fn;
+  const out = [`  • ${subject}`, `      ${item.message}`];
+  if (item.path.length > 1) {
+    out.push(`      via: ${item.path.join(' → ')}`);
+  } else if (item.entry !== item.fn) {
+    out.push(`      via: ${item.entry}`);
+  }
+  return out;
+}

--- a/packages/safegres/src/report/pretty.ts
+++ b/packages/safegres/src/report/pretty.ts
@@ -1,6 +1,7 @@
 import yanse from 'yanse';
 
 import type { Finding, Report, Severity } from '../types';
+import { renderCallGraph } from './callgraph';
 
 const SEV_LABEL: Record<Severity, string> = {
   critical: 'CRIT',
@@ -85,6 +86,9 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
 
   // --summary: score + counts only, no per-finding lines.
   if (options.summary) {
+    if (report.callGraph) {
+      lines.push('', renderCallGraph(report.callGraph, { color: colorEnabled, summary: true }));
+    }
     return lines.join('\n');
   }
   lines.push('');
@@ -121,6 +125,10 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
 
   if (findings.length === 0) {
     lines.push('no findings.');
+  }
+
+  if (report.callGraph) {
+    lines.push('', renderCallGraph(report.callGraph, { color: colorEnabled }));
   }
 
   return lines.join('\n');

--- a/packages/safegres/src/types.ts
+++ b/packages/safegres/src/types.ts
@@ -92,6 +92,11 @@ export interface Report {
   score?: import('./score/score').Score;
   /** The exposure surface the score was computed against. */
   exposure?: ExposureReport;
+  /**
+   * Unscored call-graph audit (`--call-graph`): trust boundaries reachable
+   * from the exposed entry points, for human review.
+   */
+  callGraph?: import('./callgraph/graph').CallGraphReport;
 }
 
 export function newSummary(): Summary {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2607,6 +2607,9 @@ importers:
       inquirerer:
         specifier: ^4.9.1
         version: 4.9.1
+      libpg-query:
+        specifier: ^18.1.2
+        version: 18.1.2
       pg:
         specifier: ^8.21.0
         version: 8.21.0


### PR DESCRIPTION
## Summary

Adds the unscored **call-graph audit** ([planning #1286](https://github.com/constructive-io/constructive-planning/issues/1286)): `safegres audit --call-graph` statically walks every function reachable from the exposed entry points (functions the API roles can `EXECUTE`) and emits a deterministic checklist of **trust boundaries** for human review. Nothing here affects the score — a public `SECURITY DEFINER` calling private helpers is the intended pattern (`sign_in`), so the graph tells a human *what* to audit rather than judging it.

Pipeline:
- `pg/functions.ts` — `introspectFunctions()`: pg_proc snapshot (`prosecdef`, owner + BYPASSRLS/superuser, pinned `search_path` from `proconfig`, language, `pg_get_functiondef`, EXECUTE grants via `aclexplode`, `proacl IS NULL` = default PUBLIC grant).
- `callgraph/extract.ts` — body extraction: SQL bodies via `pgsql-parser`; PL/pgSQL via `libpg-query.parsePlPgSQL`, parsing each embedded `PLpgSQL_expr` (parseMode 3 assignments get the anchored `target :=`/`target =` stripped so the RHS parses — the RHS may itself contain named-arg `:=`). Collects calls, table reads/writes, `set_config`/`SET` targets; `PLpgSQL_stmt_dynexecute` and parse failures mark the node **opaque** instead of being dropped.
- `callgraph/graph.ts` — `buildCallGraph()`: BFS from entry points, cycle-safe, overloads collapse to one node per `schema.name`, unqualified calls conservatively resolve to every user function with that name. Nodes/edges/checklist sorted stably (snapshot/diff-friendly JSON).

Checklist codes:

| | boundary |
|---|---|
| CF1 | DEFINER without pinned `search_path` (CWE-426) — provable, fix |
| CF2 | DEFINER executable by anonymous/PUBLIC — provable, confirm intent |
| CG1 | trust hop — execution crosses into a DEFINER |
| CG2 | RLS-bypass path — the DEFINER's owner owns/bypasses RLS on a table it touches |
| CG3 | auth-context mutation — writes `jwt.claims.*` / `role` |
| CG4 | non-exposed table reached from a public entry via a DEFINER path |
| CG5 | opaque node — dynamic SQL / unparseable, static analysis ends here |

Wiring: `AuditOptions.callGraph` → `report.callGraph` (full graph in `--format json`); pretty renderer appends the grouped checklist (stats-only line under `--summary`).

## Dogfood (live constructivedb, `--preset constructive`)

```
130 entry point(s) → 893 reachable function(s)  |  85 trust hop(s)  155 RLS-bypass  1 auth-context  75 internal-reach  14 opaque
```

Real signal: **80 CF1** unpinned-search_path DEFINERs (mostly `compute_*`), 155 RLS-bypass paths via postgres-owned DEFINERs, and exactly one auth-context mutation (`compute_private.tick_execution` sets `jwt.claims.database_id`). The 14 opaque nodes are 7 genuine dynamic-SQL `EXECUTE`s plus 7 parse edge cases. Runs in ~15s on 573 tables / ~900 functions.

## Testing

- New `__tests__/callgraph.test.ts` (9 tests) against a live fixture: public `sign_in` DEFINER entry → private `verify_password` (unpinned search_path, reads RLS table as superuser owner) → `issue_token` (sets `jwt.claims.*`), plus a dynamic-SQL node — exercising every checklist code, entry-point resolution, and score-neutrality.
- Full suite: 71/71 green; changed-file lint clean; dogfooded on constructivedb + diligence.

Link to Devin session: https://app.devin.ai/sessions/671aac6e50b04e8caacd3f54c1c63bc6
Requested by: @pyramation