### PR TITLE
feat(pgpm): named migration engines (`--engine`, default `pg`) and wire driver activation

### DIFF
--- a/.agents/skills/pgpm/SKILL.md
+++ b/.agents/skills/pgpm/SKILL.md
@@ -356,6 +356,7 @@ Consult these reference files for detailed documentation on specific topics:
 | [references/sql-conventions.md](references/sql-conventions.md) | SQL file format and conventions | Writing SQL files, naming conventions, header format |
 | [references/dependencies.md](references/dependencies.md) | Managing module dependencies | Within-module or cross-module dependency references |
 | [references/deploy-lifecycle.md](references/deploy-lifecycle.md) | Deploy/verify/revert lifecycle | Understanding deployment process, tagging, status checking |
+| [references/engines.md](references/engines.md) | Migration backends (`--engine`, drivers) | Deploying into PGlite without a server, configuring `engine`/`engines`, writing a driver plugin |
 | [references/docker.md](references/docker.md) | Docker container management | Starting/stopping PostgreSQL, custom container options |
 | [references/env.md](references/env.md) | Environment variable management | Loading env vars, profiles, Supabase local development |
 | [references/environment-configuration.md](references/environment-configuration.md) | @pgpmjs/env library API | Programmatic configuration, config hierarchy, utility functions |

--- a/.agents/skills/pgpm/references/engines.md
+++ b/.agents/skills/pgpm/references/engines.md
@@ -1,0 +1,93 @@
+# Engines (migration backends)
+
+pgpm deploys through a **named engine**, in the sqitch `core.engine` sense: a short
+name selects the backend that runs migrations. The default is `pg` — a real
+PostgreSQL server over TCP, exactly as pgpm has always behaved.
+
+| Engine | Backend | Notes |
+|--------|---------|-------|
+| `pg` (default) | PostgreSQL server | Full capabilities: `createdb`, `pg_dump`, Docker lifecycle, multiple connections |
+| `pglite` | In-process PGlite (WASM Postgres) | No server, no socket; the instance *is* the database |
+
+## Selecting an engine
+
+Every database command accepts the selectors, and the first match wins:
+
+```bash
+pgpm deploy --driver @acme/my-adapter   # 1. name a driver plugin package directly
+pgpm deploy --pglite                    # 2. sugar for --engine pglite (in-memory)
+pgpm deploy --pglite=./.pglite          #    ...persisted to ./.pglite
+pgpm deploy --engine pglite             # 3. by engine name
+```
+
+Otherwise the engine comes from configuration, then from the `pg` default:
+
+```json
+{
+  "packages": ["packages/*"],
+  "engine": "pglite",
+  "engines": {
+    "pglite": { "options": { "dataDir": "./.pglite" } }
+  }
+}
+```
+
+`PGPM_ENGINE=pglite` sets the same thing from the environment. The `engines` block
+is the analogue of sqitch's `[engine "name"]` sections: an entry is merged over
+its built-in, so declaring only `options` keeps the built-in plugin, and a new
+name registers a new engine:
+
+```json
+{ "engines": { "turso": { "plugin": "@acme/turso-adapter", "options": { "url": "libsql://..." } } } }
+```
+
+## Capabilities and server-only commands
+
+A driver plugin declares what its backend can do, and pgpm gates on that rather
+than special-casing backends:
+
+| Capability | Gates |
+|------------|-------|
+| `createdb` | `deploy --createdb` (skipped with a notice when unavailable) |
+| `dump` | `pgpm dump` |
+| `serverLifecycle` | `pgpm docker`, `pgpm kill`, `pgpm tune` |
+| `multiConnection` | `pgpm admin-users` |
+
+On `pglite` all four are false, so `pgpm dump` exits with
+`pgpm dump is not supported by the "pglite" engine — it has no pg_dump.`
+
+## Deploying into PGlite with no server
+
+```bash
+pnpm add -D @pgpmjs/pglite-adapter @electric-sql/pglite
+pgpm deploy --engine pglite --database anything --package pets --yes
+```
+
+The plugin is resolved from the *consumer* project's `node_modules`, so it must be
+installed in the workspace being deployed (pgpm itself never depends on PGlite).
+`--database` is still accepted but names nothing on this engine.
+
+Tests keep using `pglite-test`'s `getConnections()`, which registers the same
+in-process instance directly; the engine flag is the CLI equivalent of that.
+
+## Writing a driver plugin
+
+A plugin is any package exporting `createPgpmDriver`:
+
+```ts
+import type { PgpmDriverSession } from '@pgpmjs/types';
+
+export const createPgpmDriver = async (
+  options: Record<string, unknown> = {}
+): Promise<PgpmDriverSession> => {
+  const handle = await register(options);       // register pool/client factories
+  return {
+    capabilities: { createdb: false, dump: false, serverLifecycle: false, multiConnection: false },
+    teardown: () => handle.close()
+  };
+};
+```
+
+pgpm activates it before the command runs and tears it down afterwards, so the
+unmodified migration engine targets whatever the factories return. See
+`@pgpmjs/pglite-adapter` for a complete implementation.

