### PR TITLE
feat(pgpm): bundle-backed deploy fast path with migration ledger

### DIFF
--- a/.agents/skills/pgpm-migration-bundle/SKILL.md
+++ b/.agents/skills/pgpm-migration-bundle/SKILL.md
@@ -128,7 +128,8 @@ bundleDigest  = H( plan ‖ control ‖ [changeDigest_1 … changeDigest_n] )   
 | `packSingleFileTarGz` / `unpackSingleFileTarGz` | Deterministic single-entry tar+gzip codec (no deps) |
 | `writeBundleArtifact(dir, version)` (`@pgpmjs/core`) | Emit a module's artifact (called by `pgpm package`) |
 | `resolveBundleArtifactPath` / `readBundleArtifact` (`@pgpmjs/core`) | Locate / load a module's artifact (never throws) |
-| `deployModuleFromBundle` (`@pgpmjs/core`) | The `--bundled` deploy: verify → one-shot execute → bulk ledger |
+| `buildExecutableBundle(dir)` (`@pgpmjs/core`) | Bundle + executable SQL built from `deploy/` (no artifact needed) |
+| `deployModuleFast` (`@pgpmjs/core`) | The `fast` deploy: verify → one-shot execute → bulk ledger |
 | `createEnvelope(opts)` | Wrap schema bundle + data/fixtures parts into a shippable envelope |
 | `verifyEnvelope(envelope)` | Recompute every envelope digest incl. the schema bundle chain |
 | `writeEnvelopeFile` / `readEnvelopeFile` | Single JSON envelope artifact |
@@ -225,20 +226,27 @@ materializeBundle(received, '/tmp/deployable-module');
 slot — its deploy SQL already stripped of transaction/`CREATE EXTENSION` statements — so
 deploys never re-parse SQL. Commit the `.tar.gz`; the loose JSON is gitignored.
 
-`pgpm deploy --bundled` (`deployment.bundled`) then, per module: read the artifact →
-`verifyBundle` (mandatory sha256 gate) → execute only the pending changes' `exec` SQL in a
-single statement → bulk-insert `pgpm_migrate` packages/changes/dependencies/events in one
-round-trip. Unlike `--fast`, it writes a correct ledger, so re-deploys skip changes whose
-stored hash matches and a same-name/different-content change still errors.
+`pgpm deploy --fast` (`deployment.fast`; `--bundled` is an alias) then, per module: load the
+executable bundle — the stored artifact when `verifyBundle` passes, otherwise rebuilt from
+`deploy/` via `buildExecutableBundle` — then execute only the pending changes' `exec` SQL in
+a single statement and bulk-insert `pgpm_migrate` packages/changes/dependencies/events in
+one round-trip.
+
+**The old unledgered `fast` path no longer exists.** `fast` used to run the packaged SQL and
+record nothing, which made it non-idempotent and unauditable; it now always writes the
+ledger, so re-deploys skip changes whose stored hash matches and a same-name/
+different-content change still errors. The artifact is purely a speed optimization on that
+path, never a correctness requirement.
 
 - **Ledger hash reconciliation:** the ledger's `script_hash` for a bundled change is
   `change.deploy.digest` = sha256 of the deploy file bytes — exactly what
   `PgpmMigrate.calculateScriptHash` computes under the default `content` method, so bundled
   and per-change deploys are interchangeable. The `ast` hash method is not derivable from
   the artifact, so it falls back.
-- **Graceful fallback:** missing artifact, unreadable archive, failed verification, no
-  `exec` SQL, or `hashMethod: 'ast'` → log and fall through to the existing `--fast` /
-  per-change paths. The bundle is opportunistic; it never fails a deploy on its own.
+- **Graceful degradation:** missing artifact, unreadable archive, or failed verification →
+  rebuild from `deploy/` (same SQL, same hashes, just slower). Only `hashMethod: 'ast'` or a
+  module with no executable deploy SQL falls through to the per-change path. The artifact
+  never fails a deploy on its own.
 
 ## Where this fits (cloud functions)
 

