### PR TITLE
docs(skills): document `pgpm package --check` + de-collide "packaging" naming

### DIFF
--- a/.agents/skills/pgpm/SKILL.md
+++ b/.agents/skills/pgpm/SKILL.md
@@ -147,6 +147,7 @@ pgpm handles extension creation during deploy. Declare extensions in your `.cont
 | `pgpm migrate status` | Show deployed vs pending changes |
 | `pgpm plan` | Generate plan from SQL `-- requires:` comments |
 | `pgpm package` | Bundle module for publishing |
+| `pgpm package --check` | Verify committed bundle artifacts are in sync with `deploy/` (CI gate) |
 
 ## Essential Development Workflow
 
@@ -364,8 +365,9 @@ Consult these reference files for detailed documentation on specific topics:
 | [references/routing-profile.md](references/routing-profile.md) | Routing profile & module self-description | `extensions.json` provides/consumes, `pgpm.apply.json`, workspace `portability` in `pgpm.json`, routing precedence |
 | [references/module-naming.md](references/module-naming.md) | npm names vs control file names | Confused about which identifier to use where |
 | [references/plan-format.md](references/plan-format.md) | pgpm.plan file format | Fixing `Invalid line format` errors, editing plan files manually |
-| [references/packaging.md](references/packaging.md) | Package separation & restructuring | Splitting a database into multiple pgpm packages, cherry-picking objects into a package, change granularity, derived paths and requires |
+| [references/package-separation.md](references/package-separation.md) | Package separation & restructuring | Splitting a database into multiple pgpm packages, cherry-picking objects into a package, change granularity, derived paths and requires |
 | [references/publishing.md](references/publishing.md) | Publishing modules to npm | Bundling, versioning with lerna, publishing @pgpm/* packages |
+| [references/package-check.md](references/package-check.md) | `pgpm package --check` artifact drift gate | Verifying committed bundle artifacts match `deploy/`, wiring a CI check for changed modules |
 | [references/testing.md](references/testing.md) | PostgreSQL integration tests | Setting up pgsql-test, seed adapters, test patterns |
 | [references/troubleshooting.md](references/troubleshooting.md) | Common issues and solutions | Debugging connection, deployment, testing, or Docker problems |
 | [references/ci-cd.md](references/ci-cd.md) | GitHub Actions CI/CD workflows | Setting up CI for pgpm projects, PostgreSQL service containers, test sharding |

--- a/.agents/skills/pgpm/references/ci-cd.md
+++ b/.agents/skills/pgpm/references/ci-cd.md
@@ -421,6 +421,31 @@ steps:
     env: ${{ matrix.env }}
 ```
 
+## Bundle Drift Check
+
+Gate every PR so that no module's committed `sql/<name>--<version>.bundle.tar.gz`
+can drift from its `deploy/` SQL. `pgpm package --check` is read-only and
+touches no database, and by default only verifies the modules git says
+changed — so it is near-instant on a normal PR. See
+`references/package-check.md`.
+
+```yaml
+jobs:
+  bundle-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # need the base ref for the diff
+      # ... pnpm + node + pgpm setup ...
+      - name: Verify pgpm bundles are in sync
+        run: pgpm package --check --since origin/${{ github.base_ref }}
+```
+
+Fail-fast is the default (stops at the first stale bundle); add
+`--no-fail-fast` to list every drifted module in one run. It needs no
+PostgreSQL service container.
+
 ## Best Practices
 
 1. **Always use health checks** — Ensure PostgreSQL is ready before tests run
@@ -431,6 +456,8 @@ steps:
 6. **Bootstrap users before tests** — `pgpm admin-users` creates required roles
 7. **Use fail-fast: false** — Let all tests complete even if some fail
 8. **Pin pgpm version** — Ensure consistent behavior across runs
+9. **Gate bundle drift** — Run `pgpm package --check` on PRs so stale
+   `sql/*.bundle.tar.gz` artifacts can't merge (fetch-depth: 0 for the diff)
 
 ## References
 

--- a/.agents/skills/pgpm/references/cli.md
+++ b/.agents/skills/pgpm/references/cli.md
@@ -217,9 +217,26 @@ pgpm plan
 
 **pgpm package** — Package module for distribution
 
