### PR TITLE
feat(pgpm): `pgpm transform` — re-dial an existing module/workspace; wire `--partition` into `pgpm export`

### DIFF
--- a/pgpm/cli/__tests__/transform-e2e.test.ts
+++ b/pgpm/cli/__tests__/transform-e2e.test.ts
@@ -1,0 +1,313 @@
+/**
+ * e2e for `pgpm transform` against live Postgres.
+ *
+ * Fixture module: two schemas, tables + FK, function, trigger, policy, grant,
+ * index. Transforms to each granularity, deploys each output, asserts catalog
+ * equivalence with the original, exercises --check/--dry-run/overwrite guard,
+ * verifies, reverts, partitions into pkg-app + pkg-security, and round-trips
+ * consolidated -> atomic -> consolidated.
+ *
+ * PREREQUISITES: a running PostgreSQL instance via standard PG* env vars.
+ */
+import { diffCatalogSnapshots, snapshotCatalog } from '@pgpmjs/export';
+import * as fs from 'fs';
+import * as path from 'path';
+import { teardownPgPools } from 'pg-cache';
+
+import { CLIDeployTestFixture } from '../test-utils';
+
+jest.setTimeout(180000);
+
+afterAll(async () => {
+  await teardownPgPools();
+});
+
+const MODULE_NAME = 'transform-e2e';
+const WS = 'transform-ws';
+
+interface ChangeSpec {
+  name: string;
+  deps?: string[];
+  deploy: string;
+}
+
+/** Two schemas, tables + FK, function, trigger, policy, grant, index. */
+const CHANGES: ChangeSpec[] = [
+  {
+    name: 'schemas/tfx_app/schema',
+    deploy: 'CREATE SCHEMA tfx_app;'
+  },
+  {
+    name: 'schemas/tfx_sec/schema',
+    deploy: 'CREATE SCHEMA tfx_sec;'
+  },
+  {
+    name: 'schemas/tfx_app/tables/users/table',
+    deps: ['schemas/tfx_app/schema'],
+    deploy: 'CREATE TABLE tfx_app.users (id serial PRIMARY KEY, email text NOT NULL);'
+  },
+  {
+    name: 'schemas/tfx_sec/tables/audit/table',
+    deps: ['schemas/tfx_sec/schema', 'schemas/tfx_app/tables/users/table'],
+    deploy: [
+      'CREATE TABLE tfx_sec.audit (',
+      '  id serial PRIMARY KEY,',
+      '  user_id int NOT NULL REFERENCES tfx_app.users (id),',
+      '  note text',
+      ');'
+    ].join('\n')
+  },
+  {
+    name: 'schemas/tfx_app/procedures/touch',
+    deps: ['schemas/tfx_app/schema'],
+    deploy:
+      'CREATE FUNCTION tfx_app.touch() RETURNS trigger AS $$ BEGIN RETURN NEW; END $$ LANGUAGE plpgsql;'
+  },
+  {
+    name: 'schemas/tfx_app/tables/users/triggers/users_touch',
+    deps: ['schemas/tfx_app/tables/users/table', 'schemas/tfx_app/procedures/touch'],
+    deploy:
+      'CREATE TRIGGER users_touch BEFORE UPDATE ON tfx_app.users FOR EACH ROW EXECUTE FUNCTION tfx_app.touch();'
+  },
+  {
+    name: 'schemas/tfx_app/tables/users/policies/users_self',
+    deps: ['schemas/tfx_app/tables/users/table'],
+    deploy: [
+      'ALTER TABLE tfx_app.users ENABLE ROW LEVEL SECURITY;',
+      'CREATE POLICY users_self ON tfx_app.users FOR SELECT USING (true);'
+    ].join('\n')
+  },
+  {
+    name: 'schemas/tfx_app/tables/users/grants/select',
+    deps: ['schemas/tfx_app/tables/users/table'],
+    deploy: 'GRANT SELECT ON tfx_app.users TO PUBLIC;'
+  },
+  {
+    name: 'schemas/tfx_app/tables/users/indexes/users_email_idx',
+    deps: ['schemas/tfx_app/tables/users/table'],
+    deploy: 'CREATE INDEX users_email_idx ON tfx_app.users (email);'
+  }
+];
+
+const writeModule = (moduleDir: string) => {
+  const workspaceDir = path.dirname(moduleDir);
+  fs.mkdirSync(workspaceDir, { recursive: true });
+  fs.writeFileSync(path.join(workspaceDir, 'pgpm.json'), '{\n    "packages": [\n        "*"\n    ]\n}');
+  fs.mkdirSync(moduleDir, { recursive: true });
+  const planLines = CHANGES.map((c, i) => {
+    const deps = c.deps && c.deps.length > 0 ? ` [${c.deps.join(' ')}]` : '';
+    return `${c.name}${deps} 2024-01-0${(i % 9) + 1}T00:00:00Z test <test@example.com> # add ${c.name}`;
+  });
+  fs.writeFileSync(
+    path.join(moduleDir, 'pgpm.plan'),
+    `%syntax-version=1.0.0\n%project=${MODULE_NAME}\n%uri=https://github.com/test/${MODULE_NAME}\n\n${planLines.join('\n')}\n`
+  );
+  fs.writeFileSync(
+    path.join(moduleDir, `${MODULE_NAME}.control`),
+    `comment = 'Transform e2e module'\ndefault_version = '0.0.1'\nrelocatable = false\nsuperuser = false\n`
+  );
+  for (const c of CHANGES) {
+    const filePath = path.join(moduleDir, 'deploy', `${c.name}.sql`);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, `-- Deploy ${c.name} to pg\n\nBEGIN;\n\n${c.deploy}\n\nCOMMIT;\n`);
+    const revertPath = path.join(moduleDir, 'revert', `${c.name}.sql`);
+    fs.mkdirSync(path.dirname(revertPath), { recursive: true });
+    fs.writeFileSync(revertPath, `-- Revert ${c.name} from pg\n\nBEGIN;\n\n-- noop\n\nCOMMIT;\n`);
+    const verifyPath = path.join(moduleDir, 'verify', `${c.name}.sql`);
+    fs.mkdirSync(path.dirname(verifyPath), { recursive: true });
+    fs.writeFileSync(verifyPath, `-- Verify ${c.name} on pg\n\nBEGIN;\n\nROLLBACK;\n`);
+  }
+};
+
+const PARTITION_CONFIG = {
+  defaultPackage: 'pkg-app',
+  splitRiders: ['grant'],
+  rules: [
+    {
+      package: 'pkg-security',
+      select: [{ kind: 'policy' }, { statementKind: 'grant' }]
+    }
+  ]
+};
+
+describe('pgpm transform e2e', () => {
+  let fixture: CLIDeployTestFixture;
+  let originalDb: any;
+  let wsDir: string;
+  let moduleDir: string;
+
+  beforeAll(async () => {
+    fixture = new CLIDeployTestFixture();
+    wsDir = path.join(fixture.tempFixtureDir, WS);
+    moduleDir = path.join(wsDir, MODULE_NAME);
+    writeModule(moduleDir);
+
+    originalDb = await fixture.setupTestDatabase();
+    await fixture.runTerminalCommands(
+      `
+      cd ${WS}/${MODULE_NAME}
+      pgpm deploy --database ${originalDb.name} --package ${MODULE_NAME} --yes
+      `,
+      { database: originalDb.name }
+    );
+  });
+
+  afterAll(async () => {
+    await fixture.cleanup();
+  });
+
+  it('--dry-run prints the plan without writing anything', async () => {
+    await fixture.runTerminalCommands(
+      `
+      cd ${WS}/${MODULE_NAME}
+      pgpm transform --granularity object --dry-run
+      `,
+      {}
+    );
+    expect(fs.existsSync(path.join(wsDir, `${MODULE_NAME}-object`))).toBe(false);
+  });
+
+  it.each(['atomic', 'object', 'consolidated'] as const)(
+    'transform --granularity %s deploys with an equivalent catalog, verifies, and reverts clean',
+    async granularity => {
+      await fixture.runTerminalCommands(
+        `
+        cd ${WS}/${MODULE_NAME}
+        pgpm transform --granularity ${granularity}
+        `,
+        {}
+      );
+
+      const outDir = path.join(wsDir, `${MODULE_NAME}-${granularity}`);
+      expect(fs.existsSync(path.join(outDir, 'pgpm.plan'))).toBe(true);
+      expect(fs.existsSync(path.join(outDir, `${MODULE_NAME}-${granularity}.control`))).toBe(true);
+
+      const testDb = await fixture.setupTestDatabase();
+      await fixture.runTerminalCommands(
+        `
+        cd ${WS}/${MODULE_NAME}-${granularity}
+        pgpm deploy --database ${testDb.name} --package ${MODULE_NAME}-${granularity} --yes
+        `,
+        { database: testDb.name }
+      );
+
+      const snapOriginal = await snapshotCatalog(originalDb);
+      const snapTransformed = await snapshotCatalog(testDb);
+      expect(diffCatalogSnapshots(snapOriginal, snapTransformed)).toEqual([]);
+
+      await fixture.runTerminalCommands(
+        `
+        cd ${WS}/${MODULE_NAME}-${granularity}
+        pgpm verify --database ${testDb.name} --package ${MODULE_NAME}-${granularity} --yes
+        pgpm revert --database ${testDb.name} --package ${MODULE_NAME}-${granularity} --yes
+        `,
+        { database: testDb.name }
+      );
+
+      expect(await testDb.exists('schema', 'tfx_app')).toBe(false);
+      expect(await testDb.exists('schema', 'tfx_sec')).toBe(false);
+      const remaining = await testDb.query(
+        `SELECT COUNT(*)::int AS count FROM pgpm_migrate.changes WHERE package = $1`,
+        [`${MODULE_NAME}-${granularity}`]
+      );
+      expect(remaining.rows[0].count).toBe(0);
+    }
+  );
+
+  it('rewrites an existing output when --write is passed', async () => {
+    // The refusal path (no --write) exits the process, so it is covered by the
+    // checkOverwrite unit tests; here we prove --write re-generates in place.
+    const outDir = path.join(wsDir, `${MODULE_NAME}-object`);
+    expect(fs.existsSync(outDir)).toBe(true);
+
+    await fixture.runTerminalCommands(
+      `
+      cd ${WS}/${MODULE_NAME}
+      pgpm transform --granularity object --write
+      `,
+      {}
+    );
+    expect(fs.existsSync(path.join(outDir, 'pgpm.plan'))).toBe(true);
+  });
+
+  it('--check proves the transform is structurally lossless', async () => {
+    await fixture.runTerminalCommands(
+      `
+      cd ${WS}/${MODULE_NAME}
+      pgpm transform --granularity consolidated --write --check
+      `,
+      {}
+    );
+  });
+
+  it('partitions into pkg-app + pkg-security with catalog equivalence', async () => {
+    fs.writeFileSync(path.join(wsDir, 'partition.json'), JSON.stringify(PARTITION_CONFIG, null, 2));
+
+    await fixture.runTerminalCommands(
+      `
+      cd ${WS}/${MODULE_NAME}
+      pgpm transform --granularity object --partition ../partition.json
+      `,
+      {}
+    );
+
+    const appDir = path.join(wsDir, 'pkg-app');
+    const secDir = path.join(wsDir, 'pkg-security');
+    expect(fs.existsSync(path.join(appDir, 'pgpm.plan'))).toBe(true);
+    expect(fs.existsSync(path.join(secDir, 'pgpm.plan'))).toBe(true);
+
+    // security package requires the app package (policies/grants target app tables)
+    const secControl = fs.readFileSync(path.join(secDir, 'pkg-security.control'), 'utf-8');
+    expect(secControl).toMatch(/requires = '.*pkg-app.*'/);
+
+    const testDb = await fixture.setupTestDatabase();
+    await fixture.runTerminalCommands(
+      `
+      cd ${WS}/pkg-app
+      pgpm deploy --database ${testDb.name} --package pkg-app --yes
+      cd ../pkg-security
+      pgpm deploy --database ${testDb.name} --package pkg-security --yes
+      `,
+      { database: testDb.name }
+    );
+
+    const snapOriginal = await snapshotCatalog(originalDb);
+    const snapPartitioned = await snapshotCatalog(testDb);
+    expect(diffCatalogSnapshots(snapOriginal, snapPartitioned)).toEqual([]);
+  });
+
+  it('round-trips consolidated -> atomic -> consolidated to the same object set', async () => {
+    // consolidated already exists at <module>-consolidated (from --check test)
+    const c1 = path.join(wsDir, `${MODULE_NAME}-consolidated`);
+    expect(fs.existsSync(path.join(c1, 'pgpm.plan'))).toBe(true);
+
+    await fixture.runTerminalCommands(
+      `
+      cd ${WS}/${MODULE_NAME}-consolidated
+      pgpm transform --granularity atomic --out ../roundtrip-atomic --write
+      cd ../roundtrip-atomic/${MODULE_NAME}-consolidated-atomic
+      pgpm transform --granularity consolidated --out ../../roundtrip-consolidated --write
+      `,
+      {}
+    );
+
+    const c2 = path.join(
+      wsDir,
+      'roundtrip-consolidated',
+      `${MODULE_NAME}-consolidated-atomic-consolidated`
+    );
+    expect(fs.existsSync(path.join(c2, 'pgpm.plan'))).toBe(true);
+
+    const changeSet = (planPath: string): string[] =>
+      fs
+        .readFileSync(planPath, 'utf-8')
+        .split('\n')
+        .filter(line => line && !line.startsWith('%'))
+        .map(line => line.split(' ')[0])
+        .sort();
+
+    expect(changeSet(path.join(c2, 'pgpm.plan'))).toEqual(
+      changeSet(path.join(c1, 'pgpm.plan'))
+    );
+  });
+});

