### PR TITLE
feat(portability): @pgpmjs/portability — vendor shapes + pgsql-test seed.apply adapter

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -230,7 +230,7 @@ jobs:
       matrix:
         include:
           - batch: pg-core
-            packages: 'pgpm/ast pgpm/traverse pgpm/bundle pgpm/core pgpm/cli packages/client packages/safegres postgres/pg-codegen'
+            packages: 'pgpm/ast pgpm/traverse pgpm/bundle pgpm/core pgpm/cli pgpm/portability packages/client packages/safegres postgres/pg-codegen'
           - batch: pg-postgres
             packages: 'postgres/pgsql-test postgres/drizzle-orm-test postgres/introspectron graphile/graphile-test graphile/graphile-connection-filter graphile/graphile-postgis'
           - batch: pg-graphql

--- a/pgpm/portability/README.md
+++ b/pgpm/portability/README.md
@@ -1,0 +1,51 @@
+# @pgpmjs/portability
+
+Vendor portability for pgpm: move packages between vendor-managed PostgreSQL
+environments (Supabase, InsForge, ...) and plain PostgreSQL/pgpm — and test the
+result with `pgsql-test`.
+
+## Seed adapter
+
+Deploy a workspace target (typically an apply proxy carrying `pgpm.apply.json`)
+into a test database, through the same engine path as `pgpm deploy`:
+
+```ts
+import { getConnections } from 'pgsql-test';
+import { seed } from '@pgpmjs/portability';
+
+const { pg, teardown } = await getConnections({}, [
+  seed.apply('vendor-app-ported')
+]);
+```
+
+The workspace is discovered from the test's cwd; dependencies resolve from the
+workspace module map; proxy modules transpile and materialize through the
+apply path.
+
+## Vendor shapes
+
+A `VendorShape` describes a vendor's managed subsystems (auth schemas, roles,
+extensions schema, users table, accessor functions). Build routing profiles in
+either direction from a shape plus a provider binding:
+
+```ts
+import { fromVendorProfile, supabase, toVendorProfile } from '@pgpmjs/portability';
+
+const provider = {
+  schema: 'app_auth',
+  users: 'users',
+  accessors: { uid: 'current_user_id' },
+  roles: { authenticated: 'app_authenticated' }
+};
+
+// vendor → pgpm: exclude the vendor auth subsystem, rebind onto the provider,
+// de-qualify extension symbols, translate roles
+const off = fromVendorProfile(supabase, provider);
+
+// pgpm → vendor: the inverse — rebind onto the native subsystem, qualify
+// extension symbols, translate roles back
+const on = toVendorProfile(supabase, provider);
+```
+
+The resulting `PgpmRoutingProfile` drops into a workspace `portability` block
+or a proxy module's `pgpm.apply.json`.