--- a/pgpm/cli/__tests__/engine.test.ts
+++ b/pgpm/cli/__tests__/engine.test.ts
@@ -1,0 +1,130 @@
+import { PgpmOptions } from '@pgpmjs/types';
+
+import { PGLITE_DRIVER_PLUGIN } from '../src/utils/driver';
+import { engineDefinitions, resolveEngine, SERVER_CAPABILITIES } from '../src/utils/engine';
+import { engineCommandBlocker } from '../src/utils/engine-gating';
+
+const PGLITE_CAPABILITIES = {
+  createdb: false,
+  dump: false,
+  serverLifecycle: false,
+  multiConnection: false,
+};
+
+describe('resolveEngine', () => {
+  it('defaults to the built-in pg engine with no driver', () => {
+    expect(resolveEngine({}, {})).toEqual({ name: 'pg', driver: undefined });
+  });
+
+  it('resolves the built-in pglite engine to its plugin', () => {
+    expect(resolveEngine({ engine: 'pglite' }, {})).toEqual({
+      name: 'pglite',
+      driver: { plugin: PGLITE_DRIVER_PLUGIN, options: {} },
+    });
+  });
+
+  it('treats --pglite as sugar for the pglite engine', () => {
+    expect(resolveEngine({ pglite: true }, {})).toEqual({
+      name: 'pglite',
+      driver: { plugin: PGLITE_DRIVER_PLUGIN, options: {} },
+    });
+  });
+
+  it('maps --pglite=<dataDir> to the engine dataDir option', () => {
+    expect(resolveEngine({ pglite: './local.db' }, {})).toEqual({
+      name: 'pglite',
+      driver: { plugin: PGLITE_DRIVER_PLUGIN, options: { dataDir: './local.db' } },
+    });
+  });
+
+  it('merges configured engine options under the CLI dataDir', () => {
+    const config: PgpmOptions = {
+      engines: { pglite: { plugin: PGLITE_DRIVER_PLUGIN, options: { dataDir: './cfg', roles: false } } },
+    };
+    expect(resolveEngine({ pglite: './cli' }, config)).toEqual({
+      name: 'pglite',
+      driver: { plugin: PGLITE_DRIVER_PLUGIN, options: { dataDir: './cli', roles: false } },
+    });
+  });
+
+  it('reads the configured engine name from pgpm.json', () => {
+    expect(resolveEngine({}, { engine: 'pglite' })).toEqual({
+      name: 'pglite',
+      driver: { plugin: PGLITE_DRIVER_PLUGIN, options: {} },
+    });
+  });
+
+  it('honors the low-level driver block when no engine is selected', () => {
+    const driver = { plugin: '@acme/turso-adapter', options: { url: 'libsql://x' } };
+    expect(resolveEngine({}, { driver })).toEqual({ name: '@acme/turso-adapter', driver });
+  });
+
+  it('lets --engine win over the configured driver block', () => {
+    const config: PgpmOptions = { driver: { plugin: '@acme/turso-adapter' } };
+    expect(resolveEngine({ engine: 'pg' }, config)).toEqual({ name: 'pg', driver: undefined });
+  });
+
+  it('lets --driver name a plugin directly, bypassing the engine registry', () => {
+    expect(resolveEngine({ driver: '@acme/turso-adapter' }, { engine: 'pglite' })).toEqual({
+      name: '@acme/turso-adapter',
+      driver: { plugin: '@acme/turso-adapter', options: undefined },
+    });
+  });
+
+  it('resolves an engine declared only in pgpm.json', () => {
+    const config: PgpmOptions = { engines: { turso: { plugin: '@acme/turso-adapter' } } };
+    expect(resolveEngine({ engine: 'turso' }, config)).toEqual({
+      name: 'turso',
+      driver: { plugin: '@acme/turso-adapter', options: {} },
+    });
+  });
+
+  it('rejects an unknown engine name and lists the known ones', () => {
+    expect(() => resolveEngine({ engine: 'mysql' }, {})).toThrow(
+      /Unknown pgpm engine "mysql"\. Known engines: pg, pglite\./
+    );
+  });
+
+  it('lets pgpm.json redefine a built-in engine', () => {
+    const config: PgpmOptions = { engines: { pglite: { plugin: '@acme/pglite-fork' } } };
+    expect(engineDefinitions(config).pglite).toEqual({ plugin: '@acme/pglite-fork' });
+    expect(resolveEngine({ engine: 'pglite' }, config).driver?.plugin).toBe('@acme/pglite-fork');
+  });
+
+  it('keeps the built-in plugin when pgpm.json configures only its options', () => {
+    const config: PgpmOptions = { engines: { pglite: { options: { dataDir: './.pglite' } } } };
+    expect(resolveEngine({ engine: 'pglite' }, config)).toEqual({
+      name: 'pglite',
+      driver: { plugin: PGLITE_DRIVER_PLUGIN, options: { dataDir: './.pglite' } },
+    });
+  });
+});
+
+describe('engineCommandBlocker', () => {
+  it('allows every command on the built-in server engine', () => {
+    for (const command of ['deploy', 'dump', 'docker', 'kill', 'tune', 'admin-users']) {
+      expect(engineCommandBlocker(command, { name: 'pg' }, SERVER_CAPABILITIES)).toBeUndefined();
+    }
+  });
+
+  it('allows migration commands on a single-session backend', () => {
+    for (const command of ['deploy', 'revert', 'verify', 'plan']) {
+      expect(engineCommandBlocker(command, { name: 'pglite' }, PGLITE_CAPABILITIES)).toBeUndefined();
+    }
+  });
+
+  it('blocks server-lifecycle commands with the reason', () => {
+    expect(engineCommandBlocker('docker', { name: 'pglite' }, PGLITE_CAPABILITIES)).toBe(
+      'pgpm docker is not supported by the "pglite" engine — it has no server to manage.'
+    );
+  });
+
+  it('blocks dump and the two-connection admin bootstrap', () => {
+    expect(engineCommandBlocker('dump', { name: 'pglite' }, PGLITE_CAPABILITIES)).toMatch(
+      /no pg_dump/
+    );
+    expect(engineCommandBlocker('admin-users', { name: 'pglite' }, PGLITE_CAPABILITIES)).toMatch(
+      /single-session backend/
+    );
+  });
+});

