### PR TITLE
feat(storage): make bucket provisioning lazy by default (autoProvision: false)

### DIFF
--- a/graphile/graphile-settings/__tests__/constructive-preset-bucket-wiring.test.ts
+++ b/graphile/graphile-settings/__tests__/constructive-preset-bucket-wiring.test.ts
@@ -61,6 +61,11 @@ describe('ConstructivePreset bucket-provisioner wiring', () => {
     expect(resolveBucketName('private', DATABASE_ID)).toBe(`${PREFIX}-private-${DATABASE_ID}`);
   });
 
+  it('disables auto-provision-on-create so buckets are minted lazily / explicitly', () => {
+    createConstructivePreset();
+    expect(captured.bucketProvisionerOptions.autoProvision).toBe(false);
+  });
+
   it('does not wire the provisioner preset when presigned uploads are disabled', () => {
     createConstructivePreset({ enablePresignedUploads: false });
     expect(captured.bucketProvisionerOptions).toBeUndefined();

--- a/graphile/graphile-settings/src/presets/constructive-preset.ts
+++ b/graphile/graphile-settings/src/presets/constructive-preset.ts
@@ -211,7 +211,12 @@ export function createConstructivePreset(
         // eager provisionBucket mutation mints the identical physical name
         // (`{prefix}-{bucketKey}-{databaseId}`) instead of falling back to the
         // bare logical bucket key.
-        resolveBucketName: createProvisionerBucketNameResolver()
+        resolveBucketName: createProvisionerBucketNameResolver(),
+        // S3 buckets are provisioned lazily (on first upload) or explicitly via
+        // the provisionBucket mutation. Disable the auto-provision-on-create
+        // hook so a createBucket GraphQL mutation records the row without
+        // eagerly minting an S3 bucket that may never receive an upload.
+        autoProvision: false
       })
     );
   }

--- a/graphql/server-test/__tests__/upload.integration.test.ts
+++ b/graphql/server-test/__tests__/upload.integration.test.ts
@@ -675,6 +675,69 @@ describe('Integration tests (uploads, tenant isolation, RLS)', () => {
   });
 
   // ==========================================================================
+  // 1d. Auto-provision-on-create is disabled (Alice)
+  //
+  // ConstructivePreset wires BucketProvisionerPreset with autoProvision:false,
+  // so creating a bucket row via the createAppBucket GraphQL mutation records
+  // the row WITHOUT eagerly minting an S3 bucket. Buckets are provisioned only
+  // lazily (first upload) or explicitly (provisionBucket) — no empty-bucket
+  // sprawl on every create call.
+  // ==========================================================================
+
+  describe('Auto-provision on bucket create is disabled (Alice)', () => {
+    const aliceBucketsTable = `"${aliceSchemas[0]}".app_buckets`;
+
+    const physicalNameFor = async (key: string): Promise<string | null> => {
+      const res = await pg.query(
+        `SELECT physical_name FROM ${aliceBucketsTable} WHERE key = $1`,
+        [key]
+      );
+      return res.rows[0]?.physical_name ?? null;
+    };
+
+    const bucketFromPresignedUrl = (url: string): string =>
+      new URL(url).pathname.replace(/^\/+/, '').split('/')[0];
+
+    it('createAppBucket records the row without minting an S3 bucket; first upload provisions lazily', async () => {
+      const key = 'no-eager';
+
+      // Create the bucket ROW via the GraphQL mutation.
+      const createRes = await postGraphQL({
+        query: CREATE_APP_BUCKET,
+        variables: {
+          input: { appBucket: { key, type: 'public', isPublic: true } }
+        }
+      });
+      const created = expectSuccess(createRes).createAppBucket.appBucket;
+      expect(created.key).toBe(key);
+
+      // autoProvision:false => the create hook never runs, so no S3 bucket is
+      // minted and nothing is recorded on the row.
+      expect(await physicalNameFor(key)).toBeNull();
+
+      // The lazy path still provisions the bucket on first upload.
+      const uploadRes = await postGraphQL({
+        query: UPLOAD_APP_FILE,
+        variables: {
+          input: {
+            bucketKey: key,
+            contentHash: await hashContent('no-eager-probe'),
+            contentType: 'text/plain',
+            size: 14,
+            filename: 'no-eager.txt'
+          }
+        }
+      });
+      const uploadUrl = expectSuccess(uploadRes).uploadAppFile.uploadUrl;
+      const physical = await physicalNameFor(key);
+      expect(physical).toBeTruthy();
+      // Lazy mints the same tenant-aware name the presigned PUT targets.
+      expect(bucketFromPresignedUrl(uploadUrl)).toBe(physical);
+      expect(physical!.endsWith(`-${key}-${aliceDatabaseId}`)).toBe(true);
+    });
+  });
+
+  // ==========================================================================
   // 2. Feature flag gating via database_settings / api_settings
   // ==========================================================================
 


### PR DESCRIPTION
## Summary

Follow-up to #1589. Today an S3 bucket can be minted three ways: **lazy** (first presigned upload), **explicit** (`provisionBucket` mutation), and **auto-provision-on-create** — a hook that wraps `create*` mutations on `@storageBuckets` tables and provisions the S3 bucket right after the row commits. That hook (`autoProvision`, default `true`) was left on in `ConstructivePreset`, so **every `createAppBucket` GraphQL call eagerly hit S3**, even for buckets that never receive an upload.

This disables it, unifying on **lazy as the sole automatic trigger + explicit `provisionBucket` for deliberate pre-creation**:

```diff
 BucketProvisionerPreset({
   connection: getBucketProvisionerConnection,
   allowedOrigins: getAllowedOrigins(),
   resolveBucketName: createProvisionerBucketNameResolver(),
+  autoProvision: false
 })
```

Why: the auto-provision hook is redundant (it calls the same `BucketProvisioner.provision()` the lazy path does, just earlier) and has worse tradeoffs — empty-bucket sprawl on every create, create-mutation latency/success coupled to S3 reachability, and a committed row whose S3 bucket may not exist if provisioning throws (the hook only logs). Note this only affects the **GraphQL create** path; a raw SQL `INSERT` was always lazy since the hook is a resolver wrapper, not a DB trigger.

`provisionBucket` and the tenant-aware naming from #1589 are unchanged.

## Tests

- **Unit** (`constructive-preset-bucket-wiring.test.ts`): asserts `BucketProvisionerPreset` receives `autoProvision: false`.
- **Integration, real MinIO** (`upload.integration.test.ts`): `createAppBucket` records the row with `physical_name` still `NULL` (no S3 bucket minted), then a first `uploadAppFile` provisions it lazily to the tenant-aware `{prefix}-{key}-{databaseId}` name matching the presigned PUT target.

Full upload suite green (45), graphile-settings unit green; per-package lint 0 errors.


Link to Devin session: https://app.devin.ai/sessions/a67469461ede403dae44c74652563df3
Requested by: @pyramation