### PR TITLE
feat(pgpm): `pgpm package --check` — verify committed bundle artifacts are in sync with deploy/

### DIFF
--- a/pgpm/cli/src/commands/package.ts
+++ b/pgpm/cli/src/commands/package.ts
@@ -1,5 +1,8 @@
-import { PgpmPackage, writePackage } from '@pgpmjs/core';
+import { checkPackages, PgpmPackage, writePackage } from '@pgpmjs/core';
+import { Logger } from '@pgpmjs/logger';
 import { CLIOptions, Inquirerer, Question } from 'inquirerer';
+
+const log = new Logger('package');
 
 const packageUsageText = `
 Package Command:
@@ -17,11 +20,23 @@ Options:
   --bundle                        Also emit sql/<name>--<version>.bundle.tar.gz (default: true)
   --cwd <directory>               Working directory (default: current directory)
 
+Check mode (no writes — verify committed artifacts are in sync with deploy/):
+  --check                         Verify committed sql/<name>--<version>.bundle.tar.gz
+                                  matches deploy/ for changed modules; exit 1 on drift
+  --since <ref>                   Git branch/ref/tag to diff HEAD against for change
+                                  detection (default: PR base in CI, else working tree)
+  --all                           Check every workspace module (skip change detection)
+  --dependents                    Also re-check modules that require a changed module
+  --no-fail-fast                  Report all drifted modules instead of stopping at the first
+
 Examples:
   pgpm package                     Package with defaults
   pgpm package --no-plan           Package without plan
   pgpm package --outputDiff        Package and export AST diff files if mismatch detected
   pgpm package --no-bundle         Package without emitting the bundle artifact
+  pgpm package --check             Verify changed modules' bundles are in sync
+  pgpm package --check --since origin/main   Verify modules changed vs origin/main
+  pgpm package --check --all       Verify every module in the workspace
 `;
 
 export default async (
@@ -33,6 +48,46 @@ export default async (
   if (argv.help || argv.h) {
     console.log(packageUsageText);
     process.exit(0);
+  }
+
+  // Check mode: verify committed artifacts, never write.
+  if (argv.check) {
+    const result = await checkPackages({
+      cwd: argv.cwd,
+      since: typeof argv.since === 'string' ? argv.since : undefined,
+      all: argv.all === true,
+      dependents: argv.dependents === true,
+      failFast: argv.failFast !== false,
+    });
+
+    if (argv.all) {
+      log.info(`Checking all ${result.targeted.length} workspace module(s)`);
+    } else {
+      log.info(
+        `Change detection${result.base ? ` vs ${result.base}` : ' (working tree)'}: ` +
+          `${result.changedModules.length} changed module(s)` +
+          (result.targeted.length !== result.changedModules.length
+            ? ` (${result.targeted.length} incl. dependents)`
+            : '')
+      );
+    }
+
+    if (result.drifted.length) {
+      for (const drift of result.drifted) {
+        log.error(`✖ ${drift.name}: ${drift.detail}`);
+      }
+      log.error(
+        `${result.drifted.length} module(s) out of sync. Run \`pgpm package\` in each and commit the artifacts.`
+      );
+      process.exit(1);
+    }
+
+    if (result.checked.length === 0) {
+      log.success('No changed modules to check.');
+    } else {
+      log.success(`${result.checked.length} module(s) in sync.`);
+    }
+    return argv;
   }
   const questions: Question[] = [
     {

--- a/pgpm/core/__tests__/packaging/check.test.ts
+++ b/pgpm/core/__tests__/packaging/check.test.ts
@@ -1,0 +1,129 @@
+import { readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+import {
+  addDependents,
+  checkModuleArtifact,
+  checkPackages,
+  enumerateModules,
+  mapFilesToModules,
+} from '../../src/packaging/check';
+import { resolveBundleArtifactPath, writeBundleArtifact } from '../../src/bundle/artifact';
+import { PgpmPackage } from '../../src/core/class/pgpm';
+import { TestFixture } from '../../test-utils';
+
+const MODULES = ['my-first', 'my-second', 'my-third'] as const;
+
+/**
+ * `pgpm package --check`: verify a committed bundle artifact still matches its
+ * `deploy/`. Read + sha256 only — no DDL, no database — so these are pure,
+ * DB-free unit tests over the fixture workspace.
+ */
+describe('package check (artifact drift verification)', () => {
+  let fixture: TestFixture;
+  let root: string;
+
+  const moduleDir = (name: string): string => fixture.fixturePath('packages', name);
+
+  const emitAll = async (): Promise<void> => {
+    for (const name of MODULES) {
+      const dir = moduleDir(name);
+      const version = require(join(dir, 'package.json')).version as string;
+      await writeBundleArtifact(dir, version);
+    }
+  };
+
+  beforeEach(() => {
+    fixture = new TestFixture('sqitch', 'simple-w-tags');
+    root = fixture.fixturePath();
+  });
+
+  afterEach(() => {
+    fixture.cleanup();
+  });
+
+  it('reports no drift for a freshly packaged module', async () => {
+    await emitAll();
+    expect(checkModuleArtifact(moduleDir('my-first'), 'my-first')).toBeNull();
+  });
+
+  it('flags a missing artifact', () => {
+    const drift = checkModuleArtifact(moduleDir('my-first'), 'my-first');
+    expect(drift?.reason).toBe('missing-artifact');
+  });
+
+  it('flags an artifact whose deploy/ has changed (out of sync)', async () => {
+    await emitAll();
+    const dir = moduleDir('my-first');
+    const deployFile = join(dir, 'deploy', 'schema_myfirstapp.sql');
+    writeFileSync(deployFile, `${readFileSync(deployFile, 'utf-8')}\n-- drift\n`);
+
+    const drift = checkModuleArtifact(dir, 'my-first');
+    expect(drift?.reason).toBe('out-of-sync');
+  });
+
+  it('flags a corrupt artifact archive', async () => {
+    await emitAll();
+    writeFileSync(resolveBundleArtifactPath(moduleDir('my-second'))!, 'not-an-archive');
+    const drift = checkModuleArtifact(moduleDir('my-second'), 'my-second');
+    expect(drift?.reason).toBe('unreadable-artifact');
+  });
+
+  it('checkPackages --all verifies every module and passes when in sync', async () => {
+    await emitAll();
+    const result = await checkPackages({ cwd: root, all: true });
+    expect(new Set(result.checked)).toEqual(new Set(MODULES));
+    expect(result.drifted).toHaveLength(0);
+  });
+
+  it('checkPackages --all fails fast on the first drift by default', async () => {
+    await emitAll();
+    // Break two modules; fail-fast should report exactly one.
+    rmSync(resolveBundleArtifactPath(moduleDir('my-first'))!);
+    rmSync(resolveBundleArtifactPath(moduleDir('my-second'))!);
+    const result = await checkPackages({ cwd: root, all: true });
+    expect(result.drifted).toHaveLength(1);
+  });
+
+  it('checkPackages --all --no-fail-fast reports every drifted module', async () => {
+    await emitAll();
+    rmSync(resolveBundleArtifactPath(moduleDir('my-first'))!);
+    rmSync(resolveBundleArtifactPath(moduleDir('my-second'))!);
+    const result = await checkPackages({ cwd: root, all: true, failFast: false });
+    expect(new Set(result.drifted.map((d) => d.name))).toEqual(
+      new Set(['my-first', 'my-second'])
+    );
+  });
+});
+
+describe('package check (workspace mapping helpers)', () => {
+  let fixture: TestFixture;
+  let pkg: PgpmPackage;
+
+  beforeEach(() => {
+    fixture = new TestFixture('sqitch', 'simple-w-tags');
+    pkg = new PgpmPackage(fixture.fixturePath());
+  });
+
+  afterEach(() => {
+    fixture.cleanup();
+  });
+
+  it('maps a changed deploy file to its owning module', () => {
+    const modules = enumerateModules(pkg);
+    const changed = [fixture.fixturePath('packages', 'my-second', 'deploy', 'anything.sql')];
+    expect(mapFilesToModules(changed, modules)).toEqual(['my-second']);
+  });
+
+  it('ignores files outside any module', () => {
+    const modules = enumerateModules(pkg);
+    expect(mapFilesToModules([fixture.fixturePath('README.md')], modules)).toEqual([]);
+  });
+
+  it('expands to transitive dependents', () => {
+    // my-third requires my-second requires my-first.
+    const names = new Set(['my-first']);
+    addDependents(names, pkg);
+    expect(names).toEqual(new Set(['my-first', 'my-second', 'my-third']));
+  });
+});

--- a/pgpm/core/src/index.ts
+++ b/pgpm/core/src/index.ts
@@ -2,6 +2,7 @@ export * from './core/class/pgpm';
 export * from './rebundle';
 export * from './extensions';
 export * from './modules/modules';
+export * from './packaging/check';
 export * from './packaging/package';
 export * from './packaging/sync-versions';
 export * from './packaging/transform';

--- a/pgpm/core/src/packaging/check.ts
+++ b/pgpm/core/src/packaging/check.ts
@@ -1,0 +1,287 @@
+import { execSync } from 'child_process';
+import { isAbsolute, relative, resolve as resolvePath } from 'path';
+
+import { verifyBundle } from '@pgpmjs/bundle';
+
+import {
+  bundleMatchesModule,
+  readBundleArtifact,
+  resolveBundleArtifactPath,
+} from '../bundle/artifact';
+import { PgpmPackage } from '../core/class/pgpm';
+
+/**
+ * Why a module's committed bundle artifact no longer describes its `deploy/`.
+ *
+ * - `missing-artifact`  — no `sql/<name>--<version>.bundle.tar.gz` at all.
+ * - `unreadable-artifact` — the archive exists but could not be opened/parsed.
+ * - `integrity`         — the artifact is internally inconsistent (`verifyBundle`).
+ * - `out-of-sync`       — the artifact is valid but its plan/per-change bytes no
+ *                         longer match the files under `deploy/` (`bundleMatchesModule`).
+ */
+export type DriftReason =
+  | 'missing-artifact'
+  | 'unreadable-artifact'
+  | 'integrity'
+  | 'out-of-sync';
+
+export interface ModuleDrift {
+  name: string;
+  moduleDir: string;
+  reason: DriftReason;
+  detail: string;
+}
+
+export interface ModuleRef {
+  name: string;
+  dir: string;
+}
+
+export interface PackageCheckOptions {
+  cwd?: string;
+  /**
+   * Git ref/branch/tag to diff `HEAD` against for change detection. When
+   * omitted, the check auto-detects the base (`origin/$GITHUB_BASE_REF` in a
+   * PR, otherwise it only inspects uncommitted/untracked working-tree changes).
+   */
+  since?: string;
+  /** Check every module in the workspace, skipping git change detection. */
+  all?: boolean;
+  /**
+   * Stop at the first drifted module (default `true`). Set `false` to report
+   * every drifted module in one pass.
+   */
+  failFast?: boolean;
+  /**
+   * Also re-check modules that (transitively) `require` a changed module.
+   * Off by default: a module's packaged SQL/bundle reflects only its own
+   * `deploy/` files (`resolveWithPlan`), so a dependency's change does not
+   * alter a dependent's artifact. Exposed for completeness/paranoia.
+   */
+  dependents?: boolean;
+}
+
+export interface PackageCheckResult {
+  /** Module names selected for verification (before fail-fast truncation). */
+  targeted: string[];
+  /** Module names that were actually verified (fail-fast may stop early). */
+  checked: string[];
+  /** Modules whose committed artifact no longer matches `deploy/`. */
+  drifted: ModuleDrift[];
+  /** The git ref used for change detection, if any. */
+  base?: string;
+  /** Module names detected as directly changed (before dependent expansion). */
+  changedModules: string[];
+}
+
+/**
+ * Verify a single module's committed bundle artifact against its `deploy/`.
+ *
+ * Cheap by design — read + sha256 only, no SQL parse/deparse and no DDL — so it
+ * is safe to run in CI on every push. Returns `null` when the artifact is in
+ * sync, or a {@link ModuleDrift} describing the first problem found.
+ */
+export function checkModuleArtifact(moduleDir: string, name: string): ModuleDrift | null {
+  const artifactPath = resolveBundleArtifactPath(moduleDir);
+  if (!artifactPath) {
+    return {
+      name,
+      moduleDir,
+      reason: 'missing-artifact',
+      detail: 'no sql/<name>--<version>.bundle.tar.gz — run `pgpm package`',
+    };
+  }
+
+  const bundle = readBundleArtifact(moduleDir);
+  if (!bundle) {
+    return {
+      name,
+      moduleDir,
+      reason: 'unreadable-artifact',
+      detail: `could not read ${artifactPath} — re-run \`pgpm package\``,
+    };
+  }
+
+  const issues = verifyBundle(bundle);
+  if (issues.length) {
+    return {
+      name,
+      moduleDir,
+      reason: 'integrity',
+      detail: `bundle integrity check failed: ${issues.map((i) => i.message).join('; ')}`,
+    };
+  }
+
+  if (!bundleMatchesModule(moduleDir, bundle)) {
+    return {
+      name,
+      moduleDir,
+      reason: 'out-of-sync',
+      detail: 'committed bundle does not match deploy/ — run `pgpm package`',
+    };
+  }
+
+  return null;
+}
+
+function git(args: string, cwd: string): string {
+  return execSync(`git ${args}`, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+    maxBuffer: 64 * 1024 * 1024,
+  });
+}
+
+/**
+ * Resolve the git ref to diff against. Explicit `--since` wins; otherwise use
+ * the PR base branch when running in GitHub Actions; otherwise `undefined`
+ * (working-tree changes only).
+ */
+export function resolveBase(since?: string): string | undefined {
+  if (since) return since;
+  const prBase = process.env.GITHUB_BASE_REF;
+  if (prBase && prBase.trim()) return `origin/${prBase.trim()}`;
+  return undefined;
+}
+
+/**
+ * Collect the set of changed files, combining committed changes since `base`
+ * (three-dot diff, so it works with branches, refs, and tags) with any
+ * uncommitted/untracked changes in the working tree. Returns absolute paths.
+ */
+export function changedFiles(cwd: string, base?: string): string[] {
+  const files = new Set<string>();
+
+  const status = git('status --porcelain', cwd);
+  for (const rawLine of status.split('\n')) {
+    const line = rawLine.trimEnd();
+    if (!line) continue;
+    let p = line.slice(3);
+    const arrow = p.indexOf(' -> ');
+    if (arrow !== -1) p = p.slice(arrow + 4);
+    p = p.replace(/^"|"$/g, '');
+    if (p) files.add(resolvePath(cwd, p));
+  }
+
+  if (base) {
+    let diff: string;
+    try {
+      diff = git(`diff --name-only ${base}...HEAD`, cwd);
+    } catch (err) {
+      throw new Error(
+        `Could not diff against '${base}'. Ensure the ref exists locally ` +
+          `(e.g. \`git fetch origin\`). Original error: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+      );
+    }
+    for (const rawLine of diff.split('\n')) {
+      const p = rawLine.trim();
+      if (p) files.add(resolvePath(cwd, p));
+    }
+  }
+
+  return [...files];
+}
+
+/** Enumerate the modules to consider — the whole workspace, or the single module. */
+export function enumerateModules(pkg: PgpmPackage): ModuleRef[] {
+  const wsPath = pkg.getWorkspacePath();
+  if (wsPath) {
+    const map = pkg.getModuleMap();
+    return Object.entries(map).map(([name, m]) => ({
+      name,
+      dir: resolvePath(wsPath, m.path),
+    }));
+  }
+  if (pkg.isInModule()) {
+    return [{ name: pkg.getModuleName(), dir: pkg.getModulePath()! }];
+  }
+  return [];
+}
+
+/** Map changed file paths to the owning module (longest matching module dir). */
+export function mapFilesToModules(files: string[], modules: ModuleRef[]): string[] {
+  const hit = new Set<string>();
+  for (const file of files) {
+    let best: ModuleRef | undefined;
+    for (const mod of modules) {
+      const rel = relative(mod.dir, file);
+      if (rel.startsWith('..') || isAbsolute(rel)) continue;
+      if (!best || mod.dir.length > best.dir.length) best = mod;
+    }
+    if (best) hit.add(best.name);
+  }
+  return [...hit];
+}
+
+/** Expand a set of module names to include everything that transitively requires them. */
+export function addDependents(names: Set<string>, pkg: PgpmPackage): void {
+  const map = pkg.getModuleMap();
+  const reverse = new Map<string, string[]>();
+  for (const [name, m] of Object.entries(map)) {
+    for (const req of m.requires ?? []) {
+      if (!reverse.has(req)) reverse.set(req, []);
+      reverse.get(req)!.push(name);
+    }
+  }
+  const queue = [...names];
+  while (queue.length) {
+    const current = queue.shift()!;
+    for (const dependent of reverse.get(current) ?? []) {
+      if (!names.has(dependent)) {
+        names.add(dependent);
+        queue.push(dependent);
+      }
+    }
+  }
+}
+
+/**
+ * Verify that committed bundle artifacts are in sync with `deploy/` for the
+ * modules that changed (per git), failing fast on the first drift by default.
+ *
+ * This is the engine behind `pgpm package --check`: change detection + workspace
+ * mapping + the cheap per-module artifact verification, so CI can gate every PR
+ * with a one-liner and only pay for the modules that actually changed.
+ */
+export async function checkPackages(
+  options: PackageCheckOptions = {}
+): Promise<PackageCheckResult> {
+  const cwd = options.cwd ?? process.cwd();
+  const failFast = options.failFast ?? true;
+  const pkg = new PgpmPackage(cwd);
+  const modules = enumerateModules(pkg);
+  const byName = new Map(modules.map((m) => [m.name, m]));
+
+  let base: string | undefined;
+  let changedModules: string[] = [];
+  let targetNames: string[];
+
+  if (options.all) {
+    targetNames = modules.map((m) => m.name);
+  } else {
+    base = resolveBase(options.since);
+    const files = changedFiles(cwd, base);
+    changedModules = mapFilesToModules(files, modules);
+    const set = new Set(changedModules);
+    if (options.dependents && pkg.getWorkspacePath()) addDependents(set, pkg);
+    targetNames = [...set];
+  }
+
+  const checked: string[] = [];
+  const drifted: ModuleDrift[] = [];
+  for (const name of targetNames) {
+    const mod = byName.get(name);
+    if (!mod) continue;
+    checked.push(name);
+    const drift = checkModuleArtifact(mod.dir, name);
+    if (drift) {
+      drifted.push(drift);
+      if (failFast) break;
+    }
+  }
+
+  return { targeted: targetNames, checked, drifted, base, changedModules };
+}


### PR DESCRIPTION
## Summary

Adds a **no-write** integrity check to the packaging CLI so CI (and devs) can prove that each module's committed `sql/<name>--<version>.bundle.tar.gz` still matches its `deploy/` source — and fail fast if someone edited SQL without re-running `pgpm package`. It's granular: it only checks the modules that actually changed, so it costs nothing on unaffected packages.

```bash
pgpm package --check                      # verify changed modules (auto base)
pgpm package --check --since origin/main  # diff HEAD vs a branch/ref/tag
pgpm package --check --all                # verify every workspace module
pgpm package --check --dependents         # also re-check modules that require a changed one
pgpm package --check --no-fail-fast       # list every drifted module instead of stopping at the first
```

Exits non-zero listing each drifted module (`✖ my-second: committed bundle does not match deploy/ — run pgpm package`). It's read + sha256 only — **no DDL, no database, no parse/deparse** — so it's cheap enough to gate every PR.

### How it works

New `checkPackages()` in `pgpm/core/src/packaging/check.ts`:

1. **Change detection** (cheapest source first): explicit `--since <ref>` wins; else the PR base in CI (`origin/$GITHUB_BASE_REF`); else working-tree only. Union of `git diff --name-only <ref>...HEAD` (three-dot, so branches/refs/tags all work) + `git status --porcelain` (uncommitted/untracked).
2. **Workspace mapping**: each changed path is mapped up to its owning module via the workspace module graph (longest-matching module dir). `--dependents` optionally walks the reverse `requires` graph.
3. **Per-module verify** (`checkModuleArtifact`): `resolveBundleArtifactPath` → `readBundleArtifact` → `verifyBundle` (internal digest) → `bundleMatchesModule` (plan bytes + per-change deploy sha256 vs current `deploy/`). Returns one of `missing-artifact | unreadable-artifact | integrity | out-of-sync`, else `null`.

Note on scope: a module's packaged SQL/bundle reflects **only its own** `deploy/` (`resolveWithPlan` never inlines required modules), so a dependency's change does not alter a dependent's artifact — `--dependents` is off by default and exposed only for paranoia.

### CLI wiring

`pgpm/cli/src/commands/package.ts` short-circuits into check mode when `--check` is passed (before any prompting/writing), prints a summary, and `process.exit(1)` on drift.

## Test plan

- New `pgpm/core/__tests__/packaging/check.test.ts` (10 tests, DB-free over the `simple-w-tags` fixture): in-sync pass; missing/corrupt/out-of-sync detection; `--all` fail-fast (1) vs `--no-fail-fast` (all); file→module mapping; transitive dependents.
- Manual CLI smoke test against a temp git workspace: in-sync → exit 0; tampering a planned change → `out-of-sync` exit 1; `--since HEAD` detects only the changed module; `--dependents` expands to its dependent.

Follow-up (separate PR, after this publishes): drop the one-liner `pgpm package --check --since <base>` into constructive-db CI.


Link to Devin session: https://app.devin.ai/sessions/fb12b07b9cb0499782980ceffe689de4
Requested by: @pyramation