### PR TITLE
feat(pgpm): pgpm materialize — build an apply proxy into a plain, committed module

### DIFF
--- a/pgpm/cli/src/commands.ts
+++ b/pgpm/cli/src/commands.ts
@@ -17,6 +17,7 @@ import extension from './commands/extension';
 import init from './commands/init';
 import install from './commands/install';
 import kill from './commands/kill';
+import materialize from './commands/materialize';
 import migrate from './commands/migrate';
 import _package from './commands/package';
 import plan from './commands/plan';
@@ -57,6 +58,7 @@ const ENGINE_EXEMPT_COMMANDS = new Set([
   'init',
   'install',
   'package',
+  'materialize',
   'plan',
   'remove',
   'rename',
@@ -101,6 +103,7 @@ export const createPgpmCommandMap = (skipPgTeardown: boolean = false): Record<st
     kill: pgt(kill),
     install: pgt(install),
     migrate: pgt(migrate),
+    materialize,
     analyze: pgt(analyze),
     rename: pgt(renameCmd),
     slice,

--- a/pgpm/cli/src/commands/materialize.ts
+++ b/pgpm/cli/src/commands/materialize.ts
@@ -1,0 +1,138 @@
+import { materializeWorkspaceTarget, PgpmPackage } from '@pgpmjs/core';
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from 'fs';
+import { CLIOptions, Inquirerer } from 'inquirerer';
+import { tmpdir } from 'os';
+import { join, relative, resolve } from 'path';
+
+const materializeUsageText = `
+Materialize Command:
+
+  pgpm materialize <target> [OPTIONS]
+
+  Transpile an apply-proxy module (pgpm.apply.json) once and write the result
+  as a plain, deployable PGPM module (deploy/revert/verify + pgpm.plan +
+  .control, with the transforms baked into the SQL). The output has no
+  pgpm.apply.json and deploys like any hand-written module.
+
+  The proxy stays in the repo as the recipe; the materialized module is its
+  committed build artifact. Re-run when the source or provider binding changes.
+
+Arguments:
+  target                  Name of the apply-proxy module in the workspace.
+
+Options:
+  --help, -h              Show this help message
+  --output <dir>          Output directory (default: <workspace>/materialized/<name>)
+  --overwrite             Replace an existing output directory
+  --check                 Re-materialize to a temp dir and diff against --output;
+                          exit non-zero on any difference (drift gate for CI)
+  --cwd <directory>       Working directory (default: current directory)
+
+Examples:
+  pgpm materialize vendor-app-ported
+  pgpm materialize vendor-app-ported --output extensions/vendor-app-ported --overwrite
+  pgpm materialize vendor-app-ported --check
+`;
+
+/** Recursively list files in a directory as workspace-relative POSIX paths. */
+function listFiles(dir: string): string[] {
+  const out: string[] = [];
+  const walk = (current: string) => {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const full = join(current, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else out.push(relative(dir, full).replace(/\\/g, '/'));
+    }
+  };
+  walk(dir);
+  return out.sort();
+}
+
+/** Byte-level diff between two materialized module directories. */
+function diffDirs(expectedDir: string, actualDir: string): string[] {
+  const expected = new Set(listFiles(expectedDir));
+  const actual = new Set(listFiles(actualDir));
+  const diffs: string[] = [];
+
+  for (const file of actual) {
+    if (!expected.has(file)) diffs.push(`missing from output: ${file}`);
+  }
+  for (const file of expected) {
+    if (!actual.has(file)) {
+      diffs.push(`stale in output: ${file}`);
+      continue;
+    }
+    const a = readFileSync(join(expectedDir, file));
+    const b = readFileSync(join(actualDir, file));
+    if (!a.equals(b)) diffs.push(`content differs: ${file}`);
+  }
+  return diffs.sort();
+}
+
+export default async (
+  argv: Partial<Record<string, any>>,
+  _prompter: Inquirerer,
+  _options: CLIOptions
+) => {
+  if (argv.help || argv.h) {
+    console.log(materializeUsageText);
+    process.exit(0);
+  }
+
+  const cwd = argv.cwd ?? process.cwd();
+  const target = argv._?.[0] ?? argv.target;
+  if (!target) {
+    console.error('Error: a target apply-proxy module name is required.');
+    console.log(materializeUsageText);
+    process.exit(1);
+  }
+
+  const project = new PgpmPackage(cwd);
+  project.ensureWorkspace();
+  const workspacePath = project.workspacePath!;
+  const moduleMap = project.getModuleMap();
+
+  const check = Boolean(argv.check);
+  const overwrite = Boolean(argv.overwrite);
+  const outDir = argv.output
+    ? resolve(cwd, argv.output)
+    : resolve(workspacePath, 'materialized', String(target));
+
+  if (check) {
+    if (!existsSync(outDir)) {
+      console.error(`Error: --check requires an existing output at ${outDir}. Run \`pgpm materialize ${target}\` first.`);
+      process.exit(1);
+    }
+    const tmp = mkdtempSync(join(tmpdir(), `pgpm-materialize-check-`));
+    try {
+      const { spec } = await materializeWorkspaceTarget({ workspacePath, moduleMap, target, outDir: tmp });
+      const diffs = diffDirs(outDir, tmp);
+      if (diffs.length > 0) {
+        console.error(`Drift: materialized "${target}" (from "${spec.source.module}") differs from ${outDir}:`);
+        for (const d of diffs) console.error(`  - ${d}`);
+        console.error(`\nRe-run \`pgpm materialize ${target} --overwrite\` and commit the result.`);
+        process.exit(1);
+      }
+      console.log(`✔ ${target} is up to date with ${outDir} (byte-identical).`);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+    return argv;
+  }
+
+  if (existsSync(outDir) && !overwrite) {
+    console.error(`Error: ${outDir} already exists. Pass --overwrite to replace it.`);
+    process.exit(1);
+  }
+  if (existsSync(outDir)) rmSync(outDir, { recursive: true, force: true });
+
+  const { bundle, spec } = await materializeWorkspaceTarget({ workspacePath, moduleMap, target, outDir });
+
+  console.log(`✔ Materialized "${target}" from "${spec.source.module}"`);
+  console.log(`  Output:  ${outDir}`);
+  console.log(`  Changes: ${bundle.changes.length}`);
+  console.log(`  Digest:  ${bundle.manifest.digest}`);
+  console.log(`\nDeploy it as a plain module (no pgpm.apply.json needed).`);
+
+  return argv;
+};

--- a/pgpm/cli/src/utils/display.ts
+++ b/pgpm/cli/src/utils/display.ts
@@ -12,6 +12,7 @@ export const usageText = `
     extension          Manage module dependencies
     plan               Generate module deployment plans
     package            Package module for distribution
+    materialize        Transpile an apply proxy into a plain, committed module
     sync-versions      Sync .control/Makefile/sql metadata to package.json versions
     export             Export database migrations from existing databases
     update             Update pgpm to the latest version

--- a/pgpm/core/__tests__/apply/materialize-target.test.ts
+++ b/pgpm/core/__tests__/apply/materialize-target.test.ts
@@ -1,0 +1,97 @@
+import { existsSync, readdirSync, readFileSync, rmSync } from 'fs';
+import { join, relative } from 'path';
+
+import { PgpmPackage } from '../../src';
+import { materializeWorkspaceTarget } from '../../src/apply';
+import { TestFixture } from '../../test-utils/TestFixture';
+
+const listFiles = (dir: string): string[] => {
+  const out: string[] = [];
+  const walk = (current: string) => {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const full = join(current, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else out.push(relative(dir, full).replace(/\\/g, '/'));
+    }
+  };
+  walk(dir);
+  return out.sort();
+};
+
+describe('materializeWorkspaceTarget', () => {
+  let fixture: TestFixture;
+  let workspacePath: string;
+  let moduleMap: ReturnType<PgpmPackage['getModuleMap']>;
+  const outDirs: string[] = [];
+
+  beforeAll(() => {
+    fixture = new TestFixture('apply', 'portability');
+    workspacePath = fixture.fixturePath();
+    moduleMap = new PgpmPackage(workspacePath).getModuleMap();
+  });
+
+  afterAll(() => {
+    for (const dir of outDirs) rmSync(dir, { recursive: true, force: true });
+    fixture.cleanup();
+  });
+
+  const outDir = (name: string): string => {
+    const dir = fixture.fixturePath('materialized', name);
+    outDirs.push(dir);
+    return dir;
+  };
+
+  it('writes a plain, deployable module (no pgpm.apply.json) with transforms baked in', async () => {
+    const dir = outDir('secure-a');
+    const { bundle, spec } = await materializeWorkspaceTarget({
+      workspacePath,
+      moduleMap,
+      target: 'secure-a',
+      outDir: dir
+    });
+
+    expect(spec.source.module).toBe('secure-module');
+    // It is a normal module tree, not a proxy.
+    expect(existsSync(join(dir, 'pgpm.apply.json'))).toBe(false);
+    expect(existsSync(join(dir, 'pgpm.plan'))).toBe(true);
+    const files = listFiles(dir);
+    expect(files.some(f => f.startsWith('deploy/'))).toBe(true);
+
+    // Transforms are baked into the emitted SQL.
+    const fn = bundle.changes.find(c => c.name === 'schemas/vault_a/functions/hash_pw')!;
+    expect(fn.deploy!.sql).toContain('vault_a.hash_pw');
+    expect(fn.deploy!.sql).toMatch(/extensions\.crypt/);
+    expect(fn.deploy!.sql).toMatch(/TO anon\b/);
+    expect(fn.deploy!.sql).not.toMatch(/\banonymous\b/);
+  });
+
+  it('is deterministic — two materializations are byte-identical', async () => {
+    const a = outDir('secure-a-1');
+    const b = outDir('secure-a-2');
+    await materializeWorkspaceTarget({ workspacePath, moduleMap, target: 'secure-a', outDir: a });
+    await materializeWorkspaceTarget({ workspacePath, moduleMap, target: 'secure-a', outDir: b });
+
+    const filesA = listFiles(a);
+    expect(listFiles(b)).toEqual(filesA);
+    for (const file of filesA) {
+      expect(readFileSync(join(b, file)).equals(readFileSync(join(a, file)))).toBe(true);
+    }
+  });
+
+  it('rejects an unknown target', async () => {
+    await expect(
+      materializeWorkspaceTarget({ workspacePath, moduleMap, target: 'nope', outDir: outDir('nope') })
+    ).rejects.toThrow(/not found in the workspace/);
+  });
+
+  it('rejects a non-proxy module', async () => {
+    await expect(
+      materializeWorkspaceTarget({
+        workspacePath,
+        moduleMap,
+        target: 'secure-module',
+        outDir: outDir('secure-module')
+      })
+    ).rejects.toThrow(/not an apply proxy/);
+  });
+});

--- a/pgpm/core/src/apply/materialize.ts
+++ b/pgpm/core/src/apply/materialize.ts
@@ -1,7 +1,3 @@
-import { mkdtempSync } from 'fs';
-import { tmpdir } from 'os';
-import { join, resolve } from 'path';
-
 import {
   bundleFromModule,
   materializeBundle,
@@ -9,14 +5,17 @@ import {
   transpileBundle,
   verifyBundle
 } from '@pgpmjs/bundle';
-import { buildSchemaRouter, loadModule, makeSchemaTranspiler, parseSqlProgram, SchemaTransformPass, SqlProgram } from '@pgpmjs/transform';
 import { excludeSubsystemPrograms, stripSubsystemSql } from '@pgpmjs/slice';
+import { buildSchemaRouter, loadModule, makeSchemaTranspiler, parseSqlProgram, SchemaTransformPass, SqlProgram } from '@pgpmjs/transform';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
 
 import { ModuleMap } from '../modules/modules';
 import { hasApplySpec, readApplySpec } from './apply-spec';
 import { loadWorkspaceRoutingProfile, resolveEffectiveApplySpec } from './profile';
 import { isReuseSpec, materializeReuseModule, resolveSharedModuleName } from './reuse';
-import { ResolvedApplySpec } from './types';
+import { APPLY_SPEC_FILE, ResolvedApplySpec } from './types';
 
 export interface MaterializeApplyOptions {
   /** Directory of the source module being applied. */
@@ -277,4 +276,85 @@ export async function resolveEffectiveModulePath(
 /** Test seam: clear the per-process materialization cache. */
 export function clearApplyMaterializationCache(): void {
   materializedCache.clear();
+}
+
+export interface MaterializeWorkspaceTargetOptions {
+  /** Absolute workspace root path. */
+  workspacePath: string;
+  /** The workspace module map (proxies already synthesized in). */
+  moduleMap: ModuleMap;
+  /** Name of the apply-proxy module to materialize. */
+  target: string;
+  /** Directory to write the plain, deployable module into. */
+  outDir: string;
+}
+
+export interface MaterializeWorkspaceTargetResult {
+  /** The deployable module directory the bundle was written to. */
+  outDir: string;
+  /** The transpiled, content-addressed bundle that was materialized. */
+  bundle: MigrationBundle;
+  /** The resolved apply spec the materialization was driven by. */
+  spec: ResolvedApplySpec;
+}
+
+/**
+ * Resolve an apply-proxy module by name in a workspace and materialize it to a
+ * chosen directory as a plain, deployable module (transforms baked in — no
+ * `pgpm.apply.json`). Shared by the `pgpm materialize` command and tests; the
+ * counterpart to {@link resolveEffectiveModulePath}, but with an explicit,
+ * stable `outDir` and no per-process cache.
+ */
+export async function materializeWorkspaceTarget(
+  options: MaterializeWorkspaceTargetOptions
+): Promise<MaterializeWorkspaceTargetResult> {
+  const { workspacePath, moduleMap, target, outDir } = options;
+
+  const module = moduleMap[target];
+  if (!module) {
+    const proxies = Object.keys(moduleMap).sort();
+    throw new Error(
+      `Module "${target}" not found in the workspace.` +
+        (proxies.length ? ` Available modules: ${proxies.join(', ')}.` : '')
+    );
+  }
+
+  const modulePath = resolve(workspacePath, module.path);
+  if (!hasApplySpec(modulePath)) {
+    throw new Error(
+      `Module "${target}" is not an apply proxy (no ${APPLY_SPEC_FILE} in ${modulePath}). ` +
+        `Only apply-proxy modules can be materialized.`
+    );
+  }
+
+  const spec = resolveEffectiveApplySpec(
+    readApplySpec(modulePath),
+    loadWorkspaceRoutingProfile(workspacePath)
+  );
+
+  if (isReuseSpec(spec)) {
+    throw new Error(
+      `Apply proxy "${target}" is a reuse proxy (shared + per-tenant). ` +
+        `Reuse proxies are not yet supported by \`pgpm materialize\`.`
+    );
+  }
+
+  const sourceModule = moduleMap[spec.source.module];
+  if (!sourceModule) {
+    throw new Error(
+      `Apply spec in "${target}" references source module "${spec.source.module}", ` +
+        `which was not found in the workspace. Run \`pgpm install\` to install it` +
+        (spec.source.package ? ` (${spec.source.package})` : '') +
+        `.`
+    );
+  }
+
+  const sourceDir = resolve(workspacePath, sourceModule.path);
+  const { outDir: writtenDir, bundle } = await materializeApplyModule({
+    sourceDir,
+    spec,
+    outDir
+  });
+
+  return { outDir: writtenDir, bundle, spec };
 }


