### PR TITLE
feat(safegres): runtime-statistics rules (S1-S4) and EXPLAIN planner proof

### DIFF
--- a/.agents/skills/safegres/SKILL.md
+++ b/.agents/skills/safegres/SKILL.md
@@ -72,7 +72,7 @@ The score only improves by being **explicit** (declaring exposure and intent) or
 | R3 | medium | fail-open | RLS table has grants **TO PUBLIC** |
 | W1 | medium | meta | No exposure surface configured — DB assumed reachable, score capped |
 
-Perf-dimension rules (only collected with `--perf`, scored on their own axis): **X1** FK with no covering index (medium), **X2** policy filters on a column that leads no index (medium), **X3** policy casts/wraps its own column with no matching expression index (medium), **X4** policy calls a non-LEAKPROOF function (low), **X5** redundant/duplicate index (low), **X6** no primary key and no usable replica identity (low), **X7** search column with no index the search can use — `tsvector` w/o GIN/GiST, `vector` w/o HNSW/IVFFlat (medium), **X8** sort-shaped `timestamptz`/`date` column leading no index (info, heuristic), plus P1/P1b.
+Perf-dimension rules (only collected with `--perf`, scored on their own axis; `S*` additionally need `--stats`): **X1** FK with no covering index (medium), **X2** policy filters on a column that leads no index (medium), **X3** policy casts/wraps its own column with no matching expression index (medium), **X4** policy calls a non-LEAKPROOF function (low), **X5** redundant/duplicate index (low), **X6** no primary key and no usable replica identity (low), **X7** search column with no index the search can use — `tsvector` w/o GIN/GiST, `vector` w/o HNSW/IVFFlat (medium), **X8** sort-shaped `timestamptz`/`date` column leading no index (info, heuristic), plus P1/P1b and the runtime-statistics rules **S1**-**S4**.
 
 **Direction is the key idea:** `fail-open` = real exposure (untrusted side reaches more than intended). `fail-closed` = denied at runtime (hygiene/availability, not a leak) — contributes **0** to the score by default. R1/R2 are no-ops until you configure a role list; `safegres:constructive` sets them for `anonymous`.
 
