### PR TITLE
fix(apply): drop excluded subsystem changes instead of emitting empty tombstones

### DIFF
--- a/pgpm/bundle/src/transpile.ts
+++ b/pgpm/bundle/src/transpile.ts
@@ -1,7 +1,7 @@
 import { PgpmScriptKind } from '@pgpmjs/ast/module/types';
 import { parsePgpmHeader, renameInHeader, writePgpmScript } from '@pgpmjs/ast/files/sql/header';
 import { hashString } from '@pgpmjs/ast';
-import { renameInPlanContent } from '@pgpmjs/ast';
+import { generatePlanFileContent, parsePlanContent, renameInPlanContent } from '@pgpmjs/ast';
 import { mapScripts } from '@pgpmjs/traverse';
 import {
   computeBundleDigest,
@@ -50,6 +50,38 @@ export interface TranspileBundleOptions extends CreateBundleOptions {
    * dependency references land on the instance instead of the source.
    */
   renameModule?: string;
+  /**
+   * Select changes to drop from the transpiled bundle entirely (return `true`
+   * to exclude). Excluded changes are removed from the change list, deploy
+   * order, and plan, and their name is pruned from every surviving change's
+   * dependencies (plan brackets included).
+   *
+   * This is the mechanism behind subsystem exclusion in apply: an excluded
+   * subsystem is genuinely absent from the artifact rather than emitted as an
+   * empty script. Empty tombstones are indistinguishable by content, so they
+   * collide on the deploy ledger's `(package, script_hash)` uniqueness — a
+   * dropped change has no script to hash. Cascade safety (no survivor still
+   * references a dropped object) is the caller's responsibility.
+   */
+  excludeChange?: (name: string) => boolean;
+}
+
+/**
+ * Drop excluded changes from a plan's text and prune references to them from
+ * the surviving changes' dependency brackets, re-serializing the plan. Tags on
+ * excluded changes are dropped with them.
+ */
+function removeChangesFromPlan(plan: string, excluded: Set<string>): string {
+  const parsed = parsePlanContent(plan);
+  if (!parsed.data) return plan;
+  const changes = parsed.data.changes
+    .filter(change => !excluded.has(change.name))
+    .map(change => ({
+      ...change,
+      dependencies: change.dependencies.filter(dep => !excluded.has(dep))
+    }));
+  const tags = (parsed.data.tags ?? []).filter(tag => !excluded.has(tag.change));
+  return generatePlanFileContent({ ...parsed.data, changes, tags });
 }
 
 function renameProjectInPlan(plan: string, from: string, to: string): string {
@@ -128,23 +160,35 @@ export function transpileBundle(
   options: TranspileBundleOptions = {}
 ): MigrationBundle {
   const renameChange = options.renameChange ?? ((name: string) => name);
+  const excludeChange = options.excludeChange ?? (() => false);
   const renames = buildRenames(bundle.manifest.deployOrder, renameChange);
 
-  const changes: BundleChange[] = bundle.changes.map(change => {
-    const name = renames.get(change.name) ?? change.name;
-    const dependencies = change.dependencies.map(dep => renames.get(dep) ?? dep);
-    const { deploy, revert, verify } = mapScripts(change, script =>
-      transpileScriptSql(script, change.name, renames, options)
-    );
-    const digest = computeChangeDigest(name, {
-      deploy: deploy?.digest,
-      revert: revert?.digest,
-      verify: verify?.digest
+  const changes: BundleChange[] = bundle.changes
+    .filter(change => !excludeChange(change.name))
+    .map(change => {
+      const name = renames.get(change.name) ?? change.name;
+      const dependencies = change.dependencies
+        .filter(dep => !excludeChange(dep))
+        .map(dep => renames.get(dep) ?? dep);
+      const { deploy, revert, verify } = mapScripts(change, script =>
+        transpileScriptSql(script, change.name, renames, options)
+      );
+      const digest = computeChangeDigest(name, {
+        deploy: deploy?.digest,
+        revert: revert?.digest,
+        verify: verify?.digest
+      });
+      return { name, dependencies, deploy, revert, verify, digest };
     });
-    return { name, dependencies, deploy, revert, verify, digest };
-  });
 
   let plan = renames.size > 0 ? renameInPlanContent(bundle.plan, renames) : bundle.plan;
+  // Excluded changes are matched by source name; they are never renamed (the
+  // caller leaves excluded changes' identity intact), so prune the plan by the
+  // source names, after any survivor renames have been applied above.
+  const excluded = new Set(bundle.manifest.deployOrder.filter(excludeChange));
+  if (excluded.size > 0) {
+    plan = removeChangesFromPlan(plan, excluded);
+  }
 
   const moduleName = options.renameModule ?? bundle.manifest.name;
   if (options.renameModule && options.renameModule !== bundle.manifest.name) {

--- a/pgpm/core/__tests__/apply/apply-substitution.test.ts
+++ b/pgpm/core/__tests__/apply/apply-substitution.test.ts
@@ -97,22 +97,14 @@ describe('materializeApplyModule — subsystem substitution', () => {
     const spec = readApplySpec(fixture.fixturePath('packages', 'crm-app'));
     const { bundle, outDir } = await materializeApplyModule({ sourceDir, spec });
     try {
-      // excluded changes keep their identity as emptied tombstones
-      const identityUsers = bundle.changes.find(
-        c => c.name === 'schemas/identity/tables/users/table'
-      )!;
-      expect(identityUsers.deploy!.sql).not.toMatch(/CREATE TABLE/i);
-      expect(identityUsers.revert!.sql).not.toMatch(/DROP TABLE/i);
-      expect(identityUsers.verify!.sql).not.toMatch(/identity\.users/);
-
-      const identitySchema = bundle.changes.find(c => c.name === 'schemas/identity/schema')!;
-      expect(identitySchema.deploy!.sql).not.toMatch(/CREATE SCHEMA/i);
-      expect(identitySchema.verify!.sql).not.toMatch(/has_schema_privilege/i);
-
-      const actor = bundle.changes.find(
-        c => c.name === 'schemas/identity/procedures/current_actor'
-      )!;
-      expect(actor.deploy!.sql).not.toMatch(/CREATE FUNCTION/i);
+      // the excluded subsystem's changes are dropped from the artifact
+      // entirely — not emitted as empty tombstones (those collide on the
+      // deploy ledger's script-hash uniqueness)
+      expect(bundle.changes.find(c => c.name === 'schemas/identity/tables/users/table')).toBeUndefined();
+      expect(bundle.changes.find(c => c.name === 'schemas/identity/schema')).toBeUndefined();
+      expect(bundle.changes.find(c => c.name === 'schemas/identity/procedures/current_actor')).toBeUndefined();
+      // and their names never appear in a survivor's plan dependencies
+      expect(bundle.plan).not.toMatch(/schemas\/identity\//);
 
       // surviving app changes are transpiled and rebound onto the provider
       const notes = bundle.changes.find(c => c.name === 'schemas/crm/tables/notes/table')!;

--- a/pgpm/core/src/apply/materialize.ts
+++ b/pgpm/core/src/apply/materialize.ts
@@ -10,7 +10,7 @@ import {
   verifyBundle
 } from '@pgpmjs/bundle';
 import { buildSchemaRouter, loadModule, makeSchemaTranspiler, SchemaTransformPass } from '@pgpmjs/transform';
-import { blankScriptSql, excludeSubsystem, stripSubsystemSql } from '@pgpmjs/slice';
+import { excludeSubsystem, stripSubsystemSql } from '@pgpmjs/slice';
 
 import { ModuleMap } from '../modules/modules';
 import { hasApplySpec, readApplySpec } from './apply-spec';
@@ -56,7 +56,7 @@ function makeSubsystemStripper(
   source: MigrationBundle,
   spec: ResolvedApplySpec,
   instanceName: string
-): { strip: (sql: string, change: string) => string; excludedChanges: Set<string> } {
+): { strip: (sql: string) => string; excludedChanges: Set<string> } {
   const selector = { schemas: spec.exclude!.schemas };
   const rebinds = buildSchemaRouter({ schemaMap: spec.schemas, routes: spec.route });
 
@@ -83,9 +83,11 @@ function makeSubsystemStripper(
   }
 
   // A change whose deploy consists entirely of subsystem statements (plus
-  // transaction control) is excluded *as a change*: its verify/revert scripts
-  // target dropped objects the classifier can't always see (bare DROPs,
-  // catalog probes), so all three scripts are blanked together.
+  // transaction control) is dropped *as a change* — removed from the plan and
+  // deploy order rather than emitted as an empty script (empty scripts collide
+  // on the deploy ledger's script-hash uniqueness). Its verify/revert scripts
+  // target dropped objects the classifier can't always see (bare DROPs, catalog
+  // probes), which is exactly why the whole change is dropped, not just blanked.
   const excludedChanges = new Set<string>();
   for (const change of source.changes) {
     if (!change.deploy) continue;
@@ -98,8 +100,10 @@ function makeSubsystemStripper(
     }
   }
 
-  const strip = (sql: string, change: string): string =>
-    excludedChanges.has(change) ? blankScriptSql(sql) : stripSubsystemSql(sql, selector).sql;
+  // Surviving changes may still contain stray subsystem statements (a change
+  // that both creates a survivor and touches the excluded subsystem); strip
+  // those in place. Fully-excluded changes are dropped via `excludedChanges`.
+  const strip = (sql: string): string => stripSubsystemSql(sql, selector).sql;
 
   return { strip, excludedChanges };
 }
@@ -169,14 +173,20 @@ export async function materializeApplyModule(
     }
   });
 
-  // Excluded changes keep their source identity (an emptied tombstone) —
-  // renaming them into the replacement provider's namespace would be a lie.
+  // Excluded changes are dropped from the artifact entirely (plan + deploy
+  // order + dependency refs); surviving changes get their stray subsystem
+  // statements stripped before the namespace transform.
   const transpiled = transpileBundle(source, {
+    excludeChange: stripSubsystem
+      ? (name: string) => stripSubsystem.excludedChanges.has(name)
+      : undefined,
+    // Excluded changes keep their source identity so the plan-prune (which
+    // matches source names) can find them; survivors route normally.
     renameChange: stripSubsystem
       ? (name: string) => (stripSubsystem.excludedChanges.has(name) ? name : renameChange(name))
       : renameChange,
     transformScript: stripSubsystem
-      ? (sql, ctx) => transformScript(stripSubsystem.strip(sql, ctx.change), ctx)
+      ? (sql, ctx) => transformScript(stripSubsystem.strip(sql), ctx)
       : transformScript,
     renameModule: instanceName,
     provenance: {


### PR DESCRIPTION
## Summary

Subsystem substitution in `apply` used to emit an excluded subsystem's changes as **empty tombstone scripts** (`BEGIN;`/`COMMIT;` with the body stripped). Those tombstones are byte-identical, so when a subsystem contributes more than one excluded change they collide on the deploy ledger's uniqueness constraint and **native pgpm deploy fails**:

```
duplicate key value violates unique constraint "changes_package_script_hash_key"
Key (package, script_hash)=(vendor-app-ported, f55a60c4…) already exists.
```

(Previously this only "worked" through a hand-rolled deploy loop that never wrote to the ledger.)

Fix: an excluded subsystem should be **genuinely absent** from the artifact, not present as no-op scripts. `transpileBundle` gains an `excludeChange` predicate:

```ts
transpileBundle(source, {
  excludeChange: (name) => excludedChanges.has(name), // NEW
  renameChange, transformScript, renameModule, provenance
})
```

which:
- drops excluded changes from `bundle.changes` and the deploy order,
- prunes their name from every surviving change's `dependencies`,
- re-serializes the plan with the excluded changes (and their tags) removed and their names pruned from survivors' dependency brackets (`parsePlanContent` → filter → `generatePlanFileContent`).

`materialize.ts` wires it in and stops blanking scripts. Excluded changes keep their **source** identity (not routed) so the plan-prune — which matches source names — finds them; survivors route/rebind as before. Cascade safety is unchanged: a survivor that still references an excluded object with no rebind route still fails materialization up front.

```diff
- transformScript: (sql, ctx) => transformScript(strip(sql, ctx.change), ctx) // blank-if-excluded
+ excludeChange: (name) => excludedChanges.has(name)                          // drop entirely
+ transformScript: (sql, ctx) => transformScript(strip(sql), ctx)            // survivors only
```

## Tests

- `apply-substitution` unit test now asserts the excluded changes are **absent** from `bundle.changes` and their names never appear in the plan (was: asserting emptied tombstones).
- The existing live `apply substitution deployment (e2e)` deploy/verify/revert tests now pass through native `PgpmPackage.deploy` (they previously would have hit the ledger collision).
- `pgpm/core` apply suites (66), `pgpm/bundle` transpile/split (18), `pgpm/slice` (48) all green. `blankScriptSql` remains exported/tested as a util; it's just no longer used by apply.


Link to Devin session: https://app.devin.ai/sessions/025fb88043964fdbb335ac5e39df2478
Requested by: @pyramation