### PR TITLE
fix(pgpm-core): reject a bundle artifact that no longer matches deploy/

### DIFF
--- a/pgpm/core/__tests__/bundle/bundled-deploy.test.ts
+++ b/pgpm/core/__tests__/bundle/bundled-deploy.test.ts
@@ -185,6 +185,27 @@ describe('fast (bundle-backed) deployment', () => {
     expect((await ledger()).length).toBe(8);
   });
 
+  it('rebuilds from deploy/ when the artifact is valid but stale', async () => {
+    // A committed artifact plus a rebase: the archive verifies against itself,
+    // but `deploy/` has moved on. Using it would deploy yesterday's SQL and
+    // ledger it as today's.
+    await emitArtifacts();
+
+    const dir = modulePath('my-first');
+    const { name } = readBundleArchiveFile(resolveBundleArtifactPath(dir)!).changes[0];
+    const deployPath = join(dir, 'deploy', `${name}.sql`);
+    const updated = `${readFileSync(deployPath, 'utf-8')}\nCREATE SCHEMA rebased;\n`;
+    writeFileSync(deployPath, updated);
+
+    await fixture.deployModule('my-third', db.name, ['sqitch', 'simple-w-tags'], false, {
+      bundled: true
+    });
+
+    expect(await db.exists('schema', 'rebased')).toBe(true);
+    const row = (await ledger()).find((r: { change_name: string; script_hash: string }) => r.change_name === name);
+    expect(row!.script_hash).toBe(hashString(updated));
+  });
+
   it('rebuilds from deploy/ when the artifact archive is corrupt', async () => {
     await emitArtifacts();
     writeFileSync(resolveBundleArtifactPath(modulePath('my-second'))!, 'not-an-archive');

--- a/pgpm/core/src/bundle/artifact.ts
+++ b/pgpm/core/src/bundle/artifact.ts
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 
+import { hashString } from '@pgpmjs/ast';
 import { getExtensionName, parseControlContent } from '@pgpmjs/ast/files';
 import {
   BUNDLE_ARCHIVE_EXTENSION,
@@ -92,6 +93,31 @@ export async function writeBundleArtifact(
   const outPath = join(moduleDir, 'sql', bundleArtifactFileName(bundle.manifest.name, version));
   writeBundleArchiveFile(bundle, outPath);
   return outPath;
+}
+
+/**
+ * Whether a stored bundle still describes what is on disk.
+ *
+ * `verifyBundle` only proves an artifact is internally consistent — it cannot
+ * tell that `deploy/` moved on since the artifact was written. A committed
+ * artifact plus a rebased branch is exactly that case, and using it would
+ * deploy the stale SQL while recording hashes for it, silently.
+ *
+ * The check is deliberately I/O-only (read + sha256, no parse), so it costs a
+ * fraction of the parse/deparse work the artifact exists to avoid.
+ */
+export function bundleMatchesModule(moduleDir: string, bundle: MigrationBundle): boolean {
+  const planPath = join(moduleDir, 'pgpm.plan');
+  if (!existsSync(planPath)) return false;
+  if (readFileSync(planPath, 'utf-8') !== bundle.plan) return false;
+
+  for (const change of bundle.changes) {
+    if (!change.deploy) continue;
+    const deployPath = join(moduleDir, 'deploy', `${change.name}.sql`);
+    if (!existsSync(deployPath)) return false;
+    if (hashString(readFileSync(deployPath, 'utf-8')) !== change.deploy.digest) return false;
+  }
+  return true;
 }
 
 /**

--- a/pgpm/core/src/bundle/deploy-bundled.ts
+++ b/pgpm/core/src/bundle/deploy-bundled.ts
@@ -4,7 +4,7 @@ import { getPgPool } from 'pg-cache';
 import { PgConfig } from 'pg-env';
 
 import { PgpmMigrate } from '../migrate/client';
-import { buildExecutableBundle, readBundleArtifact } from './artifact';
+import { bundleMatchesModule, buildExecutableBundle, readBundleArtifact } from './artifact';
 
 const log = new Logger('deploy-fast');
 
@@ -83,13 +83,19 @@ async function loadExecutableBundle(
   const stored = readBundleArtifact(moduleDir);
   if (stored) {
     const issues = verifyBundle(stored);
-    if (issues.length === 0) {
+    if (issues.length > 0) {
+      log.warn(
+        `⚠️ Bundle artifact for ${stored.manifest.name} failed verification ` +
+          `(${issues.map(i => i.kind).join(', ')}); rebuilding from deploy/.`
+      );
+    } else if (!bundleMatchesModule(moduleDir, stored)) {
+      log.warn(
+        `⚠️ Bundle artifact for ${stored.manifest.name} is stale (deploy/ has ` +
+          `changed since it was packaged); rebuilding from deploy/.`
+      );
+    } else {
       return { bundle: stored, source: 'artifact' };
     }
-    log.warn(
-      `⚠️ Bundle artifact for ${stored.manifest.name} failed verification ` +
-        `(${issues.map(i => i.kind).join(', ')}); rebuilding from deploy/.`
-    );
   }
   return { bundle: await buildExecutableBundle(moduleDir), source: 'packaged' };
 }


### PR DESCRIPTION
## Summary

A correctness hole in #1520, found by hitting it for real: **a committed bundle artifact that has gone stale is used anyway, silently.**

`verifyBundle()` proves an artifact is internally consistent — every script digest, change digest and Merkle root agrees with itself. It says nothing about whether `deploy/` still looks like that. So a repo that commits `sql/<name>--<version>.bundle.tar.gz` and then merges a migration deploys **yesterday's SQL** and records **yesterday's hashes** as if they were current. The ledger then reports a database that is up to date and is not.

This is exactly what happened in constructive-db: after merging main into a branch carrying committed artifacts, `ast_plpgsql_helpers.proc_job_trigger_body` was deployed without the new `database_id_field` parameter added on main, and 30+ tests failed with `function ... does not exist` — while the deploy logged success.

The fix gates the artifact on a freshness check as well as a verification one:

```diff
 const stored = readBundleArtifact(moduleDir);
 if (stored) {
-  if (verifyBundle(stored).length === 0) return { bundle: stored, source: 'artifact' };
-  log.warn('failed verification; rebuilding from deploy/');
+  if (verifyBundle(stored).length > 0) log.warn('failed verification; rebuilding from deploy/');
+  else if (!bundleMatchesModule(moduleDir, stored)) log.warn('stale; rebuilding from deploy/');
+  else return { bundle: stored, source: 'artifact' };
 }
 return { bundle: await buildExecutableBundle(moduleDir), source: 'packaged' };
```

`bundleMatchesModule()` compares the on-disk `pgpm.plan` against `bundle.plan` (catches added/removed/reordered changes) and `hashString(deploy/<change>.sql)` against each `change.deploy.digest` (catches edited SQL). It is read + sha256 only — no parse, no deparse — so it costs a fraction of the work the artifact exists to avoid, and a stale artifact now degrades to "slower", which is what a missing or corrupt one already did.

New test pins it: valid archive, `deploy/` edited underneath → the edit is deployed and the ledger records the *new* hash.


Link to Devin session: https://app.devin.ai/sessions/924c5b516f844f10b625263cb48733d9
Requested by: @pyramation