### PR TITLE
feat(safegres): compare a run against a previous one (score/severity/rule deltas)

### DIFF
--- a/.agents/skills/safegres/SKILL.md
+++ b/.agents/skills/safegres/SKILL.md
@@ -135,6 +135,10 @@ safegres audit --perf-baseline .safegres-perf.json --fail-on-new-perf   # exit 1
 
 Entries are keyed by code + relation + policy + subject (constraint/index/expression/column/function), never by message text, so safegres upgrades don't invalidate a committed baseline. Fixed findings are reported so you can re-baseline and stop them regressing. Library: `toPerfBaseline(findings)` / `diffPerf(findings, baseline)` → `{ added, removed, accepted }`; also emitted as `report.perf.diff`. Prefer this over asserting a perf grade in a test — it fails on the change, not on inherited debt.
 
+### Delta against a previous run (`--compare`)
+
+The baseline answers "is there new debt?"; `--compare` answers "which way did the numbers move?" — a Δ column in the markdown score table (arrow, points, grade transition, finding count), the severity counts that changed, and every rule whose count changed. It reads a file, because safegres keeps no history: pass any earlier `--format json` report, or the smaller `--write-snapshot` output. `--compare-ref <label>` names the previous run in the report. Library: `compareReports(previous, report)` → `report.comparison`; `toSnapshot` / `parseSnapshot` / `serializeSnapshot` for the file. Purely descriptive — it never fails a build; that stays the baseline's job.
+
 ### Runtime statistics (`--stats`, implies `--perf`)
 
 The `S*` rules read what the workload did, from `pg_stat_user_tables` / `pg_stat_user_indexes` / optional `pg_stat_statements`: **S1** seq-scan-dominant table (medium), **S2** index the planner has never chosen (low), **S3** dead-tuple bloat (low), **S4** statement hotspot on a table in scope (info). Only meaningful against a database that has served real traffic — never in a fresh CI database. Every threshold is a floor and configurable under `perf.stats` (`minRows`, `seqScanRatio`, `minIndexBytes`, `deadTupleRatio`, `minTimeShare`, `topStatements`). `S*` findings **are scored** on the perf axis (asking for `--stats` is the opt-in); `perf.scoring.includeStats: false` demotes them to advisories. `report.perf.stats` carries provenance: tables read, `statsReset` (the window the counters describe), whether they were scored, and a note when `pg_stat_statements` isn't installed — a missing extension is never an error.
@@ -234,6 +238,8 @@ safegres audit --stats             # + runtime-statistics rules S1-S4 (implies -
 safegres audit --explain           # + prove findings with EXPLAIN (implies --perf, PG16+)
 safegres audit --format json       # machine-readable
 safegres audit --format markdown >> "$GITHUB_STEP_SUMMARY"   # CI job summary / PR comment
+safegres audit --compare main.json --compare-ref main         # + Δ vs a previous run's JSON
+safegres audit --write-snapshot scoreboard.json               # aggregates only, for a later --compare
 safegres audit --format sarif --sarif-sources ./deploy       # GitHub code scanning (upload-sarif)
 safegres audit --exposed-only      # hide internal advisories
 safegres doctor                    # config/parser/connection/catalog + exposure + stale public.read checks

--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -54,6 +54,24 @@ A plain audit is one command and one gate; `--format markdown` writes the report
 
 Scores lead, then the severity counts, then a table per dimension; internal (non-exposed) advisories and accepted baseline debt fold into `<details>` so the summary stays skimmable. To post it as a PR comment instead, pipe it to `gh pr comment --body-file -`. The same renderer is available to library callers as `renderMarkdown(report)`.
 
+#### What changed (`--compare`)
+
+A report says what the database *is*; on a pull request the only question is what the branch *did* to it. `--compare` diffs this run against a previous one and renders the movement — a Δ column in the score table, the severity counts that moved, and every rule whose finding count changed:
+
+```bash
+safegres audit --perf --compare main-report.json --compare-ref main --format markdown
+```
+
+```
+| Dimension   | Score      | Grade | Δ vs main                                | Top deductions   |
+| Security    | **99.3**   | **A+**| 🟢 ▲ +1.2 (from 98.1)                    | `A3` −4 (×2)     |
+| Performance | **72.4**   | **C** | 🔴 ▼ −2.6 (from 75.0) · B → C · 40 → 46 findings | `X1` −18 (×46) |
+```
+
+The previous run is a file, not something safegres remembers: a scanner has no memory and shouldn't acquire one, so CI decides what "previous" means (the report artifact from the base branch, a committed scoreboard, last night's nightly) and hands it over. Any earlier `--format json` output works as input. When keeping whole reports is too much, `--write-snapshot <file>` writes just the aggregates the comparison reads — scores, grades, severity counts, per-rule counts — and `--compare` accepts either. `--compare-ref` labels the previous run in the output.
+
+Library callers get the same thing as `compareReports(previous, report)`, with `toSnapshot` / `parseSnapshot` / `serializeSnapshot` for the file side; the result is carried in JSON output as `comparison`.
+
 #### Code scanning (SARIF)
 
 `--format sarif` emits SARIF 2.1.0, so findings become GitHub code-scanning alerts — Security tab, inline PR annotations, dismissals that stick:

--- a/packages/safegres/__tests__/compare.test.ts
+++ b/packages/safegres/__tests__/compare.test.ts
@@ -1,0 +1,192 @@
+import {
+  compareReports,
+  formatDelta,
+  parseSnapshot,
+  serializeSnapshot,
+  toSnapshot
+} from '../src/report/compare';
+import { renderMarkdown } from '../src/report/markdown';
+import { renderPretty } from '../src/report/pretty';
+import { computeScore } from '../src/score/score';
+import type { Finding, Report } from '../src/types';
+import { summarize } from '../src/types';
+
+function finding(over: Partial<Finding> = {}): Finding {
+  return {
+    code: 'A2',
+    severity: 'high',
+    category: 'flags',
+    exposed: true,
+    schema: 'app_public',
+    table: 'widgets',
+    message: 'grants exist on a table with RLS disabled',
+    ...over
+  };
+}
+
+function perfFinding(over: Partial<Finding> = {}): Finding {
+  return finding({
+    code: 'X1',
+    severity: 'medium',
+    category: 'index',
+    dimension: 'perf',
+    table: 'posts',
+    message: 'foreign key posts_author_id_fkey has no covering index',
+    ...over
+  });
+}
+
+function makeReport(security: Finding[], perf: Finding[] = []): Report {
+  const findings = [...security, ...perf];
+  return {
+    version: '1.0.0',
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    summary: summarize(findings),
+    findings,
+    score: computeScore(security, undefined, { exposedTables: 10, exposureKnown: true }),
+    ...(perf.length > 0 && {
+      perf: {
+        findings: perf,
+        summary: summarize(perf),
+        score: computeScore(perf, undefined, { exposedTables: 10, exposureKnown: true })
+      }
+    })
+  };
+}
+
+describe('toSnapshot / parseSnapshot', () => {
+  it('keeps the aggregates and drops the findings', () => {
+    const snapshot = toSnapshot(makeReport([finding()], [perfFinding()]), { ref: 'main' });
+    expect(snapshot.ref).toBe('main');
+    expect(snapshot.security?.findings).toBe(1);
+    expect(snapshot.security?.rules).toEqual({ A2: 1 });
+    expect(snapshot.perf?.rules).toEqual({ X1: 1 });
+    expect(JSON.stringify(snapshot)).not.toContain('has no covering index');
+  });
+
+  it('reads a full report as well as a snapshot, so CI can pass either', () => {
+    const report = makeReport([finding()], [perfFinding()]);
+    const fromReport = parseSnapshot(JSON.stringify(report));
+    const fromSnapshot = parseSnapshot(serializeSnapshot(toSnapshot(report)));
+    expect(fromSnapshot).toEqual(fromReport);
+  });
+
+  it('rejects JSON that is not a report', () => {
+    expect(() => parseSnapshot('{"hello":"world"}')).toThrow(/not a safegres report/);
+  });
+});
+
+describe('compareReports', () => {
+  it('reports an improvement as a positive delta', () => {
+    const before = toSnapshot(makeReport([finding(), finding({ table: 'orders' })]), {
+      ref: 'main'
+    });
+    const after = makeReport([finding()]);
+    const cmp = compareReports(before, after);
+
+    expect(cmp.previous.ref).toBe('main');
+    expect(cmp.security?.delta).toBeGreaterThan(0);
+    expect(cmp.security?.findingsBefore).toBe(2);
+    expect(cmp.security?.findingsAfter).toBe(1);
+    expect(cmp.summary.high).toEqual({ before: 2, after: 1, delta: -1 });
+    expect(cmp.rules).toEqual([
+      { code: 'A2', dimension: 'security', before: 2, after: 1, delta: -1 }
+    ]);
+    expect(cmp.unchanged).toBe(false);
+  });
+
+  it('reports a regression as a negative delta and sorts it first', () => {
+    const before = toSnapshot(makeReport([finding()], [perfFinding()]));
+    const after = makeReport([finding()], [perfFinding(), perfFinding({ table: 'comments' })]);
+    const cmp = compareReports(before, after);
+
+    expect(cmp.perf?.delta).toBeLessThan(0);
+    expect(cmp.rules[0]).toMatchObject({ code: 'X1', delta: 1, dimension: 'perf' });
+  });
+
+  it('notices a rule that appeared or disappeared entirely', () => {
+    const before = toSnapshot(makeReport([finding()]));
+    const after = makeReport([finding({ code: 'A5' })]);
+    const cmp = compareReports(before, after);
+
+    expect(cmp.rules).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'A5', before: 0, after: 1 }),
+        expect.objectContaining({ code: 'A2', before: 1, after: 0 })
+      ])
+    );
+  });
+
+  it('is unchanged when nothing moved', () => {
+    const report = makeReport([finding()], [perfFinding()]);
+    const cmp = compareReports(toSnapshot(report), report);
+    expect(cmp.unchanged).toBe(true);
+    expect(cmp.security?.delta).toBe(0);
+    expect(cmp.rules).toHaveLength(0);
+  });
+
+  it('tolerates a previous run that had no perf dimension', () => {
+    const before = toSnapshot(makeReport([finding()]));
+    const cmp = compareReports(before, makeReport([finding()], [perfFinding()]));
+    expect(cmp.perf).toBeUndefined();
+    expect(cmp.rules).toEqual([
+      { code: 'X1', dimension: 'perf', before: 0, after: 1, delta: 1 }
+    ]);
+  });
+});
+
+describe('formatDelta', () => {
+  it('uses a real minus sign and keeps zero unsigned', () => {
+    expect(formatDelta(2.34, 1)).toBe('+2.3');
+    expect(formatDelta(-2.34, 1)).toBe('−2.3');
+    expect(formatDelta(0)).toBe('0');
+  });
+});
+
+describe('rendering a comparison', () => {
+  const previous = toSnapshot(
+    makeReport([finding(), finding({ table: 'orders' })], [perfFinding()]),
+    { ref: 'main' }
+  );
+  const report = makeReport([finding()], [perfFinding(), perfFinding({ table: 'comments' })]);
+  report.comparison = compareReports(previous, report);
+
+  it('adds a delta column to the score table without dropping a cell', () => {
+    const out = renderMarkdown(report, { summary: true });
+    expect(out).toContain('Δ vs main');
+    const rows = out.split('\n').filter((l) => l.startsWith('| Security |') || l.startsWith('| Performance |'));
+    expect(rows).toHaveLength(2);
+    for (const row of rows) expect(row.split('|')).toHaveLength(7);
+    expect(rows[0]).toContain('🟢 ▲');
+    expect(rows[1]).toContain('🔴 ▼');
+  });
+
+  it('shows the grade transition and the per-rule movement', () => {
+    const out = renderMarkdown(report, { summary: true });
+    expect(out).toContain('Changes since main');
+    expect(out).toMatch(/\| `X1` \| perf \| 1 \| 2 \| 🔴 ▲ \+1 \|/);
+    expect(out).toMatch(/\| `A2` \| security \| 2 \| 1 \| 🟢 ▼ −1 \|/);
+  });
+
+  it('says so plainly when nothing changed', () => {
+    const unchanged = makeReport([finding()]);
+    unchanged.comparison = compareReports(toSnapshot(unchanged, { ref: 'main' }), unchanged);
+    const out = renderMarkdown(unchanged, { summary: true });
+    expect(out).toContain('No change since main');
+    expect(out).not.toContain('Changes since');
+  });
+
+  it('renders without a comparison exactly as before', () => {
+    const plain = makeReport([finding()]);
+    expect(renderMarkdown(plain, { summary: true })).toContain(
+      '| Dimension | Score | Grade | Top deductions |'
+    );
+  });
+
+  it('puts the delta under the score in the terminal renderer', () => {
+    const out = renderPretty(report, { color: false, summary: true });
+    expect(out).toMatch(/Δ vs main: ▲ \+[\d.]+ \(from [\d.]+/);
+    expect(out).toMatch(/Δ vs main: ▼ −[\d.]+/);
+    expect(out).toContain('findings 1 → 2');
+  });
+});

--- a/packages/safegres/src/cli.ts
+++ b/packages/safegres/src/cli.ts
@@ -19,6 +19,9 @@ const options: Partial<CLIOptions> = {
     string: [
       'baseline',
       'write-baseline',
+      'compare',
+      'compare-ref',
+      'write-snapshot',
       'connection',
       'host',
       'user',

--- a/packages/safegres/src/cli/audit.ts
+++ b/packages/safegres/src/cli/audit.ts
@@ -7,6 +7,7 @@ import { audit, type AuditOptions } from '../commands/audit';
 import { loadConfig } from '../config/loader';
 import type { Grade } from '../config/types';
 import { diffPerf, parsePerfBaseline, serializePerfBaseline, toPerfBaseline } from '../perf/baseline';
+import { compareReports, parseSnapshot, serializeSnapshot, toSnapshot } from '../report/compare';
 import { renderJson } from '../report/json';
 import { renderMarkdown } from '../report/markdown';
 import { renderPretty } from '../report/pretty';
@@ -83,6 +84,17 @@ Performance dimension (optional; scored separately from security):
                            EXPLAIN (GENERIC_PLAN) and attach the plan as
                            evidence; findings the planner refutes are reported
                            but unscored (implies --perf, needs PostgreSQL 16+)
+
+Comparison with a previous run (what changed, not just what is):
+  --compare <file>         Diff scores, severity counts and per-rule counts
+                           against a previous run and render the delta.
+                           <file> is any earlier --format json output, or a
+                           snapshot written by --write-snapshot
+  --compare-ref <label>    How to name the previous run in the report
+                           (e.g. "main", a commit sha). Default "previous run"
+  --write-snapshot <file>  Write the aggregate slice of this run (scores,
+                           counts, per-rule counts) for a later --compare,
+                           when keeping the whole report is too much
 
 Call graph (unscored; human review):
   --call-graph             Analyze the functions reachable from the exposed entry
@@ -202,6 +214,38 @@ export default async (
       process.exit(2);
     }
     report.perf.diff = diffPerf(report.perf.findings, parsePerfBaseline(raw));
+  }
+
+  if (typeof argv['write-snapshot'] === 'string') {
+    fs.writeFileSync(
+      argv['write-snapshot'],
+      serializeSnapshot(
+        toSnapshot(report, typeof argv['compare-ref'] === 'string' ? { ref: argv['compare-ref'] } : {})
+      )
+    );
+    log.info(`wrote snapshot: ${argv['write-snapshot']}`);
+  }
+
+  if (typeof argv.compare === 'string') {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(argv.compare, 'utf8');
+    } catch {
+      log.error(
+        `cannot read --compare file: ${argv.compare} `
+          + '(any earlier `--format json` report or `--write-snapshot` output works)'
+      );
+      process.exit(2);
+    }
+    let previous;
+    try {
+      previous = parseSnapshot(raw);
+    } catch (err) {
+      log.error(`--compare file is not a safegres report: ${(err as Error).message}`);
+      process.exit(2);
+    }
+    if (typeof argv['compare-ref'] === 'string') previous.ref = argv['compare-ref'];
+    report.comparison = compareReports(previous, report);
   }
 
   if (typeof argv.baseline === 'string' && report.callGraph) {

--- a/packages/safegres/src/index.ts
+++ b/packages/safegres/src/index.ts
@@ -121,6 +121,20 @@ export type {
 } from './pg/stats';
 export { introspectStats } from './pg/stats';
 export { renderCallGraph, renderCallGraphDiff } from './report/callgraph';
+export type {
+  DimensionSnapshot,
+  ReportComparison,
+  ReportSnapshot,
+  RuleDelta,
+  ScoreDelta
+} from './report/compare';
+export {
+  compareReports,
+  formatDelta,
+  parseSnapshot,
+  serializeSnapshot,
+  toSnapshot
+} from './report/compare';
 export { renderJson } from './report/json';
 export type { RenderMarkdownOptions } from './report/markdown';
 export { renderMarkdown } from './report/markdown';

--- a/packages/safegres/src/report/compare.ts
+++ b/packages/safegres/src/report/compare.ts
@@ -1,0 +1,204 @@
+/**
+ * Comparison against a previous run (`--compare <file>`).
+ *
+ * A report says what the database is; it never says what changed. In CI that
+ * is the only question a reviewer has — the PR comment reads "Performance 75.0
+ * (C)" whether the branch improved it by ten points or cost ten, and the
+ * numbers are only legible to someone who remembers yesterday's.
+ *
+ * The previous run is supplied as a file rather than inferred: a scanner has
+ * no memory and no business acquiring one, so CI decides what "previous" means
+ * (the artifact from the base branch, a committed scoreboard) and passes it in.
+ * Any `renderJson` output works as input, so nothing extra has to be produced
+ * for this to be usable — but `toSnapshot` exists for the case where a full
+ * report is too large to keep around, since only the aggregates are read.
+ */
+
+import type { Grade } from '../config/types';
+import type { Score } from '../score/score';
+import type { Report, Severity, Summary } from '../types';
+import { newSummary } from '../types';
+
+/** The aggregate slice of a report that a comparison reads. */
+export interface ReportSnapshot {
+  /** safegres version that produced the run. */
+  version?: string;
+  generatedAt?: string;
+  /** Free-form label for the run — a git ref, a commit sha, "main". */
+  ref?: string;
+  summary: Summary;
+  security?: DimensionSnapshot;
+  perf?: DimensionSnapshot;
+}
+
+export interface DimensionSnapshot {
+  value: number;
+  grade: Grade;
+  findings: number;
+  /** Finding count per rule code. */
+  rules: Record<string, number>;
+}
+
+export interface ScoreDelta {
+  before: number;
+  after: number;
+  /** `after - before`, rounded to one decimal. Positive is an improvement. */
+  delta: number;
+  gradeBefore: Grade;
+  gradeAfter: Grade;
+  /** Findings before → after. */
+  findingsBefore: number;
+  findingsAfter: number;
+}
+
+export interface RuleDelta {
+  code: string;
+  before: number;
+  after: number;
+  /** `after - before`. Positive means the rule fires more than it used to. */
+  delta: number;
+  dimension: 'security' | 'perf';
+}
+
+export interface ReportComparison {
+  /** Where the previous numbers came from, for the reader. */
+  previous: { ref?: string; generatedAt?: string; version?: string };
+  security?: ScoreDelta;
+  perf?: ScoreDelta;
+  /** Severity counts, before → after. */
+  summary: Record<Severity, { before: number; after: number; delta: number }>;
+  /** Rules whose finding count moved, largest regression first. */
+  rules: RuleDelta[];
+  /** Nothing moved: same scores, same counts, same rules. */
+  unchanged: boolean;
+}
+
+const SEVERITIES: Severity[] = ['critical', 'high', 'medium', 'low', 'info'];
+
+function dimensionSnapshot(score: Score | undefined, findings: number): DimensionSnapshot | undefined {
+  if (!score) return undefined;
+  const rules: Record<string, number> = {};
+  for (const d of score.deductions) rules[d.code] = d.count;
+  return { value: score.value, grade: score.grade, findings, rules };
+}
+
+/** Reduce a report to the aggregates a comparison needs. */
+export function toSnapshot(report: Report, meta: { ref?: string } = {}): ReportSnapshot {
+  const perfFindings = report.perf?.findings.length ?? 0;
+  return {
+    version: report.version,
+    generatedAt: report.generatedAt,
+    ...(meta.ref !== undefined && { ref: meta.ref }),
+    summary: report.summary,
+    ...(report.score && {
+      security: dimensionSnapshot(report.score, report.findings.length - perfFindings)
+    }),
+    ...(report.perf && { perf: dimensionSnapshot(report.perf.score, perfFindings) })
+  };
+}
+
+export function serializeSnapshot(snapshot: ReportSnapshot): string {
+  return `${JSON.stringify(snapshot, null, 2)}\n`;
+}
+
+/**
+ * Read a previous run from JSON. Accepts either a snapshot or a full report —
+ * the two are distinguished by the presence of `findings`, so CI can hand over
+ * whatever it already has on disk.
+ */
+export function parseSnapshot(json: string): ReportSnapshot {
+  const parsed = JSON.parse(json) as Partial<Report> & Partial<ReportSnapshot>;
+  if (Array.isArray(parsed.findings)) return toSnapshot(parsed as Report);
+  if (!parsed.summary) {
+    throw new Error('not a safegres report or snapshot: no "summary"');
+  }
+  return parsed as ReportSnapshot;
+}
+
+function round(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+function scoreDelta(
+  before: DimensionSnapshot | undefined,
+  after: DimensionSnapshot | undefined
+): ScoreDelta | undefined {
+  if (!before || !after) return undefined;
+  return {
+    before: before.value,
+    after: after.value,
+    delta: round(after.value - before.value),
+    gradeBefore: before.grade,
+    gradeAfter: after.grade,
+    findingsBefore: before.findings,
+    findingsAfter: after.findings
+  };
+}
+
+function ruleDeltas(
+  dimension: 'security' | 'perf',
+  before: DimensionSnapshot | undefined,
+  after: DimensionSnapshot | undefined
+): RuleDelta[] {
+  if (!before && !after) return [];
+  const codes = new Set([
+    ...Object.keys(before?.rules ?? {}),
+    ...Object.keys(after?.rules ?? {})
+  ]);
+  const out: RuleDelta[] = [];
+  for (const code of codes) {
+    const b = before?.rules[code] ?? 0;
+    const a = after?.rules[code] ?? 0;
+    if (a !== b) out.push({ code, before: b, after: a, delta: a - b, dimension });
+  }
+  return out;
+}
+
+/** Diff a fresh report against a previous run. */
+export function compareReports(previous: ReportSnapshot, current: Report): ReportComparison {
+  const now = toSnapshot(current);
+
+  const summary = {} as ReportComparison['summary'];
+  const prevSummary = previous.summary ?? newSummary();
+  for (const sev of SEVERITIES) {
+    const before = prevSummary[sev] ?? 0;
+    const after = now.summary[sev] ?? 0;
+    summary[sev] = { before, after, delta: after - before };
+  }
+
+  const rules = [
+    ...ruleDeltas('security', previous.security, now.security),
+    ...ruleDeltas('perf', previous.perf, now.perf)
+  ].sort((a, b) => b.delta - a.delta || a.code.localeCompare(b.code));
+
+  const security = scoreDelta(previous.security, now.security);
+  const perf = scoreDelta(previous.perf, now.perf);
+
+  return {
+    previous: {
+      ...(previous.ref !== undefined && { ref: previous.ref }),
+      ...(previous.generatedAt !== undefined && { generatedAt: previous.generatedAt }),
+      ...(previous.version !== undefined && { version: previous.version })
+    },
+    ...(security && { security }),
+    ...(perf && { perf }),
+    summary,
+    rules,
+    unchanged:
+      rules.length === 0
+      && (security?.delta ?? 0) === 0
+      && (perf?.delta ?? 0) === 0
+      && SEVERITIES.every((sev) => summary[sev].delta === 0)
+  };
+}
+
+/**
+ * `+2.3` / `−1.4` / `0`, with a real minus sign. Rendering-only, but shared:
+ * the markdown and pretty renderers must not disagree about which direction a
+ * number moved.
+ */
+export function formatDelta(delta: number, digits = 0): string {
+  if (delta === 0) return '0';
+  const magnitude = Math.abs(delta).toFixed(digits);
+  return delta > 0 ? `+${magnitude}` : `−${magnitude}`;
+}

--- a/packages/safegres/src/report/markdown.ts
+++ b/packages/safegres/src/report/markdown.ts
@@ -11,6 +11,7 @@
 
 import type { Score } from '../score/score';
 import type { Finding, Report, Severity } from '../types';
+import { formatDelta, type ReportComparison, type ScoreDelta } from './compare';
 
 const SEV_ICON: Record<Severity, string> = {
   critical: '🔴',
@@ -46,6 +47,9 @@ export function renderMarkdown(report: Report, options: RenderMarkdownOptions = 
   }
 
   out.push(countsTable(report), '');
+
+  if (report.comparison) out.push(...comparisonSection(report.comparison), '');
+
   if (options.summary) return out.join('\n');
 
   const security = report.perf
@@ -90,13 +94,15 @@ export function renderMarkdown(report: Report, options: RenderMarkdownOptions = 
 }
 
 function scoreTable(report: Report, options: RenderMarkdownOptions): string[] {
+  const cmp = report.comparison;
   const rows: string[] = [];
-  if (report.score) rows.push(scoreRow('Security', report.score));
-  if (report.perf) rows.push(scoreRow('Performance', report.perf.score));
+  if (report.score) rows.push(scoreRow('Security', report.score, !!cmp, cmp?.security));
+  if (report.perf) rows.push(scoreRow('Performance', report.perf.score, !!cmp, cmp?.perf));
   if (rows.length === 0) return [];
+  const deltaHeader = cmp ? ` Δ vs ${cmp.previous.ref ?? 'previous run'} |` : '';
   return [
-    '| Dimension | Score | Grade | Top deductions |',
-    '| --- | --- | --- | --- |',
+    `| Dimension | Score | Grade |${deltaHeader} Top deductions |`,
+    `| --- | --- | --- |${cmp ? ' --- |' : ''} --- |`,
     ...rows,
     '',
     ...ruleTable('Security', report.score, options),
@@ -104,14 +110,76 @@ function scoreTable(report: Report, options: RenderMarkdownOptions): string[] {
   ];
 }
 
-function scoreRow(label: string, score: Score): string {
+function scoreRow(label: string, score: Score, compared: boolean, delta?: ScoreDelta): string {
   const top = score.deductions
     .filter((d) => !d.unscored)
     .slice(0, 3)
     .map((d) => `\`${d.code}\` −${d.points} (×${d.count})`)
     .join(', ');
   const capped = score.cappedByUnknownExposure ? ' (capped)' : '';
-  return `| ${label} | **${score.value}**${capped} | **${score.grade}** | ${top || '—'} |`;
+  // The column exists for the whole table or not at all: a dimension the
+  // previous run didn't have still needs its cell.
+  const deltaCell = compared ? ` ${delta ? scoreDeltaCell(delta) : '— (new)'} |` : '';
+  return `| ${label} | **${score.value}**${capped} | **${score.grade}** |${deltaCell} ${top || '—'} |`;
+}
+
+/**
+ * The movement, made legible at a glance: an arrow for the direction, the
+ * grade transition when it crossed a band, and the finding count either way —
+ * a score can hold still while findings move underneath it.
+ */
+function scoreDeltaCell(d: ScoreDelta): string {
+  const arrow = d.delta > 0 ? '🟢 ▲' : d.delta < 0 ? '🔴 ▼' : '⚪';
+  const score = d.delta === 0 ? 'no change' : `${formatDelta(d.delta, 1)} (from ${d.before})`;
+  const grade = d.gradeBefore === d.gradeAfter ? '' : ` · ${d.gradeBefore} → ${d.gradeAfter}`;
+  const findings =
+    d.findingsAfter === d.findingsBefore
+      ? ''
+      : ` · ${d.findingsBefore} → ${d.findingsAfter} findings`;
+  return `${arrow} ${score}${grade}${findings}`;
+}
+
+/**
+ * Rendered after the counts so the two tables can be read together: what the
+ * numbers are, then which way they moved.
+ */
+function comparisonSection(cmp: ReportComparison): string[] {
+  const since = cmp.previous.ref ?? cmp.previous.generatedAt ?? 'the previous run';
+  if (cmp.unchanged) return ['', `_No change since ${since}._`];
+
+  const out = ['', `<details open><summary>Changes since ${since}</summary>`, ''];
+
+  const severities: Severity[] = ['critical', 'high', 'medium', 'low', 'info'];
+  const moved = severities.filter((sev) => cmp.summary[sev].delta !== 0);
+  if (moved.length > 0) {
+    out.push(
+      `| ${moved.map((sev) => `${SEV_ICON[sev]} ${sev}`).join(' | ')} |`,
+      `| ${moved.map(() => '---').join(' | ')} |`,
+      `| ${moved
+        .map((sev) => {
+          const s = cmp.summary[sev];
+          return `${s.before} → **${s.after}** (${formatDelta(s.delta)})`;
+        })
+        .join(' | ')} |`,
+      ''
+    );
+  }
+
+  if (cmp.rules.length > 0) {
+    out.push(
+      '| Rule | Dimension | Before | After | Δ |',
+      '| --- | --- | ---: | ---: | --- |',
+      ...cmp.rules.map(
+        (r) =>
+          `| \`${r.code}\` | ${r.dimension} | ${r.before} | ${r.after} | `
+          + `${r.delta > 0 ? '🔴 ▲' : '🟢 ▼'} ${formatDelta(r.delta)} |`
+      ),
+      ''
+    );
+  }
+
+  out.push('</details>');
+  return out;
 }
 
 /**

--- a/packages/safegres/src/report/pretty.ts
+++ b/packages/safegres/src/report/pretty.ts
@@ -3,6 +3,7 @@ import yanse from 'yanse';
 import type { Score } from '../score/score';
 import type { Finding, Report, Severity } from '../types';
 import { renderCallGraph, renderCallGraphDiff } from './callgraph';
+import { formatDelta, type ScoreDelta } from './compare';
 
 const SEV_LABEL: Record<Severity, string> = {
   critical: 'CRIT',
@@ -60,11 +61,17 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
 
   if (score) {
     lines.push(...scoreLines('score', score, colorEnabled));
+    if (report.comparison?.security) {
+      lines.push(`  ${deltaLine(report.comparison.security, report.comparison.previous.ref)}`);
+    }
     lines.push('');
   }
 
   if (report.perf) {
     lines.push(...scoreLines('perf score', report.perf.score, colorEnabled));
+    if (report.comparison?.perf) {
+      lines.push(`  ${deltaLine(report.comparison.perf, report.comparison.previous.ref)}`);
+    }
     lines.push('');
   }
 
@@ -228,6 +235,14 @@ function scoreLines(label: string, score: Score, colorEnabled: boolean): string[
     );
   }
   return lines;
+}
+
+function deltaLine(d: ScoreDelta, ref?: string): string {
+  const since = ref ? ` vs ${ref}` : ' vs previous run';
+  const arrow = d.delta > 0 ? '▲' : d.delta < 0 ? '▼' : '=';
+  const grade = d.gradeBefore === d.gradeAfter ? '' : `, ${d.gradeBefore} → ${d.gradeAfter}`;
+  return `Δ${since}: ${arrow} ${formatDelta(d.delta, 1)} (from ${d.before}${grade})`
+    + `  findings ${d.findingsBefore} → ${d.findingsAfter}`;
 }
 
 function renderFinding(f: Finding, paint: (sev: Severity, s: string) => string): string {

--- a/packages/safegres/src/types.ts
+++ b/packages/safegres/src/types.ts
@@ -170,6 +170,12 @@ export interface Report {
    * that were resolved.
    */
   callGraphDiff?: import('./callgraph/baseline').CallGraphDiff;
+  /**
+   * Movement against a previous run (`--compare`): score deltas, severity
+   * deltas and the rules that changed. A report describes a database; this is
+   * the only part that describes a change to one.
+   */
+  comparison?: import('./report/compare').ReportComparison;
 }
 
 export function newSummary(): Summary {


### PR DESCRIPTION
## Summary

The PR comment safegres posts today says what the database *is* — "Performance 75.0 (C)" — whether the branch improved it by ten points or cost ten. `--compare <file>` adds the missing half: a Δ column in the score table, the severity counts that moved, and every rule whose finding count changed.

```
| Dimension   | Score    | Grade | Δ vs main                                        | Top deductions |
| Security    | **99.3** | **A+**| 🟢 ▲ +1.2 (from 98.1)                            | `A3` −4 (×2)   |
| Performance | **72.4** | **C** | 🔴 ▼ −2.6 (from 75.0) · B → C · 40 → 46 findings | `X1` −18 (×46) |
```

**The previous run is an input, not state.** A scanner has no memory and shouldn't acquire one, so CI decides what "previous" means (the report artifact from the base branch, a committed scoreboard, last night's nightly) and hands the file over. `parseSnapshot` accepts either a full `--format json` report or the smaller `--write-snapshot` output, so nothing new has to be produced to start using it:

```ts
export function parseSnapshot(json: string): ReportSnapshot {
  const parsed = JSON.parse(json);
  if (Array.isArray(parsed.findings)) return toSnapshot(parsed as Report);  // a full report
  if (!parsed.summary) throw new Error('not a safegres report or snapshot');
  return parsed as ReportSnapshot;                                           // a snapshot
}
```

`ReportSnapshot` is the aggregate slice a comparison actually reads — scores, grades, severity counts, `{ code -> count }` per dimension — so a scoreboard can be kept around without keeping thousands of findings.

Purely descriptive: it changes no score and fails no build. Gating stays the perf baseline's job, which answers a different question ("is there new debt?" vs "which way did the numbers move?").

Rendering notes: the Δ column is present for the whole score table or not at all — a dimension the previous run didn't have still gets a cell (`— (new)`) rather than a short row. Direction is coloured by *meaning*, not sign: 🟢 for a rising score and 🔴 for a rising finding count.

New surface:

```
--compare <file>         diff against a previous run and render the delta
--compare-ref <label>    how to name it in the report (default "previous run")
--write-snapshot <file>  aggregates only, for a later --compare
```

Library: `compareReports(previous, report)` → `report.comparison`, plus `toSnapshot` / `parseSnapshot` / `serializeSnapshot` and `formatDelta`.

## Testing

`__tests__/compare.test.ts` (14): snapshot round-trip through both input shapes, improvement/regression/appeared/disappeared/unchanged, a previous run with no perf dimension, and both renderers — including an assertion that every score row keeps its cell count when the Δ column is on.

Full package suite: 18 suites, 174 tests. `tsc --noEmit` and eslint clean (two pre-existing `_extends` warnings in `config/loader.ts`).


Link to Devin session: https://app.devin.ai/sessions/ec06ef6eabae4872ae5ec3926f037c85
Requested by: @pyramation