--- a/pgpm/portability/__tests__/seed-apply.test.ts
+++ b/pgpm/portability/__tests__/seed-apply.test.ts
@@ -1,0 +1,47 @@
+import { cpSync, mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+
+import { getConnections, PgTestClient, SeedAdapter } from 'pgsql-test';
+
+import { seed } from '../src';
+
+// seed.apply must plug into pgsql-test's adapter slot as-is.
+const _typecheck: SeedAdapter = seed.apply('anything');
+
+const fixture = resolve(__dirname, '../../../__fixtures__/apply/proxy');
+
+let pg: PgTestClient;
+let teardown: () => Promise<void>;
+let workspace: string;
+
+beforeAll(async () => {
+  workspace = mkdtempSync(join(tmpdir(), 'pgpm-portability-'));
+  cpSync(fixture, workspace, { recursive: true });
+
+  ({ pg, teardown } = await getConnections({}, [
+    seed.apply('tenant-a', { cwd: workspace })
+  ]));
+});
+
+afterAll(async () => {
+  await teardown();
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+beforeEach(() => pg.beforeEach());
+afterEach(() => pg.afterEach());
+
+it('deploys the apply proxy through the engine path into the routed schema', async () => {
+  const { rows } = await pg.query(
+    `SELECT table_schema FROM information_schema.tables WHERE table_name = 'accounts'`
+  );
+  expect(rows.map(r => r.table_schema)).toEqual(['tenant_a']);
+});
+
+it('records the instance on the migration ledger', async () => {
+  const { rows } = await pg.query(
+    `SELECT DISTINCT package FROM pgpm_migrate.changes WHERE package = 'tenant-a'`
+  );
+  expect(rows).toHaveLength(1);
+});

--- a/pgpm/portability/__tests__/shapes.test.ts
+++ b/pgpm/portability/__tests__/shapes.test.ts
@@ -1,0 +1,81 @@
+import { fromVendorProfile, insforge, ProviderBinding, supabase, toVendorProfile } from '../src';
+
+const provider: ProviderBinding = {
+  schema: 'app_auth',
+  users: 'users',
+  accessors: { uid: 'current_user_id' },
+  roles: { authenticated: 'app_authenticated' }
+};
+
+describe('fromVendorProfile (vendor → pgpm)', () => {
+  const profile = fromVendorProfile(supabase, provider);
+
+  it('excludes the vendor auth subsystem', () => {
+    expect(profile.exclude).toEqual({ schemas: ['auth'] });
+  });
+
+  it('rebinds the users table and accessors onto the provider', () => {
+    expect(profile.route).toEqual([
+      { fromSchema: 'auth', kind: 'table', name: 'users', toSchema: 'app_auth' },
+      {
+        fromSchema: 'auth',
+        kind: 'function',
+        name: 'uid',
+        toSchema: 'app_auth',
+        toName: 'current_user_id'
+      }
+    ]);
+  });
+
+  it('de-qualifies vendor extension symbols', () => {
+    expect(profile.extensions).toEqual({ toSchema: null, from: ['extensions'] });
+  });
+
+  it('translates roles', () => {
+    expect(profile.roles).toEqual({ authenticated: 'app_authenticated' });
+  });
+
+  it('omits keys the shape does not need', () => {
+    const p = fromVendorProfile(insforge, { schema: 'app_auth', users: 'users' });
+    expect(p.extensions).toBeUndefined();
+    expect(p.roles).toBeUndefined();
+    expect(p.route).toEqual([
+      { fromSchema: 'auth', kind: 'table', name: 'users', toSchema: 'app_auth' }
+    ]);
+  });
+});
+
+describe('toVendorProfile (pgpm → vendor)', () => {
+  const profile = toVendorProfile(supabase, provider);
+
+  it('does not exclude anything — the vendor subsystem is native there', () => {
+    expect(profile.exclude).toBeUndefined();
+  });
+
+  it('rebinds provider objects back onto the vendor subsystem', () => {
+    expect(profile.route).toEqual([
+      { fromSchema: 'app_auth', kind: 'table', name: 'users', toSchema: 'auth' },
+      {
+        fromSchema: 'app_auth',
+        kind: 'function',
+        name: 'current_user_id',
+        toSchema: 'auth',
+        toName: 'uid'
+      }
+    ]);
+  });
+
+  it('qualifies extension symbols into the vendor extensions schema', () => {
+    expect(profile.extensions).toEqual({ toSchema: 'extensions', from: [null] });
+  });
+
+  it('translates roles back to vendor names', () => {
+    expect(profile.roles).toEqual({ app_authenticated: 'authenticated' });
+  });
+
+  it('refuses an unqualified provider — nothing to route from', () => {
+    expect(() => toVendorProfile(supabase, { schema: null, users: 'users' })).toThrow(
+      /named schema/
+    );
+  });
+});

--- a/pgpm/portability/jest.config.js
+++ b/pgpm/portability/jest.config.js
@@ -1,0 +1,18 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        babelConfig: false,
+        tsconfig: 'tsconfig.json',
+      },
+    ],
+  },
+  transformIgnorePatterns: [`/node_modules/*`],
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  modulePathIgnorePatterns: ['dist/*']
+};

--- a/pgpm/portability/package.json
+++ b/pgpm/portability/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@pgpmjs/portability",
+  "version": "0.0.1",
+  "author": "Constructive <developers@constructive.io>",
+  "description": "Vendor portability for pgpm — vendor shape profiles (supabase, insforge, ...) and pgsql-test seed adapters for deploying apply/transpile targets",
+  "main": "index.js",
+  "module": "esm/index.js",
+  "types": "index.d.ts",
+  "homepage": "https://github.com/constructive-io/constructive",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "directory": "dist"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/constructive-io/constructive"
+  },
+  "bugs": {
+    "url": "https://github.com/constructive-io/constructive/issues"
+  },
+  "scripts": {
+    "clean": "makage clean",
+    "prepack": "npm run build",
+    "build": "makage build",
+    "build:dev": "makage build --dev",
+    "lint": "eslint . --fix",
+    "test": "jest",
+    "test:watch": "jest --watch"
+  },
+  "keywords": [
+    "sql",
+    "postgres",
+    "postgresql",
+    "pgpm",
+    "pgpmjs",
+    "portability",
+    "supabase",
+    "insforge",
+    "migration",
+    "transpile"
+  ],
+  "devDependencies": {
+    "makage": "^0.3.0",
+    "pgsql-test": "workspace:^"
+  },
+  "dependencies": {
+    "@pgpmjs/core": "workspace:^",
+    "@pgpmjs/env": "workspace:^",
+    "@pgpmjs/types": "workspace:^",
+    "pg-env": "workspace:^"
+  }
+}