+Emits two artifacts into `sql/`: the consolidated `sql/<name>--<version>.sql`
+and the content-addressed `sql/<name>--<version>.bundle.tar.gz` (consumed by
+`pgpm deploy --fast`/`--bundled`).
+
 ```bash
 pgpm package
 pgpm package --no-plan
+```
+
+**pgpm package --check** — Verify committed artifacts are in sync (no writes, no DB)
+
+Fails fast when a module's committed `sql/<name>--<version>.bundle.tar.gz` no
+longer matches its `deploy/`. By default only the modules that changed (via
+git) are checked. See `references/package-check.md`.
+
+```bash
+pgpm package --check                      # changed modules (auto base)
+pgpm package --check --since origin/main  # diff HEAD vs a branch/ref/tag
+pgpm package --check --all                # every workspace module
+pgpm package --check --no-fail-fast       # list all drift instead of stopping
 ```
 
 ### Testing

--- a/.agents/skills/pgpm/references/package-check.md
+++ b/.agents/skills/pgpm/references/package-check.md
@@ -1,0 +1,91 @@
+# Package check: verify committed artifacts are in sync with `deploy/`
+
+`pgpm package --check` is a **read-only, no-DB** integrity check. It proves
+that each module's committed build artifact (`sql/<name>--<version>.bundle.tar.gz`)
+still matches the SQL in that module's `deploy/`, and fails fast when someone
+edited SQL without re-running `pgpm package`. Consult this when wiring a CI
+gate for pgpm workspaces, or when asked "how do we stop stale bundles from
+being merged".
+
+It is the verification half of the packaging story:
+
+- `pgpm package` — **build** the artifacts (`sql/<name>--<version>.sql` +
+  `sql/<name>--<version>.bundle.tar.gz`). See `references/publishing.md`.
+- `pgpm package --check` — **verify** those committed artifacts (this file).
+- `pgpm deploy --fast` / `--bundled` — **consume** the verified bundle. See
+  `references/deploy-lifecycle.md`.
+- Artifact internals (digests, AST) — the `pgpm-migration-bundle` skill.
+
+## Commands
+
+```bash
+pgpm package --check                      # verify only the modules that changed
+pgpm package --check --since origin/main  # diff HEAD vs a branch, ref, or tag
+pgpm package --check --all                # verify every module in the workspace
+pgpm package --check --dependents         # also re-check modules that require a changed one
+pgpm package --check --no-fail-fast       # list every drifted module instead of stopping at the first
+```
+
+Exits non-zero and names each drifted module, e.g.:
+
+```text
+✖ my-second: committed bundle does not match deploy/ — run `pgpm package`
+1 module(s) out of sync. Run `pgpm package` in each and commit the artifacts.
+```
+
+## How it decides what to check
+
+Change detection layers cheapest-source-first, then maps files to modules
+through the workspace graph:
+
+1. **Base ref** — explicit `--since <ref>` wins; otherwise the PR base in CI
+   (`origin/$GITHUB_BASE_REF`); otherwise working-tree only.
+2. **Changed files** — union of `git diff --name-only <base>...HEAD`
+   (three-dot, so branches/refs/tags all work) and `git status --porcelain`
+   (uncommitted + untracked). It shells out to the `git` binary — no
+   `simple-git`/Octokit dependency.
+3. **Files → modules** — each changed path is attributed to its owning module
+   (longest-matching module directory). Only those modules are checked.
+   `--all` skips detection; `--dependents` walks the reverse `requires` graph.
+
+> A module's artifact reflects **only its own** `deploy/` (`resolveWithPlan`
+> never inlines required modules), so a dependency change cannot drift a
+> dependent's artifact. `--dependents` is therefore off by default — enable it
+> only for extra-paranoid checks.
+
+## What it verifies per module
+
+For each targeted module (`checkModuleArtifact` in
+`pgpm/core/src/packaging/check.ts`):
+
+1. `resolveBundleArtifactPath` — artifact exists → else `missing-artifact`.
+2. `readBundleArtifact` — archive is readable → else `unreadable-artifact`.
+3. `verifyBundle` — internal digests are self-consistent → else `integrity`.
+4. `bundleMatchesModule` — the artifact's stored per-change sha256 + plan bytes
+   still match the current `deploy/` → else `out-of-sync`.
+
+No SQL is parsed or executed and no database is touched — it is read + sha256
+only, so it is cheap enough to gate every PR.
+
+## CI usage
+
+Drop the one-liner into a PR workflow (works in any pgpm workspace with zero
+config — it auto-detects the PR base):
+
+```yaml
+- name: Verify pgpm bundles are in sync
+  run: pgpm package --check --since origin/${{ github.base_ref }}
+```
+
+Fail-fast is the default, so the job stops at the first stale bundle. Use
+`--no-fail-fast` when you want the full list in one run.
+
+## Programmatic API
+
+```ts
+import { checkPackages } from '@pgpmjs/core';
+
+const result = await checkPackages({ since: 'origin/main' });
+if (result.drifted.length) process.exit(1);
+// result: { targeted, checked, drifted, base, changedModules }
+```