--- a/pgpm/cli/src/commands.ts
+++ b/pgpm/cli/src/commands.ts
@@ -31,7 +31,21 @@ import tune from './commands/tune';
 import updateCmd from './commands/update';
 import upgrade from './commands/upgrade';
 import verify from './commands/verify';
-import { usageText } from './utils';
+import {
+  activateEngine,
+  deactivateEngine,
+  EngineArgv,
+  engineCommandBlocker,
+  getActiveEngine,
+  usageText
+} from './utils';
+
+/**
+ * Commands that never talk to a database and must not activate a driver.
+ * `init` owns its own `--pglite` meaning (scaffold from the PGlite boilerplates),
+ * and it runs before the plugin it would scaffold is even installed.
+ */
+const ENGINE_EXEMPT_COMMANDS = new Set(['init']);
 
 const withPgTeardown = (fn: Function, skipTeardown: boolean = false) => async (...args: any[]) => {
   try {
@@ -149,7 +163,27 @@ export const commands = async (argv: Partial<ParsedArgs>, prompter: Inquirerer, 
     await cliExitWithError(`Unknown command: ${command}`, { beforeExit: teardownPgPools });
   }
 
-  await commandFn(newArgv, prompter, options);
+  // Activate the selected migration backend (`--engine`/`--driver`/`--pglite` or
+  // pgpm.json) before the command runs: the driver plugin registers its
+  // pool/client factories, so the unmodified engine targets it. The built-in
+  // `pg` engine activates nothing and behaves exactly as before.
+  const engineArgv = newArgv as unknown as EngineArgv & { cwd?: string };
+  const { engine, capabilities } = ENGINE_EXEMPT_COMMANDS.has(command)
+    ? getActiveEngine()
+    : await activateEngine(engineArgv, engineArgv.cwd).catch(async (error: Error) => {
+      await cliExitWithError(error.message, { beforeExit: teardownPgPools });
+      throw error;
+    });
+  try {
+    const blocked = engineCommandBlocker(command, engine, capabilities);
+    if (blocked) {
+      await cliExitWithError(blocked, { beforeExit: teardownPgPools });
+    }
+
+    await commandFn(newArgv, prompter, options);
+  } finally {
+    await deactivateEngine();
+  }
   prompter.close();
 
   return argv;

--- a/pgpm/cli/src/commands/deploy.ts
+++ b/pgpm/cli/src/commands/deploy.ts
@@ -8,7 +8,7 @@ import {
   getSpawnEnvWithPg,
 } from 'pg-env';
 
-import { getTargetDatabase, resolvePackageAlias } from '../utils';
+import { getActiveEngine, getTargetDatabase, resolvePackageAlias } from '../utils';
 import { selectPackage } from '../utils/module-utils';
 
 const deployUsageText = `
@@ -21,6 +21,10 @@ Deploy Command:
 Options:
   --help, -h         Show this help message
   --createdb         Create database if it doesn't exist
+  --engine <name>    Migration backend to deploy to (default: pg).
+                     Built-in engines: pg (Postgres server), pglite (in-process WASM).
+  --driver <pkg>     Driver plugin package to deploy through (escape hatch for --engine)
+  --pglite[=dataDir] Sugar for --engine pglite; persists to <dataDir> when given
   --recursive        Deploy recursively through dependencies
   --package <name>   Target specific package
   --to <target>      Deploy to specific change or tag
@@ -40,6 +44,8 @@ Examples:
   pgpm deploy --package mypackage --to @v1.0.0  Deploy specific package to tag
   pgpm deploy --fast --no-tx              Fast deployment without transactions
   pgpm deploy --bundled                    Same as --fast
+  pgpm deploy --engine pglite              Deploy into in-process PGlite (no server)
+  pgpm deploy --pglite=./.pglite           Deploy into a persisted PGlite data directory
 `;
 
 export default async (
@@ -132,11 +138,19 @@ export default async (
 
   log.debug(`Using current directory: ${cwd}`);
 
+  const { engine, capabilities } = getActiveEngine();
+
   if (createdb) {
-    log.info(`Creating database ${database}...`);
-    execSync(`createdb ${database}`, {
-      env: getSpawnEnvWithPg(pgEnv)
-    });
+    if (capabilities.createdb) {
+      log.info(`Creating database ${database}...`);
+      execSync(`createdb ${database}`, {
+        env: getSpawnEnvWithPg(pgEnv)
+      });
+    } else {
+      log.info(
+        `Skipping createdb: the "${engine.name}" engine's instance is the database.`
+      );
+    }
   }
 
   let packageName: string | undefined;

--- a/pgpm/cli/src/commands/revert.ts
+++ b/pgpm/cli/src/commands/revert.ts
@@ -24,6 +24,7 @@ Options:
   --to <target>      Revert to specific change or tag
   --to               Interactive selection of deployed changes
   --tx               Use transactions (default: true)
+  --engine <name>    Migration backend to revert in (default: pg; also pglite)
   --cwd <directory>  Working directory (default: current directory)
 
 Examples:

--- a/pgpm/cli/src/commands/verify.ts
+++ b/pgpm/cli/src/commands/verify.ts
@@ -22,6 +22,7 @@ Options:
   --package <name>   Verify specific package
   --to <target>      Verify up to specific change or tag
   --to               Interactive selection of deployed changes
+  --engine <name>    Migration backend to verify against (default: pg; also pglite)
   --cwd <directory>  Working directory (default: current directory)
 
 Examples:

--- a/pgpm/cli/src/utils/display.ts
+++ b/pgpm/cli/src/utils/display.ts
@@ -50,6 +50,11 @@ export const usageText = `
     -h, --help         Display this help information
     -v, --version      Display version information
     --cwd <directory>  Working directory (default: current directory)
+    --engine <name>    Migration backend: pg (default, Postgres server) or
+                       pglite (in-process WASM Postgres, no server). Also set by
+                       the "engine" key of pgpm.json or PGPM_ENGINE.
+    --driver <pkg>     Driver plugin package backing the engine (escape hatch)
+    --pglite[=dataDir] Sugar for --engine pglite, persisted to <dataDir> if given
 
   Individual Command Help:
     pgpm <command> --help    Display detailed help for specific command

--- a/pgpm/cli/src/utils/engine-gating.ts
+++ b/pgpm/cli/src/utils/engine-gating.ts
@@ -1,0 +1,39 @@
+import { PgpmDriverCapabilities } from '@pgpmjs/types';
+
+import { ResolvedEngine } from './engine';
+
+/**
+ * Commands that need a capability the backend may not have. Gating is declared
+ * here rather than branching per backend inside each command, so a new driver
+ * plugin only has to describe itself through {@link PgpmDriverCapabilities}.
+ */
+const COMMAND_REQUIREMENTS: Record<string, keyof PgpmDriverCapabilities> = {
+  docker: 'serverLifecycle',
+  kill: 'serverLifecycle',
+  tune: 'serverLifecycle',
+  'admin-users': 'multiConnection',
+  dump: 'dump',
+};
+
+const REQUIREMENT_REASONS: Record<keyof PgpmDriverCapabilities, string> = {
+  createdb: 'it cannot create databases (the instance is the database)',
+  dump: 'it has no pg_dump',
+  serverLifecycle: 'it has no server to manage',
+  multiConnection: 'it is a single-session backend',
+};
+
+/**
+ * The reason a command cannot run on the active engine, or undefined when it can.
+ */
+export const engineCommandBlocker = (
+  command: string,
+  engine: ResolvedEngine,
+  capabilities: PgpmDriverCapabilities
+): string | undefined => {
+  const requirement = COMMAND_REQUIREMENTS[command];
+  if (!requirement || capabilities[requirement]) return undefined;
+  return (
+    `pgpm ${command} is not supported by the "${engine.name}" engine — ` +
+    `${REQUIREMENT_REASONS[requirement]}.`
+  );
+};

--- a/pgpm/cli/src/utils/engine.ts
+++ b/pgpm/cli/src/utils/engine.ts
@@ -1,0 +1,143 @@
+import { getEnvOptions } from '@pgpmjs/env';
+import {
+  BUILTIN_ENGINES,
+  DEFAULT_ENGINE,
+  PgpmDriverCapabilities,
+  PgpmDriverConfig,
+  PgpmDriverSession,
+  PgpmEngineConfig,
+  PgpmOptions,
+} from '@pgpmjs/types';
+
+import { activateDriver, driverOverrideFromArgv, PGLITE_DRIVER_PLUGIN } from './driver';
+
+/** Everything a real Postgres server can do — the built-in `pg` engine. */
+export const SERVER_CAPABILITIES: PgpmDriverCapabilities = {
+  createdb: true,
+  dump: true,
+  serverLifecycle: true,
+  multiConnection: true,
+};
+
+/** The engine/driver selectors every command accepts. */
+export interface EngineArgv {
+  engine?: string;
+  driver?: string;
+  pglite?: boolean | string;
+}
+
+/** The engine a command runs against, plus the driver plugin backing it. */
+export interface ResolvedEngine {
+  /** Engine name, for messages: a registered name or a plugin package. */
+  name: string;
+  /** Driver plugin to activate; undefined = built-in `pg` (server) path. */
+  driver?: PgpmDriverConfig;
+}
+
+/**
+ * The engines available by name: the built-ins, overridden/extended by the
+ * `engines` block of `pgpm.json` (sqitch's `[engine "name"]` sections).
+ *
+ * A configured entry is merged over its built-in, so declaring only options
+ * (e.g. `engines.pglite.options.dataDir`) keeps the built-in plugin.
+ */
+export const engineDefinitions = (config: PgpmOptions): Record<string, PgpmEngineConfig> => {
+  const definitions: Record<string, PgpmEngineConfig> = { ...BUILTIN_ENGINES };
+  for (const [name, configured] of Object.entries(config.engines ?? {})) {
+    definitions[name] = { ...definitions[name], ...configured };
+  }
+  return definitions;
+};
+
+const definitionToDriver = (
+  definition: PgpmEngineConfig,
+  options?: Record<string, unknown>
+): PgpmDriverConfig | undefined =>
+  definition.plugin
+    ? { plugin: definition.plugin, options: { ...definition.options, ...options } }
+    : undefined;
+
+const lookupEngine = (
+  name: string,
+  config: PgpmOptions,
+  options?: Record<string, unknown>
+): ResolvedEngine => {
+  const definition = engineDefinitions(config)[name];
+  if (!definition) {
+    const known = Object.keys(engineDefinitions(config)).sort().join(', ');
+    throw new Error(
+      `Unknown pgpm engine "${name}". Known engines: ${known}.\n` +
+        'Declare it in the "engines" block of pgpm.json, or name its plugin with --driver <package>.'
+    );
+  }
+  return { name, driver: definitionToDriver(definition, options) };
+};
+
+/**
+ * Resolve which engine a command targets, mirroring sqitch's `core.engine` model:
+ * a short engine name selects the backend, and the built-in default is `pg`.
+ *
+ * Precedence (first match wins):
+ * 1. `--driver <package>` — name a driver plugin directly (escape hatch)
+ * 2. `--pglite[=dataDir]` — sugar for `--engine pglite`
+ * 3. `--engine <name>`
+ * 4. the `driver` block of `pgpm.json` — plugin-level configuration
+ * 5. the `engine` key of `pgpm.json` / `PGPM_ENGINE`
+ * 6. `pg`, the built-in server path
+ */
+export const resolveEngine = (argv: EngineArgv, config: PgpmOptions): ResolvedEngine => {
+  const override = driverOverrideFromArgv(argv);
+
+  if (override) {
+    if (override.plugin === PGLITE_DRIVER_PLUGIN && !argv.driver) {
+      // `--pglite` is the pglite engine, so it inherits that engine's configured
+      // options (e.g. a dataDir declared in pgpm.json) instead of bypassing them.
+      return lookupEngine('pglite', config, override.options);
+    }
+    return { name: override.plugin, driver: override };
+  }
+
+  if (argv.engine) return lookupEngine(argv.engine, config);
+  if (config.driver) return { name: config.driver.plugin, driver: config.driver };
+  return lookupEngine(config.engine ?? DEFAULT_ENGINE, config);
+};
+
+/** The engine activated for the running command. */
+export interface ActiveEngine {
+  engine: ResolvedEngine;
+  session?: PgpmDriverSession;
+  capabilities: PgpmDriverCapabilities;
+}
+
+let active: ActiveEngine | undefined;
+
+/**
+ * The engine activated for the running command. Commands read this to skip
+ * server-only steps (e.g. `deploy --createdb`) instead of hard-coding backends.
+ * Defaults to the built-in server path when nothing has been activated.
+ */
+export const getActiveEngine = (): ActiveEngine =>
+  active ?? { engine: { name: DEFAULT_ENGINE }, capabilities: SERVER_CAPABILITIES };
+
+/**
+ * Resolve the engine from argv + `pgpm.json` and activate its driver plugin.
+ * The driver has registered its pool/client factories by the time this resolves,
+ * so the unmodified pgpm engine runs against the selected backend.
+ */
+export const activateEngine = async (
+  argv: EngineArgv,
+  cwd: string = process.cwd()
+): Promise<ActiveEngine> => {
+  const config = getEnvOptions({}, cwd);
+  const engine = resolveEngine(argv, config);
+  const session = await activateDriver(engine.driver, undefined, cwd);
+  active = { engine, session, capabilities: session?.capabilities ?? SERVER_CAPABILITIES };
+  return active;
+};
+
+/** Tear down the active driver session and restore the built-in server path. */
+export const deactivateEngine = async (): Promise<void> => {
+  const session = active?.session;
+  active = undefined;
+  await session?.teardown();
+};

--- a/pgpm/cli/src/utils/index.ts
+++ b/pgpm/cli/src/utils/index.ts
@@ -3,6 +3,8 @@ export * from './deployed-changes';
 export * from './display';
 export * from './doctor';
 export * from './driver';
+export * from './engine';
+export * from './engine-gating';
 export * from './module-utils';
 export * from './npm-version';
 export * from './package-alias';

--- a/pgpm/env/src/env.ts
+++ b/pgpm/env/src/env.ts
@@ -17,6 +17,7 @@ export const getEnvVars = (env: NodeJS.ProcessEnv = process.env): PgpmOptions =>
       DB_EXTENSIONS,
       DB_CWD,
       PGPM_EXTENSIONS_DIR,
+      PGPM_ENGINE,
       DB_CONNECTION_USER,
       DB_CONNECTION_PASSWORD,
       DB_CONNECTION_ROLE,
@@ -82,6 +83,7 @@ export const getEnvVars = (env: NodeJS.ProcessEnv = process.env): PgpmOptions =>
 
   return {
     ...(PGPM_EXTENSIONS_DIR && { extensionsDir: PGPM_EXTENSIONS_DIR }),
+    ...(PGPM_ENGINE && { engine: PGPM_ENGINE }),
     db: {
       ...(PGROOTDATABASE && { rootDb: PGROOTDATABASE }),
       ...(PGTEMPLATE && { template: PGTEMPLATE }),

--- a/pgpm/types/src/driver.ts
+++ b/pgpm/types/src/driver.ts
@@ -65,3 +65,28 @@ export interface PgpmDriverConfig {
 
 /** Named export a driver plugin module must expose. */
 export const PGPM_DRIVER_EXPORT = 'createPgpmDriver' as const;
+
+/**
+ * A named engine, in the sqitch sense: a short name (`pg`, `pglite`) that
+ * selects a backend, so users say `--engine pglite` instead of naming a plugin
+ * package. `plugin: undefined` marks the built-in server path.
+ */
+export interface PgpmEngineConfig {
+    /** Driver plugin backing the engine; undefined = built-in `pg` (server). */
+    plugin?: string;
+    /** Default options forwarded to the plugin's `createPgpmDriver(options)`. */
+    options?: Record<string, unknown>;
+}
+
+/** Engine used when nothing selects one: the built-in Postgres server path. */
+export const DEFAULT_ENGINE = 'pg';
+
+/**
+ * Engines pgpm knows by name. Anything else must be declared in the `engines`
+ * block of `pgpm.json` (the analogue of sqitch's `[engine "name"]` sections) or
+ * named directly with `--driver <package>`.
+ */
+export const BUILTIN_ENGINES: Record<string, PgpmEngineConfig> = {
+    [DEFAULT_ENGINE]: {},
+    pglite: { plugin: '@pgpmjs/pglite-adapter' }
+};

--- a/pgpm/types/src/pgpm.ts
+++ b/pgpm/types/src/pgpm.ts
@@ -1,7 +1,7 @@
 import { execSync } from 'child_process';
 import { PgConfig } from 'pg-env';
 
-import { PgpmDriverConfig } from './driver';
+import { PgpmDriverConfig, PgpmEngineConfig } from './driver';
 
 /**
  * Authentication options for test client sessions
@@ -297,9 +297,21 @@ export interface PgpmOptions {
      */
     extensionsDir?: string;
     /**
-     * Pluggable migration backend. Undefined = built-in `pg` (server) path.
-     * Set `driver.plugin` to a package (e.g. `@pgpmjs/pglite-adapter`) resolved
-     * from the consumer's `node_modules`.
+     * Name of the migration backend to target, like sqitch's `core.engine`.
+     * Defaults to `pg` (the built-in server path); `pglite` is also built in,
+     * and any other name must be declared in {@link engines}.
+     */
+    engine?: string;
+    /**
+     * Engine definitions, the analogue of sqitch's `[engine "name"]` sections.
+     * Entries override/extend {@link BUILTIN_ENGINES}, mapping an engine name to
+     * the driver plugin backing it plus that engine's default options.
+     */
+    engines?: Record<string, PgpmEngineConfig>;
+    /**
+     * Pluggable migration backend, named by plugin package rather than by engine
+     * name — the low-level escape hatch behind {@link engine}. Undefined = the
+     * built-in `pg` (server) path. Resolved from the consumer's `node_modules`.
      */
     driver?: PgpmDriverConfig;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3296,12 +3296,18 @@ importers:
       '@pgpmjs/core':
         specifier: workspace:^
         version: link:../../pgpm/core/dist
+      '@pgpmjs/types':
+        specifier: workspace:^
+        version: link:../../pgpm/types/dist
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
       makage:
         specifier: ^0.3.0
         version: 0.3.0
+      pgpm:
+        specifier: workspace:^
+        version: link:../../pgpm/cli/dist
     publishDirectory: dist
 
   postgres/pglite-test:

--- a/postgres/pglite-adapter/README.md
+++ b/postgres/pglite-adapter/README.md
@@ -60,6 +60,32 @@ await migrate.verify({ modulePath: './my-module' });
 await close(); // restores the previous factory and closes PGlite
 ```
 
+### As a pgpm CLI engine
+
+The package also exports the pgpm driver-plugin entrypoint (`createPgpmDriver`),
+so the `pgpm` CLI can deploy into PGlite with no server once this package is
+installed in the workspace being deployed:
+
+```sh
+pgpm deploy --engine pglite --package pets --database anything --yes
+pgpm deploy --pglite=./.pglite --package pets --database anything --yes  # persisted
+```
+
+Or make it the workspace default in `pgpm.json`:
+
+```json
+{
+  "packages": ["packages/*"],
+  "engine": "pglite",
+  "engines": { "pglite": { "options": { "dataDir": "./.pglite" } } }
+}
+```
+
+The options are the same `PgliteAdapterOptions` as `registerPglite`. The
+driver reports `createdb`/`dump`/`serverLifecycle`/`multiConnection` as false, so
+pgpm skips `deploy --createdb` and refuses `pgpm dump`, `pgpm docker`, `pgpm kill`,
+`pgpm tune` and `pgpm admin-users` on this engine.
+
 ### Extensions
 
 pgpm's `cleanSql` strips `CREATE EXTENSION` from migrations, so extensions are

--- a/postgres/pglite-adapter/__tests__/cli-engine.test.ts
+++ b/postgres/pglite-adapter/__tests__/cli-engine.test.ts
@@ -1,0 +1,164 @@
+import { PGlite } from '@electric-sql/pglite';
+import { spawnSync } from 'child_process';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+
+/**
+ * End-to-end proof that the pgpm CLI deploys through this driver plugin with no
+ * PostgreSQL server anywhere: `pgpm deploy --engine pglite` (and the `engine`
+ * key of pgpm.json) resolves the plugin, activates it, and the unmodified
+ * migration engine writes into the in-process PGlite instance.
+ */
+
+const FIXTURE_MODULE = join(__dirname, 'fixtures', 'module');
+const MODULE_NAME = 'pglite-adapter-fixture';
+const ADAPTER_DIST = resolve(__dirname, '..', 'dist');
+const CLI_ENTRY = require.resolve('pgpm');
+
+// Point the default (server) path at a port nothing listens on: any deployment
+// that fell through to node-`pg` would fail with ECONNREFUSED instead of passing.
+const NO_SERVER_ENV = {
+  ...process.env,
+  PGHOST: '127.0.0.1',
+  PGPORT: '1',
+  PGPM_SKIP_UPDATE_CHECK: '1',
+};
+
+let workspace: string;
+
+const runCli = (args: string[]) =>
+  spawnSync('node', [CLI_ENTRY, ...args, '--no-tty', '--cwd', workspace], {
+    env: NO_SERVER_ENV,
+    encoding: 'utf8',
+  });
+
+const deployArgs = ['deploy', '--database', 'anything', '--package', MODULE_NAME, '--yes'];
+
+const makeWorkspace = (pgpmJson: Record<string, unknown>): string => {
+  const dir = mkdtempSync(join(tmpdir(), 'pgpm-engine-'));
+  const moduleDir = join(dir, 'packages', MODULE_NAME);
+  mkdirSync(moduleDir, { recursive: true });
+  cpSync(FIXTURE_MODULE, moduleDir, { recursive: true });
+  writeFileSync(
+    join(moduleDir, 'package.json'),
+    JSON.stringify({ name: MODULE_NAME, version: '0.0.1' })
+  );
+  writeFileSync(
+    join(moduleDir, `${MODULE_NAME}.control`),
+    [
+      `# ${MODULE_NAME} extension`,
+      `comment = '${MODULE_NAME} extension'`,
+      "default_version = '0.0.1'",
+      'relocatable = false',
+      'superuser = false',
+      ''
+    ].join('\n')
+  );
+  writeFileSync(join(dir, 'pgpm.json'), JSON.stringify({ packages: ['packages/*'], ...pgpmJson }));
+
+  // The driver loader resolves the plugin from the consumer project, so the
+  // workspace must be able to require it by package name.
+  mkdirSync(join(dir, 'node_modules', '@pgpmjs'), { recursive: true });
+  symlinkSync(ADAPTER_DIST, join(dir, 'node_modules', '@pgpmjs', 'pglite-adapter'), 'dir');
+  return dir;
+};
+
+const deployedChanges = async (dataDir: string): Promise<string[]> => {
+  const db = await PGlite.create({ dataDir });
+  try {
+    const { rows } = await db.query<{ change_name: string }>(
+      'SELECT change_name FROM pgpm_migrate.changes ORDER BY change_name'
+    );
+    const tables = await db.query(
+      "SELECT 1 FROM information_schema.tables WHERE table_schema = 'test_app' AND table_name = 'users'"
+    );
+    expect(tables.rows).toHaveLength(1);
+    return rows.map((row) => row.change_name);
+  } finally {
+    await db.close();
+  }
+};
+
+beforeAll(() => {
+  if (!existsSync(join(ADAPTER_DIST, 'index.js'))) {
+    throw new Error(`Build @pgpmjs/pglite-adapter first: ${ADAPTER_DIST} is missing`);
+  }
+});
+
+afterEach(() => {
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+describe('pgpm CLI deploys through the pglite engine with no server', () => {
+  it('deploys with --engine pglite', () => {
+    workspace = makeWorkspace({});
+    const { status, stdout, stderr } = runCli([...deployArgs, '--engine', 'pglite']);
+    expect(`${stdout}${stderr}`).not.toMatch(/ECONNREFUSED/);
+    expect(stdout).toMatch(/Successfully deployed: index/);
+    expect(status).toBe(0);
+  }, 120000);
+
+  it('deploys with --pglite=<dataDir> and persists to that directory', async () => {
+    workspace = makeWorkspace({});
+    const dataDir = join(workspace, '.pglite');
+    const { status, stdout } = runCli([...deployArgs, `--pglite=${dataDir}`]);
+    expect(status).toBe(0);
+    expect(stdout).toMatch(/Deployment complete/);
+    expect(await deployedChanges(dataDir)).toEqual(['index', 'schema', 'table']);
+  }, 120000);
+
+  it('reads the engine and its dataDir from pgpm.json', async () => {
+    workspace = makeWorkspace({ engine: 'pglite' });
+    const dataDir = join(workspace, 'configured.pglite');
+    // Declaring only options keeps the built-in plugin for the engine.
+    writeFileSync(
+      join(workspace, 'pgpm.json'),
+      JSON.stringify({
+        packages: ['packages/*'],
+        engine: 'pglite',
+        engines: { pglite: { options: { dataDir } } },
+      })
+    );
+    const { status, stdout } = runCli(deployArgs);
+    expect(status).toBe(0);
+    expect(stdout).toMatch(/Deployment complete/);
+    expect(await deployedChanges(dataDir)).toEqual(['index', 'schema', 'table']);
+  }, 120000);
+
+  it('verifies a previously deployed persisted instance', () => {
+    workspace = makeWorkspace({ engine: 'pglite' });
+    const dataDir = join(workspace, '.pglite');
+    expect(runCli([...deployArgs, `--pglite=${dataDir}`]).status).toBe(0);
+
+    const { status, stdout } = runCli([
+      'verify',
+      '--database',
+      'anything',
+      '--package',
+      MODULE_NAME,
+      '--yes',
+      `--pglite=${dataDir}`,
+    ]);
+    expect(status).toBe(0);
+    expect(stdout).toMatch(/Successfully verified: table/);
+  }, 180000);
+
+  it('refuses server-only commands on the pglite engine', () => {
+    workspace = makeWorkspace({ engine: 'pglite' });
+    const dump = runCli(['dump']);
+    expect(`${dump.stdout}${dump.stderr}`).toMatch(
+      /pgpm dump is not supported by the "pglite" engine/
+    );
+    const docker = runCli(['docker', 'start']);
+    expect(`${docker.stdout}${docker.stderr}`).toMatch(
+      /pgpm docker is not supported by the "pglite" engine/
+    );
+  }, 120000);
+
+  it('leaves the default pg engine on the server path', () => {
+    workspace = makeWorkspace({});
+    const { stdout, stderr } = runCli(deployArgs);
+    expect(`${stdout}${stderr}`).toMatch(/ECONNREFUSED/);
+  }, 120000);
+});

--- a/postgres/pglite-adapter/package.json
+++ b/postgres/pglite-adapter/package.json
@@ -42,8 +42,10 @@
   "devDependencies": {
     "@electric-sql/pglite": "0.5.4",
     "@pgpmjs/core": "workspace:^",
+    "@pgpmjs/types": "workspace:^",
     "@types/pg": "^8.20.0",
-    "makage": "^0.3.0"
+    "makage": "^0.3.0",
+    "pgpm": "workspace:^"
   },
   "dependencies": {
     "pg-cache": "workspace:^"

--- a/postgres/pglite-adapter/src/index.ts
+++ b/postgres/pglite-adapter/src/index.ts
@@ -1,4 +1,5 @@
 import { PGlite } from '@electric-sql/pglite';
+import type { PgpmDriverSession } from '@pgpmjs/types';
 import { getActivePgPoolFactory, registerPgPoolFactory } from 'pg-cache';
 
 import { createPglitePool } from './pool';
@@ -70,5 +71,31 @@ export const registerPglite = async (
       registerPgPoolFactory(previous);
       await db.close();
     }
+  };
+};
+
+/**
+ * The pgpm driver-plugin entrypoint (`createPgpmDriver`), which is how the pgpm
+ * CLI activates this backend for `--engine pglite` / `--driver
+ * @pgpmjs/pglite-adapter`. It registers the in-process PGlite instance as the
+ * pool factory — exactly what {@link registerPglite} does — and describes what
+ * PGlite cannot do so the CLI skips server-only steps generically.
+ *
+ * PGlite is one WASM instance with a single superuser session, so: the instance
+ * *is* the database (no `createdb`), there is no `pg_dump` binary and no server
+ * to manage, and a second concurrent connection is not available.
+ */
+export const createPgpmDriver = async (
+  options: PgliteAdapterOptions = {}
+): Promise<PgpmDriverSession> => {
+  const handle = await registerPglite(options);
+  return {
+    capabilities: {
+      createdb: false,
+      dump: false,
+      serverLifecycle: false,
+      multiConnection: false
+    },
+    teardown: () => handle.close()
   };
 };


### PR DESCRIPTION
## Summary

The driver seam was dead: `driverOverrideFromArgv`/`activateDriver` existed but **no command called them**, so `pgpm deploy --pglite` (and a configured `driver` block in `pgpm.json`) was silently ignored and dialed TCP `:5432` → `ECONNREFUSED`. And the one shipped plugin, `@pgpmjs/pglite-adapter`, didn't export `createPgpmDriver`, so even a wired-up loader would have thrown. In-process PGlite only ever worked through `pglite-test`'s `getConnections()` / `registerPglite()` — the library seam that e.g. `constructive-io/decryption` calls directly.

This makes the backend a **named engine** in the sqitch `core.engine` sense, with `pg` (server) as the default, and actually activates it.

Selection, first match wins — `--driver <pkg>` → `--pglite[=dataDir]` → `--engine <name>` → configured `driver` → configured `engine`/`PGPM_ENGINE` → `pg`:

```bash
pgpm deploy --engine pglite --package pets --database anything --yes   # no server
pgpm deploy --pglite=./.pglite --package pets --database anything --yes # persisted
```

```json
{ "engine": "pglite", "engines": { "pglite": { "options": { "dataDir": "./.pglite" } } } }
```

`engines` is the analogue of sqitch's `[engine "name"]` sections; an entry is *merged over* its built-in, so declaring only `options` keeps the built-in plugin, and a new name registers a new backend (`{ "turso": { "plugin": "@acme/turso-adapter" } }`).

Activation happens once, in the command dispatcher, so every database command inherits it and the engine's declared capabilities gate server-only work generically rather than special-casing PGlite:

```ts
const { engine, capabilities } = ENGINE_EXEMPT_COMMANDS.has(command)  // just `init`, which owns --pglite for scaffolding
  ? getActiveEngine()
  : await activateEngine(argv, argv.cwd);
try {
  const blocked = engineCommandBlocker(command, engine, capabilities);  // dump→dump, docker/kill/tune→serverLifecycle, admin-users→multiConnection
  if (blocked) await cliExitWithError(blocked, { beforeExit: teardownPgPools });
  await commandFn(newArgv, prompter, options);
} finally {
  await deactivateEngine();   // teardown restores the previous pool/client factories
}
```

`deploy --createdb` now consults `capabilities.createdb` instead of unconditionally shelling out to `createdb`. With no engine selected nothing is activated and capabilities are the full server set, so the `pg` path is byte-for-byte the old behavior (asserted by a test that the default still fails with `ECONNREFUSED` against a dead port).

`@pgpmjs/pglite-adapter` gains the plugin entrypoint, which is `registerPglite` plus the capability declaration:

```ts
export const createPgpmDriver = async (options: PgliteAdapterOptions = {}): Promise<PgpmDriverSession> => {
  const handle = await registerPglite(options);
  return {
    capabilities: { createdb: false, dump: false, serverLifecycle: false, multiConnection: false },
    teardown: () => handle.close()
  };
};
```

## Testing

- `pgpm/cli/__tests__/engine.test.ts` — resolution precedence, engine merging, unknown-engine error, gating matrix.
- `postgres/pglite-adapter/__tests__/cli-engine.test.ts` — spawns the real CLI in a temp workspace with `PGHOST/PGPORT` pointed at a dead port and asserts deploy/verify succeed through PGlite, that a `--pglite=<dataDir>` deploy leaves `pgpm_migrate.changes` = `schema,table,index` on disk, that `dump`/`docker` are refused, and that the default engine still hits the server path.
- Full `pgpm/cli` suite green against a real Postgres (19 suites / 134 tests), plus `pglite-adapter`, `pglite-test`, `@pgpmjs/env`.
- `pnpm lint` fails repo-wide before this branch (`.eslintrc.json` with ESLint 9 → "couldn't find an eslint.config.(js|mjs|cjs)"), unchanged by this PR.

Docs: `--engine`/`--driver`/`--pglite` in the global and per-command help, a new `.agents/skills/pgpm/references/engines.md`, and a CLI section in the adapter README.


Link to Devin session: https://app.devin.ai/sessions/81cf93e56370411ea6bfabaaa1cd2dc2
Requested by: @pyramation