--- a/pgpm/portability/src/index.ts
+++ b/pgpm/portability/src/index.ts
@@ -1,0 +1,4 @@
+export type { ApplySeedAdapter, ApplySeedContext, ApplySeedOptions } from './seed';
+export { apply, seed } from './seed';
+export type { ProviderBinding, VendorObjectRef, VendorShape } from './shapes';
+export { fromVendorProfile, insforge, supabase, toVendorProfile } from './shapes';

--- a/pgpm/portability/src/seed.ts
+++ b/pgpm/portability/src/seed.ts
@@ -1,0 +1,60 @@
+import { PgpmPackage } from '@pgpmjs/core';
+import { getEnvOptions } from '@pgpmjs/env';
+import type { PgConfig } from 'pg-env';
+
+/**
+ * The slice of pgsql-test's `SeedContext` the portability adapters need.
+ * Structural, so the adapters plug into `getConnections(_, [seed.apply(...)])`
+ * without this package depending on pgsql-test.
+ */
+export interface ApplySeedContext {
+  config: PgConfig;
+  connect: { cwd?: string };
+}
+
+/** Structurally compatible with pgsql-test's `SeedAdapter`. */
+export interface ApplySeedAdapter {
+  seed(ctx: ApplySeedContext): Promise<void>;
+}
+
+export interface ApplySeedOptions {
+  /** Enable pgpm's deployment cache. */
+  cache?: boolean;
+  /**
+   * Directory to discover the workspace from. Defaults to the test's cwd —
+   * the workspace root is found automatically by walking up from it.
+   */
+  cwd?: string;
+}
+
+/**
+ * Deploy a named workspace target — typically an apply proxy (a directory
+ * carrying `pgpm.apply.json`) — into the test database, exactly as a
+ * production `pgpm deploy <target>` would: the workspace is discovered from
+ * the test's cwd, dependencies resolve from the workspace module map, and
+ * proxy modules transpile/materialize through the engine's apply path.
+ *
+ * ```ts
+ * getConnections({}, [seed.apply('vendor-app-ported')]);
+ * ```
+ */
+export function apply(target: string, options: ApplySeedOptions = {}): ApplySeedAdapter {
+  return {
+    async seed(ctx: ApplySeedContext) {
+      const workspace = new PgpmPackage(options.cwd ?? ctx.connect.cwd ?? process.cwd());
+      await workspace.deploy(
+        getEnvOptions({
+          pg: ctx.config,
+          deployment: {
+            fast: true,
+            usePlan: true,
+            cache: options.cache ?? false
+          }
+        }),
+        target
+      );
+    }
+  };
+}
+
+export const seed = { apply };