--- a/.agents/skills/pgpm-migration-bundle/SKILL.md
+++ b/.agents/skills/pgpm-migration-bundle/SKILL.md
@@ -94,8 +94,9 @@ interface MigrationBundle {
 
 ```
 bundleDigest  = H( plan ‖ control ‖ [changeDigest_1 … changeDigest_n] )   (order-sensitive)
-  changeDigest = H( name ‖ deployDigest ‖ revertDigest ‖ verifyDigest )   (missing = empty slot)
-    scriptDigest = H( sql bytes )
+  changeDigest = H( name ‖ deployDigest ‖ revertDigest ‖ verifyDigest [‖ execDigest] )
+    scriptDigest = H( sql bytes )                          (missing script = empty slot)
+    execDigest   = H( executable deploy sql )               (only when `exec` is present)
 ```
 
 - Leaves are individual deploy/revert/verify SQL blobs; per-change nodes; root is the
@@ -121,6 +122,13 @@ bundleDigest  = H( plan ‖ control ‖ [changeDigest_1 … changeDigest_n] )   
 | `transpileBundle(bundle, opts?)` | Rewrite into a new namespace; fresh digests + lineage |
 | `computeChangeDigest` / `computeBundleDigest` | The digest primitives |
 | `BUNDLE_FORMAT_VERSION`, `BUNDLE_FILE_NAME` | Format constants |
+| `withExecutableSql(bundle, execSql)` | Attach pre-computed executable deploy SQL per change; re-derives digests |
+| `packBundle` / `unpackBundle` | Bundle ⇄ gzipped-tar artifact bytes (in memory) |
+| `writeBundleArchiveFile` / `readBundleArchiveFile` | The stored `sql/<name>--<version>.bundle.tar.gz` artifact |
+| `packSingleFileTarGz` / `unpackSingleFileTarGz` | Deterministic single-entry tar+gzip codec (no deps) |
+| `writeBundleArtifact(dir, version)` (`@pgpmjs/core`) | Emit a module's artifact (called by `pgpm package`) |
+| `resolveBundleArtifactPath` / `readBundleArtifact` (`@pgpmjs/core`) | Locate / load a module's artifact (never throws) |
+| `deployModuleFromBundle` (`@pgpmjs/core`) | The `--bundled` deploy: verify → one-shot execute → bulk ledger |
 | `createEnvelope(opts)` | Wrap schema bundle + data/fixtures parts into a shippable envelope |
 | `verifyEnvelope(envelope)` | Recompute every envelope digest incl. the schema bundle chain |
 | `writeEnvelopeFile` / `readEnvelopeFile` | Single JSON envelope artifact |
@@ -208,6 +216,29 @@ materializeBundle(received, '/tmp/deployable-module');
 - **Deploy order is part of the identity** — reordering changes changes the bundle digest.
 - Deterministic & pure: `createBundle` / `transpileBundle` / `verifyBundle` / `diff` do no
   I/O and no clock reads, so identical inputs always hash identically.
+
+## The stored artifact and the `--bundled` deploy path
+
+`pgpm package` writes `sql/<name>--<version>.bundle.tar.gz` next to the consolidated
+`sql/<name>--<version>.sql`: it *is* the JSON `MigrationBundle`, tarred + gzipped
+(deterministic bytes, single `pgpm-bundle.json` entry). Each change also carries an `exec`
+slot — its deploy SQL already stripped of transaction/`CREATE EXTENSION` statements — so
+deploys never re-parse SQL. Commit the `.tar.gz`; the loose JSON is gitignored.
+
+`pgpm deploy --bundled` (`deployment.bundled`) then, per module: read the artifact →
+`verifyBundle` (mandatory sha256 gate) → execute only the pending changes' `exec` SQL in a
+single statement → bulk-insert `pgpm_migrate` packages/changes/dependencies/events in one
+round-trip. Unlike `--fast`, it writes a correct ledger, so re-deploys skip changes whose
+stored hash matches and a same-name/different-content change still errors.
+
+- **Ledger hash reconciliation:** the ledger's `script_hash` for a bundled change is
+  `change.deploy.digest` = sha256 of the deploy file bytes — exactly what
+  `PgpmMigrate.calculateScriptHash` computes under the default `content` method, so bundled
+  and per-change deploys are interchangeable. The `ast` hash method is not derivable from
+  the artifact, so it falls back.
+- **Graceful fallback:** missing artifact, unreadable archive, failed verification, no
+  `exec` SQL, or `hashMethod: 'ast'` → log and fall through to the existing `--fast` /
+  per-change paths. The bundle is opportunistic; it never fails a deploy on its own.
 
 ## Where this fits (cloud functions)
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ graphql/server/*.heapsnapshot
 /extensions/
 # Alternate install dirs configured via `extensionsDir` / PGPM_EXTENSIONS_DIR
 /extensions-*/
+
+# Loose/expanded migration bundle JSON — the committed artifact is the
+# gzipped tarball (sql/<name>--<version>.bundle.tar.gz).
+*.bundle.json
+pgpm-bundle.json

--- a/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
+++ b/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
@@ -49,6 +49,7 @@ exports[`getEnvOptions merges pgpm defaults, graphql defaults, config, env, and 
     "useLocksForRoles": false,
   },
   "deployment": {
+    "bundled": false,
     "cache": false,
     "fast": false,
     "hashMethod": "content",

--- a/pgpm/bundle/__tests__/archive.test.ts
+++ b/pgpm/bundle/__tests__/archive.test.ts
@@ -1,0 +1,124 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+
+import { hashString } from '@pgpmjs/ast';
+import {
+  BUNDLE_ARCHIVE_ENTRY,
+  bundleFromModule,
+  packBundle,
+  packSingleFileTarGz,
+  readBundleArchiveFile,
+  unpackBundle,
+  unpackSingleFileTarGz,
+  verifyBundle,
+  withExecutableSql,
+  writeBundleArchiveFile
+} from '../src';
+
+let sourceDir: string;
+
+const PLAN = `%syntax-version=1.0.0
+%project=my-module
+%uri=my-module
+
+schemas/auth/schema 2024-01-01T00:00:00Z Dev <dev@example.com> # add schema
+schemas/auth/tables/users [schemas/auth/schema] 2024-01-01T00:00:01Z Dev <dev@example.com> # add users
+`;
+
+const CONTROL = `default_version = '0.0.1'
+requires = 'plpgsql'
+`;
+
+const DEPLOY: Record<string, string> = {
+  'schemas/auth/schema': 'CREATE SCHEMA auth;',
+  'schemas/auth/tables/users': 'CREATE TABLE auth.users (id int PRIMARY KEY);'
+};
+
+function write(rel: string, content: string): void {
+  const file = join(sourceDir, rel);
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, content);
+}
+
+beforeEach(() => {
+  sourceDir = mkdtempSync(join(tmpdir(), 'pgpm-bundle-archive-'));
+  writeFileSync(join(sourceDir, 'pgpm.plan'), PLAN);
+  writeFileSync(join(sourceDir, 'my-module.control'), CONTROL);
+  for (const [change, sql] of Object.entries(DEPLOY)) {
+    write(`deploy/${change}.sql`, `-- Deploy ${change}\nBEGIN;\n${sql}\nCOMMIT;\n`);
+  }
+});
+
+afterEach(() => {
+  rmSync(sourceDir, { recursive: true, force: true });
+});
+
+describe('single-file tar.gz codec', () => {
+  it('round-trips content', () => {
+    const archive = packSingleFileTarGz('pgpm-bundle.json', '{"hello":"wörld"}');
+    expect(unpackSingleFileTarGz(archive)).toEqual({
+      name: 'pgpm-bundle.json',
+      content: '{"hello":"wörld"}'
+    });
+  });
+
+  it('is deterministic for identical content', () => {
+    const a = packSingleFileTarGz('x.json', 'same');
+    const b = packSingleFileTarGz('x.json', 'same');
+    expect(a.equals(b)).toBe(true);
+  });
+
+  it('rejects a non-archive payload', () => {
+    expect(() => unpackSingleFileTarGz(Buffer.from('not gzip'))).toThrow();
+  });
+});
+
+describe('bundle archive artifact', () => {
+  it('round-trips a bundle through the stored artifact', () => {
+    const bundle = bundleFromModule(sourceDir);
+    const restored = unpackBundle(packBundle(bundle));
+    expect(restored).toEqual(bundle);
+    expect(unpackSingleFileTarGz(packBundle(bundle)).name).toBe(BUNDLE_ARCHIVE_ENTRY);
+  });
+
+  it('writes and reads the artifact file', () => {
+    const bundle = bundleFromModule(sourceDir);
+    const path = join(sourceDir, 'sql', 'my-module--0.0.1.bundle.tar.gz');
+    writeBundleArchiveFile(bundle, path);
+    expect(readBundleArchiveFile(path)).toEqual(bundle);
+  });
+});
+
+describe('executable SQL slot', () => {
+  const execSql = { 'schemas/auth/schema': 'CREATE SCHEMA auth;' };
+
+  it('verifies and changes the content address', () => {
+    const bundle = bundleFromModule(sourceDir);
+    const withExec = withExecutableSql(bundle, execSql);
+
+    expect(verifyBundle(withExec)).toEqual([]);
+    expect(withExec.changes[0].exec).toEqual({
+      sql: execSql['schemas/auth/schema'],
+      digest: hashString(execSql['schemas/auth/schema'])
+    });
+    expect(withExec.manifest.digest).not.toBe(bundle.manifest.digest);
+    // changes without an exec entry keep their original digest
+    expect(withExec.changes[1]).toEqual(bundle.changes[1]);
+  });
+
+  it('detects tampered executable SQL', () => {
+    const withExec = withExecutableSql(bundleFromModule(sourceDir), execSql);
+    withExec.changes[0].exec!.sql = 'DROP SCHEMA auth;';
+
+    const issues = verifyBundle(withExec);
+    expect(issues.map(i => i.kind).sort()).toEqual(['exec-digest']);
+  });
+
+  it('keeps per-change deploy digests equal to sha256 of the deploy script bytes', () => {
+    const bundle = withExecutableSql(bundleFromModule(sourceDir), execSql);
+    for (const change of bundle.changes) {
+      expect(change.deploy!.digest).toBe(hashString(change.deploy!.sql));
+    }
+  });
+});

--- a/pgpm/bundle/src/create.ts
+++ b/pgpm/bundle/src/create.ts
@@ -8,6 +8,9 @@ import {
   MigrationBundle
 } from './types';
 
+/** Executable deploy SQL per change name, as produced at package time. */
+export type ExecSqlByChange = Record<string, string>;
+
 /**
  * Digest for a single change: its name plus the digests of its scripts, in a
  * fixed deploy/revert/verify order. A missing script contributes an empty slot
@@ -15,11 +18,20 @@ import {
  */
 export function computeChangeDigest(
   name: string,
-  scripts: { deploy?: string | null; revert?: string | null; verify?: string | null }
+  scripts: {
+    deploy?: string | null;
+    revert?: string | null;
+    verify?: string | null;
+    /**
+     * Digest of the pre-computed executable deploy SQL. Only contributes when
+     * defined, so digests of bundles without an `exec` slot are unchanged.
+     */
+    exec?: string | null;
+  }
 ): string {
-  return hashString(
-    [name, scripts.deploy ?? '', scripts.revert ?? '', scripts.verify ?? ''].join('\n')
-  );
+  const parts = [name, scripts.deploy ?? '', scripts.revert ?? '', scripts.verify ?? ''];
+  if (scripts.exec != null) parts.push(scripts.exec);
+  return hashString(parts.join('\n'));
 }
 
 /**
@@ -96,6 +108,51 @@ export function createBundle(
     control: module.control
       ? { fileName: module.control.fileName, content: module.control.raw }
       : null,
+    changes
+  };
+}
+
+/**
+ * Attach pre-computed executable deploy SQL to a bundle, re-deriving the
+ * per-change and top-level digests so the artifact stays content-addressed.
+ *
+ * The `exec` SQL is the deploy script with transaction / `CREATE EXTENSION`
+ * statements stripped — the form the deploy engine actually executes. Computing
+ * it requires a SQL parser, which this layer deliberately does not depend on, so
+ * the caller (`@pgpmjs/core` at package time) supplies it.
+ *
+ * Changes with no entry in `execSql` are left untouched.
+ */
+export function withExecutableSql(
+  bundle: MigrationBundle,
+  execSql: ExecSqlByChange
+): MigrationBundle {
+  const changes: BundleChange[] = bundle.changes.map(change => {
+    const sql = execSql[change.name];
+    if (sql === undefined) return change;
+    const exec = { sql, digest: hashString(sql) };
+    return {
+      ...change,
+      exec,
+      digest: computeChangeDigest(change.name, {
+        deploy: change.deploy?.digest,
+        revert: change.revert?.digest,
+        verify: change.verify?.digest,
+        exec: exec.digest
+      })
+    };
+  });
+
+  return {
+    ...bundle,
+    manifest: {
+      ...bundle.manifest,
+      digest: computeBundleDigest(
+        bundle.plan,
+        bundle.control?.content ?? null,
+        changes.map(c => c.digest)
+      )
+    },
     changes
   };
 }

--- a/pgpm/bundle/src/index.ts
+++ b/pgpm/bundle/src/index.ts
@@ -17,6 +17,7 @@ export * from './envelope';
 export * from './io';
 export * from './reconcile';
 export * from './split';
+export * from './tar';
 export * from './transpile';
 export * from './types';
 export * from './verify';

--- a/pgpm/bundle/src/io.ts
+++ b/pgpm/bundle/src/io.ts
@@ -15,10 +15,17 @@ import {
 import { writeModule } from '@pgpmjs/ast/module/writer';
 import { mapScripts } from '@pgpmjs/traverse';
 import { createBundle, CreateBundleOptions } from './create';
+import { packSingleFileTarGz, unpackSingleFileTarGz } from './tar';
 import { BundleScript, MigrationBundle } from './types';
 
 /** Default file name for a serialized bundle artifact. */
 export const BUNDLE_FILE_NAME = 'pgpm-bundle.json';
+
+/** The single entry name inside a `.bundle.tar.gz` archive. */
+export const BUNDLE_ARCHIVE_ENTRY = BUNDLE_FILE_NAME;
+
+/** Suffix of the stored bundle artifact: `sql/<name>--<version>.bundle.tar.gz`. */
+export const BUNDLE_ARCHIVE_EXTENSION = '.bundle.tar.gz';
 
 /**
  * Build a bundle straight from a module directory on disk (readModule → createBundle).
@@ -35,7 +42,12 @@ export function bundleFromModule(
  */
 export function writeBundleFile(bundle: MigrationBundle, filePath: string): void {
   mkdirSync(dirname(filePath), { recursive: true });
-  writeFileSync(filePath, JSON.stringify(bundle, null, 2) + '\n');
+  writeFileSync(filePath, serializeBundle(bundle));
+}
+
+/** Stable JSON serialization of a bundle (2-space formatting, trailing newline). */
+export function serializeBundle(bundle: MigrationBundle): string {
+  return JSON.stringify(bundle, null, 2) + '\n';
 }
 
 /**
@@ -43,6 +55,31 @@ export function writeBundleFile(bundle: MigrationBundle, filePath: string): void
  */
 export function readBundleFile(filePath: string): MigrationBundle {
   return JSON.parse(readFileSync(filePath, 'utf-8')) as MigrationBundle;
+}
+
+/** Serialize a bundle to the stored artifact form: gzipped tar of the JSON bundle. */
+export function packBundle(bundle: MigrationBundle): Buffer {
+  return packSingleFileTarGz(BUNDLE_ARCHIVE_ENTRY, serializeBundle(bundle));
+}
+
+/**
+ * Read a stored bundle artifact (gzipped tar) back into memory. Throws when the
+ * archive or its JSON payload is unreadable.
+ */
+export function unpackBundle(archive: Buffer): MigrationBundle {
+  const { content } = unpackSingleFileTarGz(archive);
+  return JSON.parse(content) as MigrationBundle;
+}
+
+/** Write the stored `.bundle.tar.gz` artifact for a bundle. */
+export function writeBundleArchiveFile(bundle: MigrationBundle, filePath: string): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, packBundle(bundle));
+}
+
+/** Read a stored `.bundle.tar.gz` artifact from disk. */
+export function readBundleArchiveFile(filePath: string): MigrationBundle {
+  return unpackBundle(readFileSync(filePath));
 }
 
 function scriptAstFromBundleScript(script: BundleScript): PgpmScriptAst {

--- a/pgpm/bundle/src/tar.ts
+++ b/pgpm/bundle/src/tar.ts
@@ -1,0 +1,90 @@
+import { gunzipSync, gzipSync } from 'zlib';
+
+/**
+ * Minimal, dependency-free single-file tar (ustar) + gzip codec.
+ *
+ * The bundle artifact shipped next to `sql/<name>--<version>.sql` is a gzipped
+ * tarball holding exactly one entry: the JSON bundle. Only that shape is
+ * supported — deliberately, so the artifact stays byte-reproducible and the
+ * package layer needs no third-party archive dependency.
+ */
+
+const BLOCK = 512;
+const NAME_MAX = 100;
+
+function octal(value: number, length: number): string {
+  return value.toString(8).padStart(length - 1, '0') + '\0';
+}
+
+function header(name: string, size: number): Buffer {
+  if (Buffer.byteLength(name) > NAME_MAX) {
+    throw new Error(`tar entry name too long (max ${NAME_MAX} bytes): ${name}`);
+  }
+  const buf = Buffer.alloc(BLOCK);
+  buf.write(name, 0, NAME_MAX, 'utf-8');
+  buf.write(octal(0o644, 8), 100, 8, 'ascii'); // mode
+  buf.write(octal(0, 8), 108, 8, 'ascii'); // uid
+  buf.write(octal(0, 8), 116, 8, 'ascii'); // gid
+  buf.write(octal(size, 12), 124, 12, 'ascii');
+  buf.write(octal(0, 12), 136, 12, 'ascii'); // mtime — fixed for reproducibility
+  buf.write('        ', 148, 8, 'ascii'); // checksum placeholder
+  buf.write('0', 156, 1, 'ascii'); // type: regular file
+  buf.write('ustar\0', 257, 6, 'ascii');
+  buf.write('00', 263, 2, 'ascii');
+
+  let checksum = 0;
+  for (const byte of buf) checksum += byte;
+  buf.write(octal(checksum, 8), 148, 8, 'ascii');
+  return buf;
+}
+
+function pad(size: number): number {
+  const rem = size % BLOCK;
+  return rem === 0 ? 0 : BLOCK - rem;
+}
+
+/**
+ * Pack a single named file into a gzipped tarball. Deterministic: fixed mode,
+ * zero mtime/uid/gid, so identical content always yields identical bytes.
+ */
+export function packSingleFileTarGz(name: string, content: string): Buffer {
+  const body = Buffer.from(content, 'utf-8');
+  const tar = Buffer.concat([
+    header(name, body.length),
+    body,
+    Buffer.alloc(pad(body.length)),
+    Buffer.alloc(BLOCK * 2) // end-of-archive
+  ]);
+  return gzipSync(tar, { level: 9 });
+}
+
+/** One entry read back out of a single-file tarball. */
+export interface TarEntry {
+  name: string;
+  content: string;
+}
+
+/**
+ * Read the first regular-file entry out of a gzipped tarball, in memory.
+ *
+ * @throws when the archive is empty or its header is not a readable ustar block.
+ */
+export function unpackSingleFileTarGz(archive: Buffer): TarEntry {
+  const tar = gunzipSync(archive);
+  if (tar.length < BLOCK) {
+    throw new Error('invalid tar archive: shorter than one block');
+  }
+  const name = tar.subarray(0, NAME_MAX).toString('utf-8').replace(/\0.*$/, '');
+  if (!name) {
+    throw new Error('invalid tar archive: no entries');
+  }
+  const sizeField = tar.subarray(124, 136).toString('ascii').replace(/\0.*$/, '').trim();
+  const size = parseInt(sizeField, 8);
+  if (!Number.isFinite(size) || size < 0) {
+    throw new Error(`invalid tar archive: unreadable size field for ${name}`);
+  }
+  if (tar.length < BLOCK + size) {
+    throw new Error(`invalid tar archive: truncated body for ${name}`);
+  }
+  return { name, content: tar.subarray(BLOCK, BLOCK + size).toString('utf-8') };
+}

--- a/pgpm/bundle/src/types.ts
+++ b/pgpm/bundle/src/types.ts
@@ -16,6 +16,20 @@ export interface BundleScript {
 }
 
 /**
+ * Pre-computed, directly executable deploy SQL for a change: the deploy script
+ * with its transaction/`CREATE EXTENSION` statements stripped, so many changes
+ * can be concatenated and run as one statement inside a caller-owned
+ * transaction. Produced at package time — this is the disk+parse work the
+ * bundled deploy path no longer has to redo on every deployment.
+ */
+export interface BundleExec {
+  /** Executable SQL text. */
+  sql: string;
+  /** sha256 of {@link sql}. */
+  digest: string;
+}
+
+/**
  * One change inside a bundle: identity + plan dependencies + its scripts.
  */
 export interface BundleChange {
@@ -24,6 +38,12 @@ export interface BundleChange {
   deploy: BundleScript | null;
   revert: BundleScript | null;
   verify: BundleScript | null;
+  /**
+   * Optional pre-computed executable deploy SQL (see {@link BundleExec}).
+   * Absent in bundles produced before the bundled-deploy fast path; when
+   * present it participates in {@link digest}.
+   */
+  exec?: BundleExec | null;
   /** sha256 over the change's identity + script digests (see `computeChangeDigest`). */
   digest: string;
 }

--- a/pgpm/bundle/src/verify.ts
+++ b/pgpm/bundle/src/verify.ts
@@ -9,6 +9,7 @@ import { MigrationBundle } from './types';
 export interface BundleIssue {
   kind:
     | 'script-digest'
+    | 'exec-digest'
     | 'change-digest'
     | 'bundle-digest'
     | 'order-mismatch'
@@ -55,10 +56,18 @@ export function verifyBundle(bundle: MigrationBundle): BundleIssue[] {
         });
       }
     });
+    if (change.exec && hashString(change.exec.sql) !== change.exec.digest) {
+      issues.push({
+        kind: 'exec-digest',
+        change: change.name,
+        message: 'executable deploy digest does not match its sql'
+      });
+    }
     const expected = computeChangeDigest(change.name, {
       deploy: change.deploy?.digest,
       revert: change.revert?.digest,
-      verify: change.verify?.digest
+      verify: change.verify?.digest,
+      exec: change.exec?.digest
     });
     if (expected !== change.digest) {
       issues.push({

--- a/pgpm/cli/__tests__/__snapshots__/package.test.ts.snap
+++ b/pgpm/cli/__tests__/__snapshots__/package.test.ts.snap
@@ -8,6 +8,7 @@ exports[`cmds:package updates module with \`extension\` and \`package\` commands
   "Makefile",
   "verify/procedures/secretfunction.sql",
   "sql/secrets--0.0.1.sql",
+  "sql/secrets--0.0.1.bundle.tar.gz",
   "revert/procedures/secretfunction.sql",
   "deploy/procedures/secretfunction.sql",
 ]

--- a/pgpm/cli/src/commands/deploy.ts
+++ b/pgpm/cli/src/commands/deploy.ts
@@ -25,10 +25,10 @@ Options:
   --package <name>   Target specific package
   --to <target>      Deploy to specific change or tag
   --tx               Use transactions (default: true)
-  --fast             Use fast deployment strategy (one-shot SQL, no ledger)
-  --bundled          Deploy from each module's sql/*.bundle.tar.gz artifact
-                     (verified one-shot SQL + migration ledger; falls back to
-                     the standard path when no artifact is available)
+  --fast             Fast strategy: one-shot SQL + bulk migration ledger,
+                     reading each module's verified sql/*.bundle.tar.gz artifact
+                     when present and building it from deploy/ when not
+  --bundled          Alias for --fast
   --logOnly          Log-only mode, skip script execution
   --usePlan          Use deployment plan
   --cache            Enable caching
@@ -39,7 +39,7 @@ Examples:
   pgpm deploy --createdb                   Deploy with database creation
   pgpm deploy --package mypackage --to @v1.0.0  Deploy specific package to tag
   pgpm deploy --fast --no-tx              Fast deployment without transactions
-  pgpm deploy --bundled                    Deploy from prebuilt bundle artifacts
+  pgpm deploy --bundled                    Same as --fast
 `;
 
 export default async (
@@ -108,7 +108,7 @@ export default async (
     {
       name: 'bundled',
       type: 'confirm',
-      message: 'Deploy from prebuilt bundle artifacts?',
+      message: 'Prefer prebuilt bundle artifacts (alias of fast)?',
       useDefault: true,
       default: false,
       required: false

--- a/pgpm/cli/src/commands/deploy.ts
+++ b/pgpm/cli/src/commands/deploy.ts
@@ -25,7 +25,10 @@ Options:
   --package <name>   Target specific package
   --to <target>      Deploy to specific change or tag
   --tx               Use transactions (default: true)
-  --fast             Use fast deployment strategy
+  --fast             Use fast deployment strategy (one-shot SQL, no ledger)
+  --bundled          Deploy from each module's sql/*.bundle.tar.gz artifact
+                     (verified one-shot SQL + migration ledger; falls back to
+                     the standard path when no artifact is available)
   --logOnly          Log-only mode, skip script execution
   --usePlan          Use deployment plan
   --cache            Enable caching
@@ -36,6 +39,7 @@ Examples:
   pgpm deploy --createdb                   Deploy with database creation
   pgpm deploy --package mypackage --to @v1.0.0  Deploy specific package to tag
   pgpm deploy --fast --no-tx              Fast deployment without transactions
+  pgpm deploy --bundled                    Deploy from prebuilt bundle artifacts
 `;
 
 export default async (
@@ -102,6 +106,14 @@ export default async (
       required: false
     },
     {
+      name: 'bundled',
+      type: 'confirm',
+      message: 'Deploy from prebuilt bundle artifacts?',
+      useDefault: true,
+      default: false,
+      required: false
+    },
+    {
       name: 'logOnly',
       type: 'confirm',
       message: 'Log-only mode (skip script execution)?',
@@ -111,7 +123,7 @@ export default async (
     }
   ];
 
-  let { yes, recursive, createdb, cwd, tx, fast, logOnly } = await prompter.prompt(argv, questions);
+  let { yes, recursive, createdb, cwd, tx, fast, bundled, logOnly } = await prompter.prompt(argv, questions);
 
   if (!yes) {
     log.info('Operation cancelled.');
@@ -137,6 +149,7 @@ export default async (
     deployment: {
       useTx: tx !== false,
       fast: fast !== false,
+      bundled: bundled === true,
       usePlan: argv.usePlan !== false,
       cache: argv.cache !== false,
       logOnly: argv.logOnly !== false,

--- a/pgpm/cli/src/commands/package.ts
+++ b/pgpm/cli/src/commands/package.ts
@@ -14,12 +14,14 @@ Options:
   --pretty                        Pretty-print output (default: true)
   --functionDelimiter <delimiter> Function delimiter (default: $EOFCODE$)
   --outputDiff                    Export AST diff files when round-trip mismatch detected (default: false)
+  --bundle                        Also emit sql/<name>--<version>.bundle.tar.gz (default: true)
   --cwd <directory>               Working directory (default: current directory)
 
 Examples:
   pgpm package                     Package with defaults
   pgpm package --no-plan           Package without plan
   pgpm package --outputDiff        Package and export AST diff files if mismatch detected
+  pgpm package --no-bundle         Package without emitting the bundle artifact
 `;
 
 export default async (
@@ -60,10 +62,17 @@ export default async (
       default: false,
       useDefault: true,
       required: false
+    },
+    {
+      type: 'confirm',
+      name: 'bundle',
+      default: true,
+      useDefault: true,
+      required: false
     }
   ];
 
-  let { cwd, plan, pretty, functionDelimiter, outputDiff } = await prompter.prompt(argv, questions);
+  let { cwd, plan, pretty, functionDelimiter, outputDiff, bundle } = await prompter.prompt(argv, questions);
 
   const project = new PgpmPackage(cwd);
 
@@ -79,7 +88,8 @@ export default async (
     packageDir: project.modulePath,
     pretty,
     functionDelimiter,
-    outputDiff
+    outputDiff,
+    bundle: bundle !== false
   });
 
   return argv;

--- a/pgpm/core/__tests__/bundle/bundled-deploy.test.ts
+++ b/pgpm/core/__tests__/bundle/bundled-deploy.test.ts
@@ -16,11 +16,12 @@ import { CoreDeployTestFixture } from '../../test-utils/CoreDeployTestFixture';
 const MODULES = ['my-first', 'my-second', 'my-third'] as const;
 
 /**
- * The bundle-backed deploy path ("fast v2"): a pre-built, content-addressed
- * artifact is executed in one shot AND recorded in the `pgpm_migrate` ledger,
- * with graceful fallback whenever the artifact cannot be trusted.
+ * The fast deploy strategy: one-shot execution AND a `pgpm_migrate` ledger,
+ * reading the pre-built content-addressed artifact when it verifies and
+ * rebuilding from `deploy/` when it does not. Either way the executed SQL and
+ * the recorded hashes are identical — no deploy is ever left unledgered.
  */
-describe('bundled deployment', () => {
+describe('fast (bundle-backed) deployment', () => {
   let fixture: CoreDeployTestFixture;
   let db: TestDatabase;
 
@@ -127,7 +128,38 @@ describe('bundled deployment', () => {
     }
   });
 
-  it('falls back to the standard path when no artifact exists', async () => {
+  it('ledgers under the legacy `fast` flag, with and without an artifact', async () => {
+    // `fast` used to execute one-shot and record nothing; it must now produce
+    // the same ledger as every other path.
+    await fixture.deployModule('my-third', db.name, ['sqitch', 'simple-w-tags'], false, {
+      fast: true
+    });
+    expect(await db.exists('schema', 'myfirstapp')).toBe(true);
+    const withoutArtifact = await ledger();
+    expect(withoutArtifact.length).toBe(8);
+
+    const other = new CoreDeployTestFixture('sqitch', 'simple-w-tags');
+    const otherDb = await other.setupTestDatabase();
+    try {
+      for (const name of MODULES) {
+        const dir = other.fixturePath('packages', name);
+        await writeBundleArtifact(dir, require(join(dir, 'package.json')).version as string);
+      }
+      await other.deployModule('my-third', otherDb.name, ['sqitch', 'simple-w-tags'], false, {
+        fast: true
+      });
+      const withArtifact = (
+        await otherDb.query(
+          'SELECT package, change_name, script_hash FROM pgpm_migrate.changes ORDER BY package, change_name'
+        )
+      ).rows;
+      expect(withArtifact).toEqual(withoutArtifact);
+    } finally {
+      await other.cleanup();
+    }
+  });
+
+  it('still deploys and ledgers when no artifact exists', async () => {
     await fixture.deployModule('my-third', db.name, ['sqitch', 'simple-w-tags'], false, {
       bundled: true
     });
@@ -136,7 +168,7 @@ describe('bundled deployment', () => {
     expect((await ledger()).length).toBe(8);
   });
 
-  it('falls back when an artifact fails hash verification', async () => {
+  it('rebuilds from deploy/ when an artifact fails hash verification', async () => {
     await emitArtifacts();
 
     const artifactPath = resolveBundleArtifactPath(modulePath('my-first'))!;
@@ -153,7 +185,7 @@ describe('bundled deployment', () => {
     expect((await ledger()).length).toBe(8);
   });
 
-  it('falls back when the artifact archive is corrupt', async () => {
+  it('rebuilds from deploy/ when the artifact archive is corrupt', async () => {
     await emitArtifacts();
     writeFileSync(resolveBundleArtifactPath(modulePath('my-second'))!, 'not-an-archive');
 

--- a/pgpm/core/__tests__/bundle/bundled-deploy.test.ts
+++ b/pgpm/core/__tests__/bundle/bundled-deploy.test.ts
@@ -1,0 +1,174 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+import { hashString } from '@pgpmjs/ast';
+import { readBundleArchiveFile, writeBundleArchiveFile } from '@pgpmjs/bundle';
+
+import {
+  bundleArtifactFileName,
+  buildExecutableBundle,
+  resolveBundleArtifactPath,
+  writeBundleArtifact
+} from '../../src/bundle/artifact';
+import { TestDatabase } from '../../test-utils';
+import { CoreDeployTestFixture } from '../../test-utils/CoreDeployTestFixture';
+
+const MODULES = ['my-first', 'my-second', 'my-third'] as const;
+
+/**
+ * The bundle-backed deploy path ("fast v2"): a pre-built, content-addressed
+ * artifact is executed in one shot AND recorded in the `pgpm_migrate` ledger,
+ * with graceful fallback whenever the artifact cannot be trusted.
+ */
+describe('bundled deployment', () => {
+  let fixture: CoreDeployTestFixture;
+  let db: TestDatabase;
+
+  const modulePath = (name: string): string =>
+    fixture.fixturePath('packages', name);
+
+  const emitArtifacts = async (): Promise<void> => {
+    for (const name of MODULES) {
+      const dir = modulePath(name);
+      const version = require(join(dir, 'package.json')).version as string;
+      await writeBundleArtifact(dir, version);
+    }
+  };
+
+  const ledger = async () =>
+    (
+      await db.query(
+        'SELECT package, change_name, script_hash FROM pgpm_migrate.changes ORDER BY package, change_name'
+      )
+    ).rows;
+
+  beforeEach(async () => {
+    fixture = new CoreDeployTestFixture('sqitch', 'simple-w-tags');
+    db = await fixture.setupTestDatabase();
+  });
+
+  afterEach(async () => {
+    await fixture.cleanup();
+  });
+
+  it('emits an artifact whose change digests match the ledger hash scheme', async () => {
+    await emitArtifacts();
+
+    const dir = modulePath('my-first');
+    const artifactPath = resolveBundleArtifactPath(dir);
+    expect(artifactPath).toBe(
+      join(dir, 'sql', bundleArtifactFileName('my-first', '0.0.1'))
+    );
+
+    const bundle = readBundleArchiveFile(artifactPath!);
+    for (const change of bundle.changes) {
+      // The ledger's default `content` hash is sha256 over the deploy file bytes;
+      // the bundle records exactly that, so both systems agree on a change hash.
+      const onDisk = readFileSync(join(dir, 'deploy', `${change.name}.sql`), 'utf-8');
+      expect(change.deploy!.digest).toBe(hashString(onDisk));
+      expect(change.exec!.sql).not.toMatch(/\bBEGIN;/);
+    }
+  });
+
+  it('deploys from the artifact and records one ledger row per change', async () => {
+    await emitArtifacts();
+
+    await fixture.deployModule('my-third', db.name, ['sqitch', 'simple-w-tags'], false, {
+      bundled: true
+    });
+
+    expect(await db.exists('schema', 'myfirstapp')).toBe(true);
+
+    const rows = await ledger();
+    expect(rows.length).toBe(8);
+    expect(new Set(rows.map((r: any) => r.package))).toEqual(
+      new Set(['my-first', 'my-second', 'my-third'])
+    );
+
+    const deps = await db.query(
+      'SELECT count(*)::int AS count FROM pgpm_migrate.dependencies'
+    );
+    expect(deps.rows[0].count).toBeGreaterThan(0);
+  });
+
+  it('is idempotent: a second bundled deploy skips every change', async () => {
+    await emitArtifacts();
+
+    const deploy = () =>
+      fixture.deployModule('my-third', db.name, ['sqitch', 'simple-w-tags'], false, {
+        bundled: true
+      });
+
+    await deploy();
+    const first = await ledger();
+    await deploy();
+    expect(await ledger()).toEqual(first);
+  });
+
+  it('produces the same ledger as the standard per-change deploy path', async () => {
+    await emitArtifacts();
+    await fixture.deployModule('my-third', db.name, ['sqitch', 'simple-w-tags'], false, {
+      bundled: true
+    });
+    const bundled = await ledger();
+
+    const other = new CoreDeployTestFixture('sqitch', 'simple-w-tags');
+    const otherDb = await other.setupTestDatabase();
+    try {
+      await other.deployModule('my-third', otherDb.name, ['sqitch', 'simple-w-tags']);
+      const standard = (
+        await otherDb.query(
+          'SELECT package, change_name, script_hash FROM pgpm_migrate.changes ORDER BY package, change_name'
+        )
+      ).rows;
+      expect(bundled).toEqual(standard);
+    } finally {
+      await other.cleanup();
+    }
+  });
+
+  it('falls back to the standard path when no artifact exists', async () => {
+    await fixture.deployModule('my-third', db.name, ['sqitch', 'simple-w-tags'], false, {
+      bundled: true
+    });
+
+    expect(await db.exists('schema', 'myfirstapp')).toBe(true);
+    expect((await ledger()).length).toBe(8);
+  });
+
+  it('falls back when an artifact fails hash verification', async () => {
+    await emitArtifacts();
+
+    const artifactPath = resolveBundleArtifactPath(modulePath('my-first'))!;
+    const tampered = readBundleArchiveFile(artifactPath);
+    tampered.changes[0].exec!.sql = 'CREATE SCHEMA tampered;';
+    writeBundleArchiveFile(tampered, artifactPath);
+
+    await fixture.deployModule('my-third', db.name, ['sqitch', 'simple-w-tags'], false, {
+      bundled: true
+    });
+
+    expect(await db.exists('schema', 'tampered')).toBe(false);
+    expect(await db.exists('schema', 'myfirstapp')).toBe(true);
+    expect((await ledger()).length).toBe(8);
+  });
+
+  it('falls back when the artifact archive is corrupt', async () => {
+    await emitArtifacts();
+    writeFileSync(resolveBundleArtifactPath(modulePath('my-second'))!, 'not-an-archive');
+
+    await fixture.deployModule('my-third', db.name, ['sqitch', 'simple-w-tags'], false, {
+      bundled: true
+    });
+
+    expect((await ledger()).length).toBe(8);
+  });
+
+  it('builds executable SQL for every change with a deploy script', async () => {
+    const bundle = await buildExecutableBundle(modulePath('my-first'));
+    expect(bundle.changes.length).toBeGreaterThan(0);
+    for (const change of bundle.changes) {
+      expect(change.exec!.digest).toBe(hashString(change.exec!.sql));
+    }
+  });
+});

--- a/pgpm/core/src/bundle/artifact.ts
+++ b/pgpm/core/src/bundle/artifact.ts
@@ -1,0 +1,110 @@
+import { existsSync, readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+import { getExtensionName, parseControlContent } from '@pgpmjs/ast/files';
+import {
+  BUNDLE_ARCHIVE_EXTENSION,
+  bundleFromModule,
+  CreateBundleOptions,
+  ExecSqlByChange,
+  MigrationBundle,
+  readBundleArchiveFile,
+  withExecutableSql,
+  writeBundleArchiveFile
+} from '@pgpmjs/bundle';
+
+import { cleanSql } from '../migrate/clean';
+
+/**
+ * Artifact file name for a module's stored bundle: it lives beside the packaged
+ * `sql/<name>--<version>.sql` as `sql/<name>--<version>.bundle.tar.gz`.
+ */
+export function bundleArtifactFileName(name: string, version: string): string {
+  return `${name}--${version}${BUNDLE_ARCHIVE_EXTENSION}`;
+}
+
+/**
+ * Locate a module's stored bundle artifact, if it has one.
+ *
+ * Prefers the version declared in the module's `.control` file, then falls back
+ * to any single `sql/*.bundle.tar.gz` present — so a module packaged at a
+ * different version still gets the fast path instead of silently degrading.
+ * Returns `null` when the module ships no artifact.
+ */
+export function resolveBundleArtifactPath(moduleDir: string): string | null {
+  const sqlDir = join(moduleDir, 'sql');
+  if (!existsSync(sqlDir)) return null;
+
+  let name: string;
+  try {
+    name = getExtensionName(moduleDir);
+  } catch {
+    return null;
+  }
+
+  const controlPath = join(moduleDir, `${name}.control`);
+  if (existsSync(controlPath)) {
+    const { version } = parseControlContent(readFileSync(controlPath, 'utf-8'));
+    if (version) {
+      const versioned = join(sqlDir, bundleArtifactFileName(name, version));
+      if (existsSync(versioned)) return versioned;
+    }
+  }
+
+  const candidates = readdirSync(sqlDir).filter(
+    file => file.startsWith(`${name}--`) && file.endsWith(BUNDLE_ARCHIVE_EXTENSION)
+  );
+  if (candidates.length !== 1) return null;
+  return join(sqlDir, candidates[0]);
+}
+
+/**
+ * Build the executable form of a module's bundle: the content-addressed AST
+ * snapshot plus, per change, the deploy SQL with transaction / `CREATE
+ * EXTENSION` statements stripped (`cleanSql`).
+ *
+ * That pre-computation is the whole point of the artifact — the parse/deparse
+ * work moves from every deploy to the one-time package step, while the digests
+ * still cover the exact bytes that will be executed.
+ */
+export async function buildExecutableBundle(
+  moduleDir: string,
+  options?: CreateBundleOptions
+): Promise<MigrationBundle> {
+  const bundle = bundleFromModule(moduleDir, options);
+  const execSql: ExecSqlByChange = {};
+  for (const change of bundle.changes) {
+    if (!change.deploy) continue;
+    execSql[change.name] = await cleanSql(change.deploy.sql, false, '$EOFCODE$');
+  }
+  return withExecutableSql(bundle, execSql);
+}
+
+/**
+ * Emit a module's stored bundle artifact into `sql/`, returning its path.
+ */
+export async function writeBundleArtifact(
+  moduleDir: string,
+  version: string,
+  options?: CreateBundleOptions
+): Promise<string> {
+  const bundle = await buildExecutableBundle(moduleDir, options);
+  const outPath = join(moduleDir, 'sql', bundleArtifactFileName(bundle.manifest.name, version));
+  writeBundleArchiveFile(bundle, outPath);
+  return outPath;
+}
+
+/**
+ * Read a module's stored bundle artifact, or `null` when it has none or the
+ * archive cannot be read. Never throws — a broken artifact must degrade to the
+ * normal packaging path, not fail the deploy.
+ */
+export function readBundleArtifact(moduleDir: string): MigrationBundle | null {
+  const artifactPath = resolveBundleArtifactPath(moduleDir);
+  if (!artifactPath) return null;
+  try {
+    return readBundleArchiveFile(artifactPath);
+  } catch {
+    return null;
+  }
+}

--- a/pgpm/core/src/bundle/deploy-bundled.ts
+++ b/pgpm/core/src/bundle/deploy-bundled.ts
@@ -1,23 +1,27 @@
 import { Logger } from '@pgpmjs/logger';
-import { MigrationBundle, verifyBundle } from '@pgpmjs/bundle';
+import { BundleChange, MigrationBundle, verifyBundle } from '@pgpmjs/bundle';
 import { getPgPool } from 'pg-cache';
 import { PgConfig } from 'pg-env';
 
 import { PgpmMigrate } from '../migrate/client';
-import { readBundleArtifact } from './artifact';
+import { buildExecutableBundle, readBundleArtifact } from './artifact';
 
-const log = new Logger('deploy-bundled');
+const log = new Logger('deploy-fast');
 
-/** Why a bundled deploy could not be used, so the caller can fall back. */
-export type BundledDeploySkipReason =
-  | 'no-artifact'
-  | 'unverified'
-  | 'no-executable-sql'
-  | 'unsupported-hash-method';
+/**
+ * Why the one-shot path could not be used, so the caller falls back to the
+ * per-change migration path.
+ */
+export type BundledDeploySkipReason = 'no-executable-sql' | 'unsupported-hash-method';
+
+/** How the executable bundle for a module was obtained. */
+export type BundleSource = 'artifact' | 'packaged';
 
 export interface BundledDeployResult {
   /** Module (package) name from the bundle manifest. */
   name: string;
+  /** Where the executable bundle came from. */
+  source: BundleSource;
   /** Changes executed and recorded on this run, in deploy order. */
   deployed: string[];
   /** Changes already present in the ledger with a matching hash. */
@@ -35,8 +39,8 @@ export interface BundledDeployOptions {
   /**
    * Ledger hash scheme in force. The bundle's per-change digests are sha256 of
    * the deploy script's bytes, i.e. identical to `PgpmMigrate`'s `content`
-   * scheme; the `ast` scheme is not reconcilable from the artifact, so it is
-   * reported as a skip and the caller falls back.
+   * scheme; the `ast` scheme is not reproducible here, so it is reported as a
+   * skip and the caller falls back.
    */
   hashMethod?: 'content' | 'ast';
 }
@@ -51,38 +55,63 @@ export class BundledDeployConflictError extends Error {
   }
 }
 
-const isSkipped = (
-  value: BundledDeployResult | BundledDeploySkipReason
-): value is BundledDeploySkipReason => typeof value === 'string';
-
 /**
- * The ledger hash for a bundled change: the sha256 of the deploy script bytes.
+ * The ledger hash for a change: the sha256 of the deploy script bytes.
  *
  * This is deliberately the same value `PgpmMigrate.calculateScriptHash` derives
  * from `deploy/<change>.sql` under the default `content` hash method, so a
  * change hashed at package time and the hash recorded/compared at deploy time
- * agree — bundled and non-bundled deploys are interchangeable and idempotent
+ * agree — the one-shot and per-change paths are interchangeable and idempotent
  * against each other.
  */
-export function ledgerHashForChange(change: MigrationBundle['changes'][number]): string | null {
+export function ledgerHashForChange(change: BundleChange): string | null {
   return change.deploy?.digest ?? null;
 }
 
 /**
- * Deploy a module from its stored bundle artifact — the ledger-preserving "fast"
- * path.
+ * Load a module's executable bundle: its stored artifact when one verifies,
+ * otherwise built from `deploy/` on the fly.
  *
- * Reads `sql/<name>--<version>.bundle.tar.gz` (un-tarred in memory), gates on
- * `verifyBundle`, then executes the pending changes' pre-computed deploy SQL as a
- * single statement and records one `pgpm_migrate.changes` row per change with the
- * artifact's own digest as `script_hash` — bulk-inserted in one round-trip
- * instead of a `CALL pgpm_migrate.deploy` per change.
- *
- * Returns a {@link BundledDeploySkipReason} (rather than throwing) whenever the
- * artifact is missing, stale, or unverifiable, so the caller falls back to the
- * normal packaging/deploy path. Genuine SQL failures still throw.
+ * The artifact is purely an optimization — it removes the read+parse work, not
+ * a capability. Whatever the source, the resulting bundle is byte-identical in
+ * what it executes and in the hashes it records, so a module without an
+ * artifact deploys exactly the same way, just slower.
  */
-export async function deployModuleFromBundle(
+async function loadExecutableBundle(
+  moduleDir: string
+): Promise<{ bundle: MigrationBundle; source: BundleSource }> {
+  const stored = readBundleArtifact(moduleDir);
+  if (stored) {
+    const issues = verifyBundle(stored);
+    if (issues.length === 0) {
+      return { bundle: stored, source: 'artifact' };
+    }
+    log.warn(
+      `⚠️ Bundle artifact for ${stored.manifest.name} failed verification ` +
+        `(${issues.map(i => i.kind).join(', ')}); rebuilding from deploy/.`
+    );
+  }
+  return { bundle: await buildExecutableBundle(moduleDir), source: 'packaged' };
+}
+
+/**
+ * Deploy a module in one shot **and** record the migration ledger — the `fast`
+ * deploy strategy.
+ *
+ * Pending changes' deploy SQL is concatenated and executed as a single
+ * statement (the speed of the old fast path), then one `pgpm_migrate.changes`
+ * row per change is bulk-inserted with the deploy script's own sha256 as
+ * `script_hash` — one round-trip, instead of an `isDeployed` + `readScript` +
+ * `CALL pgpm_migrate.deploy` per change. Because the ledger is written, the
+ * path is idempotent and resumable: re-deploys skip changes whose stored hash
+ * matches, and a same-name/different-content change raises
+ * {@link BundledDeployConflictError} exactly as the per-change path does.
+ *
+ * Returns a {@link BundledDeploySkipReason} (rather than throwing) when it
+ * cannot honour the requested semantics, so the caller falls back to the
+ * per-change migration path. Genuine SQL failures still throw.
+ */
+export async function deployModuleFast(
   moduleDir: string,
   options: BundledDeployOptions
 ): Promise<BundledDeployResult | BundledDeploySkipReason> {
@@ -90,17 +119,7 @@ export async function deployModuleFromBundle(
     return 'unsupported-hash-method';
   }
 
-  const bundle = readBundleArtifact(moduleDir);
-  if (!bundle) return 'no-artifact';
-
-  const issues = verifyBundle(bundle);
-  if (issues.length > 0) {
-    log.warn(
-      `⚠️ Bundle artifact for ${bundle.manifest.name} failed verification ` +
-        `(${issues.map(i => i.kind).join(', ')}); falling back to packaging.`
-    );
-    return 'unverified';
-  }
+  const { bundle, source } = await loadExecutableBundle(moduleDir);
 
   const executable = bundle.changes.filter(change => change.deploy);
   if (executable.length === 0 || executable.some(change => !change.exec)) {
@@ -123,7 +142,7 @@ export async function deployModuleFromBundle(
   );
   const deployedHashes = new Map(existing.rows.map(row => [row.change_name, row.script_hash]));
 
-  const pending: typeof executable = [];
+  const pending: BundleChange[] = [];
   const skipped: string[] = [];
   for (const change of executable) {
     const hash = ledgerHashForChange(change)!;
@@ -140,7 +159,7 @@ export async function deployModuleFromBundle(
 
   if (pending.length === 0) {
     log.info(`⚡ ${packageName}: all ${skipped.length} change(s) already deployed.`);
-    return { name: packageName, deployed: [], skipped };
+    return { name: packageName, source, deployed: [], skipped };
   }
 
   const changeNames = pending.map(change => change.name);
@@ -205,15 +224,16 @@ export async function deployModuleFromBundle(
 
   log.success(
     `⚡ ${packageName}: ${changeNames.length} change(s) ${options.logOnly ? 'logged' : 'deployed'} ` +
-      `from bundle artifact (${skipped.length} already deployed).`
+      `from ${source === 'artifact' ? 'bundle artifact' : 'packaged deploy/'} ` +
+      `(${skipped.length} already deployed).`
   );
 
-  return { name: packageName, deployed: changeNames, skipped };
+  return { name: packageName, source, deployed: changeNames, skipped };
 }
 
-/** True when the value is a real bundled-deploy result rather than a skip. */
+/** True when the value is a real deploy result rather than a skip reason. */
 export function isBundledDeployResult(
   value: BundledDeployResult | BundledDeploySkipReason
 ): value is BundledDeployResult {
-  return !isSkipped(value);
+  return typeof value !== 'string';
 }

--- a/pgpm/core/src/bundle/deploy-bundled.ts
+++ b/pgpm/core/src/bundle/deploy-bundled.ts
@@ -1,0 +1,219 @@
+import { Logger } from '@pgpmjs/logger';
+import { MigrationBundle, verifyBundle } from '@pgpmjs/bundle';
+import { getPgPool } from 'pg-cache';
+import { PgConfig } from 'pg-env';
+
+import { PgpmMigrate } from '../migrate/client';
+import { readBundleArtifact } from './artifact';
+
+const log = new Logger('deploy-bundled');
+
+/** Why a bundled deploy could not be used, so the caller can fall back. */
+export type BundledDeploySkipReason =
+  | 'no-artifact'
+  | 'unverified'
+  | 'no-executable-sql'
+  | 'unsupported-hash-method';
+
+export interface BundledDeployResult {
+  /** Module (package) name from the bundle manifest. */
+  name: string;
+  /** Changes executed and recorded on this run, in deploy order. */
+  deployed: string[];
+  /** Changes already present in the ledger with a matching hash. */
+  skipped: string[];
+}
+
+export interface BundledDeployOptions {
+  config: PgConfig;
+  /** Target database (defaults to `config.database`). */
+  database?: string;
+  /** Record ledger rows without executing the DDL. */
+  logOnly?: boolean;
+  /** Wrap execution + ledger writes in one transaction. Default true. */
+  useTransaction?: boolean;
+  /**
+   * Ledger hash scheme in force. The bundle's per-change digests are sha256 of
+   * the deploy script's bytes, i.e. identical to `PgpmMigrate`'s `content`
+   * scheme; the `ast` scheme is not reconcilable from the artifact, so it is
+   * reported as a skip and the caller falls back.
+   */
+  hashMethod?: 'content' | 'ast';
+}
+
+/** Thrown when the ledger already holds a change with different content. */
+export class BundledDeployConflictError extends Error {
+  constructor(readonly packageName: string, readonly changeName: string) {
+    super(
+      `Change ${changeName} already deployed in package ${packageName} with different content`
+    );
+    this.name = 'BundledDeployConflictError';
+  }
+}
+
+const isSkipped = (
+  value: BundledDeployResult | BundledDeploySkipReason
+): value is BundledDeploySkipReason => typeof value === 'string';
+
+/**
+ * The ledger hash for a bundled change: the sha256 of the deploy script bytes.
+ *
+ * This is deliberately the same value `PgpmMigrate.calculateScriptHash` derives
+ * from `deploy/<change>.sql` under the default `content` hash method, so a
+ * change hashed at package time and the hash recorded/compared at deploy time
+ * agree — bundled and non-bundled deploys are interchangeable and idempotent
+ * against each other.
+ */
+export function ledgerHashForChange(change: MigrationBundle['changes'][number]): string | null {
+  return change.deploy?.digest ?? null;
+}
+
+/**
+ * Deploy a module from its stored bundle artifact — the ledger-preserving "fast"
+ * path.
+ *
+ * Reads `sql/<name>--<version>.bundle.tar.gz` (un-tarred in memory), gates on
+ * `verifyBundle`, then executes the pending changes' pre-computed deploy SQL as a
+ * single statement and records one `pgpm_migrate.changes` row per change with the
+ * artifact's own digest as `script_hash` — bulk-inserted in one round-trip
+ * instead of a `CALL pgpm_migrate.deploy` per change.
+ *
+ * Returns a {@link BundledDeploySkipReason} (rather than throwing) whenever the
+ * artifact is missing, stale, or unverifiable, so the caller falls back to the
+ * normal packaging/deploy path. Genuine SQL failures still throw.
+ */
+export async function deployModuleFromBundle(
+  moduleDir: string,
+  options: BundledDeployOptions
+): Promise<BundledDeployResult | BundledDeploySkipReason> {
+  if ((options.hashMethod ?? 'content') !== 'content') {
+    return 'unsupported-hash-method';
+  }
+
+  const bundle = readBundleArtifact(moduleDir);
+  if (!bundle) return 'no-artifact';
+
+  const issues = verifyBundle(bundle);
+  if (issues.length > 0) {
+    log.warn(
+      `⚠️ Bundle artifact for ${bundle.manifest.name} failed verification ` +
+        `(${issues.map(i => i.kind).join(', ')}); falling back to packaging.`
+    );
+    return 'unverified';
+  }
+
+  const executable = bundle.changes.filter(change => change.deploy);
+  if (executable.length === 0 || executable.some(change => !change.exec)) {
+    return 'no-executable-sql';
+  }
+
+  const packageName = bundle.manifest.name;
+  const config = options.database
+    ? { ...options.config, database: options.database }
+    : options.config;
+
+  // Ensures the pgpm_migrate schema/procedures exist, exactly as the
+  // per-change deploy path does.
+  await new PgpmMigrate(config, { hashMethod: 'content' }).initialize();
+
+  const pool = getPgPool(config);
+  const existing = await pool.query<{ change_name: string; script_hash: string }>(
+    'SELECT change_name, script_hash FROM pgpm_migrate.changes WHERE package = $1',
+    [packageName]
+  );
+  const deployedHashes = new Map(existing.rows.map(row => [row.change_name, row.script_hash]));
+
+  const pending: typeof executable = [];
+  const skipped: string[] = [];
+  for (const change of executable) {
+    const hash = ledgerHashForChange(change)!;
+    const recorded = deployedHashes.get(change.name);
+    if (recorded === undefined) {
+      pending.push(change);
+      continue;
+    }
+    if (recorded !== hash) {
+      throw new BundledDeployConflictError(packageName, change.name);
+    }
+    skipped.push(change.name);
+  }
+
+  if (pending.length === 0) {
+    log.info(`⚡ ${packageName}: all ${skipped.length} change(s) already deployed.`);
+    return { name: packageName, deployed: [], skipped };
+  }
+
+  const changeNames = pending.map(change => change.name);
+  const hashes = pending.map(change => ledgerHashForChange(change)!);
+  const depChanges: string[] = [];
+  const depRequires: string[] = [];
+  for (const change of pending) {
+    for (const dep of new Set(change.dependencies)) {
+      depChanges.push(change.name);
+      depRequires.push(dep.includes(':') ? dep : `${packageName}:${dep}`);
+    }
+  }
+  const deploySql = pending.map(change => change.exec!.sql).join('\n');
+
+  const client = await pool.connect();
+  const useTransaction = options.useTransaction ?? true;
+  try {
+    if (useTransaction) await client.query('BEGIN');
+    if (!options.logOnly) {
+      await client.query(deploySql);
+    }
+    await client.query(
+      'INSERT INTO pgpm_migrate.packages (package) VALUES ($1) ON CONFLICT (package) DO NOTHING',
+      [packageName]
+    );
+    await client.query(
+      `WITH input AS (
+         SELECT change_name, script_hash
+         FROM unnest($2::text[], $3::text[]) AS t(change_name, script_hash)
+       ), inserted AS (
+         INSERT INTO pgpm_migrate.changes (change_id, change_name, package, script_hash)
+         SELECT encode(sha256(($1 || change_name || script_hash)::bytea), 'hex'),
+                change_name, $1, script_hash
+         FROM input
+         ON CONFLICT (package, change_name) DO NOTHING
+         RETURNING change_id, change_name
+       ), deps AS (
+         INSERT INTO pgpm_migrate.dependencies (change_id, requires)
+         SELECT inserted.change_id, d.requires
+         FROM unnest($4::text[], $5::text[]) AS d(change_name, requires)
+         JOIN inserted ON inserted.change_name = d.change_name
+         ON CONFLICT DO NOTHING
+         RETURNING change_id
+       )
+       INSERT INTO pgpm_migrate.events (event_type, change_name, package)
+       SELECT 'deploy', change_name, $1 FROM inserted`,
+      [packageName, changeNames, hashes, depChanges, depRequires]
+    );
+    if (useTransaction) await client.query('COMMIT');
+  } catch (error) {
+    if (useTransaction) {
+      try {
+        await client.query('ROLLBACK');
+      } catch {
+        // the connection is already unusable; surface the original error
+      }
+    }
+    throw error;
+  } finally {
+    client.release();
+  }
+
+  log.success(
+    `⚡ ${packageName}: ${changeNames.length} change(s) ${options.logOnly ? 'logged' : 'deployed'} ` +
+      `from bundle artifact (${skipped.length} already deployed).`
+  );
+
+  return { name: packageName, deployed: changeNames, skipped };
+}
+
+/** True when the value is a real bundled-deploy result rather than a skip. */
+export function isBundledDeployResult(
+  value: BundledDeployResult | BundledDeploySkipReason
+): value is BundledDeployResult {
+  return !isSkipped(value);
+}

--- a/pgpm/core/src/bundle/index.ts
+++ b/pgpm/core/src/bundle/index.ts
@@ -15,3 +15,7 @@ export * from '@pgpmjs/bundle';
 export * from './apply';
 // applyEnvelope: schema apply + data/fixtures part replay for a BundleEnvelope.
 export * from './apply-envelope';
+// The stored `sql/<name>--<version>.bundle.tar.gz` artifact: emit + resolve.
+export * from './artifact';
+// The bundle-backed deploy fast path (one-shot execute + ledger).
+export * from './deploy-bundled';

--- a/pgpm/core/src/core/class/pgpm.ts
+++ b/pgpm/core/src/core/class/pgpm.ts
@@ -39,7 +39,7 @@ import {
   latestChangeAndVersion,
   ModuleMap
 } from '../../modules/modules';
-import { packageModule } from '../../packaging/package';
+import { deployModuleFast, isBundledDeployResult } from '../../bundle/deploy-bundled';
 import { syncModuleVersions, SyncVersionsOptions, SyncVersionsResult } from '../../packaging/sync-versions';
 import { resolveDependencies,resolveExtensionDependencies } from '../../resolution/deps';
 import { movePath } from '../../utils/fs';
@@ -1671,18 +1671,6 @@ ${dependencies.length > 0 ? dependencies.map(dep => `-- requires: ${dep}`).join(
     const { name, toChange } = this.parsePackageTarget(target);
 
     if (recursive) {
-      // Cache for fast deployment
-      const deployFastCache: Record<string, Awaited<ReturnType<typeof packageModule>>> = {};
-
-      const getCacheKey = (
-        pg: PgConfig,
-        name: string,
-        database: string
-      ): string => {
-        const { host, port, user } = pg ?? {};
-        return `${host}:${port}:${user}:${database}:${name}`;
-      };
-
       const modules = this.getModuleMap();
       
       let extensions: { resolved: string[]; external: string[] };
@@ -1714,51 +1702,23 @@ ${dependencies.length > 0 ? dependencies.map(dep => `-- requires: ${dep}`).join(
             );
             log.info(`📂 Deploying local module: ${extension}`);
 
-            if (opts.deployment.fast) {
-              const cacheKey = getCacheKey(opts.pg as PgConfig, extension, opts.pg.database);
-            
-              if (opts.deployment.cache && deployFastCache[cacheKey]) {
-                log.warn(`⚡ Using cached pkg for ${extension}.`);
-                await pgPool.query(deployFastCache[cacheKey].sql);
+            if (opts.deployment.fast || opts.deployment.bundled) {
+              // Fast strategy: one-shot execution plus a bulk-written
+              // pgpm_migrate ledger, from the module's verified bundle artifact
+              // when it has one and from `deploy/` when it does not.
+              const outcome = await deployModuleFast(modulePath, {
+                config: opts.pg as PgConfig,
+                logOnly: opts.deployment.logOnly,
+                useTransaction: opts.deployment.useTx,
+                hashMethod: opts.deployment.hashMethod
+              });
+              if (isBundledDeployResult(outcome)) {
                 continue;
               }
+              log.info(`↩️ Fast deploy unavailable for ${extension} (${outcome}); using per-change path.`);
+            }
 
-              let pkg;
-              try {
-                pkg = await packageModule(modulePath, { 
-                  usePlan: opts.deployment.usePlan, 
-                  extension: false 
-                });
-              } catch (err: any) {
-                const errorLines = [];
-                errorLines.push(`❌ Failed to package module "${extension}" at path: ${modulePath}`);
-                errorLines.push(`   Module Path: ${modulePath}`);
-                errorLines.push(`   Workspace Path: ${this.workspacePath}`);
-                errorLines.push(`   Error Code: ${err.code || 'N/A'}`);
-                errorLines.push(`   Error Message: ${err.message || 'Unknown error'}`);
-              
-                if (err.code === 'ENOENT') {
-                  errorLines.push('💡 Hint: File or directory not found. Check if the module path is correct.');
-                } else if (err.code === 'EACCES') {
-                  errorLines.push('💡 Hint: Permission denied. Check file permissions.');
-                } else if (err.message && err.message.includes('pgpm.plan')) {
-                  errorLines.push('💡 Hint: pgpm.plan file issue. Check if the plan file exists and is valid.');
-                }
-              
-                log.error(errorLines.join('\n'));
-                console.error(err);
-                throw errors.DEPLOYMENT_FAILED({ 
-                  type: 'Deployment', 
-                  module: extension
-                });
-              }
-
-              await pgPool.query(pkg.sql);
-
-              if (opts.deployment.cache) {
-                deployFastCache[cacheKey] = pkg;
-              }
-            } else {
+            {
               try {
                 const client = new PgpmMigrate(opts.pg as PgConfig);
               

--- a/pgpm/core/src/packaging/package.ts
+++ b/pgpm/core/src/packaging/package.ts
@@ -6,6 +6,7 @@ import { deparse } from 'pgsql-deparser';
 import { parse } from 'pgsql-parser';
 
 import { getExtensionName } from '@pgpmjs/ast/files';
+import { writeBundleArtifact } from '../bundle/artifact';
 import { resolve, resolveWithPlan } from '../resolution/resolve';
 import { transformProps } from './transform';
 
@@ -32,6 +33,12 @@ interface PackageModuleOptions {
 interface WritePackageOptions extends PackageModuleOptions {
   version: string;
   packageDir: string;
+  /**
+   * Also emit the content-addressed bundle artifact
+   * `sql/<name>--<version>.bundle.tar.gz` (default true). It is what
+   * `deploy --bundled` consumes.
+   */
+  bundle?: boolean;
 }
 
 const filterStatements = (stmts: RawStmt[], stripTransactions: boolean): RawStmt[] => {
@@ -129,6 +136,7 @@ export const writePackage = async ({
   usePlan = true,
   packageDir,
   outputDiff = false,
+  bundle = true,
 }: WritePackageOptions): Promise<void> => {
   const pkgPath = `${packageDir}/package.json`;
   const pkg = require(pkgPath);
@@ -180,4 +188,11 @@ export const writePackage = async ({
   const writePath = `${outPath}/${sqlFileName}`;
   writeFileSync(writePath, sql);
   log.success(`${relative(packageDir, writePath)} written`);
+
+  if (bundle) {
+    const bundlePath = await writeBundleArtifact(packageDir, version, {
+      createdWith: '@pgpmjs/core'
+    });
+    log.success(`${relative(packageDir, bundlePath)} written`);
+  }
 };

--- a/pgpm/core/src/projects/deploy.ts
+++ b/pgpm/core/src/projects/deploy.ts
@@ -8,28 +8,15 @@ import {PgConfig } from 'pg-env';
 
 import { resolveEffectiveModulePath } from '../apply/materialize';
 import { hasApplySpec } from '../apply/apply-spec';
-import { deployModuleFromBundle, isBundledDeployResult } from '../bundle/deploy-bundled';
+import { deployModuleFast, isBundledDeployResult } from '../bundle/deploy-bundled';
 import { PgpmPackage } from '../core/class/pgpm';
 import { PgpmMigrate } from '../migrate/client';
-import { packageModule } from '../packaging/package';
 import { resolveExtensionDependencies } from '../resolution/deps';
 
 interface Extensions {
   resolved: string[];
   external: string[];
 }
-
-// Cache for fast deployment
-const deployFastCache: Record<string, Awaited<ReturnType<typeof packageModule>>> = {};
-
-const getCacheKey = (
-  pg: PgConfig,
-  name: string,
-  database: string
-): string => {
-  const { host, port, user } = pg ?? {};
-  return `${host}:${port}:${user}:${database}:${name}`;
-};
 
 const log = new Logger('deploy');
 
@@ -83,12 +70,14 @@ export const deployProject = async (
           log.info(`🔁 Applying transpiled module (spec in ${sourcePath})`);
         }
 
-        if (mergedOpts.deployment.bundled) {
-          // Fast path v2: execute the module's pre-built, verified bundle
-          // artifact in one shot AND record the migration ledger. Any reason the
-          // artifact cannot be trusted (missing, stale, unverified) degrades to
-          // the paths below rather than failing the deploy.
-          const outcome = await deployModuleFromBundle(modulePath, {
+        // The fast strategy is opt-in; everything else uses the per-change path.
+        if (mergedOpts.deployment.fast || mergedOpts.deployment.bundled) {
+          // Fast strategy: execute the module in one shot AND record the
+          // migration ledger, from the pre-built bundle artifact when one
+          // verifies and from `deploy/` otherwise. If the semantics cannot be
+          // honoured, fall through to the per-change migration path rather than
+          // deploying without a ledger.
+          const outcome = await deployModuleFast(modulePath, {
             config: { ...(mergedOpts.pg as PgConfig), database },
             logOnly: mergedOpts.deployment.logOnly,
             useTransaction: mergedOpts.deployment.useTx,
@@ -97,63 +86,10 @@ export const deployProject = async (
           if (isBundledDeployResult(outcome)) {
             continue;
           }
-          log.info(`↩️ Bundled deploy unavailable for ${extension} (${outcome}); using standard path.`);
+          log.info(`↩️ Fast deploy unavailable for ${extension} (${outcome}); using per-change path.`);
         }
 
-        if (mergedOpts.deployment.fast) {
-          // Use fast deployment strategy
-          const localProject = new PgpmPackage(modulePath, { extensionsDir: pkg.extensionsDir });
-          const cacheKey = getCacheKey(mergedOpts.pg as PgConfig, extension, database);
-          
-          if (mergedOpts.deployment.cache && deployFastCache[cacheKey]) {
-            log.warn(`⚡ Using cached package for ${extension}.`);
-            await pgPool.query(deployFastCache[cacheKey].sql);
-            continue;
-          }
-
-          let modulePackage;
-          try {
-            modulePackage = await packageModule(localProject.modulePath, { 
-              usePlan: mergedOpts.deployment.usePlan, 
-              extension: false 
-            });
-          } catch (err: any) {
-            // Build comprehensive error message
-            const errorLines = [];
-            errorLines.push(`❌ Failed to package module "${extension}" at path: ${modulePath}`);
-            errorLines.push(`   Module Path: ${modulePath}`);
-            errorLines.push(`   Workspace Path: ${pkg.workspacePath}`);
-            errorLines.push(`   Error Code: ${err.code || 'N/A'}`);
-            errorLines.push(`   Error Message: ${err.message || 'Unknown error'}`);
-            
-            // Provide debugging hints
-            if (err.code === 'ENOENT') {
-              errorLines.push('💡 Hint: File or directory not found. Check if the module path is correct.');
-            } else if (err.code === 'EACCES') {
-              errorLines.push('💡 Hint: Permission denied. Check file permissions.');
-            } else if (err.message && err.message.includes('pgpm.plan')) {
-              errorLines.push('💡 Hint: pgpm.plan file issue. Check if the plan file exists and is valid.');
-            }
-            
-            // Log the consolidated error message
-            log.error(errorLines.join('\n'));
-            
-            console.error(err); // Preserve full stack trace
-            throw errors.DEPLOYMENT_FAILED({ 
-              type: 'Deployment', 
-              module: extension
-            });
-          }
-
-          log.debug(`→ Command: sqitch deploy db:pg:${database}`);
-          log.debug(`> ${modulePackage.sql}`);
-
-          await pgPool.query(modulePackage.sql);
-
-          if (mergedOpts.deployment.cache) {
-            deployFastCache[cacheKey] = modulePackage;
-          }
-        } else {
+        {
           // Use new migration system
           log.debug(`→ Command: constructive migrate deploy db:pg:${database}`);
           

--- a/pgpm/core/src/projects/deploy.ts
+++ b/pgpm/core/src/projects/deploy.ts
@@ -8,6 +8,7 @@ import {PgConfig } from 'pg-env';
 
 import { resolveEffectiveModulePath } from '../apply/materialize';
 import { hasApplySpec } from '../apply/apply-spec';
+import { deployModuleFromBundle, isBundledDeployResult } from '../bundle/deploy-bundled';
 import { PgpmPackage } from '../core/class/pgpm';
 import { PgpmMigrate } from '../migrate/client';
 import { packageModule } from '../packaging/package';
@@ -80,6 +81,23 @@ export const deployProject = async (
         log.debug(`→ Path: ${modulePath}`);
         if (modulePath !== sourcePath) {
           log.info(`🔁 Applying transpiled module (spec in ${sourcePath})`);
+        }
+
+        if (mergedOpts.deployment.bundled) {
+          // Fast path v2: execute the module's pre-built, verified bundle
+          // artifact in one shot AND record the migration ledger. Any reason the
+          // artifact cannot be trusted (missing, stale, unverified) degrades to
+          // the paths below rather than failing the deploy.
+          const outcome = await deployModuleFromBundle(modulePath, {
+            config: { ...(mergedOpts.pg as PgConfig), database },
+            logOnly: mergedOpts.deployment.logOnly,
+            useTransaction: mergedOpts.deployment.useTx,
+            hashMethod: mergedOpts.deployment.hashMethod
+          });
+          if (isBundledDeployResult(outcome)) {
+            continue;
+          }
+          log.info(`↩️ Bundled deploy unavailable for ${extension} (${outcome}); using standard path.`);
         }
 
         if (mergedOpts.deployment.fast) {

--- a/pgpm/core/test-utils/CoreDeployTestFixture.ts
+++ b/pgpm/core/test-utils/CoreDeployTestFixture.ts
@@ -26,7 +26,13 @@ export class CoreDeployTestFixture extends TestFixture {
     return db;
   }
 
-  async deployModule(target: string, database: string, fixturePath: string[], logOnly: boolean = false): Promise<void> {
+  async deployModule(
+    target: string,
+    database: string,
+    fixturePath: string[],
+    logOnly: boolean = false,
+    deploymentOverrides: Record<string, unknown> = {}
+  ): Promise<void> {
     const basePath = this.tempFixtureDir;
     const originalCwd = process.cwd();
 
@@ -40,7 +46,8 @@ export class CoreDeployTestFixture extends TestFixture {
         deployment: {
           fast: false,
           usePlan: true,
-          logOnly
+          logOnly,
+          ...deploymentOverrides
         }
       });
 

--- a/pgpm/env/__tests__/__snapshots__/merge.test.ts.snap
+++ b/pgpm/env/__tests__/__snapshots__/merge.test.ts.snap
@@ -35,6 +35,7 @@ exports[`getEnvOptions merges defaults, config, env, and overrides 1`] = `
     "useLocksForRoles": false,
   },
   "deployment": {
+    "bundled": false,
     "cache": true,
     "fast": false,
     "hashMethod": "content",

--- a/pgpm/env/src/env.ts
+++ b/pgpm/env/src/env.ts
@@ -50,6 +50,7 @@ export const getEnvVars = (env: NodeJS.ProcessEnv = process.env): PgpmOptions =>
 
     DEPLOYMENT_USE_TX,
     DEPLOYMENT_FAST,
+    DEPLOYMENT_BUNDLED,
     DEPLOYMENT_USE_PLAN,
     DEPLOYMENT_CACHE,
     DEPLOYMENT_TO_CHANGE,
@@ -137,6 +138,7 @@ export const getEnvVars = (env: NodeJS.ProcessEnv = process.env): PgpmOptions =>
     deployment: {
       ...(DEPLOYMENT_USE_TX && { useTx: parseEnvBoolean(DEPLOYMENT_USE_TX) }),
       ...(DEPLOYMENT_FAST && { fast: parseEnvBoolean(DEPLOYMENT_FAST) }),
+      ...(DEPLOYMENT_BUNDLED && { bundled: parseEnvBoolean(DEPLOYMENT_BUNDLED) }),
       ...(DEPLOYMENT_USE_PLAN && { usePlan: parseEnvBoolean(DEPLOYMENT_USE_PLAN) }),
       ...(DEPLOYMENT_CACHE && { cache: parseEnvBoolean(DEPLOYMENT_CACHE) }),
       ...(DEPLOYMENT_TO_CHANGE && { toChange: DEPLOYMENT_TO_CHANGE }),

--- a/pgpm/types/src/pgpm.ts
+++ b/pgpm/types/src/pgpm.ts
@@ -243,15 +243,16 @@ export interface PgpmWorkspaceConfig {
 export interface DeploymentOptions {
     /** Whether to wrap deployments in database transactions */
     useTx?: boolean;
-    /** Use fast deployment strategy (skip migration system) */
-    fast?: boolean;
     /**
-     * Deploy from each module's pre-built bundle artifact
-     * (`sql/<name>--<version>.bundle.tar.gz`): verify its sha256 digests, execute
-     * the pending changes in one round-trip, and bulk-record the `pgpm_migrate`
-     * ledger. Falls back to the standard path when a module has no verifiable
-     * artifact.
+     * Use the fast deployment strategy: execute each module's pending changes in
+     * one round-trip and bulk-record the `pgpm_migrate` ledger, reading the
+     * pre-built bundle artifact (`sql/<name>--<version>.bundle.tar.gz`) when it
+     * verifies and building the same structure from `deploy/` when it does not.
+     * Falls back to the per-change migration path if those semantics cannot be
+     * honoured (e.g. `hashMethod: 'ast'`).
      */
+    fast?: boolean;
+    /** Alias for {@link fast}, naming the bundle artifact it prefers to read. */
     bundled?: boolean;
     /** Whether to use Sqitch plan files for deployments */
     usePlan?: boolean;

--- a/pgpm/types/src/pgpm.ts
+++ b/pgpm/types/src/pgpm.ts
@@ -245,6 +245,14 @@ export interface DeploymentOptions {
     useTx?: boolean;
     /** Use fast deployment strategy (skip migration system) */
     fast?: boolean;
+    /**
+     * Deploy from each module's pre-built bundle artifact
+     * (`sql/<name>--<version>.bundle.tar.gz`): verify its sha256 digests, execute
+     * the pending changes in one round-trip, and bulk-record the `pgpm_migrate`
+     * ledger. Falls back to the standard path when a module has no verifiable
+     * artifact.
+     */
+    bundled?: boolean;
     /** Whether to use Sqitch plan files for deployments */
     usePlan?: boolean;
     /** Enable caching of deployment packages */
@@ -352,6 +360,7 @@ export const pgpmDefaults: PgpmOptions = {
   deployment: {
     useTx: true,
     fast: false,
+    bundled: false,
     usePlan: true,
     cache: false,
     logOnly: false,


### PR DESCRIPTION
## Summary

Adds a **bundle-backed deploy path ("fast v2")**: `pgpm package` now emits a content-addressed artifact `sql/<name>--<version>.bundle.tar.gz`, and `pgpm deploy --bundled` un-tars it in memory, gates on `verifyBundle()`, executes the pending changes' SQL in one statement, and — unlike today's `--fast` — writes a correct `pgpm_migrate` ledger in a single bulk round-trip. Everything is opt-in with graceful fallback: no artifact, an unreadable archive, or a digest mismatch logs and falls through to the existing paths, so the default and `--fast` behaviors are unchanged.

### Measured split (why this is worth it)

`pgpm/core` packaging vs. DDL, local Postgres 18, measured with temporary instrumentation (reverted):

| Workload | `packageModule()` (JS/disk, bundle-eliminable) | one-shot `pgPool.query` DDL (irreducible) |
|---|---|---|
| 55 local modules, 15,087 KB consolidated SQL | **5,208 ms (21.1%)** | 19,426 ms |
| largest module (`constructive`, 4,675 KB) | 2,654 ms | 15,136 ms |

So the JS/packaging share is the ~20% ceiling on the win, and the bundle path removes most of it. Replacing `packageModule()` with read-artifact + `verifyBundle` + concat, over the 14 `constructive-db` modules (1,295 changes, 8,975 KB SQL):

| Step | Time |
|---|---|
| `packageModule()` (today, every run) | **1,515 ms** |
| read `.bundle.tar.gz` + `verifyBundle` + concat exec SQL | **305 ms** |

≈5× less CPU/disk per provisioning run (`ast-plpgsql` alone: 637 ms → 95 ms), plus the artifact is 2.2 MB vs 9.0 MB of SQL text. For `pgsql-seed`/`pgsql-test` provisioning that repackages on every run (`cache:false`), this is a straight ~1.2 s/run saving on this corpus and scales with corpus size — and it is now *also* ledgered, which `--fast` never was.

### Artifact

`createBundle` output gains an optional per-change `exec` slot: the deploy SQL already stripped of transaction/`CREATE EXTENSION` statements, i.e. exactly what gets executed. Computing it needs a SQL parser, which `@pgpmjs/bundle` deliberately doesn't depend on, so core supplies it:

```ts
// @pgpmjs/bundle (pure)
withExecutableSql(bundle, { [changeName]: sql }) // re-derives change + manifest digests
packBundle(bundle) / unpackBundle(buf)           // deterministic single-entry tar+gzip, no new deps

// @pgpmjs/core (needs cleanSql)
writeBundleArtifact(moduleDir, version) // called by writePackage({ bundle: true })
```

`changeDigest = H(name ‖ deployDigest ‖ revertDigest ‖ verifyDigest [‖ execDigest])` — `execDigest` only participates when present, so pre-existing bundles hash identically. `verifyBundle` grows an `exec-digest` issue kind, so tampering with the *executed* bytes is caught, not just the source scripts.

### Ledger + hash reconciliation

The ledger `script_hash` for a bundled change is `change.deploy.digest` = sha256 of the deploy file bytes — precisely what `PgpmMigrate.calculateScriptHash` computes under the default `content` method. A test asserts the bundled deploy produces a **byte-identical `pgpm_migrate.changes` table** to the per-change path. `hashMethod: 'ast'` is not derivable from the artifact, so it reports a skip and falls back rather than writing hashes the other path would disagree with.

Instead of `isDeployed` + `readScript` + `CALL pgpm_migrate.deploy` per change, the whole module is:

```
SELECT change_name, script_hash FROM pgpm_migrate.changes WHERE package = $1  -- pending/skip split
  -- recorded hash differs => BundledDeployConflictError (same semantics as the ledger today)
BEGIN
  <concatenated exec SQL for pending changes>          -- one statement
  INSERT packages … ON CONFLICT DO NOTHING
  WITH inserted AS (INSERT INTO changes … RETURNING …),
       deps     AS (INSERT INTO dependencies … FROM inserted)
  INSERT INTO events (…) SELECT 'deploy', … FROM inserted   -- one round-trip
COMMIT
```

Re-deploys therefore skip already-applied changes by hash — the path is idempotent and resumable, which `--fast` is not.

### Surface

- `deployment.bundled` (`DEPLOYMENT_BUNDLED`), `pgpm deploy --bundled`; `pgpm package --no-bundle` to skip emission.
- `--fast` is untouched and remains the fallback; `--bundled` supersedes it functionally (same one-shot execution + a real ledger).
- Loose bundle JSON is gitignored; the `.tar.gz` is the committed artifact.
- Downstream consumers (`pgsql-seed`, `constructive-db`) are unchanged — they can flip `bundled: true` later.

## Testing

- `pgpm/bundle`: tar codec round-trip/determinism/corrupt-input, artifact round-trip, `exec` digest verification and tamper detection.
- `pgpm/core` (`__tests__/bundle/bundled-deploy.test.ts`): artifact emission + hash-scheme equivalence with on-disk deploy files, ledger population (rows + dependencies), idempotent re-deploy, ledger equality vs. the standard path, and fallback for missing artifact / failed verification / corrupt archive.
- `pgpm/{types,env,bundle,core,cli}` suites pass (`pgpm/core`: 410 tests, 67 suites). Two snapshots updated: `deployment.bundled: false` default and the new packaged artifact file.

---

## Update: `fast` is now the bundled path (old unledgered path deleted)

Per maintainer feedback — an unledgered fast path is a hazardous tool — `--fast` is no longer a separate strategy. There were two copies of the old fire-and-forget branch (`projects/deploy.ts` and `PgpmPackage.deploy`); both are deleted, along with the `deployFastCache`/`getCacheKey` package cache.

`deployModuleFromBundle` → `deployModuleFast`, and `fast` now means **one-shot execute + bulk ledger**, always:

- artifact present and `verifyBundle` passes → execute its pre-computed `exec` SQL (no packaging work);
- artifact missing/corrupt/tampered → `buildExecutableBundle()` rebuilds the same structure from `deploy/` and deploys identically, just slower.

So the artifact is a pure speed optimization, never a correctness requirement, and there is no longer any code path that deploys without recording the ledger. Only `hashMethod: 'ast'` (not reproducible from the artifact) or a module with no executable deploy SQL falls through to the per-change path.

`--bundled` remains as an explicit alias. `pgsql-seed`'s existing `fast: true` keeps working unchanged and silently gains a correct ledger — which is the point: provisioning becomes idempotent and resumable rather than always re-running everything.

New test pins it: `fast: true` produces the identical `pgpm_migrate.changes` table with and without an artifact, and equal to the per-change path.


Link to Devin session: https://app.devin.ai/sessions/924c5b516f844f10b625263cb48733d9
Requested by: @pyramation