@@ -131,6 +131,14 @@ safegres audit --perf-baseline .safegres-perf.json --fail-on-new-perf   # exit 1
 ```
 
 Entries are keyed by code + relation + policy + subject (constraint/index/expression/column/function), never by message text, so safegres upgrades don't invalidate a committed baseline. Fixed findings are reported so you can re-baseline and stop them regressing. Library: `toPerfBaseline(findings)` / `diffPerf(findings, baseline)` → `{ added, removed, accepted }`; also emitted as `report.perf.diff`. Prefer this over asserting a perf grade in a test — it fails on the change, not on inherited debt.
+
+### Runtime statistics (`--stats`, implies `--perf`)
+
+The `S*` rules read what the workload did, from `pg_stat_user_tables` / `pg_stat_user_indexes` / optional `pg_stat_statements`: **S1** seq-scan-dominant table (medium), **S2** index the planner has never chosen (low), **S3** dead-tuple bloat (low), **S4** statement hotspot on a table in scope (info). Only meaningful against a database that has served real traffic — never in a fresh CI database. Every threshold is a floor and configurable under `perf.stats` (`minRows`, `seqScanRatio`, `minIndexBytes`, `deadTupleRatio`, `minTimeShare`, `topStatements`). `S*` findings **are scored** on the perf axis (asking for `--stats` is the opt-in); `perf.scoring.includeStats: false` demotes them to advisories. `report.perf.stats` carries provenance: tables read, `statsReset` (the window the counters describe), whether they were scored, and a note when `pg_stat_statements` isn't installed — a missing extension is never an error.
+
+### Planner proof (`--explain`, implies `--perf`)
+
+Turns catalog inference into evidence: each probeable finding's query shape is planned with `EXPLAIN (GENERIC_PLAN, FORMAT JSON)` (nothing executed, parameters stay parameters) and the plan is attached as `finding.evidence`. A finding the planner serves with an index is **refuted** — acknowledged, demoted to info, dropped from the perf score (e.g. a hash index on an FK column, which X1 doesn't credit). A seq scan only **confirms** above `perf.explain.minRows` (default 1000), because an empty table always seq-scans; below that the probe is `inconclusive` and the finding is untouched. Probes exist for X1/X2/X7/X8 only — the rules that name a query shape. Requires PostgreSQL 16+; otherwise `report.perf.explain.unavailable` explains why nothing was probed.
 
 ### Presets
 
@@ -211,6 +219,8 @@ safegres audit                     # audit the connected DB (default command)
 safegres perf                      # audit + index-hygiene dimension (= audit --perf)
 safegres audit --perf --fail-on-perf-grade B
 safegres audit --perf-baseline .safegres-perf.json --fail-on-new-perf   # ratchet: only new debt fails
+safegres audit --stats             # + runtime-statistics rules S1-S4 (implies --perf)
+safegres audit --explain           # + prove findings with EXPLAIN (implies --perf, PG16+)
 safegres audit --format json       # machine-readable
 safegres audit --exposed-only      # hide internal advisories
 safegres doctor                    # config/parser/connection/catalog + exposure + stale public.read checks

--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -162,6 +162,59 @@ performance vs baseline:
 
 Entries are identified by `code` + relation + policy + subject (the constraint, index, expression, column, or function the finding is about), so rewording a message or retuning a severity between safegres versions never invalidates a committed baseline, and two findings of the same code on the same table stay distinct. Findings that disappear are reported as fixed — re-run `--write-perf-baseline` to lock the win in and stop them regressing silently. The diff is also carried in JSON output as `perf.diff`, and available to library callers as `diffPerf(findings, baseline)`.
 
+### Runtime statistics (`--stats`)
+
+The `X*` rules read the schema; the `S*` rules read what the workload actually did to it. They come from `pg_stat_user_tables`, `pg_stat_user_indexes` and — when the extension is installed — `pg_stat_statements`, so they only mean something against a database that has served representative traffic. Opt in with `--stats` (which implies `--perf`):
+
+| Code | Severity | Check |
+| --- | --- | --- |
+| S1 | medium | **Sequential-scan-dominant table** — seq scans outnumber index scans 10:1 on a table with indexes and ≥ 1000 live rows |
+| S2 | low | **Index the planner has never chosen** (`idx_scan = 0`) and larger than 1 MiB — pure write cost, unless it's there for a rare report |
+| S3 | low | **Dead-tuple bloat** — dead tuples ≥ 20% of live rows; autovacuum is not keeping up |
+| S4 | info | **Statement hotspot** — a statement taking ≥ 5% of sampled execution time whose relations are in scope |
+
+Every threshold is a floor, and every floor is configurable, because a counter is only evidence if there is enough of it:
+
+```jsonc
+{
+  "perf": {
+    "stats": {
+      "minRows": 1000,          // S1/S3: below this a scan is the right plan
+      "seqScanRatio": 10,       // S1: seq:idx scan ratio that counts as dominant
+      "minIndexBytes": 1048576, // S2: ignore indexes too small to be worth dropping
+      "deadTupleRatio": 0.2,    // S3
+      "minTimeShare": 0.05,     // S4: share of total sampled time
+      "topStatements": 5        // S4: cap
+    },
+    "scoring": { "includeStats": false }   // demote S* to advisories
+  }
+}
+```
+
+`S*` findings are **scored** on the perf axis — asking for `--stats` is the opt-in — but `perf.scoring.includeStats: false` demotes them to advisories if you want the grade to stay purely deterministic. The report carries its own provenance in `perf.stats`: how many tables were read, when the counters were last reset (the window the numbers describe), whether they were scored, and a note when `pg_stat_statements` isn't installed. Absent statistics are never an error; the audit just says so.
+
+### Planner proof (`--explain`)
+
+The `X*` rules *infer* from the catalog that nothing can serve a query shape. `--explain` asks the database instead: for each probeable finding it plans the query the finding is a claim about with `EXPLAIN (GENERIC_PLAN, FORMAT JSON)` — nothing is executed, and parameters stay parameters, so no value has to be invented for a column — and attaches the plan as `finding.evidence`.
+
+The interesting outcome is disagreement. A finding whose probe plans as an index scan is **refuted**: some index the catalog rules didn't credit (a hash index on an FK column, say) does serve it, so the finding is acknowledged, reported as info, and dropped from the perf score. The reverse is deliberately not symmetrical — an empty or unanalyzed table always seq-scans, so a seq scan **confirms** a finding only above a planner row estimate of 1000 (`perf.explain.minRows`); below that the probe is `inconclusive` and the finding is left exactly as the static rule made it.
+
+```bash
+safegres audit --perf --explain --database mydb
+```
+
+```
+[medium] X1  app_public.posts
+    foreign key posts_author_id_fkey has no covering index
+    plan (confirmed): Seq Scan
+[info] X1  app_public.notes
+    foreign key notes_author_id_fkey has no covering index — refuted by EXPLAIN (the planner serves this shape with an index)
+    plan (refuted): Bitmap Heap Scan → Bitmap Index Scan
+  planner proof: 1 confirmed, 1 refuted, 1 inconclusive of 3 probed
+```
+
+Probes exist for X1, X2, X7 and X8 — the rules that name a query shape. X5, X6, `P*` and `S*` are claims about the schema or the workload rather than a plan, so nothing is planned speculatively on their behalf. `GENERIC_PLAN` requires PostgreSQL 16+; on older servers the audit reports `perf.explain.unavailable` and leaves the findings untouched.
+
 ## Call graph (`--call-graph`)
 
 RLS findings tell you what the *tables* allow. The call graph tells you what the *functions* reach: starting from the exposed entry points (functions the API roles can `EXECUTE`), safegres statically walks each body and lists every **trust boundary** on the way — unscored, because a public `SECURITY DEFINER` calling private functions is the intended pattern (that's how `sign_in` works). The output is a deterministic checklist for human review:

--- a/packages/safegres/__tests__/fixtures/e1-explain.sql
+++ b/packages/safegres/__tests__/fixtures/e1-explain.sql
@@ -1,0 +1,44 @@
+-- Planner-proof fixture: enough rows (and fresh statistics) for the planner
+-- to prefer an index when one can serve the shape.
+--   posts.author_id  — FK with no index at all      -> X1 confirmed
+--   notes.author_id  — FK served by a HASH index    -> X1 refuted (the catalog
+--                      rule only credits btree, but the planner uses it)
+--   tiny.author_id   — FK with no index, few rows   -> X1 inconclusive
+
+CREATE SCHEMA IF NOT EXISTS fx_explain;
+
+CREATE TABLE fx_explain.authors (
+  id bigint PRIMARY KEY
+);
+
+INSERT INTO fx_explain.authors SELECT g FROM generate_series(1, 500) g;
+
+CREATE TABLE fx_explain.posts (
+  id bigint PRIMARY KEY,
+  author_id bigint NOT NULL REFERENCES fx_explain.authors (id)
+);
+
+INSERT INTO fx_explain.posts
+SELECT g, (g % 500) + 1 FROM generate_series(1, 20000) g;
+
+CREATE TABLE fx_explain.notes (
+  id bigint PRIMARY KEY,
+  author_id bigint NOT NULL REFERENCES fx_explain.authors (id)
+);
+
+INSERT INTO fx_explain.notes
+SELECT g, (g % 500) + 1 FROM generate_series(1, 20000) g;
+
+CREATE INDEX notes_author_hash_idx ON fx_explain.notes USING hash (author_id);
+
+CREATE TABLE fx_explain.tiny (
+  id bigint PRIMARY KEY,
+  author_id bigint NOT NULL REFERENCES fx_explain.authors (id)
+);
+
+INSERT INTO fx_explain.tiny SELECT g, g FROM generate_series(1, 5) g;
+
+ANALYZE fx_explain.authors;
+ANALYZE fx_explain.posts;
+ANALYZE fx_explain.notes;
+ANALYZE fx_explain.tiny;

--- a/packages/safegres/__tests__/perf-stats.test.ts
+++ b/packages/safegres/__tests__/perf-stats.test.ts
@@ -1,0 +1,254 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { getConnections, PgTestClient } from 'pgsql-test';
+
+import {
+  checkDeadTuples,
+  checkSeqScanDominant,
+  checkStats,
+  checkTopStatements,
+  checkUnusedIndexes,
+  DEFAULT_STATS_THRESHOLDS
+} from '../src/checks/stats';
+import { audit } from '../src/commands/audit';
+import type { StatementUsage, TableUsage } from '../src/pg/stats';
+import type { Finding } from '../src/types';
+
+jest.setTimeout(120000);
+
+let pg: PgTestClient;
+let teardown: () => Promise<void>;
+
+beforeAll(async () => {
+  ({ pg, teardown } = await getConnections());
+  const filepath = path.join(__dirname, 'fixtures', 'e1-explain.sql');
+  await pg.any(fs.readFileSync(filepath, 'utf8'));
+});
+
+afterAll(async () => {
+  if (teardown) await teardown();
+});
+
+function table(over: Partial<TableUsage> = {}): TableUsage {
+  return {
+    schema: 'app_public',
+    name: 'events',
+    seqScans: 0,
+    seqTuplesRead: 0,
+    indexScans: 0,
+    liveTuples: 0,
+    deadTuples: 0,
+    sizeBytes: 0,
+    lastVacuum: null,
+    lastAnalyze: null,
+    indexes: [],
+    ...over
+  };
+}
+
+/**
+ * The `S*` rules are unit-tested against synthetic snapshots: cumulative
+ * counters are shared state that a test transaction cannot deterministically
+ * produce, so asserting on live numbers would be asserting on the harness.
+ * The live path is covered by the integration tests below.
+ */
+describe('S1 — sequential-scan-dominant tables', () => {
+  const scanned = table({
+    liveTuples: 50000,
+    seqScans: 400,
+    seqTuplesRead: 20000000,
+    indexScans: 10,
+    indexes: [{ name: 'events_pkey', scans: 10, sizeBytes: 8192, unique: true, constraint: true }]
+  });
+
+  it('fires when seq scans dominate on a table above the row floor', () => {
+    const finding = checkSeqScanDominant(scanned, DEFAULT_STATS_THRESHOLDS);
+    expect(finding?.code).toBe('S1');
+    expect(finding?.severity).toBe('medium');
+    expect(finding?.context).toMatchObject({ seqScans: 400, indexScans: 10 });
+  });
+
+  it('stays silent below the row floor — a small table is meant to be scanned', () => {
+    expect(checkSeqScanDominant({ ...scanned, liveTuples: 100 }, DEFAULT_STATS_THRESHOLDS))
+      .toBeNull();
+  });
+
+  it('stays silent when the planner does use the indexes', () => {
+    expect(checkSeqScanDominant({ ...scanned, indexScans: 4000 }, DEFAULT_STATS_THRESHOLDS))
+      .toBeNull();
+  });
+
+  it('defers to X1/X6 when the table has no index at all', () => {
+    expect(checkSeqScanDominant({ ...scanned, indexes: [] }, DEFAULT_STATS_THRESHOLDS)).toBeNull();
+  });
+});
+
+describe('S2 — never-scanned indexes', () => {
+  it('flags a large unused index, and exempts constraint-backed ones', () => {
+    const findings = checkUnusedIndexes(
+      table({
+        indexes: [
+          { name: 'events_unused_idx', scans: 0, sizeBytes: 64 * 1024 * 1024, unique: false, constraint: false },
+          { name: 'events_pkey', scans: 0, sizeBytes: 64 * 1024 * 1024, unique: true, constraint: true },
+          { name: 'events_used_idx', scans: 12, sizeBytes: 64 * 1024 * 1024, unique: false, constraint: false },
+          { name: 'events_tiny_idx', scans: 0, sizeBytes: 8192, unique: false, constraint: false }
+        ]
+      }),
+      DEFAULT_STATS_THRESHOLDS
+    );
+    expect(findings.map((f) => (f.context as { index: string }).index)).toEqual([
+      'events_unused_idx'
+    ]);
+    expect(findings[0].message).toContain('64.0 MiB');
+  });
+});
+
+describe('S3 — dead-tuple bloat', () => {
+  it('fires above the ratio and stays silent below it', () => {
+    const bloated = table({ liveTuples: 10000, deadTuples: 4000 });
+    expect(checkDeadTuples(bloated, DEFAULT_STATS_THRESHOLDS)?.code).toBe('S3');
+    expect(checkDeadTuples({ ...bloated, deadTuples: 100 }, DEFAULT_STATS_THRESHOLDS)).toBeNull();
+  });
+});
+
+describe('S4 — statement hotspots', () => {
+  const statements: StatementUsage[] = [
+    {
+      query: 'SELECT * FROM app_public.events WHERE payload @> $1',
+      calls: 900,
+      totalTimeMs: 9000,
+      meanTimeMs: 10,
+      rows: 900
+    },
+    {
+      query: 'UPDATE app_public.events SET payload = $1 WHERE id = $2',
+      calls: 600,
+      totalTimeMs: 6000,
+      meanTimeMs: 10,
+      rows: 600
+    },
+    { query: 'SELECT 1', calls: 10, totalTimeMs: 5, meanTimeMs: 0.5, rows: 10 }
+  ];
+
+  it('reports only statements over the time share that touch a table in scope', () => {
+    const findings = checkTopStatements(statements, [table()], DEFAULT_STATS_THRESHOLDS);
+    // `SELECT 1` is under the share and touches nothing in scope.
+    expect(findings).toHaveLength(2);
+    expect(findings[0].code).toBe('S4');
+    expect(findings[0].severity).toBe('info');
+    expect(findings[0].context).toMatchObject({ relations: ['app_public.events'], calls: 900 });
+  });
+
+  it('ignores statements that touch nothing in scope', () => {
+    const findings = checkTopStatements(statements, [table({ name: 'other' })], DEFAULT_STATS_THRESHOLDS);
+    expect(findings).toHaveLength(0);
+  });
+
+  it('honours the configured share and count limits', () => {
+    // 9000ms and 6000ms of 15005ms total: 60% and 40%.
+    expect(
+      checkTopStatements(statements, [table()], { ...DEFAULT_STATS_THRESHOLDS, minTimeShare: 0.5 })
+    ).toHaveLength(1);
+    expect(
+      checkTopStatements(statements, [table()], { ...DEFAULT_STATS_THRESHOLDS, topStatements: 1 })
+    ).toHaveLength(1);
+  });
+});
+
+describe('checkStats', () => {
+  it('runs every rule over one snapshot', () => {
+    const findings = checkStats({
+      tables: [
+        table({
+          liveTuples: 50000,
+          deadTuples: 20000,
+          seqScans: 400,
+          indexScans: 1,
+          indexes: [
+            { name: 'events_unused_idx', scans: 0, sizeBytes: 8 * 1024 * 1024, unique: false, constraint: false }
+          ]
+        })
+      ],
+      statsReset: null
+    });
+    expect(findings.map((f) => f.code).sort()).toEqual(['S1', 'S2', 'S3']);
+  });
+});
+
+describe('--stats (live)', () => {
+  it('reports provenance and notes the missing pg_stat_statements extension', async () => {
+    const report = await audit(pg.client as never, { schemas: ['fx_explain'], stats: true });
+    expect(report.perf?.stats?.source).toBe('live');
+    expect(report.perf?.stats?.tables).toBeGreaterThan(0);
+    expect(report.perf?.stats?.scored).toBe(true);
+    const notes = report.perf?.stats?.notes ?? [];
+    // The extension is optional; whichever way this database is built, the
+    // report must say which of the two situations produced the S4 findings.
+    if (notes.length > 0) expect(notes[0]).toContain('pg_stat_statements');
+  });
+
+  it('implies --perf without being asked, and stays off otherwise', async () => {
+    const withStats = await audit(pg.client as never, { schemas: ['fx_explain'], stats: true });
+    expect(withStats.perf).toBeDefined();
+
+    const plain = await audit(pg.client as never, { schemas: ['fx_explain'] });
+    expect(plain.perf).toBeUndefined();
+    expect(plain.findings.some((f) => f.code.startsWith('S'))).toBe(false);
+  });
+
+  it('demotes S* findings to advisories when includeStats is false', async () => {
+    const report = await audit(pg.client as never, {
+      schemas: ['fx_explain'],
+      stats: true,
+      config: { perf: { scoring: { includeStats: false } } }
+    });
+    expect(report.perf?.stats?.scored).toBe(false);
+    expect(report.perf?.score.deductions.some((d) => d.code.startsWith('S'))).toBe(false);
+  });
+});
+
+describe('--explain (planner proof)', () => {
+  function evidenceFor(findings: Finding[], code: string, table: string): Finding | undefined {
+    return findings.find((f) => f.code === code && f.table === table);
+  }
+
+  it('confirms, refutes, and declines to conclude', async () => {
+    const report = await audit(pg.client as never, { schemas: ['fx_explain'], explain: true });
+    const findings = report.perf!.findings;
+
+    // No index at all on a 20k-row table: the plan is the seq scan the rule predicted.
+    const confirmed = evidenceFor(findings, 'X1', 'posts');
+    expect(confirmed?.evidence?.status).toBe('confirmed');
+    expect(confirmed?.evidence?.plan).toContain('Seq Scan');
+    expect(confirmed?.acknowledged).toBeUndefined();
+
+    // A hash index serves the equality even though the catalog rule only
+    // credits btree — the planner overrules the inference.
+    const refuted = evidenceFor(findings, 'X1', 'notes');
+    expect(refuted?.evidence?.status).toBe('refuted');
+    expect(refuted?.evidence?.plan).toContain('Index');
+    expect(refuted?.acknowledged).toBe(true);
+    expect(refuted?.severity).toBe('info');
+
+    // Five rows: a seq scan is correct, so the probe proves nothing.
+    const inconclusive = evidenceFor(findings, 'X1', 'tiny');
+    expect(inconclusive?.evidence?.status).toBe('inconclusive');
+    expect(inconclusive?.evidence?.note).toContain('estimated rows');
+    expect(inconclusive?.severity).toBe('medium');
+
+    expect(report.perf?.explain).toMatchObject({ confirmed: 1, refuted: 1, inconclusive: 1 });
+  });
+
+  it('keeps refuted findings out of the perf score', async () => {
+    const report = await audit(pg.client as never, { schemas: ['fx_explain'], explain: true });
+    const x1 = report.perf!.score.deductions.find((d) => d.code === 'X1');
+    // posts and tiny still count; notes was refuted.
+    expect(x1?.count).toBe(2);
+  });
+
+  it('implies --perf and changes nothing when off', async () => {
+    const plain = await audit(pg.client as never, { schemas: ['fx_explain'], perf: true });
+    expect(plain.perf!.findings.every((f) => f.evidence === undefined)).toBe(true);
+    expect(plain.perf!.explain).toBeUndefined();
+  });
+});

--- a/packages/safegres/__tests__/search-index.test.ts
+++ b/packages/safegres/__tests__/search-index.test.ts
@@ -33,6 +33,7 @@ function table(over: Partial<TableIndexSnapshot> = {}): TableIndexSnapshot {
     isPartition: false,
     replicaIdentity: 'd',
     hasPrimaryKey: true,
+    estimatedRows: 0,
     columns: [],
     indexes: [],
     foreignKeys: [],

--- a/packages/safegres/src/checks/stats.ts
+++ b/packages/safegres/src/checks/stats.ts
@@ -1,0 +1,223 @@
+/**
+ * Runtime-statistics checks (`--stats`, `S*`).
+ *
+ * These read the cumulative statistics views rather than the catalog, so
+ * unlike the `X*` rules they describe a workload rather than a schema: the
+ * same database can pass or fail depending on what traffic it has served.
+ * Every rule therefore takes a floor, so a cold or freshly-reset database
+ * produces silence instead of noise.
+ */
+
+import type { StatementUsage, StatsSnapshot, TableUsage } from '../pg/stats';
+import type { Finding } from '../types';
+
+export interface StatsThresholds {
+  /** Ignore tables with fewer live rows than this. Default 1000. */
+  minRows: number;
+  /** S1 fires when seqScans exceed indexScans by this factor. Default 10. */
+  seqScanRatio: number;
+  /** S2 ignores indexes smaller than this many bytes. Default 1 MiB. */
+  minIndexBytes: number;
+  /** S3 fires above this dead/live tuple ratio. Default 0.2. */
+  deadTupleRatio: number;
+  /** S4 fires for statements at or above this share of total time. Default 0.05. */
+  minTimeShare: number;
+  /** S4 reports at most this many statements. Default 5. */
+  topStatements: number;
+}
+
+export const DEFAULT_STATS_THRESHOLDS: StatsThresholds = {
+  minRows: 1000,
+  seqScanRatio: 10,
+  minIndexBytes: 1024 * 1024,
+  deadTupleRatio: 0.2,
+  minTimeShare: 0.05,
+  topStatements: 5
+};
+
+/**
+ * S1: a table the planner reaches by sequential scan far more often than by
+ * index. On a table above the row floor that is a missing index, a policy
+ * predicate the planner can't use, or a query shape nothing covers.
+ */
+export function checkSeqScanDominant(
+  table: TableUsage,
+  thresholds: StatsThresholds
+): Finding | null {
+  if (table.liveTuples < thresholds.minRows) return null;
+  if (table.seqScans === 0) return null;
+  if (table.seqScans < table.indexScans * thresholds.seqScanRatio) return null;
+  // A table with no index at all is X6/X1 territory; the stats add nothing.
+  if (table.indexes.length === 0) return null;
+
+  const perScan = Math.round(table.seqTuplesRead / Math.max(table.seqScans, 1));
+  return {
+    code: 'S1',
+    severity: 'medium',
+    category: 'index',
+    schema: table.schema,
+    table: table.name,
+    message:
+      `${table.schema}.${table.name} is scanned sequentially ${table.seqScans} times vs ${table.indexScans} index scans (${table.liveTuples} live rows, ~${perScan} rows read per scan)`,
+    hint:
+      'Find the query shape behind the scans (pg_stat_statements, auto_explain) and index for it — at this row count every seq scan reads the whole table.',
+    context: {
+      seqScans: table.seqScans,
+      indexScans: table.indexScans,
+      liveTuples: table.liveTuples
+    }
+  };
+}
+
+/**
+ * S2: an index the planner has never chosen. It still costs write throughput,
+ * disk, and vacuum time. Constraint-backed and unique indexes are exempt:
+ * they exist to enforce a constraint, not to be scanned.
+ */
+export function checkUnusedIndexes(
+  table: TableUsage,
+  thresholds: StatsThresholds
+): Finding[] {
+  const findings: Finding[] = [];
+  for (const index of table.indexes) {
+    if (index.scans > 0) continue;
+    if (index.unique || index.constraint) continue;
+    if (index.sizeBytes < thresholds.minIndexBytes) continue;
+
+    findings.push({
+      code: 'S2',
+      severity: 'low',
+      category: 'index',
+      schema: table.schema,
+      table: table.name,
+      message:
+        `Index ${index.name} on ${table.schema}.${table.name} has never been scanned (${formatBytes(index.sizeBytes)})`,
+      hint:
+        `DROP INDEX ${table.schema}.${index.name}; — confirm the counters cover a representative window first (see perf.stats.since).`,
+      context: { index: index.name, sizeBytes: index.sizeBytes }
+    });
+  }
+  return findings;
+}
+
+/**
+ * S3: dead tuples the vacuum is not keeping up with. Bloat inflates every
+ * scan of the table and every index on it, and the planner's row estimates
+ * drift with it.
+ */
+export function checkDeadTuples(
+  table: TableUsage,
+  thresholds: StatsThresholds
+): Finding | null {
+  if (table.liveTuples < thresholds.minRows) return null;
+  const ratio = table.deadTuples / Math.max(table.liveTuples, 1);
+  if (ratio < thresholds.deadTupleRatio) return null;
+
+  return {
+    code: 'S3',
+    severity: 'low',
+    category: 'index',
+    schema: table.schema,
+    table: table.name,
+    message:
+      `${table.schema}.${table.name} is ${Math.round(ratio * 100)}% dead tuples (${table.deadTuples} dead / ${table.liveTuples} live${table.lastVacuum ? `, last vacuumed ${table.lastVacuum}` : ', never vacuumed'})`,
+    hint:
+      'VACUUM (ANALYZE) the table, then tune autovacuum for it (autovacuum_vacuum_scale_factor) — bloat is read by every scan and every index on the table.',
+    context: {
+      deadTuples: table.deadTuples,
+      liveTuples: table.liveTuples,
+      lastVacuum: table.lastVacuum
+    }
+  };
+}
+
+/**
+ * S4: the statements the database actually spends its time in, restricted to
+ * ones touching a table in scope. This is not a defect — it is the ranked
+ * list to read the other findings against, so it is `info` by default.
+ */
+export function checkTopStatements(
+  statements: StatementUsage[],
+  tables: TableUsage[],
+  thresholds: StatsThresholds
+): Finding[] {
+  const totalTime = statements.reduce((sum, s) => sum + s.totalTimeMs, 0);
+  if (totalTime <= 0) return [];
+
+  const findings: Finding[] = [];
+  for (const statement of statements) {
+    if (findings.length >= thresholds.topStatements) break;
+    const share = statement.totalTimeMs / totalTime;
+    if (share < thresholds.minTimeShare) continue;
+
+    const matched = tables.filter((t) => statementTouches(statement.query, t));
+    if (matched.length === 0) continue;
+
+    const relations = matched.map((t) => `${t.schema}.${t.name}`);
+    findings.push({
+      code: 'S4',
+      severity: 'info',
+      category: 'index',
+      schema: matched[0].schema,
+      table: matched[0].name,
+      message:
+        `${Math.round(share * 100)}% of database execution time is spent in one statement over ${relations.join(', ')} (${statement.calls} calls, ${Math.round(statement.meanTimeMs)}ms mean)`,
+      hint: `EXPLAIN (ANALYZE, BUFFERS) this statement before acting on any other finding for these tables:\n    ${truncate(statement.query, 300)}`,
+      context: {
+        statement: truncate(statement.query, 300),
+        calls: statement.calls,
+        totalTimeMs: Math.round(statement.totalTimeMs),
+        meanTimeMs: Math.round(statement.meanTimeMs),
+        relations
+      }
+    });
+  }
+  return findings;
+}
+
+/** Every stats finding for one snapshot. */
+export function checkStats(
+  snapshot: StatsSnapshot,
+  thresholds: StatsThresholds = DEFAULT_STATS_THRESHOLDS
+): Finding[] {
+  const findings: Finding[] = [];
+  for (const table of snapshot.tables) {
+    const s1 = checkSeqScanDominant(table, thresholds);
+    if (s1) findings.push(s1);
+    findings.push(...checkUnusedIndexes(table, thresholds));
+    const s3 = checkDeadTuples(table, thresholds);
+    if (s3) findings.push(s3);
+  }
+  if (snapshot.statements) {
+    findings.push(...checkTopStatements(snapshot.statements, snapshot.tables, thresholds));
+  }
+  return findings;
+}
+
+/**
+ * Whether a normalised statement references a table. `pg_stat_statements`
+ * stores text, not parsed relations, so this matches the qualified name or
+ * the bare name on a word boundary — good enough to rank hotspots, and
+ * deliberately not used for anything that changes a severity.
+ */
+function statementTouches(query: string, table: TableUsage): boolean {
+  const qualified = new RegExp(`\\b${escapeRegExp(table.schema)}\\.${escapeRegExp(table.name)}\\b`, 'i');
+  if (qualified.test(query)) return true;
+  const bare = new RegExp(`\\b(from|join|into|update)\\s+"?${escapeRegExp(table.name)}"?\\b`, 'i');
+  return bare.test(query);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function truncate(value: string, max: number): string {
+  const collapsed = value.replace(/\s+/g, ' ').trim();
+  return collapsed.length <= max ? collapsed : `${collapsed.slice(0, max - 1)}…`;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024 / 1024).toFixed(1)} GiB`;
+  if (bytes >= 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MiB`;
+  return `${Math.round(bytes / 1024)} KiB`;
+}

--- a/packages/safegres/src/cli/audit.ts
+++ b/packages/safegres/src/cli/audit.ts
@@ -72,6 +72,15 @@ Performance dimension (optional; scored separately from security):
   --perf-baseline <file>   Diff perf findings against a committed baseline and
                            report only NEW debt (implies --perf)
   --fail-on-new-perf       Exit non-zero when --perf-baseline finds new debt
+  --stats                  Also run the runtime-statistics rules (S1-S4) from
+                           pg_stat_user_tables and, when installed,
+                           pg_stat_statements (implies --perf). Workload-
+                           dependent: only meaningful against a database that
+                           has served representative traffic
+  --explain                Prove each probeable perf finding with
+                           EXPLAIN (GENERIC_PLAN) and attach the plan as
+                           evidence; findings the planner refutes are reported
+                           but unscored (implies --perf, needs PostgreSQL 16+)
 
 Call graph (unscored; human review):
   --call-graph             Analyze the functions reachable from the exposed entry
@@ -130,6 +139,8 @@ export default async (
       || typeof argv['write-perf-baseline'] === 'string'
         ? true
         : undefined,
+    stats: argv.stats === true ? true : undefined,
+    explain: argv.explain === true ? true : undefined,
     callGraph:
       argv['call-graph'] === true
       || typeof argv.baseline === 'string'

--- a/packages/safegres/src/commands/audit.ts
+++ b/packages/safegres/src/commands/audit.ts
@@ -30,6 +30,7 @@ import {
   collectPredicateColumns,
   type PredicateColumn
 } from '../checks/policy-index';
+import { checkStats, DEFAULT_STATS_THRESHOLDS, type StatsThresholds } from '../checks/stats';
 import {
   checkGrantsWithoutRls,
   checkRlsEnabledNoPolicies,
@@ -47,11 +48,13 @@ import { resolveExposure } from '../pg/exposure';
 import { introspectFunctions } from '../pg/functions';
 import { introspectIndexes, type TableIndexSnapshot } from '../pg/indexes';
 import { asExecutor, type IntrospectOptions, introspectTables, type QueryExecutor, type TableSnapshot } from '../pg/introspect';
+import { type ExplainReport, proveFindings } from '../perf/explain';
 import { lookupVolatility, type ProcVolatility } from '../pg/proc';
 import { listAuditableRoles, resolveRoles } from '../pg/roles';
+import { introspectStats, type StatsSnapshot } from '../pg/stats';
 import { dimensionOf, RULES_BY_CODE } from '../rules/registry';
 import { computeScore } from '../score/score';
-import type { ExposureReport, Finding, PerfReport, Report } from '../types';
+import type { ExposureReport, Finding, PerfReport, PerfStatsReport, Report } from '../types';
 import { summarize } from '../types';
 import { version as PKG_VERSION } from '../version';
 
@@ -83,6 +86,17 @@ export interface AuditOptions extends IntrospectOptions {
    */
   perf?: boolean;
   /**
+   * Collect runtime statistics (`pg_stat_user_tables`, `pg_stat_statements`)
+   * and run the `S*` rules. Implies `perf`. Overrides `config.perf.stats.enabled`.
+   */
+  stats?: boolean;
+  /**
+   * Probe perf findings with `EXPLAIN (GENERIC_PLAN)` and attach the plan as
+   * evidence, acknowledging findings the planner refutes. Implies `perf`.
+   * Overrides `config.perf.explain.enabled`.
+   */
+  explain?: boolean;
+  /**
    * Merged safegres configuration (rules, overrides, scoring). Rule settings
    * filter and retune findings; scoring settings drive the report score.
    * Connection-independent option fields (`schemas`, `roles`, …) present on
@@ -98,7 +112,12 @@ export async function audit(
   const exec = asExecutor(client);
   const config = options.config ?? {};
   const resolved = resolveRules(config);
-  const perfEnabled = options.perf ?? config.perf?.enabled ?? false;
+  const statsEnabled = options.stats ?? config.perf?.stats?.enabled ?? false;
+  const explainEnabled = options.explain ?? config.perf?.explain?.enabled ?? false;
+  // Both tiers are refinements of the perf dimension: asking for either turns
+  // it on, but neither is reachable without opting into perf in the first place.
+  const perfEnabled =
+    (options.perf ?? config.perf?.enabled ?? false) || statsEnabled || explainEnabled;
   const skipAst =
     options.skipAstChecks || allAstRulesDisabled(resolved, { perf: perfEnabled });
 
@@ -173,6 +192,14 @@ export async function audit(
     }
   }
 
+  const statsSnapshot: StatsSnapshot | null = statsEnabled
+    ? await introspectStats(exec, {
+      schemas: options.schemas ?? config.schemas,
+      excludeSchemas: options.excludeSchemas ?? config.excludeSchemas,
+      statementLimit: config.perf?.stats?.topStatements
+    })
+    : null;
+
   if (perfEnabled) {
     for (const table of indexSnapshot) {
       findings.push(...checkUnindexedForeignKeys(table));
@@ -182,6 +209,10 @@ export async function audit(
       const x6 = checkMissingPrimaryKey(table);
       if (x6) findings.push(x6);
     }
+  }
+
+  if (statsSnapshot) {
+    findings.push(...checkStats(statsSnapshot, statsThresholds(config)));
   }
 
   findings = applyRulesToFindings(resolved, findings);
@@ -235,6 +266,18 @@ export async function audit(
     });
   }
 
+  // Planner proof runs last: it reads the findings the rules produced and
+  // acknowledges the ones the planner disagrees with, before scoring.
+  let explainReport: ExplainReport | undefined;
+  if (explainEnabled) {
+    explainReport = await proveFindings(
+      exec,
+      findings.filter((f) => f.dimension === 'perf' && !f.acknowledged),
+      indexesByTable,
+      { minRows: config.perf?.explain?.minRows }
+    );
+  }
+
   findings.sort(compareFindings);
 
   const exposureReport: ExposureReport = {
@@ -262,14 +305,36 @@ export async function audit(
   };
 
   if (perfEnabled) {
+    // `S*` findings are scored by default — opting into `--stats` is the
+    // opt-in — but can be demoted to advisories for a deterministic grade.
+    const includeStats = config.perf?.scoring?.includeStats ?? true;
+    const scorable = includeStats
+      ? perfFindings
+      : perfFindings.filter((f) => !f.code.startsWith('S'));
+
     const perf: PerfReport = {
       findings: perfFindings,
       summary: summarize(perfFindings),
-      score: computeScore(perfFindings, config.perf?.scoring, {
+      score: computeScore(scorable, config.perf?.scoring, {
         exposedTables,
         exposureKnown: exposure.known
       })
     };
+
+    if (statsSnapshot) {
+      const stats: PerfStatsReport = {
+        source: 'live',
+        tables: statsSnapshot.tables.length,
+        statsReset: statsSnapshot.statsReset,
+        scored: includeStats
+      };
+      if (statsSnapshot.statementsUnavailable) {
+        stats.notes = [statsSnapshot.statementsUnavailable];
+      }
+      perf.stats = stats;
+    }
+    if (explainReport) perf.explain = explainReport;
+
     report.perf = perf;
   }
 
@@ -289,6 +354,19 @@ export async function audit(
   }
 
   return report;
+}
+
+/** Stats floors, config over defaults. */
+function statsThresholds(config: SafegresConfig): StatsThresholds {
+  const stats = config.perf?.stats ?? {};
+  return {
+    minRows: stats.minRows ?? DEFAULT_STATS_THRESHOLDS.minRows,
+    seqScanRatio: stats.seqScanRatio ?? DEFAULT_STATS_THRESHOLDS.seqScanRatio,
+    minIndexBytes: stats.minIndexBytes ?? DEFAULT_STATS_THRESHOLDS.minIndexBytes,
+    deadTupleRatio: stats.deadTupleRatio ?? DEFAULT_STATS_THRESHOLDS.deadTupleRatio,
+    minTimeShare: stats.minTimeShare ?? DEFAULT_STATS_THRESHOLDS.minTimeShare,
+    topStatements: stats.topStatements ?? DEFAULT_STATS_THRESHOLDS.topStatements
+  };
 }
 
 async function auditTableAst(

--- a/packages/safegres/src/config/types.ts
+++ b/packages/safegres/src/config/types.ts
@@ -115,7 +115,51 @@ export interface PerfConfig {
    */
   ignore?: string[];
   /** Scoring settings for the perf axis (defaults mirror the security score). */
-  scoring?: ScoringConfig;
+  scoring?: PerfScoringConfig;
+  /** Runtime statistics (`--stats`, `S*`). Off unless enabled here or by flag. */
+  stats?: PerfStatsConfig;
+  /** Planner proof (`--explain`). Off unless enabled here or by flag. */
+  explain?: PerfExplainConfig;
+}
+
+export interface PerfScoringConfig extends ScoringConfig {
+  /**
+   * Whether runtime-statistics findings (`S*`) count toward the perf score.
+   * Default true — asking for `--stats` is the opt-in. Set false to keep the
+   * grade purely deterministic and read the `S*` findings as advisories.
+   */
+  includeStats?: boolean;
+}
+
+/**
+ * Thresholds for the runtime-statistics rules. Every one is a floor: below
+ * it the workload hasn't said enough for the finding to mean anything.
+ */
+export interface PerfStatsConfig {
+  /** Collect and check runtime statistics without passing `--stats`. */
+  enabled?: boolean;
+  /** Ignore tables with fewer live rows than this. Default 1000. */
+  minRows?: number;
+  /** S1 fires when sequential scans exceed index scans by this factor. Default 10. */
+  seqScanRatio?: number;
+  /** S2 ignores indexes smaller than this many bytes. Default 1048576 (1 MiB). */
+  minIndexBytes?: number;
+  /** S3 fires above this dead/live tuple ratio. Default 0.2. */
+  deadTupleRatio?: number;
+  /** S4 fires for statements at or above this share of total time. Default 0.05. */
+  minTimeShare?: number;
+  /** S4 reports at most this many statements. Default 5. */
+  topStatements?: number;
+}
+
+export interface PerfExplainConfig {
+  /** Probe findings with EXPLAIN without passing `--explain`. */
+  enabled?: boolean;
+  /**
+   * Below this planner row estimate a sequential scan is the right plan, so a
+   * probe can refute a finding but never confirm one. Default 1000.
+   */
+  minRows?: number;
 }
 
 export interface FailOnConfig {

--- a/packages/safegres/src/index.ts
+++ b/packages/safegres/src/index.ts
@@ -34,6 +34,15 @@ export {
   checkUnindexedSortColumns
 } from './checks/indexes';
 export type { PolicyClause, PredicateColumn } from './checks/policy-index';
+export type { StatsThresholds } from './checks/stats';
+export {
+  checkDeadTuples,
+  checkSeqScanDominant,
+  checkStats,
+  checkTopStatements,
+  checkUnusedIndexes,
+  DEFAULT_STATS_THRESHOLDS
+} from './checks/stats';
 export {
   checkNonLeakproofPolicyFunctions,
   checkPolicyColumnCasts,
@@ -81,6 +90,15 @@ export type { FunctionGrant, FunctionSnapshot, IntrospectFunctionOptions } from 
 export { introspectFunctions } from './pg/functions';
 export type { ColumnInfo, ForeignKeyInfo, IndexInfo, TableIndexSnapshot } from './pg/indexes';
 export { introspectIndexes } from './pg/indexes';
+export type {
+  IndexUsage,
+  StatementUsage,
+  StatsSnapshot,
+  TableUsage
+} from './pg/stats';
+export { introspectStats } from './pg/stats';
+export type { ExplainOptions, ExplainReport } from './perf/explain';
+export { proveFindings } from './perf/explain';
 export {
   type IntrospectOptions,
   introspectTables,

--- a/packages/safegres/src/perf/explain.ts
+++ b/packages/safegres/src/perf/explain.ts
@@ -1,0 +1,241 @@
+/**
+ * Proof by EXPLAIN (`--explain`).
+ *
+ * The `X*` rules infer from the catalog that a query *shape* has no index to
+ * serve it. This turns the inference into evidence: for each finding that has
+ * a probe shape, plan the query the finding is about and read the plan back.
+ *
+ * The planner is the authority, so the interesting outcome is disagreement —
+ * a finding whose probe plans as an index scan is **refuted** (some index the
+ * catalog rules didn't credit does serve it) and stops counting against the
+ * score. The reverse is not symmetrical: an empty or unanalyzed table always
+ * seq-scans, so a seq scan only *confirms* a finding above the row floor;
+ * below it the probe is inconclusive and the finding is left exactly as it
+ * was.
+ *
+ * Probes use `EXPLAIN (GENERIC_PLAN)` — parameters stay parameters, nothing
+ * is executed, and no value has to be invented for a column whose domain we
+ * know nothing about. That requires PostgreSQL 16+.
+ */
+
+import type { QueryExecutor } from '../pg/introspect';
+import type { TableIndexSnapshot } from '../pg/indexes';
+import type { Finding, FindingEvidence } from '../types';
+
+export interface ExplainOptions {
+  /**
+   * Below this planner row estimate a sequential scan is the correct plan, so
+   * a seq-scan result proves nothing. Default 1000.
+   */
+  minRows?: number;
+}
+
+export interface ExplainReport {
+  /** Findings that were probed. */
+  probed: number;
+  /** Probes whose plan showed the scan the finding predicted. */
+  confirmed: number;
+  /** Probes the planner served with an index — the finding was wrong. */
+  refuted: number;
+  /** Probes on tables too small for the plan to mean anything. */
+  inconclusive: number;
+  /** Why probing was skipped entirely, when it was. */
+  unavailable?: string;
+}
+
+/** The minimum server version supporting `EXPLAIN (GENERIC_PLAN)`. */
+const MIN_SERVER_VERSION = 160000;
+
+interface Probe {
+  sql: string;
+  /** The plan node that would mean "the finding is real". */
+  expect: 'seq-scan' | 'sort';
+}
+
+/**
+ * Plan a probe for every probeable perf finding and annotate it in place.
+ * Findings the planner refutes are acknowledged (reported, unscored).
+ */
+export async function proveFindings(
+  exec: QueryExecutor,
+  findings: Finding[],
+  tables: Map<string, TableIndexSnapshot>,
+  options: ExplainOptions = {}
+): Promise<ExplainReport> {
+  const minRows = options.minRows ?? 1000;
+  const report: ExplainReport = { probed: 0, confirmed: 0, refuted: 0, inconclusive: 0 };
+
+  const { rows: versionRows } = await exec.query<{ setting: string }>(
+    `SELECT setting FROM pg_settings WHERE name = 'server_version_num'`
+  );
+  const version = versionRows[0];
+  if (Number(version?.setting ?? 0) < MIN_SERVER_VERSION) {
+    report.unavailable =
+      `EXPLAIN (GENERIC_PLAN) requires PostgreSQL 16 or later (server is ${version?.setting ?? 'unknown'}) — no findings were probed`;
+    return report;
+  }
+
+  for (const finding of findings) {
+    if (!finding.schema || !finding.table) continue;
+    const table = tables.get(`${finding.schema}.${finding.table}`);
+    if (!table) continue;
+
+    const probe = buildProbe(finding, table);
+    if (!probe) continue;
+
+    const plan = await planProbe(exec, probe.sql);
+    if (!plan) continue;
+    report.probed += 1;
+
+    const nodes = collectNodeTypes(plan);
+    const servedByIndex = nodes.some((n) => n.includes('Index'));
+    const predicted = probe.expect === 'sort'
+      ? nodes.includes('Sort') || nodes.includes('Incremental Sort')
+      : nodes.includes('Seq Scan');
+
+    const evidence: FindingEvidence = {
+      source: 'explain',
+      probe: probe.sql,
+      plan: nodes.join(' → '),
+      status: 'inconclusive'
+    };
+
+    if (servedByIndex && !predicted) {
+      evidence.status = 'refuted';
+      report.refuted += 1;
+      finding.acknowledged = true;
+      finding.severity = 'info';
+      finding.message += ' — refuted by EXPLAIN (the planner serves this shape with an index)';
+      finding.hint =
+        'The planner chose an index for the probe query, so this finding does not describe a real plan. Reported for review, excluded from the perf score.';
+    } else if (predicted && estimatedRows(table) >= minRows) {
+      evidence.status = 'confirmed';
+      report.confirmed += 1;
+    } else {
+      report.inconclusive += 1;
+      evidence.note = estimatedRows(table) < minRows
+        ? `table has ~${Math.max(estimatedRows(table), 0)} estimated rows (< ${minRows}); a sequential scan is the correct plan at this size, so the probe proves nothing`
+        : 'the probe plan matched neither an index scan nor the predicted scan';
+    }
+
+    finding.evidence = evidence;
+  }
+
+  return report;
+}
+
+/**
+ * The query a finding is a claim about. `null` for findings with no probeable
+ * shape (X5 redundant indexes, X6 missing PK, S*, P*) — nothing is planned
+ * speculatively, so `--explain` never invents work.
+ */
+function buildProbe(finding: Finding, table: TableIndexSnapshot): Probe | null {
+  const relation = `${quote(table.schema)}.${quote(table.name)}`;
+  const context = finding.context ?? {};
+
+  switch (finding.code) {
+    case 'X1': {
+      const columns = asStringArray(context.columns);
+      if (columns.length === 0) return null;
+      const predicates = columns
+        .map((name, i) => equality(table, name, i + 1))
+        .filter((p): p is string => p !== null);
+      if (predicates.length !== columns.length) return null;
+      return { sql: `SELECT 1 FROM ${relation} WHERE ${predicates.join(' AND ')}`, expect: 'seq-scan' };
+    }
+    case 'X2': {
+      const predicate = typeof context.column === 'string'
+        ? equality(table, context.column, 1)
+        : null;
+      if (!predicate) return null;
+      return { sql: `SELECT 1 FROM ${relation} WHERE ${predicate}`, expect: 'seq-scan' };
+    }
+    case 'X7': {
+      const column = typeof context.column === 'string' ? context.column : null;
+      if (!column) return null;
+      const type = columnType(table, column);
+      if (!type) return null;
+      if (type === 'tsvector') {
+        return {
+          sql: `SELECT 1 FROM ${relation} WHERE ${quote(column)} @@ $1::tsquery`,
+          expect: 'seq-scan'
+        };
+      }
+      // Vector search is an ordering, not a filter: the index either serves
+      // the distance order or the plan sorts every row.
+      return {
+        sql: `SELECT 1 FROM ${relation} ORDER BY ${quote(column)} <-> $1::${type} LIMIT 10`,
+        expect: 'sort'
+      };
+    }
+    case 'X8': {
+      const column = typeof context.column === 'string' ? context.column : null;
+      if (!column) return null;
+      return {
+        sql: `SELECT 1 FROM ${relation} ORDER BY ${quote(column)} DESC LIMIT 100`,
+        expect: 'sort'
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+async function planProbe(exec: QueryExecutor, sql: string): Promise<unknown | null> {
+  try {
+    const { rows } = await exec.query<Record<string, unknown>>(
+      `EXPLAIN (GENERIC_PLAN, FORMAT JSON) ${sql}`
+    );
+    const first = rows[0];
+    if (!first) return null;
+    // node-postgres returns the single JSON column under 'QUERY PLAN'.
+    const value = first['QUERY PLAN'] ?? Object.values(first)[0];
+    return typeof value === 'string' ? JSON.parse(value) : value;
+  } catch {
+    // A probe that cannot be planned (missing operator class, permissions,
+    // an exotic type) is simply not evidence.
+    return null;
+  }
+}
+
+/** Plan node types, outermost first. */
+function collectNodeTypes(plan: unknown): string[] {
+  const out: string[] = [];
+  const visit = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      for (const item of node) visit(item);
+      return;
+    }
+    if (!node || typeof node !== 'object') return;
+    const record = node as Record<string, unknown>;
+    if (typeof record['Node Type'] === 'string') out.push(record['Node Type']);
+    for (const key of ['Plan', 'Plans']) {
+      if (key in record) visit(record[key]);
+    }
+  };
+  visit(plan);
+  return out;
+}
+
+function equality(table: TableIndexSnapshot, column: string, param: number): string | null {
+  const type = columnType(table, column);
+  if (!type) return null;
+  return `${quote(column)} = $${param}::${type}`;
+}
+
+function columnType(table: TableIndexSnapshot, column: string): string | null {
+  return table.columns.find((c) => c.name === column)?.type ?? null;
+}
+
+function estimatedRows(table: TableIndexSnapshot): number {
+  return table.estimatedRows;
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((v): v is string => typeof v === 'string');
+}
+
+function quote(identifier: string): string {
+  return `"${identifier.replace(/"/g, '""')}"`;
+}