--- a/pgpm/portability/src/shapes.ts
+++ b/pgpm/portability/src/shapes.ts
@@ -1,0 +1,170 @@
+import { PgpmRouteEntry, PgpmRouteKind, PgpmRoutingProfile } from '@pgpmjs/types';
+
+/** A vendor-owned object that portable SQL may reference. */
+export interface VendorObjectRef {
+  schema: string;
+  kind: PgpmRouteKind;
+  name: string;
+}
+
+/**
+ * A vendor's database shape: the schemas, roles, and objects its managed
+ * subsystems own — the "weirdnesses" a package must be translated across when
+ * it moves between the vendor and a plain-PostgreSQL/pgpm environment.
+ */
+export interface VendorShape {
+  /** Vendor identifier (e.g. `supabase`). */
+  vendor: string;
+  /**
+   * Schemas owned by the vendor's managed auth subsystem. Moving *off* the
+   * vendor excludes these and substitutes a provider; moving *onto* the
+   * vendor rebinds onto the native subsystem.
+   */
+  authSchemas: string[];
+  /**
+   * Schema the vendor installs extensions into (`null`: extensions live on
+   * the default `search_path`, no qualification).
+   */
+  extensionsSchema: string | null;
+  /** The vendor's application-facing role names. */
+  roles: string[];
+  /** The vendor's canonical users table, the usual FK target. */
+  users?: VendorObjectRef;
+  /**
+   * Auth accessor functions application SQL calls (e.g. `auth.uid()`),
+   * which must be rebound onto the substitute provider's equivalents.
+   */
+  accessors: VendorObjectRef[];
+}
+
+/** Supabase: `auth` subsystem, `extensions` schema, `auth.uid()`/`auth.role()`. */
+export const supabase: VendorShape = {
+  vendor: 'supabase',
+  authSchemas: ['auth'],
+  extensionsSchema: 'extensions',
+  roles: ['anon', 'authenticated', 'service_role'],
+  users: { schema: 'auth', kind: 'table', name: 'users' },
+  accessors: [
+    { schema: 'auth', kind: 'function', name: 'uid' },
+    { schema: 'auth', kind: 'function', name: 'role' }
+  ]
+};
+
+/** InsForge: `auth` subsystem with `auth.users`, roles on the default search path. */
+export const insforge: VendorShape = {
+  vendor: 'insforge',
+  authSchemas: ['auth'],
+  extensionsSchema: null,
+  roles: ['anon', 'authenticated', 'project_admin'],
+  users: { schema: 'auth', kind: 'table', name: 'users' },
+  accessors: []
+};
+
+/**
+ * How a substitute provider binds a vendor's auth surface: where the
+ * provider's objects live and which of its objects replace each vendor
+ * object. Used in both directions — the inverse binding round-trips.
+ */
+export interface ProviderBinding {
+  /** Schema the provider's objects live in (`null`: unqualified). */
+  schema: string | null;
+  /** Provider's users-table name replacing the vendor users table. */
+  users?: string;
+  /** Vendor accessor name → provider function name (e.g. `uid` → `current_user_id`). */
+  accessors?: Record<string, string>;
+  /** Vendor role name → target role name. */
+  roles?: Record<string, string>;
+}
+
+function routesFor(shape: VendorShape, provider: ProviderBinding, invert: boolean): PgpmRouteEntry[] {
+  const routes: PgpmRouteEntry[] = [];
+
+  if (invert && provider.schema === null && (provider.users || provider.accessors)) {
+    throw new Error(
+      `toVendorProfile(${shape.vendor}): provider objects must live in a named schema ` +
+        `to be routed back onto the vendor (provider.schema is null)`
+    );
+  }
+
+  if (shape.users && provider.users) {
+    routes.push(
+      invert
+        ? {
+            fromSchema: provider.schema!,
+            kind: shape.users.kind,
+            name: provider.users,
+            toSchema: shape.users.schema,
+            ...(provider.users !== shape.users.name ? { toName: shape.users.name } : {})
+          }
+        : {
+            fromSchema: shape.users.schema,
+            kind: shape.users.kind,
+            name: shape.users.name,
+            toSchema: provider.schema,
+            ...(provider.users !== shape.users.name ? { toName: provider.users } : {})
+          }
+    );
+  }
+
+  for (const accessor of shape.accessors) {
+    const target = provider.accessors?.[accessor.name];
+    if (!target) continue;
+    routes.push(
+      invert
+        ? {
+            fromSchema: provider.schema!,
+            kind: accessor.kind,
+            name: target,
+            toSchema: accessor.schema,
+            ...(target !== accessor.name ? { toName: accessor.name } : {})
+          }
+        : {
+            fromSchema: accessor.schema,
+            kind: accessor.kind,
+            name: accessor.name,
+            toSchema: provider.schema,
+            ...(target !== accessor.name ? { toName: target } : {})
+          }
+    );
+  }
+
+  return routes;
+}
+
+function invertRoles(roles?: Record<string, string>): Record<string, string> | undefined {
+  if (!roles) return undefined;
+  return Object.fromEntries(Object.entries(roles).map(([from, to]) => [to, from]));
+}
+
+/**
+ * Routing profile for moving a package *off* a vendor onto plain
+ * PostgreSQL/pgpm: exclude the vendor's auth subsystem, rebind the users FK
+ * and accessor calls onto the substitute provider, de-qualify (or re-route)
+ * extension symbols, and translate role names.
+ */
+export function fromVendorProfile(shape: VendorShape, provider: ProviderBinding): PgpmRoutingProfile {
+  return {
+    exclude: { schemas: [...shape.authSchemas] },
+    route: routesFor(shape, provider, false),
+    ...(shape.extensionsSchema
+      ? { extensions: { toSchema: null, from: [shape.extensionsSchema] } }
+      : {}),
+    ...(provider.roles ? { roles: { ...provider.roles } } : {})
+  };
+}
+
+/**
+ * The inverse of {@link fromVendorProfile}: move a pgpm-shaped package *onto*
+ * the vendor's native subsystem — rebind the provider's objects back onto the
+ * vendor's, qualify extension symbols into the vendor's extensions schema,
+ * and translate roles back to the vendor's names.
+ */
+export function toVendorProfile(shape: VendorShape, provider: ProviderBinding): PgpmRoutingProfile {
+  return {
+    route: routesFor(shape, provider, true),
+    ...(shape.extensionsSchema
+      ? { extensions: { toSchema: shape.extensionsSchema, from: [null] } }
+      : {}),
+    ...(provider.roles ? { roles: invertRoles(provider.roles)! } : {})
+  };
+}