### PR DESCRIPTION
## Summary

Today an apply proxy (`pgpm.apply.json`: a `source` module + routing/exclude profile) is only ever transpiled **in-process at deploy/verify/revert time** (`materializeApplyModule`). Great for `seed.apply(...)`, but the transpiled shape never lands on disk — nothing to review, and the transform re-runs every deploy.

This adds a **build-time** path: run the transform once and write the result as an **ordinary PGPM module** (`deploy/ revert/ verify/ pgpm.plan / .control`, transforms baked into the SQL — no `pgpm.apply.json`). The proxy stays in the repo as the recipe; the materialized module is its committed build artifact, deployed like any hand-written module.

Design + rationale (three-times-a-transform framing, drift gate, demo plan): constructive-planning#1327.

### `@pgpmjs/core` — `materializeWorkspaceTarget`

Thin resolver over the existing `materializeApplyModule`, sharing one code path with the CLI and tests. It is the counterpart to `resolveEffectiveModulePath`, but with an explicit, stable `outDir` and no per-process cache:

```ts
materializeWorkspaceTarget({ workspacePath, moduleMap, target, outDir })
//  moduleMap[target] → proxy dir  (proxies are already synthesized into getModuleMap)
//  readApplySpec + resolveEffectiveApplySpec(loadWorkspaceRoutingProfile(...))
//  moduleMap[spec.source.module] → sourceDir
//  materializeApplyModule({ sourceDir, spec, outDir })
//  → { outDir, bundle, spec }
```

