### PR TITLE
feat(safegres): policy-aware perf rules X2/X3/X4 (RLS predicate index coverage)

### DIFF
--- a/.agents/skills/safegres/SKILL.md
+++ b/.agents/skills/safegres/SKILL.md
@@ -72,7 +72,7 @@ The score only improves by being **explicit** (declaring exposure and intent) or
 | R3 | medium | fail-open | RLS table has grants **TO PUBLIC** |
 | W1 | medium | meta | No exposure surface configured — DB assumed reachable, score capped |
 
-Perf-dimension rules (only collected with `--perf`, scored on their own axis): **X1** FK with no covering index (medium), **X5** redundant/duplicate index (low), **X6** no primary key and no usable replica identity (low), plus P1/P1b.
+Perf-dimension rules (only collected with `--perf`, scored on their own axis): **X1** FK with no covering index (medium), **X2** policy filters on a column that leads no index (medium), **X3** policy casts/wraps its own column with no matching expression index (medium), **X4** policy calls a non-LEAKPROOF function (low), **X5** redundant/duplicate index (low), **X6** no primary key and no usable replica identity (low), plus P1/P1b.
 
 **Direction is the key idea:** `fail-open` = real exposure (untrusted side reaches more than intended). `fail-closed` = denied at runtime (hygiene/availability, not a leak) — contributes **0** to the score by default. R1/R2 are no-ops until you configure a role list; `safegres:constructive` sets them for `anonymous`.
 
@@ -103,7 +103,9 @@ Typed variant (`defineConfig` from `confstash`) works too — see the package RE
 
 ## Performance dimension (`--perf`, off by default)
 
-`safegres perf` / `safegres audit --perf` adds `report.perf` — its own findings, summary, and 0-100 score over index hygiene (X1/X5/X6) and policy cost (P1/P1b). Security and perf scores are never mixed: `report.score` sees only security findings, `report.perf.score` only perf ones. All checks are pure catalog analysis, so they're deterministic against an empty CI database.
+`safegres perf` / `safegres audit --perf` adds `report.perf` — its own findings, summary, and 0-100 score over index hygiene (X1/X5/X6), policy-aware index rules (X2/X3/X4) and policy cost (P1/P1b). Security and perf scores are never mixed: `report.score` sees only security findings, `report.perf.score` only perf ones. All checks are catalog + policy-AST analysis, so they're deterministic against an empty CI database.
+
+X2/X3/X4 read the policy predicate itself: RLS quals run before user quals on every candidate row, so an unindexed policy column (X2), a cast/function wrapping it (X3), or a non-LEAKPROOF call that blocks qual pushdown (X4) is a tax on every query against the table, not just one slow report.
 
 ```jsonc
 {

--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -107,12 +107,17 @@ A slow database is a different problem from an unsafe one, so safegres scores th
 | Code | Severity | Category | Check |
 | --- | --- | --- | --- |
 | X1 | medium | index | **Foreign key with no covering index** — joins and cascading deletes seq-scan the child table |
+| X2 | medium | index | **RLS policy filters on an unindexed column** — the security qual seq-scans on every query against the table |
+| X3 | medium | index | **Policy casts or wraps its own column** (`tenant_id::text = …`, `lower(email) = …`) with no matching expression index |
+| X4 | low | index | **Policy calls a non-LEAKPROOF function** — the qual can't be pushed below joins or subquery scans |
 | X5 | low | index | **Redundant index** — an exact duplicate of, or a leading-column prefix of, another index |
 | X6 | low | index | **No primary key** and no usable replica identity — rows cannot be addressed by updates, deletes, or logical replication |
 | P1 | high | anti-pattern | Policy body calls a **VOLATILE function** — re-evaluated per row |
 | P1b | medium | anti-pattern | Policy body calls a **STABLE function** in a per-row position |
 
-Every check is pure catalog analysis: deterministic, workload-free, and safe to run against an empty CI database. An index covers a foreign key only when its *leading* columns are the FK's columns and it covers every row — partial and expression indexes don't count, because the planner can't use them for the referential-integrity lookup. Constraint-backed, unique, partial, and expression indexes are never reported as redundant.
+Every check is pure catalog + AST analysis: deterministic, workload-free, and safe to run against an empty CI database. An index covers a foreign key only when its *leading* columns are the FK's columns and it covers every row — partial and expression indexes don't count, because the planner can't use them for the referential-integrity lookup. Constraint-backed, unique, partial, and expression indexes are never reported as redundant.
+
+X2–X4 are the checks a generic index linter can't make, because they read the policy predicate. RLS quals are evaluated *before* user quals, on every candidate row, for every caller — so an unindexed or cast-wrapped policy column is a whole-table tax rather than a slow query. X2 requires the policy column to be the *leading* column of some index (a trailing position can't serve the qual alone); X3 looks for an expression index matching the exact wrapped shape; X4 skips built-ins, whose leakproofness is a property of the server rather than a schema choice.
 
 ```bash
 safegres perf --database mydb

