### PR TITLE
feat(storage): tenant-aware eager bucket provisioning

### DIFF
--- a/graphile/graphile-bucket-provisioner-plugin/__tests__/plugin.test.ts
+++ b/graphile/graphile-bucket-provisioner-plugin/__tests__/plugin.test.ts
@@ -122,8 +122,11 @@ function createMockPgClient(overrides: Record<string, any> = {}) {
     },
   };
 
+  // The grafast `withPgClient` client takes the `{ text, values }` object form
+  // (mirrored here), not node-pg's positional `(text, params)` args.
   return {
-    query: jest.fn((sql: string, _params?: any[]) => {
+    query: jest.fn((arg: any) => {
+      const sql: string = typeof arg === 'string' ? arg : arg.text;
       for (const [key, value] of Object.entries({ ...defaultQueries, ...overrides })) {
         if (sql.includes(key)) {
           return Promise.resolve(value);
@@ -441,13 +444,13 @@ describe('createBucketProvisionerPlugin', () => {
       expect(result.success).toBe(true);
 
       const update = pgClient.query.mock.calls.find(
-        (c: any[]) => typeof c[0] === 'string' && c[0].includes('SET physical_name'),
+        (c: any[]) => c[0]?.text?.includes('SET physical_name'),
       );
       expect(update).toBeDefined();
       // Guarded so a re-provision never clobbers an already-recorded coordinate.
-      expect(update![0]).toContain('physical_name IS NULL');
+      expect(update![0].text).toContain('physical_name IS NULL');
       // Records the exact name returned by the provisioner against the row id.
-      expect(update![1]).toEqual(['public', 'bucket-uuid-789']);
+      expect(update![0].values).toEqual(['public', 'bucket-uuid-789']);
     });
 
     it('provisions the stored physical_name verbatim when already recorded', async () => {
@@ -512,7 +515,7 @@ describe('createBucketProvisionerPlugin', () => {
 
       expect(result.success).toBe(false);
       const update = pgClient.query.mock.calls.find(
-        (c: any[]) => typeof c[0] === 'string' && c[0].includes('SET physical_name'),
+        (c: any[]) => c[0]?.text?.includes('SET physical_name'),
       );
       expect(update).toBeUndefined();
     });

--- a/graphile/graphile-bucket-provisioner-plugin/src/plugin.ts
+++ b/graphile/graphile-bucket-provisioner-plugin/src/plugin.ts
@@ -110,6 +110,22 @@ interface StorageModuleRow {
 }
 
 /**
+ * Run a query against a grafast `withPgClient` client.
+ *
+ * That client's `query` takes the `{ text, values }` object form (the same
+ * shape the presigned-url plugin uses) — NOT node-pg's positional
+ * `(text, params)` args, which surface as "A query must have either text or a
+ * name" at runtime.
+ */
+function runQuery(
+  pgClient: any,
+  text: string,
+  values?: unknown[],
+): Promise<{ rows: any[] }> {
+  return pgClient.query(values === undefined ? { text } : { text, values });
+}
+
+/**
  * Resolve the storage module for a given scope.
  * If ownerId is provided, probes entity tables to find the matching module.
  * Otherwise, returns the app-level module.
@@ -121,18 +137,19 @@ async function resolveStorageModule(
 ): Promise<StorageModuleRow | null> {
   if (!ownerId) {
     // App-level resolution
-    const result = await pgClient.query(APP_STORAGE_MODULE_QUERY, [databaseId]);
+    const result = await runQuery(pgClient, APP_STORAGE_MODULE_QUERY, [databaseId]);
     return (result.rows[0] as StorageModuleRow) ?? null;
   }
 
   // Entity-scoped: load all modules and probe entity tables
-  const result = await pgClient.query(ALL_STORAGE_MODULES_QUERY, [databaseId]);
+  const result = await runQuery(pgClient, ALL_STORAGE_MODULES_QUERY, [databaseId]);
   const modules = result.rows as StorageModuleRow[];
   const entityModules = modules.filter((m) => m.entity_schema && m.entity_table);
 
   for (const mod of entityModules) {
     const entityTable = QuoteUtils.quoteQualifiedIdentifier(mod.entity_schema!, mod.entity_table!);
-    const probe = await pgClient.query(
+    const probe = await runQuery(
+      pgClient,
       `SELECT 1 FROM ${entityTable} WHERE id = $1 LIMIT 1`,
       [ownerId],
     );
@@ -179,7 +196,8 @@ async function recordPhysicalName(
   physicalName: string,
 ): Promise<void> {
   await withPgClient(null, (client: any) =>
-    client.query(
+    runQuery(
+      client,
       `UPDATE ${bucketsTable} SET physical_name = $1 WHERE id = $2 AND physical_name IS NULL`,
       [physicalName, bucketId],
     ),
@@ -226,7 +244,8 @@ function resolveBucketName(
  * Resolve the database_id from the JWT context.
  */
 async function resolveDatabaseId(pgClient: any): Promise<string | null> {
-  const result = await pgClient.query(
+  const result = await runQuery(
+    pgClient,
     `SELECT jwt_private.current_database_id() AS id`,
   );
   return result.rows[0]?.id ?? null;
@@ -462,7 +481,8 @@ export function createBucketProvisionerPlugin(
               // Look up the bucket row (RLS enforced via pgSettings)
               const hasOwner = ownerId && storageModule.scope !== 'app';
               const bucketsTable = QuoteUtils.quoteQualifiedIdentifier(storageModule.buckets_schema, storageModule.buckets_table);
-              const bucketResult = await pgClient.query(
+              const bucketResult = await runQuery(
+                pgClient,
                 hasOwner
                   ? `SELECT id, key, type, is_public, allowed_origins, physical_name
                      FROM ${bucketsTable}
@@ -639,7 +659,8 @@ export function createBucketProvisionerPlugin(
                     const storageModule = await resolveStorageModule(pgClient, databaseId);
                     if (storageModule) {
                       const bucketsTable = QuoteUtils.quoteQualifiedIdentifier(storageModule.buckets_schema, storageModule.buckets_table);
-                      const idResult = await pgClient.query(
+                      const idResult = await runQuery(
+                        pgClient,
                         `SELECT id FROM ${bucketsTable} WHERE key = $1 LIMIT 1`,
                         [bucketInput.key],
                       );
@@ -685,7 +706,8 @@ export function createBucketProvisionerPlugin(
 
                     // Read the full bucket row (post-update) to get type + origins
                     const bucketsTable = QuoteUtils.quoteQualifiedIdentifier(storageModule.buckets_schema, storageModule.buckets_table);
-                    const bucketResult = await pgClient.query(
+                    const bucketResult = await runQuery(
+                      pgClient,
                       `SELECT id, key, type, is_public, allowed_origins, physical_name
                        FROM ${bucketsTable}
                        WHERE key = $1

--- a/graphile/graphile-settings/__tests__/constructive-preset-bucket-wiring.test.ts
+++ b/graphile/graphile-settings/__tests__/constructive-preset-bucket-wiring.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit test: ConstructivePreset wires the tenant-aware bucket-name resolver
+ * into BucketProvisionerPreset (not just into the presigned URL plugin).
+ *
+ * Regression guard for the bug where eager `provisionBucket` fell back to the
+ * bare logical bucket key because the provisioner preset was left without a
+ * resolveBucketName — diverging from the lazy first-upload path and risking
+ * cross-tenant bucket-name collisions.
+ */
+
+const captured: { bucketProvisionerOptions?: any } = {};
+
+// Capture the options handed to BucketProvisionerPreset without pulling in the
+// real plugin (and its S3 machinery).
+jest.mock('graphile-bucket-provisioner-plugin', () => ({
+  BucketProvisionerPreset: jest.fn((options: any) => {
+    captured.bucketProvisionerOptions = options;
+    return { plugins: [] as any[] };
+  }),
+}));
+
+// The preset reads CDN config eagerly when building the presigned/provisioner
+// plugin options; provide a prefix so name minting is deterministic.
+const PREFIX = 'test-bucket';
+jest.mock('@constructive-io/graphql-env', () => ({
+  getEnvOptions: jest.fn(() => ({
+    cdn: {
+      bucketName: PREFIX,
+      provider: 'minio',
+      awsRegion: 'us-east-1',
+      awsAccessKey: 'test',
+      awsSecretKey: 'test',
+      endpoint: 'http://localhost:9000',
+    },
+  })),
+}));
+
+import { createConstructivePreset } from '../src/presets/constructive-preset';
+
+const DATABASE_ID = '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9';
+
+describe('ConstructivePreset bucket-provisioner wiring', () => {
+  beforeEach(() => {
+    captured.bucketProvisionerOptions = undefined;
+  });
+
+  it('passes a resolveBucketName into BucketProvisionerPreset when presigned uploads are enabled', () => {
+    createConstructivePreset();
+
+    const options = captured.bucketProvisionerOptions;
+    expect(options).toBeDefined();
+    expect(typeof options.resolveBucketName).toBe('function');
+  });
+
+  it('the wired resolver mints the tenant-aware {prefix}-{bucketKey}-{databaseId} name', () => {
+    createConstructivePreset();
+
+    const { resolveBucketName } = captured.bucketProvisionerOptions;
+    // provisioner plugin signature: (bucketKey, databaseId)
+    expect(resolveBucketName('public', DATABASE_ID)).toBe(`${PREFIX}-public-${DATABASE_ID}`);
+    expect(resolveBucketName('private', DATABASE_ID)).toBe(`${PREFIX}-private-${DATABASE_ID}`);
+  });
+
+  it('does not wire the provisioner preset when presigned uploads are disabled', () => {
+    createConstructivePreset({ enablePresignedUploads: false });
+    expect(captured.bucketProvisionerOptions).toBeUndefined();
+  });
+});

--- a/graphile/graphile-settings/__tests__/presigned-url-resolver.test.ts
+++ b/graphile/graphile-settings/__tests__/presigned-url-resolver.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for the bucket-name resolvers.
+ *
+ * The presigned (lazy) upload path and the bucket-provisioner (eager) path
+ * must mint the *same* physical S3 bucket name for a given (database, bucket
+ * key) pair — `{prefix}-{bucketKey}-{databaseId}` — so a bucket's physical
+ * coordinate is identical regardless of which path first provisions it.
+ *
+ * The two plugins declare their resolver with opposite argument order, so the
+ * equality below also guards against re-introducing an argument-order bug.
+ */
+
+interface CdnOptions {
+  bucketName?: string;
+}
+
+async function loadResolverModule(cdn: CdnOptions | undefined) {
+  jest.resetModules();
+
+  jest.doMock('@constructive-io/graphql-env', () => ({
+    getEnvOptions: jest.fn(() => ({ cdn })),
+  }));
+
+  return import('../src/presigned-url-resolver');
+}
+
+const PREFIX = 'test-bucket';
+const DATABASE_ID = '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9';
+
+describe('bucket-name resolvers', () => {
+  it('presigned resolver mints {prefix}-{bucketKey}-{databaseId}', async () => {
+    const { createBucketNameResolver } = await loadResolverModule({ bucketName: PREFIX });
+    const resolve = createBucketNameResolver();
+
+    // presigned plugin signature: (databaseId, bucketKey)
+    expect(resolve(DATABASE_ID, 'public')).toBe(`${PREFIX}-public-${DATABASE_ID}`);
+    expect(resolve(DATABASE_ID, 'private')).toBe(`${PREFIX}-private-${DATABASE_ID}`);
+  });
+
+  it('provisioner resolver mints the identical name despite opposite arg order', async () => {
+    const { createBucketNameResolver, createProvisionerBucketNameResolver } =
+      await loadResolverModule({ bucketName: PREFIX });
+
+    const presigned = createBucketNameResolver();
+    const provisioner = createProvisionerBucketNameResolver();
+
+    for (const key of ['public', 'private', 'temp', 'custom-cdn']) {
+      // presigned: (databaseId, bucketKey) — provisioner: (bucketKey, databaseId)
+      expect(provisioner(key, DATABASE_ID)).toBe(presigned(DATABASE_ID, key));
+      expect(provisioner(key, DATABASE_ID)).toBe(`${PREFIX}-${key}-${DATABASE_ID}`);
+    }
+  });
+
+  it('presigned resolver throws (no default bucket name) when the prefix is missing', async () => {
+    const { createBucketNameResolver } = await loadResolverModule({});
+    expect(() => createBucketNameResolver()).toThrow(/CDN_BUCKET_NAME/);
+  });
+
+  it('provisioner resolver throws (no default bucket name) when the prefix is missing', async () => {
+    const { createProvisionerBucketNameResolver } = await loadResolverModule({});
+    expect(() => createProvisionerBucketNameResolver()).toThrow(/CDN_BUCKET_NAME/);
+  });
+
+  it('both resolvers throw when CDN config is entirely absent', async () => {
+    const { createBucketNameResolver, createProvisionerBucketNameResolver } =
+      await loadResolverModule(undefined);
+    expect(() => createBucketNameResolver()).toThrow(/CDN_BUCKET_NAME/);
+    expect(() => createProvisionerBucketNameResolver()).toThrow(/CDN_BUCKET_NAME/);
+  });
+});

--- a/graphile/graphile-settings/src/presets/constructive-preset.ts
+++ b/graphile/graphile-settings/src/presets/constructive-preset.ts
@@ -26,7 +26,7 @@ import {
   PgTypeMappingsPreset,
   RequiredInputPreset
 } from '../plugins';
-import { createBucketNameResolver, createEnsureBucketProvisioned, getAllowedOrigins,getPresignedUrlS3Config } from '../presigned-url-resolver';
+import { createBucketNameResolver, createEnsureBucketProvisioned, createProvisionerBucketNameResolver, getAllowedOrigins,getPresignedUrlS3Config } from '../presigned-url-resolver';
 import { constructiveUploadFieldDefinitions } from '../upload-resolver';
 
 /**
@@ -206,7 +206,12 @@ export function createConstructivePreset(
       }),
       BucketProvisionerPreset({
         connection: getBucketProvisionerConnection,
-        allowedOrigins: getAllowedOrigins()
+        allowedOrigins: getAllowedOrigins(),
+        // Same tenant-aware naming policy as the presigned (lazy) path, so the
+        // eager provisionBucket mutation mints the identical physical name
+        // (`{prefix}-{bucketKey}-{databaseId}`) instead of falling back to the
+        // bare logical bucket key.
+        resolveBucketName: createProvisionerBucketNameResolver()
       })
     );
   }

--- a/graphile/graphile-settings/src/presigned-url-resolver.ts
+++ b/graphile/graphile-settings/src/presigned-url-resolver.ts
@@ -15,6 +15,7 @@ import { BucketProvisioner } from '@constructive-io/bucket-provisioner';
 import { getEnvOptions } from '@constructive-io/graphql-env';
 import { createS3Client } from '@constructive-io/s3-utils';
 import { Logger } from '@pgpmjs/logger';
+import type { BucketNameResolver as ProvisionerBucketNameResolver } from 'graphile-bucket-provisioner-plugin';
 import type { BucketNameResolver, EnsureBucketProvisioned,S3Config } from 'graphile-presigned-url-plugin';
 
 import { getBucketProvisionerConnection } from './bucket-provisioner-resolver';
@@ -87,16 +88,12 @@ export function getPresignedUrlS3Config(): S3Config {
 }
 
 /**
- * Create a per-(database, bucketKey) bucket name resolver.
+ * Read the configured physical-bucket-name prefix (CDN_BUCKET_NAME).
  *
- * Uses the BUCKET_NAME env var as a prefix. For each (database, bucketKey)
- * pair, the S3 bucket name becomes `{prefix}-{bucketKey}-{databaseId}`
- * (e.g., "myapp-public-abc123def456").
- *
- * This aligns with the bucket provisioner plugin which creates separate
- * S3 buckets per logical bucket key.
+ * There is no default: a missing prefix throws, mirroring
+ * getPresignedUrlS3Config, so an untenanted bucket name can never be minted.
  */
-export function createBucketNameResolver(): BucketNameResolver {
+function getBucketNamePrefix(): string {
   const { cdn } = getEnvOptions();
   const prefix = cdn?.bucketName;
 
@@ -107,9 +104,48 @@ export function createBucketNameResolver(): BucketNameResolver {
     );
   }
 
-  return (databaseId: string, bucketKey: string): string => {
-    return `${prefix}-${bucketKey}-${databaseId}`;
-  };
+  return prefix;
+}
+
+/**
+ * The single physical-bucket naming policy: `{prefix}-{bucketKey}-{databaseId}`
+ * (e.g., "myapp-public-abc123def456"). Both the presigned-upload (lazy) path
+ * and the bucket-provisioner (eager) path derive names from this one function
+ * so a bucket's physical name is identical regardless of which path mints it.
+ */
+function mintPhysicalBucketName(prefix: string, databaseId: string, bucketKey: string): string {
+  return `${prefix}-${bucketKey}-${databaseId}`;
+}
+
+/**
+ * Create a per-(database, bucketKey) bucket name resolver for the presigned
+ * URL plugin (argument order: `(databaseId, bucketKey)`).
+ *
+ * Uses CDN_BUCKET_NAME as a prefix. For each (database, bucketKey) pair, the
+ * S3 bucket name becomes `{prefix}-{bucketKey}-{databaseId}`.
+ *
+ * This aligns with the bucket provisioner plugin which creates separate
+ * S3 buckets per logical bucket key.
+ */
+export function createBucketNameResolver(): BucketNameResolver {
+  const prefix = getBucketNamePrefix();
+  return (databaseId: string, bucketKey: string): string =>
+    mintPhysicalBucketName(prefix, databaseId, bucketKey);
+}
+
+/**
+ * Create the bucket name resolver for the bucket provisioner plugin
+ * (argument order: `(bucketKey, databaseId)`).
+ *
+ * Produces the exact same physical name as createBucketNameResolver()
+ * (`{prefix}-{bucketKey}-{databaseId}`) so the eager `provisionBucket`
+ * mutation mints the identical tenant-aware name that the lazy first-upload
+ * path would. Throws on a missing prefix — no default bucket name.
+ */
+export function createProvisionerBucketNameResolver(): ProvisionerBucketNameResolver {
+  const prefix = getBucketNamePrefix();
+  return (bucketKey: string, databaseId: string): string =>
+    mintPhysicalBucketName(prefix, databaseId, bucketKey);
 }
 
 /**

--- a/graphql/server-test/__fixtures__/seed/simple-seed-storage/schema.sql
+++ b/graphql/server-test/__fixtures__/seed/simple-seed-storage/schema.sql
@@ -27,6 +27,7 @@ BEGIN
        allowed_mime_types text[] NULL,
        max_file_size bigint NULL,
        allow_custom_keys boolean NOT NULL DEFAULT false,
+       allowed_origins text[] NULL,
        physical_name text NULL,
        created_at timestamptz DEFAULT now(),
        updated_at timestamptz DEFAULT now(),

--- a/graphql/server-test/__tests__/upload.integration.test.ts
+++ b/graphql/server-test/__tests__/upload.integration.test.ts
@@ -96,6 +96,18 @@ const UPLOAD_APP_FILE = `
   }
 `;
 
+const PROVISION_BUCKET = `
+  mutation ProvisionBucket($input: ProvisionBucketInput!) {
+    provisionBucket(input: $input) {
+      success
+      bucketName
+      accessType
+      provider
+      error
+    }
+  }
+`;
+
 const APP_FILES = `
   query AppFiles {
     appFiles {
@@ -552,6 +564,113 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
       expect(bucketFromPresignedUrl(payload.uploadUrl)).toBe(customPhysical);
       // ...and the stored coordinate is left untouched.
       expect(await physicalNameFor('custom-cdn')).toBe(customPhysical);
+    });
+  });
+
+  // ==========================================================================
+  // 1c. Eager provisioning via the provisionBucket mutation (Alice)
+  //
+  // The explicit provisionBucket mutation must mint the SAME tenant-aware
+  // physical name the lazy first-upload path would (`{prefix}-{key}-{db}`) and
+  // persist it on the bucket row — never the bare logical key. This is the
+  // regression guard for BucketProvisionerPreset being wired without a
+  // resolveBucketName.
+  // ==========================================================================
+
+  describe('Eager provisioning via provisionBucket (Alice)', () => {
+    const aliceBucketsTable = `"${aliceSchemas[0]}".app_buckets`;
+
+    const physicalNameFor = async (key: string): Promise<string | null> => {
+      const res = await pg.query(
+        `SELECT physical_name FROM ${aliceBucketsTable} WHERE key = $1`,
+        [key]
+      );
+      return res.rows[0]?.physical_name ?? null;
+    };
+
+    // MinIO uses path-style URLs: http://host:9000/<bucket>/<key>?...
+    const bucketFromPresignedUrl = (url: string): string =>
+      new URL(url).pathname.replace(/^\/+/, '').split('/')[0];
+
+    // Seed a fresh, never-provisioned bucket row (physical_name IS NULL).
+    const seedBucket = async (key: string): Promise<void> => {
+      await pg.query(
+        `INSERT INTO ${aliceBucketsTable} (key, type, is_public) VALUES ($1, 'public', true)`,
+        [key]
+      );
+    };
+
+    it('mints {prefix}-{key}-{databaseId} and records it, matching what the lazy path would mint', async () => {
+      // 1. Derive the naming prefix from a bucket the LAZY path provisions.
+      const lazyKey = 'eager-lazy';
+      await seedBucket(lazyKey);
+      const lazyRes = await postGraphQL({
+        query: UPLOAD_APP_FILE,
+        variables: {
+          input: {
+            bucketKey: lazyKey,
+            contentHash: await hashContent('eager-lazy-probe'),
+            contentType: 'text/plain',
+            size: 16,
+            filename: 'eager-lazy.txt'
+          }
+        }
+      });
+      const lazyUrl = expectSuccess(lazyRes).uploadAppFile.uploadUrl;
+      expect(lazyUrl).toBeTruthy();
+      const lazyPhysical = await physicalNameFor(lazyKey);
+      expect(lazyPhysical).toBeTruthy();
+      // The lazy path records the exact bucket the presigned PUT targets.
+      expect(bucketFromPresignedUrl(lazyUrl)).toBe(lazyPhysical);
+
+      // The shared convention: {prefix}-{key}-{databaseId}.
+      const suffix = `-${lazyKey}-${aliceDatabaseId}`;
+      expect(lazyPhysical!.endsWith(suffix)).toBe(true);
+      const prefix = lazyPhysical!.slice(0, -suffix.length);
+      expect(prefix.length).toBeGreaterThan(0);
+
+      // 2. EAGER path: a fresh bucket row, provisioned via the mutation.
+      const eagerKey = 'eager-prov';
+      await seedBucket(eagerKey);
+      expect(await physicalNameFor(eagerKey)).toBeNull();
+
+      const provRes = await postGraphQL({
+        query: PROVISION_BUCKET,
+        variables: { input: { bucketKey: eagerKey } }
+      });
+      const payload = expectSuccess(provRes).provisionBucket;
+      expect(payload.error).toBeNull();
+      expect(payload.success).toBe(true);
+
+      const expected = `${prefix}-${eagerKey}-${aliceDatabaseId}`;
+      // Eager mints the tenant-aware name — NOT the bare logical key.
+      expect(payload.bucketName).toBe(expected);
+      expect(payload.bucketName).not.toBe(eagerKey);
+      // ...and persists it on the row (physical_name IS NULL-guarded record).
+      expect(await physicalNameFor(eagerKey)).toBe(expected);
+    });
+
+    it('does not clobber a physical_name recorded by a prior provision', async () => {
+      const key = 'eager-idem';
+      await seedBucket(key);
+
+      const firstRes = await postGraphQL({
+        query: PROVISION_BUCKET,
+        variables: { input: { bucketKey: key } }
+      });
+      const firstPayload = expectSuccess(firstRes).provisionBucket;
+      expect(firstPayload.success).toBe(true);
+      const recorded = await physicalNameFor(key);
+      expect(recorded).toBe(firstPayload.bucketName);
+
+      const secondRes = await postGraphQL({
+        query: PROVISION_BUCKET,
+        variables: { input: { bucketKey: key } }
+      });
+      const secondPayload = expectSuccess(secondRes).provisionBucket;
+      expect(secondPayload.success).toBe(true);
+      // The stored coordinate is authoritative and left untouched.
+      expect(await physicalNameFor(key)).toBe(recorded);
     });
   });
 


### PR DESCRIPTION
## Summary

`ConstructivePreset` wired the tenant-aware bucket-name resolver (`{CDN_BUCKET_NAME prefix}-{bucketKey}-{databaseId}`) into `PresignedUrlPreset` (the lazy first-upload path) but **not** into `BucketProvisionerPreset`. So the eager `provisionBucket` mutation fell back to the bare logical bucket key as the physical S3 name — untenanted, divergent from the lazy path, and collision-prone across tenants.

This wires the same naming policy into `BucketProvisionerPreset`, so eager provisioning mints the **identical** physical name the lazy path would and persists it to the bucket row's `physical_name` (write happens only after `CreateBucket` succeeds, guarded by the existing `physical_name IS NULL` record). No default/nullish-coalescing fallback: a missing prefix throws, matching `getPresignedUrlS3Config`.

```ts
// graphile-settings/src/presigned-url-resolver.ts — one naming policy, two arg orders
function mintPhysicalBucketName(prefix, databaseId, bucketKey) {
  return `${prefix}-${bucketKey}-${databaseId}`;
}
createBucketNameResolver()            // presigned:   (databaseId, bucketKey) => ...
createProvisionerBucketNameResolver() // provisioner: (bucketKey, databaseId) => ...  // same output

// constructive-preset.ts
BucketProvisionerPreset({
  connection: getBucketProvisionerConnection,
  allowedOrigins: getAllowedOrigins(),
+ resolveBucketName: createProvisionerBucketNameResolver()
})
```

### Also fixed: `provisionBucket` never actually ran

While adding the required real-MinIO integration test, the eager mutation surfaced `Error: A query must have either text or a name`. The provisioner plugin issued queries with node-pg's positional `query(text, params)` form, but the grafast `withPgClient` client (as used by the working presigned plugin) requires the `{ text, values }` object form. Every query in the mutation/auto-provision/CORS paths threw before naming ever happened. Routed all of them through a small `runQuery(pgClient, text, values?)` helper.

```diff
- pgClient.query(APP_STORAGE_MODULE_QUERY, [databaseId])
+ runQuery(pgClient, APP_STORAGE_MODULE_QUERY, [databaseId])   // -> query({ text, values })
```

The provisioner unit-test mock encoded the old positional contract (`query(sql, params)`), which is exactly why the bug went uncaught; updated the mock + two assertions to the real object-form contract.

## Tests

- **`graphile-settings` (unit):** `presigned-url-resolver.test.ts` proves the presigned and provisioner resolvers emit byte-identical names despite opposite arg order and both throw on a missing prefix; `constructive-preset-bucket-wiring.test.ts` asserts `BucketProvisionerPreset` receives a `resolveBucketName` minting `{prefix}-{key}-{db}` (and none when presigned uploads are disabled).
- **`graphql-server-test` (real MinIO):** new "Eager provisioning via `provisionBucket`" block asserts the mutation records a `physical_name` of `{prefix}-{key}-{databaseId}`, identical to what the lazy path mints for a sibling key, never the bare key, and is idempotent (`physical_name IS NULL` guard).
- The upload fixture's `app_buckets` was missing `allowed_origins` (part of the storage-bucket CORS contract the provisioner reads); added the nullable column so the fixture matches the real schema.

Full suites green: provisioner plugin (57), presigned plugin (14), graphile-settings (81), upload integration (44). Per-package lint clean (0 errors).


Link to Devin session: https://app.devin.ai/sessions/a67469461ede403dae44c74652563df3
Requested by: @pyramation