### PR TITLE
feat(pgpm): declarative per-module extension install (extensions.json provides)

### DIFF
--- a/__fixtures__/extensions/install/packages/crypto-ext/crypto-ext.control
+++ b/__fixtures__/extensions/install/packages/crypto-ext/crypto-ext.control
@@ -1,0 +1,7 @@
+# crypto-ext extension
+comment = 'crypto-ext extension'
+default_version = '0.0.1'
+module_pathname = '$libdir/crypto-ext'
+requires = 'pgcrypto'
+relocatable = false
+superuser = false

--- a/__fixtures__/extensions/install/packages/crypto-ext/deploy/schemas/app/functions/hash_pw.sql
+++ b/__fixtures__/extensions/install/packages/crypto-ext/deploy/schemas/app/functions/hash_pw.sql
@@ -1,0 +1,13 @@
+-- Deploy schemas/app/functions/hash_pw to pg
+
+-- requires: schemas/app/schema
+
+BEGIN;
+
+CREATE FUNCTION app.hash_pw(pw text) RETURNS text AS $$
+  SELECT extensions.crypt(pw, extensions.gen_salt('bf'));
+$$ LANGUAGE sql VOLATILE;
+
+GRANT EXECUTE ON FUNCTION app.hash_pw(text) TO authenticated;
+
+COMMIT;

--- a/__fixtures__/extensions/install/packages/crypto-ext/deploy/schemas/app/schema.sql
+++ b/__fixtures__/extensions/install/packages/crypto-ext/deploy/schemas/app/schema.sql
@@ -1,0 +1,7 @@
+-- Deploy schemas/app/schema to pg
+
+BEGIN;
+
+CREATE SCHEMA app;
+
+COMMIT;

--- a/__fixtures__/extensions/install/packages/crypto-ext/extensions.json
+++ b/__fixtures__/extensions/install/packages/crypto-ext/extensions.json
@@ -1,0 +1,10 @@
+{
+  "provides": {
+    "pgcrypto": {
+      "schema": "extensions",
+      "grants": [
+        { "privileges": "USAGE", "on": "schema", "to": ["authenticated", "administrator"] }
+      ]
+    }
+  }
+}

--- a/__fixtures__/extensions/install/packages/crypto-ext/pgpm.plan
+++ b/__fixtures__/extensions/install/packages/crypto-ext/pgpm.plan
@@ -1,0 +1,6 @@
+%syntax-version=1.0.0
+%project=crypto-ext
+%uri=crypto-ext
+
+schemas/app/schema 2024-01-01T00:00:00Z Dev <dev@example.com> # add app schema
+schemas/app/functions/hash_pw [schemas/app/schema] 2024-01-01T00:00:01Z Dev <dev@example.com> # add hash_pw

--- a/__fixtures__/extensions/install/packages/crypto-ext/revert/schemas/app/functions/hash_pw.sql
+++ b/__fixtures__/extensions/install/packages/crypto-ext/revert/schemas/app/functions/hash_pw.sql
@@ -1,0 +1,7 @@
+-- Revert schemas/app/functions/hash_pw from pg
+
+BEGIN;
+
+DROP FUNCTION app.hash_pw(text);
+
+COMMIT;

--- a/__fixtures__/extensions/install/packages/crypto-ext/revert/schemas/app/schema.sql
+++ b/__fixtures__/extensions/install/packages/crypto-ext/revert/schemas/app/schema.sql
@@ -1,0 +1,7 @@
+-- Revert schemas/app/schema from pg
+
+BEGIN;
+
+DROP SCHEMA app;
+
+COMMIT;

--- a/__fixtures__/extensions/install/packages/crypto-ext/verify/schemas/app/functions/hash_pw.sql
+++ b/__fixtures__/extensions/install/packages/crypto-ext/verify/schemas/app/functions/hash_pw.sql
@@ -1,0 +1,7 @@
+-- Verify schemas/app/functions/hash_pw on pg
+
+BEGIN;
+
+SELECT app.hash_pw('probe');
+
+ROLLBACK;

--- a/__fixtures__/extensions/install/packages/crypto-ext/verify/schemas/app/schema.sql
+++ b/__fixtures__/extensions/install/packages/crypto-ext/verify/schemas/app/schema.sql
@@ -1,0 +1,7 @@
+-- Verify schemas/app/schema on pg
+
+BEGIN;
+
+SELECT pg_catalog.has_schema_privilege('app', 'usage');
+
+ROLLBACK;

--- a/__fixtures__/extensions/install/pgpm.json
+++ b/__fixtures__/extensions/install/pgpm.json
@@ -1,0 +1,13 @@
+{
+    "packages": [
+        "packages/*"
+    ],
+    "db": {
+        "roles": {
+            "anonymous": "anon",
+            "authenticated": "authenticated",
+            "administrator": "service_role",
+            "default": "anon"
+        }
+    }
+}

