### PR TITLE
feat(safegres): exposure planes, view layer, adapters, GitHub reporting

### DIFF
--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -201,6 +201,76 @@ and `perf.ignore` for accepted performance debt. Extension-owned relations are s
 and an extension that creates objects at runtime can be skipped wholesale with
 `extensions.ignore` — see [docs/rules.md](https://github.com/constructive-io/constructive/blob/main/packages/safegres/docs/rules.md#extension-objects).
 
+### Planes: the other ways in
+
+An API is one way into a database, not the only one. Declare the others as **planes** and each
+gets its own grade — while the headline score stays exactly what it was:
+
+```jsonc
+{
+  "exposure": {
+    "schemas": ["app_public"],
+    "planes": [
+      { "name": "direct:reporting", "kind": "role", "roles": ["reporting"] },
+      { "name": "internal", "kind": "schema", "schemas": ["app_private"] }
+    ]
+  }
+}
+```
+
+```
+score  87  (B)   security      ← still the declared API surface, unchanged
+other access planes — advisory, not part of the score above:
+  direct:reporting [role] (reporting): 41 (F)  — 12 relation(s), reached via grant
+  internal [schema] (app_private): 63 (D)  — 9 relation(s)
+```
+
+A role plane is resolved through the same effective-access lattice the `L*` rules use — direct
+grants, `PUBLIC`, and role inheritance — so it answers the question a reviewer actually asks: *if
+this connection string leaks, what does it reach?* Roles with `BYPASSRLS` or superuser are
+reported as not graded rather than given a meaningless F.
+
+Secondary planes never move the headline and never touch finding identity, so adding one cannot
+invalidate a baseline. They gate nothing unless you ask — `failOn.planes` takes a name or glob:
+
+```jsonc
+{ "failOn": { "grade": "B", "planes": { "direct:*": { "grade": "D" } } } }
+```
+
+`--plane direct:reporting` (or `--plane '*'`) expands one in the terminal and markdown output;
+`--format json` always carries them all in `report.planes`.
+
+### Adapters
+
+Where the exposed surface comes from is an interface, not a hard-coded integration. An adapter is
+an object — no plugin resolution, nothing load-bearing about a package name:
+
+```ts
+// safegres.config.ts
+import type { SafegresConfig } from 'safegres';
+import { constructiveAdapter } from 'safegres/adapters';
+
+import { myGatewayAdapter } from './my-gateway-adapter';
+
+const config: SafegresConfig = {
+  exposure: { adapters: [constructiveAdapter, myGatewayAdapter] }
+};
+export default config;
+```
+
+```ts
+interface ExposureAdapter {
+  name: string;
+  detect(exec: QueryExecutor): Promise<boolean>;      // is this stack present?
+  resolve(exec: QueryExecutor): Promise<PlaneInput[]>; // one or more planes
+}
+```
+
+The built-in `constructive` adapter introspects `routing_public.apis → api_schemas` and emits a
+primary `api` plane plus one `api:<name>` plane per API. JSON configs may name a built-in
+(`"adapters": ["constructive"]`); anything else is an error rather than a silent no-op. The old
+`"resolver": "constructive"` still works.
+
 ## CI in one job
 
 One service container, your existing migration command, one audit:

--- a/packages/safegres/__tests__/fixtures/planes.sql
+++ b/packages/safegres/__tests__/fixtures/planes.sql
@@ -1,0 +1,38 @@
+-- Two ways into the same database: an API schema, and an internal schema a
+-- reporting role holds a direct grant on. The internal leak is invisible to
+-- the API surface and is exactly what a role plane is for.
+
+CREATE SCHEMA IF NOT EXISTS fx_pl_api;
+CREATE SCHEMA IF NOT EXISTS fx_pl_internal;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'fx_pl_anon') THEN
+    CREATE ROLE fx_pl_anon NOLOGIN;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'fx_pl_reporting') THEN
+    CREATE ROLE fx_pl_reporting NOLOGIN;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'fx_pl_admin') THEN
+    CREATE ROLE fx_pl_admin NOLOGIN BYPASSRLS;
+  END IF;
+END $$;
+
+GRANT USAGE ON SCHEMA fx_pl_api TO fx_pl_anon;
+GRANT USAGE ON SCHEMA fx_pl_internal TO fx_pl_reporting;
+
+CREATE TABLE fx_pl_api.posts (
+  id bigserial PRIMARY KEY,
+  owner_id uuid NOT NULL,
+  body text
+);
+ALTER TABLE fx_pl_api.posts ENABLE ROW LEVEL SECURITY;
+CREATE POLICY posts_select ON fx_pl_api.posts FOR SELECT TO fx_pl_anon
+  USING (owner_id = current_setting('jwt.claims.user_id', true)::uuid);
+GRANT SELECT ON fx_pl_api.posts TO fx_pl_anon;
+
+-- RLS off, granted directly: an A2 the API never sees.
+CREATE TABLE fx_pl_internal.ledger (
+  id bigserial PRIMARY KEY,
+  amount numeric
+);
+GRANT SELECT, UPDATE ON fx_pl_internal.ledger TO fx_pl_reporting;

--- a/packages/safegres/__tests__/github.test.ts
+++ b/packages/safegres/__tests__/github.test.ts
@@ -1,0 +1,158 @@
+import {
+  COMMENT_MARKER,
+  renderAnnotations,
+  renderGithubComment,
+  renderGithubSummary,
+  scoreBadge
+} from '../src/report/github';
+import { computeScore } from '../src/score/score';
+import type { Finding, PlaneReport, Report } from '../src/types';
+import { summarize } from '../src/types';
+
+function finding(over: Partial<Finding> = {}): Finding {
+  return {
+    code: 'A2',
+    severity: 'high',
+    category: 'flags',
+    exposed: true,
+    schema: 'app_public',
+    table: 'widgets',
+    message: 'grants exist on a table with RLS disabled',
+    ...over
+  };
+}
+
+function makeReport(over: Partial<Report> = {}): Report {
+  const findings = over.findings ?? [finding()];
+  const score = computeScore(findings, undefined, { exposedTables: 10, exposureKnown: true });
+  const secondary: PlaneReport = {
+    name: 'direct:app',
+    kind: 'role',
+    primary: false,
+    source: 'config',
+    schemas: ['app_private'],
+    roles: ['app_user'],
+    exposedTables: 3,
+    score: computeScore(findings, undefined, { exposedTables: 3, exposureKnown: true }),
+    summary: summarize(findings)
+  };
+  return {
+    version: '1.0.0',
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    summary: summarize(findings),
+    findings,
+    score,
+    exposure: {
+      known: true,
+      source: 'config',
+      plane: 'api',
+      schemas: ['app_public'],
+      exposedTables: 10,
+      totalTables: 12
+    },
+    planes: [
+      {
+        name: 'api',
+        kind: 'api',
+        primary: true,
+        source: 'config',
+        schemas: ['app_public'],
+        exposedTables: 10,
+        score,
+        summary: summarize(findings)
+      },
+      secondary
+    ],
+    ...over
+  };
+}
+
+describe('scoreBadge', () => {
+  it('renders a shields.io image colored by grade', () => {
+    const score = computeScore([], undefined, { exposedTables: 10, exposureKnown: true });
+    expect(scoreBadge('Security', score, true)).toContain('img.shields.io/badge/Security-');
+    expect(scoreBadge('Security', score, true)).toContain('brightgreen');
+  });
+
+  it('falls back to a colored dot when badges are off', () => {
+    const score = computeScore([], undefined, { exposedTables: 10, exposureKnown: true });
+    expect(scoreBadge('Security', score, false)).toMatch(/^🟢 \*\*Security 100 \(A\+\)\*\*$/);
+  });
+});
+
+describe('renderGithubSummary', () => {
+  it('leads with badges for the configured scores', () => {
+    const out = renderGithubSummary(makeReport());
+    expect(out.split('\n')[0]).toContain('img.shields.io/badge/Security-');
+    expect(out).toContain('## safegres');
+  });
+
+  it('badges a secondary plane when the config asks for it', () => {
+    const out = renderGithubSummary(makeReport(), {
+      config: { summary: ['security', 'planes:direct:*'] }
+    });
+    expect(out.split('\n')[0]).toContain('badge/direct%3Aapp-');
+  });
+});
+
+describe('renderGithubComment', () => {
+  it('is sticky and carries scores without the finding tables', () => {
+    const out = renderGithubComment(makeReport());
+    expect(out.startsWith(COMMENT_MARKER)).toBe(true);
+    expect(out).toContain('Exposure (config): **10/12** tables reachable.');
+    expect(out).not.toContain('### Security findings');
+  });
+
+  it('reports the delta when the run was compared', () => {
+    const report = makeReport();
+    report.comparison = {
+      previous: { ref: 'main' },
+      summary: {
+        critical: { before: 0, after: 0, delta: 0 },
+        high: { before: 2, after: 1, delta: -1 },
+        medium: { before: 0, after: 0, delta: 0 },
+        low: { before: 0, after: 0, delta: 0 },
+        info: { before: 0, after: 0, delta: 0 }
+      },
+      rules: [],
+      security: {
+        before: 80,
+        after: 90,
+        delta: 10,
+        gradeBefore: 'B',
+        gradeAfter: 'A',
+        findingsBefore: 2,
+        findingsAfter: 1
+      },
+      unchanged: false
+    };
+    const out = renderGithubComment(report);
+    expect(out).toContain('**Changes since main**');
+    expect(out).toContain('- security: 🟢 ▲ +10.0 (80 → 90, B → A)');
+  });
+
+  it('lists the planes when asked', () => {
+    const out = renderGithubComment(makeReport(), {
+      config: { comment: { sections: ['planes'] } }
+    });
+    expect(out).toContain('| `direct:app` | role | 3 |');
+  });
+});
+
+describe('renderAnnotations', () => {
+  it('annotates only what failed a gate by default', () => {
+    const report = makeReport();
+    expect(renderAnnotations(report)).toEqual([]);
+    expect(renderAnnotations(report, { gateFailures: report.findings })).toEqual([
+      '::error title=A2 app_public.widgets::grants exist on a table with RLS disabled'
+    ]);
+  });
+
+  it('annotates everything exposed in "all" mode, and nothing in "none"', () => {
+    const report = makeReport({
+      findings: [finding(), finding({ code: 'A3', severity: 'low', exposed: false })]
+    });
+    expect(renderAnnotations(report, { config: { annotations: 'all' } })).toHaveLength(1);
+    expect(renderAnnotations(report, { config: { annotations: 'none' } })).toEqual([]);
+  });
+});

--- a/packages/safegres/__tests__/planes.test.ts
+++ b/packages/safegres/__tests__/planes.test.ts
@@ -1,0 +1,158 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { getConnections, PgTestClient } from 'pgsql-test';
+
+import { audit } from '../src/commands/audit';
+import { definePlanes, resolveAdapters } from '../src/exposure/adapters';
+import { resolveExposure, resolvePlanes } from '../src/pg/exposure';
+
+jest.setTimeout(120000);
+
+let pg: PgTestClient;
+let teardown: () => Promise<void>;
+
+const SCHEMAS = ['fx_pl_api', 'fx_pl_internal'];
+
+beforeAll(async () => {
+  ({ pg, teardown } = await getConnections());
+  const sql = fs.readFileSync(path.join(__dirname, 'fixtures', 'planes.sql'), 'utf8');
+  await pg.any(sql);
+});
+
+afterAll(async () => {
+  if (teardown) await teardown();
+});
+
+describe('exposure planes', () => {
+  it('leaves the headline score exactly where it was when planes are added', async () => {
+    const withoutPlanes = await audit(pg.client as never, {
+      schemas: SCHEMAS,
+      exposure: { schemas: ['fx_pl_api'] }
+    });
+    const withPlanes = await audit(pg.client as never, {
+      schemas: SCHEMAS,
+      exposure: {
+        schemas: ['fx_pl_api'],
+        planes: [{ name: 'direct:reporting', kind: 'role', roles: ['fx_pl_reporting'] }]
+      }
+    });
+
+    expect(withPlanes.score!.value).toBe(withoutPlanes.score!.value);
+    expect(withPlanes.score!.grade).toBe(withoutPlanes.score!.grade);
+    expect(withoutPlanes.planes).toBeUndefined();
+    expect(withPlanes.planes![0]).toMatchObject({ primary: true, name: 'api' });
+    expect(withPlanes.planes![0].score.value).toBe(withoutPlanes.score!.value);
+  });
+
+  it('grades a role plane against what the role actually reaches', async () => {
+    const report = await audit(pg.client as never, {
+      schemas: SCHEMAS,
+      exposure: {
+        schemas: ['fx_pl_api'],
+        planes: [{ name: 'direct:reporting', kind: 'role', roles: ['fx_pl_reporting'] }]
+      }
+    });
+
+    const plane = report.planes!.find((p) => p.name === 'direct:reporting')!;
+    expect(plane).toMatchObject({ kind: 'role', primary: false, reachedVia: 'grant' });
+    expect(plane.schemas).toEqual(['fx_pl_internal']);
+    expect(plane.exposedTables).toBe(1);
+
+    // The internal A2 is off the API surface but squarely on the role's.
+    const a2 = report.findings.find((f) => f.code === 'A2' && f.schema === 'fx_pl_internal')!;
+    expect(a2.exposed).toBe(false);
+    expect(a2.planes).toContain('direct:reporting');
+    expect(a2.planes).not.toContain('api');
+    expect(plane.score.deductions.some((d) => d.code === 'A2')).toBe(true);
+
+    // …and the primary score still knows nothing about it.
+    expect(report.score!.deductions.some((d) => d.code === 'A2')).toBe(false);
+  });
+
+  it('refuses to grade a plane for a role that bypasses RLS', async () => {
+    const report = await audit(pg.client as never, {
+      schemas: SCHEMAS,
+      exposure: {
+        schemas: ['fx_pl_api'],
+        planes: [{ name: 'direct:admin', kind: 'role', roles: ['fx_pl_admin'] }]
+      }
+    });
+    const plane = report.planes!.find((p) => p.name === 'direct:admin')!;
+    expect(plane.skipped).toMatch(/bypasses row-level security/);
+    expect(plane.exposedTables).toBe(0);
+  });
+
+  it('grades a schema plane by membership', async () => {
+    const report = await audit(pg.client as never, {
+      schemas: SCHEMAS,
+      exposure: {
+        schemas: ['fx_pl_api'],
+        planes: [{ name: 'internal', kind: 'schema', schemas: ['fx_pl_internal'] }]
+      }
+    });
+    const plane = report.planes!.find((p) => p.name === 'internal')!;
+    expect(plane).toMatchObject({ kind: 'schema', exposedTables: 1, source: 'config' });
+    expect(plane.score.value).toBeLessThan(report.score!.value);
+  });
+
+  it('plane membership is not part of a finding\'s identity', async () => {
+    const bare = await audit(pg.client as never, {
+      schemas: SCHEMAS,
+      exposure: { schemas: ['fx_pl_api'] }
+    });
+    const planed = await audit(pg.client as never, {
+      schemas: SCHEMAS,
+      exposure: {
+        schemas: ['fx_pl_api'],
+        planes: [{ name: 'internal', kind: 'schema', schemas: ['fx_pl_internal'] }]
+      }
+    });
+    const key = (f: { code: string; schema?: string; table?: string; policy?: string }) =>
+      [f.code, f.schema, f.table, f.policy].join('|');
+    expect(planed.findings.map(key)).toEqual(bare.findings.map(key));
+  });
+
+  it('rejects two planes claiming the headline', async () => {
+    const exposure = await resolveExposure(pg.client as never, { schemas: ['fx_pl_api'] });
+    await expect(
+      resolvePlanes(
+        pg.client as never,
+        {
+          schemas: ['fx_pl_api'],
+          planes: [
+            { name: 'a', primary: true, schemas: ['fx_pl_api'] },
+            { name: 'b', primary: true, schemas: ['fx_pl_internal'] }
+          ]
+        },
+        exposure
+      )
+    ).rejects.toThrow(/more than one exposure plane declares/);
+  });
+});
+
+describe('exposure adapters', () => {
+  it('resolves planes from an adapter passed as a value', async () => {
+    const adapter = definePlanes('gateway', [
+      { name: 'api', kind: 'api', primary: true, schemas: ['fx_pl_api'], roles: ['fx_pl_anon'] },
+      { name: 'internal', kind: 'schema', schemas: ['fx_pl_internal'] }
+    ]);
+    const exposure = await resolveExposure(pg.client as never, { adapters: [adapter] });
+    expect(exposure).toMatchObject({ known: true, source: 'gateway', schemas: ['fx_pl_api'] });
+
+    const planes = await resolvePlanes(pg.client as never, { adapters: [adapter] }, exposure);
+    expect(planes.map((p) => p.name)).toEqual(['api', 'internal']);
+  });
+
+  it('resolves the built-in by name and rejects anything else', () => {
+    expect(resolveAdapters(['constructive'])[0].name).toBe('constructive');
+    expect(() => resolveAdapters(['safegres-plugin-mystery'])).toThrow(/unknown exposure adapter/);
+  });
+
+  it('falls through to the static surface when the adapter is not present', async () => {
+    const exposure = await resolveExposure(pg.client as never, {
+      resolver: 'constructive',
+      schemas: ['fx_pl_api']
+    });
+    expect(exposure).toMatchObject({ known: true, source: 'config' });
+  });
+});

