### PR TITLE
feat(safegres): optional performance dimension (index hygiene, separately scored)

### DIFF
--- a/.agents/skills/safegres/SKILL.md
+++ b/.agents/skills/safegres/SKILL.md
@@ -65,12 +65,14 @@ The score only improves by being **explicit** (declaring exposure and intent) or
 | A6 | info | fail-closed | UPDATE has `USING` but **no `WITH CHECK`** |
 | A7 | critical | fail-open | Trivially-permissive **WRITE** policy (`true`) |
 | A8 | low | fail-open | Trivially-permissive **SELECT** policy (`USING (true)`) |
-| P1 | high | neutral | Policy body calls a **VOLATILE** function |
+| P1 | high | neutral | Policy body calls a **VOLATILE** function (perf dimension) |
 | P5 | high | fail-open | Policy body references `session_user`/`current_user`/`pg_has_role` |
 | R1 | critical | fail-open | An **untrusted role** holds a write privilege |
 | R2 | high | fail-open | Permissive write policy applies to untrusted role or PUBLIC |
 | R3 | medium | fail-open | RLS table has grants **TO PUBLIC** |
 | W1 | medium | meta | No exposure surface configured — DB assumed reachable, score capped |
+
+Perf-dimension rules (only collected with `--perf`, scored on their own axis): **X1** FK with no covering index (medium), **X5** redundant/duplicate index (low), **X6** no primary key and no usable replica identity (low), plus P1/P1b.
 
 **Direction is the key idea:** `fail-open` = real exposure (untrusted side reaches more than intended). `fail-closed` = denied at runtime (hygiene/availability, not a leak) — contributes **0** to the score by default. R1/R2 are no-ops until you configure a role list; `safegres:constructive` sets them for `anonymous`.
 
@@ -98,6 +100,22 @@ Config is discovered by walking up from cwd: `safegres.config.{ts,js,mjs,cjs}`, 
 ```
 
 Typed variant (`defineConfig` from `confstash`) works too — see the package README.
+
+## Performance dimension (`--perf`, off by default)
+
+`safegres perf` / `safegres audit --perf` adds `report.perf` — its own findings, summary, and 0-100 score over index hygiene (X1/X5/X6) and policy cost (P1/P1b). Security and perf scores are never mixed: `report.score` sees only security findings, `report.perf.score` only perf ones. All checks are pure catalog analysis, so they're deterministic against an empty CI database.
+
+```jsonc
+{
+  "perf": {
+    "enabled": true,
+    "rules": { "X6": "off" },          // perf codes only — naming a security rule is a config error
+    "ignore": ["app_public.audit_*"],  // acknowledged: reported as info, off the perf score
+    "scoring": { "densityK": 0.17 }
+  },
+  "failOn": { "perfGrade": "B" }       // CLI: --fail-on-perf-score / --fail-on-perf-grade
+}
+```
 
 ### Presets
 
@@ -175,6 +193,8 @@ score = 100 · exp(−k · riskPoints / exposedTables)
 
 ```bash
 safegres audit                     # audit the connected DB (default command)
+safegres perf                      # audit + index-hygiene dimension (= audit --perf)
+safegres audit --perf --fail-on-perf-grade B
 safegres audit --format json       # machine-readable
 safegres audit --exposed-only      # hide internal advisories
 safegres doctor                    # config/parser/connection/catalog + exposure + stale public.read checks
@@ -194,6 +214,9 @@ await client.connect();
 const report = await audit(client, { config: { extends: 'safegres:constructive' } });
 console.log(renderPretty(report));
 console.log(report.score);   // { value, grade, model, deductions, ... }