--- a/pgpm/portability/tsconfig.esm.json
+++ b/pgpm/portability/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/esm",
+    "module": "es2022",
+    "rootDir": "src/",
+    "declaration": false
+  }
+}

--- a/pgpm/portability/tsconfig.json
+++ b/pgpm/portability/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src/"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules", "**/*.spec.*", "**/*.test.*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3052,6 +3052,29 @@ importers:
         version: 0.3.0
     publishDirectory: dist
 
+  pgpm/portability:
+    dependencies:
+      '@pgpmjs/core':
+        specifier: workspace:^
+        version: link:../core/dist
+      '@pgpmjs/env':
+        specifier: workspace:^
+        version: link:../env/dist
+      '@pgpmjs/types':
+        specifier: workspace:^
+        version: link:../types/dist
+      pg-env:
+        specifier: workspace:^
+        version: link:../../postgres/pg-env/dist
+    devDependencies:
+      makage:
+        specifier: ^0.3.0
+        version: 0.3.0
+      pgsql-test:
+        specifier: workspace:^
+        version: link:../../postgres/pgsql-test/dist
+    publishDirectory: dist
+
   pgpm/slice:
     dependencies:
       '@pgpmjs/ast':
@@ -10815,11 +10838,6 @@ packages:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
 
-  yaml@2.8.4:
-    resolution: {integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
-
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -17024,7 +17042,7 @@ snapshots:
   makage@0.3.0:
     dependencies:
       glob: 11.1.0
-      yaml: 2.8.4
+      yaml: 2.9.0
 
   make-dir@2.1.0:
     dependencies:
@@ -19310,8 +19328,6 @@ snapshots:
   yallist@4.0.0: {}
 
   yallist@5.0.0: {}
-
-  yaml@2.8.4: {}
 
   yaml@2.9.0: {}
 


### PR DESCRIPTION
## Summary

New package `pgpm/portability` (`@pgpmjs/portability`) owning the vendor-portability story, so vendor quirks stay out of pgsql-test:

- **`seed.apply('<target>')`** — a seed adapter that deploys a named workspace target (including apply proxies carrying `pgpm.apply.json`) through the engine's normal deploy path (`PgpmPackage.deploy` with fast/usePlan), replacing hand-rolled `seed.fn(async () => new PgpmPackage(root).deploy(...))` blocks in tests. The workspace root is discovered automatically from the test's cwd (`ctx.connect.cwd`); it's structurally compatible with pgsql-test's `SeedAdapter` without depending on pgsql-test at runtime:

  ```ts
  getConnections({}, [seed.apply('vendor-app-ported')]);
  ```

- **Vendor shapes** — `VendorShape` describes a vendor's managed subsystems (auth schemas, extensions schema, roles, users table, accessor functions), with `supabase` and `insforge` shipped. `fromVendorProfile(shape, provider)` / `toVendorProfile(shape, provider)` build the `PgpmRoutingProfile` for each direction (exclude+rebind+de-qualify+role-translate off the vendor; the inverse onto it), grounded in the profiles proven in supabase-test-suite's `portability/`:

  ```ts
  fromVendorProfile(supabase, { schema: 'app_auth', users: 'users',
    accessors: { uid: 'current_user_id' }, roles: { authenticated: 'app_authenticated' } })
  // → { exclude: {schemas:['auth']}, route: [users→app_auth, uid→current_user_id],
  //     extensions: {toSchema:null, from:['extensions']}, roles: {...} }
  ```

Tests: pure shape/profile tests plus a live pgsql-test run deploying the `__fixtures__/apply/proxy` tenant through `seed.apply` and asserting the routed schema and migration-ledger entry.

Link to Devin session: https://app.devin.ai/sessions/025fb88043964fdbb335ac5e39df2478
Requested by: @pyramation