### PR TITLE
perf(ast): make renameInPlanContent linear instead of O(lines × renames)

### DIFF
--- a/pgpm/ast/__tests__/plan-rename.test.ts
+++ b/pgpm/ast/__tests__/plan-rename.test.ts
@@ -1,0 +1,84 @@
+import { renameInPlanContent } from '../src/plan-rename';
+
+const PLAN = `%syntax-version=1.0.0
+%project=my-module
+%uri=my-module
+
+schemas/my-app/schema 2024-01-01T00:00:00Z Dev <dev@example.com> # add schema
+schemas/my-app/tables/users [schemas/my-app/schema] 2024-01-01T00:00:01Z Dev <dev@example.com> # add users
+schemas/my-app/tables/posts [schemas/my-app/schema schemas/my-app/tables/users] 2024-01-01T00:00:02Z Dev <dev@example.com> # add posts
+schemas/other/functions/fn [schemas/my-app/tables/users auth:schemas/auth/tables/users] 2024-01-01T00:00:03Z Dev <dev@example.com> # fn
+@v1.0.0 2024-01-01T00:00:04Z Dev <dev@example.com> # release
+`;
+
+describe('renameInPlanContent', () => {
+  it('rewrites change names and plain dependency refs, preserving format', () => {
+    const renames = new Map([['schemas/my-app/tables/users', 'schemas/my_app/tables/users']]);
+    const out = renameInPlanContent(PLAN, renames);
+    expect(out).toContain('schemas/my_app/tables/users [schemas/my-app/schema] 2024-01-01T00:00:01Z');
+    expect(out).toContain('[schemas/my-app/schema schemas/my_app/tables/users]');
+    expect(out).toContain('[schemas/my_app/tables/users auth:schemas/auth/tables/users]');
+    // cross-package ref untouched
+    expect(out).toContain('auth:schemas/auth/tables/users');
+    // metadata untouched
+    expect(out).toContain('%project=my-module');
+  });
+
+  it('does not rewrite partial-name matches', () => {
+    const renames = new Map([['schemas/my-app/schema', 'schemas/my_app/schema']]);
+    const out = renameInPlanContent(PLAN, renames);
+    expect(out).toContain('schemas/my-app/tables/users [schemas/my_app/schema]');
+    expect(out).toContain('schemas/my-app/tables/posts [schemas/my_app/schema schemas/my-app/tables/users]');
+  });
+
+  it('returns content unchanged when there are no renames', () => {
+    expect(renameInPlanContent(PLAN, new Map())).toBe(PLAN);
+  });
+
+  it('preserves a trailing @tag suffix on a dependency ref', () => {
+    const plan = 'schemas/a/b [schemas/a/c@v1.0.0] 2024-01-01T00:00:00Z Dev <dev@example.com> # x\n';
+    const renames = new Map([['schemas/a/c', 'schemas/a_c']]);
+    const out = renameInPlanContent(plan, renames);
+    expect(out).toContain('[schemas/a_c@v1.0.0]');
+  });
+
+  it('rewrites every dependency in a multi-dep bracket', () => {
+    const plan =
+      'schemas/x/d [schemas/x/a schemas/x/b schemas/x/c] 2024-01-01T00:00:00Z Dev <dev@example.com> # x\n';
+    const renames = new Map([
+      ['schemas/x/a', 'schemas/x_a'],
+      ['schemas/x/b', 'schemas/x_b'],
+      ['schemas/x/c', 'schemas/x_c']
+    ]);
+    const out = renameInPlanContent(plan, renames);
+    expect(out).toContain('[schemas/x_a schemas/x_b schemas/x_c]');
+  });
+
+  it('scales linearly: a large plan with a large rename map completes quickly', () => {
+    // Reproduces the introspection corpus scale (~8k changes, each depending
+    // on the previous). The previous O(lines × renames) implementation with a
+    // regex compiled per (line, rename) pair took ~100s here; the linear pass
+    // must complete in well under a second.
+    const n = 8000;
+    const renames = new Map<string, string>();
+    const lines: string[] = ['%syntax-version=1.0.0', '%project=big', '%uri=big', ''];
+    for (let i = 0; i < n; i++) {
+      const name = `schemas/mod-${i}/tables/t-${i}`;
+      renames.set(name, name.replace(/-/g, '_'));
+      const dep = i > 0 ? ` [schemas/mod-${i - 1}/tables/t-${i - 1}]` : '';
+      lines.push(`${name}${dep} 2024-01-01T00:00:00Z Dev <dev@example.com> # change ${i}`);
+    }
+    const content = lines.join('\n') + '\n';
+
+    const start = Date.now();
+    const out = renameInPlanContent(content, renames);
+    const elapsedMs = Date.now() - start;
+
+    expect(out).toContain('schemas/mod_0/tables/t_0 ');
+    expect(out).toContain(`schemas/mod_${n - 1}/tables/t_${n - 1}`);
+    expect(out).toContain('[schemas/mod_0/tables/t_0]');
+    // No hyphenated change tokens should remain (metadata/comments still have them).
+    expect(out).not.toMatch(/(^|[\s\[])schemas\/mod-\d/m);
+    expect(elapsedMs).toBeLessThan(2000);
+  });
+});

--- a/pgpm/ast/src/plan-rename.ts
+++ b/pgpm/ast/src/plan-rename.ts
@@ -1,16 +1,24 @@
-function escapeRe(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
 /**
  * Rewrite change names in a pgpm.plan's content according to a rename map.
  * Textual and format-preserving: only the change-name token at the start of a
  * change line, plain (same-package) dependency refs inside `[...]`, and tag
  * lines' change field are rewritten; timestamps, planners, comments,
  * cross-package refs, and tag refs are untouched.
+ *
+ * Runs in a single linear pass: each line is scanned once and every
+ * whitespace/bracket-delimited token is looked up in the rename map directly,
+ * so the rewrite is O(content length) rather than O(lines × renames). A token
+ * qualifies when it is bounded on the left by start-of-line, whitespace or `[`
+ * and on the right by end-of-line, whitespace, `]` or `@` — which is exactly
+ * the change-name and plain-dependency positions. Cross-package refs
+ * (`pkg:change`) are left untouched because their change segment is preceded by
+ * `:`, and a trailing `@tag` suffix is preserved because the token ends at `@`.
  */
 export function renameInPlanContent(content: string, renames: Map<string, string>): string {
-  const froms = Array.from(renames.keys()).sort((a, b) => b.length - a.length);
+  if (renames.size === 0) return content;
+
+  // One regex, compiled once per call (not per line or per rename).
+  const tokenRe = /(^|[\s\[])([^\s\[\]@]+)(?=$|[\s\]@])/g;
 
   return content
     .split('\n')
@@ -18,13 +26,10 @@ export function renameInPlanContent(content: string, renames: Map<string, string
       const trimmed = line.trim();
       if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith('%')) return line;
 
-      let result = line;
-      for (const from of froms) {
-        const to = renames.get(from)!;
-        const re = new RegExp(`(^|[\\s\\[])${escapeRe(from)}(?=$|[\\s\\]@])`, 'g');
-        result = result.replace(re, `$1${to}`);
-      }
-      return result;
+      return line.replace(tokenRe, (match, pre: string, token: string) => {
+        const to = renames.get(token);
+        return to === undefined ? match : `${pre}${to}`;
+      });
     })
     .join('\n');
 }


