### PR TITLE
feat(safegres): SARIF output for GitHub code scanning

### DIFF
--- a/.agents/skills/safegres/SKILL.md
+++ b/.agents/skills/safegres/SKILL.md
@@ -223,6 +223,7 @@ safegres audit --stats             # + runtime-statistics rules S1-S4 (implies -
 safegres audit --explain           # + prove findings with EXPLAIN (implies --perf, PG16+)
 safegres audit --format json       # machine-readable
 safegres audit --format markdown >> "$GITHUB_STEP_SUMMARY"   # CI job summary / PR comment
+safegres audit --format sarif --sarif-sources ./deploy       # GitHub code scanning (upload-sarif)
 safegres audit --exposed-only      # hide internal advisories
 safegres doctor                    # config/parser/connection/catalog + exposure + stale public.read checks
 safegres print-config              # resolved effective config

--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -35,6 +35,7 @@ Pretty output prints the exposure line, score, and the exposed findings. Interna
 - `--exposed-only` — drop internal findings entirely.
 - `--format json` / `--format json-pretty` — machine-readable output (always carries every finding).
 - `--format markdown` — the same report as GitHub-flavoured markdown, for a job summary or a PR comment (see [CI](#ci)).
+- `--format sarif` — SARIF 2.1.0 for GitHub code scanning (see [CI](#ci)).
 
 ### CI
 
@@ -52,6 +53,20 @@ A plain audit is one command and one gate; `--format markdown` writes the report
 ```
 
 Scores lead, then the severity counts, then a table per dimension; internal (non-exposed) advisories and accepted baseline debt fold into `<details>` so the summary stays skimmable. To post it as a PR comment instead, pipe it to `gh pr comment --body-file -`. The same renderer is available to library callers as `renderMarkdown(report)`.
+
+#### Code scanning (SARIF)
+
+`--format sarif` emits SARIF 2.1.0, so findings become GitHub code-scanning alerts — Security tab, inline PR annotations, dismissals that stick:
+
+```yaml
+- run: npx safegres audit --perf --format sarif --sarif-sources ./deploy > safegres.sarif
+- uses: github/codeql-action/upload-sarif@v3
+  with: { sarif_file: safegres.sarif }
+```
+
+An alert needs a file and a line, but safegres reads the catalog — a live database has no source location. `--sarif-sources <dir>` scans that directory's `.sql` for the `CREATE TABLE` / `CREATE POLICY` that defines each object, so a finding on `app_public.widgets` points at the migration that created it (policy findings resolve to the `CREATE POLICY` line). Findings that don't resolve are still emitted, without a location — GitHub drops those, other SARIF consumers keep them.
+
+Results are fingerprinted by finding *identity* (code + relation + policy + subject, the same key the [perf baseline](#perf-baseline-the-ratchet) uses), never by message text, so rewording a rule in a later release doesn't close and reopen every alert. Perf rules are tagged `performance`, security rules `security`.
 
 ## What it checks
 

--- a/packages/safegres/__tests__/sarif.test.ts
+++ b/packages/safegres/__tests__/sarif.test.ts
@@ -1,0 +1,169 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { buildSourceIndex, renderSarif } from '../src/report/sarif';
+import { computeScore } from '../src/score/score';
+import type { Finding, Report } from '../src/types';
+import { summarize } from '../src/types';
+
+function finding(over: Partial<Finding> = {}): Finding {
+  return {
+    code: 'A2',
+    severity: 'high',
+    category: 'flags',
+    direction: 'fail-open',
+    exposed: true,
+    schema: 'app_public',
+    table: 'widgets',
+    message: 'grants exist on a table with RLS disabled',
+    ...over
+  };
+}
+
+function makeReport(findings: Finding[]): Report {
+  return {
+    version: '1.0.0',
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    summary: summarize(findings),
+    findings,
+    score: computeScore(findings, undefined, { exposedTables: 10, exposureKnown: true })
+  };
+}
+
+function parse(findings: Finding[], options?: Parameters<typeof renderSarif>[1]) {
+  return JSON.parse(renderSarif(makeReport(findings), options));
+}
+
+describe('renderSarif', () => {
+  it('emits a valid-shaped SARIF 2.1.0 run', () => {
+    const sarif = parse([finding()]);
+    expect(sarif.version).toBe('2.1.0');
+    expect(sarif.$schema).toContain('sarif-schema-2.1.0');
+    expect(sarif.runs).toHaveLength(1);
+    expect(sarif.runs[0].tool.driver.name).toBe('safegres');
+    expect(sarif.runs[0].tool.driver.semanticVersion).toBe('1.0.0');
+  });
+
+  it('declares only the rules it emitted, with GitHub severity metadata', () => {
+    const sarif = parse([finding(), finding({ code: 'A1', severity: 'low', direction: 'fail-closed' })]);
+    const rules = sarif.runs[0].tool.driver.rules;
+    expect(rules.map((r: { id: string }) => r.id).sort()).toEqual(['A1', 'A2']);
+    const a2 = rules.find((r: { id: string }) => r.id === 'A2');
+    expect(a2.defaultConfiguration.level).toBe('error');
+    expect(a2.properties['security-severity']).toBe('7.0');
+    expect(a2.properties.tags).toContain('security');
+    expect(a2.shortDescription.text).toContain('RLS disabled');
+  });
+
+  it('tags perf rules as performance so they are separable from security alerts', () => {
+    const sarif = parse([
+      finding({ code: 'X1', severity: 'medium', category: 'index', dimension: 'perf', direction: 'neutral' })
+    ]);
+    const rule = sarif.runs[0].tool.driver.rules[0];
+    expect(rule.properties.tags).toContain('performance');
+    expect(sarif.runs[0].results[0].properties.dimension).toBe('perf');
+  });
+
+  it('maps severities onto SARIF levels', () => {
+    const sarif = parse([
+      finding({ code: 'A7', severity: 'critical' }),
+      finding({ code: 'R3', severity: 'medium' }),
+      finding({ code: 'A6', severity: 'info' })
+    ]);
+    expect(sarif.runs[0].results.map((r: { level: string }) => r.level)).toEqual(['error', 'warning', 'note']);
+  });
+
+  it('fingerprints results by identity, not message text', () => {
+    const before = parse([finding()]).runs[0].results[0].partialFingerprints;
+    const after = parse([finding({ message: 'completely reworded in a later release' })])
+      .runs[0].results[0].partialFingerprints;
+    expect(after).toEqual(before);
+    expect(before.safegresFindingKey).toContain('A2|app_public|widgets');
+  });
+
+  it('carries both scores as run properties', () => {
+    const report = makeReport([finding()]);
+    const perfFinding = finding({ code: 'X1', dimension: 'perf', severity: 'medium', category: 'index' });
+    report.perf = {
+      findings: [perfFinding],
+      summary: summarize([perfFinding]),
+      score: computeScore([perfFinding], undefined, { exposedTables: 10, exposureKnown: true })
+    };
+    const sarif = JSON.parse(renderSarif(report));
+    expect(sarif.runs[0].properties.grade).toBeDefined();
+    expect(sarif.runs[0].properties.perfGrade).toBeDefined();
+  });
+
+  it('emits an empty location list when nothing resolves', () => {
+    const sarif = parse([finding()]);
+    expect(sarif.runs[0].results[0].locations).toEqual([]);
+    expect(sarif.runs[0].results[0].message.text).toBe(
+      'app_public.widgets: grants exist on a table with RLS disabled'
+    );
+  });
+});
+
+describe('buildSourceIndex', () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'safegres-sarif-'));
+    mkdirSync(join(dir, 'deploy'), { recursive: true });
+    mkdirSync(join(dir, 'node_modules'), { recursive: true });
+    writeFileSync(
+      join(dir, 'deploy', 'widgets.sql'),
+      [
+        '-- Deploy widgets',
+        'BEGIN;',
+        'CREATE TABLE app_public.widgets (',
+        '  id uuid primary key',
+        ');',
+        'ALTER TABLE app_public.widgets ENABLE ROW LEVEL SECURITY;',
+        'CREATE POLICY widgets_select ON app_public.widgets FOR SELECT USING (true);',
+        'COMMIT;'
+      ].join('\n')
+    );
+    writeFileSync(
+      join(dir, 'deploy', 'quoted.sql'),
+      'CREATE TABLE IF NOT EXISTS "Mixed"."Case" (id int);\n'
+    );
+    // must be ignored
+    writeFileSync(join(dir, 'node_modules', 'other.sql'), 'CREATE TABLE app_public.widgets (id int);\n');
+    writeFileSync(join(dir, 'deploy', 'notes.md'), 'CREATE TABLE app_public.decoy (id int);\n');
+  });
+
+  it('indexes tables and policies with POSIX-relative paths', () => {
+    const index = buildSourceIndex(dir);
+    expect(index.get('app_public.widgets')).toEqual({ file: 'deploy/widgets.sql', line: 3 });
+    expect(index.get('app_public.widgets:widgets_select')).toEqual({ file: 'deploy/widgets.sql', line: 7 });
+  });
+
+  it('skips node_modules and non-SQL files', () => {
+    const index = buildSourceIndex(dir);
+    expect(index.get('app_public.widgets')?.file).toBe('deploy/widgets.sql');
+    expect(index.has('app_public.decoy')).toBe(false);
+  });
+
+  it('preserves quoted identifiers and folds unquoted ones', () => {
+    const index = buildSourceIndex(dir);
+    expect(index.has('Mixed.Case')).toBe(true);
+  });
+
+  it('points results at the policy line when the finding names a policy', () => {
+    const sources = buildSourceIndex(dir);
+    const sarif = parse(
+      [
+        finding({ code: 'A8', severity: 'low', category: 'anti-pattern', policy: 'widgets_select' }),
+        finding()
+      ],
+      { sources }
+    );
+    const [policyResult, tableResult] = sarif.runs[0].results;
+    expect(policyResult.locations[0].physicalLocation).toEqual({
+      artifactLocation: { uri: 'deploy/widgets.sql' },
+      region: { startLine: 7 }
+    });
+    expect(tableResult.locations[0].physicalLocation.region.startLine).toBe(3);
+  });
+});

--- a/packages/safegres/src/cli/audit.ts
+++ b/packages/safegres/src/cli/audit.ts
@@ -10,6 +10,7 @@ import { diffPerf, parsePerfBaseline, serializePerfBaseline, toPerfBaseline } fr
 import { renderJson } from '../report/json';
 import { renderMarkdown } from '../report/markdown';
 import { renderPretty } from '../report/pretty';
+import { buildSourceIndex, renderSarif } from '../report/sarif';
 import { meetsGrade } from '../score/score';
 import type { Report, Severity } from '../types';
 import { meetsThreshold, SEVERITY_ORDER, summarize } from '../types';
@@ -99,8 +100,12 @@ Audit options:
   --exclude-schemas <csv>  Skip these schemas
   --roles <csv>            Audit grants only for these roles (default: all)
   --exclude-roles <csv>    Skip grants for these roles
-  --format <fmt>           "pretty" (default) | "json" | "json-pretty" | "markdown"
-                           (markdown is for CI: a GitHub job summary or PR comment)
+  --format <fmt>           "pretty" (default) | "json" | "json-pretty" | "markdown" | "sarif"
+                           (markdown is for CI: a GitHub job summary or PR comment;
+                           sarif uploads to GitHub code scanning)
+  --sarif-sources <dir>    With --format sarif: scan <dir> for the CREATE TABLE /
+                           CREATE POLICY that defines each object, so alerts point
+                           at the SQL that produced the finding
   --summary, -q            Print only exposure, score, and severity counts (no findings)
   --verbose                Expand internal (non-exposed) advisories (listed as a count otherwise)
   --fail-on <severity>     Exit non-zero if any finding >= severity
@@ -217,6 +222,13 @@ export default async (
     break;
   case 'json-pretty':
     output = renderJson(report, { pretty: true });
+    break;
+  case 'sarif':
+    output = renderSarif(report, {
+      sources: typeof argv['sarif-sources'] === 'string'
+        ? buildSourceIndex(argv['sarif-sources'])
+        : undefined
+    });
     break;
   case 'markdown':
   case 'md':

--- a/packages/safegres/src/index.ts
+++ b/packages/safegres/src/index.ts
@@ -124,6 +124,8 @@ export { renderJson } from './report/json';
 export type { RenderMarkdownOptions } from './report/markdown';
 export { renderMarkdown } from './report/markdown';
 export { renderPretty } from './report/pretty';
+export type { BuildSourceIndexOptions, RenderSarifOptions, SourceIndex, SourceLocation } from './report/sarif';
+export { buildSourceIndex, renderSarif } from './report/sarif';
 export type { RuleMeta } from './rules/registry';
 export { dimensionOf, expandRuleSelector, isKnownRule, RULES, RULES_BY_CODE } from './rules/registry';
 export type { Score, ScoreContext, ScoreDeduction } from './score/score';

--- a/packages/safegres/src/report/sarif.ts
+++ b/packages/safegres/src/report/sarif.ts
@@ -1,0 +1,224 @@
+/**
+ * SARIF 2.1.0 rendering (`--format sarif`), so findings land in GitHub code
+ * scanning (Security tab + inline PR annotations) instead of only in a log.
+ *
+ * A code-scanning alert is a *file and a line*, but safegres reads the
+ * catalog — a live database has no source location. `buildSourceIndex()`
+ * closes that gap by scanning the SQL that produced the database
+ * (pgpm deploy scripts, migrations) for the `CREATE TABLE` / `CREATE POLICY`
+ * that defines each object, so `app_public.widgets` resolves to the line that
+ * created it. Findings that don't resolve are still emitted, without a
+ * location: GitHub drops those from the Security tab, but any other SARIF
+ * consumer keeps them, and the JSON format carries everything regardless.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative, sep } from 'path';
+
+import { findingKey, subjectOf } from '../perf/baseline';
+import { RULES, dimensionOf } from '../rules/registry';
+import type { Finding, Report, Severity } from '../types';
+
+const SARIF_VERSION = '2.1.0';
+const SCHEMA = 'https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json';
+
+/** SARIF has three visible levels; five severities have to fold into them. */
+const LEVEL: Record<Severity, 'error' | 'warning' | 'note'> = {
+  critical: 'error',
+  high: 'error',
+  medium: 'warning',
+  low: 'note',
+  info: 'note'
+};
+
+/**
+ * GitHub reads `security-severity` (a CVSS-shaped number) to bucket an alert
+ * as critical/high/medium/low in the Security tab.
+ */
+const SECURITY_SEVERITY: Record<Severity, string> = {
+  critical: '9.0',
+  high: '7.0',
+  medium: '5.0',
+  low: '3.0',
+  info: '1.0'
+};
+
+export interface SourceLocation {
+  /** Repo-relative POSIX path, as GitHub expects it. */
+  file: string;
+  line: number;
+}
+
+/** `schema.table` → definition site, plus `schema.table:policy` for policies. */
+export type SourceIndex = Map<string, SourceLocation>;
+
+export interface RenderSarifOptions {
+  /** Definition sites for relations and policies (see `buildSourceIndex`). */
+  sources?: SourceIndex;
+  /** Absolute URI of the scanned repository root, if known. */
+  repoRoot?: string;
+}
+
+export function renderSarif(report: Report, options: RenderSarifOptions = {}): string {
+  const findings = report.findings;
+  const emitted = new Set(findings.map((f) => f.code));
+
+  const sarif = {
+    $schema: SCHEMA,
+    version: SARIF_VERSION,
+    runs: [
+      {
+        tool: {
+          driver: {
+            name: 'safegres',
+            informationUri: 'https://github.com/constructive-io/constructive/tree/main/packages/safegres',
+            semanticVersion: report.version,
+            version: report.version,
+            rules: RULES.filter((r) => emitted.has(r.code)).map((rule) => ({
+              id: rule.code,
+              name: rule.code,
+              shortDescription: { text: rule.title },
+              fullDescription: { text: rule.title },
+              defaultConfiguration: { level: LEVEL[rule.defaultSeverity] },
+              properties: {
+                tags: [
+                  dimensionOf(rule) === 'perf' ? 'performance' : 'security',
+                  rule.category,
+                  rule.direction
+                ],
+                'security-severity': SECURITY_SEVERITY[rule.defaultSeverity]
+              }
+            }))
+          }
+        },
+        // Scores have nowhere to live in a SARIF result, so they ride along as
+        // run properties — enough for a consumer to gate on.
+        properties: {
+          generatedAt: report.generatedAt,
+          ...(report.score ? { score: report.score.value, grade: report.score.grade } : {}),
+          ...(report.perf ? { perfScore: report.perf.score.value, perfGrade: report.perf.score.grade } : {})
+        },
+        results: findings.map((finding) => result(finding, options))
+      }
+    ]
+  };
+
+  return JSON.stringify(sarif, null, 2);
+}
+
+function result(finding: Finding, options: RenderSarifOptions) {
+  const location = resolve(finding, options.sources);
+  const relation = [finding.schema, finding.table].filter(Boolean).join('.');
+  return {
+    ruleId: finding.code,
+    level: LEVEL[finding.severity],
+    message: { text: relation ? `${relation}: ${finding.message}` : finding.message },
+    ...(location
+      ? {
+        locations: [
+          {
+            physicalLocation: {
+              artifactLocation: {
+                uri: location.file,
+                ...(options.repoRoot ? { uriBaseId: '%SRCROOT%' } : {})
+              },
+              region: { startLine: location.line }
+            }
+          }
+        ]
+      }
+      : { locations: [] }),
+    // Identity, not text: the same key the perf baseline uses, so rewording a
+    // rule doesn't resolve-and-reopen every alert.
+    partialFingerprints: {
+      safegresFindingKey: findingKey({
+        code: finding.code,
+        schema: finding.schema,
+        table: finding.table,
+        policy: finding.policy,
+        subject: subjectOf(finding)
+      })
+    },
+    properties: {
+      severity: finding.severity,
+      category: finding.category,
+      dimension: finding.dimension ?? 'security',
+      ...(finding.direction ? { direction: finding.direction } : {}),
+      ...(finding.exposed === undefined ? {} : { exposed: finding.exposed }),
+      ...(finding.acknowledged ? { acknowledged: true } : {}),
+      ...(finding.policy ? { policy: finding.policy } : {}),
+      ...(finding.role ? { role: finding.role } : {}),
+      ...(finding.hint ? { hint: finding.hint } : {})
+    }
+  };
+}
+
+/** Policy site first — it's the precise line — then the table that owns it. */
+function resolve(finding: Finding, sources?: SourceIndex): SourceLocation | undefined {
+  if (!sources || !finding.schema || !finding.table) return undefined;
+  const relation = `${finding.schema}.${finding.table}`;
+  if (finding.policy) {
+    const policy = sources.get(`${relation}:${finding.policy}`);
+    if (policy) return policy;
+  }
+  return sources.get(relation);
+}
+
+const CREATE_TABLE = /^\s*create\s+(?:unlogged\s+|temp\w*\s+)?table\s+(?:if\s+not\s+exists\s+)?("?[\w$]+"?)\.("?[\w$]+"?)/i;
+const CREATE_POLICY = /^\s*create\s+policy\s+("?[\w$]+"?)\s+on\s+("?[\w$]+"?)\.("?[\w$]+"?)/i;
+
+export interface BuildSourceIndexOptions {
+  /** Directory names to skip. Defaults to node_modules, .git, dist. */
+  skipDirs?: string[];
+  /** Paths in the index are relative to this. Defaults to `dir`. */
+  root?: string;
+}
+
+/**
+ * Scan a directory tree of `.sql` files for the statements that define the
+ * objects safegres reports on. First definition wins: a pgpm module deploys a
+ * table once, and a later `ALTER` is not where a reviewer wants the alert.
+ */
+export function buildSourceIndex(dir: string, options: BuildSourceIndexOptions = {}): SourceIndex {
+  const skip = new Set(options.skipDirs ?? ['node_modules', '.git', 'dist']);
+  const root = options.root ?? dir;
+  const index: SourceIndex = new Map();
+
+  const walk = (current: string): void => {
+    for (const entry of readdirSync(current)) {
+      if (skip.has(entry)) continue;
+      const path = join(current, entry);
+      const stat = statSync(path);
+      if (stat.isDirectory()) walk(path);
+      else if (entry.toLowerCase().endsWith('.sql')) scan(path, root, index);
+    }
+  };
+
+  walk(dir);
+  return index;
+}
+
+function scan(path: string, root: string, index: SourceIndex): void {
+  const uri = relative(root, path).split(sep).join('/');
+  const lines = readFileSync(path, 'utf8').split('\n');
+  lines.forEach((line, i) => {
+    const table = CREATE_TABLE.exec(line);
+    if (table) {
+      add(index, `${unquote(table[1])}.${unquote(table[2])}`, uri, i + 1);
+      return;
+    }
+    const policy = CREATE_POLICY.exec(line);
+    if (policy) {
+      const relation = `${unquote(policy[2])}.${unquote(policy[3])}`;
+      add(index, `${relation}:${unquote(policy[1])}`, uri, i + 1);
+    }
+  });
+}
+
+function add(index: SourceIndex, key: string, file: string, line: number): void {
+  if (!index.has(key)) index.set(key, { file, line });
+}
+
+function unquote(identifier: string): string {
+  return identifier.startsWith('"') ? identifier.slice(1, -1) : identifier.toLowerCase();
+}


### PR DESCRIPTION
## Summary

Stacked on #1555. `--format sarif` emits SARIF 2.1.0, so findings become code-scanning alerts — Security tab, inline PR annotations, dismissals that persist:

```yaml
- run: npx safegres audit --perf --format sarif --sarif-sources ./deploy > safegres.sarif
- uses: github/codeql-action/upload-sarif@v3
  with: { sarif_file: safegres.sarif }
```

The hard part isn't the envelope, it's that **an alert is a file and a line and safegres reads the catalog** — a live database has no source location. `buildSourceIndex(dir)` (`--sarif-sources <dir>`) scans the SQL that produced the database for the statement that defines each object:

```
CREATE TABLE app_public.widgets     → app_public.widgets            → deploy/widgets.sql:3
CREATE POLICY p ON app_public.w     → app_public.widgets:p          → deploy/widgets.sql:7
```

so a policy finding points at its `CREATE POLICY` and everything else at the table's `CREATE TABLE`; first definition wins (a later `ALTER` is not where a reviewer wants the alert). Unresolved findings are still emitted with `locations: []` — GitHub drops those, every other SARIF consumer keeps them, and `--format json` is unaffected either way.

Two details that decide whether this is usable day to day:

- `partialFingerprints.safegresFindingKey` is the *identity* key the perf baseline already uses (code + relation + policy + subject), not a hash of the message — so rewording a rule in a later release doesn't close and reopen every alert, and a dismissal survives.
- `security-severity` (9.0/7.0/5.0/3.0/1.0) is what GitHub buckets alerts by; `tags` carry `security` vs `performance`, so the perf dimension stays filterable instead of landing in the security queue. Scores ride as run properties, since a SARIF result has nowhere to put them.

Only the rules actually emitted are declared in `tool.driver.rules`, so a 2-finding report doesn't advertise 20 rules.

## Tests

`__tests__/sarif.test.ts` (11 new; 147 total pass): envelope shape, rule metadata and tags, severity→level mapping, fingerprint stability under a reworded message, both scores as run properties, and the source index — table/policy resolution with POSIX-relative paths, `node_modules` and non-`.sql` skipped, quoted identifiers preserved while unquoted ones fold.


Link to Devin session: https://app.devin.ai/sessions/ec06ef6eabae4872ae5ec3926f037c85
Requested by: @pyramation