--- a/pgpm/core/__tests__/extensions/install-e2e.test.ts
+++ b/pgpm/core/__tests__/extensions/install-e2e.test.ts
@@ -1,0 +1,83 @@
+import { CoreDeployTestFixture } from '../../test-utils/CoreDeployTestFixture';
+import { TestDatabase } from '../../test-utils/TestDatabase';
+
+describe('declarative extension install (e2e) — extensions.json provides', () => {
+  let fixture: CoreDeployTestFixture;
+  let db: TestDatabase;
+
+  const path = ['extensions', 'install'];
+
+  const extensionSchema = async (extname: string): Promise<string | undefined> => {
+    const res = await db.query(
+      `SELECT n.nspname FROM pg_catalog.pg_extension e
+       JOIN pg_catalog.pg_namespace n ON n.oid = e.extnamespace
+       WHERE e.extname = $1`,
+      [extname]
+    );
+    return res.rows[0]?.nspname;
+  };
+
+  const functionExists = async (schema: string, name: string): Promise<boolean> => {
+    const res = await db.query(
+      `SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+       WHERE n.nspname = $1 AND p.proname = $2`,
+      [schema, name]
+    );
+    return res.rows.length > 0;
+  };
+
+  beforeAll(() => {
+    fixture = new CoreDeployTestFixture('extensions', 'install');
+  });
+
+  afterAll(async () => {
+    await fixture.cleanup();
+  });
+
+  beforeEach(async () => {
+    db = await fixture.setupTestDatabase();
+    // The grant targets need to exist; the workspace role map renames the
+    // conceptual `administrator` to `service_role`.
+    await db.query(
+      `DO $$ BEGIN
+         IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN CREATE ROLE authenticated; END IF;
+         IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN CREATE ROLE service_role; END IF;
+       END $$;`
+    );
+  });
+
+  test('installs pgcrypto into the declared schema with routed grants (no dynamic EXECUTE)', async () => {
+    // Fresh DB: pgcrypto is NOT pre-installed. The manifest drives placement.
+    expect(await extensionSchema('pgcrypto')).toBeUndefined();
+
+    await fixture.deployModule('crypto-ext', db.name, path);
+
+    // pgcrypto landed in `extensions`, not public.
+    expect(await extensionSchema('pgcrypto')).toBe('extensions');
+
+    // the module's function resolves the schema-qualified extension symbols
+    expect(await functionExists('app', 'hash_pw')).toBe(true);
+    const hashed = await db.query(`SELECT app.hash_pw('secret') AS h`);
+    expect(typeof hashed.rows[0].h).toBe('string');
+    expect(hashed.rows[0].h.length).toBeGreaterThan(0);
+
+    // the grant's conceptual `administrator` was routed to `service_role`
+    const priv = await db.query(
+      `SELECT has_schema_privilege('service_role', 'extensions', 'usage') AS ok`
+    );
+    expect(priv.rows[0].ok).toBe(true);
+    const priv2 = await db.query(
+      `SELECT has_schema_privilege('authenticated', 'extensions', 'usage') AS ok`
+    );
+    expect(priv2.rows[0].ok).toBe(true);
+  });
+
+  test('verify passes and revert drops the module (extension install-site left intact)', async () => {
+    await fixture.deployModule('crypto-ext', db.name, path);
+    await fixture.verifyModule('crypto-ext', db.name, path);
+
+    await fixture.revertModule('crypto-ext', db.name, path);
+    expect(await functionExists('app', 'hash_pw')).toBe(false);
+    expect(await db.exists('schema', 'app')).toBe(false);
+  });
+});

