### PR TITLE
docs(agents): document bundled deploy CLI (pgpm package / deploy --fast)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,30 @@ This guide helps AI agents quickly navigate the Constructive monorepo. Construct
 - Generate types/SDK: `cnc codegen`
 - Export schema SDL: `cnc get-graphql-schema`
 
+## Bundled Deploy (fast, ledger-preserving migrations)
+
+Every module can ship a content-addressed **bundle artifact** alongside its packaged SQL, and deploys can run from it in one shot — same speed as the old fast path, but it still writes the `pgpm_migrate` ledger. It's all driven by two CLI commands.
+
+**Emit the artifact (packaging):**
+
+```bash
+pgpm package            # writes sql/<name>--<version>.sql AND sql/<name>--<version>.bundle.tar.gz (default)
+pgpm package --no-bundle # skip the bundle artifact
+```
+
+The `.bundle.tar.gz` is a gzipped tarball of the module's JSON migration bundle (plan + per-change deploy/revert/verify SQL + a sha256 digest). **Commit it** beside the `.sql`.
+
+**Deploy from it (fast path):**
+
+```bash
+pgpm deploy --fast      # one-shot execute + bulk pgpm_migrate ledger
+pgpm deploy --bundled   # alias for --fast
+```
+
+`--fast` prefers each module's committed `sql/<name>--<version>.bundle.tar.gz`: it verifies the sha256 digest, checks the artifact still matches `deploy/`, executes the module in a single round-trip, and bulk-inserts one `pgpm_migrate` row (name + hash) per change. If the artifact is missing, stale, or fails verification it **falls back** to building the bundle from `deploy/` — no behavior change, never a hard failure. Re-deploys skip changes already recorded by hash.
+
+Programmatic API (only if you can't use the CLI): `writeBundleArtifact` / `readBundleArtifact` / `buildExecutableBundle` in `pgpm/core/src/bundle/artifact.ts`; see the `pgpm-migration-bundle` skill for the artifact/AST internals.
+
 ## Best Practices
 
 ### Environment Configuration


### PR DESCRIPTION
## Summary

Adds a prominent, CLI-first "Bundled Deploy" section to `AGENTS.md` documenting how to leverage the bundle artifact shipped in #1520. Docs-only.

The section explains the two commands and stays out of internals:
- `pgpm package` emits `sql/<name>--<version>.bundle.tar.gz` alongside the `.sql` (default; `--no-bundle` to skip) and the tarball is committed.
- `pgpm deploy --fast` / `--bundled` prefers the committed artifact → verify sha256 → check it still matches `deploy/` → one-shot execute + bulk `pgpm_migrate` ledger; graceful fallback to building from `deploy/` when missing/stale/unverified; re-deploys skip by hash.

One-line pointer to the programmatic API (`writeBundleArtifact`/`readBundleArtifact`/`buildExecutableBundle`) and the `pgpm-migration-bundle` skill for anyone who needs the internals.

Link to Devin session: https://app.devin.ai/sessions/fb12b07b9cb0499782980ceffe689de4
Requested by: @pyramation