### PR TITLE
feat(apply): graph-based subsystem exclusion — one analysis pass over per-change programs

### DIFF
--- a/pgpm/core/src/apply/materialize.ts
+++ b/pgpm/core/src/apply/materialize.ts
@@ -9,8 +9,8 @@ import {
   transpileBundle,
   verifyBundle
 } from '@pgpmjs/bundle';
-import { buildSchemaRouter, loadModule, makeSchemaTranspiler, SchemaTransformPass } from '@pgpmjs/transform';
-import { excludeSubsystem, stripSubsystemSql } from '@pgpmjs/slice';
+import { buildSchemaRouter, loadModule, makeSchemaTranspiler, parseSqlProgram, SchemaTransformPass, SqlProgram } from '@pgpmjs/transform';
+import { excludeSubsystemPrograms, stripSubsystemSql } from '@pgpmjs/slice';
 
 import { ModuleMap } from '../modules/modules';
 import { hasApplySpec, readApplySpec } from './apply-spec';
@@ -60,11 +60,13 @@ function makeSubsystemStripper(
   const selector = { schemas: spec.exclude!.schemas };
   const rebinds = buildSchemaRouter({ schemaMap: spec.schemas, routes: spec.route });
 
-  const fullDeploySql = source.changes
-    .map(c => c.deploy?.sql ?? '')
-    .filter(Boolean)
-    .join('\n');
-  const analysis = excludeSubsystem(fullDeploySql, selector, { rebinds });
+  // One parse per deploy script; the analysis runs over all programs together
+  // (cross-change references into the subsystem are caught by construction)
+  // and returns per-change drop/strip/prune decisions from the same pass.
+  const programs: Array<[string, SqlProgram]> = source.changes
+    .filter(c => c.deploy)
+    .map(c => [c.name, parseSqlProgram(c.deploy!.sql)]);
+  const analysis = excludeSubsystemPrograms(programs, selector, { rebinds });
 
   if (analysis.unsatisfied.length > 0) {
     const detail = [
@@ -82,28 +84,26 @@ function makeSubsystemStripper(
     );
   }
 
-  // A change whose deploy consists entirely of subsystem statements (plus
-  // transaction control) is dropped *as a change* — removed from the plan and
-  // deploy order rather than emitted as an empty script (empty scripts collide
-  // on the deploy ledger's script-hash uniqueness). Its verify/revert scripts
-  // target dropped objects the classifier can't always see (bare DROPs, catalog
-  // probes), which is exactly why the whole change is dropped, not just blanked.
+  // A fully-excluded change is dropped *as a change* — removed from the plan
+  // and deploy order rather than emitted as an empty script (empty scripts
+  // collide on the deploy ledger's script-hash uniqueness). Its verify/revert
+  // scripts target dropped objects the classifier can't always see (bare
+  // DROPs, catalog probes), which is exactly why the whole change is dropped,
+  // not just blanked.
   const excludedChanges = new Set<string>();
-  for (const change of source.changes) {
-    if (!change.deploy) continue;
-    const stripped = stripSubsystemSql(change.deploy.sql, selector);
-    const survivors = stripped.result.kept.filter(
-      i => !stripped.dropped.includes(i) && stripped.result.statements[i].nodeTag !== 'TransactionStmt'
-    );
-    if (stripped.dropped.length > 0 && survivors.length === 0) {
-      excludedChanges.add(change.name);
-    }
+  const strippedDeploys = new Map<string, string>();
+  for (const [name, program] of programs) {
+    const exclusion = analysis.programs.get(name)!;
+    if (exclusion.fullyExcluded) excludedChanges.add(name);
+    else strippedDeploys.set(program.source, exclusion.sql);
   }
 
   // Surviving changes may still contain stray subsystem statements (a change
   // that both creates a survivor and touches the excluded subsystem); strip
-  // those in place. Fully-excluded changes are dropped via `excludedChanges`.
-  const strip = (sql: string): string => stripSubsystemSql(sql, selector).sql;
+  // those in place. Verify/revert scripts are separate sources, stripped on
+  // demand with the same selector.
+  const strip = (sql: string): string =>
+    strippedDeploys.get(sql) ?? stripSubsystemSql(sql, selector).sql;
 
   return { strip, excludedChanges };
 }

--- a/pgpm/slice/__tests__/exclude-programs.test.ts
+++ b/pgpm/slice/__tests__/exclude-programs.test.ts
@@ -1,0 +1,106 @@
+import { parseSqlProgram, SchemaRouter, SqlProgram } from '@pgpmjs/transform';
+
+import { excludeSubsystemPrograms, loadModule } from '../src';
+
+beforeAll(async () => {
+  await loadModule();
+});
+
+// One program per pgpm change, mirroring how apply materialization sees a
+// source bundle: the subsystem spans several changes and the app references
+// it from another.
+const CHANGES: Array<[string, string]> = [
+  ['identity/schema', 'CREATE SCHEMA identity;'],
+  [
+    'identity/users',
+    `-- Deploy identity/users to pg
+CREATE TABLE identity.users (
+  id uuid PRIMARY KEY
+);
+
+GRANT SELECT ON TABLE identity.users TO web_user;
+`
+  ],
+  [
+    'identity/actor',
+    `BEGIN;
+CREATE FUNCTION identity.current_actor() RETURNS uuid AS $$
+  select nullif(current_setting('request.claims.sub', true), '')::uuid;
+$$ LANGUAGE sql STABLE;
+COMMIT;
+`
+  ],
+  ['app/schema', 'CREATE SCHEMA app;'],
+  [
+    'app/posts',
+    `CREATE TABLE app.posts (
+  id serial PRIMARY KEY,
+  owner uuid REFERENCES identity.users(id)
+);
+
+COMMENT ON TABLE identity.users IS 'vendor-owned';
+
+CREATE POLICY posts_owner ON app.posts USING (owner = identity.current_actor());
+`
+  ]
+];
+
+const selector = { schemas: ['identity'] };
+
+function programs(): Array<[string, SqlProgram]> {
+  return CHANGES.map(([name, sql]) => [name, parseSqlProgram(sql)]);
+}
+
+const router = new SchemaRouter({
+  identity: {
+    relations: { users: { schema: 'app_auth', name: 'users' } },
+    functions: { current_actor: { schema: null, name: 'current_user_id' } }
+  }
+});
+
+describe('excludeSubsystemPrograms', () => {
+  it('measures the contract across all programs and tags unsatisfied refs with their program', () => {
+    const res = excludeSubsystemPrograms(programs(), selector);
+
+    const required = res.contract.required.map(d => `${d.object.schema}.${d.object.name}`).sort();
+    expect(required).toEqual(['identity.current_actor', 'identity.users']);
+
+    expect(res.unsatisfied.map(u => u.program)).toEqual(['app/posts', 'app/posts']);
+  });
+
+  it('is satisfied when the router rebinds the full contract', () => {
+    const res = excludeSubsystemPrograms(programs(), selector, { rebinds: router });
+    expect(res.unsatisfied).toEqual([]);
+  });
+
+  it('marks subsystem-only changes fullyExcluded, transaction control included', () => {
+    const res = excludeSubsystemPrograms(programs(), selector, { rebinds: router });
+
+    expect(res.programs.get('identity/schema')!.fullyExcluded).toBe(true);
+    expect(res.programs.get('identity/users')!.fullyExcluded).toBe(true);
+    expect(res.programs.get('identity/actor')!.fullyExcluded).toBe(true);
+    expect(res.programs.get('app/schema')!.fullyExcluded).toBe(false);
+    expect(res.programs.get('app/posts')!.fullyExcluded).toBe(false);
+  });
+
+  it('strips stray subsystem statements from surviving programs, preserving headers', () => {
+    const res = excludeSubsystemPrograms(programs(), selector, { rebinds: router });
+
+    const posts = res.programs.get('app/posts')!;
+    // the opaque COMMENT ON targets a subsystem object → dropped
+    expect(posts.dropped).toEqual([1]);
+    expect(posts.sql).not.toMatch(/COMMENT ON/);
+    expect(posts.sql).toMatch(/CREATE TABLE app\.posts/);
+    expect(posts.sql).toMatch(/CREATE POLICY posts_owner/);
+
+    const users = res.programs.get('identity/users')!;
+    expect(users.dropped).toEqual([0, 1]);
+  });
+
+  it('returns the unified object graph over the same programs', () => {
+    const res = excludeSubsystemPrograms(programs(), selector, { rebinds: router });
+
+    expect(res.graph.objects.has('identity\u0000users')).toBe(true);
+    expect(res.graph.programs.size).toBe(CHANGES.length);
+  });
+});

--- a/pgpm/slice/src/exclude.ts
+++ b/pgpm/slice/src/exclude.ts
@@ -1,5 +1,6 @@
 import { parseSqlProgram, SchemaRouter, SqlProgram, StatementFacts } from '@pgpmjs/transform';
 
+import { buildObjectGraph, SqlObjectGraph } from './object-graph';
 import { SqlObjectRef } from './refs';
 
 /**
@@ -162,16 +163,52 @@ export function excludeSubsystem(
   selector: SubsystemSelector,
   options: { rebinds?: SchemaRouter } = {}
 ): ExcludeResult {
-  const schemas = new Set(selector.schemas);
   const program = parseSqlProgram(sql);
+  const analysis = analyzeProgram(program, new Set(selector.schemas), options.rebinds);
+
+  return {
+    excluded: analysis.excluded,
+    kept: analysis.kept,
+    contract: contractOf(analysis.provides, analysis.required),
+    unsatisfied: analysis.unsatisfied,
+    warnings: analysis.warnings,
+    statements: program.statements.map(s => s.facts),
+    program
+  };
+}
+
+/** Per-program exclusion analysis, shared by the single- and multi-program APIs. */
+interface ProgramAnalysis {
+  excluded: number[];
+  kept: number[];
+  warnings: ExcludeWarning[];
+  provides: SqlObjectRef[];
+  required: Map<string, SubsystemDependency>;
+  unsatisfied: UnsatisfiedReference[];
+}
+
+function contractOf(
+  provides: SqlObjectRef[],
+  required: Map<string, SubsystemDependency>
+): SubsystemContract {
+  const internal: SqlObjectRef[] = [];
+  for (const p of provides) {
+    if (!required.has(refKey(p))) pushUnique(internal, p);
+  }
+  return { provides, required: [...required.values()], internal };
+}
+
+function analyzeProgram(
+  program: SqlProgram,
+  schemas: Set<string>,
+  router: SchemaRouter | undefined
+): ProgramAnalysis {
   const statements = program.statements.map(s => s.facts);
-  const router = options.rebinds;
 
   const excluded: number[] = [];
   const kept: number[] = [];
   const warnings: ExcludeWarning[] = [];
   const provides: SqlObjectRef[] = [];
-  const internal: SqlObjectRef[] = [];
   const required = new Map<string, SubsystemDependency>();
   const unsatisfied: UnsatisfiedReference[] = [];
 
@@ -234,23 +271,113 @@ export function excludeSubsystem(
     }
   });
 
-  for (const p of provides) {
-    if (!required.has(refKey(p))) pushUnique(internal, p);
+  return { excluded, kept, warnings, provides, required, unsatisfied };
+}
+
+/** An `UnsatisfiedReference`/`ExcludeWarning` tagged with its owning program. */
+export type ProgramUnsatisfiedReference = UnsatisfiedReference & { program: string };
+export type ProgramExcludeWarning = ExcludeWarning & { program: string };
+
+/** Per-program exclusion decisions from {@link excludeSubsystemPrograms}. */
+export interface ProgramExclusion {
+  /** Statement indexes removed: subsystem members + opaque subsystem-targeted. */
+  dropped: number[];
+  /**
+   * The whole program consists of subsystem statements (plus transaction
+   * control): it should be removed as a unit rather than emptied in place.
+   */
+  fullyExcluded: boolean;
+  /** The surviving SQL with the dropped statements sliced out. */
+  sql: string;
+}
+
+export interface ExcludeProgramsResult {
+  /** The unified object graph over every analyzed program. */
+  graph: SqlObjectGraph;
+  /** The subsystem's external contract, measured across all programs. */
+  contract: SubsystemContract;
+  /** Unrebound references into the subsystem, tagged with their program. */
+  unsatisfied: ProgramUnsatisfiedReference[];
+  warnings: ProgramExcludeWarning[];
+  /** Per-program decisions, keyed by program name. */
+  programs: Map<string, ProgramExclusion>;
+}
+
+/**
+ * Analyze a subsystem exclusion across a set of already-parsed programs
+ * (typically one per pgpm change) in a single pass: the contract and cascade
+ * safety are measured over all programs together — which is what catches
+ * cross-change dependencies on the subsystem — while drop/strip/prune
+ * decisions are returned per program, derived from statement membership and
+ * ownership rather than survivor counting. The unified {@link SqlObjectGraph}
+ * over the same programs is returned for structural queries.
+ */
+export function excludeSubsystemPrograms(
+  programs: Map<string, SqlProgram> | Array<[string, SqlProgram]>,
+  selector: SubsystemSelector,
+  options: { rebinds?: SchemaRouter } = {}
+): ExcludeProgramsResult {
+  const entries = programs instanceof Map ? [...programs.entries()] : programs;
+  const schemas = new Set(selector.schemas);
+
+  const provides: SqlObjectRef[] = [];
+  const required = new Map<string, SubsystemDependency>();
+  const unsatisfied: ProgramUnsatisfiedReference[] = [];
+  const warnings: ProgramExcludeWarning[] = [];
+  const perProgram = new Map<string, ProgramExclusion>();
+
+  for (const [name, program] of entries) {
+    const analysis = analyzeProgram(program, schemas, options.rebinds);
+
+    for (const p of analysis.provides) pushUnique(provides, p);
+    for (const [key, dep] of analysis.required) {
+      const merged = required.get(key) ?? { object: dep.object, fk: false, dependents: [] };
+      merged.fk = merged.fk || dep.fk;
+      required.set(key, merged);
+    }
+    unsatisfied.push(...analysis.unsatisfied.map(u => ({ ...u, program: name })));
+    warnings.push(...analysis.warnings.map(w => ({ ...w, program: name })));
+
+    const dropped = new Set(analysis.excluded);
+    for (const i of analysis.kept) {
+      if (opaqueTargetsSubsystem(program.statements[i].stmt, schemas)) dropped.add(i);
+    }
+
+    const survivors = program.statements.filter(
+      (s, i) => !dropped.has(i) && !('TransactionStmt' in s.stmt)
+    );
+
+    perProgram.set(name, {
+      dropped: [...dropped].sort((a, b) => a - b),
+      fullyExcluded: dropped.size > 0 && survivors.length === 0,
+      sql: sliceSurvivors(program, dropped)
+    });
   }
 
   return {
-    excluded,
-    kept,
-    contract: {
-      provides,
-      required: [...required.values()],
-      internal
-    },
+    graph: buildObjectGraph(entries),
+    contract: contractOf(provides, required),
     unsatisfied,
     warnings,
-    statements,
-    program
+    programs: perProgram
   };
+}
+
+/**
+ * Slice the surviving statements out of a program's source, preserving the
+ * leading text (pgpm headers) and each survivor's original bytes.
+ */
+function sliceSurvivors(program: SqlProgram, dropped: Set<number>): string {
+  const { source, statements } = program;
+  const prefix = statements.length > 0 ? source.slice(0, statements[0].span.start) : source;
+
+  const pieces: string[] = [];
+  statements.forEach((s, i) => {
+    if (dropped.has(i)) return;
+    pieces.push(s.raw.trim() + ';');
+  });
+
+  return prefix + pieces.join('\n\n') + (pieces.length > 0 ? '\n' : '');
 }
 
 /**
@@ -333,19 +460,8 @@ export function stripSubsystemSql(
     if (opaqueTargetsSubsystem(statements[i].stmt, schemas)) drop.add(i);
   }
 
-  // Text before the first statement (pgpm headers, leading comments) is
-  // preserved verbatim so script identity headers survive the strip.
-  const prefix =
-    statements.length > 0 ? sql.slice(0, statements[0].span.start) : sql;
-
-  const pieces: string[] = [];
-  statements.forEach((s, i) => {
-    if (drop.has(i)) return;
-    pieces.push(s.raw.trim() + ';');
-  });
-
   return {
-    sql: prefix + pieces.join('\n\n') + (pieces.length > 0 ? '\n' : ''),
+    sql: sliceSurvivors(result.program, drop),
     result,
     dropped: [...drop].sort((a, b) => a - b)
   };


### PR DESCRIPTION
## Summary

Removes the last bolted-on seams in apply's subsystem exclusion (stage 4 of the AST convergence). New `@pgpmjs/slice` API:

```ts
excludeSubsystemPrograms(programs: Map<string, SqlProgram> | [string, SqlProgram][], selector, { rebinds })
  → { graph: SqlObjectGraph,          // unified graph over the same programs
      contract,                        // measured across ALL programs (cross-change refs caught by construction)
      unsatisfied: (...& { program }), // tagged with the owning change
      warnings:    (...& { program }),
      programs: Map<name, { dropped, fullyExcluded, sql }> }  // per-change decisions
```

`makeSubsystemStripper` in `pgpm/core` now:
- parses each deploy script **once** into a `SqlProgram` and runs one analysis pass — replacing the flattened `join('\n')` re-classification of the whole bundle *plus* an independent `stripSubsystemSql` re-parse per change;
- reads whole-change removal from `fullyExcluded` (statement membership + ownership) instead of counting survivors per change;
- reuses the pre-stripped SQL from the same pass for deploy scripts (verify/revert scripts are separate sources, still stripped on demand).

`excludeSubsystem`/`stripSubsystemSql` keep their exact signatures and behavior — the per-program analysis is the same code path factored into `analyzeProgram`, and the survivor-slicing logic dedupes into one `sliceSurvivors`.

Tests: new `exclude-programs.test.ts` (cross-change contract, program-tagged unsatisfied refs, fullyExcluded incl. transaction-control-only, opaque `COMMENT ON` drop, header preservation, graph exposure); all existing slice (59), bundle (52), and core apply (74, live PG) suites pass unchanged.

Link to Devin session: https://app.devin.ai/sessions/025fb88043964fdbb335ac5e39df2478
Requested by: @pyramation