--- a/pgpm/core/__tests__/extensions/manifest.test.ts
+++ b/pgpm/core/__tests__/extensions/manifest.test.ts
@@ -1,0 +1,196 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import {
+  compileExtensionInstall,
+  compileExtensionInstalls,
+  findExtensionInstall,
+  readExtensionsManifest,
+  validateExtensionsManifest
+} from '../../src/extensions';
+
+describe('extensions manifest — validation', () => {
+  it('accepts a provides declaration with schema and grants', () => {
+    const m = validateExtensionsManifest({
+      provides: {
+        pg_partman: {
+          schema: 'partman',
+          relocatable: false,
+          grants: [{ privileges: 'USAGE', on: 'schema', to: 'authenticated' }]
+        }
+      }
+    });
+    expect(m.provides!.pg_partman.schema).toBe('partman');
+    expect(m.provides!.pg_partman.grants![0].to).toBe('authenticated');
+  });
+
+  it('accepts a consumes declaration', () => {
+    const m = validateExtensionsManifest({ consumes: { pgcrypto: { symbols: ['crypt', 'gen_salt'] } } });
+    expect(m.consumes!.pgcrypto.symbols).toEqual(['crypt', 'gen_salt']);
+  });
+
+  it('accepts schema: null (unqualified/default)', () => {
+    const m = validateExtensionsManifest({ provides: { hstore: { schema: null } } });
+    expect(m.provides!.hstore.schema).toBeNull();
+  });
+
+  it.each([
+    [{ provides: [] }, /"provides" must be an object/],
+    [{ provides: { x: { schema: '' } } }, /schema must be a non-empty string or null/],
+    [{ provides: { x: { grants: [{ on: 'schema', to: 'r' }] } } }, /privileges must be a non-empty string/],
+    [{ provides: { x: { grants: [{ privileges: 'USAGE', on: 'nope', to: 'r' }] } } }, /\.on must be one of/],
+    [{ provides: { x: { grants: [{ privileges: 'USAGE', on: 'schema', to: [] }] } } }, /\.to must be a role name/],
+    [{ provides: { x: { relocatable: 'yes' } } }, /relocatable must be a boolean/],
+    [{ consumes: { x: { symbols: [1] } } }, /symbols must be an array of non-empty strings/]
+  ])('rejects %j', (input, pattern) => {
+    expect(() => validateExtensionsManifest(input)).toThrow(pattern as RegExp);
+  });
+
+  it('reads pgpm.extensions.json / extensions.json from a module dir', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ext-manifest-'));
+    try {
+      expect(readExtensionsManifest(dir)).toBeUndefined();
+      writeFileSync(
+        join(dir, 'extensions.json'),
+        JSON.stringify({ provides: { pgcrypto: { schema: 'extensions' } } })
+      );
+      expect(readExtensionsManifest(dir)!.provides!.pgcrypto.schema).toBe('extensions');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('extensions manifest — compile', () => {
+  it('compiles schema install + grants into deterministic deploy SQL (no dynamic EXECUTE)', () => {
+    const out = compileExtensionInstall('pg_partman', {
+      schema: 'partman',
+      grants: [{ privileges: 'USAGE', on: 'schema', to: 'authenticated' }]
+    });
+    expect(out.deploy).toEqual([
+      'CREATE SCHEMA IF NOT EXISTS "partman";',
+      'CREATE EXTENSION IF NOT EXISTS "pg_partman" WITH SCHEMA "partman";',
+      'GRANT USAGE ON SCHEMA "partman" TO authenticated;'
+    ]);
+    expect(out.deploy.join('\n')).not.toMatch(/EXECUTE/i);
+  });
+
+  it('reverts in reverse order and verifies the install namespace', () => {
+    const out = compileExtensionInstall('pgcrypto', {
+      schema: 'extensions',
+      dropSchema: true,
+      grants: [{ privileges: 'USAGE', on: 'schema', to: 'anon' }]
+    });
+    expect(out.revert).toEqual([
+      'REVOKE USAGE ON SCHEMA "extensions" FROM anon;',
+      'DROP EXTENSION IF EXISTS "pgcrypto";',
+      'DROP SCHEMA IF EXISTS "extensions";'
+    ]);
+    expect(out.verify[0]).toMatch(/pg_catalog\.pg_extension/);
+    expect(out.verify[0]).toMatch(/nspname = 'extensions'/);
+  });
+
+  it('routes grant role names through the workspace role map, leaving special roles alone', () => {
+    const out = compileExtensionInstall(
+      'pgcrypto',
+      {
+        schema: 'extensions',
+        grants: [{ privileges: 'USAGE', on: 'schema', to: ['anonymous', 'administrator', 'PUBLIC'] }]
+      },
+      { roleMap: { anonymous: 'anon', administrator: 'service_role' } }
+    );
+    expect(out.deploy[2]).toBe('GRANT USAGE ON SCHEMA "extensions" TO anon, service_role, PUBLIC;');
+  });
+
+  it('emits null-schema (default/unqualified) install without a CREATE SCHEMA', () => {
+    const out = compileExtensionInstall('hstore', { schema: null });
+    expect(out.deploy).toEqual(['CREATE EXTENSION IF NOT EXISTS "hstore";']);
+    expect(out.verify[0]).not.toMatch(/nspname/);
+  });
+
+  it('refuses a non-relocatable extension routed to a non-fixed schema', () => {
+    expect(() =>
+      compileExtensionInstall('postgis', { schema: 'gis', relocatable: false }, { fixedSchema: 'tiger' })
+    ).toThrow(/non-relocatable/);
+  });
+
+  it('refuses grants without an install schema', () => {
+    expect(() =>
+      compileExtensionInstall('pgcrypto', { schema: null, grants: [{ privileges: 'USAGE', on: 'schema', to: 'r' }] })
+    ).toThrow(/require an install schema/);
+  });
+
+  it('compiles a whole manifest keyed by extension name', () => {
+    const all = compileExtensionInstalls({
+      pgcrypto: { schema: 'extensions' },
+      pg_partman: { schema: 'partman' }
+    });
+    expect(Object.keys(all)).toEqual(['pgcrypto', 'pg_partman']);
+    expect(all.pgcrypto.deploy[1]).toContain('WITH SCHEMA "extensions"');
+  });
+});
+
+describe('findExtensionInstall — provider resolution across modules', () => {
+  const withModules = (
+    provides: Record<string, unknown | undefined>,
+    run: (ctx: { modules: Record<string, { path: string }>; local: string[]; ws: string }) => void
+  ) => {
+    const ws = mkdtempSync(join(tmpdir(), 'ext-resolve-'));
+    try {
+      const modules: Record<string, { path: string }> = {};
+      const local: string[] = [];
+      for (const [name, manifest] of Object.entries(provides)) {
+        const rel = name;
+        const dir = join(ws, rel);
+        mkdirSync(dir, { recursive: true });
+        if (manifest !== undefined) {
+          writeFileSync(join(dir, 'extensions.json'), JSON.stringify(manifest));
+        }
+        modules[name] = { path: rel };
+        local.push(name);
+      }
+      run({ modules, local, ws });
+    } finally {
+      rmSync(ws, { recursive: true, force: true });
+    }
+  };
+
+  it('returns undefined when no local module declares the extension', () => {
+    withModules({ a: { provides: {} }, b: undefined }, ({ modules, local, ws }) => {
+      expect(findExtensionInstall('pgcrypto', local, modules, ws)).toBeUndefined();
+    });
+  });
+
+  it('compiles the single declaring module, applying the role map', () => {
+    withModules(
+      { a: { provides: { pgcrypto: { schema: 'extensions', grants: [{ privileges: 'USAGE', on: 'schema', to: 'administrator' }] } } } },
+      ({ modules, local, ws }) => {
+        const out = findExtensionInstall('pgcrypto', local, modules, ws, {
+          roleMap: { administrator: 'service_role' }
+        });
+        expect(out!.deploy[1]).toContain('WITH SCHEMA "extensions"');
+        expect(out!.deploy[2]).toContain('TO service_role');
+      }
+    );
+  });
+
+  it('accepts identical declarations across two modules', () => {
+    const same = { provides: { pgcrypto: { schema: 'extensions', grants: [{ privileges: 'USAGE', on: 'schema', to: ['authenticated', 'administrator'] }] } } };
+    withModules({ a: same, b: same }, ({ modules, local, ws }) => {
+      expect(() => findExtensionInstall('pgcrypto', local, modules, ws)).not.toThrow();
+    });
+  });
+
+  it('throws on conflicting declarations across modules', () => {
+    withModules(
+      {
+        a: { provides: { pgcrypto: { schema: 'extensions' } } },
+        b: { provides: { pgcrypto: { schema: 'public' } } }
+      },
+      ({ modules, local, ws }) => {
+        expect(() => findExtensionInstall('pgcrypto', local, modules, ws)).toThrow(/Conflicting/);
+      }
+    );
+  });
+});

--- a/pgpm/core/src/core/class/pgpm.ts
+++ b/pgpm/core/src/core/class/pgpm.ts
@@ -41,6 +41,7 @@ import {
 } from '../../modules/modules';
 import { deployModuleFast, isBundledDeployResult } from '../../bundle/deploy-bundled';
 import { syncModuleVersions, SyncVersionsOptions, SyncVersionsResult } from '../../packaging/sync-versions';
+import { findExtensionInstall, roleMapFromRoles } from '../../extensions/resolve-install';
 import { resolveDependencies,resolveExtensionDependencies } from '../../resolution/deps';
 import { movePath } from '../../utils/fs';
 import { globPaths, globPattern, toPosixPath } from '../../utils/glob';
@@ -1684,15 +1685,32 @@ ${dependencies.length > 0 ? dependencies.map(dep => `-- requires: ${dep}`).join(
 
       const pgPool = getPgPool(opts.pg);
 
+      const localModules = extensions.resolved.filter((m) => !extensions.external.includes(m));
+      const roleMap = roleMapFromRoles(opts.db?.roles);
+
       const targetDescription = name === null ? 'all modules' : name;
       log.success(`🚀 Starting deployment to database ${opts.pg.database}...`);
 
       for (const extension of extensions.resolved) {
         try {
           if (extensions.external.includes(extension)) {
-            const msg = `CREATE EXTENSION IF NOT EXISTS "${extension}" CASCADE;`;
-            log.info(`📥 Installing external extension: ${extension}`);
-            await pgPool.query(msg);
+            const install = findExtensionInstall(
+              extension,
+              localModules,
+              modules,
+              this.workspacePath!,
+              { roleMap }
+            );
+            if (install) {
+              log.info(`📥 Installing external extension (declarative): ${extension}`);
+              for (const stmt of install.deploy) {
+                await pgPool.query(stmt);
+              }
+            } else {
+              const msg = `CREATE EXTENSION IF NOT EXISTS "${extension}" CASCADE;`;
+              log.info(`📥 Installing external extension: ${extension}`);
+              await pgPool.query(msg);
+            }
           } else {
             const modulePath = await resolveEffectiveModulePath(
               extension,

--- a/pgpm/core/src/extensions/compile.ts
+++ b/pgpm/core/src/extensions/compile.ts
@@ -1,0 +1,165 @@
+import { ExtensionGrant, ExtensionGrantTarget, ExtensionProvide } from './manifest';
+
+/** Result of compiling one `provides` entry into deployable SQL. */
+export interface CompiledExtensionInstall {
+  /** Deploy statements, in order (schema, extension, grants). */
+  deploy: string[];
+  /** Revert statements, in reverse order (drop extension, optionally schema). */
+  revert: string[];
+  /** Verify statements that error when the install is absent. */
+  verify: string[];
+}
+
+export interface CompileExtensionInstallOptions {
+  /**
+   * Optional role-name map applied to grant targets (workspace portability
+   * profile). Renames identifiers only — never touches privilege semantics.
+   * Special roles (`PUBLIC`, `CURRENT_USER`, `SESSION_USER`) pass through.
+   */
+  roleMap?: Record<string, string>;
+  /**
+   * Control-file schema for a fixed-schema (non-relocatable) extension, when
+   * known. Used to validate that a `false`-relocatable extension is only
+   * "routed" to its own fixed schema.
+   */
+  fixedSchema?: string | null;
+}
+
+const SPECIAL_ROLES: ReadonlySet<string> = new Set(['public', 'current_user', 'session_user']);
+
+const quoteIdent = (name: string): string => `"${name.replace(/"/g, '""')}"`;
+
+const routeRole = (role: string, roleMap?: Record<string, string>): string => {
+  if (!roleMap) return role;
+  if (SPECIAL_ROLES.has(role.toLowerCase())) return role;
+  return roleMap[role] ?? role;
+};
+
+const grantObjectClause = (on: ExtensionGrantTarget, schema: string): string => {
+  const s = quoteIdent(schema);
+  switch (on) {
+    case 'schema':
+      return `SCHEMA ${s}`;
+    case 'all-tables':
+      return `ALL TABLES IN SCHEMA ${s}`;
+    case 'all-sequences':
+      return `ALL SEQUENCES IN SCHEMA ${s}`;
+    case 'all-functions':
+      return `ALL FUNCTIONS IN SCHEMA ${s}`;
+  }
+};
+
+const grantSql = (
+  verb: 'GRANT' | 'REVOKE',
+  grant: ExtensionGrant,
+  schema: string,
+  roleMap?: Record<string, string>
+): string => {
+  const roles = (Array.isArray(grant.to) ? grant.to : [grant.to])
+    .map((r) => routeRole(r, roleMap))
+    .join(', ');
+  const obj = grantObjectClause(grant.on, schema);
+  return verb === 'GRANT'
+    ? `GRANT ${grant.privileges} ON ${obj} TO ${roles};`
+    : `REVOKE ${grant.privileges} ON ${obj} FROM ${roles};`;
+};
+
+/**
+ * Compile a single `provides` declaration into deploy / revert / verify SQL.
+ *
+ * Pure and deterministic: given the same input it returns byte-identical SQL,
+ * with no dynamic `EXECUTE`. This is the nuts-and-bolts primitive; wiring it
+ * into the deploy path (and eventually into real plan changes exempt from
+ * `filterStatements` stripping) composes on top of it.
+ */
+export function compileExtensionInstall(
+  extname: string,
+  provide: ExtensionProvide,
+  options: CompileExtensionInstallOptions = {}
+): CompiledExtensionInstall {
+  const { roleMap, fixedSchema } = options;
+  const schema = provide.schema === undefined ? null : provide.schema;
+  const relocatable = provide.relocatable ?? true;
+  const ifNotExists = provide.ifNotExists ?? true;
+  const cascade = provide.cascade ?? false;
+  const createSchema = provide.createSchema ?? schema !== null;
+  const dropSchema = provide.dropSchema ?? false;
+  const grants = provide.grants ?? [];
+
+  // A fixed-schema extension can only be placed at its own fixed schema.
+  if (!relocatable && schema !== null && fixedSchema != null && schema !== fixedSchema) {
+    throw new Error(
+      `Extension "${extname}" is non-relocatable (fixed schema "${fixedSchema}") and cannot be installed into "${schema}".`
+    );
+  }
+  if (grants.length > 0 && schema === null) {
+    throw new Error(
+      `Extension "${extname}" declares grants but no schema; schema-qualified grants require an install schema.`
+    );
+  }
+
+  const ext = quoteIdent(extname);
+  const deploy: string[] = [];
+  const revert: string[] = [];
+  const verify: string[] = [];
+
+  if (schema !== null && createSchema) {
+    deploy.push(`CREATE SCHEMA IF NOT EXISTS ${quoteIdent(schema)};`);
+  }
+
+  const createParts = ['CREATE EXTENSION'];
+  if (ifNotExists) createParts.push('IF NOT EXISTS');
+  createParts.push(ext);
+  if (schema !== null) createParts.push(`WITH SCHEMA ${quoteIdent(schema)}`);
+  if (cascade) createParts.push('CASCADE');
+  deploy.push(`${createParts.join(' ')};`);
+
+  for (const g of grants) {
+    deploy.push(grantSql('GRANT', g, schema as string, roleMap));
+  }
+
+  // Revert: drop grants (best-effort), then extension, then optionally schema.
+  for (const g of [...grants].reverse()) {
+    revert.push(grantSql('REVOKE', g, schema as string, roleMap));
+  }
+  revert.push(`DROP EXTENSION IF EXISTS ${ext};`);
+  if (schema !== null && createSchema && dropSchema) {
+    revert.push(`DROP SCHEMA IF EXISTS ${quoteIdent(schema)};`);
+  }
+
+  // Verify: assert the extension exists in the expected namespace.
+  if (schema !== null) {
+    verify.push(
+      [
+        'SELECT 1 / count(*)::int AS ok',
+        'FROM pg_catalog.pg_extension e',
+        'JOIN pg_catalog.pg_namespace n ON n.oid = e.extnamespace',
+        `WHERE e.extname = ${quoteLiteral(extname)} AND n.nspname = ${quoteLiteral(schema)};`
+      ].join('\n')
+    );
+  } else {
+    verify.push(
+      [
+        'SELECT 1 / count(*)::int AS ok',
+        'FROM pg_catalog.pg_extension e',
+        `WHERE e.extname = ${quoteLiteral(extname)};`
+      ].join('\n')
+    );
+  }
+
+  return { deploy, revert, verify };
+}
+
+const quoteLiteral = (s: string): string => `'${s.replace(/'/g, "''")}'`;
+
+/** Compile every `provides` entry in a manifest, keyed by extension name. */
+export function compileExtensionInstalls(
+  provides: Record<string, ExtensionProvide>,
+  options: CompileExtensionInstallOptions = {}
+): Record<string, CompiledExtensionInstall> {
+  const out: Record<string, CompiledExtensionInstall> = {};
+  for (const [extname, provide] of Object.entries(provides)) {
+    out[extname] = compileExtensionInstall(extname, provide, options);
+  }
+  return out;
+}

--- a/pgpm/core/src/extensions/index.ts
+++ b/pgpm/core/src/extensions/index.ts
@@ -1,0 +1,4 @@
+export * from './compile';
+export * from './extensions';
+export * from './manifest';
+export * from './resolve-install';

--- a/pgpm/core/src/extensions/manifest.ts
+++ b/pgpm/core/src/extensions/manifest.ts
@@ -1,0 +1,214 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Declarative extension manifest (`extensions.json`) that lives next to a
+ * module's `pgpm.plan` / `.control`. It makes a module self-describing about
+ * the PostgreSQL extensions it relates to:
+ *
+ * - `provides` — the module *is* the extension wrapper: it installs the
+ *   extension into a chosen schema (with grants). This is what replaces the
+ *   dynamic `DO $$ EXECUTE 'CREATE EXTENSION ... SCHEMA x' $$` hack, since a
+ *   literal `CREATE EXTENSION` is stripped at package time.
+ * - `consumes` — the module merely *uses* symbols from an extension installed
+ *   elsewhere (e.g. a bare `crypt()` call) and needs them qualified to wherever
+ *   the extension actually landed. This is the transform/routing side.
+ *
+ * `.control` `requires` still names the extension (dependency ordering is
+ * unchanged); this manifest only adds the *where + grants* that `.control`
+ * cannot express.
+ */
+
+/** Candidate file names, in precedence order. */
+export const EXTENSIONS_MANIFEST_FILES = ['pgpm.extensions.json', 'extensions.json'] as const;
+
+/**
+ * What a declared grant targets. Kept structural (not free-form SQL) so it can
+ * be classified, role-routed, and reverted deterministically.
+ */
+export type ExtensionGrantTarget =
+  | 'schema'
+  | 'all-tables'
+  | 'all-sequences'
+  | 'all-functions';
+
+export interface ExtensionGrant {
+  /** Privilege list, e.g. `USAGE`, `ALL`, `EXECUTE`, `SELECT`. */
+  privileges: string;
+  /** Object class the grant applies to, resolved against the install schema. */
+  on: ExtensionGrantTarget;
+  /** Role name(s). Routed through the workspace role map when one is supplied. */
+  to: string | string[];
+}
+
+export interface ExtensionProvide {
+  /**
+   * Target schema for the install. A string routes the extension there; `null`
+   * means default/unqualified (control-file location, typically `public`).
+   */
+  schema?: string | null;
+  /**
+   * Author's assertion that the extension is relocatable. Defaults to `true`.
+   * A fixed-schema (`false`) extension must not be routed to a schema that
+   * differs from its control-file schema — {@link compileExtensionInstall}
+   * refuses that combination.
+   */
+  relocatable?: boolean;
+  /** Emit `IF NOT EXISTS` on `CREATE EXTENSION`. Defaults to `true`. */
+  ifNotExists?: boolean;
+  /** Emit `CASCADE` on `CREATE EXTENSION`. Defaults to `false`. */
+  cascade?: boolean;
+  /**
+   * Create `schema` before installing (idempotent). Defaults to `true` when a
+   * schema is given. Set `false` when the schema is owned by another module.
+   */
+  createSchema?: boolean;
+  /** Also `DROP SCHEMA` on revert. Defaults to `false` (only drop the extension). */
+  dropSchema?: boolean;
+  /** Grants applied after install. */
+  grants?: ExtensionGrant[];
+}
+
+export interface ExtensionConsume {
+  /** Bare symbol names this module references (functions/types/operators). */
+  symbols?: string[];
+}
+
+export interface ExtensionsManifest {
+  provides?: Record<string, ExtensionProvide>;
+  consumes?: Record<string, ExtensionConsume>;
+}
+
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === 'object' && v !== null && !Array.isArray(v);
+
+const GRANT_TARGETS: ReadonlySet<string> = new Set<ExtensionGrantTarget>([
+  'schema',
+  'all-tables',
+  'all-sequences',
+  'all-functions'
+]);
+
+/**
+ * Validate + normalize a parsed manifest object. Throws with a precise message
+ * on malformed input so authors get actionable errors rather than silent
+ * misconfiguration.
+ */
+export function validateExtensionsManifest(raw: unknown, source = 'extensions.json'): ExtensionsManifest {
+  if (!isPlainObject(raw)) {
+    throw new Error(`${source}: manifest must be a JSON object`);
+  }
+  const manifest: ExtensionsManifest = {};
+
+  if (raw.provides !== undefined) {
+    if (!isPlainObject(raw.provides)) {
+      throw new Error(`${source}: "provides" must be an object keyed by extension name`);
+    }
+    const provides: Record<string, ExtensionProvide> = {};
+    for (const [extname, value] of Object.entries(raw.provides)) {
+      provides[extname] = validateProvide(extname, value, source);
+    }
+    manifest.provides = provides;
+  }
+
+  if (raw.consumes !== undefined) {
+    if (!isPlainObject(raw.consumes)) {
+      throw new Error(`${source}: "consumes" must be an object keyed by extension name`);
+    }
+    const consumes: Record<string, ExtensionConsume> = {};
+    for (const [extname, value] of Object.entries(raw.consumes)) {
+      if (!isPlainObject(value)) {
+        throw new Error(`${source}: consumes."${extname}" must be an object`);
+      }
+      const entry: ExtensionConsume = {};
+      if (value.symbols !== undefined) {
+        if (!Array.isArray(value.symbols) || value.symbols.some((s) => typeof s !== 'string' || !s.trim())) {
+          throw new Error(`${source}: consumes."${extname}".symbols must be an array of non-empty strings`);
+        }
+        entry.symbols = value.symbols as string[];
+      }
+      consumes[extname] = entry;
+    }
+    manifest.consumes = consumes;
+  }
+
+  return manifest;
+}
+
+function validateProvide(extname: string, value: unknown, source: string): ExtensionProvide {
+  if (!isPlainObject(value)) {
+    throw new Error(`${source}: provides."${extname}" must be an object`);
+  }
+  const provide: ExtensionProvide = {};
+
+  if (value.schema !== undefined) {
+    if (value.schema !== null && (typeof value.schema !== 'string' || !value.schema.trim())) {
+      throw new Error(`${source}: provides."${extname}".schema must be a non-empty string or null`);
+    }
+    provide.schema = value.schema as string | null;
+  }
+
+  for (const flag of ['relocatable', 'ifNotExists', 'cascade', 'createSchema', 'dropSchema'] as const) {
+    if (value[flag] !== undefined) {
+      if (typeof value[flag] !== 'boolean') {
+        throw new Error(`${source}: provides."${extname}".${flag} must be a boolean`);
+      }
+      provide[flag] = value[flag] as boolean;
+    }
+  }
+
+  if (value.grants !== undefined) {
+    if (!Array.isArray(value.grants)) {
+      throw new Error(`${source}: provides."${extname}".grants must be an array`);
+    }
+    provide.grants = value.grants.map((g, i) => validateGrant(extname, g, i, source));
+  }
+
+  return provide;
+}
+
+function validateGrant(extname: string, value: unknown, index: number, source: string): ExtensionGrant {
+  const where = `provides."${extname}".grants[${index}]`;
+  if (!isPlainObject(value)) {
+    throw new Error(`${source}: ${where} must be an object`);
+  }
+  if (typeof value.privileges !== 'string' || !value.privileges.trim()) {
+    throw new Error(`${source}: ${where}.privileges must be a non-empty string`);
+  }
+  if (typeof value.on !== 'string' || !GRANT_TARGETS.has(value.on)) {
+    throw new Error(
+      `${source}: ${where}.on must be one of ${[...GRANT_TARGETS].join(', ')}`
+    );
+  }
+  const toValid =
+    (typeof value.to === 'string' && value.to.trim()) ||
+    (Array.isArray(value.to) && value.to.length > 0 && value.to.every((r) => typeof r === 'string' && r.trim()));
+  if (!toValid) {
+    throw new Error(`${source}: ${where}.to must be a role name or non-empty array of role names`);
+  }
+  return {
+    privileges: value.privileges as string,
+    on: value.on as ExtensionGrantTarget,
+    to: value.to as string | string[]
+  };
+}
+
+/**
+ * Read + validate the `extensions.json` (or `pgpm.extensions.json`) manifest for
+ * a module directory. Returns `undefined` when the module declares no manifest.
+ */
+export function readExtensionsManifest(moduleDir: string): ExtensionsManifest | undefined {
+  for (const file of EXTENSIONS_MANIFEST_FILES) {
+    const p = join(moduleDir, file);
+    if (existsSync(p)) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(readFileSync(p, 'utf-8'));
+      } catch (e: any) {
+        throw new Error(`Failed to parse ${file} at ${moduleDir}: ${e.message}`);
+      }
+      return validateExtensionsManifest(parsed, file);
+    }
+  }
+  return undefined;
+}

--- a/pgpm/core/src/extensions/resolve-install.ts
+++ b/pgpm/core/src/extensions/resolve-install.ts
@@ -1,0 +1,82 @@
+import { resolve } from 'path';
+
+import { RoleMapping } from '@pgpmjs/types';
+import { CompiledExtensionInstall, compileExtensionInstall, CompileExtensionInstallOptions } from './compile';
+import { ExtensionProvide, readExtensionsManifest } from './manifest';
+
+/**
+ * Build a grant role-name map (workspace portability profile) from the
+ * configured {@link RoleMapping}. Keys are the conceptual role names a module
+ * author writes in its manifest (`anonymous`/`authenticated`/`administrator`);
+ * values are the actual role names for this database.
+ */
+export function roleMapFromRoles(roles?: RoleMapping): Record<string, string> | undefined {
+  if (!roles) return undefined;
+  const map: Record<string, string> = {};
+  for (const key of ['anonymous', 'authenticated', 'administrator', 'authenticatedClient'] as const) {
+    const value = roles[key];
+    if (value) map[key] = value;
+  }
+  return Object.keys(map).length > 0 ? map : undefined;
+}
+
+/**
+ * Find a declarative install for an external extension by scanning the resolved
+ * local modules for an `extensions.json` that `provides` it, and compiling it.
+ *
+ * Returns `undefined` when no module declares the extension — the caller then
+ * falls back to the legacy `CREATE EXTENSION ... CASCADE` (no schema, no grants).
+ * The first declaring module wins; a later contradictory declaration throws.
+ */
+export function findExtensionInstall(
+  extname: string,
+  localModules: string[],
+  modules: Record<string, { path: string }>,
+  workspacePath: string,
+  options: CompileExtensionInstallOptions = {}
+): CompiledExtensionInstall | undefined {
+  let winner: { moduleName: string; provide: ExtensionProvide } | undefined;
+
+  for (const moduleName of localModules) {
+    const mod = modules[moduleName];
+    if (!mod) continue;
+    const manifest = readExtensionsManifest(resolve(workspacePath, mod.path));
+    const provide = manifest?.provides?.[extname];
+    if (!provide) continue;
+
+    if (winner && !sameProvide(winner.provide, provide)) {
+      throw new Error(
+        `Conflicting extensions.json "provides" for "${extname}": ` +
+          `module "${winner.moduleName}" and module "${moduleName}" declare incompatible ` +
+          `install schema/grants. Exactly one provider (or identical declarations) is required.`
+      );
+    }
+    if (!winner) winner = { moduleName, provide };
+  }
+
+  return winner ? compileExtensionInstall(extname, winner.provide, options) : undefined;
+}
+
+/** Structural equality of two provide declarations (order-insensitive grants). */
+function sameProvide(a: ExtensionProvide, b: ExtensionProvide): boolean {
+  return normalizeProvide(a) === normalizeProvide(b);
+}
+
+function normalizeProvide(p: ExtensionProvide): string {
+  const grants = (p.grants ?? [])
+    .map(g => ({
+      privileges: g.privileges,
+      on: g.on,
+      to: (Array.isArray(g.to) ? [...g.to] : [g.to]).sort()
+    }))
+    .sort((x, y) => JSON.stringify(x).localeCompare(JSON.stringify(y)));
+  return JSON.stringify({
+    schema: p.schema ?? null,
+    relocatable: p.relocatable ?? null,
+    ifNotExists: p.ifNotExists ?? null,
+    cascade: p.cascade ?? null,
+    createSchema: p.createSchema ?? null,
+    dropSchema: p.dropSchema ?? null,
+    grants
+  });
+}

--- a/pgpm/core/src/index.ts
+++ b/pgpm/core/src/index.ts
@@ -1,6 +1,6 @@
 export * from './core/class/pgpm';
 export * from './rebundle';
-export * from './extensions/extensions';
+export * from './extensions';
 export * from './modules/modules';
 export * from './packaging/package';
 export * from './packaging/sync-versions';

--- a/pgpm/core/src/projects/deploy.ts
+++ b/pgpm/core/src/projects/deploy.ts
@@ -10,6 +10,7 @@ import { resolveEffectiveModulePath } from '../apply/materialize';
 import { hasApplySpec } from '../apply/apply-spec';
 import { deployModuleFast, isBundledDeployResult } from '../bundle/deploy-bundled';
 import { PgpmPackage } from '../core/class/pgpm';
+import { findExtensionInstall, roleMapFromRoles } from '../extensions';
 import { PgpmMigrate } from '../migrate/client';
 import { resolveExtensionDependencies } from '../resolution/deps';
 
@@ -47,15 +48,35 @@ export const deployProject = async (
 
   const pgPool = getPgPool({ ...opts.pg, database });
 
+  // Local modules (in resolve order) that may carry an `extensions.json`
+  // declaring how an external extension should be installed (schema + grants).
+  const localModules = extensions.resolved.filter((m) => !extensions.external.includes(m));
+  const roleMap = roleMapFromRoles(mergedOpts.db?.roles);
+
   log.success(`🚀 Starting deployment to database ${database}...`);
 
   for (const extension of extensions.resolved) {
     try {
       if (extensions.external.includes(extension)) {
-        const msg = `CREATE EXTENSION IF NOT EXISTS "${extension}" CASCADE;`;
-        log.info(`📥 Installing external extension: ${extension}`);
-        log.debug(`> ${msg}`);
-        await pgPool.query(msg);
+        const install = findExtensionInstall(
+          extension,
+          localModules,
+          modules,
+          pkg.workspacePath!,
+          { roleMap }
+        );
+        if (install) {
+          log.info(`📥 Installing external extension (declarative): ${extension}`);
+          for (const stmt of install.deploy) {
+            log.debug(`> ${stmt}`);
+            await pgPool.query(stmt);
+          }
+        } else {
+          const msg = `CREATE EXTENSION IF NOT EXISTS "${extension}" CASCADE;`;
+          log.info(`📥 Installing external extension: ${extension}`);
+          log.debug(`> ${msg}`);
+          await pgPool.query(msg);
+        }
       } else {
         const sourcePath = resolve(pkg.workspacePath!, modules[extension].path);
         const modulePath = await resolveEffectiveModulePath(


### PR DESCRIPTION
## Summary

A pgpm module can now declare **where** an extension it wraps should be installed (schema + grants) in a sidecar `extensions.json`, instead of the schema-less `CREATE EXTENSION ... CASCADE` fallback. This is the first-class replacement for the old hand-written `DO $$ EXECUTE 'CREATE EXTENSION ... SCHEMA x' $$` hack: `.control` `requires` still names *which* extension (dependency ordering unchanged), and the sidecar adds *where* + grants — the two things `.control` can't express. A module is now self-describing about the extensions it provides.

```jsonc
// packages/crypto-ext/extensions.json  (next to crypto-ext.control, requires='pgcrypto')
{
  "provides": {
    "pgcrypto": {
      "schema": "extensions",
      "grants": [{ "privileges": "USAGE", "on": "schema", "to": ["authenticated", "administrator"] }]
    }
  }
}
```

On deploy, when an external extension named in a module's `requires` has a `provides` declaration, we install it declaratively:

```
CREATE SCHEMA IF NOT EXISTS "extensions";
CREATE EXTENSION IF NOT EXISTS "pgcrypto" WITH SCHEMA "extensions";
GRANT USAGE ON SCHEMA "extensions" TO authenticated, service_role;   -- 'administrator' routed via workspace role map
```

### What's here (nuts-and-bolts tooling, no product-specific policy)

- `extensions/manifest.ts` — parse + strict-validate `extensions.json` / `pgpm.extensions.json` (`provides` vs `consumes`; `pgpm.extensions.json` preferred, `extensions.json` accepted).
- `extensions/compile.ts` — `compileExtensionInstall()` → deterministic `{ deploy, revert, verify }`. No dynamic `EXECUTE`; reverse-order `REVOKE`/`DROP`; verify against `pg_catalog.pg_extension` + namespace; grant role names routed through a supplied role map (special roles `PUBLIC`/`CURRENT_USER`/`SESSION_USER` left alone); refuses a non-relocatable extension routed to an incompatible fixed schema; refuses grants with no install schema.
- `extensions/resolve-install.ts` — `findExtensionInstall()` scans resolved local modules for a `provides[ext]`. Exactly one provider (or byte-identical declarations) allowed; **conflicting** declarations across modules throw. `roleMapFromRoles()` derives the grant role map from the configured `db.roles`.
- Deploy wiring (`projects/deploy.ts` + `core/class/pgpm.ts`): the external-extension branch now prefers a declarative install and falls back to legacy `CASCADE` when no manifest exists — **no behavior change when no `extensions.json` is present**.

### Tests

- 22 unit tests (validation, deterministic compile, role routing, revert order, verify, fixed-schema/grant rejection, provider resolution + conflict detection).
- 2 DB e2e tests (`CoreDeployTestFixture`, fixture `__fixtures__/extensions/install`): from a fresh DB with pgcrypto *not* pre-installed, deploying `crypto-ext` lands pgcrypto in `extensions`, `app.hash_pw` resolves `extensions.crypt`/`extensions.gen_salt` and runs, the conceptual `administrator` grant is routed to `service_role`, and verify + revert work.

### Scope / follow-ups (tracked in constructive-planning#1303)

Install statements are executed directly in the deploy loop (not yet emitted as normal migration-ledger changes), and packaging still strips literal `CreateExtensionStmt`; wiring declared installs into the ledger + a scoped packaging exemption are the next steps. Control-file-driven relocatable/fixed-schema inference and the workspace-level portability profile (`portability.roles`/`extensionsSchema`) are also follow-ups.

### Notes

- Package `typecheck` and `build` are clean. `pnpm lint` in `pgpm/core` hits the repo-wide ESLint 9 / `.eslintrc` incompatibility (no `eslint.config.js`), unchanged from #319/#320/#321 — not introduced here.


Link to Devin session: https://app.devin.ai/sessions/025fb88043964fdbb335ac5e39df2478
Requested by: @pyramation