### PR TITLE
feat(safegres): markdown report format for CI job summaries and PR comments

### DIFF
--- a/.agents/skills/safegres/SKILL.md
+++ b/.agents/skills/safegres/SKILL.md
@@ -222,6 +222,7 @@ safegres audit --perf-baseline .safegres-perf.json --fail-on-new-perf   # ratche
 safegres audit --stats             # + runtime-statistics rules S1-S4 (implies --perf)
 safegres audit --explain           # + prove findings with EXPLAIN (implies --perf, PG16+)
 safegres audit --format json       # machine-readable
+safegres audit --format markdown >> "$GITHUB_STEP_SUMMARY"   # CI job summary / PR comment
 safegres audit --exposed-only      # hide internal advisories
 safegres doctor                    # config/parser/connection/catalog + exposure + stale public.read checks
 safegres print-config              # resolved effective config

--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -34,6 +34,24 @@ Pretty output prints the exposure line, score, and the exposed findings. Interna
 - `--verbose` — expand the internal advisories instead of collapsing them to a count.
 - `--exposed-only` — drop internal findings entirely.
 - `--format json` / `--format json-pretty` — machine-readable output (always carries every finding).
+- `--format markdown` — the same report as GitHub-flavoured markdown, for a job summary or a PR comment (see [CI](#ci)).
+
+### CI
+
+A plain audit is one command and one gate; `--format markdown` writes the report where a reviewer will actually see it:
+
+```yaml
+- name: Audit RLS
+  run: |
+    npx safegres audit --format markdown >> "$GITHUB_STEP_SUMMARY"
+    npx safegres audit --fail-on-grade B --summary
+  env:
+    PGHOST: localhost
+    PGUSER: postgres
+    PGPASSWORD: postgres
+```
+
+Scores lead, then the severity counts, then a table per dimension; internal (non-exposed) advisories and accepted baseline debt fold into `<details>` so the summary stays skimmable. To post it as a PR comment instead, pipe it to `gh pr comment --body-file -`. The same renderer is available to library callers as `renderMarkdown(report)`.
 
 ## What it checks
 

--- a/packages/safegres/__tests__/markdown.test.ts
+++ b/packages/safegres/__tests__/markdown.test.ts
@@ -1,0 +1,126 @@
+import { renderMarkdown } from '../src/report/markdown';
+import { computeScore } from '../src/score/score';
+import type { Finding, Report } from '../src/types';
+import { summarize } from '../src/types';
+
+function finding(over: Partial<Finding> = {}): Finding {
+  return {
+    code: 'A2',
+    severity: 'high',
+    category: 'flags',
+    exposed: true,
+    schema: 'app_public',
+    table: 'widgets',
+    message: 'grants exist on a table with RLS disabled',
+    ...over
+  };
+}
+
+function makeReport(over: Partial<Report> = {}): Report {
+  const findings = over.findings ?? [
+    finding(),
+    finding({ schema: 'db_migrate', table: 'log', exposed: false })
+  ];
+  return {
+    version: '1.0.0',
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    summary: summarize(findings),
+    findings,
+    score: computeScore(findings, undefined, { exposedTables: 10, exposureKnown: true }),
+    ...over
+  };
+}
+
+describe('renderMarkdown', () => {
+  it('leads with a score table and severity counts', () => {
+    const out = renderMarkdown(makeReport());
+    expect(out).toContain('## safegres');
+    expect(out).toMatch(/\| Dimension \| Score \| Grade \| Top deductions \|/);
+    expect(out).toMatch(/\| Security \| \*\*[\d.]+\*\* \| \*\*[A-D+]+\*\* \|/);
+    expect(out).toContain('| 🔴 critical | 🟠 high |');
+  });
+
+  it('renders findings as a table and collapses internal advisories', () => {
+    const out = renderMarkdown(makeReport());
+    expect(out).toContain('| 🟠 high | `A2` | app_public.widgets |');
+    expect(out).toContain('<details><summary>1 internal advisory');
+    // still present, but behind the fold
+    expect(out).toContain('db_migrate.log');
+  });
+
+  it('--verbose lifts the internal advisories out of the fold', () => {
+    const out = renderMarkdown(makeReport(), { verbose: true });
+    expect(out).not.toContain('<details>');
+    expect(out).toContain('db_migrate.log');
+  });
+
+  it('--summary stops after the counts', () => {
+    const out = renderMarkdown(makeReport(), { summary: true });
+    expect(out).toContain('| 🔴 critical |');
+    expect(out).not.toContain('app_public.widgets');
+  });
+
+  it('warns when the exposure surface is unknown', () => {
+    const out = renderMarkdown(
+      makeReport({
+        exposure: {
+          known: false,
+          source: 'none',
+          schemas: [],
+          exposedTables: 0,
+          totalTables: 12
+        }
+      })
+    );
+    expect(out).toContain('> [!WARNING]');
+    expect(out).toContain('score is capped');
+  });
+
+  it('keeps a message containing a pipe inside its cell', () => {
+    const out = renderMarkdown(
+      makeReport({ findings: [finding({ message: 'policy uses a | b\n  wrapped' })] })
+    );
+    expect(out).toContain('policy uses a \\| b wrapped');
+    expect(out.split('\n').filter((l) => l.startsWith('| 🟠'))).toHaveLength(1);
+  });
+
+  it('renders the perf dimension, its provenance, and the baseline diff', () => {
+    const perfFinding = finding({
+      code: 'X1',
+      severity: 'medium',
+      category: 'index',
+      dimension: 'perf',
+      table: 'posts',
+      message: 'foreign key posts_author_id_fkey has no covering index'
+    });
+    const report = makeReport({
+      findings: [finding(), perfFinding],
+      perf: {
+        findings: [perfFinding],
+        summary: summarize([perfFinding]),
+        score: computeScore([perfFinding], undefined, { exposedTables: 10, exposureKnown: true }),
+        stats: { source: 'live', tables: 4, statsReset: '2026-01-01T00:00:00.000Z', scored: true },
+        explain: { probed: 3, confirmed: 1, refuted: 1, inconclusive: 1 },
+        diff: { added: [perfFinding], removed: [], accepted: [] }
+      }
+    });
+    const out = renderMarkdown(report);
+    expect(out).toContain('| Performance | ');
+    expect(out).toContain('### Performance findings');
+    expect(out).toContain('| 🟡 medium | `X1` | app_public.posts |');
+    // the security table must not carry the perf finding
+    const securitySection = out.slice(
+      out.indexOf('### Security findings'),
+      out.indexOf('### Performance findings')
+    );
+    expect(securitySection).not.toContain('X1');
+    expect(out).toContain('Runtime statistics: 4 tables, counters since 2026-01-01');
+    expect(out).toContain('Planner proof: 1 confirmed, 1 refuted, 1 inconclusive of 3 probed');
+    expect(out).toContain('**1 new** since the baseline');
+  });
+
+  it('says so when there is nothing to report', () => {
+    const out = renderMarkdown(makeReport({ findings: [], score: undefined }));
+    expect(out).toContain('No findings.');
+  });
+});

--- a/packages/safegres/src/cli/audit.ts
+++ b/packages/safegres/src/cli/audit.ts
@@ -8,6 +8,7 @@ import { loadConfig } from '../config/loader';
 import type { Grade } from '../config/types';
 import { diffPerf, parsePerfBaseline, serializePerfBaseline, toPerfBaseline } from '../perf/baseline';
 import { renderJson } from '../report/json';
+import { renderMarkdown } from '../report/markdown';
 import { renderPretty } from '../report/pretty';
 import { meetsGrade } from '../score/score';
 import type { Report, Severity } from '../types';
@@ -98,7 +99,8 @@ Audit options:
   --exclude-schemas <csv>  Skip these schemas
   --roles <csv>            Audit grants only for these roles (default: all)
   --exclude-roles <csv>    Skip grants for these roles
-  --format <fmt>           "pretty" (default) | "json" | "json-pretty"
+  --format <fmt>           "pretty" (default) | "json" | "json-pretty" | "markdown"
+                           (markdown is for CI: a GitHub job summary or PR comment)
   --summary, -q            Print only exposure, score, and severity counts (no findings)
   --verbose                Expand internal (non-exposed) advisories (listed as a count otherwise)
   --fail-on <severity>     Exit non-zero if any finding >= severity
@@ -215,6 +217,13 @@ export default async (
     break;
   case 'json-pretty':
     output = renderJson(report, { pretty: true });
+    break;
+  case 'markdown':
+  case 'md':
+    output = renderMarkdown(report, {
+      summary: argv.summary === true,
+      verbose: argv.verbose === true
+    });
     break;
   case 'pretty':
     output = renderPretty(report, {

--- a/packages/safegres/src/index.ts
+++ b/packages/safegres/src/index.ts
@@ -121,6 +121,8 @@ export {
 } from './perf/baseline';
 export { renderCallGraph, renderCallGraphDiff } from './report/callgraph';
 export { renderJson } from './report/json';
+export type { RenderMarkdownOptions } from './report/markdown';
+export { renderMarkdown } from './report/markdown';
 export { renderPretty } from './report/pretty';
 export type { RuleMeta } from './rules/registry';
 export { dimensionOf, expandRuleSelector, isKnownRule, RULES, RULES_BY_CODE } from './rules/registry';

--- a/packages/safegres/src/report/markdown.ts
+++ b/packages/safegres/src/report/markdown.ts
@@ -1,0 +1,156 @@
+/**
+ * Markdown rendering (`--format markdown`), for the places CI reads a report:
+ * a GitHub job summary (`$GITHUB_STEP_SUMMARY`) or a PR comment.
+ *
+ * The pretty renderer is a terminal artifact — ANSI colors, fixed-width
+ * severity labels, a long scrollable list. A PR comment is read once, by
+ * someone deciding whether to look further, so this renders the same report
+ * as tables: scores first, then findings grouped by rule, with the noisy
+ * parts (internal advisories, accepted debt) collapsed into `<details>`.
+ */
+
+import type { Score } from '../score/score';
+import type { Finding, Report, Severity } from '../types';
+
+const SEV_ICON: Record<Severity, string> = {
+  critical: '🔴',
+  high: '🟠',
+  medium: '🟡',
+  low: '🔵',
+  info: '⚪'
+};
+
+export interface RenderMarkdownOptions {
+  /** Scores and counts only — no per-finding tables. */
+  summary?: boolean;
+  /** Expand internal (non-exposed) advisories instead of collapsing them. */
+  verbose?: boolean;
+  /** Heading text. Default `safegres`. */
+  title?: string;
+}
+
+export function renderMarkdown(report: Report, options: RenderMarkdownOptions = {}): string {
+  const out: string[] = [`## ${options.title ?? 'safegres'}`, ''];
+
+  out.push(...scoreTable(report), '');
+
+  if (report.exposure) {
+    const { known, source, exposedTables, totalTables, roles } = report.exposure;
+    out.push(
+      known
+        ? `Exposure (${source}): **${exposedTables}/${totalTables}** tables reachable`
+          + `${roles && roles.length > 0 ? ` via \`${roles.join('`, `')}\`` : ''}.`
+        : '> [!WARNING]\n> Exposure unknown — the entire database is assumed reachable and the score is capped.',
+      ''
+    );
+  }
+
+  out.push(countsTable(report), '');
+  if (options.summary) return out.join('\n');
+
+  const security = report.perf
+    ? report.findings.filter((f) => f.dimension !== 'perf')
+    : report.findings;
+  out.push(...findingSection('Security findings', security, options), '');
+
+  if (report.perf) {
+    out.push(...findingSection('Performance findings', report.perf.findings, options));
+    const { stats, explain, diff } = report.perf;
+    const notes: string[] = [];
+    if (stats) {
+      notes.push(
+        `Runtime statistics: ${stats.tables} tables, counters since ${stats.statsReset ?? 'server start'}`
+          + `${stats.scored ? '' : ' (advisory — `includeStats` is false)'}.`
+      );
+      for (const note of stats.notes ?? []) notes.push(note);
+    }
+    if (explain) {
+      notes.push(
+        explain.unavailable
+          ?? `Planner proof: ${explain.confirmed} confirmed, ${explain.refuted} refuted, `
+            + `${explain.inconclusive} inconclusive of ${explain.probed} probed.`
+      );
+    }
+    if (notes.length > 0) out.push('', notes.map((n) => `_${n}_`).join('  \n'));
+
+    if (diff) {
+      out.push('', '### Performance vs baseline', '');
+      out.push(
+        diff.added.length === 0
+          ? `No new perf debt (${diff.accepted.length} accepted, ${diff.removed.length} fixed).`
+          : `**${diff.added.length} new** since the baseline `
+            + `(${diff.accepted.length} accepted, ${diff.removed.length} fixed):`
+      );
+      if (diff.added.length > 0) out.push('', findingTable(diff.added));
+    }
+    out.push('');
+  }
+
+  return out.join('\n');
+}
+
+function scoreTable(report: Report): string[] {
+  const rows: string[] = [];
+  if (report.score) rows.push(scoreRow('Security', report.score));
+  if (report.perf) rows.push(scoreRow('Performance', report.perf.score));
+  if (rows.length === 0) return [];
+  return ['| Dimension | Score | Grade | Top deductions |', '| --- | --- | --- | --- |', ...rows];
+}
+
+function scoreRow(label: string, score: Score): string {
+  const top = score.deductions
+    .slice(0, 3)
+    .map((d) => `\`${d.code}\` −${d.points} (×${d.count})`)
+    .join(', ');
+  const capped = score.cappedByUnknownExposure ? ' (capped)' : '';
+  return `| ${label} | **${score.value}**${capped} | **${score.grade}** | ${top || '—'} |`;
+}
+
+function countsTable(report: Report): string {
+  const s = report.summary;
+  return [
+    '| 🔴 critical | 🟠 high | 🟡 medium | 🔵 low | ⚪ info |',
+    '| --- | --- | --- | --- | --- |',
+    `| ${s.critical} | ${s.high} | ${s.medium} | ${s.low} | ${s.info} |`
+  ].join('\n');
+}
+
+function findingSection(
+  heading: string,
+  findings: Finding[],
+  options: RenderMarkdownOptions
+): string[] {
+  const out = [`### ${heading}`, ''];
+  const exposed = findings.filter((f) => f.exposed !== false);
+  const internal = findings.filter((f) => f.exposed === false);
+
+  if (exposed.length === 0) out.push('No findings.');
+  else out.push(findingTable(exposed));
+
+  if (internal.length > 0) {
+    const table = findingTable(internal);
+    out.push(
+      '',
+      options.verbose
+        ? table
+        : `<details><summary>${internal.length} internal `
+          + `advisor${internal.length === 1 ? 'y' : 'ies'} — not exposed via any API, `
+          + `excluded from the score</summary>\n\n${table}\n\n</details>`
+    );
+  }
+  return out;
+}
+
+function findingTable(findings: Array<Pick<Finding, 'code' | 'severity' | 'schema' | 'table' | 'policy' | 'message'>>): string {
+  const rows = findings.map((f) => {
+    const where = [f.schema, f.table].filter(Boolean).join('.') || '—';
+    const policy = f.policy ? ` \`${f.policy}\`` : '';
+    return `| ${SEV_ICON[f.severity]} ${f.severity} | \`${f.code}\` | ${where}${policy} | ${escapeCell(f.message)} |`;
+  });
+  return ['| Severity | Rule | Relation | Finding |', '| --- | --- | --- | --- |', ...rows].join('\n');
+}
+
+/** Keep a message inside its table cell: no pipes, no line breaks. */
+function escapeCell(value: string): string {
+  return value.replace(/\|/g, '\\|').replace(/\s*\n\s*/g, ' ');
+}


### PR DESCRIPTION
## Summary

`--format markdown` (also `renderMarkdown(report)`), so a scan lands where someone will read it:

```yaml
- run: npx safegres audit --perf --format markdown >> "$GITHUB_STEP_SUMMARY"
```

The pretty renderer is a terminal artifact — ANSI colors, fixed-width severity labels, a scrollable list. A job summary or PR comment is read once, by someone deciding whether to look further, so this renders the same `Report` as tables: scores first (one row per dimension, with the top deductions), then the severity counts, then a table per dimension. Everything that is noise on first read folds away — internal (non-exposed) advisories and accepted baseline debt go into `<details>`, `--summary` stops after the counts, `--verbose` unfolds. Unknown exposure renders as a GitHub `> [!WARNING]` callout rather than a line of prose, since a capped score is the thing a reviewer must not miss.

```
| Dimension | Score | Grade | Top deductions |
| --- | --- | --- | --- |
| Security | **84.4** | **B** | `A2` −10 (×1) |
| Performance | **91.2** | **A** | `X1` −4 (×1) |

| Severity | Rule | Relation | Finding |
| --- | --- | --- | --- |
| 🟠 high | `A2` | app_public.widgets | grants exist on a table with RLS disabled |
```

Perf provenance from #1552 comes along: the `--stats` window (`statsReset`), the `--explain` confirmed/refuted/inconclusive tally, and the baseline diff. Messages are escaped for the cell they live in (`|` → `\|`, newlines flattened), which is the one thing that would silently corrupt the table.

No behavior changes anywhere else — new renderer, one `case` in the format switch, one README section (`## CI`) with the workflow snippet.

## Tests

`__tests__/markdown.test.ts` (8 new; 136 total pass): score/count tables, the collapse/`--verbose`/`--summary` behaviors, the unknown-exposure callout, pipe-and-newline escaping staying inside one row, and a perf report asserting the security table doesn't carry perf findings.


Link to Devin session: https://app.devin.ai/sessions/ec06ef6eabae4872ae5ec3926f037c85
Requested by: @pyramation