### PR TITLE
fix(pgpm): don't activate drivers for connectionless commands; accept a relative --cwd

### DIFF
--- a/pgpm/cli/__tests__/driver.test.ts
+++ b/pgpm/cli/__tests__/driver.test.ts
@@ -1,3 +1,5 @@
+import { relative } from 'node:path';
+
 import {
   activateDriver,
   driverOverrideFromArgv,
@@ -83,6 +85,14 @@ describe('activateDriver', () => {
     await expect(
       activateDriver({ plugin: '@pgpmjs/pglite-adapter' }, undefined, '/nonexistent-project-root')
     ).rejects.toThrow(/is not installed in this project[\s\S]*@electric-sql\/pglite/);
+  });
+
+  it('resolves plugins from a relative cwd (as passed by --cwd)', async () => {
+    // Failure mode: createRequire rejects a relative path outright, so the
+    // plugin lookup errored before it could even be attempted.
+    await expect(
+      activateDriver({ plugin: 'pg-env' }, undefined, relative(process.cwd(), __dirname))
+    ).rejects.toThrow(/does not export createPgpmDriver/);
   });
 
   it('throws when the resolved module is not a driver plugin', async () => {

--- a/pgpm/cli/src/commands.ts
+++ b/pgpm/cli/src/commands.ts
@@ -41,11 +41,32 @@ import {
 } from './utils';
 
 /**
- * Commands that never talk to a database and must not activate a driver.
- * `init` owns its own `--pglite` meaning (scaffold from the PGlite boilerplates),
- * and it runs before the plugin it would scaffold is even installed.
+ * Commands that never open a connection, so they must not activate a driver —
+ * a workspace-wide `engine` must not make plan/scaffolding commands depend on
+ * the driver plugin being installed. `init` additionally owns its own `--pglite`
+ * meaning (scaffold from the PGlite boilerplates), and runs before the plugin
+ * it scaffolds exists.
  */
-const ENGINE_EXEMPT_COMMANDS = new Set(['init']);
+const ENGINE_EXEMPT_COMMANDS = new Set([
+  'add',
+  'analyze',
+  'cache',
+  'doctor',
+  'env',
+  'extension',
+  'init',
+  'install',
+  'package',
+  'plan',
+  'remove',
+  'rename',
+  'slice',
+  'sync-versions',
+  'tag',
+  'up',
+  'update',
+  'upgrade'
+]);
 
 const withPgTeardown = (fn: Function, skipTeardown: boolean = false) => async (...args: any[]) => {
   try {

--- a/pgpm/cli/src/utils/driver.ts
+++ b/pgpm/cli/src/utils/driver.ts
@@ -5,7 +5,7 @@ import {
   PgpmDriverSession,
 } from '@pgpmjs/types';
 import { createRequire } from 'node:module';
-import { join } from 'node:path';
+import { resolve } from 'node:path';
 
 /** Package name of the built-in PGlite driver plugin (the `--pglite` alias). */
 export const PGLITE_DRIVER_PLUGIN = '@pgpmjs/pglite-adapter';
@@ -77,8 +77,9 @@ export async function activateDriver(
   if (!cfg) return undefined;
 
   // A require bound to the consumer's project directory. `createRequire` is the
-  // one primitive available and identical in both CJS and ESM runtimes.
-  const requireFrom = createRequire(join(cwd, 'package.json'));
+  // one primitive available and identical in both CJS and ESM runtimes; it
+  // requires an absolute path, and `cwd` may come from a relative `--cwd`.
+  const requireFrom = createRequire(resolve(cwd, 'package.json'));
 
   let mod: Record<string, unknown>;
   try {

--- a/pgpm/cli/src/utils/engine.ts
+++ b/pgpm/cli/src/utils/engine.ts
@@ -8,6 +8,7 @@ import {
   PgpmEngineConfig,
   PgpmOptions,
 } from '@pgpmjs/types';
+import { resolve } from 'node:path';
 
 import { activateDriver, driverOverrideFromArgv, PGLITE_DRIVER_PLUGIN } from './driver';
 
@@ -128,9 +129,10 @@ export const activateEngine = async (
   argv: EngineArgv,
   cwd: string = process.cwd()
 ): Promise<ActiveEngine> => {
-  const config = getEnvOptions({}, cwd);
+  const dir = resolve(cwd);
+  const config = getEnvOptions({}, dir);
   const engine = resolveEngine(argv, config);
-  const session = await activateDriver(engine.driver, undefined, cwd);
+  const session = await activateDriver(engine.driver, undefined, dir);
   active = { engine, session, capabilities: session?.capabilities ?? SERVER_CAPABILITIES };
   return active;
 };

--- a/postgres/pglite-adapter/__tests__/cli-engine.test.ts
+++ b/postgres/pglite-adapter/__tests__/cli-engine.test.ts
@@ -27,8 +27,8 @@ const NO_SERVER_ENV = {
 
 let workspace: string;
 
-const runCli = (args: string[]) =>
-  spawnSync('node', [CLI_ENTRY, ...args, '--no-tty', '--cwd', workspace], {
+const runCli = (args: string[], cwd: string = workspace) =>
+  spawnSync('node', [CLI_ENTRY, ...args, '--no-tty', '--cwd', cwd], {
     env: NO_SERVER_ENV,
     encoding: 'utf8',
   });
@@ -155,6 +155,14 @@ describe('pgpm CLI deploys through the pglite engine with no server', () => {
       /pgpm docker is not supported by the "pglite" engine/
     );
   }, 120000);
+
+  it('runs connectionless commands in a pglite workspace without the plugin installed', () => {
+    workspace = makeWorkspace({ engine: 'pglite' });
+    rmSync(join(workspace, 'node_modules'), { recursive: true, force: true });
+    const { status, stdout, stderr } = runCli(['plan'], join(workspace, 'packages', MODULE_NAME));
+    expect(`${stdout}${stderr}`).not.toMatch(/is not installed in this project/);
+    expect(status).toBe(0);
+  }, 60000);
 
   it('leaves the default pg engine on the server path', () => {
     workspace = makeWorkspace({});


### PR DESCRIPTION
## Summary

Two follow-ups to #1525, both found while making the PGlite boilerplate set `"engine": "pglite"` workspace-wide (constructive-io/pglite-boilerplates#3). With that key present, plain `pgpm add`/`plan` in a fresh workspace broke.

**1. A workspace-wide `engine` must not make connectionless commands need the plugin.** The dispatcher exempted only `init`, so `pgpm add pets_table` tried to load `@pgpmjs/pglite-adapter` — before `pnpm install`, that's a hard failure on a command that never opens a connection:

```diff
-const ENGINE_EXEMPT_COMMANDS = new Set(['init']);
+const ENGINE_EXEMPT_COMMANDS = new Set([
+  'add', 'analyze', 'cache', 'doctor', 'env', 'extension', 'init', 'install',
+  'package', 'plan', 'remove', 'rename', 'slice', 'sync-versions', 'tag',
+  'up', 'update', 'upgrade'
+]);
```

The list is every command that resolves without touching `PgpmMigrate`/`pg-cache`; gated (`docker`, `kill`, `tune`, `admin-users`, `dump`) and connecting commands are unaffected.

**2. `--cwd packages/pets` (relative) crashed the loader.** `createRequire` only accepts an absolute path, so it threw *"The argument 'filename' must be a file URL object, file URL string, or absolute path string"* before the plugin lookup could report anything useful:

```diff
-const requireFrom = createRequire(join(cwd, 'package.json'));
+const requireFrom = createRequire(resolve(cwd, 'package.json'));
```

`activateEngine` also resolves `cwd` before handing it to `getEnvOptions`.

Tests: a relative-`cwd` case in `driver.test.ts`, and a CLI case asserting `pgpm plan` succeeds in an `engine: "pglite"` workspace with `node_modules` removed. Verified against the real scaffolded boilerplate: `pgpm init workspace` → `pgpm init` → `pgpm add pets_table --cwd packages/pets` → `PGPORT=1 pgpm deploy --package pets --yes` deploys into PGlite.


Link to Devin session: https://app.devin.ai/sessions/81cf93e56370411ea6bfabaaa1cd2dc2
Requested by: @pyramation