### PR TITLE
fix(safegres): color comparison deltas by direction, not severity

### DIFF
--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -68,6 +68,8 @@ safegres audit --perf --compare main-report.json --compare-ref main --format mar
 | Performance | **72.4**   | **C** | 🔴 ▼ −2.6 (from 75.0) · B → C · 40 → 46 findings | `X1` −18 (×46) |
 ```
 
+Colour tracks *direction*, never severity: 🟢 is a better score or fewer findings, 🔴 the reverse, ⚪ no movement. A rule the previous run never reported — one added by a newer safegres, or a dimension that run didn't scan — renders as `⚪ not measured before` rather than a red increase from zero, so upgrading the scanner doesn't read as a regression.
+
 The previous run is a file, not something safegres remembers: a scanner has no memory and shouldn't acquire one, so CI decides what "previous" means (the report artifact from the base branch, a committed scoreboard, last night's nightly) and hands it over. Any earlier `--format json` output works as input. When keeping whole reports is too much, `--write-snapshot <file>` writes just the aggregates the comparison reads — scores, grades, severity counts, per-rule counts — and `--compare` accepts either. `--compare-ref` labels the previous run in the output.
 
 Library callers get the same thing as `compareReports(previous, report)`, with `toSnapshot` / `parseSnapshot` / `serializeSnapshot` for the file side; the result is carried in JSON output as `comparison`.

--- a/packages/safegres/__tests__/compare.test.ts
+++ b/packages/safegres/__tests__/compare.test.ts
@@ -229,7 +229,9 @@ describe('rendering a comparison', () => {
   it('paints the terminal delta green when the score improved', () => {
     const out = renderPretty(report, { color: true, summary: true });
     // Improvement green, regression red — matching the markdown convention.
-    expect(out).toMatch(/\u001b\[32m▲ \+[\d.]+/);
-    expect(out).toMatch(/\u001b\[31m▼ −[\d.]+/);
+    const green = String.fromCharCode(27) + '[32m';
+    const red = String.fromCharCode(27) + '[31m';
+    expect(out).toContain(`${green}▲ +`);
+    expect(out).toContain(`${red}▼ −`);
   });
 });

--- a/packages/safegres/__tests__/compare.test.ts
+++ b/packages/safegres/__tests__/compare.test.ts
@@ -130,8 +130,23 @@ describe('compareReports', () => {
     const cmp = compareReports(before, makeReport([finding()], [perfFinding()]));
     expect(cmp.perf).toBeUndefined();
     expect(cmp.rules).toEqual([
-      { code: 'X1', dimension: 'perf', before: 0, after: 1, delta: 1 }
+      { code: 'X1', dimension: 'perf', before: 0, after: 1, delta: 1, unmeasuredBefore: true }
     ]);
+  });
+
+  it('separates a rule the previous run never reported from a real zero', () => {
+    // A2 fired once before and twice now — a regression. A5 is new to this
+    // version of the scanner, so its count did not move, it appeared.
+    const before = toSnapshot(makeReport([finding()]));
+    const cmp = compareReports(
+      before,
+      makeReport([finding(), finding({ table: 'orders' }), finding({ code: 'A5' })])
+    );
+
+    expect(cmp.rules.find((r) => r.code === 'A2')?.unmeasuredBefore).toBeUndefined();
+    expect(cmp.rules.find((r) => r.code === 'A5')?.unmeasuredBefore).toBe(true);
+    // Real movement leads; an unmeasured rule is not a regression.
+    expect(cmp.rules[0].code).toBe('A2');
   });
 });
 
@@ -166,6 +181,27 @@ describe('rendering a comparison', () => {
     expect(out).toContain('Changes since main');
     expect(out).toMatch(/\| `X1` \| perf \| 1 \| 2 \| 🔴 ▲ \+1 \|/);
     expect(out).toMatch(/\| `A2` \| security \| 2 \| 1 \| 🟢 ▼ −1 \|/);
+    expect(out).toContain('🟢 improvement · 🔴 regression');
+  });
+
+  it('colors severity movement by direction, not by severity', () => {
+    const out = renderMarkdown(report, { summary: true });
+    // One fewer high (green) and one more medium (red), in a table whose
+    // header icons are red and yellow — the delta must not borrow those.
+    expect(out).toMatch(/2 → \*\*1\*\* 🟢 ▼ −1/);
+    expect(out).toMatch(/1 → \*\*2\*\* 🔴 ▲ \+1/);
+  });
+
+  it('does not paint a rule the previous run never measured as a regression', () => {
+    const upgraded = makeReport([finding(), finding({ code: 'A5' })]);
+    upgraded.comparison = compareReports(
+      toSnapshot(makeReport([finding()]), { ref: 'main' }),
+      upgraded
+    );
+    const out = renderMarkdown(upgraded, { summary: true });
+
+    expect(out).toMatch(/\| `A5` \| security \| — \| 1 \| ⚪ not measured before \|/);
+    expect(out).not.toMatch(/`A5`.*🔴/);
   });
 
   it('says so plainly when nothing changed', () => {
@@ -188,5 +224,12 @@ describe('rendering a comparison', () => {
     expect(out).toMatch(/Δ vs main: ▲ \+[\d.]+ \(from [\d.]+/);
     expect(out).toMatch(/Δ vs main: ▼ −[\d.]+/);
     expect(out).toContain('findings 1 → 2');
+  });
+
+  it('paints the terminal delta green when the score improved', () => {
+    const out = renderPretty(report, { color: true, summary: true });
+    // Improvement green, regression red — matching the markdown convention.
+    expect(out).toMatch(/\u001b\[32m▲ \+[\d.]+/);
+    expect(out).toMatch(/\u001b\[31m▼ −[\d.]+/);
   });
 });

--- a/packages/safegres/src/report/compare.ts
+++ b/packages/safegres/src/report/compare.ts
@@ -58,6 +58,14 @@ export interface RuleDelta {
   /** `after - before`. Positive means the rule fires more than it used to. */
   delta: number;
   dimension: 'security' | 'perf';
+  /**
+   * The previous run reported nothing for this code — a rule that did not
+   * exist in that version, or a dimension it never ran. Distinct from a real
+   * zero: `before: 0` means the rule ran and found nothing, and an increase
+   * off it is a regression; this means the movement is unknown, and rendering
+   * it as one is how a scanner upgrade comes out looking like a catastrophe.
+   */
+  unmeasuredBefore?: boolean;
 }
 
 export interface ReportComparison {
@@ -147,9 +155,18 @@ function ruleDeltas(
   ]);
   const out: RuleDelta[] = [];
   for (const code of codes) {
+    const measured = before?.rules[code] !== undefined;
     const b = before?.rules[code] ?? 0;
     const a = after?.rules[code] ?? 0;
-    if (a !== b) out.push({ code, before: b, after: a, delta: a - b, dimension });
+    if (a === b) continue;
+    out.push({
+      code,
+      before: b,
+      after: a,
+      delta: a - b,
+      dimension,
+      ...(measured ? {} : { unmeasuredBefore: true })
+    });
   }
   return out;
 }
@@ -169,7 +186,15 @@ export function compareReports(previous: ReportSnapshot, current: Report): Repor
   const rules = [
     ...ruleDeltas('security', previous.security, now.security),
     ...ruleDeltas('perf', previous.perf, now.perf)
-  ].sort((a, b) => b.delta - a.delta || a.code.localeCompare(b.code));
+  ]
+    // Regressions first, then improvements; rules with no previous reading
+    // last, since they are not movement and should not lead the table.
+    .sort(
+      (a, b) =>
+        Number(a.unmeasuredBefore ?? false) - Number(b.unmeasuredBefore ?? false)
+        || b.delta - a.delta
+        || a.code.localeCompare(b.code)
+    );
 
   const security = scoreDelta(previous.security, now.security);
   const perf = scoreDelta(previous.perf, now.perf);

--- a/packages/safegres/src/report/markdown.ts
+++ b/packages/safegres/src/report/markdown.ts
@@ -11,7 +11,7 @@
 
 import type { Score } from '../score/score';
 import type { Finding, Report, Severity } from '../types';
-import { formatDelta, type ReportComparison, type ScoreDelta } from './compare';
+import { formatDelta, type ReportComparison, type RuleDelta, type ScoreDelta } from './compare';
 
 const SEV_ICON: Record<Severity, string> = {
   critical: '🔴',
@@ -20,6 +20,19 @@ const SEV_ICON: Record<Severity, string> = {
   low: '🔵',
   info: '⚪'
 };
+
+/**
+ * Movement, colored by whether it is good news — the severity icons already
+ * spend red on "this is serious", so a delta that reuses red for "+15 info
+ * findings" reads as a fire when nothing is burning. Green is fewer findings /
+ * a higher score, red is the reverse, grey is neither.
+ */
+function movement(delta: number, betterWhen: 'lower' | 'higher', digits = 0): string {
+  if (delta === 0) return `⚪ ${formatDelta(0)}`;
+  const improved = betterWhen === 'lower' ? delta < 0 : delta > 0;
+  const arrow = delta > 0 ? '▲' : '▼';
+  return `${improved ? '🟢' : '🔴'} ${arrow} ${formatDelta(delta, digits)}`;
+}
 
 export interface RenderMarkdownOptions {
   /** Scores and counts only — no per-finding tables. */
@@ -142,14 +155,23 @@ function scoreRow(label: string, score: Score, compared: boolean, delta?: ScoreD
  * a score can hold still while findings move underneath it.
  */
 function scoreDeltaCell(d: ScoreDelta): string {
-  const arrow = d.delta > 0 ? '🟢 ▲' : d.delta < 0 ? '🔴 ▼' : '⚪';
-  const score = d.delta === 0 ? 'no change' : `${formatDelta(d.delta, 1)} (from ${d.before})`;
+  const score =
+    d.delta === 0 ? '⚪ no change' : `${movement(d.delta, 'higher', 1)} (from ${d.before})`;
   const grade = d.gradeBefore === d.gradeAfter ? '' : ` · ${d.gradeBefore} → ${d.gradeAfter}`;
   const findings =
     d.findingsAfter === d.findingsBefore
       ? ''
-      : ` · ${d.findingsBefore} → ${d.findingsAfter} findings`;
-  return `${arrow} ${score}${grade}${findings}`;
+      : ` · ${d.findingsBefore} → ${d.findingsAfter} findings `
+        + `${movement(d.findingsAfter - d.findingsBefore, 'lower')}`;
+  return `${score}${grade}${findings}`;
+}
+
+/**
+ * A rule with no previous reading is not movement: the previous run simply did
+ * not report the code (a rule added since, or a dimension it never ran).
+ */
+function ruleDeltaCell(r: RuleDelta): string {
+  return r.unmeasuredBefore ? '⚪ not measured before' : movement(r.delta, 'lower');
 }
 
 /**
@@ -160,7 +182,13 @@ function comparisonSection(cmp: ReportComparison): string[] {
   const since = cmp.previous.ref ?? cmp.previous.generatedAt ?? 'the previous run';
   if (cmp.unchanged) return ['', `_No change since ${since}._`];
 
-  const out = ['', `<details open><summary>Changes since ${since}</summary>`, ''];
+  const out = [
+    '',
+    `<details open><summary>Changes since ${since}</summary>`,
+    '',
+    '🟢 improvement · 🔴 regression · ⚪ no change or no previous reading',
+    ''
+  ];
 
   const severities: Severity[] = ['critical', 'high', 'medium', 'low', 'info'];
   const moved = severities.filter((sev) => cmp.summary[sev].delta !== 0);
@@ -171,7 +199,7 @@ function comparisonSection(cmp: ReportComparison): string[] {
       `| ${moved
         .map((sev) => {
           const s = cmp.summary[sev];
-          return `${s.before} → **${s.after}** (${formatDelta(s.delta)})`;
+          return `${s.before} → **${s.after}** ${movement(s.delta, 'lower')}`;
         })
         .join(' | ')} |`,
       ''
@@ -184,8 +212,8 @@ function comparisonSection(cmp: ReportComparison): string[] {
       '| --- | --- | ---: | ---: | --- |',
       ...cmp.rules.map(
         (r) =>
-          `| \`${r.code}\` | ${r.dimension} | ${r.before} | ${r.after} | `
-          + `${r.delta > 0 ? '🔴 ▲' : '🟢 ▼'} ${formatDelta(r.delta)} |`
+          `| \`${r.code}\` | ${r.dimension} | ${r.unmeasuredBefore ? '—' : r.before} | `
+          + `${r.after} | ${ruleDeltaCell(r)} |`
       ),
       ''
     );