Errors clearly on: unknown target, a non-proxy target, a missing source module, and (for now) reuse proxies (fast-follow).

### `pgpm materialize` (CLI)

```
pgpm materialize <target> [--output <dir>] [--overwrite] [--check] [--cwd <dir>]
```

- default `--output`: `<workspace>/materialized/<name>`
- `--check`: re-materialize to a temp dir and **byte-diff** against `--output`, exit non-zero on drift. This is the determinism gate — `materializeApplyModule` + the `SqlProgram` dirty-aware emitter emit byte-identical output for a given source+spec, so CI can assert the committed module still matches the proxy.
- engine-exempt (opens no DB connection), like `slice`/`install`.

Example output (from the `apply/portability` fixture):

```
$ pgpm materialize secure-a --output extensions/secure-a
✔ Materialized "secure-a" from "secure-module"
  Output:  .../extensions/secure-a
  Changes: 2
  Digest:  7ad4a454...

$ cat extensions/secure-a/deploy/schemas/vault_a/functions/hash_pw.sql
CREATE FUNCTION vault_a.hash_pw(pw text) RETURNS text AS
  $$SELECT extensions.crypt(pw, extensions.gen_salt('bf'))$$ LANGUAGE sql VOLATILE;
GRANT EXECUTE ON FUNCTION vault_a.hash_pw(text) TO anon;
```

## Testing

- New `__tests__/apply/materialize-target.test.ts`: writes a plain module (asserts no `pgpm.apply.json`, has `pgpm.plan` + `deploy/`, transforms baked in), determinism (two runs byte-identical), and the unknown-target / non-proxy error paths.
- Full `apply/` suite green on PG 18 (`78 passed`). Manual CLI smoke: materialize → `--check` (clean), tamper → `--check` reports drift + non-zero, overwrite guard.

## Follow-ups

- Wire a materialize-and-`--check` demo into the InsForge / Supabase portability suites (deploy the *committed* module, not the in-process proxy).
- Reuse-proxy support (two output modules).
- Optional: emit provenance (`appliedFrom`, source package/version/digest) into the artifact.


Link to Devin session: https://app.devin.ai/sessions/025fb88043964fdbb335ac5e39df2478
Requested by: @pyramation