--- a/pgpm/cli/__tests__/transform-unit.test.ts
+++ b/pgpm/cli/__tests__/transform-unit.test.ts
@@ -1,0 +1,67 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { checkOverwrite, orderPackages, resolveOutBase } from '../src/commands/transform';
+
+describe('resolveOutBase', () => {
+  it('defaults to the source module parent (packages land as siblings)', () => {
+    expect(resolveOutBase('/ws/my-mod')).toBe('/ws');
+  });
+
+  it('resolves --out when given', () => {
+    expect(resolveOutBase('/ws/my-mod', '/tmp/out')).toBe('/tmp/out');
+  });
+});
+
+describe('checkOverwrite', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'pgpm-transform-guard-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('refuses to overwrite the source module without --write', () => {
+    const mod = join(dir, 'my-mod');
+    mkdirSync(mod);
+    expect(checkOverwrite(mod, mod, false)).toMatch(/source module/);
+    expect(checkOverwrite(mod, mod, true)).toBeNull();
+  });
+
+  it('refuses to clobber an existing output directory without --write', () => {
+    const mod = join(dir, 'my-mod');
+    const out = join(dir, 'my-mod-object');
+    mkdirSync(mod);
+    mkdirSync(out);
+    expect(checkOverwrite(out, mod, false)).toMatch(/already exists/);
+    expect(checkOverwrite(out, mod, true)).toBeNull();
+  });
+
+  it('allows a fresh output directory', () => {
+    const mod = join(dir, 'my-mod');
+    mkdirSync(mod);
+    expect(checkOverwrite(join(dir, 'fresh'), mod, false)).toBeNull();
+  });
+});
+
+describe('orderPackages', () => {
+  it('orders prerequisites before dependents', () => {
+    const ordered = orderPackages([
+      { name: 'pkg-security', requires: ['pkg-app'], rows: [] },
+      { name: 'pkg-app', requires: [], rows: [] }
+    ]);
+    expect(ordered.map(p => p.name)).toEqual(['pkg-app', 'pkg-security']);
+  });
+
+  it('keeps independent packages in input order', () => {
+    const ordered = orderPackages([
+      { name: 'a', requires: [], rows: [] },
+      { name: 'b', requires: [], rows: [] }
+    ]);
+    expect(ordered.map(p => p.name)).toEqual(['a', 'b']);
+  });
+});

--- a/pgpm/cli/src/commands.ts
+++ b/pgpm/cli/src/commands.ts
@@ -29,6 +29,7 @@ import slice from './commands/slice';
 import syncVersions from './commands/sync-versions';
 import tag from './commands/tag';
 import testPackages from './commands/test-packages';
+import transform from './commands/transform';
 import tune from './commands/tune';
 import updateCmd from './commands/update';
 import upgrade from './commands/upgrade';
@@ -112,6 +113,7 @@ export const createPgpmCommandMap = (skipPgTeardown: boolean = false): Record<st
     slice,
     'sync-versions': syncVersions,
     'test-packages': pgt(testPackages),
+    transform: pgt(transform),
     tune: pgt(tune),
     upgrade: pgt(upgrade),
     up: pgt(upgrade),

--- a/pgpm/cli/src/commands/export.ts
+++ b/pgpm/cli/src/commands/export.ts
@@ -1,5 +1,5 @@
 import { PgpmPackage } from '@pgpmjs/core';
-import { exportMigrations, exportGraphQL, GraphQLClient, graphqlRowToPostgresRow, isExportGranularity, EXPORT_GRANULARITIES } from '@pgpmjs/export';
+import { exportMigrations, exportGraphQL, GraphQLClient, graphqlRowToPostgresRow, isExportGranularity, EXPORT_GRANULARITIES, parsePartitionConfig, PartitionConfig } from '@pgpmjs/export';
 import { getEnvOptions } from '@pgpmjs/env';
 import { getGitConfigInfo } from '@pgpmjs/types';
 import { CLIOptions, Inquirerer } from 'inquirerer';
@@ -30,12 +30,16 @@ Options:
                           Change paths are derived from the naming spec and
                           requires from the statement graph. When omitted,
                           sql_actions rows are exported unchanged.
+  --partition <file>      Partition config (JSON: rules/defaultPackage/splitRiders)
+                          splitting the exported database module into multiple
+                          pgpm packages with derived cross-package requires.
   --cwd <directory>       Working directory (default: current directory)
 
 Examples:
   pgpm export              Export migrations from selected database (SQL mode)
   pgpm export --exclude-categories security,permissions,auth,memberships
   pgpm export --granularity consolidated
