### PR TITLE
feat(safegres): call-graph baseline diffing — --write-baseline, --baseline, --fail-on-new-boundaries

### DIFF
--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -130,6 +130,24 @@ CG2 — RLS-bypass paths (RLS does not protect the table on this path) (1)
 
 Bodies are analyzed for `sql` and `plpgsql` functions (via the PL/pgSQL parser); overloads collapse into one node per `schema.name`; unqualified calls resolve to every user function with that name (a conservative over-approximation). JSON output (`--format json`) carries the full graph — nodes, edges, and checklist — sorted stably so it can be snapshotted and diffed in CI.
 
+### Baseline diffing (CI gate for new trust boundaries)
+
+Snapshot the checklist once, commit it, and let CI report anything **new**:
+
+```bash
+safegres audit --write-baseline .safegres-callgraph.json   # snapshot (implies --call-graph)
+safegres audit --baseline .safegres-callgraph.json         # diff: report new/resolved boundaries
+safegres audit --baseline .safegres-callgraph.json --fail-on-new-boundaries   # gate: exit 1 on new
+```
+
+```
+baseline: 1 NEW trust boundary — review and re-baseline to accept:
+  + [CF2] app_public.new_fn
+        SECURITY DEFINER executable by PUBLIC, anonymous — widest blast radius; confirm this is intended
+```
+
+The baseline stores only boundary *identity* (`code` + entry + function + table), so message rewording and path changes between safegres versions never invalidate it. A boundary that disappears is reported as resolved; re-run `--write-baseline` to accept either direction. The diff is also carried in JSON output (`callGraphDiff`).
+
 ## Configuration
 
 safegres is configurable like a linter. Config is discovered by walking up from the current directory: `safegres.config.{ts,js,mjs,cjs}`, `.safegresrc{,.json,.yaml,.yml,.js}`, `safegres.json`, or a `"safegres"` key in package.json (via [confstash](https://github.com/constructive-io/dev-utils/tree/main/packages/confstash)).

--- a/packages/safegres/__tests__/callgraph-baseline.test.ts
+++ b/packages/safegres/__tests__/callgraph-baseline.test.ts
@@ -1,0 +1,96 @@
+import {
+  boundaryKey,
+  type CallGraphBaseline,
+  diffCallGraph,
+  parseBaseline,
+  serializeBaseline,
+  toBaseline
+} from '../src/callgraph/baseline';
+import type { CallGraphReport, ChecklistItem } from '../src/callgraph/graph';
+
+function item(partial: Partial<ChecklistItem> & Pick<ChecklistItem, 'code' | 'fn'>): ChecklistItem {
+  return {
+    entry: partial.entry ?? partial.fn,
+    path: partial.path ?? [partial.fn],
+    message: partial.message ?? 'msg',
+    ...partial
+  };
+}
+
+function report(checklist: ChecklistItem[]): CallGraphReport {
+  return {
+    entries: [],
+    nodes: [],
+    edges: [],
+    checklist,
+    stats: {
+      entryPoints: 0,
+      reachableFunctions: 0,
+      trustHops: 0,
+      rlsBypassPaths: 0,
+      authContextMutations: 0,
+      internalReach: 0,
+      opaqueNodes: 0
+    }
+  };
+}
+
+const signIn = item({ code: 'CG1', fn: 'priv.verify', entry: 'pub.sign_in', path: ['pub.sign_in', 'priv.verify'] });
+const bypass = item({ code: 'CG2', fn: 'priv.verify', entry: 'pub.sign_in', table: 'priv.users' });
+
+describe('toBaseline / serialize / parse', () => {
+  it('stores only boundary identity, deduplicated and sorted', () => {
+    const b = toBaseline(report([bypass, signIn, signIn]));
+    expect(b.boundaries).toEqual([
+      { code: 'CG1', entry: 'pub.sign_in', fn: 'priv.verify' },
+      { code: 'CG2', entry: 'pub.sign_in', fn: 'priv.verify', table: 'priv.users' }
+    ]);
+  });
+
+  it('round-trips through serialize/parse', () => {
+    const b = toBaseline(report([signIn, bypass]));
+    expect(parseBaseline(serializeBaseline(b))).toEqual(b);
+  });
+
+  it('rejects malformed baselines', () => {
+    expect(() => parseBaseline('{"boundaries": []}')).toThrow(/invalid call-graph baseline/);
+    expect(() => parseBaseline('{"version": 1}')).toThrow(/invalid call-graph baseline/);
+  });
+});
+
+describe('diffCallGraph', () => {
+  const baseline: CallGraphBaseline = toBaseline(report([signIn]));
+
+  it('reports no changes when the checklist matches the baseline', () => {
+    const diff = diffCallGraph(report([signIn]), baseline);
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+  });
+
+  it('reports new boundaries as added', () => {
+    const diff = diffCallGraph(report([signIn, bypass]), baseline);
+    expect(diff.added).toHaveLength(1);
+    expect(diff.added[0]).toMatchObject({ code: 'CG2', table: 'priv.users' });
+    expect(diff.removed).toEqual([]);
+  });
+
+  it('reports resolved boundaries as removed', () => {
+    const diff = diffCallGraph(report([bypass]), toBaseline(report([signIn, bypass])));
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([{ code: 'CG1', entry: 'pub.sign_in', fn: 'priv.verify' }]);
+  });
+
+  it('ignores message/path rewording — identity is code+entry+fn+table', () => {
+    const reworded = item({ ...signIn, message: 'different wording', path: ['pub.sign_in', 'x', 'priv.verify'] });
+    const diff = diffCallGraph(report([reworded]), baseline);
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+  });
+});
+
+describe('boundaryKey', () => {
+  it('is stable and distinguishes tables', () => {
+    expect(boundaryKey({ code: 'CG2', entry: 'e', fn: 'f', table: 't' })).toBe('CG2|e|f|t');
+    expect(boundaryKey({ code: 'CG2', entry: 'e', fn: 'f' })).toBe('CG2|e|f|');
+  });
+});

--- a/packages/safegres/src/callgraph/baseline.ts
+++ b/packages/safegres/src/callgraph/baseline.ts
@@ -1,0 +1,82 @@
+import type { CallGraphReport, ChecklistCode, ChecklistItem } from './graph';
+
+/**
+ * A committed snapshot of the call-graph checklist, used by CI to detect
+ * *new* trust boundaries introduced by a change. Only the identity of each
+ * boundary is stored (code + entry + fn + table) — messages and paths may
+ * be reworded between versions without invalidating the baseline.
+ */
+export interface CallGraphBaseline {
+  version: 1;
+  boundaries: BaselineBoundary[];
+}
+
+export interface BaselineBoundary {
+  code: ChecklistCode;
+  entry: string;
+  fn: string;
+  table?: string;
+}
+
+export interface CallGraphDiff {
+  /** Checklist items present now but not in the baseline — require sign-off. */
+  added: ChecklistItem[];
+  /** Baseline boundaries no longer present — resolved or removed. */
+  removed: BaselineBoundary[];
+}
+
+export function boundaryKey(b: BaselineBoundary): string {
+  return [b.code, b.entry, b.fn, b.table ?? ''].join('|');
+}
+
+export function toBaseline(report: CallGraphReport): CallGraphBaseline {
+  const seen = new Set<string>();
+  const boundaries: BaselineBoundary[] = [];
+  for (const item of report.checklist) {
+    const b: BaselineBoundary = {
+      code: item.code,
+      entry: item.entry,
+      fn: item.fn,
+      ...(item.table ? { table: item.table } : {})
+    };
+    const key = boundaryKey(b);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    boundaries.push(b);
+  }
+  boundaries.sort((a, b) => boundaryKey(a).localeCompare(boundaryKey(b)));
+  return { version: 1, boundaries };
+}
+
+export function diffCallGraph(
+  report: CallGraphReport,
+  baseline: CallGraphBaseline
+): CallGraphDiff {
+  const baseKeys = new Set(baseline.boundaries.map(boundaryKey));
+  const current = toBaseline(report);
+  const currentKeys = new Set(current.boundaries.map(boundaryKey));
+
+  const addedKeys = new Set<string>();
+  const added: ChecklistItem[] = [];
+  for (const item of report.checklist) {
+    const key = boundaryKey({ code: item.code, entry: item.entry, fn: item.fn, table: item.table });
+    if (baseKeys.has(key) || addedKeys.has(key)) continue;
+    addedKeys.add(key);
+    added.push(item);
+  }
+
+  const removed = baseline.boundaries.filter((b) => !currentKeys.has(boundaryKey(b)));
+  return { added, removed };
+}
+
+export function parseBaseline(raw: string): CallGraphBaseline {
+  const data = JSON.parse(raw) as Partial<CallGraphBaseline>;
+  if (data.version !== 1 || !Array.isArray(data.boundaries)) {
+    throw new Error('invalid call-graph baseline: expected { version: 1, boundaries: [...] }');
+  }
+  return { version: 1, boundaries: data.boundaries as BaselineBoundary[] };
+}
+
+export function serializeBaseline(baseline: CallGraphBaseline): string {
+  return JSON.stringify(baseline, null, 2) + '\n';
+}

--- a/packages/safegres/src/cli.ts
+++ b/packages/safegres/src/cli.ts
@@ -15,8 +15,10 @@ if (process.argv.includes('--version') || process.argv.includes('-v')) {
 const options: Partial<CLIOptions> = {
   minimistOpts: {
     alias: { v: 'version', h: 'help', q: 'summary' },
-    boolean: ['skip-ast', 'color', 'help', 'version', 'summary', 'verbose', 'call-graph'],
+    boolean: ['skip-ast', 'color', 'help', 'version', 'summary', 'verbose', 'call-graph', 'fail-on-new-boundaries'],
     string: [
+      'baseline',
+      'write-baseline',
       'connection',
       'host',
       'user',

--- a/packages/safegres/src/cli/audit.ts
+++ b/packages/safegres/src/cli/audit.ts
@@ -1,6 +1,8 @@
 import { Logger } from '@pgpmjs/logger';
+import * as fs from 'fs';
 import { CLIOptions, Inquirerer, ParsedArgs } from 'inquirerer';
 
+import { diffCallGraph, parseBaseline, serializeBaseline, toBaseline } from '../callgraph/baseline';
 import { audit, type AuditOptions } from '../commands/audit';
 import { loadConfig } from '../config/loader';
 import type { Grade } from '../config/types';
@@ -62,6 +64,11 @@ Call graph (unscored; human review):
                            points and list trust boundaries: SECURITY DEFINER hops,
                            RLS-bypass paths, auth-context mutations, internal-table
                            reach, and opaque (dynamic SQL) nodes
+  --write-baseline <file>  Snapshot the call-graph boundaries to <file>
+                           (implies --call-graph)
+  --baseline <file>        Diff the call graph against a committed snapshot and
+                           report NEW trust boundaries (implies --call-graph)
+  --fail-on-new-boundaries Exit non-zero when --baseline finds new boundaries
 
 Audit options:
   --schemas <csv>          Limit to these schemas (default: all non-system)
@@ -103,7 +110,10 @@ export default async (
     includeRoles: csvList(argv.roles),
     excludeRoles: csvList(argv['exclude-roles']),
     skipAstChecks: argv['skip-ast'] === true,
-    callGraph: argv['call-graph'] === true,
+    callGraph:
+      argv['call-graph'] === true
+      || typeof argv.baseline === 'string'
+      || typeof argv['write-baseline'] === 'string',
     exposure: exposureSchemas
       ? { ...config.exposure, schemas: exposureSchemas }
       : undefined,
@@ -122,6 +132,22 @@ export default async (
     } finally {
       await client.end();
     }
+  }
+
+  if (typeof argv['write-baseline'] === 'string' && report.callGraph) {
+    fs.writeFileSync(argv['write-baseline'], serializeBaseline(toBaseline(report.callGraph)));
+    log.info(`wrote call-graph baseline: ${argv['write-baseline']}`);
+  }
+
+  if (typeof argv.baseline === 'string' && report.callGraph) {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(argv.baseline, 'utf8');
+    } catch {
+      log.error(`cannot read --baseline file: ${argv.baseline} (create one with --write-baseline)`);
+      process.exit(2);
+    }
+    report.callGraphDiff = diffCallGraph(report.callGraph, parseBaseline(raw));
   }
 
   if (argv['exposed-only'] === true) {
@@ -175,6 +201,17 @@ export default async (
     typeof argv['fail-on-grade'] === 'string' ? (argv['fail-on-grade'] as Grade) : config.failOn?.grade;
   if (failOnGrade && report.score && !meetsGrade(report.score.grade, failOnGrade)) {
     log.error(`grade ${report.score.grade} is below --fail-on-grade ${failOnGrade}`);
+    process.exit(1);
+  }
+
+  if (
+    argv['fail-on-new-boundaries'] === true
+    && report.callGraphDiff
+    && report.callGraphDiff.added.length > 0
+  ) {
+    log.error(
+      `${report.callGraphDiff.added.length} new trust boundar${report.callGraphDiff.added.length === 1 ? 'y' : 'ies'} since the baseline — review and re-baseline to accept`
+    );
     process.exit(1);
   }
 };

--- a/packages/safegres/src/index.ts
+++ b/packages/safegres/src/index.ts
@@ -12,6 +12,12 @@ export {
   type PolicyExpression,
   PolicyParseError} from './ast/parse';
 export type {
+  BaselineBoundary,
+  CallGraphBaseline,
+  CallGraphDiff
+} from './callgraph/baseline';
+export { boundaryKey, diffCallGraph, parseBaseline, serializeBaseline, toBaseline } from './callgraph/baseline';
+export type {
   CallGraphEdge,
   CallGraphNode,
   CallGraphOptions,
@@ -67,7 +73,7 @@ export {
   type TableSnapshot
 } from './pg/introspect';
 export { listAuditableRoles, resolveRoles } from './pg/roles';
-export { renderCallGraph } from './report/callgraph';
+export { renderCallGraph, renderCallGraphDiff } from './report/callgraph';
 export { renderJson } from './report/json';
 export { renderPretty } from './report/pretty';
 export type { RuleMeta } from './rules/registry';

--- a/packages/safegres/src/report/callgraph.ts
+++ b/packages/safegres/src/report/callgraph.ts
@@ -1,5 +1,7 @@
 import yanse from 'yanse';
 
+import type { CallGraphDiff } from '../callgraph/baseline';
+import { boundaryKey } from '../callgraph/baseline';
 import type { CallGraphReport, ChecklistCode, ChecklistItem } from '../callgraph/graph';
 
 type Painter = (s: string) => string;
@@ -49,6 +51,36 @@ export function renderCallGraph(cg: CallGraphReport, options: RenderCallGraphOpt
     }
   }
 
+  return lines.join('\n');
+}
+
+export function renderCallGraphDiff(diff: CallGraphDiff, options: RenderCallGraphOptions = {}): string {
+  const color = options.color === true;
+  const paint = (p: Painter, s: string) => (color ? p(s) : s);
+
+  if (diff.added.length === 0 && diff.removed.length === 0) {
+    return paint(yanse.green, 'baseline: no new trust boundaries.');
+  }
+
+  const lines: string[] = [];
+  if (diff.added.length > 0) {
+    lines.push(
+      paint(yanse.red, `baseline: ${diff.added.length} NEW trust boundar${diff.added.length === 1 ? 'y' : 'ies'} — review and re-baseline to accept:`)
+    );
+    for (const item of diff.added) {
+      lines.push(`  + [${item.code}] ${item.table ? `${item.fn} → ${item.table}` : item.fn}`);
+      lines.push(`        ${item.message}`);
+      if (item.path.length > 1) lines.push(`        via: ${item.path.join(' → ')}`);
+    }
+  }
+  if (diff.removed.length > 0) {
+    lines.push(
+      paint(yanse.green, `baseline: ${diff.removed.length} boundar${diff.removed.length === 1 ? 'y' : 'ies'} resolved (no longer present) — re-baseline to prune:`)
+    );
+    for (const b of diff.removed) {
+      lines.push(`  - ${boundaryKey(b)}`);
+    }
+  }
   return lines.join('\n');
 }
 

--- a/packages/safegres/src/report/pretty.ts
+++ b/packages/safegres/src/report/pretty.ts
@@ -1,7 +1,7 @@
 import yanse from 'yanse';
 
 import type { Finding, Report, Severity } from '../types';
-import { renderCallGraph } from './callgraph';
+import { renderCallGraph, renderCallGraphDiff } from './callgraph';
 
 const SEV_LABEL: Record<Severity, string> = {
   critical: 'CRIT',
@@ -89,6 +89,9 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
     if (report.callGraph) {
       lines.push('', renderCallGraph(report.callGraph, { color: colorEnabled, summary: true }));
     }
+    if (report.callGraphDiff) {
+      lines.push('', renderCallGraphDiff(report.callGraphDiff, { color: colorEnabled }));
+    }
     return lines.join('\n');
   }
   lines.push('');
@@ -129,6 +132,9 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
 
   if (report.callGraph) {
     lines.push('', renderCallGraph(report.callGraph, { color: colorEnabled }));
+  }
+  if (report.callGraphDiff) {
+    lines.push('', renderCallGraphDiff(report.callGraphDiff, { color: colorEnabled }));
   }
 
   return lines.join('\n');

--- a/packages/safegres/src/types.ts
+++ b/packages/safegres/src/types.ts
@@ -97,6 +97,12 @@ export interface Report {
    * from the exposed entry points, for human review.
    */
   callGraph?: import('./callgraph/graph').CallGraphReport;
+  /**
+   * Diff against a committed call-graph baseline (`--baseline`): trust
+   * boundaries added since the snapshot (require sign-off) and boundaries
+   * that were resolved.
+   */
+  callGraphDiff?: import('./callgraph/baseline').CallGraphDiff;
 }
 
 export function newSummary(): Summary {


### PR DESCRIPTION
## Summary

Phase 2 of the call-graph audit (#1508): a committed **baseline** turns the checklist into a CI gate for *new* trust boundaries — "this PR adds 1 new anonymous-reachable SECURITY DEFINER" instead of re-reading the whole report.

- `callgraph/baseline.ts` — `toBaseline(report)` snapshots only boundary *identity* (`code|entry|fn|table`, deduped + sorted), so message rewording/path changes between safegres versions never invalidate a baseline. `diffCallGraph(report, baseline)` → `{ added: ChecklistItem[], removed: BaselineBoundary[] }`.
- CLI (all imply `--call-graph`):
  - `--write-baseline <file>` — snapshot to a committable JSON (`{ version: 1, boundaries: [...] }`)
  - `--baseline <file>` — diff and render new/resolved boundaries (also carried as `report.callGraphDiff` in `--format json`)
  - `--fail-on-new-boundaries` — exit 1 when the diff has additions
- Pretty output appends the diff (also in `--summary` mode, so the CI job summary shows `baseline: no new trust boundaries.` or the additions).

## Verified end-to-end on live constructivedb

```
$ safegres audit --preset constructive --write-baseline base.json   # 500 boundaries
$ safegres audit --preset constructive --baseline base.json --fail-on-new-boundaries
baseline: no new trust boundaries.            # exit 0
# … CREATE FUNCTION constructive_users_public.devin_test_definer() SECURITY DEFINER; GRANT EXECUTE … TO anonymous;
baseline: 3 NEW trust boundaries — review and re-baseline to accept:
  + [CF1] constructive_users_public.devin_test_definer   (unpinned search_path)
  + [CF2] …  (executable by PUBLIC, anonymous)
  + [CG1] …  (entry point is SECURITY DEFINER, runs as postgres)
# exit 1
```

A DEFINER added to a *non-exposed* schema (e.g. `jwt_public`) correctly does not trip the gate.

## Testing

- New `__tests__/callgraph-baseline.test.ts` (8 tests): snapshot dedupe/sort, serialize/parse round-trip, malformed-baseline rejection, no-change/added/removed diffs, identity stability under message/path rewording.
- Full suite 79/79 green; changed-file lint clean; live dogfood above.

Link to Devin session: https://app.devin.ai/sessions/671aac6e50b04e8caacd3f54c1c63bc6
Requested by: @pyramation