--- a/packages/safegres/__tests__/view.test.ts
+++ b/packages/safegres/__tests__/view.test.ts
@@ -1,0 +1,138 @@
+import { renderMarkdown } from '../src/report/markdown';
+import { renderPretty } from '../src/report/pretty';
+import { matchPlane, selectView } from '../src/report/view';
+import { computeScore } from '../src/score/score';
+import type { Finding, PlaneReport, Report } from '../src/types';
+import { summarize } from '../src/types';
+
+function finding(over: Partial<Finding> = {}): Finding {
+  return {
+    code: 'A2',
+    severity: 'high',
+    category: 'flags',
+    exposed: true,
+    schema: 'app_public',
+    table: 'widgets',
+    message: 'grants exist on a table with RLS disabled',
+    ...over
+  };
+}
+
+function plane(over: Partial<PlaneReport> = {}): PlaneReport {
+  const findings = [finding({ schema: 'app_private', table: 'ledger' })];
+  return {
+    name: 'direct:app',
+    kind: 'role',
+    primary: false,
+    source: 'config',
+    schemas: ['app_private'],
+    roles: ['app_user'],
+    exposedTables: 4,
+    reachedVia: 'grant',
+    score: computeScore(findings, undefined, { exposedTables: 4, exposureKnown: true }),
+    summary: summarize(findings),
+    ...over
+  };
+}
+
+function makeReport(over: Partial<Report> = {}): Report {
+  const findings = over.findings ?? [
+    finding(),
+    finding({ schema: 'app_private', table: 'ledger', exposed: false })
+  ];
+  const score = computeScore(findings, undefined, { exposedTables: 10, exposureKnown: true });
+  return {
+    version: '1.0.0',
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    summary: summarize(findings),
+    findings,
+    score,
+    planes: [
+      {
+        name: 'api',
+        kind: 'api',
+        primary: true,
+        source: 'config',
+        schemas: ['app_public'],
+        exposedTables: 10,
+        score,
+        summary: summarize(findings)
+      },
+      plane()
+    ],
+    ...over
+  };
+}
+
+describe('matchPlane', () => {
+  it('matches names and globs', () => {
+    expect(matchPlane('direct:app', 'direct:app')).toBe(true);
+    expect(matchPlane('direct:*', 'direct:app')).toBe(true);
+    expect(matchPlane('*', 'anything')).toBe(true);
+    expect(matchPlane('direct:*', 'api')).toBe(false);
+    // a glob is not a regex: the dot is literal
+    expect(matchPlane('a.b', 'axb')).toBe(false);
+  });
+});
+
+describe('selectView', () => {
+  it('lists secondary planes but keeps them out of the headline scores', () => {
+    const view = selectView(makeReport());
+    expect(view.scores.map((s) => s.id)).toEqual(['security']);
+    expect(view.planes.map((p) => p.name)).toEqual(['direct:app']);
+    expect(view.expandedPlanes).toHaveLength(0);
+    expect(view.has('planes')).toBe(true);
+  });
+
+  it('adds a score for each expanded plane', () => {
+    const view = selectView(makeReport(), { planes: ['direct:*'] });
+    expect(view.scores.map((s) => s.id)).toEqual(['security', 'plane:direct:app']);
+    expect(view.expandedPlanes.map((p) => p.name)).toEqual(['direct:app']);
+  });
+
+  it('honors the dimension and section selection', () => {
+    const view = selectView(makeReport(), { dimensions: [], sections: ['scores'] });
+    expect(view.scores).toHaveLength(0);
+    expect(view.has('planes')).toBe(false);
+    expect(view.has('scores')).toBe(true);
+  });
+
+  it('exposedOnly hides internal advisories without editing the report', () => {
+    const report = makeReport();
+    const view = selectView(report, { exposedOnly: true });
+    expect(view.security.internal).toHaveLength(0);
+    expect(report.findings).toHaveLength(2);
+  });
+
+  it('summary detail suppresses the findings section', () => {
+    expect(selectView(makeReport(), { detail: 'summary' }).has('findings')).toBe(false);
+  });
+});
+
+describe('renderers read the view', () => {
+  it('pretty summarizes planes in one advisory line each', () => {
+    const out = renderPretty(makeReport(), { color: false });
+    expect(out).toContain('other access planes — advisory, not part of the score above:');
+    expect(out).toMatch(/direct:app \[role\] \(app_user\):/);
+    expect(out).toContain('--plane <name>');
+  });
+
+  it('pretty expands the plane asked for', () => {
+    const out = renderPretty(makeReport(), { color: false, planes: ['direct:app'] });
+    expect(out).toContain('plane direct:app:');
+    expect(out).toMatch(/top deductions: A2/);
+  });
+
+  it('markdown renders the planes table', () => {
+    const out = renderMarkdown(makeReport());
+    expect(out).toContain('### Other access planes');
+    expect(out).toContain('| `direct:app` | role | `app_user` (via grant) | 4 |');
+  });
+
+  it('markdown says why a plane was not graded', () => {
+    const report = makeReport();
+    report.planes![1] = plane({ skipped: 'app_admin bypasses row-level security' });
+    const out = renderMarkdown(report);
+    expect(out).toContain('not graded — app_admin bypasses row-level security');
+  });
+});