--- a/packages/safegres/__tests__/fixtures/x2-policy-index.sql
+++ b/packages/safegres/__tests__/fixtures/x2-policy-index.sql
@@ -1,0 +1,82 @@
+-- Policy-aware perf fixtures: X2 (unindexed policy column), X3 (cast/function
+-- on a policy column), X4 (non-LEAKPROOF function in a policy).
+DROP SCHEMA IF EXISTS fx_x2 CASCADE;
+CREATE SCHEMA fx_x2;
+
+CREATE FUNCTION fx_x2.current_tenant() RETURNS uuid AS $$
+  SELECT nullif(current_setting('jwt.claims.tenant_id', true), '')::uuid;
+$$ LANGUAGE sql STABLE;
+
+-- Not marked LEAKPROOF: X4 fodder.
+CREATE FUNCTION fx_x2.is_member(tenant uuid) RETURNS boolean AS $$
+  SELECT tenant IS NOT NULL;
+$$ LANGUAGE sql STABLE;
+
+CREATE FUNCTION fx_x2.is_admin() RETURNS boolean AS $$
+  SELECT true;
+$$ LANGUAGE sql STABLE LEAKPROOF;
+
+-- X2: policy filters on tenant_id, which has no index at all.
+CREATE TABLE fx_x2.documents (
+  id uuid PRIMARY KEY,
+  tenant_id uuid NOT NULL,
+  title text NOT NULL
+);
+ALTER TABLE fx_x2.documents ENABLE ROW LEVEL SECURITY;
+CREATE POLICY documents_tenant ON fx_x2.documents
+  USING (tenant_id = fx_x2.current_tenant());
+
+-- No X2: same shape, but the policy column leads an index.
+CREATE TABLE fx_x2.invoices (
+  id uuid PRIMARY KEY,
+  tenant_id uuid NOT NULL,
+  total numeric NOT NULL
+);
+CREATE INDEX invoices_tenant_idx ON fx_x2.invoices (tenant_id, total);
+ALTER TABLE fx_x2.invoices ENABLE ROW LEVEL SECURITY;
+CREATE POLICY invoices_tenant ON fx_x2.invoices
+  USING (tenant_id = fx_x2.current_tenant());
+
+-- No X2: the policy column is only a trailing index column, so the index
+-- cannot serve the security qual on its own.
+CREATE TABLE fx_x2.receipts (
+  id uuid PRIMARY KEY,
+  kind text NOT NULL,
+  tenant_id uuid NOT NULL
+);
+CREATE INDEX receipts_kind_tenant_idx ON fx_x2.receipts (kind, tenant_id);
+ALTER TABLE fx_x2.receipts ENABLE ROW LEVEL SECURITY;
+CREATE POLICY receipts_tenant ON fx_x2.receipts
+  USING (tenant_id = fx_x2.current_tenant());
+
+-- X3: the policy casts its own column, so the plain b-tree index is unusable.
+CREATE TABLE fx_x2.accounts (
+  id uuid PRIMARY KEY,
+  tenant_id uuid NOT NULL,
+  email text NOT NULL
+);
+CREATE INDEX accounts_tenant_idx ON fx_x2.accounts (tenant_id);
+ALTER TABLE fx_x2.accounts ENABLE ROW LEVEL SECURITY;
+CREATE POLICY accounts_tenant ON fx_x2.accounts
+  USING (tenant_id::text = current_setting('jwt.claims.tenant_id', true));
+
+-- No X3: lower(email) is backed by a matching expression index.
+CREATE TABLE fx_x2.contacts (
+  id uuid PRIMARY KEY,
+  email text NOT NULL
+);
+CREATE INDEX contacts_email_lower_idx ON fx_x2.contacts (lower(email));
+ALTER TABLE fx_x2.contacts ENABLE ROW LEVEL SECURITY;
+CREATE POLICY contacts_email ON fx_x2.contacts
+  USING (lower(email) = current_setting('jwt.claims.email', true));
+
+-- X4: policy calls a non-LEAKPROOF user function. fx_x2.is_admin() is
+-- LEAKPROOF and must not be flagged.
+CREATE TABLE fx_x2.memberships (
+  id uuid PRIMARY KEY,
+  tenant_id uuid NOT NULL
+);
+CREATE INDEX memberships_tenant_idx ON fx_x2.memberships (tenant_id);
+ALTER TABLE fx_x2.memberships ENABLE ROW LEVEL SECURITY;
+CREATE POLICY memberships_member ON fx_x2.memberships
+  USING (fx_x2.is_member(tenant_id) OR fx_x2.is_admin());