+  pgpm export --granularity object --partition partition.json
   pgpm export --graphql-endpoint 'http://[::1]:3002/graphql' --migrate-endpoint 'http://[::1]:3000/graphql' --migrate-host db_migrate.localhost:3000
 `;
 
@@ -77,6 +81,18 @@ export default async (
     return;
   }
   const granularity = granularityRaw;
+
+  const partitionRaw = argv.partition;
+  let partition: PartitionConfig | undefined;
+  if (typeof partitionRaw === 'string' && partitionRaw) {
+    try {
+      partition = parsePartitionConfig(resolve(cwd, partitionRaw));
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      prompter.close();
+      return;
+    }
+  }
 
   if (graphqlEndpoint) {
     // =========================================================================
@@ -195,7 +211,8 @@ export default async (
       argv,
       username,
       excludeCategories,
-      granularity
+      granularity,
+      partition
     });
   } else {
     // =========================================================================
@@ -334,7 +351,8 @@ export default async (
       argv,
       username,
       excludeCategories,
-      granularity
+      granularity,
+      partition
     });
   }
 

--- a/pgpm/cli/src/commands/transform.ts
+++ b/pgpm/cli/src/commands/transform.ts
@@ -1,0 +1,379 @@
+import { PgpmMigrate, PgpmPackage, PgpmRow, SqlWriteOptions, writePgpmFiles, writePgpmPlan } from '@pgpmjs/core';
+import {
+  diffCatalogSnapshots,
+  EXPORT_GRANULARITIES,
+  ExportGranularity,
+  isExportGranularity,
+  loadModuleSource,
+  parsePartitionConfig,
+  PartitionConfig,
+  partitionExportRows,
+  PartitionedPackageRows,
+  restructureExportRows,
+  snapshotCatalog
+} from '@pgpmjs/export';
+import { Logger } from '@pgpmjs/logger';
+import { PartitionCycleError } from '@pgpmjs/transform';
+import * as fs from 'fs';
+import { CLIOptions, cliExitWithError, Inquirerer, ParsedArgs } from 'inquirerer';
+import * as path from 'path';
+import { getPgPool } from 'pg-cache';
+import type { PgConfig } from 'pg-env';
+import { getPgEnvOptions } from 'pg-env';
+
+const log = new Logger('transform');
+
+const transformUsageText = `
+Transform Command:
+
+  pgpm transform --granularity <atomic|object|consolidated> [OPTIONS]
+
+  Re-dial an existing pgpm module (or every module in a workspace) through the
+  dials pipeline: flatten the deploy scripts in plan order, re-project them at
+  the requested granularity with spec-derived change paths, graph-derived
+  requires, and generated revert/verify scripts.
+
+Options:
+  --help, -h              Show this help message
+  --granularity <level>   Target granularity: atomic | object | consolidated (required)
+  --partition <file>      Partition config (JSON: rules/defaultPackage/splitRiders)
+                          splitting the module into multiple pgpm packages with
+                          derived cross-package requires.
+  --naming <style>        Change path naming style: directory | flat (default: directory)
+  --cwd <directory>       Module or workspace directory (default: current directory)
+  --out <dir>             Output directory (default: sibling <module>-<granularity>)
+  --write                 Allow writing over an existing/module directory
+  --check                 Deploy original and transformed output into scratch
+                          databases and assert the catalogs are equivalent
+  --dry-run               Print the resulting plan/paths without writing
+
+Examples:
+  pgpm transform --granularity object
+  pgpm transform --granularity atomic --naming flat --out ./out
+  pgpm transform --granularity object --partition partition.json --check
+`;
+
+const NAMING_STYLES = ['directory', 'flat'] as const;
+type NamingStyle = (typeof NAMING_STYLES)[number];
+
+interface TransformedModule {
+  /** Source module directory. */
+  modulePath: string;
+  /** Module (project) name. */
+  name: string;
+  /** Base directory the output package dir(s) are created in. */
+  outBase: string;
+  /** Packages to write: one for plain transforms, N when partitioned. */
+  packages: PartitionedPackageRows[];
+  warnings: string[];
+}
+
+/**
+ * Resolve the base directory package dir(s) are created in. Without --out,
+ * packages are written as siblings of the source module — a plain transform
+ * of `my-mod` at granularity `object` lands in `../my-mod-object`.
+ */
+export const resolveOutBase = (modulePath: string, out?: string): string => {
+  if (out) return path.resolve(out);
+  return path.dirname(modulePath);
+};
+
+/**
+ * Guard against clobbering: writing into the source module requires --write,
+ * as does overwriting any existing package directory.
+ */
+export const checkOverwrite = (
+  targetDir: string,
+  modulePath: string,
+  write: boolean
+): string | null => {
+  const resolvedTarget = path.resolve(targetDir);
+  const resolvedSource = path.resolve(modulePath);
+  if (resolvedTarget === resolvedSource && !write) {
+    return `Refusing to overwrite the source module at ${resolvedSource} (pass --write to allow).`;
+  }
+  if (resolvedTarget !== resolvedSource && fs.existsSync(resolvedTarget) && !write) {
+    return `Output directory ${resolvedTarget} already exists (pass --write to overwrite).`;
+  }
+  return null;
+};
+
+/** Order partition packages so prerequisites come before dependents. */
+export const orderPackages = (packages: PartitionedPackageRows[]): PartitionedPackageRows[] => {
+  const byName = new Map(packages.map(pkg => [pkg.name, pkg]));
+  const ordered: PartitionedPackageRows[] = [];
+  const seen = new Set<string>();
+  const visit = (pkg: PartitionedPackageRows): void => {
+    if (seen.has(pkg.name)) return;
+    seen.add(pkg.name);
+    for (const req of pkg.requires) {
+      const dep = byName.get(req);
+      if (dep) visit(dep);
+    }
+    ordered.push(pkg);
+  };
+  for (const pkg of packages) visit(pkg);
+  return ordered;
+};
+
+const readControlRequires = (modulePath: string, name: string): string[] => {
+  const controlPath = path.join(modulePath, `${name}.control`);
+  if (!fs.existsSync(controlPath)) return [];
+  const match = fs.readFileSync(controlPath, 'utf-8').match(/^requires\s*=\s*'([^']*)'\s*$/m);
+  if (!match) return [];
+  return match[1].split(',').map(s => s.trim()).filter(Boolean);
+};
+
+const writeControlFile = (dir: string, name: string, requires: string[]): void => {
+  const lines = [
+    `# ${name} extension`,
+    `comment = '${name} extension'`,
+    `default_version = '0.0.1'`,
+    `relocatable = false`,
+    `superuser = false`
+  ];
+  if (requires.length) {
+    lines.push(`requires = '${requires.join(',')}'`);
+  }
+  fs.writeFileSync(path.join(dir, `${name}.control`), lines.join('\n') + '\n');
+};
+
+const writePackage = (
+  outBase: string,
+  pkg: PartitionedPackageRows,
+  sourceRequires: string[]
+): string => {
+  const dir = path.join(outBase, pkg.name);
+  fs.rmSync(path.join(dir, 'deploy'), { recursive: true, force: true });
+  fs.rmSync(path.join(dir, 'revert'), { recursive: true, force: true });
+  fs.rmSync(path.join(dir, 'verify'), { recursive: true, force: true });
+  fs.mkdirSync(dir, { recursive: true });
+
+  writeControlFile(dir, pkg.name, [...sourceRequires, ...pkg.requires]);
+
+  const opts: SqlWriteOptions = {
+    outdir: outBase,
+    name: pkg.name,
+    replacer: (str: string) => str.split('constructive-extension-name').join(pkg.name)
+  };
+  writePgpmPlan(pkg.rows, opts);
+  writePgpmFiles(pkg.rows, opts);
+  return dir;
+};
+
+const createScratchDb = async (config: PgConfig, dbName: string): Promise<void> => {
+  const adminPool = getPgPool({ ...config, database: 'postgres' });
+  await adminPool.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+  await adminPool.query(`CREATE DATABASE "${dbName}"`);
+};
+
+const dropScratchDb = async (config: PgConfig, dbName: string): Promise<void> => {
+  const adminPool = getPgPool({ ...config, database: 'postgres' });
+  await adminPool.query(`DROP DATABASE IF EXISTS "${dbName}" WITH (FORCE)`);
+};
+
+const deployModules = async (config: PgConfig, modulePaths: string[]): Promise<void> => {
+  const client = new PgpmMigrate(config);
+  for (const modulePath of modulePaths) {
+    const result = await client.deploy({ modulePath });
+    if (result.failed) {
+      throw new Error(`deploy failed at change ${result.failed} (module ${modulePath})`);
+    }
+  }
+};
+
+/**
+ * Prove the transform is structurally lossless: deploy the original module and
+ * the transformed package(s) into two scratch databases and compare catalogs.
+ */
+const runCheck = async (transformed: TransformedModule): Promise<string[]> => {
+  const config = getPgEnvOptions();
+  const stamp = Date.now();
+  const dbOriginal = `pgpm_transform_check_a_${stamp}`;
+  const dbTransformed = `pgpm_transform_check_b_${stamp}`;
+
+  try {
+    await createScratchDb(config, dbOriginal);
+    await createScratchDb(config, dbTransformed);
+
+    await deployModules({ ...config, database: dbOriginal }, [transformed.modulePath]);
+
+    const orderedDirs = orderPackages(transformed.packages).map(pkg =>
+      path.join(transformed.outBase, pkg.name)
+    );
+    await deployModules({ ...config, database: dbTransformed }, orderedDirs);
+
+    const poolOriginal = getPgPool({ ...config, database: dbOriginal });
+    const poolTransformed = getPgPool({ ...config, database: dbTransformed });
+    const snapOriginal = await snapshotCatalog(poolOriginal);
+    const snapTransformed = await snapshotCatalog(poolTransformed);
+    return diffCatalogSnapshots(snapOriginal, snapTransformed);
+  } finally {
+    try {
+      await dropScratchDb(config, dbOriginal);
+      await dropScratchDb(config, dbTransformed);
+    } catch (err) {
+      log.warn(`failed to drop scratch databases: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+};
+
+const transformModule = async (
+  modulePath: string,
+  granularity: ExportGranularity,
+  naming: NamingStyle,
+  partition: PartitionConfig | undefined,
+  out: string | undefined
+): Promise<TransformedModule> => {
+  const source = loadModuleSource(modulePath);
+  const warnings = [...source.warnings];
+
+  const rows: PgpmRow[] = source.changes.map(change => ({
+    name: change.name,
+    deploy: change.name,
+    deps: change.dependencies,
+    content: change.deploy
+  }));
+
+  const restructured = await restructureExportRows(rows, granularity, { naming });
+  warnings.push(...restructured.warnings.map(w => `restructure (${granularity}): ${w}`));
+
+  const outBase = resolveOutBase(modulePath, out);
+
+  let packages: PartitionedPackageRows[];
+  if (partition) {
+    const result = await partitionExportRows(restructured.rows, partition);
+    warnings.push(...result.warnings.map(w => `partition: ${w}`));
+    packages = result.packages;
+  } else {
+    // Distinct package name so the output can live beside the source module
+    // in the same workspace without colliding.
+    packages = [{ name: `${source.name}-${granularity}`, requires: [], rows: restructured.rows }];
+  }
+
+  return { modulePath, name: source.name, outBase, packages, warnings };
+};
+
+const printDryRun = (transformed: TransformedModule): void => {
+  console.log(`module ${transformed.name} (${transformed.modulePath})`);
+  for (const pkg of transformed.packages) {
+    console.log(`  package ${pkg.name} -> ${path.join(transformed.outBase, pkg.name)}`);
+    for (const row of pkg.rows) {
+      const deps = row.deps?.length ? ` [${row.deps.join(' ')}]` : '';
+      console.log(`    ${row.deploy}${deps}`);
+    }
+  }
+};
+
+export default async (
+  argv: Partial<ParsedArgs>,
+  prompter: Inquirerer,
+  _options: CLIOptions
+) => {
+  if (argv.help || argv.h) {
+    console.log(transformUsageText);
+    process.exit(0);
+  }
+
+  const granularityRaw = argv.granularity;
+  if (granularityRaw === undefined) {
+    await cliExitWithError(`--granularity is required. Expected one of: ${EXPORT_GRANULARITIES.join(', ')}.`);
+  }
+  if (!isExportGranularity(granularityRaw)) {
+    await cliExitWithError(`Invalid --granularity "${granularityRaw}". Expected one of: ${EXPORT_GRANULARITIES.join(', ')}.`);
+  }
+  const granularity = granularityRaw as ExportGranularity;
+
+  const namingRaw = (argv.naming as string) ?? 'directory';
+  if (!(NAMING_STYLES as readonly string[]).includes(namingRaw)) {
+    await cliExitWithError(`Invalid --naming "${namingRaw}". Expected one of: ${NAMING_STYLES.join(', ')}.`);
+  }
+  const naming = namingRaw as NamingStyle;
+
+  const cwd = (argv.cwd as string) || process.cwd();
+
+  let partition: PartitionConfig | undefined;
+  if (typeof argv.partition === 'string' && argv.partition) {
+    try {
+      partition = parsePartitionConfig(path.resolve(cwd, argv.partition));
+    } catch (err) {
+      await cliExitWithError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  const out = typeof argv.out === 'string' && argv.out ? path.resolve(cwd, argv.out) : undefined;
+  const write = Boolean(argv.write);
+  const check = Boolean(argv.check);
+  const dryRun = Boolean(argv['dry-run'] ?? argv.dryRun);
+
+  const pkg = new PgpmPackage(path.resolve(cwd));
+
+  let modulePaths: string[];
+  if (pkg.isInModule()) {
+    modulePaths = [pkg.modulePath!];
+  } else if (pkg.workspacePath) {
+    const moduleMap = pkg.getModuleMap();
+    modulePaths = Object.values(moduleMap).map(mod =>
+      path.resolve(pkg.workspacePath!, mod.path)
+    );
+    if (modulePaths.length === 0) {
+      await cliExitWithError('No modules found in workspace.');
+    }
+    if (out && modulePaths.length > 1) {
+      await cliExitWithError('--out is not supported when transforming a multi-module workspace.');
+    }
+  } else {
+    await cliExitWithError('Not inside a pgpm module or workspace (pass --cwd <dir>).');
+    return;
+  }
+
+  for (const modulePath of modulePaths) {
+    let transformed: TransformedModule;
+    try {
+      transformed = await transformModule(modulePath, granularity, naming, partition, out);
+    } catch (err) {
+      if (err instanceof PartitionCycleError) {
+        await cliExitWithError(`Partition failed: ${err.message}`);
+        return;
+      }
+      throw err;
+    }
+
+    for (const warning of transformed.warnings) {
+      console.warn(`transform: ${warning}`);
+    }
+
+    if (dryRun) {
+      printDryRun(transformed);
+      continue;
+    }
+
+    for (const pkgRows of transformed.packages) {
+      const targetDir = path.join(transformed.outBase, pkgRows.name);
+      const guard = checkOverwrite(targetDir, modulePath, write);
+      if (guard) {
+        await cliExitWithError(guard);
+      }
+    }
+
+    const sourceRequires = readControlRequires(modulePath, transformed.name);
+    for (const pkgRows of transformed.packages) {
+      const dir = writePackage(transformed.outBase, pkgRows, sourceRequires);
+      log.success(`wrote ${pkgRows.rows.length} changes to ${dir}`);
+    }
+
+    if (check) {
+      log.info('running --check: deploying original and transformed output to scratch databases...');
+      const diffs = await runCheck(transformed);
+      if (diffs.length) {
+        console.error(`--check failed: catalogs differ (${diffs.length} differences):`);
+        for (const diff of diffs) console.error(`  ${diff}`);
+        await cliExitWithError('Transform is not structurally lossless.');
+      }
+      log.success('--check passed: catalogs are structurally equivalent.');
+    }
+  }
+
+  prompter.close();
+  return argv;
+};

--- a/pgpm/cli/src/utils/display.ts
+++ b/pgpm/cli/src/utils/display.ts
@@ -12,6 +12,7 @@ export const usageText = `
     extension          Manage module dependencies
     plan               Generate module deployment plans
     regen              Generate revert/verify scripts from deploy scripts
+    transform          Re-dial a module through the dials pipeline (granularity/naming/partition)
     package            Package module for distribution
     materialize        Transpile an apply proxy into a plain, committed module
     sync-versions      Sync .control/Makefile/sql metadata to package.json versions

--- a/pgpm/export/__tests__/export-granularity.test.ts
+++ b/pgpm/export/__tests__/export-granularity.test.ts
@@ -369,4 +369,96 @@ relocatable = false
       expect(plan).toContain('migrate/0002-owners');
     });
   });