--- a/packages/safegres/docs/reporting.md
+++ b/packages/safegres/docs/reporting.md
@@ -1,7 +1,10 @@
 # Reporting — output formats, deltas, and code scanning
 
 - [Output and verbosity](#output-and-verbosity)
+- [Planes in the report](#planes-in-the-report)
+- [Analysis → view → render](#analysis--view--render)
 - [Markdown for CI](#markdown-for-ci)
+- [GitHub Actions (`--github`)](#github-actions---github)
 - [What changed (`--compare`)](#what-changed---compare)
 - [Code scanning (SARIF)](#code-scanning-sarif)
 
@@ -19,6 +22,66 @@ stays readable.
   `score`, `perf`, `exposure`, `roleAccess`, `comparison`, `callGraph` and any diffs.
 - `--format markdown` — GitHub-flavoured markdown for a job summary or PR comment.
 - `--format sarif` — SARIF 2.1.0 for GitHub code scanning.
+- `--plane <name|glob>` — expand a secondary access plane (repeatable; `'*'` for all).
+
+One audit can produce several artifacts at once, which is cheaper and less error-prone than
+auditing three times with three `--format` values:
+
+```bash
+safegres audit --perf --summary \
+  --write-json     reports/safegres.json \
+  --write-markdown reports/safegres.md \
+  --write-sarif    reports/safegres.sarif
+```
+
+## Planes in the report
+
+Every declared [plane](../README.md#planes-the-other-ways-in) appears in `report.planes` — the
+primary one first, whose score *is* `report.score`:
+
+```jsonc
+{
+  "score": { "value": 87, "grade": "B", "deductions": […] },
+  "planes": [
+    { "name": "api", "kind": "api", "primary": true, "schemas": ["app_public"],
+      "exposedTables": 24, "score": { "value": 87, "grade": "B" } },
+    { "name": "direct:reporting", "kind": "role", "primary": false, "roles": ["reporting"],
+      "reachedVia": "grant", "exposedTables": 12, "score": { "value": 41, "grade": "F" } }
+  ]
+}
+```
+
+Findings carry `planes: string[]` — every plane the finding is reachable on. It is *not* part of a
+finding's identity: `exposed`, the baseline keys, and the SARIF fingerprints are unchanged by
+adding a plane, so a plane can never invalidate a baseline. A plane whose role bypasses RLS
+(`BYPASSRLS`, superuser) reports `skipped` instead of a grade.
+
+Pretty and markdown output summarize secondary planes in one line/row each; `--plane` expands the
+per-rule deductions for the ones you name.
+
+## Analysis → view → render
+
+The library separates *what was found* from *what to show*. `audit()` produces a `Report` and
+nothing presentational; `selectView(report, viewConfig)` decides which planes, dimensions, and
+sections appear; the renderers are functions of the result.
+
+```ts
+import { audit, renderMarkdown, selectView } from 'safegres';
+
+const report = await audit(client, { exposure });
+const view = selectView(report, { planes: ['direct:*'], dimensions: ['security'] });
+view.scores;         // [{ id: 'security', … }, { id: 'plane:direct:app', … }]
+view.security;       // { exposed, internal } — partitioned, report untouched
+renderMarkdown(report, { view: { planes: ['direct:*'] } });
+```
+
+The same selection is available in config, so it is versioned with the repo:
+
+```jsonc
+{ "report": { "planes": ["direct:*"], "dimensions": ["security", "perf"] } }
+```
+
+`--summary`, `--verbose`, and `--exposed-only` remain shorthands for view settings.
 
 ## Markdown for CI
 
@@ -35,6 +98,41 @@ Library callers get the same renderer as `renderMarkdown(report)`, which additio
 `{ summary: true, title: '…' }` — the compact variant worth using when the full report is large
 (GitHub caps a job summary at 1 MB, and a report with thousands of baselined perf findings will
 exceed it). Keep the full report as a CI artifact and put the summary in the job summary.
+
+## GitHub Actions (`--github`)
+
+Inside Actions (`GITHUB_ACTIONS=true`) safegres writes its own job summary and annotations, so the
+shell plumbing above becomes unnecessary:
+
+```yaml
+- run: npx safegres audit --perf --fail-on-grade B --github --github-comment
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # only needed for the PR comment
+```
+
+- **Job summary** — grade-colored [shields.io](https://shields.io) badges, then the markdown report.
+- **Annotations** — `::error`/`::warning` on the findings that *failed a gate*, so the one finding
+  that blocked the merge is not buried under a hundred advisories.
+- **Sticky PR comment** — one comment, edited in place on every push (`--github-comment`, or
+  `--write-github-comment <file>` to post it yourself).
+
+What appears is configuration, not code:
+
+```jsonc
+{
+  "report": {
+    "github": {
+      "summary": ["security", "perf", "planes:direct:*"],  // which scores get a badge, in order
+      "comment": { "sticky": true, "sections": ["scores", "delta", "new-findings"] },
+      "annotations": "gate-failures",                       // "all" | "gate-failures" | "none"
+      "badges": true                                        // false → 🟢🟡🔴 text, no images
+    }
+  }
+}
+```
+
+GitHub Markdown has no text color, so a genuinely colored score has to be an image; `badges: false`
+falls back to emoji for air-gapped runners that cannot reach shields.io.
 
 ## What changed (`--compare`)
 

--- a/packages/safegres/package.json
+++ b/packages/safegres/package.json
@@ -25,7 +25,8 @@
   "scripts": {
     "clean": "makage clean",
     "prepack": "npm run build",
-    "build": "makage build && chmod +x dist/cli.js",
+    "version:sync": "node scripts/sync-version.js",
+    "build": "npm run version:sync && makage build && chmod +x dist/cli.js",
     "build:dev": "makage build --dev && chmod +x dist/cli.js",
     "lint": "eslint . --fix",
     "test": "jest --passWithNoTests",

--- a/packages/safegres/scripts/sync-version.js
+++ b/packages/safegres/scripts/sync-version.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+/**
+ * Keep `src/version.ts` in step with package.json.
+ *
+ * The version is stamped into every report (and into the SARIF tool record),
+ * so a stale constant silently mislabels which analyzer produced a result —
+ * exactly the metadata a baseline comparison relies on. Run before packing,
+ * after lerna has bumped the manifest.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+const { version } = require(path.join(root, 'package.json'));
+const target = path.join(root, 'src', 'version.ts');
+const next = `// Auto-synced from package.json by scripts/sync-version.js.\nexport const version = '${version}';\n`;
+
+if (fs.readFileSync(target, 'utf8') !== next) {
+  fs.writeFileSync(target, next);
+  process.stdout.write(`[safegres] synced src/version.ts -> ${version}\n`);
+}

--- a/packages/safegres/src/adapters.ts
+++ b/packages/safegres/src/adapters.ts
@@ -1,0 +1,13 @@
+/**
+ * `safegres/adapters` — the built-in exposure adapters and the interface a
+ * custom one implements. Kept as its own entry point so a config file can
+ * import an adapter without pulling in the whole auditor.
+ */
+
+export type { ExposureAdapter, PlaneInput } from './exposure/adapters';
+export {
+  BUILTIN_ADAPTERS,
+  constructiveAdapter,
+  definePlanes,
+  resolveAdapters
+} from './exposure/adapters';

--- a/packages/safegres/src/cli/audit.ts
+++ b/packages/safegres/src/cli/audit.ts
@@ -8,12 +8,14 @@ import { loadConfig } from '../config/loader';
 import type { Grade } from '../config/types';
 import { diffPerf, parsePerfBaseline, serializePerfBaseline, toPerfBaseline } from '../perf/baseline';
 import { compareReports, parseSnapshot, serializeSnapshot, toSnapshot } from '../report/compare';
+import { emitGithub, postStickyComment, renderGithubComment, renderGithubSummary } from '../report/github';
 import { renderJson } from '../report/json';
 import { renderMarkdown } from '../report/markdown';
 import { renderPretty } from '../report/pretty';
 import { buildSourceIndex, renderSarif } from '../report/sarif';
+import { matchPlane, type ViewConfig, viewConfigFromReportConfig } from '../report/view';
 import { meetsGrade } from '../score/score';
-import type { Report, Severity } from '../types';
+import type { Finding, Report, Severity } from '../types';
 import { meetsThreshold, SEVERITY_ORDER, summarize } from '../types';
 import { buildClient, configParamsFromArgv, csvList, extensionScopeFromArgv } from './shared';
 
@@ -62,6 +64,10 @@ Exposure (what the score is computed against):
   --exposure-schemas <csv> Declare the API-exposed schemas; findings outside
                            them become unscored internal advisories
   --exposed-only           Hide internal (non-exposed) findings from output
+  --plane <name|glob>      Expand a secondary access plane (repeatable; '*' for
+                           all). Planes are declared in exposure.planes and
+                           graded separately — the headline score is always the
+                           primary (API) plane and never moves
 
 Performance dimension (optional; scored separately from security):
   --perf                   Also audit index hygiene (X1/X5/X6/X7/X8), policy-aware
@@ -123,6 +129,10 @@ Audit options:
   --sarif-sources <dir>    With --format sarif: scan <dir> for the CREATE TABLE /
                            CREATE POLICY that defines each object, so alerts point
                            at the SQL that produced the finding
+  --write-json <file>      Also write the JSON report to <file>
+  --write-markdown <file>  Also write the markdown report to <file>
+  --write-sarif <file>     Also write the SARIF report to <file>
+                           (one audit, as many outputs as CI needs)
   --summary, -q            Print only exposure, score, and severity counts (no findings)
   --verbose                Expand internal (non-exposed) advisories (listed as a count otherwise)
   --fail-on <severity>     Exit non-zero if any finding >= severity
@@ -132,6 +142,16 @@ Audit options:
   --skip-ast               Skip AST-level anti-pattern checks (faster)
   --no-color               Disable ANSI colors in pretty output
   --help, -h               Show this help message
+
+GitHub Actions:
+  --github                 Write the job summary to $GITHUB_STEP_SUMMARY and
+                           emit workflow annotations (auto-detected when
+                           GITHUB_ACTIONS=true). Configure what appears with
+                           report.github in the config file
+  --github-comment         Upsert the sticky PR comment (needs GITHUB_TOKEN)
+  --write-github-comment <file>
+                           Write the PR-comment markdown to <file> instead of
+                           posting it
 `;
 
 export default async (
@@ -264,6 +284,13 @@ export default async (
     report.summary = summarize(report.findings);
   }
 
+  const planeSelectors = listArg(argv.plane);
+  const viewConfig: ViewConfig = {
+    ...viewConfigFromReportConfig(config.report),
+    ...(planeSelectors.length > 0 ? { planes: planeSelectors } : {}),
+    ...(argv['exposed-only'] === true ? { exposedOnly: true } : {})
+  };
+
   const fmt = typeof argv.format === 'string' ? argv.format : 'pretty';
   let output: string;
   switch (fmt) {
@@ -284,14 +311,16 @@ export default async (
   case 'md':
     output = renderMarkdown(report, {
       summary: argv.summary === true,
-      verbose: argv.verbose === true
+      verbose: argv.verbose === true,
+      view: viewConfig
     });
     break;
   case 'pretty':
     output = renderPretty(report, {
       color: colorEnabled,
       summary: argv.summary === true,
-      verbose: argv.verbose === true
+      verbose: argv.verbose === true,
+      view: viewConfig
     });
     break;
   default:
@@ -301,6 +330,39 @@ export default async (
   process.stdout.write(output);
   process.stdout.write('\n');
 
+  // One audit, as many renderings as CI asked for.
+  if (typeof argv['write-json'] === 'string') {
+    fs.writeFileSync(argv['write-json'], `${renderJson(report, { pretty: true })}\n`);
+    log.info(`wrote json report: ${argv['write-json']}`);
+  }
+  if (typeof argv['write-markdown'] === 'string') {
+    fs.writeFileSync(
+      argv['write-markdown'],
+      `${renderMarkdown(report, { verbose: argv.verbose === true, view: viewConfig })}\n`
+    );
+    log.info(`wrote markdown report: ${argv['write-markdown']}`);
+  }
+  if (typeof argv['write-sarif'] === 'string') {
+    fs.writeFileSync(
+      argv['write-sarif'],
+      `${renderSarif(report, {
+        sources: typeof argv['sarif-sources'] === 'string'
+          ? buildSourceIndex(argv['sarif-sources'])
+          : undefined
+      })}\n`
+    );
+    log.info(`wrote sarif report: ${argv['write-sarif']}`);
+  }
+
+  // Gates are evaluated before anything exits, so the GitHub renderers can
+  // annotate exactly the findings that failed the build.
+  let failed = false;
+  const gateFailures: Finding[] = [];
+  const fail = (message: string): void => {
+    log.error(message);
+    failed = true;
+  };
+
   const failOnSeverity =
     typeof argv['fail-on'] === 'string' ? (argv['fail-on'] as Severity) : config.failOn?.severity;
   if (failOnSeverity) {
@@ -308,23 +370,23 @@ export default async (
       log.error(`Unknown --fail-on severity: ${failOnSeverity}`);
       process.exit(2);
     }
-    if (report.findings.some((f) => meetsThreshold(f.severity, failOnSeverity))) {
-      process.exit(1);
+    const over = report.findings.filter((f) => meetsThreshold(f.severity, failOnSeverity));
+    if (over.length > 0) {
+      gateFailures.push(...over);
+      fail(`${over.length} finding(s) at or above --fail-on ${failOnSeverity}`);
     }
   }
 
   const failOnScore =
     typeof argv['fail-on-score'] === 'number' ? argv['fail-on-score'] : config.failOn?.score;
   if (failOnScore != null && report.score && report.score.value < failOnScore) {
-    log.error(`score ${report.score.value} is below --fail-on-score ${failOnScore}`);
-    process.exit(1);
+    fail(`score ${report.score.value} is below --fail-on-score ${failOnScore}`);
   }
 
   const failOnGrade =
     typeof argv['fail-on-grade'] === 'string' ? (argv['fail-on-grade'] as Grade) : config.failOn?.grade;
   if (failOnGrade && report.score && !meetsGrade(report.score.grade, failOnGrade)) {
-    log.error(`grade ${report.score.grade} is below --fail-on-grade ${failOnGrade}`);
-    process.exit(1);
+    fail(`grade ${report.score.grade} is below --fail-on-grade ${failOnGrade}`);
   }
 
   const failOnPerfScore =
@@ -332,8 +394,7 @@ export default async (
       ? argv['fail-on-perf-score']
       : config.failOn?.perfScore;
   if (failOnPerfScore != null && report.perf && report.perf.score.value < failOnPerfScore) {
-    log.error(`perf score ${report.perf.score.value} is below --fail-on-perf-score ${failOnPerfScore}`);
-    process.exit(1);
+    fail(`perf score ${report.perf.score.value} is below --fail-on-perf-score ${failOnPerfScore}`);
   }
 
   const failOnPerfGrade =
@@ -341,16 +402,30 @@ export default async (
       ? (argv['fail-on-perf-grade'] as Grade)
       : config.failOn?.perfGrade;
   if (failOnPerfGrade && report.perf && !meetsGrade(report.perf.score.grade, failOnPerfGrade)) {
-    log.error(`perf grade ${report.perf.score.grade} is below --fail-on-perf-grade ${failOnPerfGrade}`);
-    process.exit(1);
+    fail(`perf grade ${report.perf.score.grade} is below --fail-on-perf-grade ${failOnPerfGrade}`);
+  }
+
+  // Per-plane gates. A secondary plane gates nothing unless the config asks:
+  // the direct-connection surface is legitimately worse than the API's, and a
+  // parity gate would only get the plane deleted.
+  for (const [pattern, gate] of Object.entries(config.failOn?.planes ?? {})) {
+    const planes = (report.planes ?? []).filter((p) => !p.skipped && matchPlane(pattern, p.name));
+    for (const plane of planes) {
+      if (gate.score != null && plane.score.value < gate.score) {
+        fail(`plane ${plane.name} score ${plane.score.value} is below failOn.planes["${pattern}"].score ${gate.score}`);
+      }
+      if (gate.grade && !meetsGrade(plane.score.grade, gate.grade)) {
+        fail(`plane ${plane.name} grade ${plane.score.grade} is below failOn.planes["${pattern}"].grade ${gate.grade}`);
+      }
+    }
   }
 
   if (argv['fail-on-new-perf'] === true && report.perf?.diff && report.perf.diff.added.length > 0) {
     const count = report.perf.diff.added.length;
-    log.error(
+    gateFailures.push(...report.perf.diff.added);
+    fail(
       `${count} new performance finding${count === 1 ? '' : 's'} since the perf baseline — fix them, or re-baseline with --write-perf-baseline to accept`
     );
-    process.exit(1);
   }
 
   if (
@@ -358,9 +433,48 @@ export default async (
     && report.callGraphDiff
     && report.callGraphDiff.added.length > 0
   ) {
-    log.error(
+    fail(
       `${report.callGraphDiff.added.length} new trust boundar${report.callGraphDiff.added.length === 1 ? 'y' : 'ies'} since the baseline — review and re-baseline to accept`
     );
-    process.exit(1);
   }
+
+  // GitHub output: on by default inside Actions, because a report nobody has
+  // to wire up is a report people actually read.
+  const githubConfig = config.report?.github;
+  const githubMode =
+    argv.github === true || (argv.github !== false && process.env.GITHUB_ACTIONS === 'true');
+  const githubOptions = {
+    ...(githubConfig ? { config: githubConfig } : {}),
+    gateFailures,
+    view: viewConfig
+  };
+  if (githubMode) {
+    if (!emitGithub(report, githubOptions)) {
+      log.warn('--github: no $GITHUB_STEP_SUMMARY in the environment — summary not written');
+      process.stdout.write(`${renderGithubSummary(report, githubOptions)}\n`);
+    }
+  }
+
+  if (typeof argv['write-github-comment'] === 'string') {
+    fs.writeFileSync(
+      argv['write-github-comment'],
+      `${renderGithubComment(report, githubOptions)}\n`
+    );
+    log.info(`wrote github comment: ${argv['write-github-comment']}`);
+  }
+
+  if (argv['github-comment'] === true) {
+    const result = await postStickyComment(renderGithubComment(report, githubOptions));
+    if (result.posted) log.info('updated the safegres PR comment');
+    else log.warn(`--github-comment: not posted — ${result.reason}`);
+  }
+
+  if (failed) process.exit(1);
 };
+
+/** A repeatable flag: `--plane a --plane b` (minimist gives an array). */
+function listArg(value: unknown): string[] {
+  if (typeof value === 'string') return [value];
+  if (Array.isArray(value)) return value.filter((v): v is string => typeof v === 'string');
+  return [];
+}

--- a/packages/safegres/src/commands/audit.ts
+++ b/packages/safegres/src/commands/audit.ts
@@ -54,9 +54,10 @@ import {
 import { checkStats, DEFAULT_STATS_THRESHOLDS, type StatsThresholds } from '../checks/stats';
 import { allAstRulesDisabled, applyRulesToFindings, matchTablePattern, resolveRules, rulesForTable } from '../config/resolve';
 import type { ExposureConfig, SafegresConfig } from '../config/types';
+import { resolvePlaneReach, scorePlane, stampPlanes } from '../exposure/planes';
 import { type ExplainReport, proveFindings } from '../perf/explain';
 import { introspectRoleGraph, introspectSchemaAcls } from '../pg/acl';
-import { resolveExposure } from '../pg/exposure';
+import { resolveExposure, resolvePlanes } from '../pg/exposure';
 import { introspectFunctions } from '../pg/functions';
 import { introspectIndexes, introspectViewBodies, type TableIndexSnapshot } from '../pg/indexes';
 import { asExecutor, type IntrospectOptions, introspectTables, type QueryExecutor, type TableSnapshot } from '../pg/introspect';
@@ -141,8 +142,10 @@ export async function audit(
     options.excludeRoles ?? config.excludeRoles
   );
 
-  const exposure = await resolveExposure(exec, options.exposure ?? config.exposure);
+  const exposureConfig = options.exposure ?? config.exposure;
+  const exposure = await resolveExposure(exec, exposureConfig);
   const exposedSchemas = new Set(exposure.schemas);
+  const planes = await resolvePlanes(exec, exposureConfig, exposure);
 
   const extensions = options.extensions ?? config.extensions;
 
@@ -351,6 +354,7 @@ export async function audit(
   const exposureReport: ExposureReport = {
     known: exposure.known,
     source: exposure.source,
+    plane: planes[0].name,
     schemas: exposure.schemas,
     ...(exposure.roles ? { roles: exposure.roles } : {}),
     exposedTables,
@@ -371,6 +375,31 @@ export async function audit(
     }),
     exposure: exposureReport
   };
+
+  // Access planes. The primary plane's score is `report.score` — computed
+  // above, against the exposure surface — so declaring planes can never move
+  // the headline number; the secondaries answer what the headline cannot.
+  const reaches = resolvePlaneReach(planes, snapshot, roleGraph);
+  stampPlanes(findings, reaches);
+  if (reaches.length > 1) {
+    report.planes = reaches.map((reach) => {
+      if (reach.skipped) {
+        return {
+          ...scorePlane(reach, [], config.scoring, exposure.known),
+          skipped: reach.skipped
+        };
+      }
+      if (reach.plane.primary) {
+        return {
+          ...scorePlane(reach, securityFindings, config.scoring, exposure.known),
+          exposedTables,
+          score: report.score!,
+          summary: summarize(securityFindings.filter((f) => f.exposed !== false))
+        };
+      }
+      return scorePlane(reach, securityFindings, config.scoring, exposure.known);
+    });
+  }
 
   // Per-role exposure: computed for the configured untrusted roles (L5/R1
   // options), so the report answers "what can anonymous access?" directly

--- a/packages/safegres/src/config/types.ts
+++ b/packages/safegres/src/config/types.ts
@@ -1,3 +1,4 @@
+import type { ExposureAdapter } from '../exposure/adapters';
 import type { Severity } from '../types';
 
 /**
@@ -38,11 +39,54 @@ export interface ExposureConfig {
    * - `constructive`: introspect the Constructive routing plane
    *   (`routing_public.apis` → `api_schemas` → `metaschema_public.schema`,
    *   plus the platform plane) to discover exposed schemas and API roles.
+   *
+   * Equivalent to listing the corresponding built-in in `adapters`.
    */
   resolver?: 'static' | 'constructive';
+  /**
+   * Exposure adapters: objects implementing `ExposureAdapter`, or the name of
+   * a built-in (`'constructive'`). An adapter whose `detect()` succeeds
+   * contributes planes; static `schemas`/`roles` extend, never replace, what
+   * it found. Adapters are values, not module names — a custom one is an
+   * object you construct, and nothing is resolved by package name.
+   */
+  adapters?: Array<string | ExposureAdapter>;
   /** Schemas reachable from the exposed APIs (static resolver). */
   schemas?: string[];
   /** Roles reachable from the API edge (static resolver). */
+  roles?: string[];
+  /** Name of the primary plane. Default `api`. */
+  name?: string;
+  /**
+   * Additional access planes to grade: the ways into the database that are
+   * not the declared API. Each is scored on the security axis with the same
+   * model, reported alongside the primary plane, and — unless `failOn.planes`
+   * says otherwise — gates nothing.
+   */
+  planes?: PlaneConfig[];
+}
+
+/** What kind of access path a plane describes. */
+export type PlaneKind = 'api' | 'role' | 'schema';
+
+/**
+ * One graded access plane. `api`/`schema` planes are a set of schemas; a
+ * `role` plane is whatever its roles can effectively reach (direct grants,
+ * grants TO PUBLIC, and role inheritance), so it never has to be kept in
+ * sync with a schema list by hand.
+ */
+export interface PlaneConfig {
+  /** Plane identifier, e.g. `api`, `direct:app`, `internal`. */
+  name: string;
+  /** Default: `role` when `roles` is set and `schemas` is not, else `schema`. */
+  kind?: PlaneKind;
+  /**
+   * Make this plane the headline score (`report.score`). At most one plane
+   * may claim it; declaring two is a configuration error rather than a
+   * silent pick. Default: the declared API surface is primary.
+   */
+  primary?: boolean;
+  schemas?: string[];
   roles?: string[];
 }
 
@@ -223,6 +267,64 @@ export interface FailOnConfig {
   perfScore?: number;
   /** Exit non-zero if the perf grade is below this letter. */
   perfGrade?: Grade;
+  /**
+   * Per-plane gates, keyed by plane name. Secondary planes gate nothing by
+   * default: an internal role legitimately reaches internal tables, so its
+   * plane scores worse than the API's by construction and gating it at parity
+   * would only force the plane to be deleted. A floor (`{ grade: 'D' }`) is
+   * the useful shape — the direct-connection surface may be a D, but it may
+   * not become an F.
+   */
+  planes?: Record<string, PlaneFailOnConfig>;
+}
+
+export interface PlaneFailOnConfig {
+  /** Exit non-zero if the plane's score is below this value (0-100). */
+  score?: number;
+  /** Exit non-zero if the plane's grade is below this letter. */
+  grade?: Grade;
+}
+
+/** Which scores and sections a rendered report shows. */
+export interface ReportConfig {
+  /**
+   * Planes to render, by name or glob (`primary`, `*`, `direct:*`). Default:
+   * the primary plane in full, secondaries as a one-line advisory.
+   */
+  planes?: string[];
+  /** Dimensions to render. Default: both. */
+  dimensions?: Array<'security' | 'perf'>;
+  /** GitHub Actions output (job summary, annotations, PR comment). */
+  github?: GithubReportConfig;
+}
+
+/**
+ * What the GitHub integration emits. Defaults render both headline scores,
+ * the delta against the compared run, and annotations for gate failures only.
+ */
+export interface GithubReportConfig {
+  /**
+   * Scores in the job summary, in order. `security`, `perf`, and
+   * `planes:<glob>` for secondary planes (e.g. `planes:direct:*`).
+   * Default `['security', 'perf']`.
+   */
+  summary?: string[];
+  /** Sticky PR comment. */
+  comment?: GithubCommentConfig;
+  /** Which findings become workflow annotations. Default `gate-failures`. */
+  annotations?: 'all' | 'gate-failures' | 'none';
+  /**
+   * Render scores as colored shields.io badges. Default `true`; `false` falls
+   * back to 🟢/🟡/🔴 text, which needs no network fetch.
+   */
+  badges?: boolean;
+}
+
+export interface GithubCommentConfig {
+  /** Reuse one comment per PR instead of appending. Default `true`. */
+  sticky?: boolean;
+  /** Sections to include. Default `['scores', 'delta', 'new-findings']`. */
+  sections?: Array<'scores' | 'delta' | 'new-findings' | 'findings' | 'planes'>;
 }
 
 /**
@@ -249,4 +351,6 @@ export interface SafegresConfig {
   overrides?: OverrideEntry[];
   scoring?: ScoringConfig;
   failOn?: FailOnConfig;
+  /** What a rendered report shows — selection, not analysis. */
+  report?: ReportConfig;
 }

--- a/packages/safegres/src/exposure/adapters.ts
+++ b/packages/safegres/src/exposure/adapters.ts
@@ -1,0 +1,183 @@
+/**
+ * Exposure adapters: how safegres learns what a stack exposes.
+ *
+ * An adapter is a value, not a module name. Built-ins are named exports of
+ * this module, a custom one is an object you construct in your own repo, and
+ * both are passed the same way — nothing is resolved by package name, and
+ * there is no plugin loader to reason about:
+ *
+ * ```ts
+ * import { constructiveAdapter, definePlanes } from 'safegres/adapters';
+ *
+ * export default defineConfig({
+ *   exposure: { adapters: [constructiveAdapter, myAdapter], schemas: ['app_public'] }
+ * });
+ * ```
+ *
+ * `detect()` answers "is this stack present in this database?" and `resolve()`
+ * returns the planes it exposes — one per API where the stack has more than
+ * one, because "the admin API grades A and the public API grades C" is
+ * strictly more useful than their union.
+ */
+
+import type { PlaneKind } from '../config/types';
+import type { QueryExecutor } from '../pg/introspect';
+
+/** A plane as an adapter reports it, before roles are resolved against the catalog. */
+export interface PlaneInput {
+  name: string;
+  kind?: PlaneKind;
+  primary?: boolean;
+  schemas?: string[];
+  roles?: string[];
+}
+
+export interface ExposureAdapter {
+  /** Stable identifier, reported as the exposure `source`. */
+  name: string;
+  /** True when this stack is present in the connected database. */
+  detect(exec: QueryExecutor): Promise<boolean>;
+  /** The planes this stack exposes. An empty array means "present, exposes nothing". */
+  resolve(exec: QueryExecutor): Promise<PlaneInput[]>;
+}
+
+/**
+ * Constructive routing-plane introspection: an API exposes a set of schemas
+ * via `routing_public.apis` → `routing_public.api_schemas` →
+ * `metaschema_public.schema` (and the platform plane via `platform_apis` →
+ * `platform_api_schemas`). API-edge roles come from `apis.role_name` /
+ * `apis.anon_role`.
+ *
+ * Emits one `api` plane per API, plus a primary plane unioning them: the union
+ * is what the headline score has always been computed against, and the
+ * per-API planes are what let a reader see which API carries the debt.
+ */
+export const constructiveAdapter: ExposureAdapter = {
+  name: 'constructive',
+
+  async detect(exec: QueryExecutor): Promise<boolean> {
+    const { rows } = await exec.query<{ ok: boolean }>(
+      `SELECT
+         to_regclass('routing_public.apis') IS NOT NULL
+         AND to_regclass('routing_public.api_schemas') IS NOT NULL
+         AND to_regclass('metaschema_public.schema') IS NOT NULL AS ok`
+    );
+    return rows[0]?.ok === true;
+  },
+
+  async resolve(exec: QueryExecutor): Promise<PlaneInput[]> {
+    const { rows: hasPlatform } = await exec.query<{ ok: boolean }>(
+      `SELECT
+         to_regclass('routing_public.platform_apis') IS NOT NULL
+         AND to_regclass('routing_public.platform_api_schemas') IS NOT NULL AS ok`
+    );
+
+    const sources = [
+      `SELECT a.name::text AS api, s.schema_name, a.role_name, a.anon_role
+         FROM routing_public.apis a
+         JOIN routing_public.api_schemas aps ON aps.api_id = a.id
+         JOIN metaschema_public.schema s ON s.id = aps.schema_id`
+    ];
+    if (hasPlatform[0]?.ok) {
+      sources.push(
+        `SELECT a.name::text AS api, s.schema_name, a.role_name, a.anon_role
+           FROM routing_public.platform_apis a
+           JOIN routing_public.platform_api_schemas aps ON aps.api_id = a.id
+           JOIN metaschema_public.schema s ON s.id = aps.schema_id`
+      );
+    }
+
+    const { rows } = await exec.query<{
+      api: string | null;
+      schema_name: string;
+      role_name: string | null;
+      anon_role: string | null;
+    }>(sources.join(' UNION ALL '));
+
+    const byApi = new Map<string, { schemas: Set<string>; roles: Set<string> }>();
+    const all = { schemas: new Set<string>(), roles: new Set<string>() };
+    for (const r of rows) {
+      if (!r.schema_name) continue;
+      const key = r.api ?? 'api';
+      const entry = byApi.get(key) ?? { schemas: new Set<string>(), roles: new Set<string>() };
+      entry.schemas.add(r.schema_name);
+      all.schemas.add(r.schema_name);
+      for (const role of [r.role_name, r.anon_role]) {
+        if (role) {
+          entry.roles.add(role);
+          all.roles.add(role);
+        }
+      }
+      byApi.set(key, entry);
+    }
+    if (all.schemas.size === 0) return [];
+
+    const planes: PlaneInput[] = [
+      {
+        name: 'api',
+        kind: 'api',
+        primary: true,
+        schemas: sorted(all.schemas),
+        roles: sorted(all.roles)
+      }
+    ];
+    // One plane per API, but only where there is more than one to tell apart:
+    // on a single-API database they would restate the primary plane.
+    if (byApi.size > 1) {
+      for (const [api, entry] of [...byApi.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+        planes.push({
+          name: `api:${api}`,
+          kind: 'api',
+          schemas: sorted(entry.schemas),
+          roles: sorted(entry.roles)
+        });
+      }
+    }
+    return planes;
+  }
+};
+
+/** Every adapter a config may name with a string. */
+export const BUILTIN_ADAPTERS: Record<string, ExposureAdapter> = {
+  constructive: constructiveAdapter
+};
+
+/**
+ * Wrap a fixed set of planes as an adapter — the escape hatch for a surface
+ * you know but cannot introspect (a schema list your deployment tooling
+ * knows, an API gateway's config read at build time).
+ */
+export function definePlanes(name: string, planes: PlaneInput[]): ExposureAdapter {
+  return {
+    name,
+    detect: async () => planes.length > 0,
+    resolve: async () => planes
+  };
+}
+
+/**
+ * Coerce whatever a config carried in `exposure.adapters` into adapters.
+ * Strings resolve against the built-in table only — an unknown name is an
+ * error rather than a silent no-op, because a typo'd adapter name would
+ * otherwise present as an unexposed database.
+ */
+export function resolveAdapters(
+  entries: Array<string | ExposureAdapter> | undefined
+): ExposureAdapter[] {
+  if (!entries || entries.length === 0) return [];
+  return entries.map((entry) => {
+    if (typeof entry !== 'string') return entry as unknown as ExposureAdapter;
+    const builtin = BUILTIN_ADAPTERS[entry];
+    if (!builtin) {
+      throw new Error(
+        `unknown exposure adapter "${entry}" — built-ins: ${Object.keys(BUILTIN_ADAPTERS).join(', ')}`
+          + '; a custom adapter is passed as an object, not by name'
+      );
+    }
+    return builtin;
+  });
+}
+
+function sorted(values: Set<string>): string[] {
+  return [...values].sort();
+}

--- a/packages/safegres/src/exposure/planes.ts
+++ b/packages/safegres/src/exposure/planes.ts
@@ -1,0 +1,166 @@
+/**
+ * Plane reach and per-plane scoring.
+ *
+ * A plane is an access path: a set of schemas (`api`, `schema`) or a set of
+ * roles (`role`). Reach is the set of relations a plane can touch — for a
+ * schema plane that is membership, for a role plane it is the effective-grant
+ * closure the lattice rules already compute (direct grants, grants TO PUBLIC,
+ * and role inheritance). Every plane is then scored by the *same* function on
+ * the *same* findings; only the finding set and the density denominator
+ * differ.
+ */
+
+import type { RoleGraph } from '../checks/lattice';
+import { effectiveGrants } from '../checks/lattice';
+import type { ScoringConfig } from '../config/types';
+import type { ResolvedPlane } from '../pg/exposure';
+import type { TableSnapshot } from '../pg/introspect';
+import { computeScore } from '../score/score';
+import type { Finding, PlaneReport } from '../types';
+import { summarize } from '../types';
+
+/** A plane with its reach resolved against the catalog. */
+export interface PlaneReach {
+  plane: ResolvedPlane;
+  /** `schema.table` keys the plane can touch. */
+  relations: Set<string>;
+  /** Schemas the plane touches (computed for role planes, declared otherwise). */
+  schemas: string[];
+  /** Most direct provenance across the plane's relations (role planes). */
+  reachedVia?: 'grant' | 'PUBLIC' | 'inheritance';
+  /** Why a declared plane was not graded. */
+  skipped?: string;
+}
+
+export function relationKey(schema: string, table: string): string {
+  return `${schema}.${table}`;
+}
+
+/**
+ * Resolve what each plane can reach.
+ *
+ * A `role` plane for a superuser or `BYPASSRLS` role is refused rather than
+ * graded: RLS does not apply to it, so it reaches everything and grades 0 by
+ * construction — a number that teaches nothing and would read as a finding.
+ */
+export function resolvePlaneReach(
+  planes: ResolvedPlane[],
+  tables: TableSnapshot[],
+  graph: RoleGraph
+): PlaneReach[] {
+  return planes.map((plane) => {
+    if (plane.kind === 'role') return roleReach(plane, tables, graph);
+
+    const schemas = new Set(plane.schemas);
+    const relations = new Set(
+      tables.filter((t) => schemas.has(t.schema)).map((t) => relationKey(t.schema, t.name))
+    );
+    return { plane, relations, schemas: [...schemas].sort() };
+  });
+}
+
+function roleReach(plane: ResolvedPlane, tables: TableSnapshot[], graph: RoleGraph): PlaneReach {
+  const unsafe = plane.roles.filter((role) => {
+    const attrs = graph.get(role);
+    return attrs?.bypassRls === true || attrs?.isSuper === true;
+  });
+  if (unsafe.length > 0) {
+    return {
+      plane,
+      relations: new Set(),
+      schemas: [],
+      skipped:
+        `${unsafe.join(', ')} bypasses row-level security — every relation is unmediated for it, `
+        + 'so a grade would say nothing about the schema'
+    };
+  }
+
+  const relations = new Set<string>();
+  const schemas = new Set<string>();
+  let via: PlaneReach['reachedVia'];
+  for (const table of tables) {
+    for (const role of plane.roles) {
+      const grants = effectiveGrants(table, role, graph);
+      if (grants.length === 0) continue;
+      relations.add(relationKey(table.schema, table.name));
+      schemas.add(table.schema);
+      for (const grant of grants) via = mostDirect(via, viaOf(grant.via));
+      break;
+    }
+  }
+  return { plane, relations, schemas: [...schemas].sort(), ...(via ? { reachedVia: via } : {}) };
+}
+
+function viaOf(via: string): NonNullable<PlaneReach['reachedVia']> {
+  if (via === 'direct') return 'grant';
+  if (via === 'PUBLIC') return 'PUBLIC';
+  return 'inheritance';
+}
+
+const VIA_RANK: Record<NonNullable<PlaneReach['reachedVia']>, number> = {
+  grant: 0,
+  PUBLIC: 1,
+  inheritance: 2
+};
+
+function mostDirect(
+  a: PlaneReach['reachedVia'],
+  b: NonNullable<PlaneReach['reachedVia']>
+): NonNullable<PlaneReach['reachedVia']> {
+  return a === undefined || VIA_RANK[b] < VIA_RANK[a] ? b : a;
+}
+
+/**
+ * True when a finding is reachable on a plane. A finding with no relation
+ * (e.g. W1, an audit-level advisory) belongs to every plane; a schema-level
+ * finding (L4) belongs to the planes that touch the schema.
+ */
+export function onPlane(finding: Finding, reach: PlaneReach): boolean {
+  if (!finding.schema) return true;
+  if (!finding.table) return reach.schemas.includes(finding.schema);
+  return reach.relations.has(relationKey(finding.schema, finding.table));
+}
+
+/** Stamp `finding.planes` with every plane the finding is reachable on. */
+export function stampPlanes(findings: Finding[], reaches: PlaneReach[]): void {
+  const graded = reaches.filter((r) => !r.skipped);
+  if (graded.length === 0) return;
+  for (const finding of findings) {
+    const names = graded.filter((r) => onPlane(finding, r)).map((r) => r.plane.name);
+    if (names.length > 0) finding.planes = names;
+  }
+}
+
+/**
+ * Score one secondary plane. Findings are re-stamped `exposed: true` because
+ * "exposed" is a statement about the *primary* surface: a relation that is
+ * internal to the API is not internal to a role holding a direct connection
+ * to it, which is the entire point of grading the plane separately.
+ */
+export function scorePlane(
+  reach: PlaneReach,
+  securityFindings: Finding[],
+  scoring: ScoringConfig | undefined,
+  exposureKnown: boolean
+): PlaneReport {
+  const findings = securityFindings
+    .filter((f) => onPlane(f, reach))
+    .map((f) => ({ ...f, exposed: true }));
+
+  const { plane } = reach;
+  return {
+    name: plane.name,
+    kind: plane.kind,
+    primary: plane.primary,
+    source: plane.source,
+    schemas: reach.schemas,
+    ...(plane.roles.length > 0 ? { roles: plane.roles } : {}),
+    exposedTables: reach.relations.size,
+    ...(reach.reachedVia ? { reachedVia: reach.reachedVia } : {}),
+    score: computeScore(findings, scoring, {
+      exposedTables: reach.relations.size,
+      exposureKnown
+    }),
+    summary: summarize(findings)
+  };
+}

--- a/packages/safegres/src/index.ts
+++ b/packages/safegres/src/index.ts
@@ -94,14 +94,35 @@ export {
 export type {
   ExposureConfig,
   FailOnConfig,
+  GithubCommentConfig,
+  GithubReportConfig,
   Grade,
   OverrideEntry,
   PerfConfig,
+  PlaneConfig,
+  PlaneFailOnConfig,
+  PlaneKind,
+  ReportConfig,
   RulesConfig,
   RuleSetting,
   SafegresConfig,
   ScoringConfig
 } from './config/types';
+export type { ExposureAdapter, PlaneInput } from './exposure/adapters';
+export {
+  BUILTIN_ADAPTERS,
+  constructiveAdapter,
+  definePlanes,
+  resolveAdapters
+} from './exposure/adapters';
+export type { PlaneReach } from './exposure/planes';
+export {
+  onPlane,
+  relationKey,
+  resolvePlaneReach,
+  scorePlane,
+  stampPlanes
+} from './exposure/planes';
 export type { BaselineFinding, PerfBaseline, PerfDiff } from './perf/baseline';
 export {
   diffPerf,
@@ -116,8 +137,13 @@ export type { ExplainOptions, ExplainReport } from './perf/explain';
 export { proveFindings } from './perf/explain';
 export type { RoleAttributes, SchemaAclGrant, SchemaAclInfo, SchemaAclOptions } from './pg/acl';
 export { introspectRoleGraph, introspectSchemaAcls } from './pg/acl';
-export type { ResolvedExposure } from './pg/exposure';
-export { resolveConstructiveExposure, resolveExposure, UNKNOWN_EXPOSURE } from './pg/exposure';
+export type { ResolvedExposure, ResolvedPlane } from './pg/exposure';
+export {
+  resolveConstructiveExposure,
+  resolveExposure,
+  resolvePlanes,
+  UNKNOWN_EXPOSURE
+} from './pg/exposure';
 export type { FunctionGrant, FunctionSnapshot, IntrospectFunctionOptions } from './pg/functions';
 export { introspectFunctions } from './pg/functions';
 export type { ColumnInfo, ForeignKeyInfo, IndexInfo, TableIndexSnapshot } from './pg/indexes';
@@ -154,12 +180,33 @@ export {
   serializeSnapshot,
   toSnapshot
 } from './report/compare';
+export type { GithubRenderOptions } from './report/github';
+export {
+  COMMENT_MARKER,
+  emitGithub,
+  gradeBadge,
+  postStickyComment,
+  renderAnnotations,
+  renderGithubComment,
+  renderGithubSummary,
+  scoreBadge
+} from './report/github';
 export { renderJson } from './report/json';
 export type { RenderMarkdownOptions } from './report/markdown';
 export { renderMarkdown } from './report/markdown';
+export type { RenderPrettyOptions } from './report/pretty';
 export { renderPretty } from './report/pretty';
 export type { BuildSourceIndexOptions, RenderSarifOptions, SourceIndex, SourceLocation } from './report/sarif';
 export { buildSourceIndex, renderSarif } from './report/sarif';
+export type {
+  ReportView,
+  ViewConfig,
+  ViewDimension,
+  ViewFindings,
+  ViewScore,
+  ViewSection
+} from './report/view';
+export { ALL_SECTIONS, matchPlane, selectView, viewConfigFromReportConfig } from './report/view';
 export type { RuleMeta } from './rules/registry';
 export { dimensionOf, expandRuleSelector, isKnownRule, RULES, RULES_BY_CODE } from './rules/registry';
 export type { Score, ScoreContext, ScoreDeduction } from './score/score';

--- a/packages/safegres/src/pg/exposure.ts
+++ b/packages/safegres/src/pg/exposure.ts
@@ -1,18 +1,36 @@
 /**
- * Exposure-surface resolution: what is actually reachable through the
- * exposed APIs. Findings on non-exposed schemas contribute nothing to the
- * score — they are reported as internal advisories.
+ * Exposure-surface resolution: what is actually reachable, and by whom.
+ *
+ * A database has more than one way in. The declared API is the one the score
+ * is *about* — `resolveExposure` returns it, unchanged, and it stays the
+ * headline. `resolvePlanes` returns it alongside every other access path the
+ * config declares or an adapter discovers, so a direct connection as some
+ * role can be graded too, without moving the number that describes the API.
  */
 
-import type { ExposureConfig } from '../config/types';
+import type { ExposureConfig, PlaneKind } from '../config/types';
+import type { ExposureAdapter, PlaneInput } from '../exposure/adapters';
+import { BUILTIN_ADAPTERS, resolveAdapters } from '../exposure/adapters';
 import type { QueryExecutor } from './introspect';
 
 export interface ResolvedExposure {
   /** True when a surface was configured or auto-resolved. */
   known: boolean;
-  source: 'config' | 'constructive' | 'none';
+  source: string;
   schemas: string[];
   roles?: string[];
+}
+
+/** A plane before its reach is computed against the table snapshot. */
+export interface ResolvedPlane {
+  name: string;
+  kind: PlaneKind;
+  /** The headline plane: its score is `report.score`. Exactly one is primary. */
+  primary: boolean;
+  /** Where the plane came from: an adapter name, `config`, or `none`. */
+  source: string;
+  schemas: string[];
+  roles: string[];
 }
 
 export const UNKNOWN_EXPOSURE: ResolvedExposure = {
@@ -22,9 +40,9 @@ export const UNKNOWN_EXPOSURE: ResolvedExposure = {
 };
 
 /**
- * Resolve the exposure surface from config, delegating to a resolver when
- * one is named. Falls back to `UNKNOWN_EXPOSURE` when nothing is configured
- * or the resolver finds no routing plane.
+ * Resolve the primary exposure surface: the declared API. Adapters run first
+ * (static `schemas`/`roles` extend, never replace, what they find), then the
+ * static surface, then `UNKNOWN_EXPOSURE`.
  */
 export async function resolveExposure(
   exec: QueryExecutor,
@@ -32,18 +50,16 @@ export async function resolveExposure(
 ): Promise<ResolvedExposure> {
   if (!config) return UNKNOWN_EXPOSURE;
 
-  if (config.resolver === 'constructive') {
-    const resolved = await resolveConstructiveExposure(exec);
-    if (resolved) {
-      // Static schemas/roles extend (never replace) what the resolver found.
-      return {
-        known: true,
-        source: 'constructive',
-        schemas: union(resolved.schemas, config.schemas),
-        roles: union(resolved.roles ?? [], config.roles)
-      };
-    }
-    // Routing plane absent — fall through to whatever static surface exists.
+  for (const adapter of adaptersFor(config)) {
+    const planes = await runAdapter(exec, adapter);
+    if (planes.length === 0) continue;
+    const primary = planes.find((p) => p.primary) ?? planes[0];
+    return {
+      known: true,
+      source: adapter.name,
+      schemas: union(primary.schemas ?? [], config.schemas),
+      roles: union(primary.roles ?? [], config.roles)
+    };
   }
 
   if (config.schemas && config.schemas.length > 0) {
@@ -59,62 +75,116 @@ export async function resolveExposure(
 }
 
 /**
- * Constructive routing-plane introspection: an API exposes a set of schemas
- * via `routing_public.apis` → `routing_public.api_schemas` →
- * `metaschema_public.schema` (and the platform plane via `platform_apis` →
- * `platform_api_schemas`). API-edge roles come from `apis.role_name` /
- * `apis.anon_role`.
+ * Every plane to grade, primary first.
  *
- * Returns `null` when the routing plane isn't present in this database.
+ * The primary plane is the resolved exposure surface — the same set of
+ * schemas the score has always been computed against — so adding planes
+ * cannot move the headline number. Secondary planes come from adapters (one
+ * per API, where a stack has several) and from `exposure.planes`.
+ */
+export async function resolvePlanes(
+  exec: QueryExecutor,
+  config: ExposureConfig | undefined,
+  primary: ResolvedExposure
+): Promise<ResolvedPlane[]> {
+  const primaryName = config?.name ?? 'api';
+  const planes: ResolvedPlane[] = [
+    {
+      name: primaryName,
+      kind: 'api',
+      primary: true,
+      source: primary.source,
+      schemas: primary.schemas,
+      roles: primary.roles ?? []
+    }
+  ];
+
+  const seen = new Set([primaryName]);
+  const push = (input: PlaneInput, source: string): void => {
+    if (input.primary || seen.has(input.name)) return;
+    seen.add(input.name);
+    planes.push({
+      name: input.name,
+      kind: input.kind ?? defaultKind(input),
+      primary: false,
+      source,
+      schemas: [...(input.schemas ?? [])].sort(),
+      roles: [...(input.roles ?? [])].sort()
+    });
+  };
+
+  if (config && primary.known) {
+    for (const adapter of adaptersFor(config)) {
+      for (const plane of await runAdapter(exec, adapter)) push(plane, adapter.name);
+    }
+  }
+
+  const declared = config?.planes ?? [];
+  const claimingPrimary = declared.filter((p) => p.primary);
+  if (claimingPrimary.length > 1) {
+    throw new Error(
+      'more than one exposure plane declares `primary: true` '
+        + `(${claimingPrimary.map((p) => p.name).join(', ')}) — exactly one plane is the headline score`
+    );
+  }
+  for (const plane of declared) push(plane, 'config');
+
+  // A declared plane may take the headline over from the API surface: a
+  // database whose product *is* direct SQL access has no API to grade.
+  const override = claimingPrimary[0];
+  if (override) {
+    planes[0] = {
+      name: override.name,
+      kind: override.kind ?? defaultKind(override),
+      primary: true,
+      source: 'config',
+      schemas: [...(override.schemas ?? [])].sort(),
+      roles: [...(override.roles ?? [])].sort()
+    };
+  }
+
+  return planes;
+}
+
+function defaultKind(plane: PlaneInput): PlaneKind {
+  if (plane.kind) return plane.kind;
+  return plane.roles && plane.roles.length > 0 && !(plane.schemas && plane.schemas.length > 0)
+    ? 'role'
+    : 'schema';
+}
+
+/** Adapters named by the config, plus the `resolver` alias for the built-in. */
+function adaptersFor(config: ExposureConfig): ExposureAdapter[] {
+  const adapters = resolveAdapters(config.adapters);
+  if (config.resolver && config.resolver !== 'static') {
+    const builtin = BUILTIN_ADAPTERS[config.resolver];
+    if (builtin && !adapters.some((a) => a.name === builtin.name)) adapters.unshift(builtin);
+  }
+  return adapters;
+}
+
+/** An adapter that isn't present in this database contributes nothing. */
+async function runAdapter(exec: QueryExecutor, adapter: ExposureAdapter): Promise<PlaneInput[]> {
+  if (!(await adapter.detect(exec))) return [];
+  return adapter.resolve(exec);
+}
+
+/**
+ * Constructive routing-plane introspection.
+ *
+ * @deprecated Use `constructiveAdapter` from `safegres/adapters`; this wrapper
+ * preserves the pre-adapter shape (one union of every API) for callers that
+ * still import it.
  */
 export async function resolveConstructiveExposure(
   exec: QueryExecutor
 ): Promise<{ schemas: string[]; roles: string[] } | null> {
-  const { rows: present } = await exec.query<{ ok: boolean }>(
-    `SELECT
-       to_regclass('routing_public.apis') IS NOT NULL
-       AND to_regclass('routing_public.api_schemas') IS NOT NULL
-       AND to_regclass('metaschema_public.schema') IS NOT NULL AS ok`
-  );
-  if (!present[0]?.ok) return null;
-
-  const { rows: hasPlatform } = await exec.query<{ ok: boolean }>(
-    `SELECT
-       to_regclass('routing_public.platform_apis') IS NOT NULL
-       AND to_regclass('routing_public.platform_api_schemas') IS NOT NULL AS ok`
-  );
-
-  const planes = [
-    `SELECT s.schema_name, a.role_name, a.anon_role
-       FROM routing_public.apis a
-       JOIN routing_public.api_schemas aps ON aps.api_id = a.id
-       JOIN metaschema_public.schema s ON s.id = aps.schema_id`
-  ];
-  if (hasPlatform[0]?.ok) {
-    planes.push(
-      `SELECT s.schema_name, a.role_name, a.anon_role
-         FROM routing_public.platform_apis a
-         JOIN routing_public.platform_api_schemas aps ON aps.api_id = a.id
-         JOIN metaschema_public.schema s ON s.id = aps.schema_id`
-    );
-  }
-
-  const { rows } = await exec.query<{
-    schema_name: string;
-    role_name: string | null;
-    anon_role: string | null;
-  }>(planes.join(' UNION ALL '));
-
-  const schemas = new Set<string>();
-  const roles = new Set<string>();
-  for (const r of rows) {
-    if (r.schema_name) schemas.add(r.schema_name);
-    if (r.role_name) roles.add(r.role_name);
-    if (r.anon_role) roles.add(r.anon_role);
-  }
-  if (schemas.size === 0) return null;
-
-  return { schemas: [...schemas].sort(), roles: [...roles].sort() };
+  const adapter = BUILTIN_ADAPTERS.constructive;
+  if (!(await adapter.detect(exec))) return null;
+  const planes = await adapter.resolve(exec);
+  const primary = planes.find((p) => p.primary) ?? planes[0];
+  if (!primary || (primary.schemas ?? []).length === 0) return null;
+  return { schemas: primary.schemas ?? [], roles: primary.roles ?? [] };
 }
 
 function union(base: string[], extra?: string[]): string[] {

--- a/packages/safegres/src/report/github.ts
+++ b/packages/safegres/src/report/github.ts
@@ -1,0 +1,294 @@
+/**
+ * GitHub Actions output: job summary, workflow annotations, and a sticky PR
+ * comment.
+ *
+ * This is a *renderer*, not a second audit — everything here reads the same
+ * `ReportView` the terminal renderer reads, so what CI says and what a
+ * developer sees locally cannot disagree.
+ *
+ * On color: GitHub Markdown has none. The only way to get a real green/red
+ * score is an image, so scores render as shields.io badges by default, with
+ * 🟢/🟡/🔴 as the offline fallback (`report.github.badges: false`).
+ */
+
+import * as fs from 'fs';
+
+import type { GithubReportConfig } from '../config/types';
+import type { Grade } from '../config/types';
+import type { Score } from '../score/score';
+import type { Finding, Report } from '../types';
+import { renderMarkdown } from './markdown';
+import { matchPlane, selectView, type ViewConfig, type ViewScore } from './view';
+
+/** Marker that makes the PR comment sticky: one comment, edited in place. */
+export const COMMENT_MARKER = '<!-- safegres-report -->';
+
+const GRADE_COLOR: Record<string, string> = {
+  'A+': 'brightgreen',
+  A: 'brightgreen',
+  B: 'green',
+  C: 'yellow',
+  D: 'orange',
+  F: 'red'
+};
+
+const GRADE_DOT: Record<string, string> = {
+  'A+': '🟢',
+  A: '🟢',
+  B: '🟢',
+  C: '🟡',
+  D: '🟠',
+  F: '🔴'
+};
+
+export interface GithubRenderOptions {
+  config?: GithubReportConfig;
+  /** Findings that tripped a gate, for `annotations: 'gate-failures'`. */
+  gateFailures?: Finding[];
+  /** Extra view selection (planes, dimensions) from `report` config. */
+  view?: ViewConfig;
+}
+
+/** A score as a shields.io badge, or as a colored dot when badges are off. */
+export function scoreBadge(label: string, score: Score, badges: boolean): string {
+  const color = GRADE_COLOR[score.grade] ?? 'lightgrey';
+  if (!badges) return `${GRADE_DOT[score.grade] ?? '⚪'} **${label} ${score.value} (${score.grade})**`;
+  const text = encodeURIComponent(`${score.value} (${score.grade})`);
+  const name = encodeURIComponent(label);
+  return `![${label} ${score.value} ${score.grade}](https://img.shields.io/badge/${name}-${text}-${color})`;
+}
+
+export function gradeBadge(label: string, grade: Grade, badges: boolean): string {
+  const color = GRADE_COLOR[grade] ?? 'lightgrey';
+  if (!badges) return `${GRADE_DOT[grade] ?? '⚪'} **${label} ${grade}**`;
+  return `![${label} ${grade}](https://img.shields.io/badge/${encodeURIComponent(label)}-${grade}-${color})`;
+}
+
+/**
+ * The job summary: the badges a reviewer reads first, then the full markdown
+ * report. `summary` picks which scores get a badge — `security`, `perf`, and
+ * `planes:<glob>` for the secondary planes a team cares about.
+ */
+export function renderGithubSummary(report: Report, options: GithubRenderOptions = {}): string {
+  const config = options.config ?? {};
+  const badges = config.badges !== false;
+  const selectors = config.summary ?? ['security', 'perf'];
+  const view = selectView(report, {
+    planes: planePatterns(selectors),
+    ...options.view
+  });
+
+  const out: string[] = [];
+  const line = selectedScores(view.scores, selectors)
+    .map((s) => scoreBadge(s.label, s.score, badges))
+    .join(' ');
+  if (line) out.push(line, '');
+
+  out.push(renderMarkdown(report, { view: { planes: planePatterns(selectors), ...options.view } }));
+  return out.join('\n');
+}
+
+/**
+ * The sticky PR comment: shorter than the summary by design. A comment is read
+ * on the way past, so it carries the scores, the movement, and what is new —
+ * the full finding tables live in the job summary and the SARIF alerts.
+ */
+export function renderGithubComment(report: Report, options: GithubRenderOptions = {}): string {
+  const config = options.config ?? {};
+  const badges = config.badges !== false;
+  const sections = new Set(config.comment?.sections ?? ['scores', 'delta', 'new-findings']);
+  const selectors = config.summary ?? ['security', 'perf'];
+  const view = selectView(report, { planes: planePatterns(selectors), ...options.view });
+
+  const out: string[] = [COMMENT_MARKER, '## safegres', ''];
+
+  if (sections.has('scores')) {
+    out.push(
+      selectedScores(view.scores, selectors)
+        .map((s) => scoreBadge(s.label, s.score, badges))
+        .join(' '),
+      ''
+    );
+    if (report.exposure) {
+      out.push(
+        report.exposure.known
+          ? `Exposure (${report.exposure.source}): **${report.exposure.exposedTables}/`
+            + `${report.exposure.totalTables}** tables reachable.`
+          : '> [!WARNING]\n> Exposure unknown — the whole database is assumed reachable, '
+            + 'and the score is capped.',
+        ''
+      );
+    }
+  }
+
+  if (sections.has('planes') && view.planes.length > 0) {
+    out.push(
+      '| Plane | Kind | Relations | Grade |',
+      '| --- | --- | ---: | --- |',
+      ...view.planes.map((p) =>
+        p.skipped
+          ? `| \`${p.name}\` | ${p.kind} | — | not graded |`
+          : `| \`${p.name}\` | ${p.kind} | ${p.exposedTables} | **${p.score.grade}** (${p.score.value}) |`
+      ),
+      ''
+    );
+  }
+
+  if (sections.has('delta') && report.comparison) {
+    const cmp = report.comparison;
+    const since = cmp.previous.ref ?? 'the previous run';
+    if (cmp.unchanged) {
+      out.push(`_No change since ${since}._`, '');
+    } else {
+      out.push(`**Changes since ${since}**`, '');
+      for (const [dimension, d] of [
+        ['security', cmp.security],
+        ['performance', cmp.perf]
+      ] as const) {
+        if (!d) continue;
+        const arrow = d.delta > 0 ? '🟢 ▲' : d.delta < 0 ? '🔴 ▼' : '⚪';
+        out.push(
+          `- ${dimension}: ${arrow} ${d.delta > 0 ? '+' : ''}${d.delta.toFixed(1)} `
+            + `(${d.before} → ${d.after}${d.gradeBefore === d.gradeAfter ? '' : `, ${d.gradeBefore} → ${d.gradeAfter}`})`
+        );
+      }
+      out.push('');
+    }
+  }
+
+  if (sections.has('new-findings')) {
+    const added = report.perf?.diff?.added ?? [];
+    if (added.length > 0) {
+      out.push(
+        `**${added.length} new performance finding${added.length === 1 ? '' : 's'} since the baseline**`,
+        '',
+        ...added.slice(0, 10).map((f) => `- \`${f.code}\` ${location(f)} — ${f.message}`),
+        ''
+      );
+    }
+  }
+
+  if (sections.has('findings')) {
+    out.push(renderMarkdown(report, { title: 'Findings', view: options.view }), '');
+  }
+
+  return out.join('\n');
+}
+
+/**
+ * Workflow annotations. Default `gate-failures`: annotating every advisory on
+ * a large schema buries the one finding that actually blocked the merge.
+ */
+export function renderAnnotations(report: Report, options: GithubRenderOptions = {}): string[] {
+  const mode = options.config?.annotations ?? 'gate-failures';
+  if (mode === 'none') return [];
+  const findings =
+    mode === 'all'
+      ? report.findings.filter((f) => f.exposed !== false && !f.acknowledged)
+      : (options.gateFailures ?? []);
+  return findings.map((f) => {
+    const level = f.severity === 'critical' || f.severity === 'high' ? 'error' : 'warning';
+    const title = `${f.code} ${location(f)}`.trim();
+    return `::${level} title=${escapeProperty(title)}::${escapeData(f.message)}`;
+  });
+}
+
+/**
+ * Write the summary to `$GITHUB_STEP_SUMMARY` and print the annotations.
+ * Returns false when not running under GitHub Actions, so a caller can fall
+ * back to stdout rather than silently producing nothing.
+ */
+export function emitGithub(report: Report, options: GithubRenderOptions = {}): boolean {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  for (const annotation of renderAnnotations(report, options)) {
+    process.stdout.write(`${annotation}\n`);
+  }
+  if (!summaryPath) return false;
+  fs.appendFileSync(summaryPath, `${renderGithubSummary(report, options)}\n`);
+  return true;
+}
+
+/**
+ * Upsert the sticky comment on the current pull request. No-op (returning a
+ * reason) when the environment has no PR or no token: a report is not worth
+ * failing a build over, but silence about *why* is how integrations rot.
+ */
+export async function postStickyComment(
+  body: string,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<{ posted: boolean; reason?: string }> {
+  const token = env.GITHUB_TOKEN ?? env.INPUT_GITHUB_TOKEN;
+  const repo = env.GITHUB_REPOSITORY;
+  if (!token) return { posted: false, reason: 'no GITHUB_TOKEN in the environment' };
+  if (!repo) return { posted: false, reason: 'no GITHUB_REPOSITORY in the environment' };
+
+  const pr = pullRequestNumber(env);
+  if (pr == null) return { posted: false, reason: 'not running on a pull_request event' };
+
+  const api = env.GITHUB_API_URL ?? 'https://api.github.com';
+  const headers = {
+    accept: 'application/vnd.github+json',
+    authorization: `Bearer ${token}`,
+    'content-type': 'application/json'
+  };
+
+  const listed = await fetch(`${api}/repos/${repo}/issues/${pr}/comments?per_page=100`, { headers });
+  if (!listed.ok) {
+    return { posted: false, reason: `GitHub API ${listed.status} listing comments` };
+  }
+  const comments = (await listed.json()) as Array<{ id: number; body?: string }>;
+  const existing = comments.find((c) => c.body?.includes(COMMENT_MARKER));
+
+  const target = existing
+    ? `${api}/repos/${repo}/issues/comments/${existing.id}`
+    : `${api}/repos/${repo}/issues/${pr}/comments`;
+  const written = await fetch(target, {
+    method: existing ? 'PATCH' : 'POST',
+    headers,
+    body: JSON.stringify({ body })
+  });
+  if (!written.ok) return { posted: false, reason: `GitHub API ${written.status} writing comment` };
+  return { posted: true };
+}
+
+function pullRequestNumber(env: NodeJS.ProcessEnv): number | null {
+  const eventPath = env.GITHUB_EVENT_PATH;
+  if (!eventPath || !fs.existsSync(eventPath)) return null;
+  try {
+    const event = JSON.parse(fs.readFileSync(eventPath, 'utf8')) as {
+      pull_request?: { number?: number };
+      issue?: { number?: number };
+    };
+    return event.pull_request?.number ?? event.issue?.number ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** `planes:direct:*` in a summary selector is a plane glob for the view. */
+function planePatterns(selectors: string[]): string[] {
+  return selectors
+    .filter((s) => s.startsWith('planes:'))
+    .map((s) => s.slice('planes:'.length));
+}
+
+function selectedScores(scores: ViewScore[], selectors: string[]): ViewScore[] {
+  const planes = planePatterns(selectors);
+  return scores.filter((s) => {
+    if (s.plane) return planes.some((p) => matchPlane(p, s.plane!.name));
+    return selectors.includes(s.id);
+  });
+}
+
+function location(f: Finding): string {
+  return [f.schema, f.table].filter(Boolean).join('.') + (f.policy ? ` (${f.policy})` : '');
+}
+
+// https://github.com/actions/toolkit/blob/main/packages/core/src/command.ts
+function escapeData(value: string): string {
+  return value.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+}
+
+function escapeProperty(value: string): string {
+  return escapeData(value).replace(/:/g, '%3A').replace(/,/g, '%2C');
+}

--- a/packages/safegres/src/report/markdown.ts
+++ b/packages/safegres/src/report/markdown.ts
@@ -11,8 +11,9 @@
 
 import type { RoleAccessEntry } from '../checks/lattice';
 import type { Score } from '../score/score';
-import type { Finding, Report, Severity } from '../types';
+import type { Finding, PlaneReport, Report, Severity } from '../types';
 import { formatDelta, type ReportComparison, type RuleDelta, type ScoreDelta } from './compare';
+import { type ReportView, selectView, type ViewConfig } from './view';
 
 const SEV_ICON: Record<Severity, string> = {
   critical: '🔴',
@@ -42,9 +43,18 @@ export interface RenderMarkdownOptions {
   verbose?: boolean;
   /** Heading text. Default `safegres`. */
   title?: string;
+  /** Secondary planes to expand, by name or glob. Default: one summary table. */
+  planes?: string[];
+  /** Everything else the view layer selects. Beats the flags above. */
+  view?: ViewConfig;
 }
 
 export function renderMarkdown(report: Report, options: RenderMarkdownOptions = {}): string {
+  const view = selectView(report, {
+    detail: options.summary ? 'summary' : options.verbose ? 'verbose' : 'normal',
+    ...(options.planes ? { planes: options.planes } : {}),
+    ...options.view
+  });
   const out: string[] = [`## ${options.title ?? 'safegres'}`, ''];
 
   out.push(...scoreTable(report, options), '');
@@ -60,16 +70,18 @@ export function renderMarkdown(report: Report, options: RenderMarkdownOptions = 
     );
   }
 
+  if (view.has('planes')) out.push(...planeSection(view), '');
+
   out.push(countsTable(report), '');
 
   if (report.comparison) out.push(...comparisonSection(report.comparison), '');
 
-  if (options.summary) return out.join('\n');
+  if (view.detail === 'summary') return out.join('\n');
 
-  const security = report.perf
-    ? report.findings.filter((f) => f.dimension !== 'perf')
-    : report.findings;
-  out.push(...findingSection('Security findings', security, options), '');
+  out.push(
+    ...findingSection('Security findings', [...view.security.exposed, ...view.security.internal], options),
+    ''
+  );
 
   if (report.roleAccess && report.roleAccess.roles.length > 0) {
     out.push(...roleAccessSection(report.roleAccess.roles), '');
@@ -122,6 +134,53 @@ export function renderMarkdown(report: Report, options: RenderMarkdownOptions = 
   }
 
   return out.join('\n');
+}
+
+/**
+ * The other ways in, as one table. Secondary planes are advisory by
+ * construction — an internal role reaching internal tables is the schema
+ * working as designed — so they read as context under the headline rather
+ * than as a second verdict competing with it.
+ */
+function planeSection(view: ReportView): string[] {
+  const out: string[] = [
+    '### Other access planes',
+    '',
+    '_Advisory: these are not the score above. The headline grades the declared API surface; '
+      + 'a plane grades what somebody reaches without going through it._',
+    '',
+    '| Plane | Kind | Reaches | Relations | Score | Grade |',
+    '| --- | --- | --- | ---: | ---: | --- |'
+  ];
+  for (const plane of view.planes) out.push(planeRow(plane));
+  for (const plane of view.expandedPlanes) {
+    if (plane.skipped || plane.score.deductions.length === 0) continue;
+    out.push(
+      '',
+      `#### Plane \`${plane.name}\` by rule`,
+      '',
+      '| Rule | Findings | Points | Grade | Payoff |',
+      '| --- | ---: | ---: | --- | ---: |',
+      ...plane.score.deductions.map((d) =>
+        d.unscored
+          ? `| \`${d.code}\` | ${d.count} | — | — | *unscored* |`
+          : `| \`${d.code}\` | ${d.count} | −${d.points} | **${d.grade}** | +${d.potential.toFixed(1)} |`
+      )
+    );
+  }
+  return out;
+}
+
+function planeRow(plane: PlaneReport): string {
+  const who = plane.roles && plane.roles.length > 0
+    ? plane.roles.map((r) => `\`${r}\``).join(', ')
+    : plane.schemas.map((s) => `\`${s}\``).join(', ') || '—';
+  if (plane.skipped) {
+    return `| \`${plane.name}\` | ${plane.kind} | ${who} | — | — | not graded — ${plane.skipped} |`;
+  }
+  const via = plane.reachedVia ? ` (via ${plane.reachedVia})` : '';
+  return `| \`${plane.name}\` | ${plane.kind} | ${who}${via} | ${plane.exposedTables} `
+    + `| **${plane.score.value}** | **${plane.score.grade}** |`;
 }
 
 /**

--- a/packages/safegres/src/report/pretty.ts
+++ b/packages/safegres/src/report/pretty.ts
@@ -1,9 +1,10 @@
 import yanse from 'yanse';
 
 import type { Score } from '../score/score';
-import type { Finding, Report, Severity } from '../types';
+import type { Finding, PlaneReport, Report, Severity } from '../types';
 import { renderCallGraph, renderCallGraphDiff } from './callgraph';
 import { formatDelta, type ScoreDelta } from './compare';
+import { type ReportView, selectView, type ViewConfig } from './view';
 
 const SEV_LABEL: Record<Severity, string> = {
   critical: 'CRIT',
@@ -30,13 +31,24 @@ export interface RenderPrettyOptions {
   summary?: boolean;
   /** Expand the internal (non-exposed) advisories instead of collapsing them to a count. */
   verbose?: boolean;
+  /** Secondary planes to expand, by name or glob. Default: summarized in one line each. */
+  planes?: string[];
+  /** Everything else the view layer selects. Beats the flags above. */
+  view?: ViewConfig;
 }
 
 export function renderPretty(report: Report, options: RenderPrettyOptions = {}): string {
   const colorEnabled = options.color ?? process.stdout.isTTY === true;
   const paint = (sev: Severity, s: string) => (colorEnabled ? SEV_PAINT[sev](s) : noop(s));
 
-  const { summary: s, findings, score, exposure } = report;
+  const view = selectView(report, {
+    detail: options.summary ? 'summary' : options.verbose ? 'verbose' : 'normal',
+    ...(options.planes ? { planes: options.planes } : {}),
+    ...options.view
+  });
+  const verbose = view.detail === 'verbose';
+
+  const { summary: s, score, exposure } = report;
   const lines: string[] = [
     `safegres ${report.version}  (${report.generatedAt})`,
     ''
@@ -79,6 +91,10 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
     lines.push('');
   }
 
+  if (view.has('planes')) {
+    lines.push(...planeLines(view, colorEnabled), '');
+  }
+
   lines.push(
     `summary: ${paint('critical', String(s.critical))} critical  `
       + `${paint('high', String(s.high))} high  `
@@ -88,7 +104,7 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
   );
 
   // --summary: score + counts only, no per-finding lines.
-  if (options.summary) {
+  if (view.detail === 'summary') {
     if (report.callGraph) {
       lines.push('', renderCallGraph(report.callGraph, { color: colorEnabled, summary: true }));
     }
@@ -101,9 +117,7 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
 
   // Perf findings render in their own section so the two dimensions never
   // read as one list.
-  const security = report.perf ? findings.filter((f) => f.dimension !== 'perf') : findings;
-  const exposed = security.filter((f) => f.exposed !== false);
-  const internal = security.filter((f) => f.exposed === false);
+  const { exposed, internal } = view.security;
 
   for (const f of exposed) {
     lines.push(renderFinding(f, paint));
@@ -111,7 +125,7 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
 
   if (internal.length > 0) {
     // Collapse internal advisories to a count by default; --verbose lists them.
-    if (options.verbose) {
+    if (verbose) {
       lines.push(
         '',
         `internal advisories (${internal.length}) — not exposed via any API, excluded from the score:`,
@@ -132,7 +146,7 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
     }
   }
 
-  if (security.length === 0) {
+  if (exposed.length + internal.length === 0) {
     lines.push('no findings.');
   }
 
@@ -144,7 +158,7 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
           + `${entry.unmediated.length} unmediated (no RLS), ${entry.mediated} policy-mediated`
           + `${entry.dead > 0 ? `, ${entry.dead} dead (RLS default-deny)` : ''}`
       );
-      const shown = options.verbose ? entry.unmediated : entry.unmediated.slice(0, 20);
+      const shown = verbose ? entry.unmediated : entry.unmediated.slice(0, 20);
       for (const r of shown) {
         lines.push(
           paint('medium', `    ${r.schema}.${r.table}  ${r.privileges.join(', ')}  (via ${r.via})`)
@@ -186,7 +200,7 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
     } else {
       for (const f of perfExposed) lines.push(renderFinding(f, paint));
     }
-    if (perfInternal > 0 && !options.verbose) {
+    if (perfInternal > 0 && !verbose) {
       lines.push(
         paint('info', `  (${perfInternal} internal perf advisor${perfInternal === 1 ? 'y' : 'ies'} excluded from the perf score)`)
       );
@@ -240,14 +254,47 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
   return lines.join('\n');
 }
 
+/**
+ * Secondary planes: one line each, because they are not the headline. The
+ * primary score answers "how safe is the product"; these answer "and what if
+ * somebody doesn't come through it" — worth seeing, not worth competing with
+ * the number the team is being graded on. `--plane <name>` expands one.
+ */
+function planeLines(view: ReportView, colorEnabled: boolean): string[] {
+  const lines = ['other access planes — advisory, not part of the score above:'];
+  for (const plane of view.planes) {
+    lines.push(`  ${planeLine(plane, colorEnabled)}`);
+  }
+  for (const plane of view.expandedPlanes) {
+    if (plane.skipped) continue;
+    lines.push('', `plane ${plane.name}:`, ...scoreLines('  score', plane.score, colorEnabled));
+  }
+  if (view.expandedPlanes.length === 0 && view.planes.some((p) => !p.skipped)) {
+    lines.push('  (run with --plane <name> to expand one, or --plane \'*\' for all)');
+  }
+  return lines;
+}
+
+function planeLine(plane: PlaneReport, colorEnabled: boolean): string {
+  const who = plane.roles && plane.roles.length > 0
+    ? ` (${plane.roles.join(', ')})`
+    : plane.schemas.length > 0
+      ? ` (${plane.schemas.join(', ')})`
+      : '';
+  if (plane.skipped) return `${plane.name}${who}: not graded — ${plane.skipped}`;
+  const grade = colorEnabled ? gradePaintFor(plane.score)(`${plane.score.value} (${plane.score.grade})`) : `${plane.score.value} (${plane.score.grade})`;
+  const via = plane.reachedVia ? `, reached via ${plane.reachedVia}` : '';
+  return `${plane.name} [${plane.kind}]${who}: ${grade}`
+    + `  — ${plane.exposedTables} relation(s)${via}`;
+}
+
+function gradePaintFor(score: Score): Painter {
+  if (score.grade.startsWith('A')) return yanse.green;
+  return score.grade === 'B' || score.grade === 'C' ? yanse.yellow : yanse.red;
+}
+
 function scoreLines(label: string, score: Score, colorEnabled: boolean): string[] {
-  const gradePaint: (s: string) => string = colorEnabled
-    ? score.grade.startsWith('A')
-      ? yanse.green
-      : score.grade === 'B' || score.grade === 'C'
-        ? yanse.yellow
-        : yanse.red
-    : noop;
+  const gradePaint: Painter = colorEnabled ? gradePaintFor(score) : noop;
   const capNote = score.cappedByUnknownExposure ? '  (capped: exposure unknown)' : '';
   const lines = [
     `${label}: ${gradePaint(`${score.value} (${score.grade})`)}  — model: ${score.model}${capNote}`

--- a/packages/safegres/src/report/view.ts
+++ b/packages/safegres/src/report/view.ts
@@ -1,0 +1,196 @@
+/**
+ * Selection: the layer between analysis and rendering.
+ *
+ * A `Report` is what the audit found — pure data, the same for everybody. A
+ * `ReportView` is what one reader should see: which planes, which dimensions,
+ * which sections, how much detail. Renderers consume the view and decide only
+ * how it *looks*, so "the team wants the perf score and their direct-role
+ * planes in the PR comment" is answered once here, rather than four times in
+ * four renderers that drift apart.
+ */
+
+import type { ReportConfig } from '../config/types';
+import type { Finding, PlaneReport, Report } from '../types';
+import type { ScoreDelta } from './compare';
+
+export type ViewSection =
+  | 'scores'
+  | 'delta'
+  | 'findings'
+  | 'planes'
+  | 'role-access'
+  | 'call-graph';
+
+export const ALL_SECTIONS: ViewSection[] = [
+  'scores',
+  'delta',
+  'findings',
+  'planes',
+  'role-access',
+  'call-graph'
+];
+
+export type ViewDimension = 'security' | 'perf';
+
+export interface ViewConfig {
+  /**
+   * Planes to render in full, by name or glob (`*`, `direct:*`). The primary
+   * plane is always included. Default: primary only — secondaries are
+   * summarized, not expanded.
+   */
+  planes?: string[];
+  /** Dimensions to render. Default: whatever the report has. */
+  dimensions?: ViewDimension[];
+  /** Sections to render. Default: all of them the report has data for. */
+  sections?: ViewSection[];
+  /** How much of each section. Default `normal`. */
+  detail?: 'summary' | 'normal' | 'verbose';
+  /** Drop findings that are not on the primary surface entirely. */
+  exposedOnly?: boolean;
+}
+
+/** One score to render, with the delta that belongs to it. */
+export interface ViewScore {
+  /** `security`, `perf`, or `plane:<name>`. */
+  id: string;
+  label: string;
+  dimension: ViewDimension;
+  score: import('../score/score').Score;
+  /** Present for the primary security/perf scores when the run was compared. */
+  delta?: ScoreDelta;
+  /** The plane this score describes, when it is not the headline. */
+  plane?: PlaneReport;
+}
+
+export interface ViewFindings {
+  /** Reachable on the primary surface — the scored ones. */
+  exposed: Finding[];
+  /** Off the primary surface: reported, unscored. */
+  internal: Finding[];
+}
+
+export interface ReportView {
+  report: Report;
+  detail: 'summary' | 'normal' | 'verbose';
+  /** Headline scores, in render order. */
+  scores: ViewScore[];
+  /** Secondary planes to mention. Expanded ones are in `expandedPlanes`. */
+  planes: PlaneReport[];
+  /** Planes the view config asked to see in full. */
+  expandedPlanes: PlaneReport[];
+  security: ViewFindings;
+  perf?: ViewFindings;
+  has(section: ViewSection): boolean;
+}
+
+/** Glob match over plane names: `*` matches any run of characters. */
+export function matchPlane(pattern: string, name: string): boolean {
+  if (pattern === name) return true;
+  const rx = new RegExp(
+    `^${pattern.split('*').map(escapeRegExp).join('.*')}$`
+  );
+  return rx.test(name);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Everything presentation-adjacent about a report, decided once.
+ *
+ * Selection never edits the report: `exposedOnly` narrows what the view
+ * exposes, and the underlying `report.findings` stays whole so a JSON dump
+ * beside a pretty print is still the full picture.
+ */
+export function selectView(report: Report, config: ViewConfig = {}): ReportView {
+  const detail = config.detail ?? 'normal';
+  const dimensions = new Set<ViewDimension>(
+    config.dimensions ?? (['security', 'perf'] as ViewDimension[])
+  );
+  const sections = new Set<ViewSection>(config.sections ?? ALL_SECTIONS);
+
+  const scores: ViewScore[] = [];
+  if (report.score && dimensions.has('security')) {
+    scores.push({
+      id: 'security',
+      label: 'Security',
+      dimension: 'security',
+      score: report.score,
+      ...(report.comparison?.security ? { delta: report.comparison.security } : {})
+    });
+  }
+  if (report.perf && dimensions.has('perf')) {
+    scores.push({
+      id: 'perf',
+      label: 'Performance',
+      dimension: 'perf',
+      score: report.perf.score,
+      ...(report.comparison?.perf ? { delta: report.comparison.perf } : {})
+    });
+  }
+
+  const secondary = (report.planes ?? []).filter((p) => !p.primary);
+  const patterns = config.planes ?? [];
+  const expandedPlanes = secondary.filter((p) => patterns.some((q) => matchPlane(q, p.name)));
+  for (const plane of expandedPlanes) {
+    if (plane.skipped) continue;
+    scores.push({
+      id: `plane:${plane.name}`,
+      label: plane.name,
+      dimension: 'security',
+      score: plane.score,
+      plane
+    });
+  }
+
+  const securityAll = report.perf
+    ? report.findings.filter((f) => f.dimension !== 'perf')
+    : report.findings;
+
+  return {
+    report,
+    detail,
+    scores,
+    planes: secondary,
+    expandedPlanes,
+    security: partition(securityAll, config),
+    ...(report.perf && dimensions.has('perf')
+      ? { perf: partition(report.perf.findings, config) }
+      : {}),
+    has(section: ViewSection): boolean {
+      if (!sections.has(section)) return false;
+      switch (section) {
+      case 'delta':
+        return report.comparison != null;
+      case 'planes':
+        return secondary.length > 0;
+      case 'role-access':
+        return (report.roleAccess?.roles.length ?? 0) > 0;
+      case 'call-graph':
+        return report.callGraph != null || report.callGraphDiff != null;
+      case 'findings':
+        return detail !== 'summary';
+      default:
+        return true;
+      }
+    }
+  };
+}
+
+function partition(findings: Finding[], config: ViewConfig): ViewFindings {
+  const exposed = findings.filter((f) => f.exposed !== false);
+  return {
+    exposed,
+    internal: config.exposedOnly ? [] : findings.filter((f) => f.exposed === false)
+  };
+}
+
+/** The config-file half of a view: `report.planes` / `report.dimensions`. */
+export function viewConfigFromReportConfig(config: ReportConfig | undefined): ViewConfig {
+  if (!config) return {};
+  return {
+    ...(config.planes ? { planes: config.planes } : {}),
+    ...(config.dimensions ? { dimensions: config.dimensions } : {})
+  };
+}

--- a/packages/safegres/src/types.ts
+++ b/packages/safegres/src/types.ts
@@ -44,11 +44,19 @@ export interface Finding {
   /** Scoring axis. Stamped from the rule registry; defaults to `security`. */
   dimension?: Dimension;
   /**
-   * Whether the finding's table is on the resolved exposure surface.
-   * `undefined` when no exposure surface is known (everything is assumed
-   * reachable).
+   * Whether the finding's table is on the resolved exposure surface — i.e.
+   * reachable on the *primary* plane. `undefined` when no exposure surface is
+   * known (everything is assumed reachable).
    */
   exposed?: boolean;
+  /**
+   * Every access plane the finding is reachable on, by name. A relation that
+   * is internal to the API can still be reachable by a role holding a direct
+   * connection, and this is where that shows up. Not part of a finding's
+   * identity: baselines and comparisons key on the finding, not on who can
+   * reach it.
+   */
+  planes?: string[];
   /**
    * The finding is acknowledged by config as intentional (e.g. an open read
    * on a table declared in `public.read`) — reported, but excluded from the
@@ -97,12 +105,43 @@ export interface Summary {
   info: number;
 }
 
+/**
+ * One graded access plane: a way into the database, with its own score.
+ *
+ * The primary plane is the declared API surface, and its score *is*
+ * `report.score` — secondary planes never move it. They answer the question
+ * the headline cannot: what does this database grade for somebody who does
+ * not come through the API?
+ */
+export interface PlaneReport {
+  name: string;
+  kind: 'api' | 'role' | 'schema';
+  /** The headline plane. Exactly one plane is primary. */
+  primary: boolean;
+  /** Adapter name, `config`, or `none`. */
+  source: string;
+  schemas: string[];
+  roles?: string[];
+  /** Relations the plane reaches (the density denominator). */
+  exposedTables: number;
+  /** Role planes: the most direct way the reach arrives. */
+  reachedVia?: 'grant' | 'PUBLIC' | 'inheritance';
+  /** Security score for this plane, same model as the headline. */
+  score: import('./score/score').Score;
+  /** Severity counts for the findings reachable on this plane. */
+  summary: Summary;
+  /** Present when the plane was reported but deliberately not graded. */
+  skipped?: string;
+}
+
 /** The resolved exposure surface an audit was scored against. */
 export interface ExposureReport {
   /** True when a surface was configured or auto-resolved. */
   known: boolean;
-  /** Where the surface came from. */
-  source: 'config' | 'constructive' | 'none';
+  /** Where the surface came from: an adapter name, `config`, or `none`. */
+  source: string;
+  /** Name of the primary plane. */
+  plane?: string;
   /** Schemas reachable from the exposed APIs. Empty when unknown. */
   schemas: string[];
   /** API-edge roles, when the resolver can discover them. */
@@ -192,6 +231,12 @@ export interface Report {
   perf?: PerfReport;
   /** The exposure surface the score was computed against. */
   exposure?: ExposureReport;
+  /**
+   * Every graded access plane, primary first. `planes[0].score` is
+   * `report.score`; the rest are advisory unless `failOn.planes` opts them
+   * into gating.
+   */
+  planes?: PlaneReport[];
   /** Effective per-role access, for the configured untrusted roles. */
   roleAccess?: RoleAccessReport;
   /**

--- a/packages/safegres/src/version.ts
+++ b/packages/safegres/src/version.ts
@@ -1,2 +1,2 @@
-// Auto-synced from package.json during publish.
-export const version = '0.1.0';
+// Auto-synced from package.json by scripts/sync-version.js.
+export const version = '1.16.1';


### PR DESCRIPTION
## Summary

An API is one way into a database, not the only one. This teaches safegres to grade **every** access path — while leaving the headline number exactly where it was — and splits reporting into `analysis → view selection → rendering` so the four renderers stop each re-deciding what to show.

Stacked on #1598 (the README rebrand); the diff here is implementation only.

**Planes.** A plane is `(schemas, roles, kind)` where `kind ∈ 'api' | 'role' | 'schema'`. Exactly one is primary, and `report.planes[0].score === report.score` — byte-identical to today's number, so no baseline moves:

```jsonc
"exposure": {
  "schemas": ["app_public"],
  "planes": [{ "name": "direct:reporting", "kind": "role", "roles": ["reporting"] }]
}
```
```
score  84.4 (B)   ← unchanged: the declared API surface
other access planes — advisory, not part of the score above:
  direct:reporting [role] (reporting): 18.3 (F)  — 1 relation(s), reached via grant
```

A role plane's reach comes from the existing `effectiveGrants(table, role, graph)` lattice (direct grants, `PUBLIC`, inheritance) rather than a second hand-maintained grant model, and records *how* it got there (`reachedVia`). A `BYPASSRLS`/superuser role reports `skipped: "… bypasses row-level security"` instead of a meaningless F.

Findings gain `planes: string[]`, deliberately **outside** finding identity — `exposed`, baseline keys and SARIF fingerprints are untouched, so adding a plane can never invalidate a baseline (there is a test asserting exactly that). Secondary planes gate nothing unless asked: `failOn.planes: { "direct:*": { "grade": "D" } }`.

**View layer.** `selectView(report, viewConfig) → ReportView` now answers "which planes, which dimensions, which sections, how much detail" once, and the renderers consume it. `--summary`/`--verbose`/`--exposed-only` become shorthands for view settings; `--plane <name|glob>` expands a plane; `--write-json/--write-markdown/--write-sarif` emit several artifacts from one audit.

**Adapters** (replacing the hard-coded `resolver: 'constructive'` branch — which still works as an alias):

```ts
interface ExposureAdapter {
  name: string;
  detect(exec: QueryExecutor): Promise<boolean>;
  resolve(exec: QueryExecutor): Promise<PlaneInput[]>;   // may emit one plane per API
}
```
Adapters are **values**, passed in config (`exposure.adapters: [constructiveAdapter, myAdapter]`, exported from `safegres/adapters`). Nothing is resolved by package name; a JSON string may only name a built-in, and an unknown name throws rather than silently degrading to "unexposed database". The `constructive` adapter is the first in-tree implementation and emits `api` (union, primary) plus `api:<name>` per API when there is more than one.

**GitHub.** `--github` (auto-detected under `GITHUB_ACTIONS`) writes shields.io badges + the markdown report to `$GITHUB_STEP_SUMMARY`, emits `::error`/`::warning` annotations for **gate failures only** by default (annotating every advisory buries the one finding that blocked the merge), and `--github-comment` upserts a sticky PR comment via a `<!-- safegres-report -->` marker. All of it is config, not code:

```jsonc
"report": { "github": {
  "summary": ["security", "perf", "planes:direct:*"],
  "comment": { "sticky": true, "sections": ["scores", "delta", "new-findings"] },
  "annotations": "gate-failures",   // "all" | "gate-failures" | "none"
  "badges": true                    // false → 🟢🟡🔴 text for air-gapped runners
}}
```
To make this possible the CLI's gates no longer `process.exit(1)` on the first failure: they accumulate into `failed`/`gateFailures`, so the renderers can annotate precisely what broke the build, and the process exits once at the end.

**Also:** reports said `safegres 0.1.0` while the package was `1.16.1` — `src/version.ts` is now synced from the manifest at build time.

Not in this PR: reducing `constructive-db/bin/safegres-check.cjs` to Constructive-specific setup now that the generic reporting lives here.

## Verification

`pnpm lint`, `pnpm build`, `pnpm test` (22 suites / 233 tests) in `packages/safegres`, plus an end-to-end CLI run against a live database exercising `--plane`, `--github` and a failing gate. 28 new tests cover plane scoring and identity stability, adapter resolution, view selection/globbing, and the GitHub renderers.


Link to Devin session: https://app.devin.ai/sessions/b7874ecee0c7471ea271e6e7193869dc
Requested by: @pyramation