### PR TITLE
fix(server): route middleware GraphQL errors through the error registry

### DIFF
--- a/graphql/codegen/src/__tests__/codegen/__snapshots__/client-generator.test.ts.snap
+++ b/graphql/codegen/src/__tests__/codegen/__snapshots__/client-generator.test.ts.snap
@@ -246,6 +246,16 @@ export interface OrmClientConfig {
 }
 
 /**
+ * Describe a single GraphQL error, falling back to its \`extensions.code\` when
+ * the server omits \`message\` so the error never renders as an empty string.
+ */
+function describeGraphQLError(error: GraphQLError): string {
+  if (error.message) return error.message;
+  const code = error.extensions?.code;
+  return typeof code === 'string' ? code : 'Unknown error';
+}
+
+/**
  * Error thrown when GraphQL request fails
  */
 export class GraphQLRequestError extends Error {
@@ -253,7 +263,7 @@ export class GraphQLRequestError extends Error {
     public readonly errors: GraphQLError[],
     public readonly data: unknown = null,
   ) {
-    const messages = errors.map((e) => e.message).join('; ');
+    const messages = errors.map(describeGraphQLError).join('; ');
     super(\`GraphQL Error: \${messages}\`);
     this.name = 'GraphQLRequestError';
   }

--- a/graphql/codegen/src/__tests__/codegen/client-generator.test.ts
+++ b/graphql/codegen/src/__tests__/codegen/client-generator.test.ts
@@ -59,9 +59,9 @@ type FetchAdapterConstructor = new (
   ): Promise<{ ok: boolean; data: T | null; errors?: unknown[] }>;
 };
 
-function loadGeneratedFetchAdapter(
+function loadGeneratedClientExports(
   createFetch: () => typeof globalThis.fetch,
-): FetchAdapterConstructor {
+): Record<string, unknown> {
   const { content } = generateOrmClientFile();
   const { outputText } = ts.transpileModule(content, {
     compilerOptions: {
@@ -91,7 +91,14 @@ function loadGeneratedFetchAdapter(
     { filename: 'generated-orm-client.cjs' },
   );
 
-  return mod.exports.FetchAdapter as FetchAdapterConstructor;
+  return mod.exports;
+}
+
+function loadGeneratedFetchAdapter(
+  createFetch: () => typeof globalThis.fetch,
+): FetchAdapterConstructor {
+  return loadGeneratedClientExports(createFetch)
+    .FetchAdapter as FetchAdapterConstructor;
 }
 
 function createThisSensitiveFetch(payload: unknown) {
@@ -136,6 +143,18 @@ describe('client-generator', () => {
       expect(result.content).toContain('execute<T>');
       expect(result.content).toContain('QueryResult<T>');
       expect(result.content).toContain('GraphQLRequestError');
+    });
+
+    it('falls back to extensions.code when the server omits message', () => {
+      const GraphQLRequestError = loadGeneratedClientExports(
+        () => globalThis.fetch,
+      ).GraphQLRequestError as new (errors: unknown[]) => Error;
+
+      const error = new GraphQLRequestError([
+        { extensions: { code: 'UNAUTHENTICATED' } },
+      ]);
+
+      expect(error.message).toBe('GraphQL Error: UNAUTHENTICATED');
     });
 
     it('exposes an optional fetch injection in OrmClientConfig', () => {

--- a/graphql/codegen/src/core/codegen/templates/orm-client.ts
+++ b/graphql/codegen/src/core/codegen/templates/orm-client.ts
@@ -150,6 +150,16 @@ export interface OrmClientConfig {
 }
 
 /**
+ * Describe a single GraphQL error, falling back to its `extensions.code` when
+ * the server omits `message` so the error never renders as an empty string.
+ */
+function describeGraphQLError(error: GraphQLError): string {
+  if (error.message) return error.message;
+  const code = error.extensions?.code;
+  return typeof code === 'string' ? code : 'Unknown error';
+}
+
+/**
  * Error thrown when GraphQL request fails
  */
 export class GraphQLRequestError extends Error {
@@ -157,7 +167,7 @@ export class GraphQLRequestError extends Error {
     public readonly errors: GraphQLError[],
     public readonly data: unknown = null,
   ) {
-    const messages = errors.map((e) => e.message).join('; ');
+    const messages = errors.map(describeGraphQLError).join('; ');
     super(`GraphQL Error: ${messages}`);
     this.name = 'GraphQLRequestError';
   }

--- a/graphql/server/src/errors/__tests__/graphql-response.test.ts
+++ b/graphql/server/src/errors/__tests__/graphql-response.test.ts
@@ -1,0 +1,45 @@
+import { errors } from '@constructive-io/errors';
+import type { Response } from 'express';
+
+import { respondWithGraphQLError } from '../graphql-response';
+
+const createMockResponse = () => {
+  const json = jest.fn();
+  const res = { status: jest.fn(() => ({ json })) } as unknown as Response;
+  return { res, json };
+};
+
+describe('respondWithGraphQLError', () => {
+  it('always emits a top-level message so clients never render an empty error', () => {
+    const { res, json } = createMockResponse();
+
+    respondWithGraphQLError(res, errors.UNAUTHENTICATED());
+
+    const [payload] = json.mock.calls[0];
+    expect(payload.errors).toHaveLength(1);
+    expect(payload.errors[0].message).toBe('You must be signed in to do that.');
+    expect(payload.errors[0].extensions).toMatchObject({
+      code: 'UNAUTHENTICATED',
+      class: 'public',
+      http: 401,
+    });
+  });
+
+  it('responds 200 per the GraphQL-over-HTTP convention', () => {
+    const { res } = createMockResponse();
+
+    respondWithGraphQLError(res, errors.CAPTCHA_REQUIRED());
+
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('carries interpolated context in the message for dynamic codes', () => {
+    const { res, json } = createMockResponse();
+
+    respondWithGraphQLError(res, errors.INTERNAL_FAILURE({ details: 'boom' }));
+
+    const [payload] = json.mock.calls[0];
+    expect(payload.errors[0].message).toContain('boom');
+    expect(payload.errors[0].extensions.class).toBe('internal');
+  });
+});

--- a/graphql/server/src/errors/graphql-response.ts
+++ b/graphql/server/src/errors/graphql-response.ts
@@ -1,0 +1,30 @@
+/**
+ * GraphQL-over-HTTP error responses.
+ *
+ * Middleware that short-circuits a GraphQL request (auth, captcha, ...) must
+ * still answer with a valid GraphQL response body. Building that body by hand
+ * is how a code ends up shipped without a top-level `message`: clients render
+ * `errors[].message`, so an error carrying only `extensions.code` surfaces as
+ * an empty string. Route every such response through here so the message and
+ * extensions both come from the canonical error registry.
+ *
+ * @module errors/graphql-response
+ */
+
+import type { ConstructiveError } from '@constructive-io/errors';
+import type { Response } from 'express';
+
+/**
+ * Send a {@link ConstructiveError} as a GraphQL error response.
+ *
+ * Uses HTTP 200 per the GraphQL-over-HTTP convention: transport succeeded, the
+ * operation did not. The error's own `http` hint travels in `extensions`.
+ */
+export function respondWithGraphQLError(
+  res: Response,
+  error: ConstructiveError
+): void {
+  res.status(200).json({
+    errors: [{ message: error.message, extensions: error.toExtensions() }],
+  });
+}

--- a/graphql/server/src/middleware/auth.ts
+++ b/graphql/server/src/middleware/auth.ts
@@ -1,9 +1,12 @@
+import { errors } from '@constructive-io/errors';
 import { getNodeEnv } from '@pgpmjs/env';
 import { Logger } from '@pgpmjs/logger';
 import { PgpmOptions } from '@pgpmjs/types';
 import { NextFunction, Request, RequestHandler, Response } from 'express';
 import { getPgPool } from 'pg-cache';
 import pgQueryContext from 'pg-query-context';
+
+import { respondWithGraphQLError } from '../errors/graphql-response';
 import './types'; // for Request type
 
 const log = new Logger('auth');
@@ -112,9 +115,7 @@ export const createAuthenticateMiddleware = (
 
           if (result?.rowCount === 0) {
             log.info('[auth] No rows returned, returning UNAUTHENTICATED');
-            res.status(200).json({
-              errors: [{ extensions: { code: 'UNAUTHENTICATED' } }],
-            });
+            respondWithGraphQLError(res, errors.UNAUTHENTICATED());
             return;
           }
 
@@ -122,16 +123,12 @@ export const createAuthenticateMiddleware = (
           log.info(`[auth] Auth success: role=${token.role}, user_id=${token.user_id}`);
         } catch (e: any) {
           log.error('[auth] Auth error:', e.message);
-          res.status(200).json({
-            errors: [
-              {
-                extensions: {
-                  code: 'BAD_TOKEN_DEFINITION',
-                  message: e.message,
-                },
-              },
-            ],
-          });
+          respondWithGraphQLError(
+            res,
+            errors.INTERNAL_FAILURE({
+              details: isDev() ? e.message : 'authentication failed',
+            })
+          );
           return;
         }
       } else {

--- a/graphql/server/src/middleware/captcha.ts
+++ b/graphql/server/src/middleware/captcha.ts
@@ -1,5 +1,8 @@
+import { errors } from '@constructive-io/errors';
 import { Logger } from '@pgpmjs/logger';
 import type { NextFunction, Request, RequestHandler, Response } from 'express';
+
+import { respondWithGraphQLError } from '../errors/graphql-response';
 import './types'; // for Request type
 
 const log = new Logger('captcha');
@@ -102,23 +105,13 @@ export const createCaptchaMiddleware = (): RequestHandler => {
 
     const captchaToken = req.get(CAPTCHA_HEADER);
     if (!captchaToken) {
-      res.status(200).json({
-        errors: [{
-          message: 'CAPTCHA verification required',
-          extensions: { code: 'CAPTCHA_REQUIRED' },
-        }],
-      });
+      respondWithGraphQLError(res, errors.CAPTCHA_REQUIRED());
       return;
     }
 
     const valid = await verifyToken(captchaToken, secretKey);
     if (!valid) {
-      res.status(200).json({
-        errors: [{
-          message: 'CAPTCHA verification failed',
-          extensions: { code: 'CAPTCHA_FAILED' },
-        }],
-      });
+      respondWithGraphQLError(res, errors.CAPTCHA_FAILED());
       return;
     }
 

--- a/packages/errors/src/registry.ts
+++ b/packages/errors/src/registry.ts
@@ -234,6 +234,18 @@ export const registry = {
     http: 401,
     message: 'You must be signed in to do that.'
   }),
+  CAPTCHA_REQUIRED: defineError({
+    code: 'CAPTCHA_REQUIRED',
+    class: 'public',
+    http: 400,
+    message: 'Please complete the CAPTCHA challenge.'
+  }),
+  CAPTCHA_FAILED: defineError({
+    code: 'CAPTCHA_FAILED',
+    class: 'public',
+    http: 403,
+    message: 'CAPTCHA verification failed. Please try again.'
+  }),
   FORBIDDEN: defineError({
     code: 'FORBIDDEN',
     class: 'public',


### PR DESCRIPTION
## Summary

A stale session token rendered in the Platform UI as a bare `GraphQL Error:` with nothing after it. The cause is not the error registry — `@constructive-io/errors` defines `UNAUTHENTICATED` correctly (public/401/"You must be signed in to do that.") and `ConstructiveError.toExtensions()` already produces a proper payload. The cause is that `middleware/auth.ts` bypassed the registry and hand-built the response body:

```diff
-res.status(200).json({ errors: [{ extensions: { code: 'UNAUTHENTICATED' } }] });
+respondWithGraphQLError(res, errors.UNAUTHENTICATED());
```

With no top-level `message`, every client that does `errors.map(e => e.message).join('; ')` renders an empty string.

The same file's catch branch was worse: it used an unregistered code (`BAD_TOKEN_DEFINITION`) and put the raw Postgres error text in `extensions.message` — invisible to clients *and* an internals leak. It now raises `INTERNAL_FAILURE`, with the database detail included only in development.

To stop this class of bug rather than the one instance, the response shape is now built in exactly one place:

```ts
// graphql/server/src/errors/graphql-response.ts
export function respondWithGraphQLError(res: Response, error: ConstructiveError): void {
  res.status(200).json({
    errors: [{ message: error.message, extensions: error.toExtensions() }],
  });
}
```

`captcha.ts` — the only other middleware hand-writing GraphQL error payloads — is routed through it too, which required registering `CAPTCHA_REQUIRED` and `CAPTCHA_FAILED` so no middleware needs string literals for codes.

Finally, defense on the client side: the generated ORM client falls back to `extensions.code` when a server omits `message`, so a message-less error can degrade to `GraphQL Error: UNAUTHENTICATED` instead of `GraphQL Error:`.

## Testing

- `graphql/server`: new `errors/__tests__/graphql-response.test.ts` (3 tests) asserting a top-level message, HTTP 200, and context interpolation; existing middleware suites 60/60.
- `graphql/codegen`: new test constructing `GraphQLRequestError` from a message-less error and asserting the code fallback; suite 11/11 with the client snapshot updated.
- `tsc --noEmit` clean for `packages/errors`, `graphql/server`, `graphql/codegen`.

Note: `pnpm lint` fails repo-wide before this change — ESLint 9 requires a flat config and the repo still ships `.eslintrc.json`. Unrelated to this diff, but worth fixing separately.


Link to Devin session: https://app.devin.ai/sessions/4bc483ff6d644a7b9a2fed56af9a2111
Requested by: @pyramation