+
+  describe('partition dial (--partition)', () => {
+    const EXTENSION_NAME = 'pets-part';
+    const PETS_PKG = 'pets-part-pets';
+
+    beforeAll(async () => {
+      scaffoldModule(EXTENSION_NAME, 'Exported pets database schema (partitioned)');
+      scaffoldModule(PETS_PKG, 'Exported pets tables (partitioned)');
+      scaffoldModule(`${EXTENSION_NAME}-svc`, 'Exported pets service metadata (partitioned)');
+
+      const project = new PgpmPackage(exportWorkspaceDir);
+
+      await exportMigrations({
+        project,
+        options: {
+          pg: dbConfig
+        },
+        dbInfo: {
+          dbname: dbConfig.database,
+          databaseName: 'pets',
+          database_ids: [DATABASE_ID]
+        },
+        author: 'test <test@test.local>',
+        outdir: join(exportWorkspaceDir, 'packages'),
+        schema_names: ['pets_public'],
+        extensionName: EXTENSION_NAME,
+        extensionDesc: 'Exported pets database schema (partitioned)',
+        metaExtensionName: `${EXTENSION_NAME}-svc`,
+        metaExtensionDesc: 'Exported pets service metadata (partitioned)',
+        granularity: 'object',
+        partition: {
+          defaultPackage: EXTENSION_NAME,
+          rules: [
+            {
+              package: PETS_PKG,
+              select: [{ name: 'pets' }, { table: 'pets' }]
+            }
+          ]
+        }
+      });
+    });
+
+    it('writes one complete module per partition package', () => {
+      for (const pkg of [EXTENSION_NAME, PETS_PKG]) {
+        expect(existsSync(join(exportWorkspaceDir, 'packages', pkg, 'pgpm.plan'))).toBe(true);
+      }
+      const defaultPlan = readFileSync(join(exportWorkspaceDir, 'packages', EXTENSION_NAME, 'pgpm.plan'), 'utf-8');
+      expect(defaultPlan).toContain('schemas/pets_part_public/schema');
+      expect(defaultPlan).toContain('tables/owners/table');
+      expect(defaultPlan).not.toContain('tables/pets/table');
+
+      const petsPlan = readFileSync(join(exportWorkspaceDir, 'packages', PETS_PKG, 'pgpm.plan'), 'utf-8');
+      const petsChanges = petsPlan
+        .split('\n')
+        .filter(line => line && !line.startsWith('%'))
+        .map(line => line.split(' ')[0]);
+      expect(petsChanges).toContain('schemas/pets_part_public/tables/pets/table');
+      // owners appears only as a cross-package dependency, never as a change
+      expect(petsChanges).not.toContain('schemas/pets_part_public/tables/owners/table');
+    });
+
+    it('derives cross-package requires (<pkg>:<path>) and control requires', () => {
+      const petsPlan = readFileSync(join(exportWorkspaceDir, 'packages', PETS_PKG, 'pgpm.plan'), 'utf-8');
+      expect(petsPlan).toContain(`${EXTENSION_NAME}:`);
+
+      const control = readFileSync(
+        join(exportWorkspaceDir, 'packages', PETS_PKG, `${PETS_PKG}.control`),
+        'utf-8'
+      );
+      expect(control).toContain(EXTENSION_NAME);
+    });
+
+    it('deploys the partitioned packages in dependency order (round-trip)', async () => {
+      const deployer = new PgpmMigrate(dbConfig);
+      await deployer.deploy({ modulePath: join(exportWorkspaceDir, 'packages', EXTENSION_NAME) });
+      await deployer.deploy({ modulePath: join(exportWorkspaceDir, 'packages', PETS_PKG) });
+
+      const tables = await pg.query(`
+        SELECT table_name FROM information_schema.tables
+        WHERE table_schema = 'pets_part_public'
+        ORDER BY table_name
+      `);
+      expect(tables.rows.map((r: any) => r.table_name)).toEqual(['owners', 'pets']);
+
+      const fk = await pg.query(`
+        SELECT conname FROM pg_constraint
+        WHERE conname = 'pets_owner_fk'
+          AND connamespace = 'pets_part_public'::regnamespace
+      `);
+      expect(fk.rows).toHaveLength(1);
+    });
+  });
 });

