### PR TITLE
feat(pgpm): unified routing profile with workspace `portability` attach point

### DIFF
--- a/.agents/skills/pgpm-migration-bundle/SKILL.md
+++ b/.agents/skills/pgpm-migration-bundle/SKILL.md
@@ -162,6 +162,10 @@ transpileBundle(bundle, {
 - `renameChange` is validated as a bijection over touched changes (no collisions, no
   rename onto an untouched existing change).
 - Records `provenance.sourceBundleDigest` for lineage.
+- In pgpm's apply path the transpiler options come from the unified routing profile
+  (`schemas`/`route`/`extensions`/`roles`), merged from the workspace `portability`
+  field in `pgpm.json` and the proxy's `pgpm.apply.json` (inner scope wins per key) —
+  see the `pgpm` skill's `references/routing-profile.md`.
 
 ### `createEnvelope` — the shippable artifact container (fn #3)
 

--- a/.agents/skills/pgpm/SKILL.md
+++ b/.agents/skills/pgpm/SKILL.md
@@ -361,6 +361,7 @@ Consult these reference files for detailed documentation on specific topics:
 | [references/env.md](references/env.md) | Environment variable management | Loading env vars, profiles, Supabase local development |
 | [references/environment-configuration.md](references/environment-configuration.md) | @pgpmjs/env library API | Programmatic configuration, config hierarchy, utility functions |
 | [references/extensions.md](references/extensions.md) | PostgreSQL extensions & pgpm modules | Adding extensions, installing @pgpm/* modules, .control requires |
+| [references/routing-profile.md](references/routing-profile.md) | Routing profile & module self-description | `extensions.json` provides/consumes, `pgpm.apply.json`, workspace `portability` in `pgpm.json`, routing precedence |
 | [references/module-naming.md](references/module-naming.md) | npm names vs control file names | Confused about which identifier to use where |
 | [references/plan-format.md](references/plan-format.md) | pgpm.plan file format | Fixing `Invalid line format` errors, editing plan files manually |
 | [references/publishing.md](references/publishing.md) | Publishing modules to npm | Bundling, versioning with lerna, publishing @pgpm/* packages |

--- a/.agents/skills/pgpm/references/extensions.md
+++ b/.agents/skills/pgpm/references/extensions.md
@@ -77,6 +77,14 @@ The `requires` field uses **control file names**, not npm package names:
 
 See `references/module-naming.md` for the full naming convention.
 
+### Beyond `requires`: where an extension lands
+
+`.control` `requires` only orders dependencies. To declare *where* an extension installs
+(schema + grants) or which of its symbols a module consumes, use the per-module
+`extensions.json` manifest; to route those symbols in a consumer, use the routing profile
+(`portability` in `pgpm.json` or a proxy's `pgpm.apply.json`). See
+`references/routing-profile.md`.
+
 ## Adding Dependencies
 
 > New modules scaffold with **no** extensions (no `requires` line). Add them explicitly, either up front at init (`pgpm init --extensions a,b` / `--with-extensions`) or afterward with `pgpm extension` (below).

--- a/.agents/skills/pgpm/references/routing-profile.md
+++ b/.agents/skills/pgpm/references/routing-profile.md
@@ -1,0 +1,103 @@
+# Routing Profile & Module Self-Description
+
+How pgpm separates *what a module is* from *where a consumer puts it*. Two surfaces, no more:
+
+1. **Self-description (intrinsic, per module)** — the module states facts about itself:
+   `.control` `requires` (dependency ordering) + an `extensions.json` manifest
+   (`provides`/`consumes`: where an extension it wraps installs, or which symbols it uses).
+2. **Routing profile (extrinsic, consumer policy)** — one shared shape
+   (`PgpmRoutingProfile`: `schemas`, `route`, `extensions`, `roles`) attachable at two scopes:
+   the workspace (`portability` in `pgpm.json`) and per import (a proxy module's
+   `pgpm.apply.json`).
+
+Key rule: consumers never hard-code where an extension lives. The module that *provides*
+an extension declares its default schema/grants; consumers only declare the symbols they
+consume, and the transform resolves symbol qualification to wherever the provider landed.
+
+## Surface 1: module self-description
+
+### `.control` `requires`
+
+Names extension/module dependencies (control names). Ordering only — it cannot say *where*
+or *with which grants*.
+
+### `extensions.json` (or `pgpm.extensions.json`)
+
+Sits next to `pgpm.plan`. Two keys:
+
+- `provides` — this module *is* the wrapper for an extension: it declares the install
+  schema and grants. Replaces dynamic `CREATE EXTENSION ... SCHEMA x` hacks.
+- `consumes` — this module merely *uses* symbols from an extension installed elsewhere
+  and needs them qualified to wherever it actually landed.
+
+```json
+{
+  "provides": {
+    "pgcrypto": {
+      "schema": "extensions",
+      "grants": [
+        { "privileges": "USAGE", "on": "schema", "to": ["authenticated"] }
+      ]
+    }
+  },
+  "consumes": {
+    "pgcrypto": { "symbols": ["crypt", "gen_salt"] }
+  }
+}
+```
+
+## Surface 2: the routing profile
+
+One TypeScript shape, `PgpmRoutingProfile` (`@pgpmjs/types`), driven by
+`@pgsql/transform`'s SchemaRouter/ExtensionRouter/RoleRouter:
+
+| Key | Meaning |
+|-----|---------|
+| `schemas` | Whole-schema default: source schema → target schema |
+| `route` | Object-level overrides: `{ fromSchema, kind, name, toSchema }[]` |
+| `extensions` | Extension-symbol routing: `{ toSchema \| routes, only?, from? }` |
+| `roles` | Role-name translation: source role → target role |
+
+### Attach point A — workspace scope: `portability` in `pgpm.json`
+
+The default for every apply/transpile in the workspace:
+
+```json
+{
+  "packages": ["packages/*"],
+  "portability": {
+    "extensions": { "toSchema": "extensions" },
+    "roles": { "anonymous": "anon", "administrator": "service_role" }
+  }
+}
+```
+
+### Attach point B — per-import scope: `pgpm.apply.json`
+
+A proxy module's apply spec carries the same routing keys plus its `source`:
+
+```json
+{
+  "source": "secure-module",
+  "schemas": { "vault": "vault_a" },
+  "roles": { "anonymous": "anon_a" }
+}
+```
+
+### Precedence: defaults → workspace `portability` → apply spec
+
+Merged **per key** (inner scope wins, like lexical scoping): a proxy that only overrides
+`roles` still inherits the workspace `extensions` mapping. An overriding key replaces the
+whole value — there is no deep merge within a key.
+
+Everything is additive and backward compatible: with no workspace profile, apply specs
+behave exactly as before; a proxy must still declare at least one routing key of its own.
+
+## Where it lives in code
+
+- `PgpmRoutingProfile`, `mergeRoutingProfiles` — `pgpm/types/src/routing.ts`
+- Workspace attach point — `PgpmWorkspaceConfig.portability` (`pgpm/types/src/pgpm.ts`)
+- Loading + spec merge — `pgpm/core/src/apply/profile.ts`
+  (`loadWorkspaceRoutingProfile`, `resolveEffectiveApplySpec`)
+- Apply spec parsing — `pgpm/core/src/apply/apply-spec.ts`
+- Extensions manifest — `pgpm/core/src/extensions/manifest.ts`

--- a/__fixtures__/apply/workspace-profile/packages/secure-a/pgpm.apply.json
+++ b/__fixtures__/apply/workspace-profile/packages/secure-a/pgpm.apply.json
@@ -1,0 +1,6 @@
+{
+  "source": "secure-module",
+  "schemas": {
+    "vault": "vault_a"
+  }
+}

--- a/__fixtures__/apply/workspace-profile/packages/secure-b/pgpm.apply.json
+++ b/__fixtures__/apply/workspace-profile/packages/secure-b/pgpm.apply.json
@@ -1,0 +1,10 @@
+{
+  "source": "secure-module",
+  "schemas": {
+    "vault": "vault_b"
+  },
+  "roles": {
+    "anonymous": "anon_b",
+    "administrator": "service_role_b"
+  }
+}

--- a/__fixtures__/apply/workspace-profile/packages/secure-module/deploy/schemas/vault/functions/hash_pw.sql
+++ b/__fixtures__/apply/workspace-profile/packages/secure-module/deploy/schemas/vault/functions/hash_pw.sql
@@ -1,0 +1,14 @@
+-- Deploy schemas/vault/functions/hash_pw to pg
+
+-- requires: schemas/vault/schema
+
+BEGIN;
+
+CREATE FUNCTION vault.hash_pw(pw text) RETURNS text AS $$
+  SELECT crypt(pw, gen_salt('bf'));
+$$ LANGUAGE sql VOLATILE;
+
+GRANT EXECUTE ON FUNCTION vault.hash_pw(text) TO anonymous;
+GRANT USAGE ON SCHEMA vault TO administrator;
+
+COMMIT;

--- a/__fixtures__/apply/workspace-profile/packages/secure-module/deploy/schemas/vault/schema.sql
+++ b/__fixtures__/apply/workspace-profile/packages/secure-module/deploy/schemas/vault/schema.sql
@@ -1,0 +1,7 @@
+-- Deploy schemas/vault/schema to pg
+
+BEGIN;
+
+CREATE SCHEMA vault;
+
+COMMIT;

--- a/__fixtures__/apply/workspace-profile/packages/secure-module/pgpm.plan
+++ b/__fixtures__/apply/workspace-profile/packages/secure-module/pgpm.plan
@@ -1,0 +1,6 @@
+%syntax-version=1.0.0
+%project=secure-module
+%uri=secure-module
+
+schemas/vault/schema 2024-01-01T00:00:00Z Dev <dev@example.com> # add vault schema
+schemas/vault/functions/hash_pw [schemas/vault/schema] 2024-01-01T00:00:01Z Dev <dev@example.com> # add hash_pw

--- a/__fixtures__/apply/workspace-profile/packages/secure-module/revert/schemas/vault/functions/hash_pw.sql
+++ b/__fixtures__/apply/workspace-profile/packages/secure-module/revert/schemas/vault/functions/hash_pw.sql
@@ -1,0 +1,7 @@
+-- Revert schemas/vault/functions/hash_pw from pg
+
+BEGIN;
+
+DROP FUNCTION vault.hash_pw(text);
+
+COMMIT;

--- a/__fixtures__/apply/workspace-profile/packages/secure-module/revert/schemas/vault/schema.sql
+++ b/__fixtures__/apply/workspace-profile/packages/secure-module/revert/schemas/vault/schema.sql
@@ -1,0 +1,7 @@
+-- Revert schemas/vault/schema from pg
+
+BEGIN;
+
+DROP SCHEMA vault;
+
+COMMIT;

--- a/__fixtures__/apply/workspace-profile/packages/secure-module/secure-module.control
+++ b/__fixtures__/apply/workspace-profile/packages/secure-module/secure-module.control
@@ -1,0 +1,7 @@
+# secure-module extension
+comment = 'secure-module extension'
+default_version = '0.0.1'
+module_pathname = '$libdir/secure-module'
+requires = 'plpgsql'
+relocatable = false
+superuser = false

--- a/__fixtures__/apply/workspace-profile/packages/secure-module/verify/schemas/vault/functions/hash_pw.sql
+++ b/__fixtures__/apply/workspace-profile/packages/secure-module/verify/schemas/vault/functions/hash_pw.sql
@@ -1,0 +1,7 @@
+-- Verify schemas/vault/functions/hash_pw on pg
+
+BEGIN;
+
+SELECT vault.hash_pw('probe');
+
+ROLLBACK;

--- a/__fixtures__/apply/workspace-profile/packages/secure-module/verify/schemas/vault/schema.sql
+++ b/__fixtures__/apply/workspace-profile/packages/secure-module/verify/schemas/vault/schema.sql
@@ -1,0 +1,7 @@
+-- Verify schemas/vault/schema on pg
+
+BEGIN;
+
+SELECT pg_catalog.has_schema_privilege('vault', 'usage');
+
+ROLLBACK;

--- a/__fixtures__/apply/workspace-profile/pgpm.json
+++ b/__fixtures__/apply/workspace-profile/pgpm.json
@@ -1,0 +1,14 @@
+{
+    "packages": [
+        "packages/*"
+    ],
+    "portability": {
+        "extensions": {
+            "toSchema": "extensions"
+        },
+        "roles": {
+            "anonymous": "anon",
+            "administrator": "service_role"
+        }
+    }
+}

--- a/pgpm/core/__tests__/apply/apply-workspace-profile.test.ts
+++ b/pgpm/core/__tests__/apply/apply-workspace-profile.test.ts
@@ -1,0 +1,157 @@
+import {
+  clearApplyMaterializationCache,
+  loadWorkspaceRoutingProfile,
+  parseApplySpec,
+  resolveEffectiveApplySpec
+} from '../../src/apply';
+import { CoreDeployTestFixture } from '../../test-utils/CoreDeployTestFixture';
+import { TestDatabase } from '../../test-utils/TestDatabase';
+import { TestFixture } from '../../test-utils/TestFixture';
+
+const at = '/ws/packages/secure-a/pgpm.apply.json';
+
+describe('resolveEffectiveApplySpec — workspace profile precedence', () => {
+  const spec = parseApplySpec(
+    JSON.stringify({ source: 'secure-module', schemas: { vault: 'vault_a' } }),
+    at
+  );
+
+  it('no workspace profile: the spec passes through unchanged', () => {
+    expect(resolveEffectiveApplySpec(spec, undefined)).toBe(spec);
+  });
+
+  it('workspace profile fills keys the spec does not define', () => {
+    const effective = resolveEffectiveApplySpec(spec, {
+      extensions: { toSchema: 'extensions' },
+      roles: { anonymous: 'anon' }
+    });
+    expect(effective.schemas).toEqual({ vault: 'vault_a' });
+    expect(effective.extensions).toEqual({ toSchema: 'extensions' });
+    expect(effective.roles).toEqual({ anonymous: 'anon' });
+    expect(effective.name).toBe(spec.name);
+    expect(effective.source).toEqual(spec.source);
+  });
+
+  it('spec keys win whole over the workspace profile (per key)', () => {
+    const withRoles = parseApplySpec(
+      JSON.stringify({
+        source: 'secure-module',
+        schemas: { vault: 'vault_b' },
+        roles: { anonymous: 'anon_b' }
+      }),
+      at
+    );
+    const effective = resolveEffectiveApplySpec(withRoles, {
+      schemas: { vault: 'never' },
+      extensions: { toSchema: 'extensions' },
+      roles: { anonymous: 'anon', administrator: 'service_role' }
+    });
+    expect(effective.schemas).toEqual({ vault: 'vault_b' });
+    expect(effective.roles).toEqual({ anonymous: 'anon_b' });
+    expect(effective.extensions).toEqual({ toSchema: 'extensions' });
+  });
+});
+
+describe('loadWorkspaceRoutingProfile', () => {
+  let withProfile: TestFixture;
+  let withoutProfile: TestFixture;
+
+  beforeAll(() => {
+    withProfile = new TestFixture('apply', 'workspace-profile');
+    withoutProfile = new TestFixture('apply', 'portability');
+  });
+
+  afterAll(() => {
+    withProfile.cleanup();
+    withoutProfile.cleanup();
+  });
+
+  it('reads the portability field from the workspace pgpm.json', () => {
+    expect(loadWorkspaceRoutingProfile(withProfile.tempFixtureDir)).toEqual({
+      extensions: { toSchema: 'extensions' },
+      roles: { anonymous: 'anon', administrator: 'service_role' }
+    });
+  });
+
+  it('returns undefined when the workspace declares no profile', () => {
+    expect(loadWorkspaceRoutingProfile(withoutProfile.tempFixtureDir)).toBeUndefined();
+  });
+
+  it('returns undefined when there is no workspace config at all', () => {
+    expect(loadWorkspaceRoutingProfile(withProfile.fixturePath('packages'))).toBeUndefined();
+  });
+});
+
+describe('workspace profile deployment (e2e)', () => {
+  let fixture: CoreDeployTestFixture;
+  let db: TestDatabase;
+
+  const functionExists = async (schema: string, name: string): Promise<boolean> => {
+    const res = await db.query(
+      `SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+       WHERE n.nspname = $1 AND p.proname = $2`,
+      [schema, name]
+    );
+    return res.rows.length > 0;
+  };
+
+  beforeAll(() => {
+    fixture = new CoreDeployTestFixture('apply', 'workspace-profile');
+  });
+
+  afterAll(async () => {
+    await fixture.cleanup();
+  });
+
+  beforeEach(async () => {
+    clearApplyMaterializationCache();
+    db = await fixture.setupTestDatabase();
+    await db.query('CREATE SCHEMA IF NOT EXISTS extensions');
+    await db.query('CREATE EXTENSION IF NOT EXISTS pgcrypto SCHEMA extensions');
+    await db.query(
+      `DO $$ BEGIN
+         IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN CREATE ROLE anon; END IF;
+         IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN CREATE ROLE service_role; END IF;
+         IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon_b') THEN CREATE ROLE anon_b; END IF;
+         IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role_b') THEN CREATE ROLE service_role_b; END IF;
+       END $$;`
+    );
+  });
+
+  test('a proxy with no routing beyond schemas inherits the workspace extensions + roles', async () => {
+    await fixture.deployModule('secure-a', db.name, ['apply', 'workspace-profile']);
+
+    expect(await db.exists('schema', 'vault')).toBe(false);
+    expect(await functionExists('vault_a', 'hash_pw')).toBe(true);
+
+    // extension symbols resolved via the workspace extensions mapping
+    const a = await db.query(`SELECT vault_a.hash_pw('secret') AS h`);
+    expect(typeof a.rows[0].h).toBe('string');
+
+    // grants use the workspace role translation
+    const priv = await db.query(
+      `SELECT has_schema_privilege('service_role', 'vault_a', 'usage') AS ok`
+    );
+    expect(priv.rows[0].ok).toBe(true);
+  });
+
+  test('a proxy that overrides roles keeps the workspace extensions mapping', async () => {
+    await fixture.deployModule('secure-b', db.name, ['apply', 'workspace-profile']);
+
+    expect(await functionExists('vault_b', 'hash_pw')).toBe(true);
+
+    // workspace extensions mapping still applies (function resolves crypt/gen_salt)
+    const b = await db.query(`SELECT vault_b.hash_pw('secret') AS h`);
+    expect(typeof b.rows[0].h).toBe('string');
+
+    // the proxy's own role map wins over the workspace one
+    const overridden = await db.query(
+      `SELECT has_schema_privilege('service_role_b', 'vault_b', 'usage') AS ok`
+    );
+    expect(overridden.rows[0].ok).toBe(true);
+    const workspaceRole = await db.query(
+      `SELECT has_schema_privilege('service_role', 'vault_b', 'usage') AS ok`
+    );
+    expect(workspaceRole.rows[0].ok).toBe(false);
+  });
+});

--- a/pgpm/core/src/apply/index.ts
+++ b/pgpm/core/src/apply/index.ts
@@ -1,4 +1,5 @@
 export * from './materialize';
+export * from './profile';
 export * from './apply-spec';
 export * from './reuse';
 export * from './types';

--- a/pgpm/core/src/apply/materialize.ts
+++ b/pgpm/core/src/apply/materialize.ts
@@ -13,6 +13,7 @@ import { loadModule, makeSchemaTranspiler, SchemaTransformPass } from '@pgpmjs/t
 
 import { ModuleMap } from '../modules/modules';
 import { hasApplySpec, readApplySpec } from './apply-spec';
+import { loadWorkspaceRoutingProfile, resolveEffectiveApplySpec } from './profile';
 import { isReuseSpec, materializeReuseModule, resolveSharedModuleName } from './reuse';
 import { ResolvedApplySpec } from './types';
 
@@ -160,7 +161,10 @@ export async function resolveEffectiveModulePath(
   const cached = materializedCache.get(cacheKey);
   if (cached) return cached;
 
-  const spec = readApplySpec(modulePath);
+  const spec = resolveEffectiveApplySpec(
+    readApplySpec(modulePath),
+    loadWorkspaceRoutingProfile(workspacePath)
+  );
   const sourceModule = moduleMap[spec.source.module];
   if (!sourceModule) {
     throw new Error(

--- a/pgpm/core/src/apply/profile.ts
+++ b/pgpm/core/src/apply/profile.ts
@@ -1,0 +1,40 @@
+import { loadConfigSyncFromDir } from '@pgpmjs/env';
+import { mergeRoutingProfiles, PgpmRoutingProfile, PgpmWorkspaceConfig } from '@pgpmjs/types';
+
+import { ResolvedApplySpec } from './types';
+
+/**
+ * Load the workspace-level routing profile (the `portability` field of the
+ * workspace `pgpm.json` / `pgpm.config.js`). Returns `undefined` when the
+ * workspace has no config file or no profile.
+ */
+export function loadWorkspaceRoutingProfile(
+  workspacePath: string
+): PgpmRoutingProfile | undefined {
+  let config: PgpmWorkspaceConfig;
+  try {
+    config = loadConfigSyncFromDir(workspacePath) as PgpmWorkspaceConfig;
+  } catch {
+    return undefined;
+  }
+  return config?.portability;
+}
+
+/**
+ * Resolve the routing profile effective for one apply spec: defaults →
+ * workspace `portability` → the spec's own routing keys, merged per key
+ * (inner scope wins; see {@link mergeRoutingProfiles}).
+ */
+export function resolveEffectiveApplySpec(
+  spec: ResolvedApplySpec,
+  workspaceProfile?: PgpmRoutingProfile
+): ResolvedApplySpec {
+  if (!workspaceProfile) return spec;
+  const merged = mergeRoutingProfiles(workspaceProfile, {
+    schemas: spec.schemas,
+    route: spec.route,
+    extensions: spec.extensions,
+    roles: spec.roles
+  });
+  return { ...spec, ...merged };
+}

--- a/pgpm/core/src/apply/types.ts
+++ b/pgpm/core/src/apply/types.ts
@@ -11,6 +11,13 @@
  * transpiled code is never committed.
  */
 
+import {
+  PgpmExtensionsRouting,
+  PgpmRolesRouting,
+  PgpmRouteEntry,
+  PgpmRoutingProfile
+} from '@pgpmjs/types';
+
 /** File name of the apply spec inside a proxy module directory. */
 export const APPLY_SPEC_FILE = 'pgpm.apply.json';
 
@@ -36,22 +43,11 @@ export interface ApplySpecSource {
 }
 
 /**
- * An object-level route in a `pgpm.apply.json` spec: send one named object out
- * of a source schema to a target schema, overriding the whole-schema default
- * for that object only. Kinds are expressed as separate properties (no dotted
- * identity strings), so a table and a function of the same name route
- * independently.
+ * An object-level route in a `pgpm.apply.json` spec. The shared
+ * routing-profile shape ({@link PgpmRouteEntry} from `@pgpmjs/types`), usable
+ * at both the workspace and per-import scopes.
  */
-export interface ApplyRouteEntry {
-  /** Source schema the object is defined in (e.g. `users`). */
-  fromSchema: string;
-  /** Object namespace: `table`/`view` → relation, `procedure` → function. */
-  kind: 'table' | 'view' | 'function' | 'procedure' | 'type';
-  /** Unqualified object name (e.g. `accounts`). */
-  name: string;
-  /** Target schema the object is routed to (e.g. `reporting`). */
-  toSchema: string;
-}
+export type ApplyRouteEntry = PgpmRouteEntry;
 
 /**
  * A per-tenant seed object in a reuse spec: the objects that must be
@@ -95,40 +91,22 @@ export interface ApplyReuseSpec {
 
 /**
  * Extension-routing declaration in a `pgpm.apply.json`: where the transpiled
- * instance should install extensions and resolve the symbols they provide
- * (e.g. isolate `pgcrypto` in a dedicated `extensions` schema, qualifying bare
- * `crypt(...)` calls, or the reverse). A distinct dimension from schema
- * routing — driven by a version-aware symbol inventory, not by the objects the
- * SQL itself creates. Forwarded to `@pgpmjs/transform`'s extension router.
+ * instance should resolve the symbols extensions provide. The shared
+ * routing-profile shape ({@link PgpmExtensionsRouting} from `@pgpmjs/types`);
+ * forwarded to `@pgpmjs/transform`'s extension router.
  */
-export interface ApplyExtensionsSpec {
-  /**
-   * Install the matched extensions and route their provided symbols to this
-   * schema. `null` strips qualification (rely on `search_path`). Ignored when
-   * `routes` is given.
-   */
-  toSchema?: string | null;
-  /** With `toSchema`: limit to these extensions (default: every inventoried one). */
-  only?: string[];
-  /**
-   * With `toSchema`: which source qualifications to rewrite (a `null` entry
-   * also rewrites bare references). Defaults to `public` + bare.
-   */
-  from?: (string | null)[];
-  /**
-   * Advanced: explicit per-extension routes (`{ "<ext>": { "to": "<schema>|null",
-   * "from"?: [...] } }`). Overrides `toSchema`/`only`/`from`.
-   */
-  routes?: Record<string, { to: string | null; from?: (string | null)[] }>;
-  /** Target PostgreSQL major version, for core-graduation awareness. */
-  serverVersion?: number;
-}
+export type ApplyExtensionsSpec = PgpmExtensionsRouting;
 
 /** Role-name translation: source role name → target role name. */
-export type ApplyRolesSpec = Record<string, string>;
+export type ApplyRolesSpec = PgpmRolesRouting;
 
-/** The parsed, normalized `pgpm.apply.json` spec. */
-export interface PgpmApplySpec {
+/**
+ * The parsed, normalized `pgpm.apply.json` spec: a source-module reference
+ * plus a per-import routing profile ({@link PgpmRoutingProfile}). The routing
+ * keys override the workspace `portability` profile per key (inner scope
+ * wins).
+ */
+export interface PgpmApplySpec extends PgpmRoutingProfile {
   /**
    * Module name this instance is deployed as. Defaults to the proxy
    * directory's name.
@@ -137,32 +115,11 @@ export interface PgpmApplySpec {
   /** Source module reference: a module name, or the expanded object form. */
   source: string | ApplySpecSource;
   /**
-   * Whole-schema default: source schema → target schema (drives the AST + plan
-   * rewrite). Optional when `route` fully covers the objects being moved.
-   */
-  schemas?: Record<string, string>;
-  /**
-   * Object-level routes. Each entry overrides the `schemas` default for its
-   * specific object, letting one source schema fan out per object (e.g. a
-   * table into a tenant schema and a function into a shared schema).
-   */
-  route?: ApplyRouteEntry[];
-  /**
    * Reuse declaration: split shared vs per-tenant objects (see
    * {@link ApplyReuseSpec}). When present, this proxy expands into two modules —
    * a shared module and a per-tenant module that `requires` it.
    */
   reuse?: ApplyReuseSpec;
-  /**
-   * Extension routing: where to install extensions and resolve their provided
-   * symbols in the transpiled instance (see {@link ApplyExtensionsSpec}).
-   */
-  extensions?: ApplyExtensionsSpec;
-  /**
-   * Role-name translation applied to the transpiled instance's SQL
-   * (see {@link ApplyRolesSpec}). Renames role identifiers only.
-   */
-  roles?: ApplyRolesSpec;
   /**
    * Runtime requires of the transpiled output (native extensions and other
    * modules). Defaults to the source module's own requires.

--- a/pgpm/types/__tests__/routing.test.ts
+++ b/pgpm/types/__tests__/routing.test.ts
@@ -1,0 +1,57 @@
+import { mergeRoutingProfiles, PgpmRoutingProfile } from '../src';
+
+describe('mergeRoutingProfiles', () => {
+  const workspace: PgpmRoutingProfile = {
+    extensions: { toSchema: 'extensions' },
+    roles: { anonymous: 'anon', administrator: 'service_role' }
+  };
+
+  it('returns undefined when no input defines any key', () => {
+    expect(mergeRoutingProfiles()).toBeUndefined();
+    expect(mergeRoutingProfiles(undefined, undefined)).toBeUndefined();
+    expect(mergeRoutingProfiles({}, {})).toBeUndefined();
+  });
+
+  it('workspace-only: passes the workspace profile through', () => {
+    expect(mergeRoutingProfiles(workspace, undefined)).toEqual(workspace);
+    expect(mergeRoutingProfiles(workspace, {})).toEqual(workspace);
+  });
+
+  it('proxy-only: passes the inner profile through', () => {
+    const proxy: PgpmRoutingProfile = { schemas: { vault: 'vault_a' } };
+    expect(mergeRoutingProfiles(undefined, proxy)).toEqual(proxy);
+  });
+
+  it('both: inner scope wins per key, other keys are inherited', () => {
+    const proxy: PgpmRoutingProfile = {
+      schemas: { vault: 'vault_a' },
+      roles: { anonymous: 'anon_a' }
+    };
+    expect(mergeRoutingProfiles(workspace, proxy)).toEqual({
+      schemas: { vault: 'vault_a' },
+      extensions: { toSchema: 'extensions' },
+      roles: { anonymous: 'anon_a' }
+    });
+  });
+
+  it('overriding keys replace whole values (no deep merge)', () => {
+    const outer: PgpmRoutingProfile = {
+      extensions: { toSchema: 'ext', only: ['pgcrypto'] },
+      route: [{ fromSchema: 'a', kind: 'table', name: 't', toSchema: 'b' }]
+    };
+    const inner: PgpmRoutingProfile = { extensions: { toSchema: null } };
+    expect(mergeRoutingProfiles(outer, inner)).toEqual({
+      extensions: { toSchema: null },
+      route: [{ fromSchema: 'a', kind: 'table', name: 't', toSchema: 'b' }]
+    });
+  });
+
+  it('merges left to right across more than two scopes', () => {
+    const defaults: PgpmRoutingProfile = { roles: { anonymous: 'anonymous' } };
+    const inner: PgpmRoutingProfile = { roles: { anonymous: 'anon_inner' } };
+    expect(mergeRoutingProfiles(defaults, workspace, inner)).toEqual({
+      extensions: { toSchema: 'extensions' },
+      roles: { anonymous: 'anon_inner' }
+    });
+  });
+});

--- a/pgpm/types/src/index.ts
+++ b/pgpm/types/src/index.ts
@@ -3,4 +3,5 @@ export * from './error';
 export * from './error-factory';
 export * from './pg-error-format';
 export * from './pgpm';
+export * from './routing';
 export * from './update';

--- a/pgpm/types/src/pgpm.ts
+++ b/pgpm/types/src/pgpm.ts
@@ -2,6 +2,7 @@ import { execSync } from 'child_process';
 import { PgConfig } from 'pg-env';
 
 import { PgpmDriverConfig, PgpmEngineConfig } from './driver';
+import { PgpmRoutingProfile } from './routing';
 
 /**
  * Authentication options for test client sessions
@@ -235,6 +236,13 @@ export interface PgpmWorkspaceConfig {
     /** Template variant directory */
     dir?: string;
   };
+  /**
+   * Workspace-level routing profile: the default routing policy (schemas,
+   * object routes, extension routing, role translation) applied to every
+   * apply/transpile in the workspace. A proxy module's `pgpm.apply.json`
+   * overrides it per key (inner scope wins).
+   */
+  portability?: PgpmRoutingProfile;
 }
 
 /**

--- a/pgpm/types/src/routing.ts
+++ b/pgpm/types/src/routing.ts
@@ -1,0 +1,104 @@
+/**
+ * The unified routing profile: the single, shared shape for consumer-side
+ * routing policy ("where should schemas/objects/extensions/roles land?").
+ *
+ * It attaches at two scopes:
+ * - workspace scope: the `portability` field of `pgpm.json`
+ *   ({@link PgpmWorkspaceConfig.portability}) — the default for every
+ *   apply/transpile in the workspace;
+ * - per-import scope: the routing keys of a proxy module's `pgpm.apply.json` —
+ *   overrides the workspace profile per key (inner scope wins).
+ *
+ * Module self-description (what a module provides/consumes) lives elsewhere:
+ * the per-module `extensions.json` manifest and `.control` `requires`.
+ */
+
+/** Object kinds an object-level route can target. */
+export type PgpmRouteKind = 'table' | 'view' | 'function' | 'procedure' | 'type';
+
+/**
+ * An object-level route: send one named object out of a source schema to a
+ * target schema, overriding the whole-schema default for that object only.
+ * Kinds are expressed as separate properties (no dotted identity strings), so
+ * a table and a function of the same name route independently.
+ */
+export interface PgpmRouteEntry {
+  /** Source schema the object is defined in (e.g. `users`). */
+  fromSchema: string;
+  /** Object namespace: `table`/`view` → relation, `procedure` → function. */
+  kind: PgpmRouteKind;
+  /** Unqualified object name (e.g. `accounts`). */
+  name: string;
+  /** Target schema the object is routed to (e.g. `reporting`). */
+  toSchema: string;
+}
+
+/**
+ * Extension routing: where the transpiled output should resolve the symbols
+ * extensions provide (e.g. isolate `pgcrypto` in a dedicated `extensions`
+ * schema, qualifying bare `crypt(...)` calls, or the reverse). A distinct
+ * dimension from schema routing — driven by a version-aware symbol inventory,
+ * not by the objects the SQL itself creates.
+ */
+export interface PgpmExtensionsRouting {
+  /**
+   * Route the matched extensions' provided symbols to this schema. `null`
+   * strips qualification (rely on `search_path`). Ignored when `routes` is
+   * given.
+   */
+  toSchema?: string | null;
+  /** With `toSchema`: limit to these extensions (default: every inventoried one). */
+  only?: string[];
+  /**
+   * With `toSchema`: which source qualifications to rewrite (a `null` entry
+   * also rewrites bare references). Defaults to `public` + bare.
+   */
+  from?: (string | null)[];
+  /**
+   * Advanced: explicit per-extension routes (`{ "<ext>": { "to": "<schema>|null",
+   * "from"?: [...] } }`). Overrides `toSchema`/`only`/`from`.
+   */
+  routes?: Record<string, { to: string | null; from?: (string | null)[] }>;
+  /** Target PostgreSQL major version, for core-graduation awareness. */
+  serverVersion?: number;
+}
+
+/** Role-name translation: source role name → target role name. */
+export type PgpmRolesRouting = Record<string, string>;
+
+/** The unified routing profile. Every key is optional and merges per key. */
+export interface PgpmRoutingProfile {
+  /** Whole-schema default: source schema → target schema. */
+  schemas?: Record<string, string>;
+  /** Object-level routes overriding the `schemas` default per object. */
+  route?: PgpmRouteEntry[];
+  /** Extension routing (see {@link PgpmExtensionsRouting}). */
+  extensions?: PgpmExtensionsRouting;
+  /** Role-name translation (see {@link PgpmRolesRouting}). */
+  roles?: PgpmRolesRouting;
+}
+
+/** The routing-profile keys, in a stable order. */
+export const ROUTING_PROFILE_KEYS = ['schemas', 'route', 'extensions', 'roles'] as const;
+
+/**
+ * Merge routing profiles per key: for each of `schemas`/`route`/`extensions`/
+ * `roles`, the last profile that defines the key wins whole (no deep merge),
+ * like lexical scoping — a profile that only overrides `roles` still inherits
+ * an outer `extensions` mapping. Returns `undefined` when no input defines any
+ * key.
+ */
+export function mergeRoutingProfiles(
+  ...profiles: (PgpmRoutingProfile | undefined)[]
+): PgpmRoutingProfile | undefined {
+  const merged: PgpmRoutingProfile = {};
+  for (const profile of profiles) {
+    if (!profile) continue;
+    for (const key of ROUTING_PROFILE_KEYS) {
+      if (profile[key] !== undefined) {
+        (merged as any)[key] = profile[key];
+      }
+    }
+  }
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}


### PR DESCRIPTION
## Summary

Consolidates pgpm's portability config from three vocabularies to two: module **self-description** (`extensions.json` `provides`/`consumes` + `.control` `requires`, unchanged) and one **routing profile** shape attachable at two scopes — workspace and per-import.

New shared type in `@pgpmjs/types` (`pgpm/types/src/routing.ts`), no transform deps:

```ts
interface PgpmRoutingProfile {
  schemas?: Record<string, string>;
  route?: PgpmRouteEntry[];            // { fromSchema, kind, name, toSchema }
  extensions?: PgpmExtensionsRouting;  // { toSchema | routes, only?, from?, serverVersion? }
  roles?: PgpmRolesRouting;            // source role -> target role
}
mergeRoutingProfiles(...profiles)      // per-key, last defined wins whole (no deep merge)
```

The apply-spec types are now aliases of the shared shape (no duplicated definitions):

```diff
-export interface ApplyRouteEntry { ... }        // pgpm/core/src/apply/types.ts
-export interface ApplyExtensionsSpec { ... }
-export type ApplyRolesSpec = Record<string, string>;
-export interface PgpmApplySpec { schemas?; route?; extensions?; roles?; ... }
+export type ApplyRouteEntry = PgpmRouteEntry;
+export type ApplyExtensionsSpec = PgpmExtensionsRouting;
+export type ApplyRolesSpec = PgpmRolesRouting;
+export interface PgpmApplySpec extends PgpmRoutingProfile { ... }
```

Workspace attach point: `PgpmWorkspaceConfig.portability?: PgpmRoutingProfile` in `pgpm.json`, read via the existing `@pgpmjs/env` `loadConfigSyncFromDir` (no new config mechanism). Wired into the one deploy-path seam:

```ts
// pgpm/core/src/apply/profile.ts (new)
loadWorkspaceRoutingProfile(workspacePath)          // pgpm.json portability, or undefined
resolveEffectiveApplySpec(spec, workspaceProfile)   // defaults -> workspace -> spec, per key

// pgpm/core/src/apply/materialize.ts::resolveEffectiveModulePath
-const spec = readApplySpec(modulePath);
+const spec = resolveEffectiveApplySpec(readApplySpec(modulePath),
+                                       loadWorkspaceRoutingProfile(workspacePath));
```

Precedence is lexical: a proxy that only overrides `roles` still inherits the workspace `extensions` mapping; an overriding key replaces its whole value.

Fully additive/backward compatible: existing `pgpm.apply.json` files behave identically; no workspace profile ⇒ no behavior change. A proxy must still declare at least one routing key of its own (spec validation unchanged). `migrate/clean.ts` untouched.

Docs: new `.agents/skills/pgpm/references/routing-profile.md` documenting the two-surface model with examples; pointers added in the `pgpm` skill index, `extensions.md`, and the `pgpm-migration-bundle` skill.

## Tests

- `pgpm/types`: 6 new `mergeRoutingProfiles` unit tests (neither/workspace-only/proxy-only/both/whole-key replace/multi-scope) — 6/6 pass.
- `pgpm/core`: new `__tests__/apply/apply-workspace-profile.test.ts` — `resolveEffectiveApplySpec` precedence, `loadWorkspaceRoutingProfile`, and a PG-backed e2e (`__fixtures__/apply/workspace-profile`) where the workspace profile routes extensions/roles and one proxy overrides only `roles`.
- Full local runs: `pgpm/core` 71 suites / 446 tests pass; `pgpm/types` 1 suite / 6 tests; `pgpm/env` 2 suites / 26 tests. `npx tsc --noEmit` clean in `pgpm/types`, `pgpm/env`, `pgpm/core`.


Link to Devin session: https://app.devin.ai/sessions/49ac030311c642e3b1d13c7e29c8f112
Requested by: @pyramation