--- a/packages/safegres/__tests__/perf.test.ts
+++ b/packages/safegres/__tests__/perf.test.ts
@@ -108,6 +108,48 @@ describe('perf dimension', () => {
   });
 });
 
+describe('policy-aware perf rules', () => {
+  beforeAll(async () => {
+    await applyFixture('x2-policy-index.sql');
+  });
+
+  it('X2: flags policy columns that lead no index', async () => {
+    const report = await audit(pg.client as never, { schemas: ['fx_x2'], perf: true });
+    expect(tablesFor(report.perf!.findings, 'X2')).toEqual([
+      'fx_x2.documents',
+      'fx_x2.receipts'
+    ]);
+    const documents = report.perf!.findings.find((f) => f.code === 'X2' && f.table === 'documents');
+    expect(documents?.policy).toBe('documents_tenant');
+    expect(documents?.context).toMatchObject({ column: 'tenant_id', clause: 'USING' });
+  });
+
+  it('X2: is not raised when the policy column leads an index', async () => {
+    const report = await audit(pg.client as never, { schemas: ['fx_x2'], perf: true });
+    expect(tablesFor(report.perf!.findings, 'X2')).not.toContain('fx_x2.invoices');
+  });
+
+  it('X3: flags casts/functions on policy columns without a matching expression index', async () => {
+    const report = await audit(pg.client as never, { schemas: ['fx_x2'], perf: true });
+    expect(tablesFor(report.perf!.findings, 'X3')).toEqual(['fx_x2.accounts']);
+    const accounts = report.perf!.findings.find((f) => f.code === 'X3');
+    expect(accounts?.context).toMatchObject({ column: 'tenant_id', expression: 'tenant_id::text' });
+  });
+
+  it('X4: flags non-LEAKPROOF policy functions, not LEAKPROOF ones', async () => {
+    const report = await audit(pg.client as never, { schemas: ['fx_x2'], perf: true });
+    const x4 = report.perf!.findings.filter((f) => f.code === 'X4');
+    const functions = x4.map((f) => (f.context as { function: string }).function).sort();
+    expect(functions).toContain('fx_x2.is_member');
+    expect(functions).not.toContain('fx_x2.is_admin');
+  });
+
+  it('X2/X3/X4 stay off when perf is disabled', async () => {
+    const report = await audit(pg.client as never, { schemas: ['fx_x2'] });
+    expect(report.findings.filter((f) => ['X2', 'X3', 'X4'].includes(f.code))).toHaveLength(0);
+  });
+});
+
 describe('P1/P1b re-homed to the perf dimension', () => {
   it('keeps P1 out of the security score', async () => {
     await applyFixture('p1-volatile-func.sql');

--- a/packages/safegres/src/checks/policy-index.ts
+++ b/packages/safegres/src/checks/policy-index.ts
@@ -1,0 +1,290 @@
+/**
+ * Policy-aware performance checks (X2/X3/X4).
+ *
+ * These are the checks a generic index linter can't make: they read the RLS
+ * policy predicate and ask whether the *security* qual — the one Postgres
+ * evaluates first, on every candidate row, for every query against the table —
+ * can actually use an index.
+ *
+ * All three are static (catalog + AST only); no runtime statistics, no EXPLAIN.
+ */
+
+import { NodePath, walk } from '@pgsql/traverse';
+
+import type { PgAstNode } from '../ast/parse';
+import { columnRefPath, funcNameQualified } from '../ast/walk';
+import type { TableIndexSnapshot } from '../pg/indexes';
+import type { TableSnapshot } from '../pg/introspect';
+import type { ProcVolatility } from '../pg/proc';
+import type { Finding } from '../types';
+
+export type PolicyClause = 'USING' | 'WITH CHECK';
+
+/** A column of the policy's own table, as referenced by the policy predicate. */
+export interface PredicateColumn {
+  column: string;
+  clause: PolicyClause;
+  /**
+   * The cast type or function name wrapping the column reference, if any.
+   * `undefined` means the column is compared directly (index-usable).
+   */
+  wrappedBy?: string;
+  /** True when `wrappedBy` is a cast rather than a function call. */
+  isCast?: boolean;
+}
+
+/**
+ * Comparison-ish nodes worth indexing for. We deliberately ignore `IS NULL`,
+ * boolean tests and the like: an index rarely helps there, so flagging them
+ * would be noise.
+ */
+const COMPARISON_TAGS = new Set(['A_Expr', 'SubLink', 'NullTest', 'ScalarArrayOpExpr']);
+
+/**
+ * Collect the policy's own columns that participate in a comparison, along
+ * with any cast/function wrapping them.
+ *
+ * Only single-part column references (`tenant_id`) and references qualified
+ * with the table's own name/alias (`posts.tenant_id`) count — a column from a
+ * subquery's table belongs to that table's policies, not this one.
+ */
+export function collectPredicateColumns(
+  expr: PgAstNode,
+  clause: PolicyClause,
+  tableName: string
+): PredicateColumn[] {
+  const out: PredicateColumn[] = [];
+  const seen = new Set<string>();
+
+  walk(expr as object, (path: NodePath) => {
+    if (path.tag !== 'ColumnRef') return;
+
+    const parts = columnRefPath(path.node as Record<string, unknown>);
+    const column = ownColumnName(parts, tableName);
+    if (!column) return;
+
+    const { wrappedBy, isCast } = wrappingOf(path);
+    if (!inComparison(path)) return;
+
+    const key = `${clause}:${column}:${wrappedBy ?? ''}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    out.push({ column, clause, wrappedBy, isCast });
+  });
+
+  return out;
+}
+
+/**
+ * X2: a policy predicate compares a column that has no index with that column
+ * in the leading position, so the security qual degrades to a sequential scan
+ * on every query touching the table.
+ */
+export function checkUnindexedPolicyColumns(
+  table: TableSnapshot,
+  indexes: TableIndexSnapshot,
+  columns: Map<string, PredicateColumn[]>
+): Finding[] {
+  const out: Finding[] = [];
+  const leading = leadingColumns(indexes);
+
+  for (const [policyName, cols] of columns) {
+    const reported = new Set<string>();
+    for (const col of cols) {
+      // A wrapped column is X3's business — the raw column being indexed
+      // wouldn't help the wrapped comparison anyway.
+      if (col.wrappedBy) continue;
+      if (leading.has(col.column)) continue;
+      if (reported.has(col.column)) continue;
+      reported.add(col.column);
+
+      out.push({
+        code: 'X2',
+        severity: 'medium',
+        category: 'index',
+        schema: table.schema,
+        table: table.name,
+        policy: policyName,
+        message:
+          `Policy "${policyName}" on ${table.schema}.${table.name} filters by ${col.column}, which is not the leading column of any index`,
+        hint:
+          `RLS quals run before user quals on every row the planner considers, so an unindexed policy column forces a sequential scan for all callers. CREATE INDEX ON ${table.schema}.${table.name} (${col.column}).`,
+        context: { column: col.column, clause: col.clause }
+      });
+    }
+  }
+
+  return out;
+}
+
+/**
+ * X3: the policy wraps its own column in a cast or function call
+ * (`tenant_id::text = ...`, `lower(email) = ...`). A plain b-tree index on the
+ * bare column can't serve that comparison — it needs a matching expression
+ * index, or the cast should move to the other side of the operator.
+ */
+export function checkPolicyColumnCasts(
+  table: TableSnapshot,
+  indexes: TableIndexSnapshot,
+  columns: Map<string, PredicateColumn[]>
+): Finding[] {
+  const out: Finding[] = [];
+  const expressionDefs = indexes.indexes
+    .filter((i) => i.expression)
+    .map((i) => i.definition.toLowerCase());
+
+  for (const [policyName, cols] of columns) {
+    const reported = new Set<string>();
+    for (const col of cols) {
+      if (!col.wrappedBy) continue;
+      const key = `${col.column}:${col.wrappedBy}`;
+      if (reported.has(key)) continue;
+      reported.add(key);
+      if (expressionDefs.some((def) => defCovers(def, col))) continue;
+
+      const shape = col.isCast
+        ? `${col.column}::${col.wrappedBy}`
+        : `${col.wrappedBy}(${col.column})`;
+      out.push({
+        code: 'X3',
+        severity: 'medium',
+        category: 'index',
+        schema: table.schema,
+        table: table.name,
+        policy: policyName,
+        message:
+          `Policy "${policyName}" on ${table.schema}.${table.name} compares ${shape} — a plain index on ${col.column} cannot serve this`,
+        hint: col.isCast
+          ? `Cast the other side of the comparison instead, or add a matching expression index: CREATE INDEX ON ${table.schema}.${table.name} ((${shape})).`
+          : `Add a matching expression index: CREATE INDEX ON ${table.schema}.${table.name} ((${shape})).`,
+        context: { column: col.column, expression: shape, clause: col.clause }
+      });
+    }
+  }
+
+  return out;
+}
+
+/**
+ * X4: the policy predicate calls a non-LEAKPROOF function.
+ *
+ * Postgres assigns security quals a lower security level than user quals and
+ * will not push a non-leakproof qual below a join or subquery scan. The
+ * practical effect is that the policy filter is applied later and to more rows
+ * than necessary, and index scans on the underlying relation are given up.
+ *
+ * System functions are exempt: their leakproofness is a fixed property of the
+ * server, not something the schema author chose.
+ */
+export function checkNonLeakproofPolicyFunctions(
+  table: TableSnapshot,
+  expr: PgAstNode,
+  volatility: Map<string, ProcVolatility>,
+  policyName: string
+): Finding[] {
+  const out: Finding[] = [];
+  const seen = new Set<string>();
+
+  walk(expr as object, (path: NodePath) => {
+    if (path.tag !== 'FuncCall') return;
+    const qualified = funcNameQualified(path.node as Record<string, unknown>);
+    const bare = qualified.split('.').pop() ?? qualified;
+    const info = volatility.get(qualified) ?? volatility.get(bare);
+    if (!info) return;
+    if (info.isSystem) return;
+    if (info.isLeakproof) return;
+    if (seen.has(info.name)) return;
+    seen.add(info.name);
+
+    out.push({
+      code: 'X4',
+      severity: 'low',
+      category: 'index',
+      schema: table.schema,
+      table: table.name,
+      policy: policyName,
+      message:
+        `Policy "${policyName}" on ${table.schema}.${table.name} calls non-LEAKPROOF function ${info.name}`,
+      hint:
+        'Non-leakproof quals cannot be pushed below joins or subquery scans, so the policy filter is applied late and to more rows than necessary. If the function provably leaks nothing about its arguments (no error messages containing values), mark it LEAKPROOF.',
+      context: { function: info.name }
+    });
+  });
+
+  return out;
+}
+
+/** Columns that sit in the leading position of at least one index. */
+function leadingColumns(indexes: TableIndexSnapshot): Set<string> {
+  const out = new Set<string>();
+  for (const index of indexes.indexes) {
+    const first = index.columnNames[0];
+    if (first) out.add(first);
+  }
+  return out;
+}
+
+/**
+ * Resolve a column reference to a bare column name on `tableName`, or null if
+ * it belongs to another relation (or is `*`).
+ */
+function ownColumnName(parts: string[], tableName: string): string | null {
+  if (parts.length === 1) return parts[0] === '*' ? null : parts[0];
+  if (parts.length === 2 && parts[0] === tableName) return parts[1] === '*' ? null : parts[1];
+  return null;
+}
+
+/** Nearest enclosing cast or function call, if the column is wrapped by one. */
+function wrappingOf(path: NodePath): { wrappedBy?: string; isCast?: boolean } {
+  const parent = path.parent;
+  if (!parent) return {};
+
+  if (parent.tag === 'TypeCast') {
+    const typeName = castTypeName(parent.node as Record<string, unknown>);
+    return typeName ? { wrappedBy: typeName, isCast: true } : {};
+  }
+
+  if (parent.tag === 'FuncCall') {
+    return { wrappedBy: funcNameQualified(parent.node as Record<string, unknown>), isCast: false };
+  }
+
+  return {};
+}
+
+/** True when the column participates in a comparison rather than, say, a projection. */
+function inComparison(path: NodePath): boolean {
+  let cursor: NodePath | null = path.parent;
+  // Allow one or two wrapping levels (cast, function call) between the column
+  // and the comparison it feeds.
+  for (let depth = 0; cursor && depth < 3; depth++) {
+    if (COMPARISON_TAGS.has(cursor.tag)) return true;
+    cursor = cursor.parent;
+  }
+  return false;
+}
+
+function castTypeName(typeCast: Record<string, unknown>): string | null {
+  const typeName = typeCast.typeName as Record<string, unknown> | undefined;
+  if (!typeName) return null;
+  const names = typeName.names;
+  if (!Array.isArray(names) || names.length === 0) return null;
+  const last = names[names.length - 1] as Record<string, unknown>;
+  const str = (last.String ?? last.string) as Record<string, unknown> | undefined;
+  if (!str) return null;
+  const value = String((str.sval ?? str.str) ?? '');
+  return value.length > 0 ? value : null;
+}
+
+/**
+ * Heuristic match of an expression index definition against a wrapped column.
+ * `pg_get_indexdef` renders casts as `((col)::text)` and calls as `lower(col)`,
+ * so requiring both tokens is enough to avoid the common false positive
+ * without parsing the definition back into an AST.
+ */
+function defCovers(definitionLower: string, col: PredicateColumn): boolean {
+  const wrapper = (col.wrappedBy ?? '').toLowerCase();
+  const column = col.column.toLowerCase();
+  if (!wrapper) return false;
+  if (col.isCast) return definitionLower.includes(`::${wrapper}`) && definitionLower.includes(column);
+  return definitionLower.includes(`${wrapper}(`) && definitionLower.includes(column);
+}

--- a/packages/safegres/src/commands/audit.ts
+++ b/packages/safegres/src/commands/audit.ts
@@ -22,6 +22,13 @@ import {
   checkUnindexedForeignKeys
 } from '../checks/indexes';
 import {
+  checkNonLeakproofPolicyFunctions,
+  checkPolicyColumnCasts,
+  checkUnindexedPolicyColumns,
+  collectPredicateColumns,
+  type PredicateColumn
+} from '../checks/policy-index';
+import {
   checkGrantsWithoutRls,
   checkRlsEnabledNoPolicies,
   checkRlsNotForced
@@ -36,7 +43,7 @@ import { allAstRulesDisabled, applyRulesToFindings, matchTablePattern, resolveRu
 import type { ExposureConfig, SafegresConfig } from '../config/types';
 import { resolveExposure } from '../pg/exposure';
 import { introspectFunctions } from '../pg/functions';
-import { introspectIndexes } from '../pg/indexes';
+import { introspectIndexes, type TableIndexSnapshot } from '../pg/indexes';
 import { asExecutor, type IntrospectOptions, introspectTables, type QueryExecutor, type TableSnapshot } from '../pg/introspect';
 import { lookupVolatility, type ProcVolatility } from '../pg/proc';
 import { listAuditableRoles, resolveRoles } from '../pg/roles';
@@ -89,7 +96,9 @@ export async function audit(
   const exec = asExecutor(client);
   const config = options.config ?? {};
   const resolved = resolveRules(config);
-  const skipAst = options.skipAstChecks || allAstRulesDisabled(resolved);
+  const perfEnabled = options.perf ?? config.perf?.enabled ?? false;
+  const skipAst =
+    options.skipAstChecks || allAstRulesDisabled(resolved, { perf: perfEnabled });
 
   // Resolve role set.
   const allRoles = await listAuditableRoles(exec);
@@ -113,6 +122,17 @@ export async function audit(
     : snapshot.length;
 
   let findings: Finding[] = [];
+
+  // --- Performance dimension (opt-in): index hygiene ---
+  const indexSnapshot = perfEnabled
+    ? await introspectIndexes(exec, {
+      schemas: options.schemas ?? config.schemas,
+      excludeSchemas: options.excludeSchemas ?? config.excludeSchemas
+    })
+    : [];
+  const indexesByTable = new Map<string, TableIndexSnapshot>(
+    indexSnapshot.map((t) => [`${t.schema}.${t.name}`, t])
+  );
 
   for (const table of snapshot) {
     // --- RLS flags (structural) ---
@@ -139,19 +159,19 @@ export async function audit(
     );
     findings.push(...checkPublicGrants(table));
 
-    // --- AST-level anti-patterns ---
+    // --- AST-level anti-patterns (and, with perf on, policy-aware index rules) ---
     if (!skipAst) {
-      findings.push(...(await auditTableAst(exec, table)));
+      findings.push(
+        ...(await auditTableAst(
+          exec,
+          table,
+          perfEnabled ? indexesByTable.get(`${table.schema}.${table.name}`) : undefined
+        ))
+      );
     }
   }
 
-  // --- Performance dimension (opt-in): index hygiene ---
-  const perfEnabled = options.perf ?? config.perf?.enabled ?? false;
   if (perfEnabled) {
-    const indexSnapshot = await introspectIndexes(exec, {
-      schemas: options.schemas ?? config.schemas,
-      excludeSchemas: options.excludeSchemas ?? config.excludeSchemas
-    });
     for (const table of indexSnapshot) {
       findings.push(...checkUnindexedForeignKeys(table));
       findings.push(...checkRedundantIndexes(table));
@@ -269,7 +289,8 @@ export async function audit(
 
 async function auditTableAst(
   exec: QueryExecutor,
-  table: TableSnapshot
+  table: TableSnapshot,
+  indexes?: TableIndexSnapshot
 ): Promise<Finding[]> {
   if (table.policies.length === 0) return [];
 
@@ -298,6 +319,8 @@ async function auditTableAst(
   }
 
   const findings: Finding[] = [];
+  const predicateColumns = new Map<string, PredicateColumn[]>();
+
   for (const { policy, using, withCheck } of parsed) {
     const trivial = checkTriviallyPermissive(table, policy, using, withCheck);
     if (trivial) findings.push(trivial);
@@ -309,6 +332,25 @@ async function auditTableAst(
       findings.push(...checkVolatileFunctions(table, withCheck, volatility, policy.name));
       findings.push(...checkSessionUserGating(table, withCheck, policy.name));
     }
+
+    if (!indexes) continue;
+
+    // --- Policy-aware perf rules (X2/X3/X4) ---
+    const cols: PredicateColumn[] = [];
+    if (using) {
+      cols.push(...collectPredicateColumns(using, 'USING', table.name));
+      findings.push(...checkNonLeakproofPolicyFunctions(table, using, volatility, policy.name));
+    }
+    if (withCheck) {
+      cols.push(...collectPredicateColumns(withCheck, 'WITH CHECK', table.name));
+      findings.push(...checkNonLeakproofPolicyFunctions(table, withCheck, volatility, policy.name));
+    }
+    if (cols.length > 0) predicateColumns.set(policy.name, cols);
+  }
+
+  if (indexes && predicateColumns.size > 0) {
+    findings.push(...checkUnindexedPolicyColumns(table, indexes, predicateColumns));
+    findings.push(...checkPolicyColumnCasts(table, indexes, predicateColumns));
   }
 
   return dedupe(findings);

--- a/packages/safegres/src/config/resolve.ts
+++ b/packages/safegres/src/config/resolve.ts
@@ -201,9 +201,20 @@ export function applyRulesToFindings(resolved: ResolvedRules, findings: Finding[
   return out;
 }
 
-/** True when every AST-scoped rule is disabled (lets the audit skip parsing). */
-export function allAstRulesDisabled(resolved: ResolvedRules): boolean {
-  const astCodes = RULES.filter((r) => r.scope === 'policy-ast').map((r) => r.code);
+/**
+ * True when every AST-scoped rule is disabled (lets the audit skip parsing).
+ *
+ * The policy-aware index rules (X2–X4) are AST-scoped but only run when the
+ * perf dimension is on, so they hold parsing open only in that mode.
+ */
+export function allAstRulesDisabled(
+  resolved: ResolvedRules,
+  options: { perf?: boolean } = {}
+): boolean {
+  const astCodes = RULES
+    .filter((r) => r.scope === 'policy-ast')
+    .filter((r) => options.perf || r.category !== 'index')
+    .map((r) => r.code);
   const base = astCodes.every((code) => resolved.rules.get(code)?.enabled === false);
   if (!base) return false;
   // An override could re-enable an AST rule for some table.

--- a/packages/safegres/src/index.ts
+++ b/packages/safegres/src/index.ts
@@ -31,6 +31,13 @@ export {
   checkRedundantIndexes,
   checkUnindexedForeignKeys
 } from './checks/indexes';
+export type { PolicyClause, PredicateColumn } from './checks/policy-index';
+export {
+  checkNonLeakproofPolicyFunctions,
+  checkPolicyColumnCasts,
+  checkUnindexedPolicyColumns,
+  collectPredicateColumns
+} from './checks/policy-index';
 export type { RoleTrustOptions } from './checks/role-trust';
 export {
   checkPublicGrants,

--- a/packages/safegres/src/pg/proc.ts
+++ b/packages/safegres/src/pg/proc.ts
@@ -8,6 +8,8 @@ export interface ProcVolatility {
   name: string;
   volatility: Volatility;
   isSecurityDefiner: boolean;
+  /** `pg_proc.proleakproof` — a leakproof function can be pushed below a security qual. */
+  isLeakproof: boolean;
   /** True if this is a built-in / system function (we usually allow-list these). */
   isSystem: boolean;
 }
@@ -44,13 +46,15 @@ export async function lookupVolatility(
     proname: string;
     volatility: Volatility;
     security_definer: boolean;
+    leakproof: boolean;
   }>(
     `
     SELECT
       n.nspname     AS schema,
       p.proname     AS proname,
       p.provolatile AS volatility,
-      p.prosecdef   AS security_definer
+      p.prosecdef   AS security_definer,
+      p.proleakproof AS leakproof
     FROM pg_proc p
     JOIN pg_namespace n ON n.oid = p.pronamespace
     WHERE (n.nspname, p.proname) IN (
@@ -69,6 +73,7 @@ export async function lookupVolatility(
       name: `${r.schema}.${r.proname}`,
       volatility: r.volatility,
       isSecurityDefiner: r.security_definer,
+      isLeakproof: r.leakproof,
       isSystem: SYSTEM_SCHEMAS.has(r.schema)
     };
     map.set(`${r.schema}.${r.proname}`, info);

--- a/packages/safegres/src/rules/registry.ts
+++ b/packages/safegres/src/rules/registry.ts
@@ -168,6 +168,33 @@ export const RULES: RuleMeta[] = [
     scope: 'index'
   },
   {
+    code: 'X2',
+    category: 'index',
+    defaultSeverity: 'medium',
+    direction: 'neutral',
+    dimension: 'perf',
+    title: 'RLS policy filters on a column that is not the leading column of any index',
+    scope: 'policy-ast'
+  },
+  {
+    code: 'X3',
+    category: 'index',
+    defaultSeverity: 'medium',
+    direction: 'neutral',
+    dimension: 'perf',
+    title: 'RLS policy casts or wraps its own column, defeating a plain index',
+    scope: 'policy-ast'
+  },
+  {
+    code: 'X4',
+    category: 'index',
+    defaultSeverity: 'low',
+    direction: 'neutral',
+    dimension: 'perf',
+    title: 'RLS policy calls a non-LEAKPROOF function, blocking qual pushdown',
+    scope: 'policy-ast'
+  },
+  {
     code: 'X5',
     category: 'index',
     defaultSeverity: 'low',


### PR DESCRIPTION
## Summary

Phase 2 of the perf dimension (plan: constructive-io/constructive-planning#1328; Phase 1: #1543). These are the three checks a generic index linter structurally cannot make, because they require reading the RLS policy predicate: the security qual is evaluated *before* user quals, on every candidate row, for every caller — so an unindexed policy column is a tax on the whole table, not one slow query.

Still off by default (`--perf` / `perf.enabled`), still scored only into `report.perf.score`.

| Code | Sev | Check |
| --- | --- | --- |
| X2 | medium | Policy compares a column of its own table that is not the **leading** column of any index |
| X3 | medium | Policy wraps its own column in a cast or function (`tenant_id::text = …`, `lower(email) = …`) with no matching expression index |
| X4 | low | Policy calls a non-LEAKPROOF **user** function — the qual can't be pushed below joins/subquery scans, so filtering happens late and on more rows |

### How it works

`src/checks/policy-index.ts` walks the already-parsed USING / WITH CHECK AST (no second parse, no extra round trip) and collects the predicate's *own* columns:

```ts
collectPredicateColumns(usingAst, 'USING', table.name)
// → [{ column: 'tenant_id', clause: 'USING', wrappedBy: 'text', isCast: true }]
```

- Only `col` and `table.col` count — a column belonging to a subquery's relation is that table's policies' problem, not this one's.
- A reference must feed a comparison (`A_Expr` / `SubLink` / `ScalarArrayOpExpr` / `NullTest`) within a couple of wrapping levels; projections aren't index-relevant.
- Wrapped columns route to X3 and never X2: indexing the bare column wouldn't serve the wrapped comparison anyway.
- X3 clears a finding when an expression index matches the wrapped shape. `pg_get_indexdef` renders `((col)::text)` / `lower(col)`, so requiring both tokens kills the common false positive without re-parsing the definition back into an AST.
- X4 exempts system functions — their leakproofness is a property of the server, not a schema choice. `pg_proc.proleakproof` now rides along on `ProcVolatility.isLeakproof` (additive field on the batched lookup P1 already performs).

`auditTableAst` receives the per-table index snapshot only when perf is on, so a security-only audit is unchanged and does no extra catalog work.

One subtlety: X2–X4 are `policy-ast` scoped, so they would otherwise defeat the "all AST rules off ⇒ skip parsing" fast path for people who never asked for perf. Hence:

```diff
-export function allAstRulesDisabled(resolved: ResolvedRules): boolean {
-  const astCodes = RULES.filter((r) => r.scope === 'policy-ast')…
+export function allAstRulesDisabled(resolved, options: { perf?: boolean } = {}) {
+  const astCodes = RULES.filter((r) => r.scope === 'policy-ast')
+    .filter((r) => options.perf || r.category !== 'index')…
```

### Tests

`__tests__/fixtures/x2-policy-index.sql` covers each rule's positive *and* negative case: indexed policy column, trailing-position-only index (still X2 — the index can't serve the qual alone), cast without an expression index vs `lower(email)` with one, LEAKPROOF vs non-LEAKPROOF function, and everything silent when perf is off. 92 tests pass in `packages/safegres`; `tsc --noEmit` clean.

Repo-wide `pnpm lint` remains broken independently of this change (ESLint 9 installed, repo still on legacy `.eslintrc`).

### Follow-ups

Unchanged from the plan: X7/X8 (Constructive search smart-tags, exposed sort/pagination), opt-in S1–S4 runtime stats, `--explain` proof mode, and migrating `constructive-db/application/app-performance` onto a safegres baseline/ratchet.


Link to Devin session: https://app.devin.ai/sessions/ec06ef6eabae4872ae5ec3926f037c85
Requested by: @pyramation