--- a/pgpm/export/__tests__/module-source.test.ts
+++ b/pgpm/export/__tests__/module-source.test.ts
@@ -1,0 +1,152 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { loadModuleSource, stripTransactionWrapper } from '../src/module-source';
+import { parsePartitionConfig } from '../src/partition';
+
+describe('stripTransactionWrapper', () => {
+  it('removes standalone BEGIN/COMMIT lines', () => {
+    const sql = 'BEGIN;\n\nCREATE SCHEMA app;\n\nCOMMIT;\n';
+    expect(stripTransactionWrapper(sql)).toBe('CREATE SCHEMA app;');
+  });
+
+  it('keeps BEGIN inside function bodies', () => {
+    const sql = [
+      'CREATE FUNCTION app.f() RETURNS void AS $$',
+      'BEGIN',
+      '  RETURN;',
+      'END;',
+      '$$ LANGUAGE plpgsql;'
+    ].join('\n');
+    expect(stripTransactionWrapper(sql)).toContain('BEGIN');
+    expect(stripTransactionWrapper(sql)).toContain('END;');
+  });
+});
+
+describe('loadModuleSource', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'pgpm-module-source-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const writeModule = () => {
+    writeFileSync(
+      join(dir, 'pgpm.plan'),
+      [
+        '%syntax-version=1.0.0',
+        '%project=my-mod',
+        '%uri=my-mod',
+        '',
+        'schemas/app/schema 2017-08-11T08:11:51Z tester <tester@x> # add schema',
+        'schemas/app/tables/users/table [schemas/app/schema] 2017-08-11T08:11:51Z tester <tester@x> # add table',
+        ''
+      ].join('\n')
+    );
+    mkdirSync(join(dir, 'deploy', 'schemas', 'app', 'tables', 'users'), { recursive: true });
+    writeFileSync(
+      join(dir, 'deploy', 'schemas', 'app', 'schema.sql'),
+      '-- Deploy: schemas/app/schema to pg\nBEGIN;\nCREATE SCHEMA app;\nCOMMIT;\n'
+    );
+    writeFileSync(
+      join(dir, 'deploy', 'schemas', 'app', 'tables', 'users', 'table.sql'),
+      '-- Deploy: schemas/app/tables/users/table to pg\n-- requires: schemas/app/schema\nBEGIN;\nCREATE TABLE app.users (id int);\nCOMMIT;\n'
+    );
+  };
+
+  it('flattens deploy scripts in plan order with deps', () => {
+    writeModule();
+    const source = loadModuleSource(dir);
+    expect(source.name).toBe('my-mod');
+    expect(source.changes.map(c => c.name)).toEqual([
+      'schemas/app/schema',
+      'schemas/app/tables/users/table'
+    ]);
+    expect(source.changes[0].deploy).toBe('CREATE SCHEMA app;');
+    expect(source.changes[1].deploy).toBe('CREATE TABLE app.users (id int);');
+    expect(source.changes[1].dependencies).toEqual(['schemas/app/schema']);
+    expect(source.warnings).toEqual([]);
+  });
+
+  it('warns and skips changes with missing deploy scripts', () => {
+    writeModule();
+    rmSync(join(dir, 'deploy', 'schemas', 'app', 'tables'), { recursive: true });
+    const source = loadModuleSource(dir);
+    expect(source.changes.map(c => c.name)).toEqual(['schemas/app/schema']);
+    expect(source.warnings).toEqual([
+      'schemas/app/tables/users/table: no deploy script found, skipping'
+    ]);
+  });
+
+  it('throws on a missing plan', () => {
+    expect(() => loadModuleSource(join(dir, 'nope'))).toThrow();
+  });
+});
+
+describe('parsePartitionConfig', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'pgpm-partition-config-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const writeConfig = (contents: string): string => {
+    const file = join(dir, 'partition.json');
+    writeFileSync(file, contents);
+    return file;
+  };
+
+  it('parses a valid config', () => {
+    const file = writeConfig(
+      JSON.stringify({
+        defaultPackage: 'pkg-app',
+        rules: [{ package: 'pkg-security', select: [{ kind: 'policy' }] }]
+      })
+    );
+    const config = parsePartitionConfig(file);
+    expect(config.defaultPackage).toBe('pkg-app');
+    expect(config.rules).toHaveLength(1);
+  });
+
+  it('rejects a missing file', () => {
+    expect(() => parsePartitionConfig(join(dir, 'nope.json'))).toThrow(/not found/);
+  });
+
+  it('rejects invalid JSON', () => {
+    const file = writeConfig('{nope');
+    expect(() => parsePartitionConfig(file)).toThrow(/not valid JSON/);
+  });
+
+  it('rejects a missing defaultPackage', () => {
+    const file = writeConfig(JSON.stringify({ rules: [] }));
+    expect(() => parsePartitionConfig(file)).toThrow(/defaultPackage/);
+  });
+
+  it('rejects non-array rules', () => {
+    const file = writeConfig(JSON.stringify({ defaultPackage: 'a', rules: {} }));
+    expect(() => parsePartitionConfig(file)).toThrow(/"rules" must be an array/);
+  });
+
+  it('rejects a rule without selectors', () => {
+    const file = writeConfig(
+      JSON.stringify({ defaultPackage: 'a', rules: [{ package: 'b', select: [] }] })
+    );
+    expect(() => parsePartitionConfig(file)).toThrow(/select/);
+  });
+
+  it('rejects an invalid style', () => {
+    const file = writeConfig(
+      JSON.stringify({ defaultPackage: 'a', rules: [], style: 'nested' })
+    );
+    expect(() => parsePartitionConfig(file)).toThrow(/style/);
+  });
+});

