### PR TITLE
chore(safegres): mention the perf dimension in package description/keywords

### DIFF
--- a/packages/safegres/package.json
+++ b/packages/safegres/package.json
@@ -2,7 +2,7 @@
   "name": "safegres",
   "version": "1.12.0",
   "author": "Constructive <developers@constructive.io>",
-  "description": "Pure-Postgres Row-Level Security auditor: grants, RLS enforcement, policy coverage, and risky SQL policy patterns. No app framework required.",
+  "description": "Pure-Postgres Row-Level Security auditor: grants, RLS enforcement, policy coverage, and risky SQL policy patterns, plus an optional index-hygiene performance score. No app framework required.",
   "main": "index.js",
   "module": "esm/index.js",
   "types": "index.d.ts",
@@ -37,6 +37,8 @@
     "row-level-security",
     "audit",
     "security",
+    "performance",
+    "index",
     "safegres",
     "constructive"
   ],


### PR DESCRIPTION
## Summary

Follow-up to #1543 (merged): the npm-facing metadata still described safegres as RLS-only. Adds "plus an optional index-hygiene performance score" to `description` and `performance`/`index` to `keywords`. No code change.


Link to Devin session: https://app.devin.ai/sessions/ec06ef6eabae4872ae5ec3926f037c85
Requested by: @pyramation