### PR TITLE
feat(safegres): collect access-path signals behind X1, reported not acted on

### DIFF
--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -172,15 +172,30 @@ Every check is pure catalog + AST analysis: deterministic, workload-free, and sa
 
 X7 exists because the column type *is* the API declaration: `graphile-search` exposes a full-text filter for every `tsvector` column and a similarity search for every `vector` column, purely from the codec — so an unindexed one is a first-class API field backed by a sequential scan plus a per-row match or distance computation. BM25 and pg_trgm are deliberately not checked: those adapters are discovered *from* their indexes, so a missing index means the feature was never exposed. X8 is the one heuristic in the set — any column is orderable over a connection, but timestamps are what feeds are actually sorted and keyset-paginated by — so it defaults to `info`, contributes 0 to the score, and is meant to be read, not gated on (`perf.rules: { "X8": "off" }` to silence it). Trailing-position and partial indexes don't count for either rule: neither can serve the sort or the search on its own.
 
-### Access paths: which foreign keys X1 applies to
+### Access paths: the evidence behind X1
 
 X1 is right about the mechanics — a `DELETE` on the parent really does scan the child — but it assumes the child is a relation somebody traverses. On a provisioning-config table, one whose keys are written once at setup and never looked rows up by, the index it asks for is a write on every insert in exchange for speeding up a scan of one row. Acting on X1 across such a schema makes the database measurably worse while the grade goes up.
 
 The tempting gate, `pg_class.reltuples`, doesn't work here: safegres grades an ephemeral CI database that has never held data, so every row estimate is 0 at exactly the moment it grades. And row count is the wrong question anyway — a huge append-only log nobody joins on wants no FK index, while a tiny lookup table every request hits does. The property that matters is whether anything reads the key, which is structural, so it survives an empty database.
 
-So before running X1, safegres classifies every foreign key. A **write-once pointer** is a key whose every column has a constant default (`uuid_nil()`, a literal) and whose column names appear in no RLS policy predicate and no view body anywhere in the database — a `NOT NULL` key that starts life pointing at the nil UUID is a slot a provisioner fills in, not something rows are found by. A table with two or more of them is a **config record**, and on one, every key nothing reads is exempt from X1. The count of exempted keys is reported in `report.perf.paths` and printed with the findings, so the suppression is never silent.
+So safegres collects **signals** about every foreign key, each pointing one way and saying why, and reports them on the finding (`context.pathSignals`) and in aggregate (`report.perf.paths`):
 
-The tenant key needs no special case: `database_id` appears in essentially every RLS policy, so the policy check keeps it hot on its own. Turn the whole thing off with `perf.paths.infer: false`, or demand more pointers before a table counts with `perf.paths.minPointers`.
+| Signal | Direction | Fires when |
+| --- | --- | --- |
+| `policy-read` | read | an RLS policy predicate names one of the key's columns |
+| `view-read` | read | a view or materialized view names one of them |
+| `write-once-pointer` | shape | every column of the key has a constant default (`uuid_nil()`, a literal) |
+| `config-record` | shape | the table carries two or more write-once pointers (`perf.paths.minPointers`) |
+
+A **read** signal is decisive — the database itself traverses the column, so the key is a query path and X1 applies as written. That is what keeps the tenant key out of trouble with no special case: `database_id` appears in essentially every policy. A **shape** signal is not: a `NOT NULL` key defaulting to the nil UUID looks like a slot a provisioner fills in, but a generated API can expose a reverse relation over any foreign key regardless of how its default is written, and if it does, the index is wanted after all.
+
+So by default the shape **changes nothing** — no finding is removed, no severity moves, no score shifts. What it does is tell you where to look, and `perf.paths.onWriteOncePointer` decides what X1 does about it:
+
+- `report` (default) — the finding stands, with the signals attached to it;
+- `demote` — write-once-shaped keys drop to `info`, so they are read rather than gated on and contribute nothing to the score;
+- `suppress` — no finding. Only defensible once you know the generated API does not expose these relations; a shape is not a proof.
+
+The signal that *would* settle it is the one that isn't here yet: whether the generated GraphQL surface still contains the field. It slots in as another signal, and only then does "nothing can reach this key" become a conclusion anything should act on. `perf.paths.infer: false` skips the collection entirely.
 
 X2–X4 and X9 are the checks a generic index linter can't make, because they read the policy predicate. RLS quals are evaluated *before* user quals, on every candidate row, for every caller — so an unindexed or cast-wrapped policy column is a whole-table tax rather than a slow query. X2 requires the policy column to be the *leading* column of some index (a trailing position can't serve the qual alone); X3 looks for an expression index matching the exact wrapped shape; X4 skips built-ins, whose leakproofness is a property of the server rather than a schema choice.
 
@@ -204,7 +219,7 @@ safegres audit --database mydb --perf --fail-on-perf-grade B
     "enabled": true,
     "rules": { "X6": "off" },          // perf-dimension codes only
     "ignore": ["app_public.audit_*"],  // declared-intentional perf debt
-    "paths": { "infer": true },        // X1 skips keys nothing reads (default)
+    "paths": { "onWriteOncePointer": "report" }, // signals are reported, not acted on (default)
     "scoring": { "densityK": 0.17 }
   },
   "failOn": { "perfGrade": "B" }

--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -154,6 +154,16 @@ Every check is pure catalog + AST analysis: deterministic, workload-free, and sa
 
 X7 exists because the column type *is* the API declaration: `graphile-search` exposes a full-text filter for every `tsvector` column and a similarity search for every `vector` column, purely from the codec — so an unindexed one is a first-class API field backed by a sequential scan plus a per-row match or distance computation. BM25 and pg_trgm are deliberately not checked: those adapters are discovered *from* their indexes, so a missing index means the feature was never exposed. X8 is the one heuristic in the set — any column is orderable over a connection, but timestamps are what feeds are actually sorted and keyset-paginated by — so it defaults to `info`, contributes 0 to the score, and is meant to be read, not gated on (`perf.rules: { "X8": "off" }` to silence it). Trailing-position and partial indexes don't count for either rule: neither can serve the sort or the search on its own.
 
