### PR TITLE
ci: npm Trusted Publishing (OIDC) via manually-gated npm-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -1,0 +1,63 @@
+name: npm-publish
+
+# Publishes all workspace packages whose package.json version is not yet on
+# the npm registry, using npm Trusted Publishing (OIDC) — no NPM_TOKEN.
+#
+# Release flow:
+#   1. Version + tag locally:  pnpm lerna version
+#   2. Trigger this workflow (workflow_dispatch), approve the `npm-publish`
+#      environment gate, and it publishes everything not yet on the registry.
+#
+# npm side (per package): Settings -> Trusted Publisher ->
+#   GitHub Actions, repository `constructive-io/constructive`,
+#   workflow `npm-publish.yaml`, environment `npm-publish`.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dist-tag:
+        description: npm dist-tag to publish under
+        required: false
+        default: latest
+      dry-run:
+        description: Dry run (no packages are published)
+        type: boolean
+        default: false
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    permissions:
+      id-token: write # required for npm Trusted Publishing (OIDC)
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Publish
+        run: >
+          pnpm publish -r
+          --tag "${{ inputs.dist-tag || 'latest' }}"
+          --no-git-checks
+          ${{ inputs.dry-run == true && '--dry-run' || '' }}

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -1,6 +1,72 @@
-## publishing
+# Publishing
 
+Packages are published to npm via [Trusted Publishing (OIDC)](https://docs.npmjs.com/trusted-publishers)
+from the [`npm-publish` workflow](.github/workflows/npm-publish.yaml). No npm
+tokens are used anywhere — GitHub Actions proves its identity to npm with a
+short-lived OIDC token, and npm only accepts publishes from the exact
+repository + workflow + environment configured per package. Every publish
+also gets provenance attestations automatically.
+
+## Release flow
+
+1. Version and tag locally (from `main`):
+
+   ```bash
+   pnpm install
+   pnpm lerna version
+   ```
+
+   This bumps versions with conventional commits, commits, tags, and pushes.
+
+2. Kick off the publish: GitHub → Actions → **npm-publish** → *Run workflow*.
+   The run pauses on the `npm-publish` environment gate until a required
+   reviewer approves it. It then builds and runs `pnpm publish -r`, which
+   publishes every package whose `package.json` version is not yet on the
+   registry.
+
+You can also do a dry run (workflow input `dry-run`) or publish under a
+different dist-tag (input `dist-tag`).
+
+## One-time setup
+
+### GitHub
+
+1. Repo → Settings → Environments → create `npm-publish`.
+2. Add **Required reviewers** (you) so nothing publishes without your
+   approval, and restrict **Deployment branches** to `main`.
+
+### npm (per package)
+
+For each published package, on npmjs.com go to the package → **Settings** →
+**Trusted Publisher** and configure:
+
+- Publisher: **GitHub Actions**
+- Organization/user: `constructive-io`
+- Repository: `constructive`
+- Workflow filename: `npm-publish.yaml`
+- Environment: `npm-publish`
+
+Then under the same settings page set **Publishing access** to *Require
+two-factor authentication and disallow tokens* (trusted publishing is
+exempt), so tokens can never be used to publish.
+
+List all publishable packages:
+
+```bash
+pnpm ls -r --depth -1 --json | node -e "
+let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{
+  for (const p of JSON.parse(s)) {
+    const pj=require(p.path+'/package.json');
+    if(!pj.private) console.log('https://www.npmjs.com/package/'+pj.name+'/access');
+  }
+});"
 ```
-pnpm install
-pnpm lerna publish
-```
+
+### Caveats
+
+- Trusted publishers can only be configured on packages that already exist on
+  npm. A brand-new package's first publish must be done manually (e.g.
+  locally with `npm publish` + 2FA); after that, configure its trusted
+  publisher and it flows through the workflow like the rest.
+- Trusted publishing requires npm ≥ 11.5.1 or pnpm ≥ 10.9 in CI (the
+  workflow uses pnpm 10).


### PR DESCRIPTION
## Summary
Moves npm publishing from local token-based `lerna publish` to npm [Trusted Publishing (OIDC)](https://docs.npmjs.com/trusted-publishers) — no NPM_TOKEN anywhere, and publishes can only happen when a release is explicitly kicked off and approved.

- `.github/workflows/npm-publish.yaml`: `workflow_dispatch`-only workflow, gated behind a GitHub environment `npm-publish` (add yourself as required reviewer + restrict deployment branches to `main`). Grants only `id-token: write`; builds with pnpm 10 (OIDC support) and runs `pnpm publish -r --no-git-checks`, which publishes every non-private package whose version isn't yet on the registry. Inputs: `dist-tag`, `dry-run`.
- `PUBLISH.md`: new release flow (`pnpm lerna version` locally → trigger workflow → approve gate), the one-time npm per-package trusted-publisher config (repo `constructive-io/constructive`, workflow `npm-publish.yaml`, environment `npm-publish`), and a one-liner listing all 111 publishable packages' settings URLs.

Caveats documented: trusted publishers must be configured per package on npmjs.com (existing packages only — a brand-new package's first publish is still manual), and after configuring, set each package's publishing access to "Require 2FA and disallow tokens" so tokens can never publish.

Link to Devin session: https://app.devin.ai/sessions/6c597a673ca24ff0a086c3fa8076c6b8
Requested by: @pyramation