### PR TITLE
feat(safegres): perf baseline ratchet (fail only on new performance debt)

### DIFF
--- a/.agents/skills/safegres/SKILL.md
+++ b/.agents/skills/safegres/SKILL.md
@@ -119,6 +119,17 @@ X2/X3/X4 read the policy predicate itself: RLS quals run before user quals on ev
 }
 ```
 
+### Perf baseline (ratchet)
+
+An existing schema won't be perf-clean on day one, so gate on *new* debt instead of total debt:
+
+```bash
+safegres audit --write-perf-baseline .safegres-perf.json          # snapshot accepted debt (implies --perf)
+safegres audit --perf-baseline .safegres-perf.json --fail-on-new-perf   # exit 1 only on new findings
+```
+
+Entries are keyed by code + relation + policy + subject (constraint/index/expression/column/function), never by message text, so safegres upgrades don't invalidate a committed baseline. Fixed findings are reported so you can re-baseline and stop them regressing. Library: `toPerfBaseline(findings)` / `diffPerf(findings, baseline)` → `{ added, removed, accepted }`; also emitted as `report.perf.diff`. Prefer this over asserting a perf grade in a test — it fails on the change, not on inherited debt.
+
 ### Presets
 
 | Preset | Behavior |
@@ -197,6 +208,7 @@ score = 100 · exp(−k · riskPoints / exposedTables)
 safegres audit                     # audit the connected DB (default command)
 safegres perf                      # audit + index-hygiene dimension (= audit --perf)
 safegres audit --perf --fail-on-perf-grade B
+safegres audit --perf-baseline .safegres-perf.json --fail-on-new-perf   # ratchet: only new debt fails
 safegres audit --format json       # machine-readable
 safegres audit --exposed-only      # hide internal advisories
 safegres doctor                    # config/parser/connection/catalog + exposure + stale public.read checks

--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -138,6 +138,26 @@ safegres audit --database mydb --perf --fail-on-perf-grade B
 
 Tables matched by `perf.ignore` are acknowledged — reported as info, excluded from the perf score — the same way `public.read` works for open reads. Perf findings live in `report.findings` alongside the security ones (so `--fail-on <severity>` still sees them), but only they feed `report.perf.score`, and only security findings feed `report.score`.
 
+### Perf baseline (the ratchet)
+
+An established schema will not reach a clean perf report in one pass — but it can refuse to get worse. Commit today's findings as accepted debt, then gate CI on findings that are *not* in the baseline:
+
+```bash
+safegres audit --write-perf-baseline .safegres-perf.json          # snapshot (implies --perf)
+safegres audit --perf-baseline .safegres-perf.json                # diff: new vs accepted vs fixed
+safegres audit --perf-baseline .safegres-perf.json --fail-on-new-perf   # gate: exit 1 on new debt
+```
+
+```
+performance vs baseline:
+
+1 new perf finding since the baseline:
+  [medium] X1 app_public.comments — foreign key with no covering index
+  (14 accepted, 2 fixed)
+```
+
+Entries are identified by `code` + relation + policy + subject (the constraint, index, expression, column, or function the finding is about), so rewording a message or retuning a severity between safegres versions never invalidates a committed baseline, and two findings of the same code on the same table stay distinct. Findings that disappear are reported as fixed — re-run `--write-perf-baseline` to lock the win in and stop them regressing silently. The diff is also carried in JSON output as `perf.diff`, and available to library callers as `diffPerf(findings, baseline)`.
+
 ## Call graph (`--call-graph`)
 
 RLS findings tell you what the *tables* allow. The call graph tells you what the *functions* reach: starting from the exposed entry points (functions the API roles can `EXECUTE`), safegres statically walks each body and lists every **trust boundary** on the way — unscored, because a public `SECURITY DEFINER` calling private functions is the intended pattern (that's how `sign_in` works). The output is a deterministic checklist for human review:

--- a/packages/safegres/__tests__/perf-baseline.test.ts
+++ b/packages/safegres/__tests__/perf-baseline.test.ts
@@ -1,0 +1,92 @@
+import {
+  diffPerf,
+  findingKey,
+  parsePerfBaseline,
+  serializePerfBaseline,
+  subjectOf,
+  toPerfBaseline
+} from '../src/perf/baseline';
+import type { Finding } from '../src/types';
+
+function finding(over: Partial<Finding> = {}): Finding {
+  return {
+    code: 'X1',
+    severity: 'medium',
+    category: 'index',
+    schema: 'app_public',
+    table: 'posts',
+    message: 'foreign key with no covering index',
+    dimension: 'perf',
+    ...over
+  };
+}
+
+describe('perf baseline', () => {
+  it('identifies findings by code + relation + policy + subject, not by message', () => {
+    const before = finding({ context: { constraint: 'posts_author_id_fkey' } });
+    const after = finding({
+      message: 'reworded in a later safegres release',
+      severity: 'high',
+      context: { constraint: 'posts_author_id_fkey' }
+    });
+    expect(findingKey(toPerfBaseline([before]).findings[0]))
+      .toBe(findingKey(toPerfBaseline([after]).findings[0]));
+    expect(diffPerf([after], toPerfBaseline([before])).added).toHaveLength(0);
+  });
+
+  it('separates two findings of the same code on the same table', () => {
+    const a = finding({ context: { constraint: 'posts_author_id_fkey' } });
+    const b = finding({ context: { constraint: 'posts_org_id_fkey' } });
+    const baseline = toPerfBaseline([a]);
+    const diff = diffPerf([a, b], baseline);
+    expect(diff.added).toEqual([b]);
+    expect(diff.accepted).toEqual([a]);
+    expect(diff.removed).toHaveLength(0);
+  });
+
+  it('reports baseline entries that no longer occur as fixed', () => {
+    const a = finding({ context: { constraint: 'posts_author_id_fkey' } });
+    const diff = diffPerf([], toPerfBaseline([a]));
+    expect(diff.added).toHaveLength(0);
+    expect(diff.removed).toEqual([
+      { code: 'X1', schema: 'app_public', table: 'posts', subject: 'posts_author_id_fkey' }
+    ]);
+  });
+
+  it('keys policy-scoped findings by policy', () => {
+    const x2a = finding({ code: 'X2', policy: 'posts_tenant', context: { column: 'tenant_id' } });
+    const x2b = finding({ code: 'X2', policy: 'posts_author', context: { column: 'tenant_id' } });
+    expect(diffPerf([x2a, x2b], toPerfBaseline([x2a])).added).toEqual([x2b]);
+  });
+
+  it('derives the subject from the rule-specific context key', () => {
+    expect(subjectOf(finding({ context: { index: 'posts_tenant_idx' } }))).toBe('posts_tenant_idx');
+    expect(subjectOf(finding({ context: { column: 'tenant_id' } }))).toBe('tenant_id');
+    // X3 carries both — the expression is the narrower identity.
+    expect(subjectOf(finding({ context: { column: 'tenant_id', expression: 'tenant_id::text' } })))
+      .toBe('tenant_id::text');
+    // X6 fires at most once per relation, so it needs no subject.
+    expect(subjectOf(finding({ code: 'X6', context: { replicaIdentity: 'd' } }))).toBeUndefined();
+    expect(subjectOf(finding())).toBeUndefined();
+  });
+
+  it('round-trips deterministically through JSON', () => {
+    const findings = [
+      finding({ context: { constraint: 'b_fkey' } }),
+      finding({ table: 'aaa', context: { constraint: 'a_fkey' } })
+    ];
+    const serialized = serializePerfBaseline(toPerfBaseline(findings));
+    expect(serialized.endsWith('\n')).toBe(true);
+    const reparsed = parsePerfBaseline(serialized);
+    expect(reparsed).toEqual(toPerfBaseline(findings));
+    // Sorted by key, so re-running the audit can't churn the committed file.
+    expect(reparsed.findings.map((f) => f.table)).toEqual(['aaa', 'posts']);
+    // Duplicate findings collapse to one entry.
+    expect(toPerfBaseline([findings[0], findings[0]]).findings).toHaveLength(1);
+  });
+
+  it('rejects a malformed baseline file', () => {
+    expect(() => parsePerfBaseline('{"version":2,"findings":[]}')).toThrow(/invalid perf baseline/);
+    expect(() => parsePerfBaseline('{"version":1}')).toThrow(/invalid perf baseline/);
+  });
+});

--- a/packages/safegres/__tests__/perf.test.ts
+++ b/packages/safegres/__tests__/perf.test.ts
@@ -4,6 +4,7 @@ import { getConnections, PgTestClient } from 'pgsql-test';
 
 import { audit } from '../src/commands/audit';
 import { ConfigValidationError, resolveRules } from '../src/config/resolve';
+import { diffPerf, toBaselineFinding, toPerfBaseline } from '../src/perf/baseline';
 import type { Finding } from '../src/types';
 
 jest.setTimeout(120000);
@@ -158,5 +159,23 @@ describe('P1/P1b re-homed to the perf dimension', () => {
     expect(p1?.dimension).toBe('perf');
     expect(report.perf!.findings).toContain(p1);
     expect(report.score!.deductions.some((d) => d.code === 'P1')).toBe(false);
+  });
+});
+
+describe('perf baseline ratchet', () => {
+  it('accepts committed debt and flags only what is new', async () => {
+    const report = await audit(pg.client as never, { schemas: ['fx_x1'], perf: true });
+    const findings = report.perf!.findings;
+    expect(findings.length).toBeGreaterThan(1);
+
+    const full = toPerfBaseline(findings);
+    expect(diffPerf(findings, full).added).toHaveLength(0);
+    expect(diffPerf(findings, full).accepted).toHaveLength(findings.length);
+
+    // A baseline missing one entry is what "someone added new debt" looks like.
+    const partial = { ...full, findings: full.findings.slice(1) };
+    const diff = diffPerf(findings, partial);
+    expect(diff.added).toHaveLength(1);
+    expect(toBaselineFinding(diff.added[0])).toEqual(full.findings[0]);
   });
 });

--- a/packages/safegres/src/cli/audit.ts
+++ b/packages/safegres/src/cli/audit.ts
@@ -6,6 +6,7 @@ import { diffCallGraph, parseBaseline, serializeBaseline, toBaseline } from '../
 import { audit, type AuditOptions } from '../commands/audit';
 import { loadConfig } from '../config/loader';
 import type { Grade } from '../config/types';
+import { diffPerf, parsePerfBaseline, serializePerfBaseline, toPerfBaseline } from '../perf/baseline';
 import { renderJson } from '../report/json';
 import { renderPretty } from '../report/pretty';
 import { meetsGrade } from '../score/score';
@@ -60,10 +61,17 @@ Exposure (what the score is computed against):
   --exposed-only           Hide internal (non-exposed) findings from output
 
 Performance dimension (optional; scored separately from security):
-  --perf                   Also audit index hygiene (X1/X5/X6) and score it on
-                           its own 0-100 axis (report.perf)
+  --perf                   Also audit index hygiene (X1/X5/X6), policy-aware
+                           index coverage (X2/X3/X4) and policy cost (P1/P1b),
+                           scored on its own 0-100 axis (report.perf)
   --fail-on-perf-score <n> Exit non-zero if the perf score is below n (0-100)
   --fail-on-perf-grade <g> Exit non-zero if the perf grade is below g (A+|A|B|C|D)
+  --write-perf-baseline <file>
+                           Snapshot today's perf findings to <file> as accepted
+                           debt (implies --perf)
+  --perf-baseline <file>   Diff perf findings against a committed baseline and
+                           report only NEW debt (implies --perf)
+  --fail-on-new-perf       Exit non-zero when --perf-baseline finds new debt
 
 Call graph (unscored; human review):
   --call-graph             Analyze the functions reachable from the exposed entry
@@ -116,7 +124,12 @@ export default async (
     includeRoles: csvList(argv.roles),
     excludeRoles: csvList(argv['exclude-roles']),
     skipAstChecks: argv['skip-ast'] === true,
-    perf: argv.perf === true ? true : undefined,
+    perf:
+      argv.perf === true
+      || typeof argv['perf-baseline'] === 'string'
+      || typeof argv['write-perf-baseline'] === 'string'
+        ? true
+        : undefined,
     callGraph:
       argv['call-graph'] === true
       || typeof argv.baseline === 'string'
@@ -144,6 +157,27 @@ export default async (
   if (typeof argv['write-baseline'] === 'string' && report.callGraph) {
     fs.writeFileSync(argv['write-baseline'], serializeBaseline(toBaseline(report.callGraph)));
     log.info(`wrote call-graph baseline: ${argv['write-baseline']}`);
+  }
+
+  if (typeof argv['write-perf-baseline'] === 'string' && report.perf) {
+    fs.writeFileSync(
+      argv['write-perf-baseline'],
+      serializePerfBaseline(toPerfBaseline(report.perf.findings))
+    );
+    log.info(`wrote perf baseline: ${argv['write-perf-baseline']}`);
+  }
+
+  if (typeof argv['perf-baseline'] === 'string' && report.perf) {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(argv['perf-baseline'], 'utf8');
+    } catch {
+      log.error(
+        `cannot read --perf-baseline file: ${argv['perf-baseline']} (create one with --write-perf-baseline)`
+      );
+      process.exit(2);
+    }
+    report.perf.diff = diffPerf(report.perf.findings, parsePerfBaseline(raw));
   }
 
   if (typeof argv.baseline === 'string' && report.callGraph) {
@@ -226,6 +260,14 @@ export default async (
       : config.failOn?.perfGrade;
   if (failOnPerfGrade && report.perf && !meetsGrade(report.perf.score.grade, failOnPerfGrade)) {
     log.error(`perf grade ${report.perf.score.grade} is below --fail-on-perf-grade ${failOnPerfGrade}`);
+    process.exit(1);
+  }
+
+  if (argv['fail-on-new-perf'] === true && report.perf?.diff && report.perf.diff.added.length > 0) {
+    const count = report.perf.diff.added.length;
+    log.error(
+      `${count} new performance finding${count === 1 ? '' : 's'} since the perf baseline — fix them, or re-baseline with --write-perf-baseline to accept`
+    );
     process.exit(1);
   }
 

--- a/packages/safegres/src/index.ts
+++ b/packages/safegres/src/index.ts
@@ -89,6 +89,16 @@ export {
   type TableSnapshot
 } from './pg/introspect';
 export { listAuditableRoles, resolveRoles } from './pg/roles';
+export type { BaselineFinding, PerfBaseline, PerfDiff } from './perf/baseline';
+export {
+  diffPerf,
+  findingKey,
+  parsePerfBaseline,
+  serializePerfBaseline,
+  subjectOf,
+  toBaselineFinding,
+  toPerfBaseline
+} from './perf/baseline';
 export { renderCallGraph, renderCallGraphDiff } from './report/callgraph';
 export { renderJson } from './report/json';
 export { renderPretty } from './report/pretty';

--- a/packages/safegres/src/perf/baseline.ts
+++ b/packages/safegres/src/perf/baseline.ts
@@ -1,0 +1,113 @@
+/**
+ * Perf baseline: a committed snapshot of accepted performance debt.
+ *
+ * The point is the ratchet. A large schema will not reach a clean perf report
+ * in one pass, but it can refuse to get worse: commit the current findings,
+ * then fail CI only on findings that are *not* in the baseline.
+ *
+ * Only the identity of a finding is stored — code, relation, policy, and the
+ * one context field that distinguishes findings of the same code on the same
+ * relation. Messages, severities and hints may be reworded between safegres
+ * versions without invalidating a committed baseline.
+ */
+
+import type { Finding } from '../types';
+
+export interface PerfBaseline {
+  version: 1;
+  findings: BaselineFinding[];
+}
+
+export interface BaselineFinding {
+  code: string;
+  schema?: string;
+  table?: string;
+  policy?: string;
+  /** The rule-specific subject: constraint, index, column, expression, or function. */
+  subject?: string;
+}
+
+export interface PerfDiff {
+  /** Findings present now but absent from the baseline — new debt. */
+  added: Finding[];
+  /** Baseline entries no longer produced — fixed, or the relation is gone. */
+  removed: BaselineFinding[];
+  /** Findings that matched the baseline — accepted debt, still reported. */
+  accepted: Finding[];
+}
+
+/**
+ * Context keys that identify *which* object a finding is about, in priority
+ * order (X3 carries both `expression` and `column`; the expression is the
+ * narrower identity). Rules that can only fire once per relation — X6 — set
+ * none of these and are keyed by code + relation alone.
+ */
+const SUBJECT_KEYS = ['constraint', 'index', 'expression', 'column', 'function'] as const;
+
+export function subjectOf(finding: Finding): string | undefined {
+  const context = finding.context;
+  if (!context) return undefined;
+  for (const key of SUBJECT_KEYS) {
+    const value = context[key];
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+export function findingKey(entry: BaselineFinding): string {
+  return [entry.code, entry.schema ?? '', entry.table ?? '', entry.policy ?? '', entry.subject ?? ''].join('|');
+}
+
+export function toBaselineFinding(finding: Finding): BaselineFinding {
+  const subject = subjectOf(finding);
+  return {
+    code: finding.code,
+    ...(finding.schema ? { schema: finding.schema } : {}),
+    ...(finding.table ? { table: finding.table } : {}),
+    ...(finding.policy ? { policy: finding.policy } : {}),
+    ...(subject ? { subject } : {})
+  };
+}
+
+export function toPerfBaseline(findings: Finding[]): PerfBaseline {
+  const seen = new Set<string>();
+  const out: BaselineFinding[] = [];
+  for (const finding of findings) {
+    const entry = toBaselineFinding(finding);
+    const key = findingKey(entry);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(entry);
+  }
+  out.sort((a, b) => findingKey(a).localeCompare(findingKey(b)));
+  return { version: 1, findings: out };
+}
+
+export function diffPerf(findings: Finding[], baseline: PerfBaseline): PerfDiff {
+  const baseKeys = new Set(baseline.findings.map(findingKey));
+  const currentKeys = new Set<string>();
+
+  const added: Finding[] = [];
+  const accepted: Finding[] = [];
+  for (const finding of findings) {
+    const key = findingKey(toBaselineFinding(finding));
+    currentKeys.add(key);
+    if (baseKeys.has(key)) accepted.push(finding);
+    else added.push(finding);
+  }
+
+  const removed = baseline.findings.filter((entry) => !currentKeys.has(findingKey(entry)));
+  return { added, removed, accepted };
+}
+
+export function parsePerfBaseline(raw: string): PerfBaseline {
+  const data = JSON.parse(raw) as Partial<PerfBaseline>;
+  if (data.version !== 1 || !Array.isArray(data.findings)) {
+    throw new Error('invalid perf baseline: expected { version: 1, findings: [...] }');
+  }
+  return { version: 1, findings: data.findings as BaselineFinding[] };
+}
+
+export function serializePerfBaseline(baseline: PerfBaseline): string {
+  return JSON.stringify(baseline, null, 2) + '\n';
+}

--- a/packages/safegres/src/report/pretty.ts
+++ b/packages/safegres/src/report/pretty.ts
@@ -125,6 +125,25 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
     lines.push('no findings.');
   }
 
+  if (report.perf?.diff) {
+    const { added, removed, accepted } = report.perf.diff;
+    lines.push('', 'performance vs baseline:', '');
+    if (added.length === 0) {
+      lines.push(`no new perf debt (${accepted.length} accepted, ${removed.length} fixed).`);
+    } else {
+      lines.push(
+        paint('high', `${added.length} new perf finding${added.length === 1 ? '' : 's'} since the baseline:`)
+      );
+      for (const f of added) lines.push(renderFinding(f, paint));
+      lines.push(paint('info', `  (${accepted.length} accepted, ${removed.length} fixed)`));
+    }
+    if (removed.length > 0) {
+      lines.push(
+        paint('info', `  fixed since the baseline: ${removed.map((r) => `${r.code} ${r.schema}.${r.table}`).join(', ')} — re-baseline to lock the win in`)
+      );
+    }
+  }
+
   if (report.perf) {
     const perfExposed = report.perf.findings.filter((f) => f.exposed !== false);
     const perfInternal = report.perf.findings.length - perfExposed.length;

--- a/packages/safegres/src/types.ts
+++ b/packages/safegres/src/types.ts
@@ -104,6 +104,11 @@ export interface PerfReport {
   summary: Summary;
   /** Perf score — computed only over perf-dimension findings. */
   score: import('./score/score').Score;
+  /**
+   * Diff against a committed perf baseline (`--perf-baseline`): which findings
+   * are new debt, which were fixed, which are accepted.
+   */
+  diff?: import('./perf/baseline').PerfDiff;
 }
 
 export interface Report {


### PR DESCRIPTION
## Summary

A real schema won't be perf-clean on day one, so `--fail-on-perf-grade` is unusable as a gate on an established database — it fails on inherited debt forever. This adds the ratchet: commit today's perf findings as accepted debt, then fail CI only on findings that aren't in the baseline. It's the mechanism that lets constructive-db's always-passing `fk_missing_indexes.json` artifact become an actual check.

```bash
safegres audit --write-perf-baseline .safegres-perf.json          # snapshot (implies --perf)
safegres audit --perf-baseline .safegres-perf.json                # diff
safegres audit --perf-baseline .safegres-perf.json --fail-on-new-perf   # gate
```

New `src/perf/baseline.ts`, deliberately mirroring the existing call-graph baseline (`toBaseline`/`diffCallGraph`/`parseBaseline`) so the two ratchets read the same:

```ts
diffPerf(findings, baseline) -> { added: Finding[], removed: BaselineFinding[], accepted: Finding[] }
```

The only interesting design decision is the identity key. Findings are keyed by `code | schema | table | policy | subject` and *not* by message, severity, or hint — so rewording a rule message or retuning a severity in a later safegres release can't invalidate a committed baseline. `subject` is the one context field naming the object the finding is about, resolved in priority order:

```ts
const SUBJECT_KEYS = ['constraint', 'index', 'expression', 'column', 'function'];
```

That keeps two findings of the same code on the same table distinct (`X1 posts_author_id_fkey` vs `X1 posts_org_id_fkey`), and picks the narrower identity for X3, which carries both `expression` and `column`. X6 sets none of them, which is correct — it can only fire once per relation. Baseline entries are deduped and sorted by key so re-running the audit never churns the committed file.

Findings that disappear come back as `removed` rather than being ignored, and the pretty output nudges you to re-baseline so a fixed index can't silently regress. The diff is carried in JSON as `perf.diff` and exported for library callers (`toPerfBaseline`, `diffPerf`, `parsePerfBaseline`, `serializePerfBaseline`).

`--write-perf-baseline` / `--perf-baseline` imply `--perf`; nothing changes when perf is off.

## Testing

`100` tests pass (`12` suites) — 8 new, covering key stability across rewording, same-code-same-table separation, fixed detection, policy-scoped keying, subject priority, deterministic JSON round-trip, malformed-file rejection, and an end-to-end ratchet over a real audit of the X1 fixture.

Repo-wide `pnpm lint` remains broken independently of this change (ESLint 9 vs the repo's legacy `.eslintrc.json`).

## Follow-ups

Next in the plan issue (constructive-planning#1328): retire `constructive-db/application/app-performance/__tests__/fk_indexes.test.ts` onto this baseline, then X7/X8 (search smart-tags, exposed sort/pagination), opt-in runtime stats S1–S4, and `--explain` proof mode.


Link to Devin session: https://app.devin.ai/sessions/ec06ef6eabae4872ae5ec3926f037c85
Requested by: @pyramation