### PR TITLE
fix(pgpm): stop stripping CREATE EXTENSION on deploy (only strip transactions)

### DIFF
--- a/pgpm/core/__tests__/migrate/clean.test.ts
+++ b/pgpm/core/__tests__/migrate/clean.test.ts
@@ -1,0 +1,35 @@
+import { cleanSql } from '../../src/migrate/clean';
+
+describe('cleanSql', () => {
+  it('strips transaction-control statements (pgpm owns the transaction)', async () => {
+    const sql = [
+      'BEGIN;',
+      'CREATE TABLE app.thing (id int);',
+      'COMMIT;'
+    ].join('\n');
+    const cleaned = await cleanSql(sql, false, '$EOFCODE$');
+    expect(cleaned).not.toMatch(/\bBEGIN\b/i);
+    expect(cleaned).not.toMatch(/\bCOMMIT\b/i);
+    expect(cleaned).toMatch(/CREATE TABLE app\.thing/i);
+  });
+
+  it('preserves CREATE EXTENSION and its dependent statements together', async () => {
+    // Regression: previously CREATE EXTENSION was stripped while the dependent
+    // COMMENT ON EXTENSION survived, leaving a dangling reference that aborted
+    // deploy with `extension "..." does not exist`.
+    const sql = [
+      'CREATE SCHEMA IF NOT EXISTS graphql;',
+      'CREATE EXTENSION IF NOT EXISTS pg_graphql WITH SCHEMA graphql;',
+      "COMMENT ON EXTENSION pg_graphql IS 'pg_graphql: GraphQL support';"
+    ].join('\n');
+    const cleaned = await cleanSql(sql, false, '$EOFCODE$');
+    expect(cleaned).toMatch(/CREATE EXTENSION IF NOT EXISTS pg_graphql/i);
+    expect(cleaned).toMatch(/COMMENT ON EXTENSION pg_graphql/i);
+  });
+
+  it('returns the input unchanged when there is nothing to strip', async () => {
+    const sql = 'CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA extensions;';
+    const cleaned = await cleanSql(sql, false, '$EOFCODE$');
+    expect(cleaned).toBe(sql);
+  });
+});

--- a/pgpm/core/src/bundle/artifact.ts
+++ b/pgpm/core/src/bundle/artifact.ts
@@ -60,8 +60,8 @@ export function resolveBundleArtifactPath(moduleDir: string): string | null {
 
 /**
  * Build the executable form of a module's bundle: the content-addressed AST
- * snapshot plus, per change, the deploy SQL with transaction / `CREATE
- * EXTENSION` statements stripped (`cleanSql`).
+ * snapshot plus, per change, the deploy SQL with transaction-control
+ * statements stripped (`cleanSql`).
  *
  * That pre-computation is the whole point of the artifact — the parse/deparse
  * work moves from every deploy to the one-time package step, while the digests

--- a/pgpm/core/src/migrate/clean.ts
+++ b/pgpm/core/src/migrate/clean.ts
@@ -4,8 +4,7 @@ import { deparse,parse } from 'pgsql-parser';
 const filterStatements = (stmts: RawStmt[]): { filteredStmts: RawStmt[], hasFiltered: boolean } => {
   const filteredStmts = stmts.filter(node => {
     const stmt = node.stmt;
-    return stmt && !stmt.hasOwnProperty('TransactionStmt') && 
-           !stmt.hasOwnProperty('CreateExtensionStmt');
+    return stmt && !stmt.hasOwnProperty('TransactionStmt');
   });
   
   const hasFiltered = filteredStmts.length !== stmts.length;


### PR DESCRIPTION
## Summary

`cleanSql` (used by the live per-change deploy in `migrate/client.ts` **and** the bundle's executable SQL in `bundle/artifact.ts`) stripped two node kinds before executing a change's SQL: `TransactionStmt` and `CreateExtensionStmt`. Stripping `CREATE EXTENSION` while leaving the statements that *depend on the extension existing* (`COMMENT ON EXTENSION`, `ALTER EXTENSION … SET SCHEMA`, `DROP EXTENSION`) leaves a dangling reference, so deploy aborts with `extension "…" does not exist`.

```diff
 const filteredStmts = stmts.filter(node => {
   const stmt = node.stmt;
-  return stmt && !stmt.hasOwnProperty('TransactionStmt') &&
-         !stmt.hasOwnProperty('CreateExtensionStmt');
+  return stmt && !stmt.hasOwnProperty('TransactionStmt');
 });
```

**Why keep the transaction strip but drop the extension strip:** pgpm owns the per-change transaction (and savepoints), so an embedded `BEGIN`/`COMMIT` would corrupt the migration boundary — those must still go. But `CREATE EXTENSION` has no such conflict: `CREATE EXTENSION IF NOT EXISTS` is idempotent and harmless, and a module that literally asks to create an extension should get it. Passing it through also lets extension-wrapper modules (e.g. pg_partman) drop the dynamic `DO $$ EXECUTE 'CREATE EXTENSION … SCHEMA x' $$` hack that only existed to smuggle the statement past this filter.

Scope: this only touches the **live-deploy** path (`cleanSql`). Whole-module **extension-script packaging** (`packaging/package.ts` `mergeSqlStatements`) keeps its own strip — stripping nested `CREATE EXTENSION` there is part of the Postgres extension-file format contract (deps come from the control file's `requires`), and its snapshots are unchanged.

### Symptom this fixes

A module whose deploy SQL does:

```sql
CREATE SCHEMA IF NOT EXISTS graphql;
CREATE EXTENSION IF NOT EXISTS pg_graphql WITH SCHEMA graphql;  -- was stripped
COMMENT ON EXTENSION pg_graphql IS 'pg_graphql: GraphQL support'; -- survived -> dangling ref
```

previously aborted deploy (`extension "pg_graphql" does not exist`), cascading into hundreds of downstream "relation … does not exist" failures.

## Testing

- New `pgpm/core/__tests__/migrate/clean.test.ts` (3 cases): transactions stripped; `CREATE EXTENSION` + dependent `COMMENT ON EXTENSION` preserved together; no-op passthrough.
- Full `@pgpmjs/core` suite: **69 suites / 435 tests** pass (incl. the 69 packaging snapshots, which are unaffected).
- `pgpm/bundle` (7/52), `pgpm/transform` (4/31), `pgpm/cli` (19/134) pass.
- End-to-end against a live Supabase Postgres stack (the repro): the `supabase-test-suite` package went from **203 failing / 35 failing suites** to **246 passing / 44 suites** with this change applied.


Link to Devin session: https://app.devin.ai/sessions/025fb88043964fdbb335ac5e39df2478
Requested by: @pyramation