### PR TITLE
feat(safegres): grant/RLS/policy lattice rules (L1–L5) and per-role exposure report

### DIFF
--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -105,13 +105,46 @@ Results are fingerprinted by finding *identity* (code + relation + policy + subj
 | R1 | critical | fail-open | anti-pattern | An **untrusted role** (options: `{ roles: [...] }`) holds a write privilege |
 | R2 | high | fail-open | anti-pattern | A permissive write policy applies to an untrusted role or PUBLIC |
 | R3 | medium | fail-open | anti-pattern | An RLS table has grants **TO PUBLIC** (includes all current/future roles) |
+| L1 | low | fail-closed | coverage | **Dead indirect grant** — a privilege arriving via `PUBLIC` or role inheritance that no permissive policy can admit |
+| L2 | low | fail-closed | coverage | **Dead policy** — a permissive policy applies to a role holding no corresponding grant (direct, PUBLIC, or inherited) |
+| L3 | low | fail-closed | coverage | **Unreachable grant** — object privilege without `USAGE` on the schema |
+| L4 | info | neutral | coverage | **Dead schema USAGE** — the role reaches no relation and no function in the schema (advisory) |
+| L5 | info | fail-open | anti-pattern | An untrusted role (options: `{ roles: [...] }`) reaches an **RLS-off table via PUBLIC or inheritance** |
 | W1 | medium | — | meta | No exposure surface configured — whole database assumed reachable, score capped |
 
 **Direction matters**: `fail-open` findings are actual exposure (the untrusted side can reach more than intended). `fail-closed` findings are denied at runtime — an availability/hygiene concern, not a leak — and contribute **nothing to the score** by default (tune with `scoring.failClosedWeight`).
 
 Coverage is aggregated `(table, role) → { hasUsing, hasWithCheck }` across every applicable permissive policy (FOR ALL + PUBLIC-role policies considered). Roles with `BYPASSRLS` are suppressed.
 
-R1/R2 are no-ops until a role list is configured — e.g. `"R1": ["critical", { "roles": ["anonymous"] }]` — so they cost nothing on databases without an untrusted-role model. The `safegres:constructive` preset configures them for `anonymous`.
+R1/R2 (and L5) are no-ops until a role list is configured — e.g. `"R1": ["critical", { "roles": ["anonymous"] }]` — so they cost nothing on databases without an untrusted-role model. The `safegres:constructive` preset configures them for `anonymous`.
+
+### The grant/RLS/policy lattice (L rules)
+
+The A/R rules read grants exactly as the catalog stores them, which misses the
+two ways access actually arrives without an ACL row naming the role:
+`GRANT ... TO PUBLIC` (applies to every role) and role inheritance
+(`pg_auth_members`, INHERIT-following). The L rules evaluate the *effective*
+cell each `(relation, role, privilege)` lands in:
+
+| grant | RLS | policy | verdict |
+| --- | --- | --- | --- |
+| yes | on | yes | normal — policy-mediated access |
+| yes | on | no | dead grant (L1 indirect; A4/A5 direct) |
+| yes | off | — | unmediated (A2 table-level; L5 per untrusted role, indirect) |
+| no | — | yes | dead policy (L2) |
+
+plus schema composition: an object grant is unreachable without `USAGE` on
+its schema (L3), and `USAGE` that reaches no relation and no function is dead
+surface (L4). Restrictive-only policies never count as coverage, `BYPASSRLS`
+and superuser roles are exempt from policy checks, and policies are matched
+with `pg_has_role` semantics (a policy `TO authenticated` covers a member of
+`authenticated`).
+
+When untrusted roles are configured (via L5/R1 options), the report also
+carries `roleAccess` — the direct answer to “what can role X access?”: every
+relation the role effectively reaches, with provenance (`direct`, `PUBLIC`,
+`member of <role>`) and whether RLS mediates the access. Rendered as a
+“Role access” section in pretty and markdown output.
 
 ## Exposure surface
 

--- a/packages/safegres/__tests__/fixtures/clean-table.sql
+++ b/packages/safegres/__tests__/fixtures/clean-table.sql
@@ -19,6 +19,7 @@ CREATE TABLE fx_clean.items (
 ALTER TABLE fx_clean.items ENABLE ROW LEVEL SECURITY;
 ALTER TABLE fx_clean.items FORCE ROW LEVEL SECURITY;
 
+GRANT USAGE ON SCHEMA fx_clean TO fx_clean_user;
 GRANT SELECT, INSERT, UPDATE ON fx_clean.items TO fx_clean_user;
 
 -- Non-trivial policies gated on the row owner column.

--- a/packages/safegres/__tests__/lattice.test.ts
+++ b/packages/safegres/__tests__/lattice.test.ts
@@ -1,0 +1,291 @@
+import {
+  checkDeadPolicies,
+  checkDeadSchemaUsage,
+  checkIndirectCoverageGaps,
+  checkUnreachableGrants,
+  checkUntrustedIndirectAccess,
+  computeRoleAccess,
+  effectiveGrants,
+  type RoleGraph
+} from '../src/checks/lattice';
+import type { RoleAttributes, SchemaAclInfo } from '../src/pg/acl';
+import type { GrantInfo, PolicyInfo, TableSnapshot } from '../src/pg/introspect';
+
+function table(partial: Partial<TableSnapshot> = {}): TableSnapshot {
+  return {
+    schema: 'app',
+    name: 'docs',
+    oid: 1,
+    rlsEnabled: true,
+    rlsForced: true,
+    isPartitioned: false,
+    owner: 'app_owner',
+    grants: [],
+    policies: [],
+    ...partial
+  };
+}
+
+function grant(role: string, privilege: GrantInfo['privilege']): GrantInfo {
+  return { role, privilege, grantable: false, bypassRls: false };
+}
+
+function policy(partial: Partial<PolicyInfo> = {}): PolicyInfo {
+  return {
+    name: 'p',
+    cmd: 'ALL',
+    permissive: true,
+    roles: ['authenticated'],
+    using: 'true',
+    withCheck: 'true',
+    ...partial
+  };
+}
+
+function role(name: string, partial: Partial<RoleAttributes> = {}): [string, RoleAttributes] {
+  return [name, { name, bypassRls: false, isSuper: false, inheritsFrom: [], ...partial }];
+}
+
+function graph(...entries: Array<[string, RoleAttributes]>): RoleGraph {
+  return new Map(entries);
+}
+
+const BASE_GRAPH = graph(
+  role('anonymous'),
+  role('authenticated'),
+  role('app_owner'),
+  role('app_admin', { inheritsFrom: ['authenticated'] }),
+  role('superrole', { bypassRls: true, isSuper: true })
+);
+
+function schemaAcl(partial: Partial<SchemaAclInfo> = {}): SchemaAclInfo {
+  return {
+    schema: 'app',
+    owner: 'app_owner',
+    grants: [],
+    executeRoles: [],
+    ...partial
+  };
+}
+
+describe('effectiveGrants', () => {
+  it('collects direct, PUBLIC, and inherited grants with most-direct provenance', () => {
+    const t = table({
+      grants: [
+        grant('app_admin', 'SELECT'),
+        grant('PUBLIC', 'SELECT'),
+        grant('PUBLIC', 'INSERT'),
+        grant('authenticated', 'UPDATE'),
+        grant('authenticated', 'INSERT')
+      ]
+    });
+    const eff = effectiveGrants(t, 'app_admin', BASE_GRAPH);
+    expect(eff).toEqual([
+      { privilege: 'INSERT', via: 'PUBLIC' },
+      { privilege: 'SELECT', via: 'direct' },
+      { privilege: 'UPDATE', via: 'member of authenticated' }
+    ]);
+  });
+
+  it('sees nothing for a role with no path to any grant', () => {
+    const t = table({ grants: [grant('authenticated', 'SELECT')] });
+    expect(effectiveGrants(t, 'anonymous', BASE_GRAPH)).toEqual([]);
+  });
+});
+
+describe('L1 checkIndirectCoverageGaps', () => {
+  it('flags a PUBLIC grant no policy can admit', () => {
+    const t = table({ grants: [grant('PUBLIC', 'SELECT')] });
+    const out = checkIndirectCoverageGaps(t, BASE_GRAPH);
+    expect(out).toHaveLength(1);
+    expect(out[0].code).toBe('L1');
+    expect(out[0].role).toBe('PUBLIC');
+    expect(out[0].privilege).toBe('SELECT');
+  });
+
+  it('does not flag a PUBLIC grant a permissive policy covers', () => {
+    const t = table({
+      grants: [grant('PUBLIC', 'SELECT')],
+      policies: [policy({ cmd: 'SELECT', roles: ['PUBLIC'] })]
+    });
+    expect(checkIndirectCoverageGaps(t, BASE_GRAPH)).toEqual([]);
+  });
+
+  it('flags an inherited grant with no applicable policy', () => {
+    const t = table({
+      grants: [grant('authenticated', 'SELECT')],
+      policies: [policy({ cmd: 'SELECT', roles: ['some_other_role'] })]
+    });
+    const out = checkIndirectCoverageGaps(t, BASE_GRAPH);
+    expect(out).toHaveLength(1);
+    expect(out[0].role).toBe('app_admin');
+    expect(out[0].message).toContain('member of authenticated');
+  });
+
+  it('accepts coverage through a policy on the granted (parent) role', () => {
+    const t = table({
+      grants: [grant('authenticated', 'SELECT')],
+      policies: [policy({ cmd: 'SELECT', roles: ['authenticated'] })]
+    });
+    expect(checkIndirectCoverageGaps(t, BASE_GRAPH)).toEqual([]);
+  });
+
+  it('is silent when RLS is disabled', () => {
+    const t = table({ rlsEnabled: false, grants: [grant('PUBLIC', 'SELECT')] });
+    expect(checkIndirectCoverageGaps(t, BASE_GRAPH)).toEqual([]);
+  });
+});
+
+describe('L2 checkDeadPolicies', () => {
+  it('flags a policy naming a role with no grant on the table', () => {
+    const t = table({
+      grants: [grant('authenticated', 'SELECT')],
+      policies: [policy({ name: 'anon_read', cmd: 'SELECT', roles: ['anonymous'] })]
+    });
+    const out = checkDeadPolicies(t, BASE_GRAPH);
+    expect(out).toHaveLength(1);
+    expect(out[0].code).toBe('L2');
+    expect(out[0].policy).toBe('anon_read');
+    expect(out[0].role).toBe('anonymous');
+  });
+
+  it('accepts a grant arriving by inheritance', () => {
+    const t = table({
+      grants: [grant('authenticated', 'SELECT')],
+      policies: [policy({ cmd: 'SELECT', roles: ['app_admin'] })]
+    });
+    expect(checkDeadPolicies(t, BASE_GRAPH)).toEqual([]);
+  });
+
+  it('flags a PUBLIC policy on a table nobody is granted', () => {
+    const t = table({
+      grants: [],
+      policies: [policy({ name: 'open', roles: ['PUBLIC'] })]
+    });
+    const out = checkDeadPolicies(t, BASE_GRAPH);
+    expect(out).toHaveLength(1);
+    expect(out[0].role).toBe('PUBLIC');
+  });
+
+  it('accepts a PUBLIC policy when any non-owner grant exists', () => {
+    const t = table({
+      grants: [grant('authenticated', 'SELECT')],
+      policies: [policy({ roles: ['PUBLIC'] })]
+    });
+    expect(checkDeadPolicies(t, BASE_GRAPH)).toEqual([]);
+  });
+});
+
+describe('L3 checkUnreachableGrants', () => {
+  it('flags an object grant when the grantee lacks schema USAGE', () => {
+    const t = table({ grants: [grant('authenticated', 'SELECT'), grant('authenticated', 'UPDATE')] });
+    const acls = new Map([['app', schemaAcl({ grants: [{ role: 'app_admin', privilege: 'USAGE' }] })]]);
+    const out = checkUnreachableGrants(t, acls, BASE_GRAPH);
+    expect(out).toHaveLength(1);
+    expect(out[0].code).toBe('L3');
+    expect(out[0].role).toBe('authenticated');
+    expect(out[0].privilege).toBe('SELECT, UPDATE');
+  });
+
+  it('accepts USAGE via PUBLIC, inheritance, or schema ownership', () => {
+    const t = table({
+      grants: [grant('authenticated', 'SELECT'), grant('app_admin', 'SELECT'), grant('app_owner', 'SELECT')]
+    });
+    const acls = new Map([
+      ['app', schemaAcl({ grants: [{ role: 'PUBLIC', privilege: 'USAGE' }] })]
+    ]);
+    expect(checkUnreachableGrants(t, acls, BASE_GRAPH)).toEqual([]);
+
+    const inherited = new Map([
+      ['app', schemaAcl({ grants: [{ role: 'authenticated', privilege: 'USAGE' }] })]
+    ]);
+    const out = checkUnreachableGrants(t, inherited, BASE_GRAPH);
+    // app_admin inherits authenticated's USAGE; app_owner owns the schema.
+    expect(out).toEqual([]);
+  });
+
+  it('skips schemas outside the introspected ACL set', () => {
+    const t = table({ schema: 'not_introspected', grants: [grant('authenticated', 'SELECT')] });
+    expect(checkUnreachableGrants(t, new Map(), BASE_GRAPH)).toEqual([]);
+  });
+});
+
+describe('L4 checkDeadSchemaUsage', () => {
+  it('flags USAGE that reaches no relation and no function', () => {
+    const acl = schemaAcl({ grants: [{ role: 'anonymous', privilege: 'USAGE' }] });
+    const out = checkDeadSchemaUsage([acl], [table()], BASE_GRAPH);
+    expect(out).toHaveLength(1);
+    expect(out[0].code).toBe('L4');
+    expect(out[0].role).toBe('anonymous');
+  });
+
+  it('accepts USAGE when the role reaches a relation or a function', () => {
+    const aclFn = schemaAcl({
+      grants: [{ role: 'anonymous', privilege: 'USAGE' }],
+      executeRoles: ['PUBLIC']
+    });
+    expect(checkDeadSchemaUsage([aclFn], [table()], BASE_GRAPH)).toEqual([]);
+
+    const aclRel = schemaAcl({ grants: [{ role: 'anonymous', privilege: 'USAGE' }] });
+    const t = table({ grants: [grant('PUBLIC', 'SELECT')] });
+    expect(checkDeadSchemaUsage([aclRel], [t], BASE_GRAPH)).toEqual([]);
+  });
+});
+
+describe('L5 checkUntrustedIndirectAccess', () => {
+  it('flags an untrusted role reaching an RLS-off table via PUBLIC', () => {
+    const t = table({ rlsEnabled: false, grants: [grant('PUBLIC', 'SELECT')] });
+    const out = checkUntrustedIndirectAccess(t, BASE_GRAPH, { roles: ['anonymous'] });
+    expect(out).toHaveLength(1);
+    expect(out[0].code).toBe('L5');
+    expect(out[0].role).toBe('anonymous');
+    expect(out[0].message).toContain('via PUBLIC');
+  });
+
+  it('ignores direct grants (A2/R1 territory) and RLS-on tables', () => {
+    const direct = table({ rlsEnabled: false, grants: [grant('anonymous', 'SELECT')] });
+    expect(checkUntrustedIndirectAccess(direct, BASE_GRAPH, { roles: ['anonymous'] })).toEqual([]);
+
+    const rlsOn = table({ grants: [grant('PUBLIC', 'SELECT')] });
+    expect(checkUntrustedIndirectAccess(rlsOn, BASE_GRAPH, { roles: ['anonymous'] })).toEqual([]);
+  });
+
+  it('is a no-op with no roles configured', () => {
+    const t = table({ rlsEnabled: false, grants: [grant('PUBLIC', 'SELECT')] });
+    expect(checkUntrustedIndirectAccess(t, BASE_GRAPH)).toEqual([]);
+  });
+});
+
+describe('computeRoleAccess', () => {
+  it('classifies unmediated, mediated, and dead access per role', () => {
+    const tables = [
+      // RLS off + PUBLIC SELECT → unmediated (the SPRT shape).
+      table({ name: 'sprt', rlsEnabled: false, grants: [grant('PUBLIC', 'SELECT')] }),
+      // RLS on + covered grant → mediated.
+      table({
+        name: 'covered',
+        grants: [grant('anonymous', 'SELECT')],
+        policies: [policy({ cmd: 'SELECT', roles: ['anonymous'] })]
+      }),
+      // RLS on + uncovered grant → dead.
+      table({ name: 'dead', grants: [grant('anonymous', 'SELECT')] }),
+      // No path at all → not counted.
+      table({ name: 'unreachable', grants: [grant('authenticated', 'SELECT')] })
+    ];
+
+    const [entry] = computeRoleAccess(tables, BASE_GRAPH, ['anonymous']);
+    expect(entry.role).toBe('anonymous');
+    expect(entry.accessibleTables).toBe(2);
+    expect(entry.mediated).toBe(1);
+    expect(entry.dead).toBe(1);
+    expect(entry.unmediated).toEqual([
+      {
+        schema: 'app',
+        table: 'sprt',
+        privileges: ['SELECT'],
+        via: 'PUBLIC',
+        access: 'unmediated'
+      }
+    ]);
+  });
+});

--- a/packages/safegres/src/checks/coverage.ts
+++ b/packages/safegres/src/checks/coverage.ts
@@ -22,9 +22,9 @@ import type { Finding } from '../types';
  */
 
 /** What clause kind satisfies coverage for a given privilege. */
-type ClauseKind = 'USING' | 'WITH CHECK';
+export type ClauseKind = 'USING' | 'WITH CHECK';
 
-const CLAUSE_REQUIRED: Partial<Record<PgPrivilege, ClauseKind>> = {
+export const CLAUSE_REQUIRED: Partial<Record<PgPrivilege, ClauseKind>> = {
   SELECT: 'USING',
   INSERT: 'WITH CHECK',
   UPDATE: 'USING',
@@ -32,7 +32,7 @@ const CLAUSE_REQUIRED: Partial<Record<PgPrivilege, ClauseKind>> = {
 };
 
 /** `polcmd` → the single verb the policy can satisfy (`ALL` satisfies every verb). */
-const POLICY_CMDS: Record<PolicyCmd, PgPrivilege[]> = {
+export const POLICY_CMDS: Record<PolicyCmd, PgPrivilege[]> = {
   SELECT: ['SELECT'],
   INSERT: ['INSERT'],
   UPDATE: ['UPDATE'],
@@ -135,7 +135,7 @@ export function checkUpdateWithCheckCoverage(table: TableSnapshot): Finding[] {
   return out;
 }
 
-function policyProvidesClause(
+export function policyProvidesClause(
   p: PolicyInfo,
   role: string,
   privilege: PgPrivilege,

--- a/packages/safegres/src/checks/lattice.ts
+++ b/packages/safegres/src/checks/lattice.ts
@@ -1,0 +1,443 @@
+/**
+ * The grant/RLS/policy lattice (L-series).
+ *
+ * The A/R rules reason from grants exactly as the catalog stores them, which
+ * misses two ways access actually arrives: `GRANT TO PUBLIC` (one ACL row
+ * that applies to every role) and role inheritance (zero ACL rows on the
+ * member). The lattice rules evaluate the *effective* cell each
+ * (relation, role, privilege) lands in:
+ *
+ *   | grant | RLS | policy | verdict                                   |
+ *   |-------|-----|--------|-------------------------------------------|
+ *   | yes   | on  | yes    | normal — policy-mediated access           |
+ *   | yes   | on  | no     | dead grant (L1, indirect; A4/A5, direct)  |
+ *   | yes   | off | —      | unmediated (L5 for untrusted, indirect)   |
+ *   | no    | —   | yes    | dead policy (L2)                          |
+ *
+ * plus schema-USAGE composition: an object grant the grantee cannot reach
+ * because USAGE is missing (L3), and USAGE that reaches no object (L4).
+ *
+ * Every L rule ships signal-only: L1–L3 are fail-closed (zero score weight by
+ * default), L4/L5 default to `info`. Escalate via config once the findings
+ * prove themselves.
+ */
+
+import type { RoleAttributes, SchemaAclInfo } from '../pg/acl';
+import type { PgPrivilege, PolicyInfo, TableSnapshot } from '../pg/introspect';
+import type { Finding } from '../types';
+import { CLAUSE_REQUIRED, POLICY_CMDS } from './coverage';
+
+export type RoleGraph = Map<string, RoleAttributes>;
+
+/** How an effective privilege arrived at a role. */
+export type GrantVia = 'direct' | 'PUBLIC' | `member of ${string}`;
+
+export interface EffectiveGrant {
+  privilege: PgPrivilege;
+  via: GrantVia;
+}
+
+const RLS_PRIVILEGES: PgPrivilege[] = ['SELECT', 'INSERT', 'UPDATE', 'DELETE'];
+
+/**
+ * Every privilege `role` effectively holds on `table`: direct grants, grants
+ * TO PUBLIC, and grants to roles it inherits from. Deduplicated per privilege
+ * with the most direct provenance winning (direct > PUBLIC > inherited).
+ */
+export function effectiveGrants(
+  table: TableSnapshot,
+  role: string,
+  graph: RoleGraph
+): EffectiveGrant[] {
+  const byPrivilege = new Map<PgPrivilege, GrantVia>();
+  const rank = (via: GrantVia): number =>
+    via === 'direct' ? 0 : via === 'PUBLIC' ? 1 : 2;
+  const record = (privilege: PgPrivilege, via: GrantVia) => {
+    const existing = byPrivilege.get(privilege);
+    if (existing === undefined || rank(via) < rank(existing)) {
+      byPrivilege.set(privilege, via);
+    }
+  };
+
+  const ancestors = new Set(graph.get(role)?.inheritsFrom ?? []);
+  for (const g of table.grants) {
+    if (g.role === role) record(g.privilege, 'direct');
+    else if (g.role === 'PUBLIC') record(g.privilege, 'PUBLIC');
+    else if (ancestors.has(g.role)) record(g.privilege, `member of ${g.role}`);
+  }
+
+  return [...byPrivilege.entries()]
+    .map(([privilege, via]) => ({ privilege, via }))
+    .sort((a, b) => a.privilege.localeCompare(b.privilege));
+}
+
+/**
+ * Whether a policy applies to `role` at runtime: named directly, via PUBLIC,
+ * or via a role it inherits from (`pg_has_role(..., 'member')` semantics).
+ */
+function policyAppliesToRole(p: PolicyInfo, role: string, graph: RoleGraph): boolean {
+  if (p.roles.includes('PUBLIC') || p.roles.includes(role)) return true;
+  const ancestors = graph.get(role)?.inheritsFrom ?? [];
+  return ancestors.some((a) => p.roles.includes(a));
+}
+
+function coveredForRole(
+  table: TableSnapshot,
+  role: string,
+  privilege: PgPrivilege,
+  graph: RoleGraph
+): boolean {
+  const clause = CLAUSE_REQUIRED[privilege];
+  if (!clause) return true;
+  return table.policies.some(
+    (p) =>
+      p.permissive
+      && POLICY_CMDS[p.cmd].includes(privilege)
+      && policyAppliesToRole(p, role, graph)
+      && (clause === 'USING' ? p.using != null : p.withCheck != null)
+  );
+}
+
+/**
+ * L1: an *indirect* grant (TO PUBLIC, or inherited from a granted role) on an
+ * RLS-enabled table with no applicable permissive policy — a dead grant that
+ * A4/A5 cannot see because no direct ACL row names the role. Default-deny
+ * admits nothing today; the risk is the grant silently activating the day a
+ * broad policy is added.
+ */
+export function checkIndirectCoverageGaps(
+  table: TableSnapshot,
+  graph: RoleGraph
+): Finding[] {
+  if (!table.rlsEnabled) return [];
+  const out: Finding[] = [];
+
+  // PUBLIC grants: dead if no permissive policy provides the clause for anyone.
+  for (const g of table.grants) {
+    if (g.role !== 'PUBLIC') continue;
+    const clause = CLAUSE_REQUIRED[g.privilege];
+    if (!clause) continue;
+    const covered = table.policies.some(
+      (p) =>
+        p.permissive
+        && POLICY_CMDS[p.cmd].includes(g.privilege)
+        && (clause === 'USING' ? p.using != null : p.withCheck != null)
+    );
+    if (covered) continue;
+    out.push({
+      code: 'L1',
+      severity: 'low',
+      category: 'coverage',
+      schema: table.schema,
+      table: table.name,
+      role: 'PUBLIC',
+      privilege: g.privilege,
+      message: `${g.privilege} is granted TO PUBLIC on ${table.schema}.${table.name} but no permissive policy can admit it — a dead grant under RLS default-deny`,
+      hint: 'Revoke the PUBLIC grant: it admits nothing today, and it silently activates for every role the day a broad policy is added.'
+    });
+  }
+
+  // Inherited grants: evaluate roles that inherit from anything, skipping
+  // bypass roles (policies don't apply) and privileges the role also holds
+  // directly (A4/A5 own that report).
+  for (const [role, attrs] of graph) {
+    if (attrs.inheritsFrom.length === 0 || attrs.bypassRls) continue;
+    if (role === table.owner) continue;
+    const direct = new Set(
+      table.grants.filter((g) => g.role === role).map((g) => g.privilege)
+    );
+    for (const eff of effectiveGrants(table, role, graph)) {
+      if (eff.via === 'direct' || eff.via === 'PUBLIC') continue;
+      if (direct.has(eff.privilege)) continue;
+      if (!CLAUSE_REQUIRED[eff.privilege]) continue;
+      if (coveredForRole(table, role, eff.privilege, graph)) continue;
+      out.push({
+        code: 'L1',
+        severity: 'low',
+        category: 'coverage',
+        schema: table.schema,
+        table: table.name,
+        role,
+        privilege: eff.privilege,
+        message: `Role ${role} holds ${eff.privilege} on ${table.schema}.${table.name} (${eff.via}) but no applicable permissive policy can admit it — a dead inherited grant`,
+        hint: `Either add a policy covering ${role} (or the granted role) or revoke ${eff.privilege} from the granted role — today the grant admits nothing.`
+      });
+    }
+  }
+
+  return out;
+}
+
+/**
+ * L2: a permissive policy names a role that holds no grant the policy could
+ * mediate — authorization written for a role that cannot reach the table.
+ * Either the grant was forgotten (a broken feature) or the policy is stale.
+ */
+export function checkDeadPolicies(table: TableSnapshot, graph: RoleGraph): Finding[] {
+  if (!table.rlsEnabled) return [];
+  const out: Finding[] = [];
+
+  const anyGrantee = table.grants.some((g) => g.role !== table.owner);
+
+  for (const policy of table.policies) {
+    if (!policy.permissive) continue;
+    const privileges = POLICY_CMDS[policy.cmd];
+
+    if (policy.roles.includes('PUBLIC')) {
+      if (!anyGrantee) {
+        out.push(deadPolicyFinding(table, policy, 'PUBLIC',
+          `Permissive policy ${policy.name} on ${table.schema}.${table.name} applies to PUBLIC but no role holds any grant on the table`));
+      }
+      continue;
+    }
+
+    for (const role of policy.roles) {
+      const attrs = graph.get(role);
+      if (attrs?.bypassRls) continue; // policies never apply to it anyway
+      const held = effectiveGrants(table, role, graph).map((e) => e.privilege);
+      if (privileges.some((p) => held.includes(p))) continue;
+      out.push(deadPolicyFinding(table, policy, role,
+        `Permissive ${policy.cmd} policy ${policy.name} on ${table.schema}.${table.name} applies to ${role}, but ${role} holds no ${privileges.join('/')} grant (directly, via PUBLIC, or by inheritance)`));
+    }
+  }
+
+  return out;
+}
+
+function deadPolicyFinding(
+  table: TableSnapshot,
+  policy: PolicyInfo,
+  role: string,
+  message: string
+): Finding {
+  return {
+    code: 'L2',
+    severity: 'low',
+    category: 'coverage',
+    schema: table.schema,
+    table: table.name,
+    policy: policy.name,
+    role,
+    message,
+    hint: 'A policy is not a grant: without the underlying privilege the role gets nothing. Grant the privilege if the access is intended, or drop the stale policy.'
+  };
+}
+
+/**
+ * L3: an object grant the grantee cannot use because it lacks USAGE on the
+ * schema — direct, via PUBLIC, or inherited. The grant is unreachable today
+ * and activates silently the day USAGE is granted.
+ */
+export function checkUnreachableGrants(
+  table: TableSnapshot,
+  schemaAcls: Map<string, SchemaAclInfo>,
+  graph: RoleGraph
+): Finding[] {
+  const acl = schemaAcls.get(table.schema);
+  if (!acl) return [];
+
+  const usageRoles = new Set(
+    acl.grants.filter((g) => g.privilege === 'USAGE').map((g) => g.role)
+  );
+
+  const byRole = new Map<string, PgPrivilege[]>();
+  for (const g of table.grants) {
+    if (g.role === 'PUBLIC') continue; // per-role USAGE cannot be asserted for PUBLIC grantees
+    const attrs = graph.get(g.role);
+    if (!attrs || attrs.isSuper) continue; // superusers skip ACL checks entirely
+    if (g.role === acl.owner) continue;
+    if (usageRoles.has('PUBLIC') || usageRoles.has(g.role)) continue;
+    if (attrs.inheritsFrom.some((a) => usageRoles.has(a) || a === acl.owner)) continue;
+    byRole.set(g.role, [...(byRole.get(g.role) ?? []), g.privilege]);
+  }
+
+  return [...byRole.entries()].map(([role, privileges]) => ({
+    code: 'L3',
+    severity: 'low',
+    category: 'coverage',
+    schema: table.schema,
+    table: table.name,
+    role,
+    privilege: [...new Set(privileges)].sort().join(', '),
+    message: `Role ${role} is granted ${[...new Set(privileges)].sort().join(', ')} on ${table.schema}.${table.name} but has no USAGE on schema ${table.schema} — the grant is unreachable`,
+    hint: 'Grant USAGE on the schema if the access is intended, or revoke the unreachable object grant so it cannot activate silently later.'
+  }));
+}
+
+/**
+ * L4: schema USAGE that opens the door to nothing — the role reaches no
+ * relation (directly, via PUBLIC, or by inheritance) and can EXECUTE no
+ * function in the schema. Advisory only: sequences, types and future objects
+ * are not modeled, so this is a review candidate, not a proof.
+ */
+export function checkDeadSchemaUsage(
+  schemaAcls: SchemaAclInfo[],
+  tables: TableSnapshot[],
+  graph: RoleGraph
+): Finding[] {
+  const tablesBySchema = new Map<string, TableSnapshot[]>();
+  for (const t of tables) {
+    tablesBySchema.set(t.schema, [...(tablesBySchema.get(t.schema) ?? []), t]);
+  }
+
+  const out: Finding[] = [];
+  for (const acl of schemaAcls) {
+    const schemaTables = tablesBySchema.get(acl.schema) ?? [];
+    const executes = new Set(acl.executeRoles);
+
+    for (const g of acl.grants) {
+      if (g.privilege !== 'USAGE' || g.role === 'PUBLIC') continue;
+      const attrs = graph.get(g.role);
+      if (!attrs || attrs.isSuper) continue;
+      if (g.role === acl.owner) continue;
+
+      const reachesRelation = schemaTables.some(
+        (t) => effectiveGrants(t, g.role, graph).length > 0
+      );
+      if (reachesRelation) continue;
+
+      const reachesFunction =
+        executes.has('PUBLIC')
+        || executes.has(g.role)
+        || attrs.inheritsFrom.some((a) => executes.has(a));
+      if (reachesFunction) continue;
+
+      out.push({
+        code: 'L4',
+        severity: 'info',
+        category: 'coverage',
+        schema: acl.schema,
+        role: g.role,
+        privilege: 'USAGE',
+        message: `Role ${g.role} has USAGE on schema ${acl.schema} but reaches no relation and can execute no function in it — dead schema USAGE`,
+        hint: 'Advisory: sequences, types and default privileges are not modeled. If nothing in the schema is meant for this role, revoke USAGE to keep the surface airtight.'
+      });
+    }
+  }
+  return out;
+}
+
+export interface LatticeRoleOptions {
+  /** Role names considered untrusted (exact match). */
+  roles?: string[];
+}
+
+/**
+ * L5: an untrusted role reaches an RLS-disabled table *indirectly* — through
+ * a grant TO PUBLIC or by inheriting from a granted role. Direct grants are
+ * A2/R1 territory; the indirect paths are exactly the ones that slip past
+ * exact-name matching (e.g. a world-readable table reached by `anonymous`
+ * through PUBLIC).
+ */
+export function checkUntrustedIndirectAccess(
+  table: TableSnapshot,
+  graph: RoleGraph,
+  options: LatticeRoleOptions = {}
+): Finding[] {
+  const untrusted = options.roles ?? [];
+  if (untrusted.length === 0 || table.rlsEnabled) return [];
+
+  const out: Finding[] = [];
+  for (const role of untrusted) {
+    const indirect = effectiveGrants(table, role, graph).filter(
+      (e) => e.via !== 'direct' && RLS_PRIVILEGES.includes(e.privilege)
+    );
+    if (indirect.length === 0) continue;
+    const privileges = indirect.map((e) => e.privilege).join(', ');
+    const vias = [...new Set(indirect.map((e) => e.via))].join(', ');
+    out.push({
+      code: 'L5',
+      severity: 'info',
+      category: 'anti-pattern',
+      schema: table.schema,
+      table: table.name,
+      role,
+      privilege: privileges,
+      message: `Untrusted role ${role} reaches ${table.schema}.${table.name} (${privileges}) via ${vias} — RLS is disabled, so every row is visible`,
+      hint: 'Narrow the grant to the trusted roles that need it, or enable RLS. PUBLIC and inherited grants apply to untrusted roles even though no ACL row names them.'
+    });
+  }
+  return out;
+}
+
+/** One role's effective reach into one relation. */
+export interface RoleAccessRelation {
+  schema: string;
+  table: string;
+  privileges: PgPrivilege[];
+  /** Most direct provenance across the privileges. */
+  via: GrantVia;
+  /** `unmediated` = RLS off or bypassed; `mediated` = at least one applicable policy; `dead` = RLS default-deny. */
+  access: 'unmediated' | 'mediated' | 'dead';
+}
+
+export interface RoleAccessEntry {
+  role: string;
+  /** Relations where at least one privilege is usable (mediated or unmediated). */
+  accessibleTables: number;
+  /** Relations readable/writable with no RLS mediation at all. */
+  unmediated: RoleAccessRelation[];
+  /** Relations reachable only through policies. */
+  mediated: number;
+  /** Relations where every effective privilege is dead (RLS default-deny). */
+  dead: number;
+}
+
+/**
+ * The direct answer to "what can role X see?": every relation the role
+ * effectively reaches, classified by whether RLS mediates the access.
+ */
+export function computeRoleAccess(
+  tables: TableSnapshot[],
+  graph: RoleGraph,
+  roles: string[]
+): RoleAccessEntry[] {
+  const out: RoleAccessEntry[] = [];
+  for (const role of roles) {
+    const attrs = graph.get(role);
+    const entry: RoleAccessEntry = {
+      role,
+      accessibleTables: 0,
+      unmediated: [],
+      mediated: 0,
+      dead: 0
+    };
+
+    for (const table of tables) {
+      const grants = effectiveGrants(table, role, graph).filter((e) =>
+        RLS_PRIVILEGES.includes(e.privilege)
+      );
+      if (grants.length === 0) continue;
+
+      const privileges = grants.map((g) => g.privilege);
+      const via = grants.reduce<GrantVia>(
+        (best, g) => (rankVia(g.via) < rankVia(best) ? g.via : best),
+        grants[0].via
+      );
+
+      if (!table.rlsEnabled || attrs?.bypassRls || (role === table.owner && !table.rlsForced)) {
+        entry.accessibleTables += 1;
+        entry.unmediated.push({ schema: table.schema, table: table.name, privileges, via, access: 'unmediated' });
+        continue;
+      }
+
+      const usable = privileges.some((p) => coveredForRole(table, role, p, graph));
+      if (usable) {
+        entry.accessibleTables += 1;
+        entry.mediated += 1;
+      } else {
+        entry.dead += 1;
+      }
+    }
+
+    entry.unmediated.sort((a, b) =>
+      a.schema === b.schema ? a.table.localeCompare(b.table) : a.schema.localeCompare(b.schema)
+    );
+    out.push(entry);
+  }
+  return out;
+}
+
+function rankVia(via: GrantVia): number {
+  return via === 'direct' ? 0 : via === 'PUBLIC' ? 1 : 2;
+}

--- a/packages/safegres/src/commands/audit.ts
+++ b/packages/safegres/src/commands/audit.ts
@@ -24,6 +24,15 @@ import {
   checkUnindexedSortColumns
 } from '../checks/indexes';
 import {
+  checkDeadPolicies,
+  checkDeadSchemaUsage,
+  checkIndirectCoverageGaps,
+  checkUnreachableGrants,
+  checkUntrustedIndirectAccess,
+  computeRoleAccess,
+  type LatticeRoleOptions
+} from '../checks/lattice';
+import {
   checkNonLeakproofPolicyFunctions,
   checkPolicyColumnCasts,
   checkUnhoistedPolicyFunctions,
@@ -46,6 +55,7 @@ import { checkStats, DEFAULT_STATS_THRESHOLDS, type StatsThresholds } from '../c
 import { allAstRulesDisabled, applyRulesToFindings, matchTablePattern, resolveRules, rulesForTable } from '../config/resolve';
 import type { ExposureConfig, SafegresConfig } from '../config/types';
 import { type ExplainReport, proveFindings } from '../perf/explain';
+import { introspectRoleGraph, introspectSchemaAcls } from '../pg/acl';
 import { resolveExposure } from '../pg/exposure';
 import { introspectFunctions } from '../pg/functions';
 import { introspectIndexes, introspectViewBodies, type TableIndexSnapshot } from '../pg/indexes';
@@ -56,7 +66,7 @@ import { listAuditableRoles, resolveRoles } from '../pg/roles';
 import { introspectStats, type StatsSnapshot } from '../pg/stats';
 import { dimensionOf, RULES_BY_CODE } from '../rules/registry';
 import { computeScore } from '../score/score';
-import type { ExposureReport, Finding, PerfReport, PerfStatsReport, Report } from '../types';
+import type { ExposureReport, Finding, PerfReport, PerfStatsReport, Report, RoleAccessReport } from '../types';
 import { summarize } from '../types';
 import { version as PKG_VERSION } from '../version';
 
@@ -147,6 +157,15 @@ export async function audit(
     ? snapshot.filter((t) => exposedSchemas.has(t.schema)).length
     : snapshot.length;
 
+  // Effective-access inputs for the lattice rules: the INHERIT-following
+  // role graph and the schema USAGE ACLs. Both are single cheap queries.
+  const roleGraph = await introspectRoleGraph(exec);
+  const schemaAcls = await introspectSchemaAcls(exec, {
+    schemas: options.schemas ?? config.schemas,
+    excludeSchemas: options.excludeSchemas ?? config.excludeSchemas
+  });
+  const schemaAclsByName = new Map(schemaAcls.map((a) => [a.schema, a]));
+
   let findings: Finding[] = [];
 
   // --- Performance dimension (opt-in): index hygiene ---
@@ -202,6 +221,18 @@ export async function audit(
     );
     findings.push(...checkPublicGrants(table));
 
+    // --- Grant/RLS/policy lattice (effective access: PUBLIC + inheritance) ---
+    findings.push(...checkIndirectCoverageGaps(table, roleGraph));
+    findings.push(...checkDeadPolicies(table, roleGraph));
+    findings.push(...checkUnreachableGrants(table, schemaAclsByName, roleGraph));
+    findings.push(
+      ...checkUntrustedIndirectAccess(
+        table,
+        roleGraph,
+        tableRules.get('L5')?.options as LatticeRoleOptions
+      )
+    );
+
     // --- AST-level anti-patterns (and, with perf on, policy-aware index rules) ---
     if (!skipAst) {
       findings.push(
@@ -213,6 +244,8 @@ export async function audit(
       );
     }
   }
+
+  findings.push(...checkDeadSchemaUsage(schemaAcls, snapshot, roleGraph));
 
   const statsSnapshot: StatsSnapshot | null = statsEnabled
     ? await introspectStats(exec, {
@@ -338,6 +371,20 @@ export async function audit(
     }),
     exposure: exposureReport
   };
+
+  // Per-role exposure: computed for the configured untrusted roles (L5/R1
+  // options), so the report answers "what can anonymous access?" directly
+  // even when no finding fires.
+  const untrustedRoles = [...new Set([
+    ...((resolved.rules.get('L5')?.options as LatticeRoleOptions | undefined)?.roles ?? []),
+    ...((resolved.rules.get('R1')?.options as RoleTrustOptions | undefined)?.roles ?? [])
+  ])].sort();
+  if (untrustedRoles.length > 0) {
+    const roleAccess: RoleAccessReport = {
+      roles: computeRoleAccess(snapshot, roleGraph, untrustedRoles)
+    };
+    report.roleAccess = roleAccess;
+  }
 
   if (perfEnabled) {
     // `S*` findings are scored by default — opting into `--stats` is the

--- a/packages/safegres/src/config/presets.ts
+++ b/packages/safegres/src/config/presets.ts
@@ -54,7 +54,8 @@ export const constructive: SafegresConfig = {
     P5: 'critical',
     R1: ['critical', { roles: ['anonymous'] }],
     R2: ['high', { roles: ['anonymous'] }],
-    R3: 'medium'
+    R3: 'medium',
+    L5: ['info', { roles: ['anonymous'] }]
   },
   scoring: { floorOnCritical: 'C' }
 };

--- a/packages/safegres/src/index.ts
+++ b/packages/safegres/src/index.ts
@@ -33,6 +33,23 @@ export {
   checkUnindexedSearchColumns,
   checkUnindexedSortColumns
 } from './checks/indexes';
+export type {
+  EffectiveGrant,
+  GrantVia,
+  LatticeRoleOptions,
+  RoleAccessEntry,
+  RoleAccessRelation,
+  RoleGraph
+} from './checks/lattice';
+export {
+  checkDeadPolicies,
+  checkDeadSchemaUsage,
+  checkIndirectCoverageGaps,
+  checkUnreachableGrants,
+  checkUntrustedIndirectAccess,
+  computeRoleAccess,
+  effectiveGrants
+} from './checks/lattice';
 export type { PolicyClause, PredicateColumn } from './checks/policy-index';
 export {
   checkNonLeakproofPolicyFunctions,
@@ -97,6 +114,8 @@ export {
 } from './perf/baseline';
 export type { ExplainOptions, ExplainReport } from './perf/explain';
 export { proveFindings } from './perf/explain';
+export type { RoleAttributes, SchemaAclGrant, SchemaAclInfo, SchemaAclOptions } from './pg/acl';
+export { introspectRoleGraph, introspectSchemaAcls } from './pg/acl';
 export type { ResolvedExposure } from './pg/exposure';
 export { resolveConstructiveExposure, resolveExposure, UNKNOWN_EXPOSURE } from './pg/exposure';
 export type { FunctionGrant, FunctionSnapshot, IntrospectFunctionOptions } from './pg/functions';

--- a/packages/safegres/src/pg/acl.ts
+++ b/packages/safegres/src/pg/acl.ts
@@ -1,0 +1,212 @@
+/**
+ * Role-graph and schema-ACL introspection for the grant/policy lattice.
+ *
+ * The table snapshot reports grants exactly as the catalog stores them —
+ * `GRANT TO PUBLIC` is one row, membership in a granted role is zero rows.
+ * The lattice rules reason about *effective* access, which needs:
+ *
+ *   - the role inheritance closure (`pg_auth_members`, INHERIT-respecting);
+ *   - which roles bypass RLS entirely (superuser / BYPASSRLS);
+ *   - schema USAGE ACLs (an object grant without USAGE on its schema is
+ *     unreachable);
+ *   - whether a schema holds any function the role can EXECUTE (so "dead
+ *     schema USAGE" doesn't false-positive on function-only schemas).
+ */
+
+import type { QueryExecutor } from './introspect';
+
+export interface RoleAttributes {
+  name: string;
+  /** Superuser or BYPASSRLS — policies never apply. */
+  bypassRls: boolean;
+  /** Superuser — ACL checks never apply either. */
+  isSuper: boolean;
+  /**
+   * Roles this role inherits privileges from, transitively. Only memberships
+   * that actually confer inheritance (INHERIT) are followed.
+   */
+  inheritsFrom: string[];
+}
+
+export interface SchemaAclGrant {
+  role: string; // 'PUBLIC' for grantee oid 0
+  privilege: 'USAGE' | 'CREATE';
+}
+
+export interface SchemaAclInfo {
+  schema: string;
+  owner: string;
+  grants: SchemaAclGrant[];
+  /** Roles (incl. 'PUBLIC') holding EXECUTE on at least one function in the schema. */
+  executeRoles: string[];
+}
+
+/**
+ * Every non-system role with its RLS-bypass flags and its transitive
+ * INHERIT-following membership closure.
+ */
+export async function introspectRoleGraph(
+  exec: QueryExecutor
+): Promise<Map<string, RoleAttributes>> {
+  const { rows: roleRows } = await exec.query<{
+    rolname: string;
+    rolsuper: boolean;
+    rolbypassrls: boolean;
+    rolinherit: boolean;
+  }>(`
+    SELECT rolname, rolsuper, rolbypassrls, rolinherit
+    FROM pg_roles
+    WHERE rolname NOT LIKE 'pg\\_%'
+    ORDER BY rolname
+  `);
+
+  // PG16+ decides inheritance per membership (`inherit_option`); before that
+  // it is the member role's INHERIT attribute. Read the per-membership flag
+  // when the column exists, fall back to the role attribute otherwise.
+  let memberRows: Array<{ member: string; parent: string; inherits: boolean }>;
+  try {
+    const { rows } = await exec.query<{ member: string; parent: string; inherits: boolean }>(`
+      SELECT m.rolname AS member, p.rolname AS parent, am.inherit_option AS inherits
+      FROM pg_auth_members am
+      JOIN pg_roles m ON m.oid = am.member
+      JOIN pg_roles p ON p.oid = am.roleid
+      WHERE m.rolname NOT LIKE 'pg\\_%' AND p.rolname NOT LIKE 'pg\\_%'
+    `);
+    memberRows = rows;
+  } catch (e) {
+    if (!isUndefinedColumn(e)) throw e;
+    const { rows } = await exec.query<{ member: string; parent: string; inherits: boolean }>(`
+      SELECT m.rolname AS member, p.rolname AS parent, m.rolinherit AS inherits
+      FROM pg_auth_members am
+      JOIN pg_roles m ON m.oid = am.member
+      JOIN pg_roles p ON p.oid = am.roleid
+      WHERE m.rolname NOT LIKE 'pg\\_%' AND p.rolname NOT LIKE 'pg\\_%'
+    `);
+    memberRows = rows;
+  }
+
+  const parents = new Map<string, string[]>();
+  for (const m of memberRows) {
+    if (!m.inherits) continue;
+    const list = parents.get(m.member) ?? [];
+    list.push(m.parent);
+    parents.set(m.member, list);
+  }
+
+  const graph = new Map<string, RoleAttributes>();
+  for (const r of roleRows) {
+    graph.set(r.rolname, {
+      name: r.rolname,
+      bypassRls: r.rolsuper || r.rolbypassrls,
+      isSuper: r.rolsuper,
+      inheritsFrom: closure(r.rolname, parents)
+    });
+  }
+  return graph;
+}
+
+/** Transitive parents of `role`, excluding itself, cycle-safe. */
+function closure(role: string, parents: Map<string, string[]>): string[] {
+  const seen = new Set<string>();
+  const stack = [...(parents.get(role) ?? [])];
+  while (stack.length > 0) {
+    const next = stack.pop()!;
+    if (next === role || seen.has(next)) continue;
+    seen.add(next);
+    stack.push(...(parents.get(next) ?? []));
+  }
+  return [...seen].sort();
+}
+
+function isUndefinedColumn(e: unknown): boolean {
+  return (e as { code?: string }).code === '42703';
+}
+
+export interface SchemaAclOptions {
+  schemas?: string[];
+  excludeSchemas?: string[];
+}
+
+const DEFAULT_EXCLUDES = ['pg_catalog', 'information_schema', 'pg_toast'];
+
+/**
+ * Schema ACLs plus, per schema, the roles holding EXECUTE on at least one of
+ * its functions. A NULL `nspacl` means the default ACL (owner-only + nothing
+ * for PUBLIC on non-`public` schemas); a NULL `proacl` means EXECUTE for
+ * PUBLIC, which is why the EXECUTE aggregation has to account for it.
+ */
+export async function introspectSchemaAcls(
+  exec: QueryExecutor,
+  options: SchemaAclOptions = {}
+): Promise<SchemaAclInfo[]> {
+  const excludes = [...DEFAULT_EXCLUDES, ...(options.excludeSchemas ?? [])];
+  const schemaFilter = options.schemas && options.schemas.length > 0
+    ? `AND n.nspname = ANY($1::text[])`
+    : `AND NOT (n.nspname = ANY($2::text[]))`;
+
+  const sql = `
+    WITH _params AS (
+      SELECT $1::text[] AS include_schemas, $2::text[] AS exclude_schemas
+    ),
+    ns AS (
+      SELECT n.oid, n.nspname, pg_get_userbyid(n.nspowner) AS owner, n.nspacl
+      FROM pg_namespace n
+      WHERE n.nspname NOT LIKE 'pg\\_%'
+        ${schemaFilter}
+    ),
+    schema_grants AS (
+      SELECT
+        ns.oid,
+        CASE WHEN a.grantee = 0 THEN 'PUBLIC' ELSE rol.rolname END AS grantee,
+        a.privilege_type
+      FROM ns, aclexplode(ns.nspacl) a
+      LEFT JOIN pg_roles rol ON rol.oid = a.grantee
+      WHERE ns.nspacl IS NOT NULL
+    ),
+    fn_execute AS (
+      SELECT
+        p.pronamespace AS oid,
+        CASE
+          WHEN p.proacl IS NULL THEN 'PUBLIC'
+          WHEN a.grantee = 0 THEN 'PUBLIC'
+          ELSE rol.rolname
+        END AS grantee
+      FROM pg_proc p
+      LEFT JOIN LATERAL aclexplode(p.proacl) a
+        ON p.proacl IS NOT NULL AND a.privilege_type = 'EXECUTE'
+      LEFT JOIN pg_roles rol ON rol.oid = a.grantee
+      WHERE p.pronamespace IN (SELECT oid FROM ns)
+    )
+    SELECT
+      ns.nspname AS schema_name,
+      ns.owner,
+      COALESCE(
+        (SELECT jsonb_agg(DISTINCT jsonb_build_object('role', g.grantee, 'privilege', g.privilege_type))
+         FROM schema_grants g WHERE g.oid = ns.oid),
+        '[]'::jsonb
+      ) AS grants,
+      COALESCE(
+        (SELECT array_agg(DISTINCT f.grantee) FROM fn_execute f
+         WHERE f.oid = ns.oid AND f.grantee IS NOT NULL),
+        ARRAY[]::text[]
+      ) AS execute_roles
+    FROM ns
+    ORDER BY ns.nspname
+  `;
+
+  const { rows } = await exec.query<{
+    schema_name: string;
+    owner: string;
+    grants: Array<{ role: string; privilege: string }>;
+    execute_roles: string[];
+  }>(sql, [options.schemas ?? [], excludes]);
+
+  return rows.map((r) => ({
+    schema: r.schema_name,
+    owner: r.owner,
+    grants: r.grants
+      .filter((g) => g.privilege === 'USAGE' || g.privilege === 'CREATE')
+      .map((g) => ({ role: g.role, privilege: g.privilege as 'USAGE' | 'CREATE' })),
+    executeRoles: r.execute_roles
+  }));
+}

--- a/packages/safegres/src/pg/introspect.ts
+++ b/packages/safegres/src/pg/introspect.ts
@@ -161,8 +161,11 @@ export async function introspectTables(
 ): Promise<TableSnapshot[]> {
   const excludes = [...DEFAULT_EXCLUDES, ...(options.excludeSchemas ?? [])];
 
+  // PUBLIC (grantee oid 0) always survives the role filter: it is not a role
+  // that can be included or excluded — it is every role, including every one
+  // in the filter.
   const roleFilter = options.roles && options.roles.length > 0
-    ? `AND (CASE WHEN g.grantee_oid = 0 THEN 'PUBLIC' ELSE rol.rolname END) = ANY($3::text[])`
+    ? `AND (g.grantee_oid = 0 OR rol.rolname = ANY($3::text[]))`
     : '';
   const schemaFilter = options.schemas && options.schemas.length > 0
     ? `AND n.nspname = ANY($1::text[])`

--- a/packages/safegres/src/report/markdown.ts
+++ b/packages/safegres/src/report/markdown.ts
@@ -9,6 +9,7 @@
  * parts (internal advisories, accepted debt) collapsed into `<details>`.
  */
 
+import type { RoleAccessEntry } from '../checks/lattice';
 import type { Score } from '../score/score';
 import type { Finding, Report, Severity } from '../types';
 import { formatDelta, type ReportComparison, type RuleDelta, type ScoreDelta } from './compare';
@@ -70,6 +71,10 @@ export function renderMarkdown(report: Report, options: RenderMarkdownOptions = 
     : report.findings;
   out.push(...findingSection('Security findings', security, options), '');
 
+  if (report.roleAccess && report.roleAccess.roles.length > 0) {
+    out.push(...roleAccessSection(report.roleAccess.roles), '');
+  }
+
   if (report.perf) {
     out.push(...findingSection('Performance findings', report.perf.findings, options));
     const { paths, stats, explain, diff } = report.perf;
@@ -117,6 +122,33 @@ export function renderMarkdown(report: Report, options: RenderMarkdownOptions = 
   }
 
   return out.join('\n');
+}
+
+/**
+ * The direct answer to "what can role X access?" — effective grants
+ * (direct, TO PUBLIC, inherited), classified by whether RLS mediates them.
+ */
+function roleAccessSection(roles: RoleAccessEntry[]): string[] {
+  const out: string[] = ['### Role access', ''];
+  for (const entry of roles) {
+    out.push(
+      `\`${entry.role}\`: **${entry.accessibleTables}** relation(s) accessible — `
+        + `${entry.unmediated.length} unmediated (no RLS), ${entry.mediated} policy-mediated`
+        + `${entry.dead > 0 ? `, ${entry.dead} dead (RLS default-deny)` : ''}.`,
+      ''
+    );
+    if (entry.unmediated.length > 0) {
+      out.push(
+        '| Relation | Privileges | Via |',
+        '| --- | --- | --- |',
+        ...entry.unmediated.map(
+          (r) => `| \`${r.schema}.${r.table}\` | ${r.privileges.join(', ')} | ${r.via} |`
+        ),
+        ''
+      );
+    }
+  }
+  return out;
 }
 
 function scoreTable(report: Report, options: RenderMarkdownOptions): string[] {

--- a/packages/safegres/src/report/pretty.ts
+++ b/packages/safegres/src/report/pretty.ts
@@ -136,6 +136,28 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
     lines.push('no findings.');
   }
 
+  if (report.roleAccess && report.roleAccess.roles.length > 0) {
+    lines.push('', 'role access — effective grants (direct, PUBLIC, inherited):', '');
+    for (const entry of report.roleAccess.roles) {
+      lines.push(
+        `  ${entry.role}: ${entry.accessibleTables} relation(s) accessible — `
+          + `${entry.unmediated.length} unmediated (no RLS), ${entry.mediated} policy-mediated`
+          + `${entry.dead > 0 ? `, ${entry.dead} dead (RLS default-deny)` : ''}`
+      );
+      const shown = options.verbose ? entry.unmediated : entry.unmediated.slice(0, 20);
+      for (const r of shown) {
+        lines.push(
+          paint('medium', `    ${r.schema}.${r.table}  ${r.privileges.join(', ')}  (via ${r.via})`)
+        );
+      }
+      if (shown.length < entry.unmediated.length) {
+        lines.push(
+          paint('info', `    … ${entry.unmediated.length - shown.length} more — run with --verbose to list.`)
+        );
+      }
+    }
+  }
+
   if (report.perf?.diff) {
     const { added, removed, accepted } = report.perf.diff;
     lines.push('', 'performance vs baseline:', '');

--- a/packages/safegres/src/rules/registry.ts
+++ b/packages/safegres/src/rules/registry.ts
@@ -151,6 +151,46 @@ export const RULES: RuleMeta[] = [
     scope: 'table'
   },
   {
+    code: 'L1',
+    category: 'coverage',
+    defaultSeverity: 'low',
+    direction: 'fail-closed',
+    title: 'Dead indirect grant — privilege arrives via PUBLIC or role inheritance but no policy can admit it',
+    scope: 'table'
+  },
+  {
+    code: 'L2',
+    category: 'coverage',
+    defaultSeverity: 'low',
+    direction: 'fail-closed',
+    title: 'Dead policy — a permissive policy applies to a role holding no corresponding grant',
+    scope: 'table'
+  },
+  {
+    code: 'L3',
+    category: 'coverage',
+    defaultSeverity: 'low',
+    direction: 'fail-closed',
+    title: 'Unreachable grant — object privilege without USAGE on the schema',
+    scope: 'table'
+  },
+  {
+    code: 'L4',
+    category: 'coverage',
+    defaultSeverity: 'info',
+    direction: 'neutral',
+    title: 'Dead schema USAGE — the role reaches no relation and no function in the schema (advisory)',
+    scope: 'table'
+  },
+  {
+    code: 'L5',
+    category: 'anti-pattern',
+    defaultSeverity: 'info',
+    direction: 'fail-open',
+    title: 'Untrusted role reaches an RLS-off table via PUBLIC or inheritance (options: { roles: [...] })',
+    scope: 'table'
+  },
+  {
     code: 'W1',
     category: 'meta',
     defaultSeverity: 'medium',

--- a/packages/safegres/src/types.ts
+++ b/packages/safegres/src/types.ts
@@ -171,6 +171,16 @@ export interface PerfStatsReport {
   notes?: string[];
 }
 
+/**
+ * The per-role exposure report: the direct answer to "what can role X
+ * access?", computed over effective grants (direct, TO PUBLIC, inherited)
+ * for the configured untrusted roles. Present whenever such roles are
+ * configured (e.g. L5/R1 options), independent of any findings.
+ */
+export interface RoleAccessReport {
+  roles: import('./checks/lattice').RoleAccessEntry[];
+}
+
 export interface Report {
   version: string;
   generatedAt: string;
@@ -182,6 +192,8 @@ export interface Report {
   perf?: PerfReport;
   /** The exposure surface the score was computed against. */
   exposure?: ExposureReport;
+  /** Effective per-role access, for the configured untrusted roles. */
+  roleAccess?: RoleAccessReport;
   /**
    * Unscored call-graph audit (`--call-graph`): trust boundaries reachable
    * from the exposed entry points, for human review.


### PR DESCRIPTION
## Summary

The A/R rules read grants exactly as the catalog stores them, which misses the two ways access arrives with no ACL row naming the role: `GRANT ... TO PUBLIC` and role inheritance (`pg_auth_members`). This adds the effective-access layer and the lattice rules on top of it, per [constructive-planning#1358](https://github.com/constructive-io/constructive-planning/issues/1358).

**New introspection** (`src/pg/acl.ts`): `introspectRoleGraph()` — every role with `bypassRls`/`isSuper` and its transitive INHERIT-following membership closure (reads PG16+ per-membership `inherit_option`, falls back to `rolinherit`); `introspectSchemaAcls()` — schema `USAGE`/`CREATE` ACLs plus which roles hold `EXECUTE` on at least one function per schema.

**Effective grants** (`src/checks/lattice.ts`):

```ts
effectiveGrants(table, role, graph): { privilege, via }[]
// via: 'direct' | 'PUBLIC' | 'member of <role>' — most direct provenance wins
```

Policy applicability uses `pg_has_role` semantics: a policy `TO authenticated` covers a member of `authenticated`.

**New rules** (signal-only: L1–L3 fail-closed = zero score weight by default, L4/L5 `info`):

| code | finding |
| --- | --- |
| L1 | dead *indirect* grant — arrives via PUBLIC/inheritance, no permissive policy can admit it (A4/A5 only see direct grants) |
| L2 | dead policy — permissive policy names a role holding no corresponding grant by any route |
| L3 | unreachable grant — object privilege without `USAGE` on the schema |
| L4 | dead schema USAGE — role reaches no relation and no function in the schema (advisory) |
| L5 | untrusted role reaches an RLS-off table via PUBLIC/inheritance (`{ roles: [...] }`; preset configures `anonymous`) |

**Per-role exposure report**: when untrusted roles are configured, `report.roleAccess` answers "what can role X access?" directly — every relation effectively reached, with provenance and an `unmediated` / `mediated` / `dead` verdict — rendered in pretty and markdown output even when no finding fires.

**Bug fix** (`src/pg/introspect.ts`): the ACL role filter dropped `PUBLIC` grants whenever a role list was active — which it always is, since role resolution always yields a list. `GRANT TO PUBLIC` was therefore invisible to every downstream check (R3 could never fire under a filter). PUBLIC (grantee oid 0) now always survives the filter.

Measured against the constructive-db codegen export: `roleAccess` for `anonymous` reports exactly the known answer — the two `constructive_memberships_private.*_sprt` tables (PUBLIC SELECT, RLS off) plus two benign lookup tables (`inflection.inflection_rules`, `unique_names.words`); L5 flags the same four. Security score unchanged (100/A+ → signal-only confirmed). 20 new unit tests cover every lattice cell, PUBLIC expansion, inheritance, and the access classification.

Link to Devin session: https://app.devin.ai/sessions/ec06ef6eabae4872ae5ec3926f037c85
Requested by: @pyramation