### PR TITLE
feat(portability): add auth.uid accessor to the insforge vendor shape

### DIFF
--- a/pgpm/portability/__tests__/shapes.test.ts
+++ b/pgpm/portability/__tests__/shapes.test.ts
@@ -79,3 +79,48 @@ describe('toVendorProfile (pgpm → vendor)', () => {
     );
   });
 });
+
+describe('insforge shape (second vendor — no extensions schema)', () => {
+  const provider: ProviderBinding = {
+    schema: 'app_auth',
+    users: 'users',
+    accessors: { uid: 'current_user_id' },
+    roles: { authenticated: 'app_authenticated' }
+  };
+
+  it('excludes auth, rebinds the users table and the uid accessor, translates roles', () => {
+    const profile = fromVendorProfile(insforge, provider);
+    expect(profile.exclude).toEqual({ schemas: ['auth'] });
+    expect(profile.route).toEqual([
+      { fromSchema: 'auth', kind: 'table', name: 'users', toSchema: 'app_auth' },
+      {
+        fromSchema: 'auth',
+        kind: 'function',
+        name: 'uid',
+        toSchema: 'app_auth',
+        toName: 'current_user_id'
+      }
+    ]);
+    expect(profile.roles).toEqual({ authenticated: 'app_authenticated' });
+  });
+
+  it('emits no extensions transform — InsForge has no extensions schema', () => {
+    expect(fromVendorProfile(insforge, provider).extensions).toBeUndefined();
+    expect(toVendorProfile(insforge, provider).extensions).toBeUndefined();
+  });
+
+  it('round-trips onto the native subsystem in reverse', () => {
+    const profile = toVendorProfile(insforge, provider);
+    expect(profile.route).toEqual([
+      { fromSchema: 'app_auth', kind: 'table', name: 'users', toSchema: 'auth' },
+      {
+        fromSchema: 'app_auth',
+        kind: 'function',
+        name: 'current_user_id',
+        toSchema: 'auth',
+        toName: 'uid'
+      }
+    ]);
+    expect(profile.roles).toEqual({ app_authenticated: 'authenticated' });
+  });
+});

--- a/pgpm/portability/src/shapes.ts
+++ b/pgpm/portability/src/shapes.ts
@@ -50,14 +50,17 @@ export const supabase: VendorShape = {
   ]
 };
 
-/** InsForge: `auth` subsystem with `auth.users`, roles on the default search path. */
+/**
+ * InsForge: `auth` subsystem with `auth.users` and the `auth.uid()` claim
+ * accessor, extensions on the default search path (no extensions schema).
+ */
 export const insforge: VendorShape = {
   vendor: 'insforge',
   authSchemas: ['auth'],
   extensionsSchema: null,
   roles: ['anon', 'authenticated', 'project_admin'],
   users: { schema: 'auth', kind: 'table', name: 'users' },
-  accessors: []
+  accessors: [{ schema: 'auth', kind: 'function', name: 'uid' }]
 };
 
 /**


### PR DESCRIPTION
## Summary

The `insforge` `VendorShape` modeled only `auth.users`, with `accessors: []`. But InsForge's auth subsystem exposes `auth.uid()` (RLS policies call it, exactly like Supabase). Without it in the shape, `fromVendorProfile(insforge, ...)` never emits a rebind for `auth.uid()` call sites, so cross-shape exclusion refuses (the surviving `auth.uid()` reference has no substitute).

```diff
 export const insforge: VendorShape = {
   ...
   users: { schema: 'auth', kind: 'table', name: 'users' },
-  accessors: []
+  accessors: [{ schema: 'auth', kind: 'function', name: 'uid' }]
 };
```

Now `fromVendorProfile(insforge, { schema: 'app_auth', users: 'users', accessors: { uid: 'current_user_id' }, roles: {...} })` produces the users + `uid`→`current_user_id` routes (and no `extensions` transform, since InsForge has no extensions schema). Adds forward/reverse insforge profile tests. Enables the insforge-test-suite portability workspace to consume this shape.

Link to Devin session: https://app.devin.ai/sessions/025fb88043964fdbb335ac5e39df2478
Requested by: @pyramation