--- a/packages/safegres/src/report/pretty.ts
+++ b/packages/safegres/src/report/pretty.ts
@@ -62,7 +62,9 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
   if (score) {
     lines.push(...scoreLines('score', score, colorEnabled));
     if (report.comparison?.security) {
-      lines.push(`  ${deltaLine(report.comparison.security, report.comparison.previous.ref)}`);
+      lines.push(
+        `  ${deltaLine(report.comparison.security, report.comparison.previous.ref, colorEnabled)}`
+      );
     }
     lines.push('');
   }
@@ -70,7 +72,9 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
   if (report.perf) {
     lines.push(...scoreLines('perf score', report.perf.score, colorEnabled));
     if (report.comparison?.perf) {
-      lines.push(`  ${deltaLine(report.comparison.perf, report.comparison.previous.ref)}`);
+      lines.push(
+        `  ${deltaLine(report.comparison.perf, report.comparison.previous.ref, colorEnabled)}`
+      );
     }
     lines.push('');
   }
@@ -249,12 +253,21 @@ function scoreLines(label: string, score: Score, colorEnabled: boolean): string[
   return lines;
 }
 
-function deltaLine(d: ScoreDelta, ref?: string): string {
+function deltaLine(d: ScoreDelta, ref: string | undefined, colorEnabled: boolean): string {
   const since = ref ? ` vs ${ref}` : ' vs previous run';
   const arrow = d.delta > 0 ? '▲' : d.delta < 0 ? '▼' : '=';
+  // Same convention as the markdown report: green is the direction you want.
+  const paint = (better: boolean, s: string) =>
+    colorEnabled ? (better ? yanse.green(s) : yanse.red(s)) : s;
+  const movement = `${arrow} ${formatDelta(d.delta, 1)}`;
+  const score = d.delta === 0 ? movement : paint(d.delta > 0, movement);
   const grade = d.gradeBefore === d.gradeAfter ? '' : `, ${d.gradeBefore} → ${d.gradeAfter}`;
-  return `Δ${since}: ${arrow} ${formatDelta(d.delta, 1)} (from ${d.before}${grade})`
-    + `  findings ${d.findingsBefore} → ${d.findingsAfter}`;
+  const findingMove = `${d.findingsBefore} → ${d.findingsAfter}`;
+  const findings =
+    d.findingsAfter === d.findingsBefore
+      ? findingMove
+      : paint(d.findingsAfter < d.findingsBefore, findingMove);
+  return `Δ${since}: ${score} (from ${d.before}${grade})  findings ${findings}`;
 }
 
 function renderFinding(f: Finding, paint: (sev: Severity, s: string) => string): string {


### PR DESCRIPTION
## Summary

The comparison tables reused the severity palette for movement, so a PR comment came out solid red even when the branch improved everything — the reader's first impression was a fire. Two causes, both fixed here.

**1. Colour now tracks direction.** Severity icons mean "this is serious"; a delta icon must mean "this got better/worse". One helper, used by the score cell, the severity row (which previously had no colour at all) and the rule table:

```ts
movement(delta, betterWhen: 'lower' | 'higher')
//  -1 findings → 🟢 ▼ −1      +1 findings → 🔴 ▲ +1      0 → ⚪ 0
```

**2. "The previous run never reported this rule" is no longer a regression.** `ruleDeltas` defaulted a missing code to `0`, so upgrading safegres — which adds rules, and this repo's `constructive-db` run just went 1.15 → 1.16 — rendered `A6 0 → 153 🔴 ▲ +153` for rules that hadn't moved at all. A real zero (rule ran, found nothing) and no reading are now distinct:

```ts
const measured = before?.rules[code] !== undefined;
out.push({ ..., ...(measured ? {} : { unmeasuredBefore: true }) });
```

which renders `| A6 | security | — | 153 | ⚪ not measured before |` and sorts after genuine movement instead of leading the table as the biggest regression.

The terminal renderer follows the same convention (green improvement, red regression) instead of an uncoloured arrow. Legend added above the changes table.

Screenshot of the before, from constructive-db#2676: every row red, `+153`/`+131`/`+125` on rules that were simply new to the scanner.


Link to Devin session: https://app.devin.ai/sessions/ec06ef6eabae4872ae5ec3926f037c85
Requested by: @pyramation