--- a/pgpm/export/src/catalog-check.ts
+++ b/pgpm/export/src/catalog-check.ts
@@ -1,0 +1,168 @@
+/**
+ * Structural catalog snapshot + equivalence check, used by
+ * `pgpm transform --check` to prove a transform is lossless: deploy the
+ * original and the transformed module(s) into two scratch databases and
+ * assert the resulting catalogs describe the same schema.
+ *
+ * The snapshot is intentionally order-insensitive per object class (objects
+ * are keyed by identity and compared by definition), but column order within
+ * a table IS part of the comparison — the dials pipeline preserves it.
+ */
+/** Minimal query surface: satisfied by pg Pool/PoolClient and test clients. */
+export interface CatalogQueryable {
+  query(text: string): Promise<{ rows: any[] }>;
+}
+
+/** Catalog snapshot: object identity -> normalized definition. */
+export interface CatalogSnapshot {
+  schemas: Record<string, string>;
+  tables: Record<string, string>;
+  columns: Record<string, string>;
+  constraints: Record<string, string>;
+  indexes: Record<string, string>;
+  functions: Record<string, string>;
+  triggers: Record<string, string>;
+  policies: Record<string, string>;
+  rls: Record<string, string>;
+  grants: Record<string, string>;
+}
+
+const SYSTEM_SCHEMAS = `('pg_catalog', 'information_schema', 'pg_toast', 'pgpm_migrate', 'public')`;
+
+const record = (rows: any[], key: (r: any) => string, value: (r: any) => string): Record<string, string> => {
+  const out: Record<string, string> = {};
+  for (const row of rows) out[key(row)] = value(row);
+  return out;
+};
+
+/**
+ * Snapshot the user-schema surface of a database: schemas, tables, columns,
+ * constraints, indexes, functions, triggers, policies, RLS flags, and table
+ * grants. System schemas, `public`, and the pgpm ledger are excluded.
+ */
+export const snapshotCatalog = async (db: CatalogQueryable): Promise<CatalogSnapshot> => {
+  const schemas = await db.query(`
+    SELECT nspname FROM pg_namespace
+    WHERE nspname NOT IN ${SYSTEM_SCHEMAS} AND nspname NOT LIKE 'pg_temp%' AND nspname NOT LIKE 'pg_toast%'
+    ORDER BY nspname
+  `);
+
+  const tables = await db.query(`
+    SELECT table_schema, table_name FROM information_schema.tables
+    WHERE table_schema NOT IN ${SYSTEM_SCHEMAS} AND table_type = 'BASE TABLE'
+  `);
+
+  const columns = await db.query(`
+    SELECT table_schema, table_name, column_name, ordinal_position,
+           data_type, is_nullable, column_default, character_maximum_length
+    FROM information_schema.columns
+    WHERE table_schema NOT IN ${SYSTEM_SCHEMAS}
+  `);
+
+  const constraints = await db.query(`
+    SELECT n.nspname AS schema, cl.relname AS table, c.conname,
+           pg_get_constraintdef(c.oid) AS def
+    FROM pg_constraint c
+    JOIN pg_class cl ON cl.oid = c.conrelid
+    JOIN pg_namespace n ON n.oid = cl.relnamespace
+    WHERE n.nspname NOT IN ${SYSTEM_SCHEMAS}
+  `);
+
+  const indexes = await db.query(`
+    SELECT schemaname, tablename, indexname, indexdef
+    FROM pg_indexes WHERE schemaname NOT IN ${SYSTEM_SCHEMAS}
+  `);
+
+  const functions = await db.query(`
+    SELECT n.nspname AS schema, p.proname,
+           pg_get_function_identity_arguments(p.oid) AS args,
+           pg_get_functiondef(p.oid) AS def
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname NOT IN ${SYSTEM_SCHEMAS}
+  `);
+
+  const triggers = await db.query(`
+    SELECT n.nspname AS schema, cl.relname AS table, t.tgname,
+           pg_get_triggerdef(t.oid) AS def
+    FROM pg_trigger t
+    JOIN pg_class cl ON cl.oid = t.tgrelid
+    JOIN pg_namespace n ON n.oid = cl.relnamespace
+    WHERE NOT t.tgisinternal AND n.nspname NOT IN ${SYSTEM_SCHEMAS}
+  `);
+
+  const policies = await db.query(`
+    SELECT schemaname, tablename, policyname, permissive, roles, cmd,
+           qual, with_check
+    FROM pg_policies WHERE schemaname NOT IN ${SYSTEM_SCHEMAS}
+  `);
+
+  const rls = await db.query(`
+    SELECT n.nspname AS schema, cl.relname AS table,
+           cl.relrowsecurity, cl.relforcerowsecurity
+    FROM pg_class cl
+    JOIN pg_namespace n ON n.oid = cl.relnamespace
+    WHERE cl.relkind = 'r' AND n.nspname NOT IN ${SYSTEM_SCHEMAS}
+  `);
+
+  const grants = await db.query(`
+    SELECT table_schema, table_name, grantee, privilege_type
+    FROM information_schema.role_table_grants
+    WHERE table_schema NOT IN ${SYSTEM_SCHEMAS}
+      AND grantee <> (SELECT current_user)
+  `);
+
+  return {
+    schemas: record(schemas.rows, r => r.nspname, () => 'schema'),
+    tables: record(tables.rows, r => `${r.table_schema}.${r.table_name}`, () => 'table'),
+    columns: record(
+      columns.rows,
+      r => `${r.table_schema}.${r.table_name}.${r.column_name}`,
+      r =>
+        `#${r.ordinal_position} ${r.data_type}${r.character_maximum_length ? `(${r.character_maximum_length})` : ''} nullable=${r.is_nullable} default=${r.column_default ?? 'none'}`
+    ),
+    constraints: record(constraints.rows, r => `${r.schema}.${r.table}.${r.conname}`, r => r.def),
+    indexes: record(indexes.rows, r => `${r.schemaname}.${r.tablename}.${r.indexname}`, r => r.indexdef),
+    functions: record(functions.rows, r => `${r.schema}.${r.proname}(${r.args})`, r => r.def),
+    triggers: record(triggers.rows, r => `${r.schema}.${r.table}.${r.tgname}`, r => r.def),
+    policies: record(
+      policies.rows,
+      r => `${r.schemaname}.${r.tablename}.${r.policyname}`,
+      r =>
+        `permissive=${r.permissive} roles=${[...(r.roles ?? [])].sort().join(',')} cmd=${r.cmd} qual=${r.qual ?? 'none'} check=${r.with_check ?? 'none'}`
+    ),
+    rls: record(
+      rls.rows,
+      r => `${r.schema}.${r.table}`,
+      r => `enabled=${r.relrowsecurity} forced=${r.relforcerowsecurity}`
+    ),
+    grants: record(
+      grants.rows,
+      r => `${r.table_schema}.${r.table_name}:${r.grantee}:${r.privilege_type}`,
+      () => 'grant'
+    )
+  };
+};
+
+/**
+ * Compare two catalog snapshots. Returns a flat list of human-readable
+ * differences; an empty list means the catalogs are structurally equivalent.
+ */
+export const diffCatalogSnapshots = (a: CatalogSnapshot, b: CatalogSnapshot): string[] => {
+  const diffs: string[] = [];
+  for (const section of Object.keys(a) as (keyof CatalogSnapshot)[]) {
+    const left = a[section];
+    const right = b[section];
+    for (const key of Object.keys(left).sort()) {
+      if (!(key in right)) {
+        diffs.push(`${section}: ${key} only in original`);
+      } else if (left[key] !== right[key]) {
+        diffs.push(`${section}: ${key} differs\n  original:    ${left[key]}\n  transformed: ${right[key]}`);
+      }
+    }
+    for (const key of Object.keys(right).sort()) {
+      if (!(key in left)) diffs.push(`${section}: ${key} only in transformed`);
+    }
+  }
+  return diffs;
+};

--- a/pgpm/export/src/export-graphql.ts
+++ b/pgpm/export/src/export-graphql.ts
@@ -14,6 +14,7 @@ import { createClient } from '@pgpmjs/migrate-client';
 import { GraphQLClient } from './graphql-client';
 import { exportGraphQLMeta } from './export-graphql-meta';
 import { graphqlRowToPostgresRow } from './graphql-naming';
