### PR TITLE
feat: persist physical S3 bucket name on the bucket row at provision time

### DIFF
--- a/graphile/graphile-bucket-provisioner-plugin/__tests__/plugin.test.ts
+++ b/graphile/graphile-bucket-provisioner-plugin/__tests__/plugin.test.ts
@@ -424,6 +424,99 @@ describe('createBucketProvisionerPlugin', () => {
       expect(result.bucketName).toBe('public');
     });
 
+    it('records physical_name on the bucket row after successful provisioning', async () => {
+      createBucketProvisionerPlugin(createDefaultOptions());
+
+      const pgClient = createMockPgClient();
+      const mockWithPgClient = jest.fn((_settings: any, callback: any) =>
+        callback(pgClient),
+      );
+
+      const result = await capturedLambdaCallback!({
+        input: { bucketKey: 'public' },
+        withPgClient: mockWithPgClient,
+        pgSettings: { role: 'admin' },
+      });
+
+      expect(result.success).toBe(true);
+
+      const update = pgClient.query.mock.calls.find(
+        (c: any[]) => typeof c[0] === 'string' && c[0].includes('SET physical_name'),
+      );
+      expect(update).toBeDefined();
+      // Guarded so a re-provision never clobbers an already-recorded coordinate.
+      expect(update![0]).toContain('physical_name IS NULL');
+      // Records the exact name returned by the provisioner against the row id.
+      expect(update![1]).toEqual(['public', 'bucket-uuid-789']);
+    });
+
+    it('provisions the stored physical_name verbatim when already recorded', async () => {
+      createBucketProvisionerPlugin(createDefaultOptions());
+
+      const pgClient = createMockPgClient({
+        app_public: {
+          rows: [{
+            id: 'bucket-uuid-789',
+            key: 'public',
+            type: 'public',
+            is_public: true,
+            allowed_origins: null,
+            physical_name: 'preexisting-cdn-bucket',
+          }],
+        },
+      });
+      mockProvision.mockResolvedValue({
+        bucketName: 'preexisting-cdn-bucket',
+        accessType: 'public',
+        endpoint: 'http://minio:9000',
+        provider: 'minio',
+        region: 'us-east-1',
+        publicUrlPrefix: null,
+        blockPublicAccess: false,
+        versioning: false,
+        corsRules: [],
+        lifecycleRules: [],
+      });
+      const mockWithPgClient = jest.fn((_settings: any, callback: any) =>
+        callback(pgClient),
+      );
+
+      const result = await capturedLambdaCallback!({
+        input: { bucketKey: 'public' },
+        withPgClient: mockWithPgClient,
+        pgSettings: { role: 'admin' },
+      });
+
+      expect(result.success).toBe(true);
+      // The stored coordinate is provisioned as-is; no prefix/resolver name is minted.
+      expect(mockProvision).toHaveBeenCalledWith(
+        expect.objectContaining({ bucketName: 'preexisting-cdn-bucket' }),
+      );
+    });
+
+    it('does not record physical_name when provisioning fails', async () => {
+      mockProvision.mockRejectedValue(new Error('S3 connection refused'));
+
+      createBucketProvisionerPlugin(createDefaultOptions());
+
+      const pgClient = createMockPgClient();
+      const mockWithPgClient = jest.fn((_settings: any, callback: any) =>
+        callback(pgClient),
+      );
+
+      const result = await capturedLambdaCallback!({
+        input: { bucketKey: 'public' },
+        withPgClient: mockWithPgClient,
+        pgSettings: {},
+      });
+
+      expect(result.success).toBe(false);
+      const update = pgClient.query.mock.calls.find(
+        (c: any[]) => typeof c[0] === 'string' && c[0].includes('SET physical_name'),
+      );
+      expect(update).toBeUndefined();
+    });
+
     it('applies per-database endpoint override from storage module', async () => {
       createBucketProvisionerPlugin(createDefaultOptions());
 

--- a/graphile/graphile-bucket-provisioner-plugin/src/plugin.ts
+++ b/graphile/graphile-bucket-provisioner-plugin/src/plugin.ts
@@ -150,6 +150,29 @@ interface BucketRow {
   type: string;
   is_public: boolean;
   allowed_origins: string[] | null;
+  physical_name: string | null;
+}
+
+/**
+ * Record the physical S3 bucket name on the source bucket row.
+ *
+ * Runs in the system lane (`withPgClient(null, ...)`) — server bookkeeping,
+ * RLS-independent. Idempotent via the `physical_name IS NULL` guard so a
+ * re-provision never clobbers an already-recorded coordinate.
+ */
+async function recordPhysicalName(
+  withPgClient: (pgSettings: null, cb: (client: any) => Promise<unknown>) => Promise<unknown>,
+  bucketsTable: string,
+  bucketId: string,
+  physicalName: string,
+): Promise<void> {
+  await withPgClient(null, (client: any) =>
+    client.query(
+      `UPDATE ${bucketsTable} SET physical_name = $1 WHERE id = $2 AND physical_name IS NULL`,
+      [physicalName, bucketId],
+    ),
+  );
+  log.info(`Recorded physical_name="${physicalName}" on bucket ${bucketId}`);
 }
 
 // --- Helpers ---
@@ -251,8 +274,10 @@ async function provisionBucketForRow(
   bucketType: string,
   bucketAllowedOrigins: string[] | null | undefined,
   options: BucketProvisionerPluginOptions,
+  storedPhysicalName: string | null,
 ): Promise<ProvisionResult> {
-  const s3BucketName = resolveBucketName(bucketKey, databaseId, options);
+  // Stored physical coordinate wins; the naming hook only mints on first provision.
+  const s3BucketName = storedPhysicalName ?? resolveBucketName(bucketKey, databaseId, options);
   const accessType = bucketType as 'public' | 'private' | 'temp';
 
   // Read storage module config to check for endpoint/provider/CORS overrides
@@ -298,8 +323,9 @@ async function updateBucketCors(
   bucketType: string,
   bucketAllowedOrigins: string[] | null | undefined,
   options: BucketProvisionerPluginOptions,
+  storedPhysicalName: string | null,
 ): Promise<void> {
-  const s3BucketName = resolveBucketName(bucketKey, databaseId, options);
+  const s3BucketName = storedPhysicalName ?? resolveBucketName(bucketKey, databaseId, options);
   const accessType = bucketType as 'public' | 'private' | 'temp';
 
   const storageModule = await resolveStorageModule(pgClient, databaseId);
@@ -429,11 +455,11 @@ export function createBucketProvisionerPlugin(
               const bucketsTable = QuoteUtils.quoteQualifiedIdentifier(storageModule.buckets_schema, storageModule.buckets_table);
               const bucketResult = await pgClient.query(
                 hasOwner
-                  ? `SELECT id, key, type, is_public, allowed_origins
+                  ? `SELECT id, key, type, is_public, allowed_origins, physical_name
                      FROM ${bucketsTable}
                      WHERE key = $1 AND owner_id = $2
                      LIMIT 1`
-                  : `SELECT id, key, type, is_public, allowed_origins
+                  : `SELECT id, key, type, is_public, allowed_origins, physical_name
                      FROM ${bucketsTable}
                      WHERE key = $1
                      LIMIT 1`,
@@ -454,7 +480,11 @@ export function createBucketProvisionerPlugin(
                   bucket.type,
                   bucket.allowed_origins,
                   options,
+                  bucket.physical_name,
                 );
+
+                // Record the exact provisioned name on the source row.
+                await recordPhysicalName(withPgClient, bucketsTable, bucket.id, result.bucketName);
 
                 return {
                   success: true,
@@ -468,7 +498,7 @@ export function createBucketProvisionerPlugin(
                 log.error(`Failed to provision bucket "${bucketKey}": ${err.message}`);
                 return {
                   success: false,
-                  bucketName: resolveBucketName(bucket.key, databaseId, options),
+                  bucketName: bucket.physical_name ?? resolveBucketName(bucket.key, databaseId, options),
                   accessType: bucket.type,
                   provider: resolveConnection(options).provider,
                   endpoint: resolveConnection(options).endpoint ?? null,
@@ -578,14 +608,28 @@ export function createBucketProvisionerPlugin(
                       return;
                     }
 
-                    await provisionBucketForRow(
+                    // Newly-created row has no stored coordinate yet — mint on first provision.
+                    const result = await provisionBucketForRow(
                       pgClient,
                       databaseId,
                       bucketInput.key,
                       bucketInput.type,
                       bucketInput.allowedOrigins ?? bucketInput.allowed_origins ?? null,
                       options,
+                      null,
                     );
+
+                    // Record the provisioned name on the just-created row.
+                    const storageModule = await resolveStorageModule(pgClient, databaseId);
+                    if (storageModule) {
+                      const bucketsTable = QuoteUtils.quoteQualifiedIdentifier(storageModule.buckets_schema, storageModule.buckets_table);
+                      const idResult = await pgClient.query(
+                        `SELECT id FROM ${bucketsTable} WHERE key = $1 LIMIT 1`,
+                        [bucketInput.key],
+                      );
+                      const bucketId = idResult.rows[0]?.id;
+                      if (bucketId) await recordPhysicalName(withPgClient, bucketsTable, bucketId, result.bucketName);
+                    }
                   });
                 } else {
                   // --- UPDATE: re-apply CORS if allowed_origins is in the patch ---
@@ -626,7 +670,7 @@ export function createBucketProvisionerPlugin(
                     // Read the full bucket row (post-update) to get type + origins
                     const bucketsTable = QuoteUtils.quoteQualifiedIdentifier(storageModule.buckets_schema, storageModule.buckets_table);
                     const bucketResult = await pgClient.query(
-                      `SELECT id, key, type, is_public, allowed_origins
+                      `SELECT id, key, type, is_public, allowed_origins, physical_name
                        FROM ${bucketsTable}
                        WHERE key = $1
                        LIMIT 1`,
@@ -647,6 +691,7 @@ export function createBucketProvisionerPlugin(
                       bucket.type,
                       bucket.allowed_origins,
                       options,
+                      bucket.physical_name,
                     );
                   });
                 }

--- a/graphile/graphile-bucket-provisioner-plugin/src/plugin.ts
+++ b/graphile/graphile-bucket-provisioner-plugin/src/plugin.ts
@@ -154,6 +154,18 @@ interface BucketRow {
 }
 
 /**
+ * Normalize the recorded physical coordinate at the DB boundary.
+ *
+ * A bucket row either carries a recorded coordinate or it does not; SQL nulls
+ * and absent columns both mean "never provisioned". Collapsing them here is
+ * the single place that shape is interpreted — callers branch on `string`
+ * vs `null` and never coalesce a bucket name into existence.
+ */
+function storedPhysicalName(row: Pick<BucketRow, 'physical_name'>): string | null {
+  return row.physical_name == null ? null : row.physical_name;
+}
+
+/**
  * Record the physical S3 bucket name on the source bucket row.
  *
  * Runs in the system lane (`withPgClient(null, ...)`) — server bookkeeping,
@@ -274,10 +286,8 @@ async function provisionBucketForRow(
   bucketType: string,
   bucketAllowedOrigins: string[] | null | undefined,
   options: BucketProvisionerPluginOptions,
-  storedPhysicalName: string | null,
+  s3BucketName: string,
 ): Promise<ProvisionResult> {
-  // Stored physical coordinate wins; the naming hook only mints on first provision.
-  const s3BucketName = storedPhysicalName ?? resolveBucketName(bucketKey, databaseId, options);
   const accessType = bucketType as 'public' | 'private' | 'temp';
 
   // Read storage module config to check for endpoint/provider/CORS overrides
@@ -323,9 +333,8 @@ async function updateBucketCors(
   bucketType: string,
   bucketAllowedOrigins: string[] | null | undefined,
   options: BucketProvisionerPluginOptions,
-  storedPhysicalName: string | null,
+  s3BucketName: string,
 ): Promise<void> {
-  const s3BucketName = storedPhysicalName ?? resolveBucketName(bucketKey, databaseId, options);
   const accessType = bucketType as 'public' | 'private' | 'temp';
 
   const storageModule = await resolveStorageModule(pgClient, databaseId);
@@ -472,6 +481,13 @@ export function createBucketProvisionerPlugin(
 
               const bucket = bucketResult.rows[0] as BucketRow;
 
+              // First provision mints a name; afterwards the stored coordinate
+              // is authoritative and the naming hook is never consulted again.
+              const recorded = storedPhysicalName(bucket);
+              const s3BucketName = recorded === null
+                ? resolveBucketName(bucket.key, databaseId, options)
+                : recorded;
+
               try {
                 const result = await provisionBucketForRow(
                   pgClient,
@@ -480,7 +496,7 @@ export function createBucketProvisionerPlugin(
                   bucket.type,
                   bucket.allowed_origins,
                   options,
-                  bucket.physical_name,
+                  s3BucketName,
                 );
 
                 // Record the exact provisioned name on the source row.
@@ -498,7 +514,7 @@ export function createBucketProvisionerPlugin(
                 log.error(`Failed to provision bucket "${bucketKey}": ${err.message}`);
                 return {
                   success: false,
-                  bucketName: bucket.physical_name ?? resolveBucketName(bucket.key, databaseId, options),
+                  bucketName: s3BucketName,
                   accessType: bucket.type,
                   provider: resolveConnection(options).provider,
                   endpoint: resolveConnection(options).endpoint ?? null,
@@ -616,7 +632,7 @@ export function createBucketProvisionerPlugin(
                       bucketInput.type,
                       bucketInput.allowedOrigins ?? bucketInput.allowed_origins ?? null,
                       options,
-                      null,
+                      resolveBucketName(bucketInput.key, databaseId, options),
                     );
 
                     // Record the provisioned name on the just-created row.
@@ -684,6 +700,11 @@ export function createBucketProvisionerPlugin(
 
                     const bucket = bucketResult.rows[0] as BucketRow;
 
+                    // CORS applies to the recorded physical bucket; if the row was
+                    // never provisioned there is nothing to update yet, so mint the
+                    // conventional name the first provision would use.
+                    const recorded = storedPhysicalName(bucket);
+
                     await updateBucketCors(
                       pgClient,
                       databaseId,
@@ -691,7 +712,9 @@ export function createBucketProvisionerPlugin(
                       bucket.type,
                       bucket.allowed_origins,
                       options,
-                      bucket.physical_name,
+                      recorded === null
+                        ? resolveBucketName(bucket.key, databaseId, options)
+                        : recorded,
                     );
                   });
                 }

--- a/graphile/graphile-presigned-url-plugin/src/download-url-field.ts
+++ b/graphile/graphile-presigned-url-plugin/src/download-url-field.ts
@@ -62,11 +62,13 @@ function resolveS3ForDatabase(
   storageConfig: StorageModuleConfig,
   databaseId: string,
   bucketKey: string,
+  physicalName: string | null,
 ): S3Config {
   const globalS3 = resolveS3(options);
-  const bucket = options.resolveBucketName
-    ? options.resolveBucketName(databaseId, bucketKey)
-    : globalS3.bucket;
+  const bucket = physicalName
+    ?? (options.resolveBucketName
+      ? options.resolveBucketName(databaseId, bucketKey)
+      : globalS3.bucket);
   const publicUrlPrefix = storageConfig.publicUrlPrefix ?? globalS3.publicUrlPrefix;
 
   if (bucket === globalS3.bucket && publicUrlPrefix === globalS3.publicUrlPrefix) {
@@ -166,24 +168,26 @@ export function createDownloadUrlPlugin(
                             : null;
                           const resolved = config
                             ? await withPgClient(pgSettings, async (pgClient: any) => {
-                              // Look up the bucket key for scoped S3 resolution
+                              // Look up the bucket key + stored physical coordinate for scoped S3 resolution
                               let bucketKey = 'public';
+                              let physicalName: string | null = null;
                               if (bucketId) {
                                 const bucketResult = await pgClient.query({
-                                  text: `SELECT key FROM ${config.bucketsQualifiedName} WHERE id = $1 LIMIT 1`,
+                                  text: `SELECT key, physical_name FROM ${config.bucketsQualifiedName} WHERE id = $1 LIMIT 1`,
                                   values: [bucketId],
                                 });
                                 if (bucketResult.rows[0]?.key) {
                                   bucketKey = bucketResult.rows[0].key;
                                 }
+                                physicalName = bucketResult.rows[0]?.physical_name ?? null;
                               }
 
-                              return { config, databaseId, bucketKey };
+                              return { config, databaseId, bucketKey, physicalName };
                             })
                             : null;
                           if (resolved) {
                             downloadUrlExpirySeconds = resolved.config.downloadUrlExpirySeconds;
-                            s3ForDb = resolveS3ForDatabase(options, resolved.config, resolved.databaseId, resolved.bucketKey);
+                            s3ForDb = resolveS3ForDatabase(options, resolved.config, resolved.databaseId, resolved.bucketKey, resolved.physicalName);
                           }
                         }
                       } catch {

--- a/graphile/graphile-presigned-url-plugin/src/download-url-field.ts
+++ b/graphile/graphile-presigned-url-plugin/src/download-url-field.ts
@@ -26,7 +26,7 @@ import { context as grafastContext, lambda, object } from 'grafast';
 import type { GraphileConfig } from 'graphile-config';
 
 import { generatePresignedGetUrl } from './s3-signer';
-import { loadAllStorageModules, resolveStorageConfigFromCodec } from './storage-module-cache';
+import { loadAllStorageModules, resolveStorageConfigFromCodec, storedPhysicalName } from './storage-module-cache';
 import type { PresignedUrlPluginOptions, S3Config, StorageModuleConfig } from './types';
 
 const log = new Logger('graphile-presigned-url:download-url');
@@ -54,30 +54,27 @@ function resolveS3(options: PresignedUrlPluginOptions): S3Config {
 }
 
 /**
- * Build a per-database S3Config by overlaying storage_module overrides
- * onto the global S3Config. Same logic as plugin.ts resolveS3ForDatabase.
+ * Build a per-database S3Config for a *known* physical bucket. `physicalName`
+ * is required — the stored coordinate on the bucket row is the only source;
+ * no name is ever recomputed here. Same logic as plugin.ts resolveS3ForDatabase.
  */
 function resolveS3ForDatabase(
   options: PresignedUrlPluginOptions,
   storageConfig: StorageModuleConfig,
-  databaseId: string,
-  bucketKey: string,
-  physicalName: string | null,
+  physicalName: string,
 ): S3Config {
   const globalS3 = resolveS3(options);
-  const bucket = physicalName
-    ?? (options.resolveBucketName
-      ? options.resolveBucketName(databaseId, bucketKey)
-      : globalS3.bucket);
-  const publicUrlPrefix = storageConfig.publicUrlPrefix ?? globalS3.publicUrlPrefix;
+  const publicUrlPrefix = storageConfig.publicUrlPrefix != null
+    ? storageConfig.publicUrlPrefix
+    : globalS3.publicUrlPrefix;
 
-  if (bucket === globalS3.bucket && publicUrlPrefix === globalS3.publicUrlPrefix) {
+  if (physicalName === globalS3.bucket && publicUrlPrefix === globalS3.publicUrlPrefix) {
     return globalS3;
   }
 
   return {
     ...globalS3,
-    bucket,
+    bucket: physicalName,
     ...(publicUrlPrefix != null ? { publicUrlPrefix } : {}),
   };
 }
@@ -166,28 +163,24 @@ export function createDownloadUrlPlugin(
                               await withPgClient(null, (pgClient: any) => loadAllStorageModules(pgClient, databaseId)),
                             )
                             : null;
-                          const resolved = config
+                          const resolved = config && bucketId
                             ? await withPgClient(pgSettings, async (pgClient: any) => {
-                              // Look up the bucket key + stored physical coordinate for scoped S3 resolution
-                              let bucketKey = 'public';
-                              let physicalName: string | null = null;
-                              if (bucketId) {
-                                const bucketResult = await pgClient.query({
-                                  text: `SELECT key, physical_name FROM ${config.bucketsQualifiedName} WHERE id = $1 LIMIT 1`,
-                                  values: [bucketId],
-                                });
-                                if (bucketResult.rows[0]?.key) {
-                                  bucketKey = bucketResult.rows[0].key;
-                                }
-                                physicalName = bucketResult.rows[0]?.physical_name ?? null;
-                              }
-
-                              return { config, databaseId, bucketKey, physicalName };
+                              // Look up the stored physical coordinate for scoped S3 resolution
+                              const bucketResult = await pgClient.query({
+                                text: `SELECT key, physical_name FROM ${config.bucketsQualifiedName} WHERE id = $1 LIMIT 1`,
+                                values: [bucketId],
+                              });
+                              const row = bucketResult.rows[0] as { key: string; physical_name?: string | null } | undefined;
+                              return row ? { config, physicalName: storedPhysicalName(row) } : null;
                             })
                             : null;
                           if (resolved) {
+                            if (resolved.physicalName === null) {
+                              // No physical bucket was ever provisioned — no object can exist.
+                              return null;
+                            }
                             downloadUrlExpirySeconds = resolved.config.downloadUrlExpirySeconds;
-                            s3ForDb = resolveS3ForDatabase(options, resolved.config, resolved.databaseId, resolved.bucketKey, resolved.physicalName);
+                            s3ForDb = resolveS3ForDatabase(options, resolved.config, resolved.physicalName);
                           }
                         }
                       } catch {

--- a/graphile/graphile-presigned-url-plugin/src/plugin.ts
+++ b/graphile/graphile-presigned-url-plugin/src/plugin.ts
@@ -24,7 +24,7 @@ import { access, context as grafastContext, lambda, object } from 'grafast';
 import type { GraphileConfig } from 'graphile-config';
 
 import { deleteS3Object,generatePresignedPutUrl } from './s3-signer';
-import { getBucketConfig, isS3BucketProvisioned, loadAllStorageModules, markS3BucketProvisioned,resolveStorageConfigFromCodec } from './storage-module-cache';
+import { getBucketConfig, isS3BucketProvisioned, loadAllStorageModules, markS3BucketProvisioned,resolveStorageConfigFromCodec, storedPhysicalName } from './storage-module-cache';
 import type { BucketConfig,PresignedUrlPluginOptions, S3Config, StorageModuleConfig } from './types';
 
 const log = new Logger('graphile-presigned-url:plugin');
@@ -90,63 +90,73 @@ function resolveS3(options: PresignedUrlPluginOptions): S3Config {
 }
 
 /**
- * Resolve the physical S3 bucket to read/write for a logical bucket row.
+ * Mint the physical S3 bucket name for a logical bucket's first provision.
  *
- * The row's stored `physical_name` is the source of truth once set; the
- * `resolveBucketName` hook only mints a name the first time (before the
- * physical bucket has been provisioned and recorded). Passing a `physicalName`
- * of `null` means "not provisioned yet" and falls back to the naming hook.
+ * This is a naming *policy*, consulted exactly once per bucket — before the
+ * physical bucket exists. Once provisioned, the recorded `physical_name` on
+ * the row is authoritative and this function must not be consulted again.
+ */
+function mintPhysicalBucketName(
+  options: PresignedUrlPluginOptions,
+  databaseId: string,
+  bucketKey: string,
+): string {
+  if (options.resolveBucketName) {
+    return options.resolveBucketName(databaseId, bucketKey);
+  }
+  // Single-bucket deployment: the globally configured bucket is the physical bucket.
+  return resolveS3(options).bucket;
+}
+
+/**
+ * Build the S3 config for a *known* physical bucket. `physicalName` is
+ * required — callers must resolve the coordinate (stored row value, or a
+ * freshly provisioned name) before getting here. No name is ever recomputed.
  */
 function resolveS3ForDatabase(
   options: PresignedUrlPluginOptions,
   storageConfig: StorageModuleConfig,
-  databaseId: string,
-  bucketKey: string,
-  physicalName: string | null,
+  physicalName: string,
 ): S3Config {
   const globalS3 = resolveS3(options);
-  const bucket = physicalName
-    ?? (options.resolveBucketName
-      ? options.resolveBucketName(databaseId, bucketKey)
-      : globalS3.bucket);
-  const publicUrlPrefix = storageConfig.publicUrlPrefix ?? globalS3.publicUrlPrefix;
+  const publicUrlPrefix = storageConfig.publicUrlPrefix != null
+    ? storageConfig.publicUrlPrefix
+    : globalS3.publicUrlPrefix;
 
-  if (bucket === globalS3.bucket && publicUrlPrefix === globalS3.publicUrlPrefix) {
+  if (physicalName === globalS3.bucket && publicUrlPrefix === globalS3.publicUrlPrefix) {
     return globalS3;
   }
 
   return {
     ...globalS3,
-    bucket,
+    bucket: physicalName,
     ...(publicUrlPrefix != null ? { publicUrlPrefix } : {}),
   };
 }
 
 /**
- * Ensure the physical S3 bucket exists and record its name on the bucket row.
+ * First provision of a logical bucket: mint a name, create the physical S3
+ * bucket, and record the exact name on the source row. Returns the recorded
+ * physical name.
  *
- * The stored `physical_name` on the row is the durable "provisioned" marker:
- * when it is already set we assume the physical bucket exists and do nothing.
- * On first use we (idempotently) create the physical bucket, then persist the
- * exact name onto the source row so route resolution and every later read hand
- * consumers the real coordinate instead of recomputing it.
+ * Only called when the row has no `physical_name` yet. Afterwards the stored
+ * value is the durable coordinate: route resolution and every later read use
+ * it verbatim; nothing is recomputed.
  *
  * The record write runs in the system lane (`withPgClient(null, ...)`) — it is
  * server bookkeeping, not request data, and anonymous request roles cannot
  * UPDATE bucket rows under RLS. `bucket` (the cached config) is mutated in place
  * so subsequent reads observe the recorded name without a DB round-trip.
  */
-async function ensureAndRecordPhysicalBucket(
+async function provisionAndRecordPhysicalBucket(
   options: PresignedUrlPluginOptions,
   withPgClient: (pgSettings: null, cb: (client: any) => Promise<unknown>) => Promise<unknown>,
   storageConfig: StorageModuleConfig,
   databaseId: string,
   bucket: BucketConfig,
-  s3BucketName: string,
   allowedOrigins: string[] | null,
-): Promise<void> {
-  // Row already carries the physical coordinate → the physical bucket exists.
-  if (bucket.physical_name) return;
+): Promise<string> {
+  const s3BucketName = mintPhysicalBucketName(options, databaseId, bucket.key);
 
   if (options.ensureBucketProvisioned && !isS3BucketProvisioned(s3BucketName)) {
     log.info(`Lazy-provisioning S3 bucket "${s3BucketName}" for database ${databaseId}`);
@@ -167,6 +177,7 @@ async function ensureAndRecordPhysicalBucket(
   );
   bucket.physical_name = s3BucketName;
   log.info(`Recorded physical_name="${s3BucketName}" on bucket ${bucket.id}`);
+  return s3BucketName;
 }
 
 // --- Plugin factory ---
@@ -330,10 +341,12 @@ export function createPresignedUrlPlugin(
                       );
                       if (!bucket) throw new Error('BUCKET_NOT_FOUND');
 
-                      // Resolve the physical bucket (stored coordinate first), provision on
-                      // first use, and record the exact name on the source row.
-                      const s3ForDb = resolveS3ForDatabase(options, storageConfig, databaseId, bucket.key, bucket.physical_name);
-                      await ensureAndRecordPhysicalBucket(options, vals.withPgClient, storageConfig, databaseId, bucket, s3ForDb.bucket, storageConfig.allowedOrigins);
+                      // First provision mints + records the coordinate; afterwards the
+                      // stored physical_name is authoritative and nothing is recomputed.
+                      const physicalName = bucket.physical_name === null
+                        ? await provisionAndRecordPhysicalBucket(options, vals.withPgClient, storageConfig, databaseId, bucket, storageConfig.allowedOrigins)
+                        : bucket.physical_name;
+                      const s3ForDb = resolveS3ForDatabase(options, storageConfig, physicalName);
 
                       // File row INSERT under the request role (RLS enforced).
                       return vals.withPgClient(vals.pgSettings, (pgClient: any) =>
@@ -455,10 +468,12 @@ export function createPresignedUrlPlugin(
                         );
                       }
 
-                      // Resolve the physical bucket (stored coordinate first), provision on
-                      // first use, and record the exact name on the source row.
-                      const s3ForDb = resolveS3ForDatabase(options, storageConfig, databaseId, bucket.key, bucket.physical_name);
-                      await ensureAndRecordPhysicalBucket(options, vals.withPgClient, storageConfig, databaseId, bucket, s3ForDb.bucket, storageConfig.allowedOrigins);
+                      // First provision mints + records the coordinate; afterwards the
+                      // stored physical_name is authoritative and nothing is recomputed.
+                      const physicalName = bucket.physical_name === null
+                        ? await provisionAndRecordPhysicalBucket(options, vals.withPgClient, storageConfig, databaseId, bucket, storageConfig.allowedOrigins)
+                        : bucket.physical_name;
+                      const s3ForDb = resolveS3ForDatabase(options, storageConfig, physicalName);
 
                       // File row INSERTs under the request role (RLS enforced).
                       return vals.withPgClient(vals.pgSettings, (pgClient: any) =>
@@ -606,12 +621,18 @@ export function createPresignedUrlPlugin(
                         text: `SELECT key, physical_name FROM ${storageConfig.bucketsQualifiedName} WHERE id = $1 LIMIT 1`,
                         values: [fileRow!.bucket_id],
                       });
-                      const bucketKey = bucketResult.rows[0]?.key;
-                      if (!bucketKey) {
+                      const bucketRow = bucketResult.rows[0] as { key: string; physical_name?: string | null } | undefined;
+                      if (!bucketRow) {
                         log.warn(`Bucket not found for bucket_id=${fileRow!.bucket_id}; skipping S3 delete`);
                         return;
                       }
-                      const s3ForDb = resolveS3ForDatabase(options, storageConfig, databaseId, bucketKey, bucketResult.rows[0]?.physical_name ?? null);
+                      const physicalName = storedPhysicalName(bucketRow);
+                      if (physicalName === null) {
+                        // No physical bucket was ever provisioned — there is no object to delete.
+                        log.warn(`Bucket ${fileRow!.bucket_id} has no physical_name; skipping S3 delete`);
+                        return;
+                      }
+                      const s3ForDb = resolveS3ForDatabase(options, storageConfig, physicalName);
                       await deleteS3Object(s3ForDb, fileRow!.key);
                       log.info(`Sync S3 delete succeeded for key=${fileRow!.key}`);
                     });

--- a/graphile/graphile-presigned-url-plugin/src/plugin.ts
+++ b/graphile/graphile-presigned-url-plugin/src/plugin.ts
@@ -89,16 +89,26 @@ function resolveS3(options: PresignedUrlPluginOptions): S3Config {
   return options.s3;
 }
 
+/**
+ * Resolve the physical S3 bucket to read/write for a logical bucket row.
+ *
+ * The row's stored `physical_name` is the source of truth once set; the
+ * `resolveBucketName` hook only mints a name the first time (before the
+ * physical bucket has been provisioned and recorded). Passing a `physicalName`
+ * of `null` means "not provisioned yet" and falls back to the naming hook.
+ */
 function resolveS3ForDatabase(
   options: PresignedUrlPluginOptions,
   storageConfig: StorageModuleConfig,
   databaseId: string,
   bucketKey: string,
+  physicalName: string | null,
 ): S3Config {
   const globalS3 = resolveS3(options);
-  const bucket = options.resolveBucketName
-    ? options.resolveBucketName(databaseId, bucketKey)
-    : globalS3.bucket;
+  const bucket = physicalName
+    ?? (options.resolveBucketName
+      ? options.resolveBucketName(databaseId, bucketKey)
+      : globalS3.bucket);
   const publicUrlPrefix = storageConfig.publicUrlPrefix ?? globalS3.publicUrlPrefix;
 
   if (bucket === globalS3.bucket && publicUrlPrefix === globalS3.publicUrlPrefix) {
@@ -112,20 +122,51 @@ function resolveS3ForDatabase(
   };
 }
 
-async function ensureS3BucketExists(
+/**
+ * Ensure the physical S3 bucket exists and record its name on the bucket row.
+ *
+ * The stored `physical_name` on the row is the durable "provisioned" marker:
+ * when it is already set we assume the physical bucket exists and do nothing.
+ * On first use we (idempotently) create the physical bucket, then persist the
+ * exact name onto the source row so route resolution and every later read hand
+ * consumers the real coordinate instead of recomputing it.
+ *
+ * The record write runs in the system lane (`withPgClient(null, ...)`) — it is
+ * server bookkeeping, not request data, and anonymous request roles cannot
+ * UPDATE bucket rows under RLS. `bucket` (the cached config) is mutated in place
+ * so subsequent reads observe the recorded name without a DB round-trip.
+ */
+async function ensureAndRecordPhysicalBucket(
   options: PresignedUrlPluginOptions,
-  s3BucketName: string,
-  bucket: BucketConfig,
+  withPgClient: (pgSettings: null, cb: (client: any) => Promise<unknown>) => Promise<unknown>,
+  storageConfig: StorageModuleConfig,
   databaseId: string,
+  bucket: BucketConfig,
+  s3BucketName: string,
   allowedOrigins: string[] | null,
 ): Promise<void> {
-  if (!options.ensureBucketProvisioned) return;
-  if (isS3BucketProvisioned(s3BucketName)) return;
+  // Row already carries the physical coordinate → the physical bucket exists.
+  if (bucket.physical_name) return;
 
-  log.info(`Lazy-provisioning S3 bucket "${s3BucketName}" for database ${databaseId}`);
-  await options.ensureBucketProvisioned(s3BucketName, bucket.type, databaseId, allowedOrigins);
-  markS3BucketProvisioned(s3BucketName);
-  log.info(`Lazy-provisioned S3 bucket "${s3BucketName}" successfully`);
+  if (options.ensureBucketProvisioned && !isS3BucketProvisioned(s3BucketName)) {
+    log.info(`Lazy-provisioning S3 bucket "${s3BucketName}" for database ${databaseId}`);
+    await options.ensureBucketProvisioned(s3BucketName, bucket.type, databaseId, allowedOrigins);
+    markS3BucketProvisioned(s3BucketName);
+    log.info(`Lazy-provisioned S3 bucket "${s3BucketName}" successfully`);
+  }
+
+  // Record the physical coordinate on the source row. The `physical_name IS NULL`
+  // guard keeps this idempotent and race-safe across concurrent first uploads.
+  await withPgClient(null, (client: any) =>
+    client.query({
+      text: `UPDATE ${storageConfig.bucketsQualifiedName}
+             SET physical_name = $1
+             WHERE id = $2 AND physical_name IS NULL`,
+      values: [s3BucketName, bucket.id],
+    }),
+  );
+  bucket.physical_name = s3BucketName;
+  log.info(`Recorded physical_name="${s3BucketName}" on bucket ${bucket.id}`);
 }
 
 // --- Plugin factory ---
@@ -283,25 +324,29 @@ export function createPresignedUrlPlugin(
                       const storageConfig = resolveStorageConfigFromCodec(capturedFilesCodec, allConfigs);
                       if (!storageConfig) throw new Error('STORAGE_MODULE_NOT_FOUND');
 
-                      return vals.withPgClient(vals.pgSettings, async (pgClient: any) => {
-                        return pgClient.withTransaction(async (txClient: any) => {
-                          const bucket = await getBucketConfig(
-                            txClient, storageConfig, databaseId, vals.bucketKey, vals.ownerId || undefined,
-                          );
-                          if (!bucket) throw new Error('BUCKET_NOT_FOUND');
+                      // Bucket config read under the request role (RLS-gated visibility).
+                      const bucket = await vals.withPgClient(vals.pgSettings, (pgClient: any) =>
+                        getBucketConfig(pgClient, storageConfig, databaseId, vals.bucketKey, vals.ownerId || undefined),
+                      );
+                      if (!bucket) throw new Error('BUCKET_NOT_FOUND');
 
-                          const s3ForDb = resolveS3ForDatabase(options, storageConfig, databaseId, bucket.key);
-                          await ensureS3BucketExists(options, s3ForDb.bucket, bucket, databaseId, storageConfig.allowedOrigins);
+                      // Resolve the physical bucket (stored coordinate first), provision on
+                      // first use, and record the exact name on the source row.
+                      const s3ForDb = resolveS3ForDatabase(options, storageConfig, databaseId, bucket.key, bucket.physical_name);
+                      await ensureAndRecordPhysicalBucket(options, vals.withPgClient, storageConfig, databaseId, bucket, s3ForDb.bucket, storageConfig.allowedOrigins);
 
-                          return processSingleFile(options, txClient, storageConfig, databaseId, bucket, s3ForDb, {
+                      // File row INSERT under the request role (RLS enforced).
+                      return vals.withPgClient(vals.pgSettings, (pgClient: any) =>
+                        pgClient.withTransaction((txClient: any) =>
+                          processSingleFile(options, txClient, storageConfig, databaseId, bucket, s3ForDb, {
                             contentHash: vals.contentHash,
                             contentType: vals.contentType,
                             size: vals.size,
                             filename: vals.filename,
                             key: vals.customKey,
-                          });
-                        });
-                      });
+                          }),
+                        ),
+                      );
                     });
                   },
                 },
@@ -390,30 +435,34 @@ export function createPresignedUrlPlugin(
                       const storageConfig = resolveStorageConfigFromCodec(capturedFilesCodec, allConfigs);
                       if (!storageConfig) throw new Error('STORAGE_MODULE_NOT_FOUND');
 
-                      return vals.withPgClient(vals.pgSettings, async (pgClient: any) => {
-                        return pgClient.withTransaction(async (txClient: any) => {
-                          const bucket = await getBucketConfig(
-                            txClient, storageConfig, databaseId, vals.bucketKey, vals.ownerId || undefined,
-                          );
-                          if (!bucket) throw new Error('BUCKET_NOT_FOUND');
+                      // Bucket config read under the request role (RLS-gated visibility).
+                      const bucket = await vals.withPgClient(vals.pgSettings, (pgClient: any) =>
+                        getBucketConfig(pgClient, storageConfig, databaseId, vals.bucketKey, vals.ownerId || undefined),
+                      );
+                      if (!bucket) throw new Error('BUCKET_NOT_FOUND');
 
-                          // Enforce bulk upload limits
-                          const filesArray = vals.files as any[];
-                          if (filesArray.length > storageConfig.maxBulkFiles) {
-                            throw new Error(
-                              `BULK_UPLOAD_FILES_EXCEEDED: ${filesArray.length} files exceeds maximum of ${storageConfig.maxBulkFiles} per batch`,
-                            );
-                          }
-                          const totalSize = filesArray.reduce((sum: number, f: any) => sum + (f.size || 0), 0);
-                          if (totalSize > storageConfig.maxBulkTotalSize) {
-                            throw new Error(
-                              `BULK_UPLOAD_SIZE_EXCEEDED: ${totalSize} bytes exceeds maximum of ${storageConfig.maxBulkTotalSize} bytes per batch`,
-                            );
-                          }
+                      // Enforce bulk upload limits
+                      const filesArray = vals.files as any[];
+                      if (filesArray.length > storageConfig.maxBulkFiles) {
+                        throw new Error(
+                          `BULK_UPLOAD_FILES_EXCEEDED: ${filesArray.length} files exceeds maximum of ${storageConfig.maxBulkFiles} per batch`,
+                        );
+                      }
+                      const totalSize = filesArray.reduce((sum: number, f: any) => sum + (f.size || 0), 0);
+                      if (totalSize > storageConfig.maxBulkTotalSize) {
+                        throw new Error(
+                          `BULK_UPLOAD_SIZE_EXCEEDED: ${totalSize} bytes exceeds maximum of ${storageConfig.maxBulkTotalSize} bytes per batch`,
+                        );
+                      }
 
-                          const s3ForDb = resolveS3ForDatabase(options, storageConfig, databaseId, bucket.key);
-                          await ensureS3BucketExists(options, s3ForDb.bucket, bucket, databaseId, storageConfig.allowedOrigins);
+                      // Resolve the physical bucket (stored coordinate first), provision on
+                      // first use, and record the exact name on the source row.
+                      const s3ForDb = resolveS3ForDatabase(options, storageConfig, databaseId, bucket.key, bucket.physical_name);
+                      await ensureAndRecordPhysicalBucket(options, vals.withPgClient, storageConfig, databaseId, bucket, s3ForDb.bucket, storageConfig.allowedOrigins);
 
+                      // File row INSERTs under the request role (RLS enforced).
+                      return vals.withPgClient(vals.pgSettings, (pgClient: any) =>
+                        pgClient.withTransaction(async (txClient: any) => {
                           const results = [];
                           for (const file of filesArray) {
                             results.push(
@@ -427,8 +476,8 @@ export function createPresignedUrlPlugin(
                             );
                           }
                           return { files: results };
-                        });
-                      });
+                        }),
+                      );
                     });
                   },
                 },
@@ -550,10 +599,11 @@ export function createPresignedUrlPlugin(
                         return;
                       }
 
-                      // No other references — attempt sync S3 delete
-                      // Look up the bucket key for scoped S3 resolution
+                      // No other references — attempt sync S3 delete.
+                      // Read the stored physical coordinate; the object lives in the
+                      // recorded bucket, never a recomputed prefix name.
                       const bucketResult = await pgClient.query({
-                        text: `SELECT key FROM ${storageConfig.bucketsQualifiedName} WHERE id = $1 LIMIT 1`,
+                        text: `SELECT key, physical_name FROM ${storageConfig.bucketsQualifiedName} WHERE id = $1 LIMIT 1`,
                         values: [fileRow!.bucket_id],
                       });
                       const bucketKey = bucketResult.rows[0]?.key;
@@ -561,7 +611,7 @@ export function createPresignedUrlPlugin(
                         log.warn(`Bucket not found for bucket_id=${fileRow!.bucket_id}; skipping S3 delete`);
                         return;
                       }
-                      const s3ForDb = resolveS3ForDatabase(options, storageConfig, databaseId, bucketKey);
+                      const s3ForDb = resolveS3ForDatabase(options, storageConfig, databaseId, bucketKey, bucketResult.rows[0]?.physical_name ?? null);
                       await deleteS3Object(s3ForDb, fileRow!.key);
                       log.info(`Sync S3 delete succeeded for key=${fileRow!.key}`);
                     });

--- a/graphile/graphile-presigned-url-plugin/src/storage-module-cache.ts
+++ b/graphile/graphile-presigned-url-plugin/src/storage-module-cache.ts
@@ -436,11 +436,11 @@ export async function getBucketConfig(
   const hasOwner = ownerId && isEntityScoped;
   const result = await pgClient.query({
     text: hasOwner
-      ? `SELECT id, key, type, is_public, owner_id, allowed_mime_types, max_file_size, allow_custom_keys
+      ? `SELECT id, key, type, is_public, owner_id, allowed_mime_types, max_file_size, allow_custom_keys, physical_name
          FROM ${storageConfig.bucketsQualifiedName}
          WHERE key = $1 AND owner_id = $2
          LIMIT 1`
-      : `SELECT id, key, type, is_public, ${isEntityScoped ? 'owner_id,' : ''} allowed_mime_types, max_file_size, allow_custom_keys
+      : `SELECT id, key, type, is_public, ${isEntityScoped ? 'owner_id,' : ''} allowed_mime_types, max_file_size, allow_custom_keys, physical_name
          FROM ${storageConfig.bucketsQualifiedName}
          WHERE key = $1
          LIMIT 1`,
@@ -460,6 +460,7 @@ export async function getBucketConfig(
     allowed_mime_types: string[] | null;
     max_file_size: number | null;
     allow_custom_keys: boolean;
+    physical_name: string | null;
   };
 
   const config: BucketConfig = {
@@ -471,6 +472,7 @@ export async function getBucketConfig(
     allowed_mime_types: row.allowed_mime_types,
     max_file_size: row.max_file_size,
     allow_custom_keys: row.allow_custom_keys ?? false,
+    physical_name: row.physical_name ?? null,
   };
 
   bucketCache.set(cacheKey, config);

--- a/graphile/graphile-presigned-url-plugin/src/storage-module-cache.ts
+++ b/graphile/graphile-presigned-url-plugin/src/storage-module-cache.ts
@@ -403,6 +403,18 @@ const bucketCache = new LRUCache<string, BucketConfig>({
 });
 
 /**
+ * Normalize the recorded physical coordinate at the DB boundary.
+ *
+ * A bucket row either carries a recorded coordinate or it does not; SQL nulls
+ * and absent columns both mean "never provisioned". Collapsing them here is
+ * the single place that shape is interpreted — callers branch on `string`
+ * vs `null` and never coalesce a bucket name into existence.
+ */
+export function storedPhysicalName(row: { physical_name?: string | null }): string | null {
+  return row.physical_name == null ? null : row.physical_name;
+}
+
+/**
  * Resolve bucket metadata for a given database + bucket key, using the LRU cache.
  *
  * On cache miss, queries the bucket table (RLS-enforced via pgSettings on
@@ -472,7 +484,7 @@ export async function getBucketConfig(
     allowed_mime_types: row.allowed_mime_types,
     max_file_size: row.max_file_size,
     allow_custom_keys: row.allow_custom_keys ?? false,
-    physical_name: row.physical_name ?? null,
+    physical_name: storedPhysicalName(row),
   };
 
   bucketCache.set(cacheKey, config);

--- a/graphile/graphile-presigned-url-plugin/src/types.ts
+++ b/graphile/graphile-presigned-url-plugin/src/types.ts
@@ -12,6 +12,13 @@ export interface BucketConfig {
   allowed_mime_types: string[] | null;
   max_file_size: number | null;
   allow_custom_keys: boolean;
+  /**
+   * The physical S3/MinIO bucket name recorded when the physical bucket was
+   * first provisioned. NULL until the first upload provisions it. Once set,
+   * it is the source of truth for the physical bucket — reads never
+   * reconstruct the name from a prefix convention.
+   */
+  physical_name: string | null;
 }
 
 /**

--- a/graphile/graphile-settings/src/presigned-url-resolver.ts
+++ b/graphile/graphile-settings/src/presigned-url-resolver.ts
@@ -98,7 +98,14 @@ export function getPresignedUrlS3Config(): S3Config {
  */
 export function createBucketNameResolver(): BucketNameResolver {
   const { cdn } = getEnvOptions();
-  const prefix = cdn?.bucketName || 'test-bucket';
+  const prefix = cdn?.bucketName;
+
+  if (!prefix) {
+    throw new Error(
+      '[presigned-url-resolver] Missing CDN bucket name prefix. ' +
+      'Set CDN_BUCKET_NAME environment variable; there is no default bucket name.',
+    );
+  }
 
   return (databaseId: string, bucketKey: string): string => {
     return `${prefix}-${bucketKey}-${databaseId}`;

--- a/graphql/server-test/__fixtures__/seed/simple-seed-storage/schema.sql
+++ b/graphql/server-test/__fixtures__/seed/simple-seed-storage/schema.sql
@@ -27,6 +27,7 @@ BEGIN
        allowed_mime_types text[] NULL,
        max_file_size bigint NULL,
        allow_custom_keys boolean NOT NULL DEFAULT false,
+       physical_name text NULL,
        created_at timestamptz DEFAULT now(),
        updated_at timestamptz DEFAULT now(),
        UNIQUE (key)

--- a/graphql/server-test/__tests__/upload.integration.test.ts
+++ b/graphql/server-test/__tests__/upload.integration.test.ts
@@ -30,6 +30,7 @@
 
 import { hashContent, putToPresignedUrl } from '@constructive-io/upload-client';
 import path from 'path';
+import type { PgTestClient } from 'pgsql-test';
 import type supertest from 'supertest';
 
 import { getConnections, seed } from '../src';
@@ -265,6 +266,7 @@ function expectSuccess(res: supertest.Response): Record<string, any> {
 
 describe('Integration tests (uploads, tenant isolation, RLS)', () => {
   let request: supertest.Agent;
+  let pg: PgTestClient;
   let teardown: () => Promise<void>;
 
   const postGraphQL = (payload: {
@@ -310,7 +312,7 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
 
   // Single setup: one server, one pool, all three schemas registered
   beforeAll(async () => {
-    ({ request, teardown } = await getConnections(
+    ({ request, pg, teardown } = await getConnections(
       {
         schemas: [...aliceSchemas, ...bobSchemas, ...mallorySchemas],
         authRole: 'anonymous',
@@ -445,6 +447,111 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
         expect(payload.expiresAt).toBeNull();
         expect(payload.fileId).toBeTruthy();
       });
+    });
+  });
+
+  // ==========================================================================
+  // 1b. physical_name persistence (Alice)
+  //
+  // The provisioner records the exact physical S3 bucket name on the source
+  // bucket row at first-provision time; every later read uses that stored
+  // coordinate instead of recomputing it from a prefix convention.
+  // ==========================================================================
+
+  describe('physical_name persistence (Alice)', () => {
+    const aliceBucketsTable = `"${aliceSchemas[0]}".app_buckets`;
+
+    const physicalNameFor = async (key: string): Promise<string | null> => {
+      const res = await pg.query(
+        `SELECT physical_name FROM ${aliceBucketsTable} WHERE key = $1`,
+        [key]
+      );
+      return res.rows[0]?.physical_name ?? null;
+    };
+
+    // MinIO uses path-style URLs: http://host:9000/<bucket>/<key>?...
+    const bucketFromPresignedUrl = (url: string): string =>
+      new URL(url).pathname.replace(/^\/+/, '').split('/')[0];
+
+    it('records physical_name on the row after upload, matching the presigned URL bucket', async () => {
+      const fileContent = 'physical-name coordinate check';
+      const contentHash = await hashContent(fileContent);
+
+      const res = await postGraphQL({
+        query: UPLOAD_APP_FILE,
+        variables: {
+          input: {
+            bucketKey: 'public',
+            contentHash,
+            contentType: 'text/plain',
+            size: Buffer.byteLength(fileContent),
+            filename: 'physical-name-check.txt'
+          }
+        }
+      });
+      const payload = expectSuccess(res).uploadAppFile;
+      expect(payload.uploadUrl).toBeTruthy();
+
+      const stored = await physicalNameFor('public');
+      expect(stored).toBeTruthy();
+      // Matches the resolver contract: {prefix}-{bucketKey}-{databaseId}
+      expect(stored).toContain('public');
+      expect(stored).toContain(aliceDatabaseId);
+      // ...and is exactly the bucket the presigned PUT targets.
+      expect(bucketFromPresignedUrl(payload.uploadUrl)).toBe(stored);
+    });
+
+    it('does not clobber physical_name on subsequent uploads', async () => {
+      const before = await physicalNameFor('public');
+      expect(before).toBeTruthy();
+
+      const fileContent = 'second upload, same bucket';
+      const contentHash = await hashContent(fileContent);
+      const res = await postGraphQL({
+        query: UPLOAD_APP_FILE,
+        variables: {
+          input: {
+            bucketKey: 'public',
+            contentHash,
+            contentType: 'text/plain',
+            size: Buffer.byteLength(fileContent),
+            filename: 'second-upload.txt'
+          }
+        }
+      });
+      expectSuccess(res);
+
+      expect(await physicalNameFor('public')).toBe(before);
+    });
+
+    it('honors a preexisting custom physical_name verbatim (resolver never consulted)', async () => {
+      const customPhysical = 'preexisting-custom-cdn-bucket';
+      await pg.query(
+        `INSERT INTO ${aliceBucketsTable} (key, type, is_public, physical_name)
+         VALUES ($1, 'public', true, $2)`,
+        ['custom-cdn', customPhysical]
+      );
+
+      const fileContent = 'custom physical bucket check';
+      const contentHash = await hashContent(fileContent);
+      const res = await postGraphQL({
+        query: UPLOAD_APP_FILE,
+        variables: {
+          input: {
+            bucketKey: 'custom-cdn',
+            contentHash,
+            contentType: 'text/plain',
+            size: Buffer.byteLength(fileContent),
+            filename: 'custom-cdn.txt'
+          }
+        }
+      });
+      const payload = expectSuccess(res).uploadAppFile;
+
+      // The presigned URL targets the stored custom bucket, not a resolver-minted name.
+      expect(bucketFromPresignedUrl(payload.uploadUrl)).toBe(customPhysical);
+      // ...and the stored coordinate is left untouched.
+      expect(await physicalNameFor('custom-cdn')).toBe(customPhysical);
     });
   });
 

--- a/pgpm.json
+++ b/pgpm.json
@@ -3,10 +3,10 @@
     "testing/*"
   ],
   "dependencies": {
-    "@constructive-db/apps": "4.0.0",
-    "@constructive-db/catalog": "4.0.0",
-    "@constructive-db/routing": "5.0.0",
-    "@constructive-db/routing-platform": "4.0.0",
+    "@constructive-db/apps": "4.2.0",
+    "@constructive-db/catalog": "4.2.0",
+    "@constructive-db/routing": "5.2.0",
+    "@constructive-db/routing-platform": "4.2.0",
     "@pgpm/database-jobs": "0.33.1",
     "@pgpm/function-resolution": "0.33.1",
     "@pgpm/jwt-claims": "0.33.0",


### PR DESCRIPTION
## Summary

Completes the app-side half of the free-tier static-website lane: the provisioner now **records the exact physical S3/MinIO bucket name onto the source bucket row's `physical_name` column** at provision time, so route resolution (and every later read) uses the stored coordinate instead of recomputing it from a prefix convention.

Previously the physical bucket was created on first upload but its name was never persisted, so `catalog_public.buckets.physical_name` stayed `NULL` and `resolve_route()` handed the static gateway nothing → published sites 404 with "no content provisioned". The DB/catalog half already shipped in constructive-db (`@constructive-db/catalog@4.2.0` / `routing@5.2.0`); this PR writes the value.

The scoped-table column is populated here; the catalog projection is maintained downstream by the storage-module catalog-sync trigger (`copy_fields` includes `physical_name`), which propagates the late `UPDATE` to `catalog_public.buckets`.

### What changed

- **`pgpm.json`** — bump `@constructive-db/{apps,catalog}` 4.0.0→4.2.0, `routing` 5.0.0→5.2.0, `routing-platform` 4.0.0→4.2.0 (the versions carrying the `physical_name` schema).
- **graphile-presigned-url-plugin** — lazy path. `resolveS3ForDatabase(...)` now takes the stored `physicalName` and prefers it; the naming hook (`resolveBucketName`) only mints a name the first time:
  ```ts
  const bucket = physicalName ?? (resolveBucketName?.(databaseId, bucketKey) ?? globalS3.bucket);
  ```
  `ensureS3BucketExists` → `ensureAndRecordPhysicalBucket`: after (idempotently) creating the physical bucket, it persists the exact name and mutates the cached `BucketConfig`:
  ```ts
  if (bucket.physical_name) return;            // row already carries it → done
  if (ensureBucketProvisioned && !alreadyProvisioned) { await ensureBucketProvisioned(...); mark(); }
  await withPgClient(null, c => c.query({      // system lane: RLS-independent bookkeeping
    text: `UPDATE <buckets> SET physical_name = $1 WHERE id = $2 AND physical_name IS NULL`,
    values: [s3BucketName, bucket.id] }));
  bucket.physical_name = s3BucketName;
  ```
  The write runs in the **system lane** (`withPgClient(null, ...)`) — anonymous request roles cannot UPDATE bucket rows under RLS — and the `IS NULL` guard keeps it idempotent/race-safe across concurrent first uploads. Single + bulk upload paths split into: request-role bucket lookup → system-lane record → request-role file INSERT. Delete + download paths read `key, physical_name` and resolve S3 from the stored coordinate.
- **graphile-bucket-provisioner-plugin** — eager path. New `recordPhysicalName(...)` (system lane, `IS NULL`-guarded). `provisionBucketForRow`/`updateBucketCors` take `storedPhysicalName` and use it verbatim when present (`storedPhysicalName ?? resolveBucketName(...)`). Explicit `provisionBucket` and the auto-provision create hook record `result.bucketName` after a successful provision; a failed provision records nothing.
- **fixtures/tests** — `physical_name text NULL` added to the handwritten `app_buckets` fixture; real-MinIO integration coverage in `upload.integration.test.ts` (records `physical_name` matching the presigned URL bucket; stable across re-uploads; preexisting custom name honored verbatim); unit tests in the provisioner plugin (records after success, provisions stored name verbatim, no record on failure).

### Testing

- `upload.integration.test.ts` (real MinIO): 42/42 pass, incl. 3 new physical_name assertions.
- graphile-bucket-provisioner-plugin: 57/57 (3 new). graphile-presigned-url-plugin: 14/14.
- `pnpm lint` clean on touched packages; full `pnpm build` green.

Not in scope: distributed rate limiting, org attribution on catalog rows, new gateway runtime behavior.


Link to Devin session: https://app.devin.ai/sessions/a36069d7d4bc40328567bb0caa9ba250
Requested by: @pyramation