--- a/packages/safegres/src/pg/indexes.ts
+++ b/packages/safegres/src/pg/indexes.ts
@@ -58,6 +58,8 @@ export interface TableIndexSnapshot {
   /** `pg_class.relreplident`: `d` default, `n` nothing, `f` full, `i` index. */
   replicaIdentity: string;
   hasPrimaryKey: boolean;
+  /** `pg_class.reltuples` — planner row estimate, `-1` when never analyzed. */
+  estimatedRows: number;
   /** User columns (no system or dropped attributes), in attribute order. */
   columns: ColumnInfo[];
   indexes: IndexInfo[];
@@ -90,7 +92,8 @@ export async function introspectIndexes(
         c.relname          AS table_name,
         c.oid              AS oid,
         c.relispartition   AS is_partition,
-        c.relreplident     AS replica_identity
+        c.relreplident     AS replica_identity,
+        c.reltuples        AS estimated_rows
       FROM pg_class c
       JOIN pg_namespace n ON n.oid = c.relnamespace
       WHERE c.relkind IN ('r', 'p')
@@ -130,6 +133,7 @@ export async function introspectIndexes(
       r.oid::int                                        AS oid,
       r.is_partition,
       r.replica_identity::text                          AS replica_identity,
+      r.estimated_rows::float8                          AS estimated_rows,
       COALESCE(
         (SELECT jsonb_agg(jsonb_build_object(
           'name', x.name,
@@ -176,6 +180,7 @@ export async function introspectIndexes(
     oid: number;
     is_partition: boolean;
     replica_identity: string;
+    estimated_rows: number;
     indexes: IndexInfo[];
     foreign_keys: ForeignKeyInfo[];
     columns: ColumnInfo[];
@@ -188,6 +193,7 @@ export async function introspectIndexes(
     isPartition: r.is_partition,
     replicaIdentity: r.replica_identity,
     hasPrimaryKey: r.indexes.some((i) => i.primary),
+    estimatedRows: Number(r.estimated_rows),
     columns: r.columns,
     indexes: r.indexes,
     foreignKeys: r.foreign_keys

--- a/packages/safegres/src/pg/stats.ts
+++ b/packages/safegres/src/pg/stats.ts
@@ -1,0 +1,221 @@
+/**
+ * Runtime statistics snapshot (`--stats`).
+ *
+ * Everything here reads the cumulative statistics views — `pg_stat_user_tables`,
+ * `pg_stat_user_indexes`, and (when installed) `pg_stat_statements`. Unlike the
+ * catalog checks, these numbers describe a *workload*: they are only as good as
+ * the traffic the database has seen since the counters were last reset, which is
+ * why the snapshot carries `statsReset` and why the checks take floors.
+ */
+
+import type { IntrospectOptions, QueryExecutor } from './introspect';
+
+export interface IndexUsage {
+  name: string;
+  /** `pg_stat_user_indexes.idx_scan` — times the planner chose this index. */
+  scans: number;
+  /** `pg_relation_size` of the index, in bytes. */
+  sizeBytes: number;
+  unique: boolean;
+  /** Backs a PRIMARY KEY / UNIQUE / EXCLUDE constraint — never droppable alone. */
+  constraint: boolean;
+}
+
+export interface TableUsage {
+  schema: string;
+  name: string;
+  seqScans: number;
+  seqTuplesRead: number;
+  /** Index scans across every index on the table. */
+  indexScans: number;
+  liveTuples: number;
+  deadTuples: number;
+  /** `pg_relation_size` of the heap, in bytes. */
+  sizeBytes: number;
+  /** Most recent vacuum, manual or auto (ISO 8601), null if never. */
+  lastVacuum: string | null;
+  /** Most recent analyze, manual or auto (ISO 8601), null if never. */
+  lastAnalyze: string | null;
+  indexes: IndexUsage[];
+}
+
+export interface StatementUsage {
+  /** Normalised query text (parameters replaced by `$n`). */
+  query: string;
+  calls: number;
+  /** Total execution time across all calls, in milliseconds. */
+  totalTimeMs: number;
+  meanTimeMs: number;
+  /** Rows returned/affected across all calls. */
+  rows: number;
+}
+
+export interface StatsSnapshot {
+  tables: TableUsage[];
+  /** Present only when `pg_stat_statements` is installed and readable. */
+  statements?: StatementUsage[];
+  /**
+   * When the cumulative counters were last reset (ISO 8601), from
+   * `pg_stat_database`. A recent reset means the numbers describe a short
+   * window and the checks should be read as provisional.
+   */
+  statsReset: string | null;
+  /** Why `statements` is absent, for the report's `notes`. */
+  statementsUnavailable?: string;
+}
+
+const DEFAULT_EXCLUDES = ['pg_catalog', 'information_schema', 'pg_toast'];
+
+/** Statements slower than this in aggregate are worth reporting at all. */
+export const DEFAULT_STATEMENT_LIMIT = 20;
+
+export async function introspectStats(
+  exec: QueryExecutor,
+  options: Pick<IntrospectOptions, 'schemas' | 'excludeSchemas'> & {
+    statementLimit?: number;
+  } = {}
+): Promise<StatsSnapshot> {
+  const excludes = [...DEFAULT_EXCLUDES, ...(options.excludeSchemas ?? [])];
+  const schemaFilter = options.schemas && options.schemas.length > 0
+    ? `AND s.schemaname = ANY($1::text[])`
+    : `AND NOT (s.schemaname = ANY($2::text[]))`;
+
+  // Both parameters are referenced (even when only one filters) so Postgres
+  // can infer their types — an unused $N errors out at bind time.
+  const sql = `
+    WITH _params AS (
+      SELECT $1::text[] AS include_schemas, $2::text[] AS exclude_schemas
+    )
+    SELECT
+      s.schemaname                                      AS schema_name,
+      s.relname                                         AS table_name,
+      s.seq_scan                                        AS seq_scans,
+      s.seq_tup_read                                    AS seq_tuples_read,
+      COALESCE(s.idx_scan, 0)                           AS index_scans,
+      s.n_live_tup                                      AS live_tuples,
+      s.n_dead_tup                                      AS dead_tuples,
+      pg_relation_size(s.relid)                         AS size_bytes,
+      GREATEST(s.last_vacuum, s.last_autovacuum)        AS last_vacuum,
+      GREATEST(s.last_analyze, s.last_autoanalyze)      AS last_analyze,
+      COALESCE(
+        (SELECT jsonb_agg(jsonb_build_object(
+          'name', i.indexrelname,
+          'scans', COALESCE(i.idx_scan, 0),
+          'sizeBytes', pg_relation_size(i.indexrelid),
+          'unique', ix.indisunique,
+          'constraint', (con.oid IS NOT NULL)
+        ) ORDER BY i.indexrelname)
+         FROM pg_stat_user_indexes i
+         JOIN pg_index ix ON ix.indexrelid = i.indexrelid
+         LEFT JOIN pg_constraint con
+           ON con.conindid = i.indexrelid AND con.contype IN ('p', 'u', 'x')
+         WHERE i.relid = s.relid),
+        '[]'::jsonb
+      )                                                 AS indexes
+    FROM pg_stat_user_tables s
+    WHERE true
+      ${schemaFilter}
+    ORDER BY s.schemaname, s.relname
+  `;
+
+  const { rows } = await exec.query<{
+    schema_name: string;
+    table_name: string;
+    seq_scans: string | number;
+    seq_tuples_read: string | number;
+    index_scans: string | number;
+    live_tuples: string | number;
+    dead_tuples: string | number;
+    size_bytes: string | number;
+    last_vacuum: Date | string | null;
+    last_analyze: Date | string | null;
+    indexes: IndexUsage[];
+  }>(sql, [options.schemas ?? [], excludes]);
+
+  const tables: TableUsage[] = rows.map((r) => ({
+    schema: r.schema_name,
+    name: r.table_name,
+    seqScans: num(r.seq_scans),
+    seqTuplesRead: num(r.seq_tuples_read),
+    indexScans: num(r.index_scans),
+    liveTuples: num(r.live_tuples),
+    deadTuples: num(r.dead_tuples),
+    sizeBytes: num(r.size_bytes),
+    lastVacuum: iso(r.last_vacuum),
+    lastAnalyze: iso(r.last_analyze),
+    indexes: r.indexes.map((i) => ({ ...i, scans: num(i.scans), sizeBytes: num(i.sizeBytes) }))
+  }));
+
+  const { rows: resetRows } = await exec.query<{ stats_reset: Date | string | null }>(
+    `SELECT stats_reset FROM pg_stat_database WHERE datname = current_database()`
+  );
+  const resetRow = resetRows[0];
+
+  const snapshot: StatsSnapshot = {
+    tables,
+    statsReset: iso(resetRow?.stats_reset ?? null)
+  };
+
+  const statements = await introspectStatements(exec, options.statementLimit);
+  if (typeof statements === 'string') snapshot.statementsUnavailable = statements;
+  else snapshot.statements = statements;
+
+  return snapshot;
+}
+
+/**
+ * Top statements by total execution time. Returns a reason string instead of
+ * rows when `pg_stat_statements` is not installed or not readable by the
+ * connected role — an optional extension is a normal state, not an error.
+ */
+async function introspectStatements(
+  exec: QueryExecutor,
+  limit = DEFAULT_STATEMENT_LIMIT
+): Promise<StatementUsage[] | string> {
+  const { rows: installedRows } = await exec.query<{ present: boolean }>(
+    `SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') AS present`
+  );
+  if (!installedRows[0]?.present) {
+    return 'pg_stat_statements is not installed — statement-level findings (S4) were skipped';
+  }
+
+  try {
+    const { rows } = await exec.query<{
+      query: string;
+      calls: string | number;
+      total_time_ms: string | number;
+      mean_time_ms: string | number;
+      rows: string | number;
+    }>(
+      `SELECT
+         query,
+         calls,
+         total_exec_time AS total_time_ms,
+         mean_exec_time  AS mean_time_ms,
+         rows
+       FROM pg_stat_statements
+       ORDER BY total_exec_time DESC
+       LIMIT $1`,
+      [limit]
+    );
+    return rows.map((r) => ({
+      query: r.query,
+      calls: num(r.calls),
+      totalTimeMs: Number(r.total_time_ms),
+      meanTimeMs: Number(r.mean_time_ms),
+      rows: num(r.rows)
+    }));
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return `pg_stat_statements is installed but unreadable (${message}) — S4 was skipped`;
+  }
+}
+
+function num(value: string | number): number {
+  return typeof value === 'number' ? value : Number(value);
+}
+
+function iso(value: Date | string | null): string | null {
+  if (value === null || value === undefined) return null;
+  return value instanceof Date ? value.toISOString() : String(value);
+}

--- a/packages/safegres/src/report/pretty.ts
+++ b/packages/safegres/src/report/pretty.ts
@@ -162,6 +162,27 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
         lines.push(renderFinding(f, paint));
       }
     }
+
+    const { stats, explain } = report.perf;
+    if (stats) {
+      lines.push(
+        paint(
+          'info',
+          `  runtime statistics: ${stats.tables} tables, counters since ${stats.statsReset ?? 'server start'}`
+            + `${stats.scored ? '' : ' (S* findings advisory — perf.scoring.includeStats is false)'}`
+        )
+      );
+      for (const note of stats.notes ?? []) lines.push(paint('info', `  ${note}`));
+    }
+    if (explain) {
+      lines.push(
+        paint(
+          'info',
+          explain.unavailable
+            ?? `  planner proof: ${explain.confirmed} confirmed, ${explain.refuted} refuted, ${explain.inconclusive} inconclusive of ${explain.probed} probed`
+        )
+      );
+    }
   }
 
   if (report.callGraph) {
@@ -201,5 +222,8 @@ function renderFinding(f: Finding, paint: (sev: Severity, s: string) => string):
   const head = `[${label}] ${f.code}  ${loc}`;
   const body = `    ${f.message}`;
   const hint = f.hint ? `    hint: ${f.hint}` : '';
-  return [head, body, hint].filter(Boolean).join('\n');
+  const evidence = f.evidence
+    ? `    plan (${f.evidence.status}): ${f.evidence.plan}${f.evidence.note ? ` — ${f.evidence.note}` : ''}`
+    : '';
+  return [head, body, hint, evidence].filter(Boolean).join('\n');
 }

--- a/packages/safegres/src/rules/registry.ts
+++ b/packages/safegres/src/rules/registry.ts
@@ -27,7 +27,7 @@ export interface RuleMeta {
    * Rules with `scope: 'policy-ast'` require parsing policy expressions.
    * When every one of them is disabled the audit skips AST work entirely.
    */
-  scope: 'table' | 'policy-ast' | 'index';
+  scope: 'table' | 'policy-ast' | 'index' | 'stats';
 }
 
 /** The scoring axis a rule belongs to (`security` unless declared otherwise). */
@@ -229,6 +229,42 @@ export const RULES: RuleMeta[] = [
     dimension: 'perf',
     title: 'Sort-shaped column (timestamp/date) leads no index — heuristic advisory',
     scope: 'index'
+  },
+  {
+    code: 'S1',
+    category: 'index',
+    defaultSeverity: 'medium',
+    direction: 'neutral',
+    dimension: 'perf',
+    title: 'Sequential-scan-dominant table (runtime statistics)',
+    scope: 'stats'
+  },
+  {
+    code: 'S2',
+    category: 'index',
+    defaultSeverity: 'low',
+    direction: 'neutral',
+    dimension: 'perf',
+    title: 'Index the planner has never chosen (runtime statistics)',
+    scope: 'stats'
+  },
+  {
+    code: 'S3',
+    category: 'index',
+    defaultSeverity: 'low',
+    direction: 'neutral',
+    dimension: 'perf',
+    title: 'Dead-tuple bloat — autovacuum is not keeping up (runtime statistics)',
+    scope: 'stats'
+  },
+  {
+    code: 'S4',
+    category: 'index',
+    defaultSeverity: 'info',
+    direction: 'neutral',
+    dimension: 'perf',
+    title: 'Statement hotspot on a table in scope (pg_stat_statements)',
+    scope: 'stats'
   }
 ];
 

--- a/packages/safegres/src/types.ts
+++ b/packages/safegres/src/types.ts
@@ -67,6 +67,26 @@ export interface Finding {
   hint?: string;
   /** Optional machine-readable extras (AST nodes, offending function name, …). */
   context?: Record<string, unknown>;
+  /**
+   * Proof attached by `--explain`: the plan the database produced for the
+   * query shape this finding is a claim about.
+   */
+  evidence?: FindingEvidence;
+}
+
+/**
+ * Planner evidence for a finding. `refuted` means the planner disagreed with
+ * the catalog inference — the finding is reported but no longer scored.
+ */
+export interface FindingEvidence {
+  source: 'explain';
+  status: 'confirmed' | 'refuted' | 'inconclusive';
+  /** The probe query, with parameters left unbound. */
+  probe: string;
+  /** Plan node types, outermost first. */
+  plan: string;
+  /** Why an inconclusive probe was inconclusive. */
+  note?: string;
 }
 
 export interface Summary {
@@ -109,6 +129,23 @@ export interface PerfReport {
    * are new debt, which were fixed, which are accepted.
    */
   diff?: import('./perf/baseline').PerfDiff;
+  /** Runtime-statistics provenance, present when the audit ran with `--stats`. */
+  stats?: PerfStatsReport;
+  /** Planner-proof summary, present when the audit ran with `--explain`. */
+  explain?: import('./perf/explain').ExplainReport;
+}
+
+/** Where the `S*` findings' numbers came from, and how much to trust them. */
+export interface PerfStatsReport {
+  source: 'live';
+  /** Tables whose cumulative statistics were read. */
+  tables: number;
+  /** When the counters were last reset — the window the numbers describe. */
+  statsReset: string | null;
+  /** Whether `S*` findings counted toward the perf score. */
+  scored: boolean;
+  /** Non-fatal gaps, e.g. `pg_stat_statements` not installed. */
+  notes?: string[];
 }
 
 export interface Report {


### PR DESCRIPTION
## Summary

Tiers 2 and 3 of the perf plan ([#1328](https://github.com/constructive-io/constructive-planning/issues/1328)), both opt-in refinements of the perf dimension. A plain `safegres audit` is unchanged: security-only, no perf report, no runtime query.

```
audit                      → security score only
audit --perf               → + X1-X8, P1/P1b   (static, deterministic)
audit --stats              → + S1-S4           (implies --perf; reads pg_stat_*)
audit --explain            → + plan evidence   (implies --perf; PG16+)
```

**`--stats` (S1-S4).** The `X*` rules read the schema; the `S*` rules read what the workload did to it — `pg_stat_user_tables`, `pg_stat_user_indexes`, and `pg_stat_statements` when installed. S1 seq-scan-dominant table (medium), S2 index the planner has never chosen (low), S3 dead-tuple bloat (low), S4 statement hotspot on a table in scope (info). Every threshold is a floor (`perf.stats.{minRows,seqScanRatio,minIndexBytes,deadTupleRatio,minTimeShare,topStatements}`) because a counter is only evidence if there's enough of it — S1 additionally stays quiet on tables with no index at all, which is X1/X6's job, not a runtime observation.

`S*` findings **are scored** on the perf axis: asking for `--stats` is the opt-in. `perf.scoring.includeStats: false` demotes them to advisories for anyone who wants the grade to stay deterministic. `report.perf.stats` carries the provenance the numbers need to be read honestly — table count, `statsReset` (the window the counters describe), whether they were scored, and a note when `pg_stat_statements` isn't installed. A missing extension or an unreadable view is never an error.

**`--explain` (planner proof).** Turns catalog *inference* into *evidence*. For each probeable finding it plans the query the finding is a claim about and reads the node types back:

```ts
// X1 on posts(author_id) →
EXPLAIN (GENERIC_PLAN, FORMAT JSON) SELECT 1 FROM "app"."posts" WHERE "author_id" = $1::bigint
```

`GENERIC_PLAN` (PG16+) means nothing is executed and parameters stay parameters, so no value has to be invented for a column whose domain we know nothing about. The interesting outcome is disagreement:

- **refuted** — the planner served the shape with an index the catalog rule didn't credit (a hash index on an FK column, say). The finding is acknowledged, demoted to `info`, and drops out of the perf score.
- **confirmed** — the predicted scan, on a table above `perf.explain.minRows` (default 1000).
- **inconclusive** — the predicted scan below the floor. An empty or unanalyzed table always seq-scans, so this proves nothing and the finding is left exactly as the static rule made it. Deliberately asymmetric: EXPLAIN can only ever *remove* a finding from the score, never add one.

Probes exist for X1/X2/X7/X8 — the rules that name a query shape. X5, X6, `P*`, `S*` get none; nothing is planned speculatively. Any probe that fails to plan (exotic type, missing operator class, permissions) is simply not evidence.

New surface: `finding.evidence: { source, status, probe, plan, note? }`, `report.perf.stats`, `report.perf.explain`. `TableIndexSnapshot` gains `estimatedRows` (`pg_class.reltuples`) — the row floor — from the existing single index-catalog query, so nothing extra is read when perf is off.

## Tests

`__tests__/perf-stats.test.ts` (16 new; 128 total pass). The `S*` rules are unit-tested against synthetic snapshots — cumulative counters are shared state a test transaction can't deterministically produce, so asserting on live numbers would be asserting on the harness — with the live path covered by integration tests for provenance, `--perf` implication, and `includeStats: false`. The EXPLAIN fixture builds all three outcomes in one schema: 20k-row table with no index (confirmed), the same shape behind a **hash** index (refuted — X1 only credits btree, the planner disagrees), and a 5-row table (inconclusive).

`pnpm lint` remains broken repo-wide, independently of this change (ESLint 9 expects `eslint.config.*`; the repo still has a legacy `.eslintrc.json`).


Link to Devin session: https://app.devin.ai/sessions/ec06ef6eabae4872ae5ec3926f037c85
Requested by: @pyramation