+import { PartitionConfig, partitionExportRows } from './partition';
 import { ExportGranularity, restructureExportRows } from './restructure';
 import {
   DB_REQUIRED_EXTENSIONS,
@@ -85,6 +86,13 @@ export interface ExportGraphQLOptions {
    * When omitted, sql_actions rows are written through unchanged.
    */
   granularity?: ExportGranularity;
+  /**
+   * Partition dial: split the exported database module into multiple pgpm
+   * packages per the config's rules (`partitionUnits` in `@pgpmjs/transform`).
+   * Cross-package dependencies become `<pkg>:<path>` requires. Throws
+   * `PartitionCycleError` on an unshippable partition.
+   */
+  partition?: PartitionConfig;
 }
 
 export const exportGraphQL = async ({
@@ -110,7 +118,8 @@ export const exportGraphQL = async ({
   username,
   serviceOutdir,
   skipSchemaRenaming = false,
-  granularity
+  granularity,
+  partition
 }: ExportGraphQLOptions): Promise<void> => {
   const normalizedOutdir = normalizeOutdir(outdir);
   const svcOutdir = normalizeOutdir(serviceOutdir || outdir);
@@ -204,22 +213,6 @@ export const exportGraphQL = async ({
   if (sqlActionRows.length > 0) {
     const dbMissingResult = await detectMissingModules(project, [...DB_REQUIRED_EXTENSIONS], prompter, argv);
 
-    const dbModuleDir = await preparePackage({
-      project,
-      author,
-      outdir: normalizedOutdir,
-      name,
-      description: dbExtensionDesc,
-      extensions: [...DB_REQUIRED_EXTENSIONS],
-      prompter,
-      repoName,
-      username
-    });
-
-    if (dbMissingResult.shouldInstall) {
-      await installMissingModules(dbModuleDir, dbMissingResult.missingModules);
-    }
-
     let dbRows = sqlActionRows as unknown as PgpmRow[];
     if (granularity) {
       const { rows, warnings } = await restructureExportRows(dbRows, granularity);
@@ -227,8 +220,49 @@ export const exportGraphQL = async ({
       warnings.forEach(warning => console.warn(`restructure (${granularity}): ${warning}`));
     }
 
-    writePgpmPlan(dbRows, opts);
-    writePgpmFiles(dbRows, opts);
+    if (partition) {
+      const { packages, warnings } = await partitionExportRows(dbRows, partition);
+      warnings.forEach(warning => console.warn(`partition: ${warning}`));
+
+      for (const pkg of packages) {
+        const pkgDir = await preparePackage({
+          project,
+          author,
+          outdir: normalizedOutdir,
+          name: pkg.name,
+          description: `${pkg.name} (partitioned from ${name})`,
+          extensions: [...DB_REQUIRED_EXTENSIONS, ...pkg.requires],
+          prompter,
+          repoName,
+          username
+        });
+        if (dbMissingResult.shouldInstall) {
+          await installMissingModules(pkgDir, dbMissingResult.missingModules);
+        }
+        const pkgOpts: SqlWriteOptions = { ...opts, name: pkg.name };
+        writePgpmPlan(pkg.rows, pkgOpts);
+        writePgpmFiles(pkg.rows, pkgOpts);
+      }
+    } else {
+      const dbModuleDir = await preparePackage({
+        project,
+        author,
+        outdir: normalizedOutdir,
+        name,
+        description: dbExtensionDesc,
+        extensions: [...DB_REQUIRED_EXTENSIONS],
+        prompter,
+        repoName,
+        username
+      });
+
+      if (dbMissingResult.shouldInstall) {
+        await installMissingModules(dbModuleDir, dbMissingResult.missingModules);
+      }
+
+      writePgpmPlan(dbRows, opts);
+      writePgpmFiles(dbRows, opts);
+    }
   } else {
     console.log('No sql_actions found. Skipping database module export.');
   }

--- a/pgpm/export/src/export-migrations.ts
+++ b/pgpm/export/src/export-migrations.ts
@@ -4,6 +4,7 @@ import { getPgPool } from 'pg-cache';
 
 import { PgpmPackage, PgpmRow, SqlWriteOptions, writePgpmFiles, writePgpmPlan } from '@pgpmjs/core';
 import { exportMeta } from './export-meta';
+import { PartitionConfig, partitionExportRows } from './partition';
 import { ExportGranularity, restructureExportRows } from './restructure';
 import {
   DB_REQUIRED_EXTENSIONS,
@@ -58,6 +59,13 @@ interface ExportMigrationsToDiskOptions {
    * When omitted, sql_actions rows are written through unchanged.
    */
   granularity?: ExportGranularity;
+  /**
+   * Partition dial: split the exported database module into multiple pgpm
+   * packages per the config's rules (`partitionUnits` in `@pgpmjs/transform`).
+   * Cross-package dependencies become `<pkg>:<path>` requires. Throws
+   * `PartitionCycleError` on an unshippable partition.
+   */
+  partition?: PartitionConfig;
 }
 
 interface ExportOptions {
@@ -102,6 +110,13 @@ interface ExportOptions {
    * When omitted, sql_actions rows are written through unchanged.
    */
   granularity?: ExportGranularity;
+  /**
+   * Partition dial: split the exported database module into multiple pgpm
+   * packages per the config's rules (`partitionUnits` in `@pgpmjs/transform`).
+   * Cross-package dependencies become `<pkg>:<path>` requires. Throws
+   * `PartitionCycleError` on an unshippable partition.
+   */
+  partition?: PartitionConfig;
 }
 
 const exportMigrationsToDisk = async ({
@@ -124,7 +139,8 @@ const exportMigrationsToDisk = async ({
   serviceOutdir,
   skipSchemaRenaming = false,
   excludeCategories,
-  granularity
+  granularity,
+  partition
 }: ExportMigrationsToDiskOptions): Promise<void> => {
   const normalizedOutdir = normalizeOutdir(outdir);
   // Use serviceOutdir for service module, defaulting to outdir if not provided
@@ -210,24 +226,6 @@ const exportMigrationsToDisk = async ({
     // Detect missing modules at workspace level and prompt user
     const dbMissingResult = await detectMissingModules(project, [...DB_REQUIRED_EXTENSIONS], prompter, argv);
 
-    // Create/prepare the module directory
-    const dbModuleDir = await preparePackage({
-      project,
-      author,
-      outdir: normalizedOutdir,
-      name,
-      description: dbExtensionDesc,
-      extensions: [...DB_REQUIRED_EXTENSIONS],
-      prompter,
-      repoName,
-      username
-    });
-
-    // Install missing modules if user confirmed (now that module exists)
-    if (dbMissingResult.shouldInstall) {
-      await installMissingModules(dbModuleDir, dbMissingResult.missingModules);
-    }
-
     let dbRows = appRows;
     if (granularity) {
       const { rows, warnings } = await restructureExportRows(appRows, granularity);
@@ -235,8 +233,54 @@ const exportMigrationsToDisk = async ({
       warnings.forEach(warning => console.warn(`restructure (${granularity}): ${warning}`));
     }
 
-    writePgpmPlan(dbRows, opts);
-    writePgpmFiles(dbRows, opts);
+    if (partition) {
+      // Partition dial: split the database module into N packages. Each
+      // package requires its cross-package prerequisites as extensions so
+      // recursive deploys order them correctly.
+      const { packages, warnings } = await partitionExportRows(dbRows, partition);
+      warnings.forEach(warning => console.warn(`partition: ${warning}`));
+
+      for (const pkg of packages) {
+        const pkgDir = await preparePackage({
+          project,
+          author,
+          outdir: normalizedOutdir,
+          name: pkg.name,
+          description: `${pkg.name} (partitioned from ${name})`,
+          extensions: [...DB_REQUIRED_EXTENSIONS, ...pkg.requires],
+          prompter,
+          repoName,
+          username
+        });
+        if (dbMissingResult.shouldInstall) {
+          await installMissingModules(pkgDir, dbMissingResult.missingModules);
+        }
+        const pkgOpts: SqlWriteOptions = { ...opts, name: pkg.name };
+        writePgpmPlan(pkg.rows, pkgOpts);
+        writePgpmFiles(pkg.rows, pkgOpts);
+      }
+    } else {
+      // Create/prepare the module directory
+      const dbModuleDir = await preparePackage({
+        project,
+        author,
+        outdir: normalizedOutdir,
+        name,
+        description: dbExtensionDesc,
+        extensions: [...DB_REQUIRED_EXTENSIONS],
+        prompter,
+        repoName,
+        username
+      });
+
+      // Install missing modules if user confirmed (now that module exists)
+      if (dbMissingResult.shouldInstall) {
+        await installMissingModules(dbModuleDir, dbMissingResult.missingModules);
+      }
+
+      writePgpmPlan(dbRows, opts);
+      writePgpmFiles(dbRows, opts);
+    }
   } else {
     console.log('No sql_actions found — skipping database module. Meta/service module will still be exported.');
   }
@@ -375,7 +419,8 @@ export const exportMigrations = async ({
   serviceOutdir,
   skipSchemaRenaming,
   excludeCategories,
-  granularity
+  granularity,
+  partition
 }: ExportOptions): Promise<void> => {
   for (let v = 0; v < dbInfo.database_ids.length; v++) {
     const databaseId = dbInfo.database_ids[v];
@@ -399,7 +444,8 @@ export const exportMigrations = async ({
       serviceOutdir,
       skipSchemaRenaming,
       excludeCategories,
-      granularity
+      granularity,
+      partition
     });
   }
 };

--- a/pgpm/export/src/index.ts
+++ b/pgpm/export/src/index.ts
@@ -4,7 +4,13 @@ export * from './export-migrations';
 export * from './export-graphql';
 export * from './export-graphql-meta';
 export { EXPORT_GRANULARITIES, isExportGranularity, restructureExportRows } from './restructure';
-export type { ExportGranularity, RestructureExportRowsResult } from './restructure';
+export type { ExportGranularity, RestructureExportRowsOptions, RestructureExportRowsResult } from './restructure';
+export { loadModuleSource, stripTransactionWrapper } from './module-source';
+export type { ModuleSource, ModuleSourceChange } from './module-source';
+export { parsePartitionConfig, partitionExportRows } from './partition';
+export type { PartitionConfig, PartitionedPackageRows, PartitionExportRowsResult } from './partition';
+export { diffCatalogSnapshots, snapshotCatalog } from './catalog-check';
+export type { CatalogQueryable, CatalogSnapshot } from './catalog-check';
 export { GraphQLClient } from './graphql-client';
 export { getGraphQLQueryName, getGraphQLTypeName, graphqlRowToPostgresRow, buildFieldsFragment, mapGraphQLTypeToFieldType, unwrapGraphQLType, GraphQLTypeInfo } from './graphql-naming';
 export {

--- a/pgpm/export/src/module-source.ts
+++ b/pgpm/export/src/module-source.ts
@@ -1,0 +1,83 @@
+/**
+ * Module ingestion for the dials pipeline: load an on-disk pgpm module into
+ * the flattened, classified change list the transform/partition drivers
+ * consume. `pgpm transform` uses this today; a future `pgpm import` (dumps)
+ * and `pgpm diff` are expected to reuse the same seam.
+ */
+import { parsePgpmHeader, parsePlanFile, readScript } from '@pgpmjs/core';
+import * as path from 'path';
+
+/** One change of a loaded module: headerless, unwrapped deploy SQL. */
+export interface ModuleSourceChange {
+  /** Change name (plan token). */
+  name: string;
+  /** Change names this change requires, as recorded in the plan. */
+  dependencies: string[];
+  /** Deploy SQL with the pgpm header and BEGIN/COMMIT wrapper stripped. */
+  deploy: string;
+}
+
+/** A pgpm module loaded from disk, flattened in plan order. */
+export interface ModuleSource {
+  /** Module (project) name from pgpm.plan. */
+  name: string;
+  /** Absolute module directory. */
+  modulePath: string;
+  /** Changes in plan order. */
+  changes: ModuleSourceChange[];
+  /** Non-fatal notes (missing deploy scripts, etc.). */
+  warnings: string[];
+}
+
+const TX_LINE = /^\s*(BEGIN|COMMIT|ROLLBACK)\s*;\s*$/i;
+
+/**
+ * Strip the transaction wrapper some modules carry inside their scripts
+ * (standalone `BEGIN;` / `COMMIT;` / `ROLLBACK;` lines). The caller owns
+ * transaction control.
+ */
+export const stripTransactionWrapper = (sql: string): string =>
+  sql
+    .split('\n')
+    .filter(line => !TX_LINE.test(line))
+    .join('\n')
+    .trim();
+
+/**
+ * Load a pgpm module from disk: parse pgpm.plan and read each change's
+ * deploy script, stripping pgpm headers and transaction wrappers so the
+ * result can be flattened straight into the dials pipeline
+ * (`restructureChanges` / `partitionUnits`).
+ */
+export const loadModuleSource = (moduleDir: string): ModuleSource => {
+  const modulePath = path.resolve(moduleDir);
+  const planResult = parsePlanFile(path.join(modulePath, 'pgpm.plan'));
+  if (!planResult.data) {
+    const reasons = planResult.errors.map(e => e.message).join(', ');
+    throw new Error(`Failed to parse pgpm.plan in ${modulePath}: ${reasons}`);
+  }
+
+  const warnings: string[] = [];
+  const changes: ModuleSourceChange[] = [];
+
+  for (const change of planResult.data.changes) {
+    const raw = readScript(modulePath, 'deploy', change.name);
+    if (!raw) {
+      warnings.push(`${change.name}: no deploy script found, skipping`);
+      continue;
+    }
+    const { body } = parsePgpmHeader(raw);
+    changes.push({
+      name: change.name,
+      dependencies: change.dependencies ?? [],
+      deploy: stripTransactionWrapper(body)
+    });
+  }
+
+  return {
+    name: planResult.data.package,
+    modulePath,
+    changes,
+    warnings
+  };
+};

--- a/pgpm/export/src/partition.ts
+++ b/pgpm/export/src/partition.ts
@@ -1,0 +1,124 @@
+/**
+ * Partition dial wiring shared by `pgpm transform --partition` and
+ * `pgpm export --partition`: parse a partition config file, run
+ * `partitionUnits` (`@pgpmjs/transform`), and lift the emitted packages back
+ * onto the PgpmRow seam with generated revert/verify per change.
+ */
+import { PgpmRow } from '@pgpmjs/core';
+import { PathStyle } from '@pgpmjs/naming-spec';
+import {
+  loadModule,
+  PartitionConfig,
+  PartitionInputChange,
+  partitionUnits,
+  regenerateScripts
+} from '@pgpmjs/transform';
+import * as fs from 'fs';
+
+export type { PartitionConfig } from '@pgpmjs/transform';
+
+const PATH_STYLES: readonly PathStyle[] = ['directory', 'flat'];
+
+/**
+ * Parse and validate a partition config file (JSON matching
+ * `PartitionConfig`: rules, defaultPackage, optional style/splitRiders).
+ * Throws with a message naming the offending field.
+ */
+export const parsePartitionConfig = (filePath: string): PartitionConfig => {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    throw new Error(`Partition config not found: ${filePath}`);
+  }
+  let parsed: any;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err: any) {
+    throw new Error(`Partition config is not valid JSON (${filePath}): ${err?.message ?? err}`);
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`Partition config must be a JSON object (${filePath})`);
+  }
+  if (typeof parsed.defaultPackage !== 'string' || !parsed.defaultPackage) {
+    throw new Error('Partition config: "defaultPackage" must be a non-empty string');
+  }
+  if (!Array.isArray(parsed.rules)) {
+    throw new Error('Partition config: "rules" must be an array');
+  }
+  parsed.rules.forEach((rule: any, i: number) => {
+    if (typeof rule !== 'object' || rule === null) {
+      throw new Error(`Partition config: rules[${i}] must be an object`);
+    }
+    if (typeof rule.package !== 'string' || !rule.package) {
+      throw new Error(`Partition config: rules[${i}].package must be a non-empty string`);
+    }
+    if (!Array.isArray(rule.select) || rule.select.length === 0) {
+      throw new Error(`Partition config: rules[${i}].select must be a non-empty array of selectors`);
+    }
+  });
+  if (parsed.style !== undefined && !PATH_STYLES.includes(parsed.style)) {
+    throw new Error(`Partition config: "style" must be one of: ${PATH_STYLES.join(', ')}`);
+  }
+  if (parsed.splitRiders !== undefined && !Array.isArray(parsed.splitRiders)) {
+    throw new Error('Partition config: "splitRiders" must be an array of statement kinds');
+  }
+  return parsed as PartitionConfig;
+};
+
+/** One partitioned package on the PgpmRow seam, ready to write to disk. */
+export interface PartitionedPackageRows {
+  name: string;
+  /** Package names this package requires (cross-package edges). */
+  requires: string[];
+  rows: PgpmRow[];
+}
+
+export interface PartitionExportRowsResult {
+  packages: PartitionedPackageRows[];
+  warnings: string[];
+}
+
+/**
+ * Partition changes into packages and generate revert/verify for every
+ * emitted change. Cross-package dependencies keep the `<pkg>:<path>`
+ * convention in `deps`. May throw `PartitionCycleError`.
+ */
+export const partitionExportRows = async (
+  rows: PgpmRow[],
+  config: PartitionConfig
+): Promise<PartitionExportRowsResult> => {
+  await loadModule();
+
+  const input: PartitionInputChange[] = rows.map(row => ({
+    name: row.deploy,
+    dependencies: row.deps ?? [],
+    deploy: row.content
+  }));
+
+  const { packages, warnings } = partitionUnits(input, config);
+
+  const result: PartitionedPackageRows[] = packages.map(pkg => ({
+    name: pkg.name,
+    requires: pkg.requires,
+    rows: pkg.changes.map(change => {
+      const scripts = regenerateScripts(change.deploy);
+      for (const warning of scripts.revert.warnings) {
+        warnings.push(`${pkg.name}:${change.name}: ${warning}`);
+      }
+      for (const warning of scripts.verify.warnings) {
+        warnings.push(`${pkg.name}:${change.name}: ${warning}`);
+      }
+      return {
+        name: change.name,
+        deploy: change.name,
+        deps: change.dependencies,
+        content: change.deploy,
+        revert: scripts.revert.sql,
+        verify: scripts.verify.sql
+      };
+    })
+  }));
+
+  return { packages: result, warnings };
+};

--- a/pgpm/export/src/restructure.ts
+++ b/pgpm/export/src/restructure.ts
@@ -6,8 +6,8 @@
  * hand-chained deps recorded at action time.
  */
 import { PgpmRow } from '@pgpmjs/core';
-import { alterationPathFor } from '@pgpmjs/naming-spec';
-import { Granularity, loadModule, restructureChanges } from '@pgpmjs/transform';
+import { alterationPathFor, pathFor, PathStyle } from '@pgpmjs/naming-spec';
+import { Granularity, identityOf, loadModule, restructureChanges, StatementFacts } from '@pgpmjs/transform';
 
 export type ExportGranularity = Granularity;
 
@@ -19,6 +19,11 @@ export const isExportGranularity = (value: unknown): value is ExportGranularity 
 export interface RestructureExportRowsResult {
   rows: PgpmRow[];
   warnings: string[];
+}
+
+export interface RestructureExportRowsOptions {
+  /** Naming-spec rendering style for derived paths (default `directory`). */
+  naming?: PathStyle;
 }
 
 /**
@@ -39,9 +44,17 @@ export interface RestructureExportRowsResult {
  */
 export const restructureExportRows = async (
   rows: PgpmRow[],
-  granularity: ExportGranularity
+  granularity: ExportGranularity,
+  options: RestructureExportRowsOptions = {}
 ): Promise<RestructureExportRowsResult> => {
   await loadModule();
+
+  const style = options.naming ?? 'directory';
+  const changeName = (facts: StatementFacts): string => {
+    const identity = identityOf(facts);
+    if (identity) return pathFor(identity, { style });
+    return 'misc/statements';
+  };
 
   const { changes, warnings } = restructureChanges(
     rows.map(row => ({
@@ -49,7 +62,7 @@ export const restructureExportRows = async (
       dependencies: row.deps ?? [],
       deploy: row.content
     })),
-    { granularity }
+    { granularity, changeName }
   );
 
   const counters = new Map<string, number>();


### PR DESCRIPTION
## Summary

Part B of constructive-planning#1340 (also closes the "wire the partition dial into `pgpm export`" TODO on constructive-planning#1329): the dials pipeline gets a second front door — existing pgpm modules, not just live databases.

```
pgpm transform --granularity <atomic|object|consolidated> \
  [--partition <partition.json>] [--naming directory|flat] \
  [--cwd <module-or-workspace>] [--out <dir>] [--write] [--check] [--dry-run]
```

Flow: `loadModuleSource(moduleDir)` (pgpm.plan → deploy scripts flattened in plan order, PGPM headers/tx wrappers stripped) → `restructureExportRows` (spec-derived paths, graph-derived requires, generated revert/verify) → optional `partitionExportRows` → complete pgpm package(s) written per partition.

New shared seam in `@pgpmjs/export` (one code path for transform *and* export; `loadModuleSource` is the reusable "module → flattened classified change list" helper intended for future `pgpm import` (dumps) and `pgpm diff`):

- `module-source.ts` — `loadModuleSource`, `stripTransactionWrapper`
- `partition.ts` — `parsePartitionConfig` (validated JSON matching `PartitionConfig`), `partitionExportRows` (runs `partitionUnits`, regenerates revert/verify per emitted change, keeps `<pkg>:<path>` cross-package deps and package-level `requires`)
- `catalog-check.ts` — `snapshotCatalog` / `diffCatalogSnapshots`, an order-insensitive structural catalog snapshot (schemas, tables, columns incl. order, constraints, indexes, functions, triggers, policies, RLS, grants) used by `--check`

Behavior notes:

- Output packages are named `<module>-<granularity>` (or the partition package names) and written as siblings of the source module by default, so they can coexist in the same workspace; `--out` overrides the base dir. Overwriting the source module or any existing output requires `--write`.
- Workspace mode iterates every module; `--dry-run` prints packages/changes/deps without writing; `PartitionCycleError` and dynamic-SQL warnings surface as clean CLI errors/warnings.
- `--check` deploys the original module and the transformed package(s) (in dependency order) into two scratch databases and asserts the catalogs are structurally equivalent. Column order IS compared; per-class object sets are compared by identity+definition, so change granularity/naming can differ freely.
- `pgpm export --granularity ... --partition <file>` goes through the exact same `partitionExportRows` path, emitting N packages with cross-package `requires` merged into each `.control` via `preparePackage` (SQL and GraphQL export modes).

Tests:

- Unit: module loading/flattening/tx-stripping, partition config validation, out-dir resolution, overwrite guards, package dependency ordering.
- Live-Postgres e2e (`pgpm/cli/__tests__/transform-e2e.test.ts`): fixture with 2 schemas, tables + FK, function, trigger, policy, grant, index → transform to each granularity → deploy → catalog equivalence with the original → `pgpm verify` → `pgpm revert` leaves the DB clean; `--check`; `--dry-run`; partition split into pkg-app + pkg-security (splitRiders: grant) deployed in dependency order with catalog equivalence; round-trip consolidated → atomic → consolidated yields the same change set.
- Export partition e2e added to `export-granularity.test.ts` (two packages, `<pkg>:<path>` requires, dependency-order deploy round-trip).

Known pre-existing failures (verified identical on a clean `main` worktree in this environment): `export-utils`/`export-meta`/`export-flow`/`cross-flow-parity` (7 tests) and repo-wide ESLint 9 flat-config lint — untouched.

Link to Devin session: https://app.devin.ai/sessions/98edd75e27db4328aec77c581e211092
Requested by: @pyramation