+### Access paths: which foreign keys X1 applies to
+
+X1 is right about the mechanics — a `DELETE` on the parent really does scan the child — but it assumes the child is a relation somebody traverses. On a provisioning-config table, one whose keys are written once at setup and never looked rows up by, the index it asks for is a write on every insert in exchange for speeding up a scan of one row. Acting on X1 across such a schema makes the database measurably worse while the grade goes up.
+
+The tempting gate, `pg_class.reltuples`, doesn't work here: safegres grades an ephemeral CI database that has never held data, so every row estimate is 0 at exactly the moment it grades. And row count is the wrong question anyway — a huge append-only log nobody joins on wants no FK index, while a tiny lookup table every request hits does. The property that matters is whether anything reads the key, which is structural, so it survives an empty database.
+
+So before running X1, safegres classifies every foreign key. A **write-once pointer** is a key whose every column has a constant default (`uuid_nil()`, a literal) and whose column names appear in no RLS policy predicate and no view body anywhere in the database — a `NOT NULL` key that starts life pointing at the nil UUID is a slot a provisioner fills in, not something rows are found by. A table with two or more of them is a **config record**, and on one, every key nothing reads is exempt from X1. The count of exempted keys is reported in `report.perf.paths` and printed with the findings, so the suppression is never silent.
+
+The tenant key needs no special case: `database_id` appears in essentially every RLS policy, so the policy check keeps it hot on its own. Turn the whole thing off with `perf.paths.infer: false`, or demand more pointers before a table counts with `perf.paths.minPointers`.
+
 X2–X4 are the checks a generic index linter can't make, because they read the policy predicate. RLS quals are evaluated *before* user quals, on every candidate row, for every caller — so an unindexed or cast-wrapped policy column is a whole-table tax rather than a slow query. X2 requires the policy column to be the *leading* column of some index (a trailing position can't serve the qual alone); X3 looks for an expression index matching the exact wrapped shape; X4 skips built-ins, whose leakproofness is a property of the server rather than a schema choice.
 
 ```bash
@@ -167,6 +177,7 @@ safegres audit --database mydb --perf --fail-on-perf-grade B
     "enabled": true,
     "rules": { "X6": "off" },          // perf-dimension codes only
     "ignore": ["app_public.audit_*"],  // declared-intentional perf debt
+    "paths": { "infer": true },        // X1 skips keys nothing reads (default)
     "scoring": { "densityK": 0.17 }
   },
   "failOn": { "perfGrade": "B" }

--- a/packages/safegres/__tests__/fixtures/x1-cold-paths.sql
+++ b/packages/safegres/__tests__/fixtures/x1-cold-paths.sql
@@ -1,0 +1,64 @@
+-- Cold access paths: provisioning-config tables whose foreign keys are
+-- write-once pointers nothing ever looks rows up by (X1 must stay quiet),
+-- alongside real relations on the same shape (X1 must still fire).
+
+DROP SCHEMA IF EXISTS fx_cold CASCADE;
+CREATE SCHEMA fx_cold;
+
+CREATE TABLE fx_cold.databases (
+  id uuid PRIMARY KEY
+);
+
+CREATE TABLE fx_cold.tables (
+  id uuid PRIMARY KEY,
+  database_id uuid NOT NULL REFERENCES fx_cold.databases (id)
+);
+
+CREATE TABLE fx_cold.users (
+  id uuid PRIMARY KEY
+);
+
+-- A config record: several write-once pointers filled in at provisioning
+-- time, none of them read by a policy or a view. Every FK here is cold,
+-- including `field_table_id`, which carries no default of its own — the
+-- table-level classification is what catches it.
+CREATE TABLE fx_cold.agent_module (
+  id uuid PRIMARY KEY,
+  database_id uuid NOT NULL REFERENCES fx_cold.databases (id),
+  thread_table_id uuid NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000' REFERENCES fx_cold.tables (id),
+  message_table_id uuid NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000' REFERENCES fx_cold.tables (id),
+  field_table_id uuid REFERENCES fx_cold.tables (id)
+);
+
+ALTER TABLE fx_cold.agent_module ENABLE ROW LEVEL SECURITY;
+CREATE POLICY agent_module_select ON fx_cold.agent_module
+  FOR SELECT USING (database_id = current_setting('fx.database_id', true)::uuid);
+
+-- One write-once pointer is not enough to call a table a config record.
+CREATE TABLE fx_cold.one_pointer (
+  id uuid PRIMARY KEY,
+  thread_table_id uuid NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000' REFERENCES fx_cold.tables (id),
+  owner_id uuid NOT NULL REFERENCES fx_cold.users (id)
+);
+
+-- A hot relationship table: same "several uuid FKs" shape, but the keys carry
+-- no constant default, so nothing here is cold.
+CREATE TABLE fx_cold.grants (
+  id uuid PRIMARY KEY,
+  actor_id uuid NOT NULL REFERENCES fx_cold.users (id),
+  grantor_id uuid NOT NULL REFERENCES fx_cold.users (id)
+);
+
+-- A config-record-shaped table whose pointers a view reads, which refutes
+-- coldness: something does look rows up by them.
+CREATE TABLE fx_cold.read_module (
+  id uuid PRIMARY KEY,
+  primary_view_table_id uuid NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000' REFERENCES fx_cold.tables (id),
+  secondary_view_table_id uuid NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000' REFERENCES fx_cold.tables (id)
+);
+
+CREATE VIEW fx_cold.read_module_tables AS
+  SELECT t.id
+  FROM fx_cold.tables t
+  JOIN fx_cold.read_module m
+    ON m.primary_view_table_id = t.id OR m.secondary_view_table_id = t.id;

--- a/packages/safegres/__tests__/perf.test.ts
+++ b/packages/safegres/__tests__/perf.test.ts
@@ -47,6 +47,78 @@ describe('perf dimension', () => {
     expect(posts?.context).toMatchObject({ columns: ['author_id'] });
   });
 
+  describe('X1 cold access paths', () => {
+    function coldConstraints(findings: Finding[]): string[] {
+      return findings
+        .filter((f) => f.code === 'X1')
+        .map((f) => (f.context as { constraint: string }).constraint)
+        .sort();
+    }
+
+    it('exempts write-once pointers on a config record, but not its tenant key', async () => {
+      await applyFixture('x1-cold-paths.sql');
+      const report = await audit(pg.client as never, { schemas: ['fx_cold'], perf: true });
+
+      // agent_module: only the tenant key is a query path — a policy filters
+      // on it. The three pointer keys are cold and raise nothing.
+      expect(coldConstraints(report.perf!.findings).filter((c) => c.startsWith('agent_module')))
+        .toEqual(['agent_module_database_id_fkey']);
+    });
+
+    it('leaves hot relationships, single-pointer tables and view-read keys alone', async () => {
+      const report = await audit(pg.client as never, { schemas: ['fx_cold'], perf: true });
+      const all = coldConstraints(report.perf!.findings);
+
+      // No constant defaults: a real relationship table, every key hot.
+      expect(all).toEqual(expect.arrayContaining([
+        'grants_actor_id_fkey',
+        'grants_grantor_id_fkey'
+      ]));
+      // One pointer is below the config-record threshold.
+      expect(all).toEqual(expect.arrayContaining([
+        'one_pointer_owner_id_fkey',
+        'one_pointer_thread_table_id_fkey'
+      ]));
+      // A view reads these columns, which refutes coldness.
+      expect(all).toEqual(expect.arrayContaining([
+        'read_module_primary_view_table_id_fkey',
+        'read_module_secondary_view_table_id_fkey'
+      ]));
+    });
+
+    it('demands an index for every key when classification is off', async () => {
+      const report = await audit(pg.client as never, {
+        schemas: ['fx_cold'],
+        perf: true,
+        config: { perf: { paths: { infer: false } } }
+      });
+      expect(coldConstraints(report.perf!.findings).filter((c) => c.startsWith('agent_module')))
+        .toEqual([
+          'agent_module_database_id_fkey',
+          'agent_module_field_table_id_fkey',
+          'agent_module_message_table_id_fkey',
+          'agent_module_thread_table_id_fkey'
+        ]);
+    });
+
+    it('reports what it classified rather than suppressing findings silently', async () => {
+      const report = await audit(pg.client as never, { schemas: ['fx_cold'], perf: true });
+      expect(report.perf!.paths).toEqual({ total: 11, cold: 3, tables: 1 });
+    });
+
+    it('raises the config-record threshold on request', async () => {
+      const report = await audit(pg.client as never, {
+        schemas: ['fx_cold'],
+        perf: true,
+        config: { perf: { paths: { minPointers: 3 } } }
+      });
+      // agent_module has two write-once pointers, so a threshold of three
+      // stops classifying it and X1 returns for all four keys.
+      expect(coldConstraints(report.perf!.findings).filter((c) => c.startsWith('agent_module')))
+        .toHaveLength(4);
+    });
+  });
+
   it('X5: flags duplicate and prefix indexes, not unique/partial/expression ones', async () => {
     await applyFixture('x5-redundant-index.sql');
     const report = await audit(pg.client as never, { schemas: ['fx_x5'], perf: true });

--- a/packages/safegres/__tests__/perf.test.ts
+++ b/packages/safegres/__tests__/perf.test.ts
@@ -47,74 +47,113 @@ describe('perf dimension', () => {
     expect(posts?.context).toMatchObject({ columns: ['author_id'] });
   });
 
-  describe('X1 cold access paths', () => {
-    function coldConstraints(findings: Finding[]): string[] {
+  describe('X1 access-path signals', () => {
+    function x1Constraints(findings: Finding[]): string[] {
       return findings
         .filter((f) => f.code === 'X1')
         .map((f) => (f.context as { constraint: string }).constraint)
         .sort();
     }
 
-    it('exempts write-once pointers on a config record, but not its tenant key', async () => {
+    function x1For(findings: Finding[], constraint: string): Finding | undefined {
+      return findings.find(
+        (f) => f.code === 'X1' && (f.context as { constraint: string }).constraint === constraint
+      );
+    }
+
+    it('reports the shape without acting on it: every key still raises X1', async () => {
       await applyFixture('x1-cold-paths.sql');
       const report = await audit(pg.client as never, { schemas: ['fx_cold'], perf: true });
 
-      // agent_module: only the tenant key is a query path — a policy filters
-      // on it. The three pointer keys are cold and raise nothing.
-      expect(coldConstraints(report.perf!.findings).filter((c) => c.startsWith('agent_module')))
-        .toEqual(['agent_module_database_id_fkey']);
-    });
-
-    it('leaves hot relationships, single-pointer tables and view-read keys alone', async () => {
-      const report = await audit(pg.client as never, { schemas: ['fx_cold'], perf: true });
-      const all = coldConstraints(report.perf!.findings);
-
-      // No constant defaults: a real relationship table, every key hot.
-      expect(all).toEqual(expect.arrayContaining([
-        'grants_actor_id_fkey',
-        'grants_grantor_id_fkey'
-      ]));
-      // One pointer is below the config-record threshold.
-      expect(all).toEqual(expect.arrayContaining([
-        'one_pointer_owner_id_fkey',
-        'one_pointer_thread_table_id_fkey'
-      ]));
-      // A view reads these columns, which refutes coldness.
-      expect(all).toEqual(expect.arrayContaining([
-        'read_module_primary_view_table_id_fkey',
-        'read_module_secondary_view_table_id_fkey'
-      ]));
-    });
-
-    it('demands an index for every key when classification is off', async () => {
-      const report = await audit(pg.client as never, {
-        schemas: ['fx_cold'],
-        perf: true,
-        config: { perf: { paths: { infer: false } } }
-      });
-      expect(coldConstraints(report.perf!.findings).filter((c) => c.startsWith('agent_module')))
+      // A shape is not proof that nothing queries the relation — a generated
+      // API can expose a reverse relation over any of these keys — so the
+      // default changes no finding and no severity.
+      expect(x1Constraints(report.perf!.findings).filter((c) => c.startsWith('agent_module')))
         .toEqual([
           'agent_module_database_id_fkey',
           'agent_module_field_table_id_fkey',
           'agent_module_message_table_id_fkey',
           'agent_module_thread_table_id_fkey'
         ]);
+      expect(x1For(report.perf!.findings, 'agent_module_thread_table_id_fkey')?.severity)
+        .toBe('medium');
     });
 
-    it('reports what it classified rather than suppressing findings silently', async () => {
+    it('attaches the signals that fired to each finding', async () => {
       const report = await audit(pg.client as never, { schemas: ['fx_cold'], perf: true });
-      expect(report.perf!.paths).toEqual({ total: 11, cold: 3, tables: 1 });
+      const findings = report.perf!.findings;
+
+      // A write-once pointer on a config record: shape only.
+      expect(x1For(findings, 'agent_module_thread_table_id_fkey')?.context)
+        .toMatchObject({ pathSignals: ['write-once-pointer', 'config-record'] });
+      // The tenant key of the same table: an RLS policy filters on it.
+      expect(x1For(findings, 'agent_module_database_id_fkey')?.context)
+        .toMatchObject({ pathSignals: ['policy-read'] });
+      // A view reads these, which is a read signal wherever they sit.
+      expect(x1For(findings, 'read_module_primary_view_table_id_fkey')?.context)
+        .toMatchObject({ pathSignals: ['view-read'] });
+      // A real relationship table: no constant defaults, nothing to say.
+      expect(x1For(findings, 'grants_actor_id_fkey')?.context)
+        .toMatchObject({ pathSignals: [] });
+      // One pointer is below the config-record threshold, so the shape does
+      // not hold at the table level and the key is not write-once-shaped.
+      expect(x1For(findings, 'one_pointer_thread_table_id_fkey')?.context)
+        .toMatchObject({ pathSignals: ['write-once-pointer'] });
+    });
+
+    it('demotes write-once-shaped keys to info when asked', async () => {
+      const report = await audit(pg.client as never, {
+        schemas: ['fx_cold'],
+        perf: true,
+        config: { perf: { paths: { onWriteOncePointer: 'demote' } } }
+      });
+      const findings = report.perf!.findings;
+      expect(x1For(findings, 'agent_module_thread_table_id_fkey')?.severity).toBe('info');
+      // The tenant key is read by a policy, so it keeps its severity.
+      expect(x1For(findings, 'agent_module_database_id_fkey')?.severity).toBe('medium');
+    });
+
+    it('suppresses write-once-shaped keys when asked, but never a read one', async () => {
+      const report = await audit(pg.client as never, {
+        schemas: ['fx_cold'],
+        perf: true,
+        config: { perf: { paths: { onWriteOncePointer: 'suppress' } } }
+      });
+      expect(x1Constraints(report.perf!.findings).filter((c) => c.startsWith('agent_module')))
+        .toEqual(['agent_module_database_id_fkey']);
+    });
+
+    it('collects no signals at all when inference is off', async () => {
+      const report = await audit(pg.client as never, {
+        schemas: ['fx_cold'],
+        perf: true,
+        config: { perf: { paths: { infer: false, onWriteOncePointer: 'suppress' } } }
+      });
+      expect(report.perf!.paths).toBeUndefined();
+      expect(x1Constraints(report.perf!.findings).filter((c) => c.startsWith('agent_module')))
+        .toHaveLength(4);
+    });
+
+    it('reports the signal counts and what X1 did with them', async () => {
+      const report = await audit(pg.client as never, { schemas: ['fx_cold'], perf: true });
+      expect(report.perf!.paths).toEqual({
+        total: 11,
+        read: 4,
+        writeOnceShaped: 3,
+        tables: 1,
+        onWriteOncePointer: 'report'
+      });
     });
 
     it('raises the config-record threshold on request', async () => {
       const report = await audit(pg.client as never, {
         schemas: ['fx_cold'],
         perf: true,
-        config: { perf: { paths: { minPointers: 3 } } }
+        config: { perf: { paths: { minPointers: 3, onWriteOncePointer: 'suppress' } } }
       });
       // agent_module has two write-once pointers, so a threshold of three
-      // stops classifying it and X1 returns for all four keys.
-      expect(coldConstraints(report.perf!.findings).filter((c) => c.startsWith('agent_module')))
+      // stops the config-record signal firing and X1 returns for all four keys.
+      expect(x1Constraints(report.perf!.findings).filter((c) => c.startsWith('agent_module')))
         .toHaveLength(4);
     });
   });

--- a/packages/safegres/__tests__/search-index.test.ts
+++ b/packages/safegres/__tests__/search-index.test.ts
@@ -7,7 +7,7 @@ import type { ColumnInfo, IndexInfo, TableIndexSnapshot } from '../src/pg/indexe
  * and the check reads nothing but the catalog shape.
  */
 function column(name: string, attnum: number, type: string, baseType = type): ColumnInfo {
-  return { name, attnum, type, baseType };
+  return { name, attnum, type, baseType, notNull: false, defaultExpr: null };
 }
 
 function index(name: string, method: string, columns: number[], partial = false): IndexInfo {

--- a/packages/safegres/src/checks/indexes.ts
+++ b/packages/safegres/src/checks/indexes.ts
@@ -10,6 +10,21 @@ import { type AccessPath, pathKey } from '../pg/paths';
 import type { Finding } from '../types';
 
 /**
+ * What X1 does with a foreign key whose only evidence is shape — it looks like
+ * a write-once provisioning pointer, but nothing has proven the path is
+ * unreachable.
+ *
+ * `report` is the default and the only honest one until a signal exists that
+ * can observe the generated API surface: the finding stands, and the shape is
+ * attached to it as context so a reviewer can act on it. The other two exist
+ * so the decision is a line of config rather than a fork of the scanner.
+ *
+ * `demote` is applied in `audit()` rather than here, because severities are
+ * restamped from the rule registry after the checks run.
+ */
+export type WriteOncePointerPolicy = 'report' | 'demote' | 'suppress';
+
+/**
  * X1: a foreign key with no index that can serve it.
  *
  * An index covers a FK when its *leading* columns are exactly the FK's
@@ -21,13 +36,13 @@ import type { Finding } from '../types';
  * Partial and expression indexes do not count: the planner cannot rely on
  * them for the referential-integrity lookup.
  *
- * `paths` classifies each foreign key as a query path or not. A cold path is
- * skipped: the index would be paid for on every insert and read by nothing.
- * See {@link classifyPaths}.
+ * `paths` supplies the access-path signals. They never remove a finding on
+ * their own — see {@link WriteOncePointerPolicy} and `classifyPaths`.
  */
 export function checkUnindexedForeignKeys(
   table: TableIndexSnapshot,
-  paths?: Map<string, AccessPath>
+  paths?: Map<string, AccessPath>,
+  onWriteOncePointer: WriteOncePointerPolicy = 'report'
 ): Finding[] {
   // Partitions inherit their parent's indexes; the parent carries the finding.
   if (table.isPartition) return [];
@@ -36,7 +51,10 @@ export function checkUnindexedForeignKeys(
   for (const fk of table.foreignKeys) {
     if (fk.columns.length === 0) continue;
     if (table.indexes.some((idx) => indexCoversColumns(idx, fk.columns))) continue;
-    if (paths?.get(pathKey(table.schema, table.name, fk.name))?.state === 'cold') continue;
+
+    const path = paths?.get(pathKey(table.schema, table.name, fk.name));
+    const writeOnceShaped = path?.assessment === 'write-once-shaped';
+    if (writeOnceShaped && onWriteOncePointer === 'suppress') continue;
 
     const cols = fk.columnNames.join(', ');
     findings.push({
@@ -47,9 +65,15 @@ export function checkUnindexedForeignKeys(
       table: table.name,
       message:
         `Foreign key ${fk.name} on ${table.schema}.${table.name} (${cols}) has no covering index`,
-      hint:
-        `CREATE INDEX ON ${table.schema}.${table.name} (${cols}); without it, deletes/updates on ${fk.references} and joins across this key scan the whole table.`,
-      context: { constraint: fk.name, columns: fk.columnNames, references: fk.references }
+      hint: writeOnceShaped
+        ? `CREATE INDEX ON ${table.schema}.${table.name} (${cols}) — or, if nothing queries this relation, stop exposing it. ${path!.signals.map((s) => s.detail).join('; ')}.`
+        : `CREATE INDEX ON ${table.schema}.${table.name} (${cols}); without it, deletes/updates on ${fk.references} and joins across this key scan the whole table.`,
+      context: {
+        constraint: fk.name,
+        columns: fk.columnNames,
+        references: fk.references,
+        ...(path ? { pathSignals: path.signals.map((s) => s.name), pathAssessment: path.assessment } : {})
+      }
     });
   }
   return findings;

--- a/packages/safegres/src/checks/indexes.ts
+++ b/packages/safegres/src/checks/indexes.ts
@@ -6,6 +6,7 @@
  */
 
 import type { IndexInfo, TableIndexSnapshot } from '../pg/indexes';
+import { type AccessPath, pathKey } from '../pg/paths';
 import type { Finding } from '../types';
 
 /**
@@ -19,8 +20,15 @@ import type { Finding } from '../types';
  *
  * Partial and expression indexes do not count: the planner cannot rely on
  * them for the referential-integrity lookup.
+ *
+ * `paths` classifies each foreign key as a query path or not. A cold path is
+ * skipped: the index would be paid for on every insert and read by nothing.
+ * See {@link classifyPaths}.
  */
-export function checkUnindexedForeignKeys(table: TableIndexSnapshot): Finding[] {
+export function checkUnindexedForeignKeys(
+  table: TableIndexSnapshot,
+  paths?: Map<string, AccessPath>
+): Finding[] {
   // Partitions inherit their parent's indexes; the parent carries the finding.
   if (table.isPartition) return [];
 
@@ -28,6 +36,7 @@ export function checkUnindexedForeignKeys(table: TableIndexSnapshot): Finding[] 
   for (const fk of table.foreignKeys) {
     if (fk.columns.length === 0) continue;
     if (table.indexes.some((idx) => indexCoversColumns(idx, fk.columns))) continue;
+    if (paths?.get(pathKey(table.schema, table.name, fk.name))?.state === 'cold') continue;
 
     const cols = fk.columnNames.join(', ');
     findings.push({

--- a/packages/safegres/src/commands/audit.ts
+++ b/packages/safegres/src/commands/audit.ts
@@ -47,8 +47,9 @@ import type { ExposureConfig, SafegresConfig } from '../config/types';
 import { type ExplainReport, proveFindings } from '../perf/explain';
 import { resolveExposure } from '../pg/exposure';
 import { introspectFunctions } from '../pg/functions';
-import { introspectIndexes, type TableIndexSnapshot } from '../pg/indexes';
+import { introspectIndexes, introspectViewBodies, type TableIndexSnapshot } from '../pg/indexes';
 import { asExecutor, type IntrospectOptions, introspectTables, type QueryExecutor, type TableSnapshot } from '../pg/introspect';
+import { type AccessPath, classifyPaths } from '../pg/paths';
 import { lookupVolatility, type ProcVolatility } from '../pg/proc';
 import { listAuditableRoles, resolveRoles } from '../pg/roles';
 import { introspectStats, type StatsSnapshot } from '../pg/stats';
@@ -155,6 +156,21 @@ export async function audit(
     indexSnapshot.map((t) => [`${t.schema}.${t.name}`, t])
   );
 
+  // Which foreign keys are query paths. Without this X1 demands an index for
+  // every key, including write-once provisioning pointers nothing reads —
+  // where the index is a write on every insert in exchange for nothing.
+  const paths: Map<string, AccessPath> = perfEnabled && config.perf?.paths?.infer !== false
+    ? classifyPaths(
+      indexSnapshot,
+      snapshot,
+      await introspectViewBodies(exec, {
+        schemas: options.schemas ?? config.schemas,
+        excludeSchemas: options.excludeSchemas ?? config.excludeSchemas
+      }),
+      { minPointers: config.perf?.paths?.minPointers }
+    )
+    : new Map();
+
   for (const table of snapshot) {
     // --- RLS flags (structural) ---
     const a1 = checkRlsEnabledNoPolicies(table);
@@ -202,7 +218,7 @@ export async function audit(
 
   if (perfEnabled) {
     for (const table of indexSnapshot) {
-      findings.push(...checkUnindexedForeignKeys(table));
+      findings.push(...checkUnindexedForeignKeys(table, paths));
       findings.push(...checkRedundantIndexes(table));
       findings.push(...checkUnindexedSearchColumns(table));
       findings.push(...checkUnindexedSortColumns(table));
@@ -320,6 +336,15 @@ export async function audit(
         exposureKnown: exposure.known
       })
     };
+
+    if (paths.size > 0) {
+      const cold = [...paths.values()].filter((p) => p.state === 'cold');
+      perf.paths = {
+        total: paths.size,
+        cold: cold.length,
+        tables: new Set(cold.map((p) => `${p.schema}.${p.table}`)).size
+      };
+    }
 
     if (statsSnapshot) {
       const stats: PerfStatsReport = {

--- a/packages/safegres/src/commands/audit.ts
+++ b/packages/safegres/src/commands/audit.ts
@@ -161,9 +161,10 @@ export async function audit(
     indexSnapshot.map((t) => [`${t.schema}.${t.name}`, t])
   );
 
-  // Which foreign keys are query paths. Without this X1 demands an index for
-  // every key, including write-once provisioning pointers nothing reads —
-  // where the index is a write on every insert in exchange for nothing.
+  // Evidence about which foreign keys anything reads. Reported alongside the
+  // findings; by default it changes neither, because no signal available on an
+  // empty database proves a path is unreachable.
+  const onWriteOncePointer = config.perf?.paths?.onWriteOncePointer ?? 'report';
   const paths: Map<string, AccessPath> = perfEnabled && config.perf?.paths?.infer !== false
     ? classifyPaths(
       indexSnapshot,
@@ -224,7 +225,7 @@ export async function audit(
 
   if (perfEnabled) {
     for (const table of indexSnapshot) {
-      findings.push(...checkUnindexedForeignKeys(table, paths));
+      findings.push(...checkUnindexedForeignKeys(table, paths, onWriteOncePointer));
       findings.push(...checkRedundantIndexes(table));
       findings.push(...checkUnindexedSearchColumns(table));
       findings.push(...checkUnindexedSortColumns(table));
@@ -247,6 +248,18 @@ export async function audit(
     if (meta && f.direction === undefined) f.direction = meta.direction;
     if (meta && f.dimension === undefined) f.dimension = dimensionOf(meta);
     if (exposure.known && f.schema) f.exposed = exposedSchemas.has(f.schema);
+
+    // A key that looks like a write-once provisioning pointer, where the
+    // reviewer has chosen to read the finding rather than gate on it. Applied
+    // here because severities are restamped from the rule registry above.
+    if (
+      onWriteOncePointer === 'demote' && f.code === 'X1'
+      && (f.context as { pathAssessment?: string } | undefined)?.pathAssessment === 'write-once-shaped'
+    ) {
+      f.acknowledged = true;
+      f.severity = 'info';
+      f.message += ' — write-once-shaped (perf.paths.onWriteOncePointer)';
+    }
 
     // Declared-intentional perf debt: cold tables, tiny lookups, anything the
     // planner will seq-scan regardless. Reported, but off the perf score.
@@ -344,11 +357,14 @@ export async function audit(
     };
 
     if (paths.size > 0) {
-      const cold = [...paths.values()].filter((p) => p.state === 'cold');
+      const all = [...paths.values()];
+      const shaped = all.filter((p) => p.assessment === 'write-once-shaped');
       perf.paths = {
         total: paths.size,
-        cold: cold.length,
-        tables: new Set(cold.map((p) => `${p.schema}.${p.table}`)).size
+        read: all.filter((p) => p.assessment === 'read').length,
+        writeOnceShaped: shaped.length,
+        tables: new Set(shaped.map((p) => `${p.schema}.${p.table}`)).size,
+        onWriteOncePointer
       };
     }
 

--- a/packages/safegres/src/config/types.ts
+++ b/packages/safegres/src/config/types.ts
@@ -126,16 +126,28 @@ export interface PerfConfig {
 
 export interface PerfPathsConfig {
   /**
-   * Classify write-once pointer keys on provisioning-config tables as cold,
-   * exempting them from X1. Default true. Set false to demand an index for
-   * every foreign key regardless of whether anything reads it.
+   * Collect access-path signals for every foreign key. Default true. Signals
+   * are reported, and by default change no finding and no score; set false to
+   * skip the introspection entirely.
    */
   infer?: boolean;
   /**
-   * Write-once pointers a table needs before it counts as a config record.
-   * Default 2. Raise it to classify fewer tables.
+   * Write-once pointers a table needs before the `config-record` signal fires.
+   * Default 2. Raise it for a narrower signal.
    */
   minPointers?: number;
+  /**
+   * What X1 does with a key whose only evidence is shape — it looks like a
+   * write-once provisioning pointer, but nothing has proven the path is
+   * unreachable.
+   *
+   * - `report` (default) — the finding stands, with the signals attached.
+   * - `demote` — the finding drops to `info`, so it is read rather than gated
+   *   on and contributes nothing to the score.
+   * - `suppress` — no finding. Only defensible once you know the generated API
+   *   does not expose these relations; a shape is not a proof.
+   */
+  onWriteOncePointer?: 'report' | 'demote' | 'suppress';
 }
 
 export interface PerfScoringConfig extends ScoringConfig {

--- a/packages/safegres/src/config/types.ts
+++ b/packages/safegres/src/config/types.ts
@@ -120,6 +120,22 @@ export interface PerfConfig {
   stats?: PerfStatsConfig;
   /** Planner proof (`--explain`). Off unless enabled here or by flag. */
   explain?: PerfExplainConfig;
+  /** Access-path classification, which decides whether X1 applies to a key. */
+  paths?: PerfPathsConfig;
+}
+
+export interface PerfPathsConfig {
+  /**
+   * Classify write-once pointer keys on provisioning-config tables as cold,
+   * exempting them from X1. Default true. Set false to demand an index for
+   * every foreign key regardless of whether anything reads it.
+   */
+  infer?: boolean;
+  /**
+   * Write-once pointers a table needs before it counts as a config record.
+   * Default 2. Raise it to classify fewer tables.
+   */
+  minPointers?: number;
 }
 
 export interface PerfScoringConfig extends ScoringConfig {

--- a/packages/safegres/src/pg/indexes.ts
+++ b/packages/safegres/src/pg/indexes.ts
@@ -38,6 +38,10 @@ export interface ColumnInfo {
   type: string;
   /** Base type name without modifiers, e.g. `timestamptz`, `vector`. */
   baseType: string;
+  /** `pg_attribute.attnotnull`. */
+  notNull: boolean;
+  /** The column default as SQL, or `null` when it has none. */
+  defaultExpr: string | null;
 }
 
 export interface ForeignKeyInfo {
@@ -163,10 +167,13 @@ export async function introspectIndexes(
           'name', a.attname,
           'attnum', a.attnum,
           'type', format_type(a.atttypid, a.atttypmod),
-          'baseType', t.typname
+          'baseType', t.typname,
+          'notNull', a.attnotnull,
+          'defaultExpr', pg_get_expr(d.adbin, d.adrelid)
         ) ORDER BY a.attnum)
          FROM pg_attribute a
          JOIN pg_type t ON t.oid = a.atttypid
+         LEFT JOIN pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
          WHERE a.attrelid = r.oid AND a.attnum > 0 AND NOT a.attisdropped),
         '[]'::jsonb
       )                                                 AS columns
@@ -198,6 +205,38 @@ export async function introspectIndexes(
     indexes: r.indexes,
     foreignKeys: r.foreign_keys
   }));
+}
+
+/**
+ * Every view and materialized-view body in scope, as SQL text.
+ *
+ * A column named in a view definition is read by something, which is the
+ * cheapest available refutation of "nothing queries this column" — see
+ * {@link classifyPaths}.
+ */
+export async function introspectViewBodies(
+  exec: QueryExecutor,
+  options: Pick<IntrospectOptions, 'schemas' | 'excludeSchemas'> = {}
+): Promise<string[]> {
+  const excludes = [...DEFAULT_EXCLUDES, ...(options.excludeSchemas ?? [])];
+  const schemaFilter = options.schemas && options.schemas.length > 0
+    ? `AND n.nspname = ANY($1::text[])`
+    : `AND NOT (n.nspname = ANY($2::text[]))`;
+
+  const { rows } = await exec.query<{ definition: string }>(
+    // Both parameters are referenced (even when only one filters) so Postgres
+    // can infer their types — an unused $N errors out at bind time.
+    `WITH _params AS (
+       SELECT $1::text[] AS include_schemas, $2::text[] AS exclude_schemas
+     )
+     SELECT pg_get_viewdef(c.oid) AS definition
+     FROM pg_class c
+     JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE c.relkind IN ('v', 'm')
+       ${schemaFilter}`,
+    [options.schemas ?? [], excludes]
+  );
+  return rows.map((r) => r.definition);
 }
 
 /**

--- a/packages/safegres/src/pg/paths.ts
+++ b/packages/safegres/src/pg/paths.ts
@@ -1,6 +1,6 @@
 /**
- * Access-path classification: which foreign keys are query paths, and which
- * are write-once pointers nothing ever looks rows up by.
+ * Access-path signals: independent, individually-auditable pieces of evidence
+ * about whether anything reads a foreign key.
  *
  * X1 ("foreign key with no covering index") is right about the mechanics — a
  * `DELETE` on the parent really does scan the child — but it assumes the child
@@ -10,34 +10,63 @@
  *
  * The tempting gate, `pg_class.reltuples`, is useless here: safegres grades an
  * ephemeral CI database that has never held data, so every row estimate is 0
- * at exactly the moment we grade. Worse, row count is the wrong question —
- * a huge append-only log nobody joins on wants no FK index, and a tiny lookup
- * table hammered by every request does. The property we need is *reachability*,
- * and reachability is structural, which is why it survives an empty database.
+ * at exactly the moment we grade. Worse, row count is the wrong question — a
+ * huge append-only log nobody joins on wants no FK index, and a tiny lookup
+ * table hammered by every request does. The property we need is *reachability*.
  *
- * The classification is pure catalog arithmetic — same input, same output, no
- * statistics and no thresholds tuned against a corpus:
+ * Reachability is not one boolean, and this module deliberately does not
+ * compute one. It collects signals, each of which points in one direction and
+ * says why, and leaves the verdict to the caller:
  *
- * - a **degenerate pointer** is a foreign key whose every referencing column
- *   carries a constant default (`uuid_nil()`, a literal) and whose column names
- *   appear in no RLS policy predicate and no view body anywhere in the
- *   database. A `NOT NULL` key that starts life pointing at the nil UUID is a
- *   slot a provisioner fills in, not something rows are found by;
- * - a **config record** is a table with at least {@link ClassifyOptions.minPointers}
- *   degenerate pointers. On one, every foreign key whose columns are likewise
- *   absent from all policy predicates and view bodies is a **cold path**.
+ * - `policy-read` and `view-read` are **reads**. They are decisive: the
+ *   database itself traverses the column, so no amount of contrary evidence
+ *   makes the path unreachable.
+ * - `write-once-pointer` and `config-record` are **shape**. They are not
+ *   evidence of unreachability, only of a schema idiom — a `NOT NULL` key
+ *   defaulting to the nil UUID is a slot a provisioner fills in, and a table
+ *   with several of them looks like a config record rather than a relation.
  *
- * The tenant key is never cold and needs no special case: `database_id` appears
- * in essentially every RLS policy, so the policy check excludes it on its own.
+ * Shape alone must never suppress a finding. A generated API can expose a
+ * reverse relation over any foreign key regardless of how its default is
+ * written, and if it does, the path is reachable and the index is wanted. The
+ * signal that settles it is therefore the one this module does *not* yet have:
+ * whether the generated GraphQL surface still contains the field. Add it as
+ * another {@link PathSignal} — the shape of the API is designed for that — and
+ * only then is `unreachable` a conclusion anything should act on.
  */
 
 import type { TableIndexSnapshot } from './indexes';
 import type { TableSnapshot } from './introspect';
 
-export type PathState = 'hot' | 'cold';
+/**
+ * Which way a signal points. `read` means something demonstrably traverses the
+ * key; `shape` means the schema resembles an idiom in which nothing does, which
+ * is a suspicion rather than a finding.
+ */
+export type SignalDirection = 'read' | 'shape';
 
-/** How a path came to be classified — reported so a reviewer can audit it. */
-export type PathSource = 'inferred';
+export type SignalName = 'policy-read' | 'view-read' | 'write-once-pointer' | 'config-record';
+
+export interface PathSignal {
+  name: SignalName;
+  direction: SignalDirection;
+  /** Why this signal fired, in one human-readable clause. */
+  detail: string;
+}
+
+/**
+ * The caller-facing summary of a path's signals. Note there is no `unreachable`
+ * member: nothing safegres can currently observe proves a path is unreachable,
+ * and inventing the state is how a scanner ends up recommending that you drop
+ * an index a live API is using.
+ */
+export type PathAssessment =
+  /** At least one `read` signal. The key is traversed; X1 applies as written. */
+  | 'read'
+  /** Only `shape` signals. Looks like a provisioning pointer; unproven. */
+  | 'write-once-shaped'
+  /** No signal fired either way. */
+  | 'unknown';
 
 export interface AccessPath {
   schema: string;
@@ -46,15 +75,14 @@ export interface AccessPath {
   columns: string[];
   /** The foreign-key constraint this path belongs to. */
   constraint: string;
-  state: PathState;
-  source: PathSource;
-  /** Why the classifier reached this state, in one human-readable clause. */
-  reason: string;
+  /** Every signal that fired, so a reviewer can audit the assessment. */
+  signals: PathSignal[];
+  assessment: PathAssessment;
 }
 
 export interface ClassifyOptions {
   /**
-   * Degenerate pointers a table needs before it counts as a config record.
+   * Write-once pointers a table needs before the `config-record` signal fires.
    * Default 2. Lifting the test from the column to the table is what catches
    * the nullable, undefaulted pointer sitting alongside the defaulted ones.
    */
@@ -82,14 +110,26 @@ export function pathKey(schema: string, table: string, constraint: string): stri
 }
 
 /**
- * Classify every foreign key in the snapshot as a hot or cold access path.
+ * One real reader ends the discussion, so a `read` signal always wins. Absent
+ * one, the shape has to hold at the *table* level before it means anything: a
+ * lone defaulted column is a habit, whereas a table built entirely out of them
+ * is an idiom. `write-once-pointer` on its own is therefore reported and not
+ * acted on.
+ */
+export function assess(signals: PathSignal[]): PathAssessment {
+  if (signals.some((s) => s.direction === 'read')) return 'read';
+  if (signals.some((s) => s.name === 'config-record')) return 'write-once-shaped';
+  return 'unknown';
+}
+
+/**
+ * Collect the signals for every foreign key in the snapshot.
  *
  * `tables` supplies the RLS policy predicates (as SQL text) and `viewBodies`
- * the view definitions; a column named in either is read by something, which
- * refutes coldness. Both are matched as whole-word tokens across the *whole*
- * database rather than per relation — deliberately conservative, since the
- * cost of missing a cold path is one spurious finding while the cost of a
- * wrong one is a dropped index.
+ * the view definitions. Both are matched as whole-word tokens across the
+ * *whole* database rather than per relation — deliberately over-eager, because
+ * a spurious `read` signal costs one retained finding while a missing one
+ * could cost a dropped index.
  */
 export function classifyPaths(
   indexSnapshot: TableIndexSnapshot[],
@@ -98,29 +138,69 @@ export function classifyPaths(
   options: ClassifyOptions = {}
 ): Map<string, AccessPath> {
   const minPointers = options.minPointers ?? DEFAULT_MIN_POINTERS;
-  const referenced = referencedColumnNames(tables, viewBodies);
+  const policyTokens = identifierTokens(
+    tables.flatMap((t) => t.policies.flatMap((p) => [p.using, p.withCheck]))
+  );
+  const viewTokens = identifierTokens(viewBodies);
   const paths = new Map<string, AccessPath>();
 
   for (const table of indexSnapshot) {
     const defaults = new Map(table.columns.map((c) => [c.attnum, c.defaultExpr]));
-    const unread = (columns: string[]) => columns.every((c) => !referenced.has(c.toLowerCase()));
-    const degenerate = table.foreignKeys.filter(
-      (fk) => fk.columns.every((a) => isConstantDefault(defaults.get(a) ?? null)) && unread(fk.columnNames)
+    const readBy = (tokens: Set<string>, columns: string[]) =>
+      columns.filter((c) => tokens.has(c.toLowerCase()));
+
+    const pointers = table.foreignKeys.filter(
+      (fk) =>
+        fk.columns.length > 0 &&
+        fk.columns.every((a) => isConstantDefault(defaults.get(a) ?? null)) &&
+        readBy(policyTokens, fk.columnNames).length === 0 &&
+        readBy(viewTokens, fk.columnNames).length === 0
     );
-    const isConfigRecord = degenerate.length >= minPointers;
 
     for (const fk of table.foreignKeys) {
-      const cold = isConfigRecord && unread(fk.columnNames);
+      const signals: PathSignal[] = [];
+
+      const inPolicy = readBy(policyTokens, fk.columnNames);
+      if (inPolicy.length > 0) {
+        signals.push({
+          name: 'policy-read',
+          direction: 'read',
+          detail: `an RLS policy predicate names ${inPolicy.join(', ')}`
+        });
+      }
+
+      const inView = readBy(viewTokens, fk.columnNames);
+      if (inView.length > 0) {
+        signals.push({
+          name: 'view-read',
+          direction: 'read',
+          detail: `a view or materialized view names ${inView.join(', ')}`
+        });
+      }
+
+      if (pointers.some((p) => p.name === fk.name)) {
+        signals.push({
+          name: 'write-once-pointer',
+          direction: 'shape',
+          detail: `every column of ${fk.name} has a constant default`
+        });
+      }
+
+      if (pointers.length >= minPointers && inPolicy.length === 0 && inView.length === 0) {
+        signals.push({
+          name: 'config-record',
+          direction: 'shape',
+          detail: `${table.name} carries ${pointers.length} write-once pointers`
+        });
+      }
+
       paths.set(pathKey(table.schema, table.name, fk.name), {
         schema: table.schema,
         table: table.name,
         columns: fk.columnNames,
         constraint: fk.name,
-        state: cold ? 'cold' : 'hot',
-        source: 'inferred',
-        reason: cold
-          ? `config record: ${degenerate.length} write-once pointer${degenerate.length === 1 ? '' : 's'} with a constant default, and no policy or view reads ${fk.columnNames.join(', ')}`
-          : 'no evidence the path is unreachable'
+        signals,
+        assessment: assess(signals)
       });
     }
   }
@@ -129,22 +209,15 @@ export function classifyPaths(
 }
 
 /**
- * Every identifier-shaped token appearing in an RLS policy predicate or a view
- * body, lowercased. Tokenising rather than substring-matching keeps `schema_id`
- * from being "found" inside `private_schema_id`.
+ * Every identifier-shaped token appearing in the given SQL, lowercased.
+ * Tokenising rather than substring-matching keeps `schema_id` from being
+ * "found" inside `private_schema_id`.
  */
-function referencedColumnNames(tables: TableSnapshot[], viewBodies: string[]): Set<string> {
+function identifierTokens(sources: (string | null)[]): Set<string> {
   const out = new Set<string>();
-  const add = (sql: string | null) => {
-    if (!sql) return;
+  for (const sql of sources) {
+    if (!sql) continue;
     for (const token of sql.toLowerCase().match(/[a-z_][a-z0-9_$]*/g) ?? []) out.add(token);
-  };
-  for (const table of tables) {
-    for (const policy of table.policies) {
-      add(policy.using);
-      add(policy.withCheck);
-    }
   }
-  for (const body of viewBodies) add(body);
   return out;
 }

--- a/packages/safegres/src/pg/paths.ts
+++ b/packages/safegres/src/pg/paths.ts
@@ -1,0 +1,150 @@
+/**
+ * Access-path classification: which foreign keys are query paths, and which
+ * are write-once pointers nothing ever looks rows up by.
+ *
+ * X1 ("foreign key with no covering index") is right about the mechanics — a
+ * `DELETE` on the parent really does scan the child — but it assumes the child
+ * is a relation somebody traverses. On a provisioning-config table that
+ * assumption is false, and acting on the finding buys a write penalty on every
+ * insert in exchange for speeding up a scan of one row.
+ *
+ * The tempting gate, `pg_class.reltuples`, is useless here: safegres grades an
+ * ephemeral CI database that has never held data, so every row estimate is 0
+ * at exactly the moment we grade. Worse, row count is the wrong question —
+ * a huge append-only log nobody joins on wants no FK index, and a tiny lookup
+ * table hammered by every request does. The property we need is *reachability*,
+ * and reachability is structural, which is why it survives an empty database.
+ *
+ * The classification is pure catalog arithmetic — same input, same output, no
+ * statistics and no thresholds tuned against a corpus:
+ *
+ * - a **degenerate pointer** is a foreign key whose every referencing column
+ *   carries a constant default (`uuid_nil()`, a literal) and whose column names
+ *   appear in no RLS policy predicate and no view body anywhere in the
+ *   database. A `NOT NULL` key that starts life pointing at the nil UUID is a
+ *   slot a provisioner fills in, not something rows are found by;
+ * - a **config record** is a table with at least {@link ClassifyOptions.minPointers}
+ *   degenerate pointers. On one, every foreign key whose columns are likewise
+ *   absent from all policy predicates and view bodies is a **cold path**.
+ *
+ * The tenant key is never cold and needs no special case: `database_id` appears
+ * in essentially every RLS policy, so the policy check excludes it on its own.
+ */
+
+import type { TableIndexSnapshot } from './indexes';
+import type { TableSnapshot } from './introspect';
+
+export type PathState = 'hot' | 'cold';
+
+/** How a path came to be classified — reported so a reviewer can audit it. */
+export type PathSource = 'inferred';
+
+export interface AccessPath {
+  schema: string;
+  table: string;
+  /** Referencing column names, in constraint order. */
+  columns: string[];
+  /** The foreign-key constraint this path belongs to. */
+  constraint: string;
+  state: PathState;
+  source: PathSource;
+  /** Why the classifier reached this state, in one human-readable clause. */
+  reason: string;
+}
+
+export interface ClassifyOptions {
+  /**
+   * Degenerate pointers a table needs before it counts as a config record.
+   * Default 2. Lifting the test from the column to the table is what catches
+   * the nullable, undefaulted pointer sitting alongside the defaulted ones.
+   */
+  minPointers?: number;
+}
+
+export const DEFAULT_MIN_POINTERS = 2;
+
+/**
+ * Defaults that pin a key column to one value for every row the application
+ * does not overwrite — the nil UUID, a literal, a constant of any scalar type.
+ * A call to anything else (`uuidv7()`, `now()`, a sequence) is excluded: those
+ * produce a real distribution of keys.
+ */
+const CONSTANT_DEFAULT = /^(uuid_nil\(\)|'(?:[^']|'')*'(?:::[\w .]+(?:\[\])?)?|-?\d+(?:\.\d+)?|true|false)$/i;
+
+export function isConstantDefault(defaultExpr: string | null): boolean {
+  if (!defaultExpr) return false;
+  return CONSTANT_DEFAULT.test(defaultExpr.trim());
+}
+
+/** Key for {@link AccessPath} lookups: the relation plus the constraint name. */
+export function pathKey(schema: string, table: string, constraint: string): string {
+  return `${schema}.${table}.${constraint}`;
+}
+
+/**
+ * Classify every foreign key in the snapshot as a hot or cold access path.
+ *
+ * `tables` supplies the RLS policy predicates (as SQL text) and `viewBodies`
+ * the view definitions; a column named in either is read by something, which
+ * refutes coldness. Both are matched as whole-word tokens across the *whole*
+ * database rather than per relation — deliberately conservative, since the
+ * cost of missing a cold path is one spurious finding while the cost of a
+ * wrong one is a dropped index.
+ */
+export function classifyPaths(
+  indexSnapshot: TableIndexSnapshot[],
+  tables: TableSnapshot[],
+  viewBodies: string[],
+  options: ClassifyOptions = {}
+): Map<string, AccessPath> {
+  const minPointers = options.minPointers ?? DEFAULT_MIN_POINTERS;
+  const referenced = referencedColumnNames(tables, viewBodies);
+  const paths = new Map<string, AccessPath>();
+
+  for (const table of indexSnapshot) {
+    const defaults = new Map(table.columns.map((c) => [c.attnum, c.defaultExpr]));
+    const unread = (columns: string[]) => columns.every((c) => !referenced.has(c.toLowerCase()));
+    const degenerate = table.foreignKeys.filter(
+      (fk) => fk.columns.every((a) => isConstantDefault(defaults.get(a) ?? null)) && unread(fk.columnNames)
+    );
+    const isConfigRecord = degenerate.length >= minPointers;
+
+    for (const fk of table.foreignKeys) {
+      const cold = isConfigRecord && unread(fk.columnNames);
+      paths.set(pathKey(table.schema, table.name, fk.name), {
+        schema: table.schema,
+        table: table.name,
+        columns: fk.columnNames,
+        constraint: fk.name,
+        state: cold ? 'cold' : 'hot',
+        source: 'inferred',
+        reason: cold
+          ? `config record: ${degenerate.length} write-once pointer${degenerate.length === 1 ? '' : 's'} with a constant default, and no policy or view reads ${fk.columnNames.join(', ')}`
+          : 'no evidence the path is unreachable'
+      });
+    }
+  }
+
+  return paths;
+}
+
+/**
+ * Every identifier-shaped token appearing in an RLS policy predicate or a view
+ * body, lowercased. Tokenising rather than substring-matching keeps `schema_id`
+ * from being "found" inside `private_schema_id`.
+ */
+function referencedColumnNames(tables: TableSnapshot[], viewBodies: string[]): Set<string> {
+  const out = new Set<string>();
+  const add = (sql: string | null) => {
+    if (!sql) return;
+    for (const token of sql.toLowerCase().match(/[a-z_][a-z0-9_$]*/g) ?? []) out.add(token);
+  };
+  for (const table of tables) {
+    for (const policy of table.policies) {
+      add(policy.using);
+      add(policy.withCheck);
+    }
+  }
+  for (const body of viewBodies) add(body);
+  return out;
+}

--- a/packages/safegres/src/report/markdown.ts
+++ b/packages/safegres/src/report/markdown.ts
@@ -55,8 +55,15 @@ export function renderMarkdown(report: Report, options: RenderMarkdownOptions = 
 
   if (report.perf) {
     out.push(...findingSection('Performance findings', report.perf.findings, options));
-    const { stats, explain, diff } = report.perf;
+    const { paths, stats, explain, diff } = report.perf;
     const notes: string[] = [];
+    if (paths && paths.cold > 0) {
+      notes.push(
+        `Access paths: ${paths.cold} of ${paths.total} foreign keys across ${paths.tables} `
+          + 'provisioning-config tables are written once and read by nothing, so X1 does not '
+          + 'ask for an index on them (`perf.paths.infer: false` to disable).'
+      );
+    }
     if (stats) {
       notes.push(
         `Runtime statistics: ${stats.tables} tables, counters since ${stats.statsReset ?? 'server start'}`

--- a/packages/safegres/src/report/markdown.ts
+++ b/packages/safegres/src/report/markdown.ts
@@ -57,11 +57,17 @@ export function renderMarkdown(report: Report, options: RenderMarkdownOptions = 
     out.push(...findingSection('Performance findings', report.perf.findings, options));
     const { paths, stats, explain, diff } = report.perf;
     const notes: string[] = [];
-    if (paths && paths.cold > 0) {
+    if (paths && paths.writeOnceShaped > 0) {
+      const acted = {
+        report: 'X1 still asks for an index on each of them',
+        demote: 'their X1 findings are demoted to `info`',
+        suppress: 'their X1 findings are suppressed'
+      }[paths.onWriteOncePointer];
       notes.push(
-        `Access paths: ${paths.cold} of ${paths.total} foreign keys across ${paths.tables} `
-          + 'provisioning-config tables are written once and read by nothing, so X1 does not '
-          + 'ask for an index on them (`perf.paths.infer: false` to disable).'
+        `Access paths: of ${paths.total} foreign keys, ${paths.read} are named by an RLS policy `
+          + `or a view, and ${paths.writeOnceShaped} across ${paths.tables} tables look like `
+          + `write-once provisioning pointers — ${acted}. A shape is not proof that nothing `
+          + 'queries the relation (`perf.paths.onWriteOncePointer` to change what X1 does).'
       );
     }
     if (stats) {

--- a/packages/safegres/src/report/pretty.ts
+++ b/packages/safegres/src/report/pretty.ts
@@ -163,7 +163,16 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
       }
     }
 
-    const { stats, explain } = report.perf;
+    const { paths, stats, explain } = report.perf;
+    if (paths && paths.cold > 0) {
+      lines.push(
+        paint(
+          'info',
+          `  access paths: ${paths.cold}/${paths.total} foreign keys on ${paths.tables} `
+            + 'config tables are written once and read by nothing — X1 exempt'
+        )
+      );
+    }
     if (stats) {
       lines.push(
         paint(

--- a/packages/safegres/src/report/pretty.ts
+++ b/packages/safegres/src/report/pretty.ts
@@ -164,12 +164,15 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
     }
 
     const { paths, stats, explain } = report.perf;
-    if (paths && paths.cold > 0) {
+    if (paths && paths.writeOnceShaped > 0) {
+      const acted = { report: 'reported', demote: 'demoted to info', suppress: 'suppressed' }[
+        paths.onWriteOncePointer
+      ];
       lines.push(
         paint(
           'info',
-          `  access paths: ${paths.cold}/${paths.total} foreign keys on ${paths.tables} `
-            + 'config tables are written once and read by nothing — X1 exempt'
+          `  access paths: ${paths.total} foreign keys — ${paths.read} read by a policy or view, `
+            + `${paths.writeOnceShaped} on ${paths.tables} tables write-once shaped (X1 ${acted})`
         )
       );
     }

--- a/packages/safegres/src/types.ts
+++ b/packages/safegres/src/types.ts
@@ -131,8 +131,24 @@ export interface PerfReport {
   diff?: import('./perf/baseline').PerfDiff;
   /** Runtime-statistics provenance, present when the audit ran with `--stats`. */
   stats?: PerfStatsReport;
+  /**
+   * Access-path classification: how many foreign keys X1 was not applied to,
+   * because nothing reads them. Reported so a suppression this broad is never
+   * silent.
+   */
+  paths?: PerfPathsReport;
   /** Planner-proof summary, present when the audit ran with `--explain`. */
   explain?: import('./perf/explain').ExplainReport;
+}
+
+/** What the access-path classifier concluded, and over what. */
+export interface PerfPathsReport {
+  /** Foreign keys considered. */
+  total: number;
+  /** Foreign keys classified as never queried, and so exempt from X1. */
+  cold: number;
+  /** Tables classified as provisioning-config records. */
+  tables: number;
 }
 
 /** Where the `S*` findings' numbers came from, and how much to trust them. */

--- a/packages/safegres/src/types.ts
+++ b/packages/safegres/src/types.ts
@@ -141,14 +141,21 @@ export interface PerfReport {
   explain?: import('./perf/explain').ExplainReport;
 }
 
-/** What the access-path classifier concluded, and over what. */
+/**
+ * What the access-path signals found, and what X1 did about it. Reported so
+ * the evidence is visible even when — as by default — it changes nothing.
+ */
 export interface PerfPathsReport {
-  /** Foreign keys considered. */
+  /** Foreign keys examined. */
   total: number;
-  /** Foreign keys classified as never queried, and so exempt from X1. */
-  cold: number;
-  /** Tables classified as provisioning-config records. */
+  /** Keys with a `read` signal: an RLS policy or a view names the column. */
+  read: number;
+  /** Keys whose only signals are shape: they look like provisioning pointers. */
+  writeOnceShaped: number;
+  /** Tables carrying enough write-once pointers to look like config records. */
   tables: number;
+  /** What X1 did with the write-once-shaped keys. */
+  onWriteOncePointer: 'report' | 'demote' | 'suppress';
 }
 
 /** Where the `S*` findings' numbers came from, and how much to trust them. */


### PR DESCRIPTION
## Summary

X1 ("foreign key with no covering index") assumes every FK is a relation somebody traverses. On a provisioning-config table it isn't, and acting on the finding buys a write on every insert to speed up a scan of one row — which is how ~374 indexes landed in `metaschema_modules_public` and the perf grade went 31.0/F → 91.7/A while the database got worse.

This collects **evidence about which keys anything reads** and reports it. It deliberately does **not** decide anything with it — X1 fires exactly as before, no severity moves, no score changes.

The first revision of this PR did decide, and was wrong. It read "no RLS policy or view names this column" as "nothing reads this key" and suppressed X1 on 395 keys. But `metaschema_modules_public` is exposed through the `modules` API, only 26 of its 477 FKs are omitted, and PostGraphile generates a reverse relation for the rest — those paths are reachable and the index behind them is defensible. A missing signal is not a negative signal.

So the classifier becomes a signal collector with no verdict:

```ts
type SignalDirection = 'read' | 'shape';

