### PR TITLE
fix(pgpm): ignore PG17+ list offsets in the AST round-trip check

### DIFF
--- a/pgpm/core/__tests__/packaging/round-trip-diff.test.ts
+++ b/pgpm/core/__tests__/packaging/round-trip-diff.test.ts
@@ -1,0 +1,28 @@
+import { mergeSqlStatements } from '../../src/packaging/package';
+
+/**
+ * The round-trip check (parse -> deparse -> reparse) must ignore positional
+ * metadata. PG17+ emits list_start/list_end (A_ArrayExpr) and
+ * rexpr_list_start/rexpr_list_end (A_Expr IN lists), which shift whenever the
+ * deparsed SQL is formatted differently than the source.
+ */
+describe('AST round-trip diff detection', () => {
+  it('does not flag ARRAY[...] expressions', async () => {
+    const { diff } = await mergeSqlStatements(
+      `CREATE TABLE things (
+         id int,
+         tags text[] DEFAULT ARRAY['a', 'b', 'c']::text[]
+       );`,
+      {}
+    );
+    expect(diff).toBeUndefined();
+  });
+
+  it('does not flag IN (...) lists', async () => {
+    const { diff } = await mergeSqlStatements(
+      `SELECT * FROM things WHERE id IN (1, 2, 3);`,
+      {}
+    );
+    expect(diff).toBeUndefined();
+  });
+});

--- a/pgpm/core/src/packaging/package.ts
+++ b/pgpm/core/src/packaging/package.ts
@@ -22,6 +22,24 @@ export const cleanTree = (tree: any): any => {
   });
 };
 
+/**
+ * Same as cleanTree, but also drops the byte-offset fields PG17+ added for list
+ * expressions (`ARRAY[...]`, `x IN (...)`). They are positional metadata, not
+ * semantics, so they must not count as a round-trip difference. Kept separate
+ * from cleanTree so migration hashes (hashSqlFile) stay stable.
+ */
+export const cleanTreeForDiff = (tree: any): any => {
+  return transformProps(tree, {
+    stmt_len: noop,
+    stmt_location: noop,
+    location: noop,
+    list_start: noop,
+    list_end: noop,
+    rexpr_list_start: noop,
+    rexpr_list_end: noop,
+  });
+};
+
 interface PackageModuleOptions {
   usePlan?: boolean;
   extension?: boolean;
@@ -94,11 +112,11 @@ export const mergeSqlStatements = async (
     sql: `${topLine}${finalSql}`,
   };
 
-  const diff = JSON.stringify(cleanTree(tree1)) !== JSON.stringify(cleanTree(tree2));
+  const diff = JSON.stringify(cleanTreeForDiff(tree1)) !== JSON.stringify(cleanTreeForDiff(tree2));
   if (diff) {
     results.diff = true;
-    results.tree1 = JSON.stringify(cleanTree(tree1), null, 2);
-    results.tree2 = JSON.stringify(cleanTree(tree2), null, 2);
+    results.tree1 = JSON.stringify(cleanTreeForDiff(tree1), null, 2);
+    results.tree2 = JSON.stringify(cleanTreeForDiff(tree2), null, 2);
   }
 
   return results;


### PR DESCRIPTION
## Summary

`pgpm package` warns `⚠️ AST round-trip diff detected!` on nearly every module. Almost all of it is noise: PG17+ added positional fields that `cleanTree` never stripped — `A_ArrayExpr.list_start/list_end` and `A_Expr.rexpr_list_start/rexpr_list_end`. Any `ARRAY[...]` or `x IN (...)` shifts those byte offsets when the SQL is reformatted, so the reparsed tree never matches. Scanning constructive-db: 3775 + 78 offset-only differences across 30 modules, hiding exactly one real deparser bug (a dropped EXCLUDE constraint name — fixed in constructive-io/pgsql-parser#331).

The diff check now uses a separate `cleanTreeForDiff` that also drops those four keys. `cleanTree` is deliberately left alone because `hashSqlFile` uses it for `pgpm_migrate` ledger hashes — widening it there would rewrite the hash of every already-deployed change containing an array.


Link to Devin session: https://app.devin.ai/sessions/5cfcc6690b574cdd96de080ee3b94b4e
Requested by: @pyramation