--- a/.agents/skills/pgpm/references/package-separation.md
+++ b/.agents/skills/pgpm/references/package-separation.md
@@ -1,10 +1,16 @@
-# Packaging: restructuring and separating pgpm packages
+# Package separation & restructuring
 
 How pgpm derives modular packages from one canonical substrate: statement
 facts and a typed dependency graph. Consult this when asked to split a
 database into multiple pgpm packages, cherry-pick objects into a package,
 restructure change granularity, or understand how change paths and
 `requires` are derived.
+
+> **Naming note:** this is *not* the `pgpm package` build command. `pgpm
+> package` compiles one module into its distributable artifacts (see
+> `references/publishing.md` to build+publish, `references/package-check.md`
+> to verify those artifacts). This file is about *separating* one deploy
+> surface into several packages.
 
 Everything here lives in `@pgpmjs/transform` (`pgpm/transform`), with paths
 rendered by `@pgpmjs/naming-spec` (`pgpm/naming-spec`). The underlying facts,


### PR DESCRIPTION
## Summary

Adds skill docs for the new `pgpm package --check` command (from #1559) and untangles the overloaded word **"packaging"** in the `pgpm` skill so agents/readers stop conflating three different things:

| concept | command / file | what it is |
|---|---|---|
| **build** a module's artifacts | `pgpm package` | emits `sql/<name>--<version>.sql` + `.bundle.tar.gz` (`publishing.md`) |
| **verify** those artifacts | `pgpm package --check` | new `package-check.md` |
| **separate** one DB into many packages | `partitionUnits`/granularity | renamed `packaging.md` → `package-separation.md` |

The just-merged `packaging.md` (#1560) is actually about *splitting a database into multiple packages*, which collides with the `pgpm package` build command — so it's renamed and given a "this is not `pgpm package`" note. Only `SKILL.md` referenced the old path (verified via grep), so the rename is safe.

## Changes

- **Rename** `references/packaging.md` → `references/package-separation.md`; title → "Package separation & restructuring" + a naming-note callout pointing to `publishing.md`/`package-check.md`.
- **New** `references/package-check.md`: commands (`--since`/`--all`/`--dependents`/`--no-fail-fast`), git-based change detection (`git status` + `diff <base>...HEAD`, `GITHUB_BASE_REF`, no `simple-git`/Octokit dep), the four drift classes (`missing`/`unreadable`/`integrity`/`out-of-sync`), the CI one-liner, and the `checkPackages()` API. Notes that `--dependents` is off by default because a module's artifact reflects only its own `deploy/`.
- **`SKILL.md`**: added `pgpm package --check` to the command table; updated the reference index (packaging→package-separation, added package-check).
- **`cli.md`**: expanded the `pgpm package` entry (documents both emitted artifacts) and added a `pgpm package --check` entry.
- **`ci-cd.md`**: new "Bundle Drift Check" workflow section + a best-practice bullet.

## Test plan

Docs-only. Verified no remaining references to the old `packaging.md` path across the repo.


Link to Devin session: https://app.devin.ai/sessions/fb12b07b9cb0499782980ceffe689de4
Requested by: @pyramation