### PR DESCRIPTION
## Summary

`renameInPlanContent` (`@pgpmjs/ast`) rewrote change names in a `pgpm.plan` in **O(plan_lines × renames)** with a regex **compiled inside the inner loop**:

```js
const froms = [...renames.keys()].sort(...);
for (const line of lines)
  for (const from of froms)                        // ~8k–13k renames
    line = line.replace(new RegExp(`(^|[\\s\\[])${escapeRe(from)}(?=$|[\\s\\]@])`, 'g'), ...); // built per (line, rename) pair
```

For the Constructive introspection corpus (~8k changes, one plan line each) that is ~63M regex compilations. This is the dominant cost of `renameChanges`, which was measured at **~314s** during `generate:constructive` in `constructive-io/constructive-db` (the actual SQL parse/deparse of all ~40k files is only ~24s by comparison).

This replaces the per-rename loop with a **single linear pass**: scan each line once and look up every whitespace/bracket-delimited token in the rename map directly.

```js
const tokenRe = /(^|[\s\[])([^\s\[\]@]+)(?=$|[\s\]@])/g;   // compiled once per call
line.replace(tokenRe, (m, pre, token) =>
  renames.has(token) ? pre + renames.get(token) : m);
```

The token boundaries reproduce the old semantics exactly: a token qualifies when bounded left by start/whitespace/`[` and right by end/whitespace/`]`/`@`, which is precisely the change-name and plain-dependency positions. Cross-package refs (`pkg:change`) stay untouched (their change segment is preceded by `:`), a trailing `@tag` suffix is preserved (the token ends at `@`), and `#`/`%`/blank lines are still skipped.

## Correctness & performance

- Verified **byte-identical output** against the previous implementation over the real `application/constructive/pgpm.plan` (7,943 lines) with a realistic 7,938-entry rename map.
- Same input: **111,148ms → 26ms** (~4300×).
- Added `pgpm/ast/__tests__/plan-rename.test.ts` (correctness: change/dep rewrite, partial-name safety, cross-package refs, `@tag` suffix, empty map; plus a linear-scaling guard on an 8k-change plan that must finish < 2s).
- Existing `@pgpmjs/core` `rename-changes.test.ts` (12 tests) and the full `@pgpmjs/ast` suite (106 tests) pass.

Note: a full `pnpm build` currently fails on `main` in `@pgpmjs/transform`/`@pgpmjs/slice` (installed `@pgsql/transform` lacks `RouteSpec`/`SchemaRouter`) — pre-existing and unrelated to this change; `@pgpmjs/ast` builds and tests cleanly.


Link to Devin session: https://app.devin.ai/sessions/fb12b07b9cb0499782980ceffe689de4
Requested by: @pyramation