### PR TITLE
feat(pgpm): change-granularity dial — one change per alteration (planning #1342)

### DIFF
--- a/examples/pgpm-projections/README.md
+++ b/examples/pgpm-projections/README.md
@@ -24,7 +24,8 @@ one canonical model:
 
 | Axis | Projections | What changes | What stays the same |
 | --- | --- | --- | --- |
-| **granularity** | `atomic` · `object` · `consolidated` | how finely a change is split (one `ALTER` per column vs one statement per object vs the whole thing) | the resulting catalog |
+| **granularity** | `atomic` · `object` · `consolidated` | the SQL statement shape (one `ALTER` per column vs one statement per object vs the whole thing) | the schema |
+| **change granularity** | `object` · `alteration` | the plan-entry shape (one change per object vs one change per column/constraint, each with its own deploy/revert/verify) | the schema |
 | **partition** | one module vs many | which objects live in which package | the combined schema |
 | **diff** | `v1 → v2` migration | — | derived, never hand-written |
 | **output** | pgpm module · linear `.sql` · bundle | the artifact format | the migration |
@@ -47,6 +48,10 @@ pgpm import schema/schema.sql --pkg blog --out ./out
 cd out/blog
 pgpm transform --granularity atomic
 pgpm transform --granularity consolidated
+
+# 2b. The fourth dial: one change PER ALTERATION — every column and constraint
+#     becomes its own plan entry with its own deploy/revert/verify + requires
+pgpm transform --granularity atomic --change-granularity alteration --out ../alteration
 
 # 3. Partition the source into app + security modules
 cd ../..
@@ -74,8 +79,12 @@ The suite ([`__tests__/projections.e2e.test.ts`](./__tests__/projections.e2e.tes
 runs the real CLI and then compares the emitted artifacts **semantically** — no
 database needed, because equivalence is checked at the identity-keyed model:
 
-- **granularity-invariant** — `object` and `consolidated` normalize to the same
-  schema (empty diff).
+- **granularity-invariant** — `atomic`, `object`, and `consolidated` all
+  normalize to the same schema (empty diff), including standalone
+  `ADD CONSTRAINT` placement.
+- **change-granularity-invariant** — one change per alteration (per column /
+  per constraint plan entries) still normalizes to the same schema (empty
+  diff).
 - **partition-invariant** — the `blog-core` + `blog-security` modules recombine
   to the same schema as the single module (empty diff).
 - **diff is exact** — `schema.sql → schema-v2.sql` derives precisely the real
@@ -91,12 +100,5 @@ catalog**; that is the guarantee `--check` / `--verify` enforce, and it is
 covered against live Postgres by the engine's own suites
 (`pgpm/cli` `transform-e2e` "dial parity" and `diff-e2e`). This example is
 deliberately database-free and asserts the model-level invariants above.
-
-> Note: `atomic` authorship emits standalone `ALTER TABLE … ADD CONSTRAINT`
-> statements. Because Postgres names such constraints at deploy time, the
-> semantic normalizer does not yet fold every standalone constraint back into
-> its owning table object, so `atomic` is guaranteed **catalog-equivalent**
-> rather than AST-identical to `object`/`consolidated`. Tightening that
-> normalization is tracked in `constructive-planning`.
 
 It's a normal workspace package, so `pnpm install` at the repo root wires it up.

--- a/examples/pgpm-projections/__tests__/projections.e2e.test.ts
+++ b/examples/pgpm-projections/__tests__/projections.e2e.test.ts
@@ -3,19 +3,21 @@
 // One SQL schema (schema/schema.sql) is the source of truth. We normalize it
 // to an identity-keyed object set and then *project* it into many shapes:
 //
-//   granularity   object | consolidated  (atomic too — see the note below)
-//   partition     one module vs app + security modules
-//   diff          schema.sql -> schema-v2.sql as a generated migration
-//   output        pgpm module | linear .sql
+//   granularity          atomic | object | consolidated  (statement shape)
+//   change granularity   object | alteration             (plan-entry shape)
+//   partition            one module vs app + security modules
+//   diff                 schema.sql -> schema-v2.sql as a generated migration
+//   output               pgpm module | linear .sql
 //
 // The headline guarantee: a projection changes the *representation*, never the
 // *meaning*. We prove it WITHOUT a database by normalizing each projection back
 // to its object set and asserting the diff is empty — authoring granularity,
-// naming, partitioning, ordering, and whitespace all wash out.
+// change granularity, naming, partitioning, ordering, and whitespace all wash
+// out.
 //
-// (Deploy-level catalog equivalence for every projection, including `atomic`,
-// is proven against live Postgres by the engine's own suites — pgpm/cli
-// transform-e2e "dial parity" and diff-e2e. See README.)
+// (Deploy-level catalog equivalence for every projection is also proven
+// against live Postgres by the engine's own suites — pgpm/cli transform-e2e
+// "dial parity" and diff-e2e. See README.)
 //
 // This suite is intentionally database-free: it only runs the CLI and compares
 // the emitted artifacts semantically.
@@ -49,6 +51,12 @@ describe('pgpm projections: one schema, every shape, one meaning', () => {
     // Re-dial the same module to other granularities (siblings blog-<gran>).
     pgpm(work, ['transform', '--granularity', 'atomic', '--cwd', path.join(work, 'blog')]);
     pgpm(work, ['transform', '--granularity', 'consolidated', '--cwd', path.join(work, 'blog')]);
+
+    // The fourth dial: one change per alteration (per column / per constraint).
+    pgpm(work, [
+      'transform', '--granularity', 'atomic', '--change-granularity', 'alteration',
+      '--cwd', path.join(work, 'blog'), '--out', path.join(work, 'alteration')
+    ]);
 
     // Partition the same source into app + security modules.
     pgpm(work, [
@@ -93,19 +101,25 @@ describe('pgpm projections: one schema, every shape, one meaning', () => {
     expect(diffChangeSets(object, partitioned).identical).toBe(true);
   });
 
-  it('emits the atomic projection as a deployable module covering the same schemas', () => {
-    // atomic explodes objects into per-column / per-constraint statements. It
-    // deploys to the same catalog as the other granularities (proven against
-    // live Postgres by pgpm/cli transform-e2e "dial parity"); here we assert it
-    // is a well-formed module spanning the same schemas.
-    const atomicDir = path.join(work, 'blog-atomic');
-    expect(fs.existsSync(path.join(atomicDir, 'pgpm.plan'))).toBe(true);
-    const atomicChanges = changesOf(atomicDir);
-    expect(atomicChanges.length).toBeGreaterThan(0);
+  it('is granularity-invariant: atomic normalizes to the same schema too', () => {
+    // atomic explodes objects into per-column / per-constraint statements, yet
+    // constraint-placement normalization folds them back — full semantic
+    // identity, not just catalog equivalence.
+    const object = changesOf(path.join(work, 'blog'));
+    const atomic = changesOf(path.join(work, 'blog-atomic'));
+    expect(diffChangeSets(object, atomic).identical).toBe(true);
+  });
 
-    const schemasOf = (changes: ChangeSet): string[] =>
-      [...new Set(changes.map(c => c.name.split('/')[1]).filter(Boolean))].sort();
-    expect(schemasOf(atomicChanges)).toEqual(schemasOf(changesOf(path.join(work, 'blog'))));
+  it('is change-granularity-invariant: one change per alteration, same schema', () => {
+    const alterationDir = path.join(work, 'alteration', 'blog-atomic');
+    const plan = fs.readFileSync(path.join(alterationDir, 'pgpm.plan'), 'utf-8');
+    // every column and constraint is its own plan entry...
+    expect(plan).toMatch(/\/columns\/[a-z_]+\/column/);
+    expect(plan).toMatch(/\/constraints\/[a-z_]+\/constraint/);
+    // ...and the meaning is untouched.
+    const object = changesOf(path.join(work, 'blog'));
+    const alteration = changesOf(alterationDir);
+    expect(diffChangeSets(object, alteration).identical).toBe(true);
   });
 
   it('derives the v1 -> v2 migration: exactly the real changes, nothing guessed', () => {

--- a/pgpm/cli/__tests__/diff-e2e.test.ts
+++ b/pgpm/cli/__tests__/diff-e2e.test.ts
@@ -324,6 +324,33 @@ describe('pgpm diff e2e', () => {
     }
   );
 
+  it('emits an alteration-change-granularity migration that reaches the same v2 catalog', async () => {
+    const pkg = 'diff-mig-alteration';
+    await fixture.runTerminalCommands(
+      `
+      cd ${WS}
+      pgpm diff diff-v1 diff-v2 --emit-migration . --pkg ${pkg} --granularity atomic --change-granularity alteration
+      `,
+      {}
+    );
+    expect(fs.existsSync(path.join(wsDir, pkg, 'pgpm.plan'))).toBe(true);
+
+    const testDb = await fixture.setupTestDatabase();
+    await fixture.runTerminalCommands(
+      `
+      cd ${WS}/diff-v1
+      pgpm deploy --database ${testDb.name} --package diff-v1 --yes
+      cd ../${pkg}
+      pgpm deploy --database ${testDb.name} --package ${pkg} --yes
+      `,
+      { database: testDb.name }
+    );
+
+    const snapMigrated = await snapshotCatalog(testDb);
+    const snapV2 = await snapshotCatalog(v2Db);
+    expect(diffCatalogSnapshots(withoutColumnOrder(snapMigrated), withoutColumnOrder(snapV2))).toEqual([]);
+  });
+
   it('--verify proves the emitted migration is a catalog-level oracle match', async () => {
     await fixture.runTerminalCommands(
       `

--- a/pgpm/cli/__tests__/transform-e2e.test.ts
+++ b/pgpm/cli/__tests__/transform-e2e.test.ts
@@ -215,6 +215,52 @@ describe('pgpm transform e2e', () => {
     }
   );
 
+  it('--change-granularity alteration splits per column/constraint, deploys equivalently, verifies, and reverts clean', async () => {
+    await fixture.runTerminalCommands(
+      `
+      cd ${WS}/${MODULE_NAME}
+      pgpm transform --granularity atomic --change-granularity alteration --out ../alteration-out
+      `,
+      {}
+    );
+
+    const outDir = path.join(wsDir, 'alteration-out', `${MODULE_NAME}-atomic`);
+    const plan = fs.readFileSync(path.join(outDir, 'pgpm.plan'), 'utf-8');
+    expect(plan).toContain('schemas/tfx_app/tables/users/columns/id/column');
+    expect(plan).toContain('schemas/tfx_app/tables/users/columns/email/column');
+    expect(plan).toContain('schemas/tfx_app/tables/users/constraints/users_pkey/constraint');
+    expect(plan).toContain('schemas/tfx_sec/tables/audit/constraints/audit_user_id_fkey/constraint');
+
+    // Each alteration has its own deploy/revert/verify triple.
+    const columnChange = 'schemas/tfx_app/tables/users/columns/email/column';
+    expect(fs.readFileSync(path.join(outDir, 'deploy', `${columnChange}.sql`), 'utf-8')).toContain('ADD COLUMN email');
+    expect(fs.readFileSync(path.join(outDir, 'revert', `${columnChange}.sql`), 'utf-8')).toContain('DROP COLUMN email');
+    expect(fs.readFileSync(path.join(outDir, 'verify', `${columnChange}.sql`), 'utf-8')).toContain('information_schema.columns');
+
+    const testDb = await fixture.setupTestDatabase();
+    await fixture.runTerminalCommands(
+      `
+      cd ${WS}/alteration-out/${MODULE_NAME}-atomic
+      pgpm deploy --database ${testDb.name} --package ${MODULE_NAME}-atomic --yes
+      `,
+      { database: testDb.name }
+    );
+
+    const snapOriginal = await snapshotCatalog(originalDb);
+    const snapTransformed = await snapshotCatalog(testDb);
+    expect(diffCatalogSnapshots(snapOriginal, snapTransformed)).toEqual([]);
+
+    await fixture.runTerminalCommands(
+      `
+      cd ${WS}/alteration-out/${MODULE_NAME}-atomic
+      pgpm verify --database ${testDb.name} --package ${MODULE_NAME}-atomic --yes
+      pgpm revert --database ${testDb.name} --package ${MODULE_NAME}-atomic --yes
+      `,
+      { database: testDb.name }
+    );
+    expect(await testDb.exists('schema', 'tfx_app')).toBe(false);
+  });
+
   it('rewrites an existing output when --write is passed', async () => {
     // The refusal path (no --write) exits the process, so it is covered by the
     // checkOverwrite unit tests; here we prove --write re-generates in place.

--- a/pgpm/cli/src/commands/diff.ts
+++ b/pgpm/cli/src/commands/diff.ts
@@ -8,9 +8,12 @@ import {
 import { Logger } from '@pgpmjs/logger';
 import {
   appendModule,
+  CHANGE_GRANULARITIES,
+  ChangeGranularity,
   diffChangeSets,
   EXPORT_GRANULARITIES,
   ExportGranularity,
+  isChangeGranularity,
   isExportGranularity,
   loadModule,
   SemanticDiffResult,
@@ -70,6 +73,9 @@ Options:
   --pkg <name>             Emitted migration package name (default: diff-migration)
   --granularity <level>    Granularity for emitted changes: atomic | object |
                            consolidated (default: object)
+  --change-granularity <level>
+                           Change-level distribution for emitted changes:
+                           object | alteration (default: object)
   --naming <style>         Change path naming style: directory | flat (default: directory)
   --json                   Machine-readable output
   --verify                 Oracle mode: deploy A plus the emitted migration into
@@ -230,6 +236,12 @@ export default async (
   }
   const granularity = granularityRaw as ExportGranularity;
 
+  const changeGranularityRaw = (argv['change-granularity'] as string) ?? (argv.changeGranularity as string) ?? 'object';
+  if (!isChangeGranularity(changeGranularityRaw)) {
+    await cliExitWithError(`Invalid --change-granularity "${changeGranularityRaw}". Expected one of: ${CHANGE_GRANULARITIES.join(', ')}.`);
+  }
+  const changeGranularity = changeGranularityRaw as ChangeGranularity;
+
   const namingRaw = (argv.naming as string) ?? 'directory';
   if (!(NAMING_STYLES as readonly string[]).includes(namingRaw)) {
     await cliExitWithError(`Invalid --naming "${namingRaw}". Expected one of: ${NAMING_STYLES.join(', ')}.`);
@@ -276,7 +288,7 @@ export default async (
     return;
   }
 
-  const result = diffChangeSets(sideA.changes, sideB.changes, { granularity, style: naming });
+  const result = diffChangeSets(sideA.changes, sideB.changes, { granularity, changeGranularity, style: naming });
   const warnings = [
     ...sideA.warnings.map(w => `${sideA.label}: ${w}`),
     ...sideB.warnings.map(w => `${sideB.label}: ${w}`),

--- a/pgpm/cli/src/commands/import.ts
+++ b/pgpm/cli/src/commands/import.ts
@@ -6,8 +6,11 @@ import {
 } from '@pgpmjs/import';
 import { Logger } from '@pgpmjs/logger';
 import {
+  CHANGE_GRANULARITIES,
+  ChangeGranularity,
   EXPORT_GRANULARITIES,
   ExportGranularity,
+  isChangeGranularity,
   isExportGranularity,
   parsePartitionConfig,
   PartitionConfig,
@@ -56,6 +59,9 @@ Options:
   --help, -h              Show this help message
   --pkg <name>            Module name for the generated package (required)
   --granularity <level>   Granularity dial: atomic | object | consolidated
+                          (default: object)
+  --change-granularity <level>
+                          Change-level distribution: object | alteration
                           (default: object)
   --naming <style>        Change path naming style: directory | flat (default: directory)
   --out <dir>             Output base directory (default: current directory);
@@ -116,6 +122,12 @@ export default async (
   }
   const granularity = granularityRaw as ExportGranularity;
 
+  const changeGranularityRaw = (argv['change-granularity'] as string) ?? (argv.changeGranularity as string) ?? 'object';
+  if (!isChangeGranularity(changeGranularityRaw)) {
+    await cliExitWithError(`Invalid --change-granularity "${changeGranularityRaw}". Expected one of: ${CHANGE_GRANULARITIES.join(', ')}.`);
+  }
+  const changeGranularity = changeGranularityRaw as ChangeGranularity;
+
   const namingRaw = (argv.naming as string) ?? 'directory';
   if (!(NAMING_STYLES as readonly string[]).includes(namingRaw)) {
     await cliExitWithError(`Invalid --naming "${namingRaw}". Expected one of: ${NAMING_STYLES.join(', ')}.`);
@@ -159,7 +171,7 @@ export default async (
     console.warn(`\nWARNING: ${warning}\n`);
   }
 
-  const result = await importDumpRows(source, { granularity, naming, withData });
+  const result = await importDumpRows(source, { granularity, changeGranularity, naming, withData });
 
   let packages: { name: string; requires: string[]; rows: typeof result.rows }[];
   if (partition) {

--- a/pgpm/cli/src/commands/transform.ts
+++ b/pgpm/cli/src/commands/transform.ts
@@ -1,8 +1,11 @@
 import { PgpmMigrate, PgpmPackage, PgpmRow } from '@pgpmjs/core';
 import { Logger } from '@pgpmjs/logger';
 import {
+  CHANGE_GRANULARITIES,
+  ChangeGranularity,
   EXPORT_GRANULARITIES,
   ExportGranularity,
+  isChangeGranularity,
   isExportGranularity,
   loadModuleSource,
   parsePartitionConfig,
@@ -44,6 +47,11 @@ Transform Command:
 Options:
   --help, -h              Show this help message
   --granularity <level>   Target granularity: atomic | object | consolidated (required)
+  --change-granularity <level>
+                          Change-level distribution: object | alteration
+                          (default: object). With alteration, every ADD COLUMN /
+                          ADD CONSTRAINT becomes its own change with its own
+                          deploy/revert/verify and requires.
   --partition <file>      Partition config (JSON: rules/defaultPackage/splitRiders)
                           splitting the module into multiple pgpm packages with
                           derived cross-package requires.
@@ -69,6 +77,7 @@ Examples:
   pgpm transform --granularity atomic --naming flat --out ./out
   pgpm transform --granularity object --partition partition.json --check
   pgpm transform --granularity consolidated --emit-sql migration.sql
+  pgpm transform --granularity atomic --change-granularity alteration
 `;
 
 const NAMING_STYLES = ['directory', 'flat'] as const;
@@ -155,6 +164,7 @@ const runCheck = async (transformed: TransformedModule): Promise<string[]> => {
 const transformModule = async (
   modulePath: string,
   granularity: ExportGranularity,
+  changeGranularity: ChangeGranularity,
   naming: NamingStyle,
   partition: PartitionConfig | undefined,
   out: string | undefined
@@ -169,7 +179,7 @@ const transformModule = async (
     content: change.deploy
   }));
 
-  const restructured = await restructureExportRows(rows, granularity, { naming });
+  const restructured = await restructureExportRows(rows, granularity, { naming, changeGranularity });
   warnings.push(...restructured.warnings.map(w => `restructure (${granularity}): ${w}`));
 
   const outBase = resolveOutBase(modulePath, out);
@@ -217,6 +227,12 @@ export default async (
     await cliExitWithError(`Invalid --granularity "${granularityRaw}". Expected one of: ${EXPORT_GRANULARITIES.join(', ')}.`);
   }
   const granularity = granularityRaw as ExportGranularity;
+
+  const changeGranularityRaw = (argv['change-granularity'] as string) ?? (argv.changeGranularity as string) ?? 'object';
+  if (!isChangeGranularity(changeGranularityRaw)) {
+    await cliExitWithError(`Invalid --change-granularity "${changeGranularityRaw}". Expected one of: ${CHANGE_GRANULARITIES.join(', ')}.`);
+  }
+  const changeGranularity = changeGranularityRaw as ChangeGranularity;
 
   const namingRaw = (argv.naming as string) ?? 'directory';
   if (!(NAMING_STYLES as readonly string[]).includes(namingRaw)) {
@@ -276,7 +292,7 @@ export default async (
   for (const modulePath of modulePaths) {
     let transformed: TransformedModule;
     try {
-      transformed = await transformModule(modulePath, granularity, naming, partition, out);
+      transformed = await transformModule(modulePath, granularity, changeGranularity, naming, partition, out);
     } catch (err) {
       if (err instanceof PartitionCycleError) {
         await cliExitWithError(`Partition failed: ${err.message}`);

--- a/pgpm/cli/src/utils/scratch-db.ts
+++ b/pgpm/cli/src/utils/scratch-db.ts
@@ -13,8 +13,8 @@
  * `PgpmMigrate` from `@pgpmjs/core`, and `core` already depends on `transform`
  * — hosting the oracle in `transform` would close that cycle.
  */
-import { CatalogSnapshot, diffCatalogSnapshots, snapshotCatalog } from '@pgpmjs/transform';
 import { Logger } from '@pgpmjs/logger';
+import { CatalogSnapshot, diffCatalogSnapshots, snapshotCatalog } from '@pgpmjs/transform';
 import { getPgPool } from 'pg-cache';
 import type { PgConfig } from 'pg-env';
 

--- a/pgpm/import/src/import.ts
+++ b/pgpm/import/src/import.ts
@@ -21,7 +21,7 @@
  */
 import { PgpmRow } from '@pgpmjs/ast';
 import { ObjectIdentity, pathFor, PathStyle } from '@pgpmjs/naming-spec';
-import { classifyStatements, ExportGranularity, loadModule, regenerateScripts, restructureExportRows, StatementFacts } from '@pgpmjs/transform';
+import { ChangeGranularity, classifyStatements, ExportGranularity, loadModule, regenerateScripts, restructureExportRows, StatementFacts } from '@pgpmjs/transform';
 
 import { copyBlockToInsert, copyTargetOf, DumpSource } from './dump-source';
 
@@ -30,6 +30,8 @@ export const MISC_CHANGE_PATH = 'misc/statements';
 export interface ImportDumpRowsOptions {
   /** Granularity dial (default: `object`). */
   granularity?: ExportGranularity;
+  /** Change-level distribution (default: `object`). */
+  changeGranularity?: ChangeGranularity;
   /** Naming spec path style (default: `directory`). */
   naming?: PathStyle;
   /** Emit data statements (COPY blocks, INSERTs) as seed fixture changes. */
@@ -494,7 +496,7 @@ export const importDumpRows = async (
       ? [{ name: 'import/dump', deploy: 'import/dump', deps: [], content: program }]
       : [],
     granularity,
-    { naming: style }
+    { naming: style, changeGranularity: options.changeGranularity }
   );
   warnings.push(...restructured.warnings);
 

--- a/pgpm/naming-spec/__tests__/naming-spec.test.ts
+++ b/pgpm/naming-spec/__tests__/naming-spec.test.ts
@@ -38,6 +38,10 @@ describe('PGPM naming spec v1', () => {
       .toBe('schemas/app/tables/users/indexes/users_email_idx');
     expect(pathFor(id({ kind: 'constraint', name: 'users_pkey', table: 'users' })))
       .toBe('schemas/app/tables/users/constraints/users_pkey/constraint');
+    expect(pathFor(id({ kind: 'column', name: 'email', table: 'users' })))
+      .toBe('schemas/app/tables/users/columns/email/column');
+    expect(pathFor(id({ kind: 'column', name: 'email', table: 'users' }), { style: 'flat' }))
+      .toBe('schemas/app/tables/users/columns/email');
     expect(pathFor(id({ kind: 'seed_dml', name: 'users', table: 'users' })))
       .toBe('schemas/app/tables/users/fixtures/users');
   });

--- a/pgpm/naming-spec/src/index.ts
+++ b/pgpm/naming-spec/src/index.ts
@@ -61,6 +61,7 @@ export type ObjectIdentityKind =
   | 'index'
   | 'trigger'
   | 'policy'
+  | 'column'
   | 'constraint'
   | 'seed_dml'
   | 'other';
@@ -99,6 +100,7 @@ const TABLE_SCOPED = new Set<ObjectIdentityKind>([
   'trigger',
   'policy',
   'index',
+  'column',
   'constraint',
   'seed_dml'
 ]);
@@ -116,6 +118,7 @@ const TABLE_DIRS: Partial<Record<ObjectIdentityKind, string>> = {
   trigger: 'triggers',
   policy: 'policies',
   index: 'indexes',
+  column: 'columns',
   constraint: 'constraints',
   seed_dml: 'fixtures'
 };
@@ -125,6 +128,7 @@ const KIND_TOKENS: Partial<Record<ObjectIdentityKind, string>> = {
   function: 'procedure',
   view: 'view',
   policy: 'policy',
+  column: 'column',
   constraint: 'constraint'
 };
 

--- a/pgpm/transform/__tests__/granularity-driver.test.ts
+++ b/pgpm/transform/__tests__/granularity-driver.test.ts
@@ -124,6 +124,77 @@ describe('restructureChanges', () => {
     )).toBe(true);
   });
 
+  describe('changeGranularity: alteration', () => {
+    const opts = { granularity: 'atomic' as const, changeGranularity: 'alteration' as const };
+
+    it('splits each ADD COLUMN / ADD CONSTRAINT into its own change', () => {
+      const result = restructureChanges(ATOMIC_CHANGES, opts);
+      const names = result.changes.map(c => c.name);
+      expect(names).toEqual([
+        'schemas/app/schema',
+        'schemas/app/tables/users/table',
+        'schemas/app/tables/users/columns/id/column',
+        'schemas/app/tables/users/constraints/users_pkey/constraint',
+        'schemas/app/tables/orders/table',
+        'schemas/app/tables/orders/columns/id/column',
+        'schemas/app/tables/orders/columns/user_id/column',
+        'schemas/app/tables/orders/constraints/orders_user_fk/constraint'
+      ]);
+    });
+
+    it('gives each alteration its own deploy/revert/verify', () => {
+      const result = restructureChanges(ATOMIC_CHANGES, opts);
+
+      const column = result.changes.find(c => c.name === 'schemas/app/tables/users/columns/id/column')!;
+      expect(column.deploy).toContain('ADD COLUMN id');
+      expect(column.revert).toContain('DROP COLUMN id');
+      expect(column.verify).toContain('information_schema.columns');
+
+      const pkey = result.changes.find(c => c.name === 'schemas/app/tables/users/constraints/users_pkey/constraint')!;
+      expect(pkey.deploy).toContain('ADD CONSTRAINT users_pkey');
+      expect(pkey.revert).toContain('DROP CONSTRAINT users_pkey');
+      expect(pkey.verify).toContain('information_schema.table_constraints');
+    });
+
+    it('derives per-alteration requires: column requires table, constraint requires its columns', () => {
+      const result = restructureChanges(ATOMIC_CHANGES, opts);
+
+      const column = result.changes.find(c => c.name === 'schemas/app/tables/users/columns/id/column')!;
+      expect(column.dependencies).toContain('schemas/app/tables/users/table');
+
+      const pkey = result.changes.find(c => c.name === 'schemas/app/tables/users/constraints/users_pkey/constraint')!;
+      expect(pkey.dependencies).toContain('schemas/app/tables/users/table');
+      expect(pkey.dependencies).toContain('schemas/app/tables/users/columns/id/column');
+
+      const fk = result.changes.find(c => c.name === 'schemas/app/tables/orders/constraints/orders_user_fk/constraint')!;
+      expect(fk.dependencies).toContain('schemas/app/tables/orders/columns/user_id/column');
+    });
+
+    it('names unnamed constraints with their Postgres default so each change is revertible', () => {
+      const result = restructureChanges([
+        {
+          name: 'schemas/app/tables/users/table',
+          dependencies: [],
+          deploy: [
+            'CREATE TABLE app.users ();',
+            'ALTER TABLE app.users ADD COLUMN id int;',
+            'ALTER TABLE app.users ADD PRIMARY KEY (id);'
+          ].join('\n')
+        }
+      ], opts);
+      const pkey = result.changes.find(c => c.name === 'schemas/app/tables/users/constraints/users_pkey/constraint')!;
+      expect(pkey.deploy).toContain('ADD CONSTRAINT users_pkey');
+      expect(pkey.revert).toContain('DROP CONSTRAINT users_pkey');
+      expect(result.warnings.filter(w => w.includes('revert not derivable'))).toEqual([]);
+    });
+
+    it('default object mode is unchanged', () => {
+      const object = restructureChanges(ATOMIC_CHANGES, { granularity: 'atomic' });
+      const explicit = restructureChanges(ATOMIC_CHANGES, { granularity: 'atomic', changeGranularity: 'object' });
+      expect(explicit.changes).toEqual(object.changes);
+    });
+  });
+
   it('supports custom change naming', () => {
     const result = restructureChanges(ATOMIC_CHANGES, {
       granularity: 'consolidated',

--- a/pgpm/transform/__tests__/sub-object.test.ts
+++ b/pgpm/transform/__tests__/sub-object.test.ts
@@ -1,0 +1,72 @@
+import { classifyStatements } from '@pgsql/transform';
+import { loadModule } from 'plpgsql-parser';
+
+import { nameUnnamedConstraints, subObjectIdentityOf } from '../src/sub-object';
+
+beforeAll(async () => {
+  await loadModule();
+});
+
+const factsOf = (sql: string) => classifyStatements(sql);
+
+describe('subObjectIdentityOf', () => {
+  it('recovers the column identity from ADD COLUMN', () => {
+    const [f] = factsOf('ALTER TABLE app.users ADD COLUMN email text NOT NULL;');
+    expect(subObjectIdentityOf(f)).toEqual({
+      kind: 'column',
+      schema: 'app',
+      name: 'email',
+      table: 'users'
+    });
+  });
+
+  it('recovers the constraint identity from a named ADD CONSTRAINT', () => {
+    const [f] = factsOf('ALTER TABLE app.users ADD CONSTRAINT users_pkey PRIMARY KEY (id);');
+    expect(subObjectIdentityOf(f)).toEqual({
+      kind: 'constraint',
+      schema: 'app',
+      name: 'users_pkey',
+      table: 'users'
+    });
+  });
+
+  it('names unnamed constraints with their Postgres default', () => {
+    const [pk] = factsOf('ALTER TABLE app.users ADD PRIMARY KEY (id);');
+    expect(subObjectIdentityOf(pk)!.name).toEqual('users_pkey');
+
+    const [uq] = factsOf('ALTER TABLE app.users ADD UNIQUE (email);');
+    expect(subObjectIdentityOf(uq)!.name).toEqual('users_email_key');
+
+    const [fk] = factsOf('ALTER TABLE app.posts ADD FOREIGN KEY (user_id) REFERENCES app.users (id);');
+    expect(subObjectIdentityOf(fk)!.name).toEqual('posts_user_id_fkey');
+  });
+
+  it('returns null for multi-command ALTERs and other statements', () => {
+    const [multi] = factsOf('ALTER TABLE app.users ADD COLUMN a int, ADD COLUMN b int;');
+    expect(subObjectIdentityOf(multi)).toBeNull();
+
+    const [create] = factsOf('CREATE TABLE app.users (id int);');
+    expect(subObjectIdentityOf(create)).toBeNull();
+
+    const [rls] = factsOf('ALTER TABLE app.users ENABLE ROW LEVEL SECURITY;');
+    expect(subObjectIdentityOf(rls)).toBeNull();
+  });
+});
+
+describe('nameUnnamedConstraints', () => {
+  it('rewrites unnamed ADD <constraint> to carry its Postgres default name', () => {
+    const out = nameUnnamedConstraints('ALTER TABLE app.users ADD PRIMARY KEY (id);');
+    expect(out).toContain('ADD CONSTRAINT users_pkey PRIMARY KEY (id)');
+  });
+
+  it('leaves already-named constraints and other statements untouched', () => {
+    const sql = [
+      'CREATE TABLE app.users (id int);',
+      'ALTER TABLE app.users ADD CONSTRAINT my_pk PRIMARY KEY (id);'
+    ].join('\n');
+    const out = nameUnnamedConstraints(sql);
+    expect(out).toContain('CREATE TABLE app.users (id int);');
+    expect(out).toContain('ADD CONSTRAINT my_pk PRIMARY KEY (id)');
+    expect(out).not.toContain('users_pkey');
+  });
+});

--- a/pgpm/transform/src/granularity-driver.ts
+++ b/pgpm/transform/src/granularity-driver.ts
@@ -17,6 +17,7 @@
  *                    (FKs, indexes, triggers, policies) stay separate.
  * - `consolidated` — additionally inlines FKs proven safe by the graph.
  */
+import type { ObjectIdentity as NamingIdentity } from '@pgpmjs/naming-spec';
 import { pathFor } from '@pgpmjs/naming-spec';
 import { revertFor, verifyFor } from '@pgsql/scripts';
 import type { Granularity, StatementFacts } from '@pgsql/transform';
@@ -27,7 +28,27 @@ import {
   restructureSql
 } from '@pgsql/transform';
 
+import { nameUnnamedConstraints, subObjectIdentityOf } from './sub-object';
+
 export type { Granularity } from '@pgsql/transform';
+
+/**
+ * How statements are distributed across pgpm changes — orthogonal to
+ * `Granularity`, which shapes the SQL *within* a change.
+ *
+ * - `object`     — one change per created object (the default): a table's
+ *                  CREATE and all its ALTERs share one plan entry.
+ * - `alteration` — one change per alteration: every `ADD COLUMN` /
+ *                  `ADD CONSTRAINT` becomes its own plan entry with its own
+ *                  deploy/revert/verify and graph-derived requires, so a
+ *                  single column can deploy or revert independently.
+ */
+export type ChangeGranularity = 'object' | 'alteration';
+
+export const CHANGE_GRANULARITIES: readonly ChangeGranularity[] = ['object', 'alteration'];
+
+export const isChangeGranularity = (value: string): value is ChangeGranularity =>
+  (CHANGE_GRANULARITIES as readonly string[]).includes(value);
 
 /** A change's deploy surface going into or out of the restructure. */
 export interface GranularityChange {
@@ -57,6 +78,21 @@ export interface RestructuredChange extends GranularityChange {
 
 export interface RestructureModuleOptions {
   granularity: Granularity;
+  /**
+   * Change-level distribution (default `object`). With `alteration`, every
+   * single-command `ALTER TABLE ADD COLUMN` / `ADD CONSTRAINT` in the
+   * restructured script becomes its own change, named by the sub-object's
+   * naming-spec path (`.../columns/{name}/column`,
+   * `.../constraints/{name}/constraint`); unnamed constraints are first
+   * given their Postgres default name so each change stays revertible.
+   */
+  changeGranularity?: ChangeGranularity;
+  /**
+   * Derive a change name for an alteration group from its sub-object
+   * identity (used only with `changeGranularity: 'alteration'`). Defaults to
+   * `pathFor` in `directory` style.
+   */
+  subObjectName?: (identity: NamingIdentity) => string;
   /**
    * Derive a change name for a statement group from the facts of its primary
    * (creating) statement. Defaults to {@link defaultChangeName}: naming spec
@@ -109,15 +145,19 @@ export function restructureChanges(
   options: RestructureModuleOptions
 ): RestructureModuleResult {
   const nameFor = options.changeName ?? defaultChangeName;
+  const subNameFor = options.subObjectName ?? ((identity: NamingIdentity): string => pathFor(identity));
+  const alteration = options.changeGranularity === 'alteration';
 
   const flattened = changes
     .map(c => c.deploy.trim())
     .filter(Boolean)
     .join('\n\n');
 
-  const { sql, warnings } = restructureSql(flattened, {
+  const restructured = restructureSql(flattened, {
     granularity: options.granularity
   });
+  const warnings = restructured.warnings;
+  const sql = alteration ? nameUnnamedConstraints(restructured.sql) : restructured.sql;
 
   // Re-classify the emitted script; group statements by the object they
   // target (creates[0]), so a table's CREATE and its remaining ALTERs land
@@ -129,6 +169,10 @@ export function restructureChanges(
   const groupKeys: string[] = [];
   const groupFacts: StatementFacts[] = [];
   const groupKeyToIndex = new Map<string, number>();
+  /** Sub-object path for alteration groups; null means name via `nameFor`. */
+  const groupSubName: (string | null)[] = [];
+  /** For alteration groups: the object-group key of the owning table. */
+  const groupOwnerKey: (string | null)[] = [];
 
   facts.forEach((f, i) => {
     const created = f.creates[0];
@@ -138,12 +182,31 @@ export function restructureChanges(
       if (i > 0 && groupOf[i - 1] !== -1) groupOf[i] = groupOf[i - 1];
       return;
     }
+    if (alteration) {
+      const sub = subObjectIdentityOf(f);
+      if (sub) {
+        const key = `sub\u0000${sub.kind}\u0000${sub.schema ?? ''}\u0000${sub.table}\u0000${sub.name}`;
+        let g = groupKeyToIndex.get(key);
+        if (g === undefined) {
+          g = groupKeys.length;
+          groupKeys.push(key);
+          groupFacts.push(f);
+          groupSubName.push(subNameFor(sub));
+          groupOwnerKey.push(`${sub.schema ?? ''}.${sub.table}`);
+          groupKeyToIndex.set(key, g);
+        }
+        groupOf[i] = g;
+        return;
+      }
+    }
     const key = `${created.schema ?? ''}.${created.name}`;
     let g = groupKeyToIndex.get(key);
     if (g === undefined) {
       g = groupKeys.length;
       groupKeys.push(key);
       groupFacts.push(f);
+      groupSubName.push(null);
+      groupOwnerKey.push(null);
       groupKeyToIndex.set(key, g);
     } else if (!(groupFacts[g].kind in KIND_DIRS) && groupFacts[g].kind !== 'schema' && (f.kind in KIND_DIRS || f.kind === 'schema')) {
       // Prefer naming the group after its creating statement over an ALTER.
@@ -152,7 +215,7 @@ export function restructureChanges(
     groupOf[i] = g;
   });
 
-  const groupNames = groupFacts.map(nameFor);
+  const groupNames = groupFacts.map((f, g) => groupSubName[g] ?? nameFor(f));
 
   // Schema producers, for schema-level change dependencies.
   const schemaGroup = new Map<string, number>();
@@ -197,6 +260,40 @@ export function restructureChanges(
       if (to !== undefined && to !== from) groupDeps[from].add(to);
     }
   });
+
+  // Alteration groups depend on their table's own change, and constraint
+  // groups additionally on the column changes they key on — the statement
+  // graph keys everything by the table, so these finer edges are added here.
+  if (alteration) {
+    const columnGroup = new Map<string, number>();
+    groupKeys.forEach((key, g) => {
+      const parts = key.split('\u0000');
+      if (parts[0] === 'sub' && parts[1] === 'column') {
+        columnGroup.set(`${parts[2]}.${parts[3]}.${parts[4]}`, g);
+      }
+    });
+    groupKeys.forEach((key, g) => {
+      const owner = groupOwnerKey[g];
+      if (owner === null) return;
+      const tableGroup = groupKeyToIndex.get(owner);
+      if (tableGroup !== undefined && tableGroup !== g) groupDeps[g].add(tableGroup);
+      const parts = key.split('\u0000');
+      if (parts[1] !== 'constraint') return;
+      const constraint = (groupFacts[g].stmt?.AlterTableStmt as {
+        cmds?: { AlterTableCmd?: { def?: { Constraint?: {
+          keys?: { String?: { sval?: string } }[];
+          fk_attrs?: { String?: { sval?: string } }[];
+        } } } }[];
+      } | undefined)?.cmds?.[0]?.AlterTableCmd?.def?.Constraint;
+      const referenced = [...(constraint?.keys ?? []), ...(constraint?.fk_attrs ?? [])]
+        .map(k => k.String?.sval)
+        .filter((s): s is string => typeof s === 'string');
+      for (const col of referenced) {
+        const to = columnGroup.get(`${owner}.${col}`);
+        if (to !== undefined && to !== g) groupDeps[g].add(to);
+      }
+    });
+  }
 
   // Emit groups in first-statement order (already topological).
   const order = [...groupNames.keys()].sort((a, b) => {

--- a/pgpm/transform/src/index.ts
+++ b/pgpm/transform/src/index.ts
@@ -34,13 +34,16 @@ export type {
 } from './fixture-closure';
 export { resolveFixtureClosure } from './fixture-closure';
 export type {
+  ChangeGranularity,
   GranularityChange,
   RestructuredChange,
   RestructureModuleOptions,
   RestructureModuleResult,
 } from './granularity-driver';
 export {
+  CHANGE_GRANULARITIES,
   defaultChangeName,
+  isChangeGranularity,
   restructureChanges,
 } from './granularity-driver';
 export type { AppendModuleResult, PgpmModuleModel } from './module-emit';
@@ -93,5 +96,6 @@ export {
   diffChangeSets,
   diffSchemas,
 } from './semantic-diff-driver';
+export { nameUnnamedConstraints, subObjectIdentityOf } from './sub-object';
 export * from '@pgsql/transform';
 export { loadModule } from 'plpgsql-parser';

--- a/pgpm/transform/src/restructure.ts
+++ b/pgpm/transform/src/restructure.ts
@@ -10,7 +10,7 @@ import { alterationPathFor, pathFor, PathStyle } from '@pgpmjs/naming-spec';
 import { Granularity, identityOf, StatementFacts } from '@pgsql/transform';
 import { loadModule } from 'plpgsql-parser';
 
-import { restructureChanges } from './granularity-driver';
+import { ChangeGranularity, restructureChanges } from './granularity-driver';
 
 export type ExportGranularity = Granularity;
 
@@ -27,6 +27,12 @@ export interface RestructureExportRowsResult {
 export interface RestructureExportRowsOptions {
   /** Naming-spec rendering style for derived paths (default `directory`). */
   naming?: PathStyle;
+  /**
+   * Change-level distribution (default `object`): with `alteration`, each
+   * `ADD COLUMN` / `ADD CONSTRAINT` becomes its own change. See
+   * {@link ChangeGranularity}.
+   */
+  changeGranularity?: ChangeGranularity;
 }
 
 /**
@@ -65,7 +71,12 @@ export const restructureExportRows = async (
       dependencies: row.deps ?? [],
       deploy: row.content
     })),
-    { granularity, changeName }
+    {
+      granularity,
+      changeGranularity: options.changeGranularity,
+      changeName,
+      subObjectName: identity => pathFor(identity, { style })
+    }
   );
 
   const counters = new Map<string, number>();

--- a/pgpm/transform/src/semantic-diff-driver.ts
+++ b/pgpm/transform/src/semantic-diff-driver.ts
@@ -39,7 +39,7 @@ import {
 import { Deparser, parseSync } from 'plpgsql-parser';
 
 import { ConstraintNode, defaultConstraintName } from './constraint-names';
-import { GranularityChange, restructureChanges } from './granularity-driver';
+import { ChangeGranularity, GranularityChange, restructureChanges } from './granularity-driver';
 
 /** How one object differs between the two sides. */
 export type ObjectDelta = 'added' | 'removed' | 'modified';
@@ -58,6 +58,8 @@ export interface SemanticObjectDiff {
 export interface SemanticDiffOptions {
   /** Granularity for the emitted CREATE/ALTER changes (default `object`). */
   granularity?: Granularity;
+  /** Change-level distribution for emitted changes (default `object`). */
+  changeGranularity?: ChangeGranularity;
   /** Naming-spec rendering style (default `directory`). */
   style?: PathStyle;
 }
@@ -571,7 +573,11 @@ export function diffSchemas(
   if (forwardSql.length > 0) {
     const { changes, warnings: w } = restructureChanges(
       [{ name: 'delta', dependencies: [], deploy: forwardSql.join('\n\n') }],
-      { granularity: options.granularity ?? 'object' }
+      {
+        granularity: options.granularity ?? 'object',
+        changeGranularity: options.changeGranularity,
+        subObjectName: identity => pathFor(identity, { style })
+      }
     );
     forwardChanges = changes.map(c => ({
       ...c,

--- a/pgpm/transform/src/sub-object.ts
+++ b/pgpm/transform/src/sub-object.ts
@@ -1,0 +1,107 @@
+/**
+ * Sub-object identities: the column or constraint a single `ALTER TABLE`
+ * statement adds.
+ *
+ * `identityOf` summarizes an ALTER TABLE by the table it targets — the right
+ * grouping key for object-level changes, but lossy one level down: the added
+ * column's `colname` and the added constraint's `conname` stay behind in the
+ * raw parse node (`facts.stmt`). This module recovers them, giving the
+ * change-granularity pipeline a stable identity (and naming-spec path) for
+ * every alteration.
+ */
+import type { ObjectIdentity } from '@pgpmjs/naming-spec';
+import type { StatementFacts } from '@pgsql/transform';
+import { Deparser, parseSync } from 'plpgsql-parser';
+
+import { ConstraintNode, defaultConstraintName } from './constraint-names';
+
+interface AlterTableCmdNode {
+  subtype?: string;
+  def?: {
+    ColumnDef?: { colname?: string };
+    Constraint?: ConstraintNode;
+  };
+}
+
+interface AlterTableStmtNode {
+  relation?: { schemaname?: string; relname?: string };
+  cmds?: { AlterTableCmd?: AlterTableCmdNode }[];
+}
+
+/** The single AlterTableCmd of a one-command ALTER TABLE, or null. */
+function singleCmd(stmt: AlterTableStmtNode): AlterTableCmdNode | null {
+  const cmds = stmt.cmds ?? [];
+  if (cmds.length !== 1) return null;
+  return cmds[0].AlterTableCmd ?? null;
+}
+
+/**
+ * The column or constraint a one-command `ALTER TABLE .. ADD COLUMN` /
+ * `ADD CONSTRAINT` statement adds, as a naming-spec identity
+ * (`kind: 'column' | 'constraint'`, `table` set). Unnamed constraints get
+ * their Postgres default name. Returns `null` for anything else — multi-
+ * command ALTERs, other subtypes, non-ALTER statements — so callers fall
+ * back to object-level grouping.
+ */
+export function subObjectIdentityOf(facts: StatementFacts): ObjectIdentity | null {
+  const stmt = facts.stmt?.AlterTableStmt as AlterTableStmtNode | undefined;
+  if (!stmt?.relation?.relname) return null;
+  const cmd = singleCmd(stmt);
+  if (!cmd) return null;
+
+  const schema = stmt.relation.schemaname ?? null;
+  const table = stmt.relation.relname;
+
+  if (cmd.subtype === 'AT_AddColumn' && cmd.def?.ColumnDef?.colname) {
+    return { kind: 'column', schema, name: cmd.def.ColumnDef.colname, table };
+  }
+  if (cmd.subtype === 'AT_AddConstraint' && cmd.def?.Constraint) {
+    const constraint = cmd.def.Constraint;
+    const name = constraint.conname ?? defaultConstraintName(table, constraint);
+    if (!name) return null;
+    return { kind: 'constraint', schema, name, table };
+  }
+  return null;
+}
+
+/**
+ * Rewrite a script so every unnamed `ALTER TABLE .. ADD <constraint>` carries
+ * its Postgres default name (`ADD PRIMARY KEY (id)` becomes `ADD CONSTRAINT
+ * {table}_pkey PRIMARY KEY (id)`) — the exact name the catalog would assign
+ * anyway. Naming them makes each constraint change independently revertible
+ * (`DROP CONSTRAINT <name>`) and verifiable. Statements that need no rewrite
+ * keep their original text.
+ */
+export function nameUnnamedConstraints(sql: string): string {
+  const parsed = parseSync(sql);
+  const pieces: string[] = [];
+  for (const raw of parsed.sql.stmts) {
+    const node = raw.stmt as Record<string, unknown>;
+    const stmt = node.AlterTableStmt as AlterTableStmtNode | undefined;
+    const table = stmt?.relation?.relname;
+    let rewritten = false;
+    if (stmt && table) {
+      for (const cmd of stmt.cmds ?? []) {
+        const at = cmd.AlterTableCmd;
+        const constraint = at?.subtype === 'AT_AddConstraint' ? at.def?.Constraint : undefined;
+        if (constraint && !constraint.conname) {
+          const name = defaultConstraintName(table, constraint);
+          if (name) {
+            constraint.conname = name;
+            rewritten = true;
+          }
+        }
+      }
+    }
+    if (rewritten) {
+      pieces.push(`${Deparser.deparse(node, { pretty: true })};`);
+    } else {
+      const start = (raw as { stmt_location?: number }).stmt_location ?? 0;
+      const len = (raw as { stmt_len?: number }).stmt_len;
+      const text = len === undefined ? sql.slice(start) : sql.slice(start, start + len);
+      const trimmed = text.trim();
+      pieces.push(trimmed.endsWith(';') ? trimmed : `${trimmed};`);
+    }
+  }
+  return pieces.join('\n\n');
+}


### PR DESCRIPTION
## Summary

The fourth dial (planning constructive-planning#1342): **statement granularity** (`--granularity atomic|object|consolidated`, SQL shape *within* a change) is now orthogonal to **change granularity** (`--change-granularity object|alteration`, how statements are distributed *across* pgpm changes). Default `object` is byte-identical to today.

With `alteration`, every single-command `ALTER TABLE ADD COLUMN` / `ADD CONSTRAINT` becomes its own plan entry with its own deploy/revert/verify and requires:

```
schemas/app/tables/users/table                                CREATE TABLE ()
schemas/app/tables/users/columns/id/column                    ADD COLUMN id …        [table]
schemas/app/tables/users/constraints/users_pkey/constraint    ADD CONSTRAINT …       [table, columns/id]
```

revert is `DROP COLUMN` / `DROP CONSTRAINT`; verify checks `information_schema.columns` / `table_constraints` — so a single column can deploy or revert independently.

How it works:
- `@pgpmjs/naming-spec`: new `column` identity kind → `schemas/{s}/tables/{t}/columns/{c}/column`.
- `@pgpmjs/transform` `sub-object.ts`: `subObjectIdentityOf(facts)` recovers the column/constraint name from the raw parse node (`facts.stmt`) that `identityOf` summarizes away — no parser changes needed. `nameUnnamedConstraints(sql)` rewrites `ADD PRIMARY KEY (id)` → `ADD CONSTRAINT users_pkey PRIMARY KEY (id)` (the exact name Postgres would assign, via `defaultConstraintName` from #1584) so each constraint change is revertible.
- `restructureChanges({ changeGranularity: 'alteration' })` groups those statements by sub-object identity instead of owning object, and adds finer edges the statement graph (keyed by table) can't express: alteration → its table's change, constraint → the column changes it keys on (`keys`/`fk_attrs`).
- Wired through `restructureExportRows`, `diffChangeSets`, `importDumpRows`, and the `pgpm transform` / `pgpm diff` / `pgpm import` CLIs.

Semantic invariance holds across **both** axes: `examples/pgpm-projections` now asserts atomic ≡ object ≡ consolidated ≡ alteration at the identity-keyed model (the old "atomic is only catalog-equivalent" caveat is removed — #1584 fixed that), and live-Postgres e2e (transform-e2e, diff-e2e) proves alteration-mode modules deploy to the identical catalog, verify, and revert clean.


Link to Devin session: https://app.devin.ai/sessions/798445577ac8487abf80e28f9ff7a916
Requested by: @pyramation