// 'policy-read' | 'view-read'          → read   (decisive: the DB traverses it)
// 'write-once-pointer' | 'config-record' → shape (an idiom, not a fact)

assess(signals) =
  signals.some(s => s.direction === 'read')       ? 'read'
: signals.some(s => s.name === 'config-record')   ? 'write-once-shaped'
:                                                   'unknown';
```

A `read` signal is a veto — one real reader ends the discussion, so it can't be outvoted by shape. `write-once-shaped` is a suspicion and is treated as one: the signals ride along on the finding (`context.pathSignals`) and in aggregate (`report.perf.paths`), and `perf.paths.onWriteOncePointer` decides what X1 does about it — `report` (default, no change), `demote` (→ `info`, off the score), `suppress`.

The signal that *would* settle it is the one that isn't here: whether the generated GraphQL surface still contains the field. `@omit many` compiles to `-manyRelation:resource:{list,connection}`, which deletes the reverse connection and makes the path unreachable *by construction* rather than by inference. That plugs in as one more `PathSignal`, and only then does an "index nothing can reach" finding become defensible.

Verified against a live constructive-db deploy: 806 FKs — 239 with a read signal, 395 write-once-shaped across 65 tables — and X1 stays at **40 findings**, the same as before this branch. No baseline change, no grade change.


Link to Devin session: https://app.devin.ai/sessions/956c7d07e62b4bc786c4d6e551323838
Requested by: @pyramation