+
+const perfReport = await audit(client, { perf: true });
+console.log(perfReport.perf?.score);   // separate 0-100 perf axis (undefined unless perf is on)
 ```
 
 ## CI integration

--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -47,7 +47,7 @@ Pretty output prints the exposure line, score, and the exposed findings. Interna
 | A6 | info | fail-closed | coverage | UPDATE has `USING` but **no `WITH CHECK`** (row-smuggling surface) |
 | A7 | critical | fail-open | anti-pattern | Trivially-permissive **WRITE** policy (INSERT/UPDATE/DELETE/ALL with literal `true`) |
 | A8 | low | fail-open | anti-pattern | Trivially-permissive **SELECT** policy (`USING (true)` — confirm public-read is intended) |
-| P1 | high | neutral | anti-pattern | Policy body calls a **VOLATILE function** (per-row evaluation) |
+| P1 | high | neutral | anti-pattern | Policy body calls a **VOLATILE function** (per-row evaluation) — *scored on the [perf axis](#performance-dimension---perf)* |
 | P5 | high | fail-open | anti-pattern | Policy body references **`session_user`** / `current_user` / `pg_has_role(...)` |
 | R1 | critical | fail-open | anti-pattern | An **untrusted role** (options: `{ roles: [...] }`) holds a write privilege |
 | R2 | high | fail-open | anti-pattern | A permissive write policy applies to an untrusted role or PUBLIC |
@@ -99,6 +99,39 @@ Some open reads are deliberate — pricing tables, reference data, a public user
 - An open SELECT policy (`USING (true)` — rule A8) on a declared table is **acknowledged**: reported as info, excluded from the score.
 - An open read on any *undeclared* table stays a scored finding — even in a `*_public`-named schema. Naming is never treated as intent; the config declaration is.
 - `safegres doctor` warns about stale `public.read` patterns that no longer match any table.
+
+## Performance dimension (`--perf`)
+
+A slow database is a different problem from an unsafe one, so safegres scores them separately: `safegres perf` (or `safegres audit --perf`) adds `report.perf` with its own findings, summary, and 0-100 score. It is **off by default** — a plain `audit` behaves exactly as before, and no perf finding ever touches the security score.
+
+| Code | Severity | Category | Check |
+| --- | --- | --- | --- |
+| X1 | medium | index | **Foreign key with no covering index** — joins and cascading deletes seq-scan the child table |
+| X5 | low | index | **Redundant index** — an exact duplicate of, or a leading-column prefix of, another index |
+| X6 | low | index | **No primary key** and no usable replica identity — rows cannot be addressed by updates, deletes, or logical replication |
+| P1 | high | anti-pattern | Policy body calls a **VOLATILE function** — re-evaluated per row |
+| P1b | medium | anti-pattern | Policy body calls a **STABLE function** in a per-row position |
+
+Every check is pure catalog analysis: deterministic, workload-free, and safe to run against an empty CI database. An index covers a foreign key only when its *leading* columns are the FK's columns and it covers every row — partial and expression indexes don't count, because the planner can't use them for the referential-integrity lookup. Constraint-backed, unique, partial, and expression indexes are never reported as redundant.
+
+```bash
+safegres perf --database mydb
+safegres audit --database mydb --perf --fail-on-perf-grade B
+```
+
+```jsonc
+{
+  "perf": {
+    "enabled": true,
+    "rules": { "X6": "off" },          // perf-dimension codes only
+    "ignore": ["app_public.audit_*"],  // declared-intentional perf debt
+    "scoring": { "densityK": 0.17 }
+  },
+  "failOn": { "perfGrade": "B" }
+}
+```
+
+Tables matched by `perf.ignore` are acknowledged — reported as info, excluded from the perf score — the same way `public.read` works for open reads. Perf findings live in `report.findings` alongside the security ones (so `--fail-on <severity>` still sees them), but only they feed `report.perf.score`, and only security findings feed `report.score`.
 
 ## Call graph (`--call-graph`)
 

--- a/packages/safegres/__tests__/fixtures/x1-fk-no-index.sql
+++ b/packages/safegres/__tests__/fixtures/x1-fk-no-index.sql
@@ -1,0 +1,47 @@
+-- X1 seed: one FK with a covering index, one without, and a multi-column FK
+-- whose columns are indexed but not in the leading position.
+-- Expected findings: X1 on posts(author_id), X1 on pairs(a, b)
+
+CREATE SCHEMA IF NOT EXISTS fx_x1;
+
+CREATE TABLE fx_x1.authors (
+  id bigint PRIMARY KEY
+);
+
+CREATE TABLE fx_x1.author_pairs (
+  a bigint,
+  b bigint,
+  PRIMARY KEY (a, b)
+);
+
+-- Unindexed FK.
+CREATE TABLE fx_x1.posts (
+  id bigint PRIMARY KEY,
+  author_id bigint REFERENCES fx_x1.authors (id)
+);
+
+-- Indexed FK — must not be reported.
+CREATE TABLE fx_x1.comments (
+  id bigint PRIMARY KEY,
+  author_id bigint REFERENCES fx_x1.authors (id)
+);
+CREATE INDEX comments_author_id_idx ON fx_x1.comments (author_id);
+
+-- FK columns appear in a wider index, but not as its leading columns.
+CREATE TABLE fx_x1.pairs (
+  id bigint PRIMARY KEY,
+  a bigint,
+  b bigint,
+  FOREIGN KEY (a, b) REFERENCES fx_x1.author_pairs (a, b)
+);
+CREATE INDEX pairs_id_a_b_idx ON fx_x1.pairs (id, a, b);
+
+-- Leading columns match the FK in the other order — equality lookups still
+-- use it, so this must not be reported.
+CREATE TABLE fx_x1.pairs_ok (
+  id bigint PRIMARY KEY,
+  a bigint,
+  b bigint,
+  FOREIGN KEY (a, b) REFERENCES fx_x1.author_pairs (a, b)
+);
+CREATE INDEX pairs_ok_b_a_idx ON fx_x1.pairs_ok (b, a, id);

--- a/packages/safegres/__tests__/fixtures/x5-redundant-index.sql
+++ b/packages/safegres/__tests__/fixtures/x5-redundant-index.sql
@@ -1,0 +1,26 @@
+-- X5 seed: a duplicate index, a prefix index, and shapes that must not be
+-- reported (unique, partial, expression, constraint-backed).
+-- Expected findings: X5 on widgets_tenant_a_idx, widgets_tenant_b_idx (its
+-- duplicate), and widgets_tenant_idx (a prefix of both).
+
+CREATE SCHEMA IF NOT EXISTS fx_x5;
+
+CREATE TABLE fx_x5.widgets (
+  id bigint PRIMARY KEY,
+  tenant_id bigint,
+  kind text,
+  slug text,
+  archived_at timestamptz
+);
+
+CREATE INDEX widgets_tenant_a_idx ON fx_x5.widgets (tenant_id, kind);
+CREATE INDEX widgets_tenant_b_idx ON fx_x5.widgets (tenant_id, kind);
+
+CREATE INDEX widgets_tenant_idx ON fx_x5.widgets (tenant_id);
+CREATE INDEX widgets_tenant_kind_idx ON fx_x5.widgets (tenant_id, kind, slug);
+
+-- Not redundant: unique, partial, and expression indexes each carry semantics
+-- a wider plain index does not.
+CREATE UNIQUE INDEX widgets_slug_uidx ON fx_x5.widgets (slug);
+CREATE INDEX widgets_slug_live_idx ON fx_x5.widgets (slug) WHERE archived_at IS NULL;
+CREATE INDEX widgets_slug_lower_idx ON fx_x5.widgets (lower(slug));

--- a/packages/safegres/__tests__/fixtures/x6-no-primary-key.sql
+++ b/packages/safegres/__tests__/fixtures/x6-no-primary-key.sql
@@ -1,0 +1,20 @@
+-- X6 seed: a table with no primary key, one with a PK, and one with no PK but
+-- REPLICA IDENTITY FULL (rows are still identifiable).
+-- Expected finding: X6 on events only.
+
+CREATE SCHEMA IF NOT EXISTS fx_x6;
+
+CREATE TABLE fx_x6.events (
+  payload jsonb,
+  recorded_at timestamptz
+);
+
+CREATE TABLE fx_x6.keyed (
+  id bigint PRIMARY KEY,
+  payload jsonb
+);
+
+CREATE TABLE fx_x6.full_identity (
+  payload jsonb
+);
+ALTER TABLE fx_x6.full_identity REPLICA IDENTITY FULL;

--- a/packages/safegres/__tests__/perf.test.ts
+++ b/packages/safegres/__tests__/perf.test.ts
@@ -1,0 +1,120 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { getConnections, PgTestClient } from 'pgsql-test';
+
+import { audit } from '../src/commands/audit';
+import { ConfigValidationError, resolveRules } from '../src/config/resolve';
+import type { Finding } from '../src/types';
+
+jest.setTimeout(120000);
+
+let pg: PgTestClient;
+let teardown: () => Promise<void>;
+
+async function applyFixture(name: string): Promise<void> {
+  const filepath = path.join(__dirname, 'fixtures', name);
+  await pg.any(fs.readFileSync(filepath, 'utf8'));
+}
+
+function tablesFor(findings: Finding[], code: string): string[] {
+  return findings.filter((f) => f.code === code).map((f) => `${f.schema}.${f.table}`).sort();
+}
+
+beforeAll(async () => {
+  ({ pg, teardown } = await getConnections());
+});
+
+afterAll(async () => {
+  if (teardown) await teardown();
+});
+
+describe('perf dimension', () => {
+  it('is off by default — no X rules, no perf report', async () => {
+    await applyFixture('x1-fk-no-index.sql');
+    const report = await audit(pg.client as never, { schemas: ['fx_x1'] });
+    expect(report.perf).toBeUndefined();
+    expect(report.findings.filter((f) => f.code.startsWith('X'))).toHaveLength(0);
+  });
+
+  it('X1: flags foreign keys with no covering index', async () => {
+    const report = await audit(pg.client as never, { schemas: ['fx_x1'], perf: true });
+    expect(tablesFor(report.perf!.findings, 'X1')).toEqual(['fx_x1.pairs', 'fx_x1.posts']);
+
+    const posts = report.perf!.findings.find((f) => f.code === 'X1' && f.table === 'posts');
+    expect(posts?.severity).toBe('medium');
+    expect(posts?.dimension).toBe('perf');
+    expect(posts?.context).toMatchObject({ columns: ['author_id'] });
+  });
+
+  it('X5: flags duplicate and prefix indexes, not unique/partial/expression ones', async () => {
+    await applyFixture('x5-redundant-index.sql');
+    const report = await audit(pg.client as never, { schemas: ['fx_x5'], perf: true });
+    const names = report.perf!.findings
+      .filter((f) => f.code === 'X5')
+      .map((f) => (f.context as { index: string }).index)
+      .sort();
+    expect(names).toEqual([
+      'widgets_tenant_a_idx',
+      'widgets_tenant_b_idx',
+      'widgets_tenant_idx'
+    ]);
+    const duplicate = report.perf!.findings.find(
+      (f) => f.code === 'X5' && (f.context as { index: string }).index === 'widgets_tenant_b_idx'
+    );
+    expect(duplicate?.context).toMatchObject({ coveredBy: 'widgets_tenant_a_idx', duplicate: true });
+  });
+
+  it('X6: flags tables with no primary key and no replica identity', async () => {
+    await applyFixture('x6-no-primary-key.sql');
+    const report = await audit(pg.client as never, { schemas: ['fx_x6'], perf: true });
+    expect(tablesFor(report.perf!.findings, 'X6')).toEqual(['fx_x6.events']);
+  });
+
+  it('scores perf separately from security and keeps both in report.findings', async () => {
+    const report = await audit(pg.client as never, { schemas: ['fx_x1', 'fx_x5', 'fx_x6'], perf: true });
+    expect(report.perf!.score.value).toBeLessThan(100);
+    expect(report.perf!.score.deductions.map((d) => d.code)).toEqual(
+      expect.arrayContaining(['X1'])
+    );
+    // The security score never sees perf findings.
+    expect(report.score!.deductions.some((d) => d.code.startsWith('X'))).toBe(false);
+    expect(report.findings.some((f) => f.code === 'X1')).toBe(true);
+    expect(report.perf!.findings.every((f) => f.dimension === 'perf')).toBe(true);
+  });
+
+  it('perf.ignore acknowledges declared perf debt', async () => {
+    const report = await audit(pg.client as never, {
+      schemas: ['fx_x1'],
+      perf: true,
+      config: { perf: { ignore: ['fx_x1.*'] } }
+    });
+    const x1 = report.perf!.findings.filter((f) => f.code === 'X1');
+    expect(x1.length).toBeGreaterThan(0);
+    expect(x1.every((f) => f.acknowledged && f.severity === 'info')).toBe(true);
+    // Nothing left to deduct (the score itself is still capped by the unknown
+    // exposure surface these fixtures run without).
+    expect(report.perf!.score.deductions).toHaveLength(0);
+  });
+
+  it('perf.rules retunes perf rules only', async () => {
+    const report = await audit(pg.client as never, {
+      schemas: ['fx_x1'],
+      perf: true,
+      config: { perf: { rules: { X1: 'off' } } }
+    });
+    expect(report.perf!.findings.filter((f) => f.code === 'X1')).toHaveLength(0);
+
+    expect(() => resolveRules({ perf: { rules: { A2: 'off' } } })).toThrow(ConfigValidationError);
+  });
+});
+
+describe('P1/P1b re-homed to the perf dimension', () => {
+  it('keeps P1 out of the security score', async () => {
+    await applyFixture('p1-volatile-func.sql');
+    const report = await audit(pg.client as never, { schemas: ['fx_p1'], perf: true });
+    const p1 = report.findings.find((f) => f.code === 'P1');
+    expect(p1?.dimension).toBe('perf');
+    expect(report.perf!.findings).toContain(p1);
+    expect(report.score!.deductions.some((d) => d.code === 'P1')).toBe(false);
+  });
+});

--- a/packages/safegres/src/checks/indexes.ts
+++ b/packages/safegres/src/checks/indexes.ts
@@ -1,0 +1,134 @@
+/**
+ * Structural index-hygiene checks (perf dimension, `X*`).
+ *
+ * Everything here is pure catalog analysis — deterministic, workload-free,
+ * and safe to run in CI against an empty database.
+ */
+
+import type { IndexInfo, TableIndexSnapshot } from '../pg/indexes';
+import type { Finding } from '../types';
+
+/**
+ * X1: a foreign key with no index that can serve it.
+ *
+ * An index covers a FK when its *leading* columns are exactly the FK's
+ * columns (order among them is irrelevant for equality lookups) and it
+ * covers every row. Without one, `ON DELETE`/`ON UPDATE` checks on the
+ * referenced side and joins on the referencing side degrade to sequential
+ * scans.
+ *
+ * Partial and expression indexes do not count: the planner cannot rely on
+ * them for the referential-integrity lookup.
+ */
+export function checkUnindexedForeignKeys(table: TableIndexSnapshot): Finding[] {
+  // Partitions inherit their parent's indexes; the parent carries the finding.
+  if (table.isPartition) return [];
+
+  const findings: Finding[] = [];
+  for (const fk of table.foreignKeys) {
+    if (fk.columns.length === 0) continue;
+    if (table.indexes.some((idx) => indexCoversColumns(idx, fk.columns))) continue;
+
+    const cols = fk.columnNames.join(', ');
+    findings.push({
+      code: 'X1',
+      severity: 'medium',
+      category: 'index',
+      schema: table.schema,
+      table: table.name,
+      message:
+        `Foreign key ${fk.name} on ${table.schema}.${table.name} (${cols}) has no covering index`,
+      hint:
+        `CREATE INDEX ON ${table.schema}.${table.name} (${cols}); without it, deletes/updates on ${fk.references} and joins across this key scan the whole table.`,
+      context: { constraint: fk.name, columns: fk.columnNames, references: fk.references }
+    });
+  }
+  return findings;
+}
+
+/**
+ * X5: an index that another index already serves.
+ *
+ * Two shapes: an exact duplicate, or a non-unique index whose columns are a
+ * leading-column prefix of a wider index. Both cost write throughput and
+ * disk for nothing. Constraint-backed indexes (PK/UNIQUE/EXCLUDE) are never
+ * reported — dropping them would drop the constraint.
+ */
+export function checkRedundantIndexes(table: TableIndexSnapshot): Finding[] {
+  const findings: Finding[] = [];
+  const candidates = table.indexes.filter(
+    (i) => !i.primary && !i.constraint && !i.partial && !i.expression && !i.unique
+  );
+
+  for (const idx of candidates) {
+    const covering = table.indexes.find((other) => {
+      if (other.name === idx.name) return false;
+      if (other.partial || other.expression) return false;
+      if (other.method !== idx.method) return false;
+      if (!isPrefix(idx.columns, other.columns)) return false;
+      // Exact duplicates: report only one of the pair, deterministically.
+      if (idx.columns.length === other.columns.length && idx.name < other.name) return false;
+      return true;
+    });
+    if (!covering) continue;
+
+    const duplicate = idx.columns.length === covering.columns.length;
+    findings.push({
+      code: 'X5',
+      severity: 'low',
+      category: 'index',
+      schema: table.schema,
+      table: table.name,
+      message:
+        `Index ${idx.name} (${idx.columnNames.join(', ')}) is ${duplicate ? 'a duplicate of' : 'a leading-column prefix of'} `
+        + `${covering.name} (${covering.columnNames.join(', ')})`,
+      hint: `DROP INDEX ${table.schema}.${idx.name}; every query it serves is served by ${covering.name}.`,
+      context: { index: idx.name, coveredBy: covering.name, duplicate }
+    });
+  }
+  return findings;
+}
+
+/**
+ * X6: no primary key and no usable replica identity.
+ *
+ * Rows cannot be addressed individually: updates and deletes have no cheap
+ * lookup path, logical replication and CDC cannot identify old rows, and
+ * realtime/change-feed features break.
+ */
+export function checkMissingPrimaryKey(table: TableIndexSnapshot): Finding | null {
+  if (table.isPartition) return null;
+  if (table.hasPrimaryKey) return null;
+  // `f` (FULL) and `i` (index) still give logical decoding an identity.
+  if (table.replicaIdentity === 'f' || table.replicaIdentity === 'i') return null;
+
+  return {
+    code: 'X6',
+    severity: 'low',
+    category: 'index',
+    schema: table.schema,
+    table: table.name,
+    message: `${table.schema}.${table.name} has no primary key`,
+    hint:
+      'Add a primary key, or set REPLICA IDENTITY FULL / USING INDEX, so rows can be addressed by updates, deletes, and logical replication.',
+    context: { replicaIdentity: table.replicaIdentity }
+  };
+}
+
+/**
+ * True when `index` can serve an equality lookup on exactly `columns`:
+ * its leading columns are that same set, and it covers every row.
+ */
+function indexCoversColumns(index: IndexInfo, columns: number[]): boolean {
+  if (index.partial || index.expression) return false;
+  if (index.method !== 'btree') return false;
+  if (index.columns.length < columns.length) return false;
+  const leading = new Set(index.columns.slice(0, columns.length));
+  return columns.every((c) => leading.has(c));
+}
+
+/** True when `a` is a leading-column prefix of `b` (`a` may equal `b`). */
+function isPrefix(a: number[], b: number[]): boolean {
+  if (a.length > b.length) return false;
+  return a.every((col, i) => b[i] === col);
+}

--- a/packages/safegres/src/cli/audit.ts
+++ b/packages/safegres/src/cli/audit.ts
@@ -59,6 +59,12 @@ Exposure (what the score is computed against):
                            them become unscored internal advisories
   --exposed-only           Hide internal (non-exposed) findings from output
 
+Performance dimension (optional; scored separately from security):
+  --perf                   Also audit index hygiene (X1/X5/X6) and score it on
+                           its own 0-100 axis (report.perf)
+  --fail-on-perf-score <n> Exit non-zero if the perf score is below n (0-100)
+  --fail-on-perf-grade <g> Exit non-zero if the perf grade is below g (A+|A|B|C|D)
+
 Call graph (unscored; human review):
   --call-graph             Analyze the functions reachable from the exposed entry
                            points and list trust boundaries: SECURITY DEFINER hops,
@@ -110,6 +116,7 @@ export default async (
     includeRoles: csvList(argv.roles),
     excludeRoles: csvList(argv['exclude-roles']),
     skipAstChecks: argv['skip-ast'] === true,
+    perf: argv.perf === true ? true : undefined,
     callGraph:
       argv['call-graph'] === true
       || typeof argv.baseline === 'string'
@@ -201,6 +208,24 @@ export default async (
     typeof argv['fail-on-grade'] === 'string' ? (argv['fail-on-grade'] as Grade) : config.failOn?.grade;
   if (failOnGrade && report.score && !meetsGrade(report.score.grade, failOnGrade)) {
     log.error(`grade ${report.score.grade} is below --fail-on-grade ${failOnGrade}`);
+    process.exit(1);
+  }
+
+  const failOnPerfScore =
+    typeof argv['fail-on-perf-score'] === 'number'
+      ? argv['fail-on-perf-score']
+      : config.failOn?.perfScore;
+  if (failOnPerfScore != null && report.perf && report.perf.score.value < failOnPerfScore) {
+    log.error(`perf score ${report.perf.score.value} is below --fail-on-perf-score ${failOnPerfScore}`);
+    process.exit(1);
+  }
+
+  const failOnPerfGrade =
+    typeof argv['fail-on-perf-grade'] === 'string'
+      ? (argv['fail-on-perf-grade'] as Grade)
+      : config.failOn?.perfGrade;
+  if (failOnPerfGrade && report.perf && !meetsGrade(report.perf.score.grade, failOnPerfGrade)) {
+    log.error(`perf grade ${report.perf.score.grade} is below --fail-on-perf-grade ${failOnPerfGrade}`);
     process.exit(1);
   }
 

--- a/packages/safegres/src/cli/commands.ts
+++ b/packages/safegres/src/cli/commands.ts
@@ -15,6 +15,7 @@ Usage:
 
 Commands:
   audit           Audit grants, RLS flags, policy coverage, and anti-patterns
+  perf            Audit index hygiene and policy cost (audit --perf)
   doctor          Diagnose environment, connection, and configuration
   print-config    Show the resolved effective configuration
   help            Show this help message
@@ -27,6 +28,7 @@ const commandMap: Record<
   (argv: ParsedArgs, prompter: Inquirerer, options: CLIOptions) => unknown
 > = {
   audit,
+  perf: (argv, prompter, options) => audit({ ...argv, perf: true }, prompter, options),
   doctor,
   'print-config': printConfig
 };

--- a/packages/safegres/src/commands/audit.ts
+++ b/packages/safegres/src/commands/audit.ts
@@ -17,6 +17,11 @@ import {
   checkUpdateWithCheckCoverage
 } from '../checks/coverage';
 import {
+  checkMissingPrimaryKey,
+  checkRedundantIndexes,
+  checkUnindexedForeignKeys
+} from '../checks/indexes';
+import {
   checkGrantsWithoutRls,
   checkRlsEnabledNoPolicies,
   checkRlsNotForced
@@ -31,12 +36,13 @@ import { allAstRulesDisabled, applyRulesToFindings, matchTablePattern, resolveRu
 import type { ExposureConfig, SafegresConfig } from '../config/types';
 import { resolveExposure } from '../pg/exposure';
 import { introspectFunctions } from '../pg/functions';
+import { introspectIndexes } from '../pg/indexes';
 import { asExecutor, type IntrospectOptions, introspectTables, type QueryExecutor, type TableSnapshot } from '../pg/introspect';
 import { lookupVolatility, type ProcVolatility } from '../pg/proc';
 import { listAuditableRoles, resolveRoles } from '../pg/roles';
-import { RULES_BY_CODE } from '../rules/registry';
+import { dimensionOf, RULES_BY_CODE } from '../rules/registry';
 import { computeScore } from '../score/score';
-import type { ExposureReport, Finding, Report } from '../types';
+import type { ExposureReport, Finding, PerfReport, Report } from '../types';
 import { summarize } from '../types';
 import { version as PKG_VERSION } from '../version';
 
@@ -61,6 +67,12 @@ export interface AuditOptions extends IntrospectOptions {
    * exposed entry points. Adds `report.callGraph`.
    */
   callGraph?: boolean;
+  /**
+   * Collect and score the performance dimension: index-hygiene rules (`X*`)
+   * on top of the policy-cost rules (P1/P1b) the audit already runs. Adds
+   * `report.perf` with its own score. Overrides `config.perf.enabled`.
+   */
+  perf?: boolean;
   /**
    * Merged safegres configuration (rules, overrides, scoring). Rule settings
    * filter and retune findings; scoring settings drive the report score.
@@ -133,14 +145,43 @@ export async function audit(
     }
   }
 
+  // --- Performance dimension (opt-in): index hygiene ---
+  const perfEnabled = options.perf ?? config.perf?.enabled ?? false;
+  if (perfEnabled) {
+    const indexSnapshot = await introspectIndexes(exec, {
+      schemas: options.schemas ?? config.schemas,
+      excludeSchemas: options.excludeSchemas ?? config.excludeSchemas
+    });
+    for (const table of indexSnapshot) {
+      findings.push(...checkUnindexedForeignKeys(table));
+      findings.push(...checkRedundantIndexes(table));
+      const x6 = checkMissingPrimaryKey(table);
+      if (x6) findings.push(x6);
+    }
+  }
+
   findings = applyRulesToFindings(resolved, findings);
 
   // Stamp direction (from the registry) and exposure on every finding.
   const publicRead = config.public?.read ?? [];
+  const perfIgnore = config.perf?.ignore ?? [];
   for (const f of findings) {
     const meta = RULES_BY_CODE.get(f.code);
     if (meta && f.direction === undefined) f.direction = meta.direction;
+    if (meta && f.dimension === undefined) f.dimension = dimensionOf(meta);
     if (exposure.known && f.schema) f.exposed = exposedSchemas.has(f.schema);
+
+    // Declared-intentional perf debt: cold tables, tiny lookups, anything the
+    // planner will seq-scan regardless. Reported, but off the perf score.
+    if (
+      f.dimension === 'perf' && f.schema && f.table
+      && perfIgnore.some((p) => matchTablePattern(p, `${f.schema}.${f.table}`))
+    ) {
+      f.acknowledged = true;
+      f.severity = 'info';
+      f.message += ' — acknowledged (perf.ignore)';
+      f.hint = 'This table is declared in `perf.ignore`, so the finding is treated as intentional and does not affect the perf score.';
+    }
 
     // Declared-public reads: an open SELECT on a table listed in
     // `public.read` is intent, not a finding — acknowledge it (info,
@@ -181,17 +222,32 @@ export async function audit(
     totalTables: snapshot.length
   };
 
+  const securityFindings = findings.filter((f) => f.dimension !== 'perf');
+  const perfFindings = findings.filter((f) => f.dimension === 'perf');
+
   const report: Report = {
     version: PKG_VERSION,
     generatedAt: new Date().toISOString(),
     summary: summarize(findings),
     findings,
-    score: computeScore(findings, config.scoring, {
+    score: computeScore(securityFindings, config.scoring, {
       exposedTables,
       exposureKnown: exposure.known
     }),
     exposure: exposureReport
   };
+
+  if (perfEnabled) {
+    const perf: PerfReport = {
+      findings: perfFindings,
+      summary: summarize(perfFindings),
+      score: computeScore(perfFindings, config.perf?.scoring, {
+        exposedTables,
+        exposureKnown: exposure.known
+      })
+    };
+    report.perf = perf;
+  }
 
   if (options.callGraph) {
     const functions = await introspectFunctions(exec, {

--- a/packages/safegres/src/config/resolve.ts
+++ b/packages/safegres/src/config/resolve.ts
@@ -1,5 +1,5 @@
-import { expandRuleSelector, isKnownRule, RULES, RULES_BY_CODE } from '../rules/registry';
-import type { Finding, Severity } from '../types';
+import { dimensionOf, expandRuleSelector, isKnownRule, RULES, RULES_BY_CODE } from '../rules/registry';
+import type { Dimension, Finding, Severity } from '../types';
 import { SEVERITY_ORDER } from '../types';
 import type { OverrideEntry, RulesConfig, RuleSetting, SafegresConfig } from './types';
 
@@ -92,6 +92,10 @@ export function resolveRules(config: SafegresConfig): ResolvedRules {
   if (config.rules) {
     rules = applyRulesConfig(rules, config.rules);
   }
+  if (config.perf?.rules) {
+    assertPerfSelectors(config.perf.rules);
+    rules = applyRulesConfig(rules, config.perf.rules);
+  }
   const overrides = config.overrides ?? [];
   for (const o of overrides) {
     if (!Array.isArray(o.tables) || o.tables.length === 0) {
@@ -106,7 +110,44 @@ export function resolveRules(config: SafegresConfig): ResolvedRules {
       throw new ConfigValidationError('"public.read" must be an array of non-empty schema.table glob patterns.');
     }
   }
+  const perfIgnore = config.perf?.ignore;
+  if (perfIgnore !== undefined) {
+    if (!Array.isArray(perfIgnore) || perfIgnore.some((p) => typeof p !== 'string' || p.length === 0)) {
+      throw new ConfigValidationError('"perf.ignore" must be an array of non-empty schema.table glob patterns.');
+    }
+  }
   return { rules, overrides };
+}
+
+/**
+ * `perf.rules` may only retune perf-dimension codes — otherwise a security
+ * rule would silently change behind the perf flag.
+ */
+function assertPerfSelectors(rules: RulesConfig): void {
+  for (const selector of Object.keys(rules)) {
+    const codes = expandRuleSelector(selector);
+    if (codes.length === 0) {
+      throw new ConfigValidationError(
+        `Unknown rule code "${selector}" in "perf.rules". Perf rules: ${perfRuleCodes().join(', ')}.`
+      );
+    }
+    const security = codes.filter((code) => dimensionOf(RULES_BY_CODE.get(code)!) !== 'perf');
+    if (security.length > 0) {
+      throw new ConfigValidationError(
+        `"perf.rules" may only configure perf-dimension rules; "${selector}" matches security rule(s) `
+          + `${security.join(', ')}. Configure those under the top-level "rules".`
+      );
+    }
+  }
+}
+
+/** Rule codes belonging to a scoring dimension. */
+export function ruleCodesForDimension(dimension: Dimension): string[] {
+  return RULES.filter((r) => dimensionOf(r) === dimension).map((r) => r.code);
+}
+
+function perfRuleCodes(): string[] {
+  return ruleCodesForDimension('perf');
 }
 
 /** Simple `*` glob match against a qualified `schema.table` name. */

--- a/packages/safegres/src/config/types.ts
+++ b/packages/safegres/src/config/types.ts
@@ -94,6 +94,30 @@ export interface ScoringConfig {
   gradeBands?: Partial<Record<Exclude<Grade, 'F'>, number>>;
 }
 
+/**
+ * The optional performance dimension: index-hygiene and policy-cost rules
+ * (`X*`, plus P1/P1b), scored on their own axis against the same exposure
+ * surface. Off by default — `safegres perf` / `--perf` / `enabled: true`.
+ */
+export interface PerfConfig {
+  /** Collect and score perf findings without passing `--perf`. */
+  enabled?: boolean;
+  /**
+   * Rule settings for perf-dimension codes only. Applied on top of the
+   * top-level `rules`; naming a security rule here is a config error.
+   */
+  rules?: RulesConfig;
+  /**
+   * Glob patterns matched against the qualified `schema.table` name for
+   * tables whose perf findings are intentional (cold audit logs, tiny
+   * lookup tables the planner will seq-scan anyway). Acknowledged findings
+   * are reported as info and excluded from the perf score.
+   */
+  ignore?: string[];
+  /** Scoring settings for the perf axis (defaults mirror the security score). */
+  scoring?: ScoringConfig;
+}
+
 export interface FailOnConfig {
   /** Exit non-zero if any finding is at/above this severity. */
   severity?: Severity;
@@ -101,6 +125,10 @@ export interface FailOnConfig {
   score?: number;
   /** Exit non-zero if the grade is below this letter. */
   grade?: Grade;
+  /** Exit non-zero if the perf score is below this value (0-100). */
+  perfScore?: number;
+  /** Exit non-zero if the perf grade is below this letter. */
+  perfGrade?: Grade;
 }
 
 /**
@@ -115,6 +143,8 @@ export interface SafegresConfig {
   exposure?: ExposureConfig;
   /** Tables whose open reads are deliberate (declared public surface). */
   public?: PublicConfig;
+  /** The optional performance dimension. */
+  perf?: PerfConfig;
   schemas?: string[];
   excludeSchemas?: string[];
   roles?: string[];

--- a/packages/safegres/src/index.ts
+++ b/packages/safegres/src/index.ts
@@ -26,6 +26,11 @@ export type {
   ChecklistItem
 } from './callgraph/graph';
 export { buildCallGraph } from './callgraph/graph';
+export {
+  checkMissingPrimaryKey,
+  checkRedundantIndexes,
+  checkUnindexedForeignKeys
+} from './checks/indexes';
 export type { RoleTrustOptions } from './checks/role-trust';
 export {
   checkPublicGrants,
@@ -47,6 +52,7 @@ export {
   defaultRuleMap,
   matchTablePattern,
   resolveRules,
+  ruleCodesForDimension,
   rulesForTable
 } from './config/resolve';
 export type {
@@ -54,6 +60,7 @@ export type {
   FailOnConfig,
   Grade,
   OverrideEntry,
+  PerfConfig,
   RulesConfig,
   RuleSetting,
   SafegresConfig,
@@ -63,6 +70,8 @@ export type { ResolvedExposure } from './pg/exposure';
 export { resolveConstructiveExposure, resolveExposure, UNKNOWN_EXPOSURE } from './pg/exposure';
 export type { FunctionGrant, FunctionSnapshot, IntrospectFunctionOptions } from './pg/functions';
 export { introspectFunctions } from './pg/functions';
+export type { ForeignKeyInfo, IndexInfo, TableIndexSnapshot } from './pg/indexes';
+export { introspectIndexes } from './pg/indexes';
 export {
   type IntrospectOptions,
   introspectTables,
@@ -77,7 +86,7 @@ export { renderCallGraph, renderCallGraphDiff } from './report/callgraph';
 export { renderJson } from './report/json';
 export { renderPretty } from './report/pretty';
 export type { RuleMeta } from './rules/registry';
-export { expandRuleSelector, isKnownRule, RULES, RULES_BY_CODE } from './rules/registry';
+export { dimensionOf, expandRuleSelector, isKnownRule, RULES, RULES_BY_CODE } from './rules/registry';
 export type { Score, ScoreContext, ScoreDeduction } from './score/score';
 export { computeScore, DEFAULT_GRADE_BANDS, DEFAULT_WEIGHTS, meetsGrade } from './score/score';
 export * from './types';

--- a/packages/safegres/src/pg/indexes.ts
+++ b/packages/safegres/src/pg/indexes.ts
@@ -1,0 +1,186 @@
+/**
+ * Catalog introspection for the performance dimension: indexes, foreign-key
+ * constraints, primary keys, and replica identity, in one query.
+ *
+ * Kept separate from {@link introspectTables} so a security-only audit never
+ * pays for it.
+ */
+
+import type { IntrospectOptions, QueryExecutor } from './introspect';
+
+export interface IndexInfo {
+  name: string;
+  /**
+   * Attribute numbers of the indexed columns, in index order. `0` marks an
+   * expression column (the expression itself is in `definition`).
+   */
+  columns: number[];
+  /** Column names aligned with `columns`; expression columns render as `(expr)`. */
+  columnNames: string[];
+  unique: boolean;
+  primary: boolean;
+  /** Backed by a constraint (PRIMARY KEY / UNIQUE / EXCLUDE). */
+  constraint: boolean;
+  /** Has a `WHERE` clause — only covers a subset of rows. */
+  partial: boolean;
+  /** Contains at least one expression column. */
+  expression: boolean;
+  /** Access method (`btree`, `gin`, …). */
+  method: string;
+  definition: string;
+}
+
+export interface ForeignKeyInfo {
+  name: string;
+  /** Referencing column attribute numbers, in constraint order. */
+  columns: number[];
+  columnNames: string[];
+  /** Schema-qualified referenced table. */
+  references: string;
+}
+
+export interface TableIndexSnapshot {
+  schema: string;
+  name: string;
+  oid: number;
+  /** The table is a partition of a partitioned table (indexes live on the parent). */
+  isPartition: boolean;
+  /** `pg_class.relreplident`: `d` default, `n` nothing, `f` full, `i` index. */
+  replicaIdentity: string;
+  hasPrimaryKey: boolean;
+  indexes: IndexInfo[];
+  foreignKeys: ForeignKeyInfo[];
+}
+
+const DEFAULT_EXCLUDES = ['pg_catalog', 'information_schema', 'pg_toast'];
+
+/**
+ * One-query snapshot of the index-shaped catalog for every table in scope.
+ */
+export async function introspectIndexes(
+  exec: QueryExecutor,
+  options: Pick<IntrospectOptions, 'schemas' | 'excludeSchemas'> = {}
+): Promise<TableIndexSnapshot[]> {
+  const excludes = [...DEFAULT_EXCLUDES, ...(options.excludeSchemas ?? [])];
+  const schemaFilter = options.schemas && options.schemas.length > 0
+    ? `AND n.nspname = ANY($1::text[])`
+    : `AND NOT (n.nspname = ANY($2::text[]))`;
+
+  // Both parameters are referenced (even when only one filters) so Postgres
+  // can infer their types — an unused $N errors out at bind time.
+  const sql = `
+    WITH _params AS (
+      SELECT $1::text[] AS include_schemas, $2::text[] AS exclude_schemas
+    ),
+    rels AS (
+      SELECT
+        n.nspname          AS schema_name,
+        c.relname          AS table_name,
+        c.oid              AS oid,
+        c.relispartition   AS is_partition,
+        c.relreplident     AS replica_identity
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE c.relkind IN ('r', 'p')
+        ${schemaFilter}
+    ),
+    indexes AS (
+      SELECT
+        ix.indrelid                                     AS oid,
+        i.relname                                       AS name,
+        string_to_array(ix.indkey::text, ' ')::int[]    AS columns,
+        ix.indisunique                                  AS is_unique,
+        ix.indisprimary                                 AS is_primary,
+        (con.oid IS NOT NULL)                           AS is_constraint,
+        (ix.indpred IS NOT NULL)                        AS is_partial,
+        (ix.indexprs IS NOT NULL)                       AS is_expression,
+        am.amname                                       AS method,
+        pg_get_indexdef(i.oid)                          AS definition
+      FROM pg_index ix
+      JOIN pg_class i ON i.oid = ix.indexrelid
+      JOIN pg_am am ON am.oid = i.relam
+      LEFT JOIN pg_constraint con
+        ON con.conindid = i.oid AND con.contype IN ('p', 'u', 'x')
+      WHERE ix.indislive
+    ),
+    fks AS (
+      SELECT
+        co.conrelid                                     AS oid,
+        co.conname                                      AS name,
+        co.conkey::int[]                                AS columns,
+        co.confrelid::regclass::text                    AS references_table
+      FROM pg_constraint co
+      WHERE co.contype = 'f'
+    )
+    SELECT
+      r.schema_name,
+      r.table_name,
+      r.oid::int                                        AS oid,
+      r.is_partition,
+      r.replica_identity::text                          AS replica_identity,
+      COALESCE(
+        (SELECT jsonb_agg(jsonb_build_object(
+          'name', x.name,
+          'columns', to_jsonb(x.columns),
+          'columnNames', to_jsonb(${columnNamesExpr('x')}),
+          'unique', x.is_unique,
+          'primary', x.is_primary,
+          'constraint', x.is_constraint,
+          'partial', x.is_partial,
+          'expression', x.is_expression,
+          'method', x.method,
+          'definition', x.definition
+        ) ORDER BY x.name) FROM indexes x WHERE x.oid = r.oid),
+        '[]'::jsonb
+      )                                                 AS indexes,
+      COALESCE(
+        (SELECT jsonb_agg(jsonb_build_object(
+          'name', f.name,
+          'columns', to_jsonb(f.columns),
+          'columnNames', to_jsonb(${columnNamesExpr('f')}),
+          'references', f.references_table
+        ) ORDER BY f.name) FROM fks f WHERE f.oid = r.oid),
+        '[]'::jsonb
+      )                                                 AS foreign_keys
+    FROM rels r
+    ORDER BY r.schema_name, r.table_name
+  `;
+
+  const { rows } = await exec.query<{
+    schema_name: string;
+    table_name: string;
+    oid: number;
+    is_partition: boolean;
+    replica_identity: string;
+    indexes: IndexInfo[];
+    foreign_keys: ForeignKeyInfo[];
+  }>(sql, [options.schemas ?? [], excludes]);
+
+  return rows.map((r) => ({
+    schema: r.schema_name,
+    name: r.table_name,
+    oid: r.oid,
+    isPartition: r.is_partition,
+    replicaIdentity: r.replica_identity,
+    hasPrimaryKey: r.indexes.some((i) => i.primary),
+    indexes: r.indexes,
+    foreignKeys: r.foreign_keys
+  }));
+}
+
+/**
+ * Resolve attribute numbers to column names for the relation `alias.oid`.
+ * `0` (an expression column) renders as `(expr)` so positions stay aligned.
+ */
+function columnNamesExpr(alias: string): string {
+  return `(
+    SELECT COALESCE(array_agg(
+      COALESCE((
+        SELECT att.attname
+        FROM pg_attribute att
+        WHERE att.attrelid = ${alias}.oid AND att.attnum = k.attnum
+      ), '(expr)') ORDER BY k.ord
+    ), ARRAY[]::text[])
+    FROM unnest(${alias}.columns) WITH ORDINALITY AS k(attnum, ord)
+  )`;
+}

--- a/packages/safegres/src/report/pretty.ts
+++ b/packages/safegres/src/report/pretty.ts
@@ -1,5 +1,6 @@
 import yanse from 'yanse';
 
+import type { Score } from '../score/score';
 import type { Finding, Report, Severity } from '../types';
 import { renderCallGraph, renderCallGraphDiff } from './callgraph';
 
@@ -58,21 +59,12 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
   }
 
   if (score) {
-    const gradePaint: (s: string) => string = colorEnabled
-      ? score.grade.startsWith('A')
-        ? yanse.green
-        : score.grade === 'B' || score.grade === 'C'
-          ? yanse.yellow
-          : yanse.red
-      : noop;
-    const capNote = score.cappedByUnknownExposure ? '  (capped: exposure unknown)' : '';
-    lines.push(`score: ${gradePaint(`${score.value} (${score.grade})`)}  — model: ${score.model}${capNote}`);
-    const top = score.deductions.slice(0, 3);
-    if (top.length > 0) {
-      lines.push(
-        `  top deductions: ${top.map((d) => `${d.code} −${d.points} (×${d.count})`).join('  ')}`
-      );
-    }
+    lines.push(...scoreLines('score', score, colorEnabled));
+    lines.push('');
+  }
+
+  if (report.perf) {
+    lines.push(...scoreLines('perf score', report.perf.score, colorEnabled));
     lines.push('');
   }
 
@@ -96,8 +88,11 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
   }
   lines.push('');
 
-  const exposed = findings.filter((f) => f.exposed !== false);
-  const internal = findings.filter((f) => f.exposed === false);
+  // Perf findings render in their own section so the two dimensions never
+  // read as one list.
+  const security = report.perf ? findings.filter((f) => f.dimension !== 'perf') : findings;
+  const exposed = security.filter((f) => f.exposed !== false);
+  const internal = security.filter((f) => f.exposed === false);
 
   for (const f of exposed) {
     lines.push(renderFinding(f, paint));
@@ -126,8 +121,28 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
     }
   }
 
-  if (findings.length === 0) {
+  if (security.length === 0) {
     lines.push('no findings.');
+  }
+
+  if (report.perf) {
+    const perfExposed = report.perf.findings.filter((f) => f.exposed !== false);
+    const perfInternal = report.perf.findings.length - perfExposed.length;
+    lines.push('', 'performance (index hygiene) — scored separately from security:', '');
+    if (perfExposed.length === 0) {
+      lines.push('no perf findings.');
+    } else {
+      for (const f of perfExposed) lines.push(renderFinding(f, paint));
+    }
+    if (perfInternal > 0 && !options.verbose) {
+      lines.push(
+        paint('info', `  (${perfInternal} internal perf advisor${perfInternal === 1 ? 'y' : 'ies'} excluded from the perf score)`)
+      );
+    } else if (perfInternal > 0) {
+      for (const f of report.perf.findings.filter((f) => f.exposed === false)) {
+        lines.push(renderFinding(f, paint));
+      }
+    }
   }
 
   if (report.callGraph) {
@@ -138,6 +153,27 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
   }
 
   return lines.join('\n');
+}
+
+function scoreLines(label: string, score: Score, colorEnabled: boolean): string[] {
+  const gradePaint: (s: string) => string = colorEnabled
+    ? score.grade.startsWith('A')
+      ? yanse.green
+      : score.grade === 'B' || score.grade === 'C'
+        ? yanse.yellow
+        : yanse.red
+    : noop;
+  const capNote = score.cappedByUnknownExposure ? '  (capped: exposure unknown)' : '';
+  const lines = [
+    `${label}: ${gradePaint(`${score.value} (${score.grade})`)}  — model: ${score.model}${capNote}`
+  ];
+  const top = score.deductions.slice(0, 3);
+  if (top.length > 0) {
+    lines.push(
+      `  top deductions: ${top.map((d) => `${d.code} −${d.points} (×${d.count})`).join('  ')}`
+    );
+  }
+  return lines;
 }
 
 function renderFinding(f: Finding, paint: (sev: Severity, s: string) => string): string {

--- a/packages/safegres/src/rules/registry.ts
+++ b/packages/safegres/src/rules/registry.ts
@@ -1,4 +1,4 @@
-import type { Direction, Finding, Severity } from '../types';
+import type { Dimension, Direction, Finding, Severity } from '../types';
 
 /**
  * Static metadata for every rule safegres can emit. Severity here is the
@@ -16,12 +16,23 @@ export interface RuleMeta {
    * to the score by default. `fail-open` findings are actual exposure.
    */
   direction: Direction;
+  /**
+   * Scoring axis. `security` rules drive the audit score; `perf` rules drive
+   * the optional performance score and are only collected when the perf
+   * dimension is enabled. Defaults to `security` when omitted.
+   */
+  dimension?: Dimension;
   title: string;
   /**
    * Rules with `scope: 'policy-ast'` require parsing policy expressions.
    * When every one of them is disabled the audit skips AST work entirely.
    */
-  scope: 'table' | 'policy-ast';
+  scope: 'table' | 'policy-ast' | 'index';
+}
+
+/** The scoring axis a rule belongs to (`security` unless declared otherwise). */
+export function dimensionOf(meta: RuleMeta): Dimension {
+  return meta.dimension ?? 'security';
 }
 
 export const RULES: RuleMeta[] = [
@@ -94,6 +105,7 @@ export const RULES: RuleMeta[] = [
     category: 'anti-pattern',
     defaultSeverity: 'high',
     direction: 'neutral',
+    dimension: 'perf',
     title: 'Policy body calls a VOLATILE function (per-row evaluation)',
     scope: 'policy-ast'
   },
@@ -102,6 +114,7 @@ export const RULES: RuleMeta[] = [
     category: 'anti-pattern',
     defaultSeverity: 'medium',
     direction: 'neutral',
+    dimension: 'perf',
     title: 'Policy body calls a SECURITY DEFINER wrapper (cannot be inlined)',
     scope: 'policy-ast'
   },
@@ -144,6 +157,33 @@ export const RULES: RuleMeta[] = [
     direction: 'neutral',
     title: 'No exposure surface configured — the whole database is assumed reachable and the score is capped',
     scope: 'table'
+  },
+  {
+    code: 'X1',
+    category: 'index',
+    defaultSeverity: 'medium',
+    direction: 'neutral',
+    dimension: 'perf',
+    title: 'Foreign key with no covering index (slow joins and cascading deletes)',
+    scope: 'index'
+  },
+  {
+    code: 'X5',
+    category: 'index',
+    defaultSeverity: 'low',
+    direction: 'neutral',
+    dimension: 'perf',
+    title: 'Redundant index — duplicated by, or a leading-column prefix of, another index',
+    scope: 'index'
+  },
+  {
+    code: 'X6',
+    category: 'index',
+    defaultSeverity: 'low',
+    direction: 'neutral',
+    dimension: 'perf',
+    title: 'Table has no primary key / no usable replica identity',
+    scope: 'index'
   }
 ];
 

--- a/packages/safegres/src/types.ts
+++ b/packages/safegres/src/types.ts
@@ -17,6 +17,14 @@ export type Severity = 'critical' | 'high' | 'medium' | 'low' | 'info';
  */
 export type Direction = 'fail-open' | 'fail-closed' | 'neutral';
 
+/**
+ * Which axis a finding is scored on. `security` findings drive `report.score`;
+ * `perf` findings drive `report.perf.score`. The two are never mixed — a
+ * database can be an A+ on security and a D on index hygiene, and both
+ * numbers stay meaningful.
+ */
+export type Dimension = 'security' | 'perf';
+
 export const SEVERITY_ORDER: Record<Severity, number> = {
   critical: 4,
   high: 3,
@@ -30,9 +38,11 @@ export interface Finding {
   code: string;
   severity: Severity;
   /** High-level bucket — helps renderers group findings. */
-  category: 'flags' | 'coverage' | 'anti-pattern' | 'sync' | 'match' | 'meta';
+  category: 'flags' | 'coverage' | 'anti-pattern' | 'index' | 'sync' | 'match' | 'meta';
   /** Leak vs deny vs directionless. Stamped from the rule registry. */
   direction?: Direction;
+  /** Scoring axis. Stamped from the rule registry; defaults to `security`. */
+  dimension?: Dimension;
   /**
    * Whether the finding's table is on the resolved exposure surface.
    * `undefined` when no exposure surface is known (everything is assumed
@@ -83,6 +93,19 @@ export interface ExposureReport {
   totalTables: number;
 }
 
+/**
+ * The optional performance dimension (`--perf`): index-hygiene and
+ * policy-cost findings, scored on their own 0-100 axis against the same
+ * exposure surface.
+ */
+export interface PerfReport {
+  /** Perf-dimension findings (also present in `report.findings`). */
+  findings: Finding[];
+  summary: Summary;
+  /** Perf score — computed only over perf-dimension findings. */
+  score: import('./score/score').Score;
+}
+
 export interface Report {
   version: string;
   generatedAt: string;
@@ -90,6 +113,8 @@ export interface Report {
   findings: Finding[];
   /** Config-driven audit score (weighted deductions, 0-100 + grade). */
   score?: import('./score/score').Score;
+  /** Performance dimension, present when the audit ran with `perf` enabled. */
+  perf?: PerfReport;
   /** The exposure surface the score was computed against. */
   exposure?: ExposureReport;
   /**


### PR DESCRIPTION
## Summary

Phase 1 of https://github.com/constructive-io/constructive-planning/issues/1328: safegres grows a second, **optional** scoring axis for performance, so it can absorb the OSS scanning that `constructive-db/application/app-performance` does by hand today (a FK-missing-index query that writes a JSON artifact and always passes).

Off by default and additive — a plain `safegres audit` behaves exactly as before. With `safegres perf` / `audit --perf`:

```ts
report.score        // security findings only  (unchanged behavior)
report.perf = {     // present only when perf is enabled
  findings, summary,
  score             // perf findings only — never mixed with security
}
```

Every rule now carries a `dimension` (`'security'` by default); the audit stamps it on each finding and splits the two lists before scoring. `P1`/`P1b` (volatile/stable function in a policy body) are re-homed to `perf` — they were always cost findings scored as security, so they now stop deducting from `report.score`.

New rules, all pure catalog analysis (deterministic, workload-free, safe against an empty CI database) from a single new `introspectIndexes()` query:

| | |
|---|---|
| `X1` (medium) | FK with no covering index. Covered means a **btree** index whose *leading* columns are the FK's columns (order among them irrelevant), covering every row — partial/expression indexes don't count, the planner can't use them for the RI lookup. |
| `X5` (low) | Index that is an exact duplicate of, or a leading-column prefix of, another index. Constraint-backed, unique, partial, and expression indexes are never reported; exact-duplicate pairs report one side deterministically (name order). |
| `X6` (low) | No primary key **and** no usable replica identity (`FULL`/`USING INDEX` are accepted). Partitions are skipped — the parent carries the finding. |

Config and gates mirror the security side:

```jsonc
{
  "perf": {
    "enabled": true,
    "rules": { "X6": "off" },          // perf codes only; naming a security rule is a ConfigValidationError
    "ignore": ["app_public.audit_*"],  // acknowledged → info, excluded from the perf score
    "scoring": { "densityK": 0.17 }
  },
  "failOn": { "perfGrade": "B" }       // CLI: --perf, --fail-on-perf-score, --fail-on-perf-grade
}
```

Perf findings stay in `report.findings` (so `--fail-on <severity>` still sees them) but render in their own section of the pretty report under a separate score line.

Follow-ups from the plan issue, not in this PR: the policy-aware index rules (`X2`–`X4`, unindexed policy predicate columns, casts defeating indexes, non-LEAKPROOF quals), Constructive search/sort rules (`X7`/`X8`), opt-in runtime stats (`S1`–`S4`), `--explain` proof, and migrating `constructive-db`'s FK test onto `safegres/pgpm-test` with a committed baseline.

## Testing

`__tests__/perf.test.ts` (8 new cases, fixture-driven) covers: perf off by default (no `X*` findings, no `report.perf`), each of X1/X5/X6 including the shapes that must *not* be reported, score separation, `perf.ignore` acknowledgement, and `perf.rules` validation. Full package suite: 87 passed.

Repo-wide `pnpm lint` is broken independently of this change (ESLint 9 installed against the repo's legacy `.eslintrc.json`); `tsc --noEmit` on the package is clean.


Link to Devin session: https://app.devin.ai/sessions/ec06ef6eabae4872ae5ec3926f037c85
Requested by: @pyramation