### PR TITLE
feat(safegres): stack + posture presets and four more exposure adapters

### DIFF
--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -266,10 +266,14 @@ interface ExposureAdapter {
 }
 ```
 
-The built-in `constructive` adapter introspects `routing_public.apis → api_schemas` and emits a
-primary `api` plane plus one `api:<name>` plane per API. JSON configs may name a built-in
-(`"adapters": ["constructive"]`); anything else is an error rather than a silent no-op. The old
-`"resolver": "constructive"` still works.
+Built-ins ship for `constructive`, `postgrest`, `supabase`, `hasura` and `graphile` — each reading
+the signal its stack actually leaves in the catalog (see [Configuration](#configuration)), and
+each emitting a primary `api` plane plus whatever secondary planes it can prove: one `api:<name>`
+per API for Constructive, a `direct:<authenticator>` role plane for PostgREST, `app_private` as an
+internal plane for graphile-starter. JSON configs may name a built-in
+(`"adapters": ["supabase"]`); anything else is an error rather than a silent no-op — a typo'd
+adapter would otherwise present as an unexposed database. The old `"resolver": "constructive"`
+still works.
 
 ## CI in one job
 
@@ -356,8 +360,9 @@ Precedence: **CLI > project config > preset > built-in defaults**.
   "public": { "read": ["app_public.plans*", "app_public.event_types"] },
   "extensions": { "ignore": ["pg_partman"] },
   "rules": {
-    "A3": "off",          // disable
+    "A3": "info",         // demote — still reported, contributes nothing
     "A5": "high",         // retune a severity
+    "A7": "off",          // disable outright
     "P*": "medium"        // prefix wildcard (exact codes win)
   },
   "overrides": [
@@ -371,12 +376,38 @@ Precedence: **CLI > project config > preset > built-in defaults**.
 
 A typed `safegres.config.ts` with `defineConfig` from `confstash` works identically.
 
-| Preset | Behavior |
+Presets come in three kinds, and they compose. A **stack** preset knows how your framework
+declares exposure and what its role names mean; a **posture** preset says how harshly to read
+what it finds; both are just partial configs, so `extends` takes an array:
+
+```jsonc
+{ "extends": ["safegres:supabase", "safegres:multi-tenant"] }
+```
+
+| Stack | Resolves exposure from | Treats as untrusted |
+| --- | --- | --- |
+| `safegres:constructive` | `routing_public.apis` → `api_schemas` → `metaschema_public.schema` | `anonymous` |
+| `safegres:postgrest` | `pgrst.db_schemas` in `pg_db_role_setting` | `anon` |
+| `safegres:supabase` | same (Supabase *is* PostgREST) | `anon`, `authenticated` |
+| `safegres:hasura` | tracked tables in `hdb_catalog` | `anonymous`, `public` |
+| `safegres:graphile` | the `graphile-starter` layout (`app_public` + `app_hidden`) | `visitor` |
+
+Each reads a real catalog signal — not a schema name. The one exception is `graphile`, because
+PostGraphile's schema list is a process argument that leaves no trace in the database: naming that
+preset *is* the declaration that the starter layout holds. If it doesn't, list
+`exposure.schemas` instead.
+
+| Posture | Behavior |
 | --- | --- |
 | `safegres:recommended` | Every rule at its default severity (the no-config behavior) |
 | `safegres:strict` | Everything escalated; fail-closed counts 25%; `failOn: high` |
-| `safegres:constructive` | Exposure auto-resolved from the routing plane; R1/R2 watch `anonymous`; A2/P5 critical; A3 off; `pg_partman` ignored |
+| `safegres:multi-tenant` | Row-visibility rules (A1/A2, L1–L3, L5) escalated — in a shared-table database an RLS gap is a cross-tenant read; one critical floors the grade at D |
+| `safegres:oltp` | Perf axis first: the policy-shape rules that turn an index scan into a per-row function call (X2–X4, X9) escalated; `failOn: perfGrade C` |
 | `safegres:minimal` | Structural flags only (A1–A3) — fast smoke check |
+
+Presets **retune**, they don't delete: a rule that doesn't apply to a stack is demoted to `info`
+(zero weight, so the score is unchanged) rather than switched off, so it stays in the report and
+stays re-tunable. `minimal` is the deliberate exception — being a smoke check is its whole job.
 
 CLI: `--config <path>`, `--preset <name>`, `--rule CODE=off|severity` (repeatable).
 
@@ -460,5 +491,3 @@ console.log(report.score.grade, report.perf?.score.grade);
   database. The `X*` and `A*`/`L*`/`R*` rules are deterministic and work fine on an empty one.
 - safegres **reads**. It never creates, alters, or drops anything, and `--explain` plans without
   executing.
-
-MIT © Constructive

--- a/packages/safegres/__tests__/fixtures/stacks.sql
+++ b/packages/safegres/__tests__/fixtures/stacks.sql
@@ -1,0 +1,45 @@
+-- Minimal catalog state that the stack adapters key off. Not a real
+-- PostgREST/Hasura/PostGraphile install: each adapter reads exactly one
+-- catalog signal, and this fixture reproduces that signal.
+
+-- PostgREST / Supabase: exposure is a GUC on the connecting role, which lands
+-- in pg_db_role_setting. `anon` is the role an unauthenticated request runs as.
+CREATE SCHEMA IF NOT EXISTS fx_pgrst_api;
+CREATE SCHEMA IF NOT EXISTS fx_pgrst_private;
+
+CREATE TABLE IF NOT EXISTS fx_pgrst_api.notes (id serial PRIMARY KEY, body text);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'fx_anon') THEN
+    CREATE ROLE fx_anon NOLOGIN;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'fx_authenticator') THEN
+    CREATE ROLE fx_authenticator NOLOGIN;
+  END IF;
+END
+$$;
+
+GRANT SELECT ON fx_pgrst_api.notes TO fx_anon;
+ALTER ROLE fx_authenticator SET pgrst.db_schemas = 'fx_pgrst_api';
+ALTER ROLE fx_authenticator SET pgrst.db_anon_role = 'fx_anon';
+
+-- Hasura v2+: one JSON metadata document; only *tracked* tables are served.
+CREATE SCHEMA IF NOT EXISTS hdb_catalog;
+CREATE SCHEMA IF NOT EXISTS fx_hasura_api;
+CREATE TABLE IF NOT EXISTS fx_hasura_api.articles (id serial PRIMARY KEY);
+CREATE TABLE IF NOT EXISTS hdb_catalog.hdb_metadata (id integer PRIMARY KEY, metadata jsonb NOT NULL);
+INSERT INTO hdb_catalog.hdb_metadata (id, metadata)
+VALUES (
+  1,
+  '{"sources": [{"name": "default", "tables": [{"table": {"schema": "fx_hasura_api", "name": "articles"}}]}]}'::jsonb
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- graphile-starter layout: app_public served, app_hidden reachable through it,
+-- app_private not exposed.
+CREATE SCHEMA IF NOT EXISTS app_public;
+CREATE SCHEMA IF NOT EXISTS app_hidden;
+CREATE SCHEMA IF NOT EXISTS app_private;
+CREATE TABLE IF NOT EXISTS app_public.posts (id serial PRIMARY KEY);
+CREATE TABLE IF NOT EXISTS app_private.sessions (id serial PRIMARY KEY);

--- a/packages/safegres/__tests__/presets.test.ts
+++ b/packages/safegres/__tests__/presets.test.ts
@@ -1,0 +1,120 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { getConnections, PgTestClient } from 'pgsql-test';
+
+import { PRESETS } from '../src/config/presets';
+import { resolveRules } from '../src/config/resolve';
+import type { SafegresConfig } from '../src/config/types';
+import {
+  BUILTIN_ADAPTERS,
+  graphileAdapter,
+  hasuraAdapter,
+  postgrestAdapter
+} from '../src/exposure/adapters';
+
+jest.setTimeout(120000);
+
+let pg: PgTestClient;
+let teardown: () => Promise<void>;
+
+beforeAll(async () => {
+  ({ pg, teardown } = await getConnections());
+  const sql = fs.readFileSync(path.join(__dirname, 'fixtures', 'stacks.sql'), 'utf8');
+  await pg.any(sql);
+});
+
+afterAll(async () => {
+  if (teardown) await teardown();
+});
+
+/** Every rule setting a preset carries, flattened across its `extends` chain. */
+function settings(config: SafegresConfig): SafegresConfig['rules'] {
+  return config.rules ?? {};
+}
+
+describe('built-in presets', () => {
+  it('every preset resolves to a valid rule set', () => {
+    for (const [name, config] of Object.entries(PRESETS)) {
+      expect(() => resolveRules(config)).not.toThrow();
+      expect(name.startsWith('safegres:')).toBe(true);
+    }
+  });
+
+  it('names every built-in adapter it references', () => {
+    for (const [name, config] of Object.entries(PRESETS)) {
+      for (const adapter of config.exposure?.adapters ?? []) {
+        if (typeof adapter !== 'string') continue;
+        expect(`${name}:${adapter in BUILTIN_ADAPTERS}`).toBe(`${name}:true`);
+      }
+    }
+  });
+
+  it('configures rules rather than switching them off', () => {
+    // `minimal` is the deliberate exception: it exists to be a smoke check.
+    for (const [name, config] of Object.entries(PRESETS)) {
+      if (name === 'safegres:minimal') continue;
+      for (const [rule, setting] of Object.entries(settings(config))) {
+        const severity = Array.isArray(setting) ? setting[0] : setting;
+        expect(`${name}/${rule}=${severity as string}`).not.toContain('=off');
+      }
+    }
+  });
+
+  it('scopes platform-managed schemas by demotion, not exclusion', () => {
+    const supabase = PRESETS['safegres:supabase'];
+    const managed = supabase.overrides![0];
+    expect(managed.tables).toContain('auth.*');
+    expect(managed.rules['*']).toBe('info');
+  });
+
+  it('treats Supabase authenticated as untrusted — anyone can sign up', () => {
+    const [, options] = PRESETS['safegres:supabase'].rules!.R1 as [string, { roles: string[] }];
+    expect(options.roles).toEqual(['anon', 'authenticated']);
+  });
+
+  it('composes a stack preset with a posture preset', () => {
+    // multi-tenant carries no exposure of its own: it is a posture, layered
+    // on whichever stack resolves the surface.
+    expect(PRESETS['safegres:multi-tenant'].exposure).toBeUndefined();
+    expect(PRESETS['safegres:oltp'].exposure).toBeUndefined();
+    expect(PRESETS['safegres:multi-tenant'].scoring!.floorOnCritical).toBe('D');
+  });
+});
+
+describe('stack adapters', () => {
+  it('reads the PostgREST surface out of pg_db_role_setting', async () => {
+    expect(await postgrestAdapter.detect(pg.client as never)).toBe(true);
+    const planes = await postgrestAdapter.resolve(pg.client as never);
+
+    const primary = planes.find((p) => p.primary);
+    expect(primary).toMatchObject({ kind: 'api', schemas: ['fx_pgrst_api'], roles: ['fx_anon'] });
+    // The authenticator is graded separately: it can SET ROLE, so its own
+    // grants are a different question from what the API serves.
+    expect(planes.map((p) => p.name)).toContain('direct:fx_authenticator');
+  });
+
+  it('resolves Hasura exposure from tracked tables only', async () => {
+    expect(await hasuraAdapter.detect(pg.client as never)).toBe(true);
+    const planes = await hasuraAdapter.resolve(pg.client as never);
+    expect(planes).toEqual([
+      { name: 'api', kind: 'api', primary: true, schemas: ['fx_hasura_api'] }
+    ]);
+  });
+
+  it('resolves the graphile-starter layout, app_private as its own plane', async () => {
+    expect(await graphileAdapter.detect(pg.client as never)).toBe(true);
+    const planes = await graphileAdapter.resolve(pg.client as never);
+
+    expect(planes[0]).toMatchObject({
+      primary: true,
+      schemas: ['app_public', 'app_hidden']
+    });
+    expect(planes[1]).toMatchObject({ name: 'internal', kind: 'schema', schemas: ['app_private'] });
+  });
+
+  it('does not detect a stack that is not installed', async () => {
+    // The constructive adapter shares this database and must stay quiet.
+    const { constructiveAdapter } = await import('../src/exposure/adapters');
+    expect(await constructiveAdapter.detect(pg.client as never)).toBe(false);
+  });
+});

--- a/packages/safegres/src/adapters.ts
+++ b/packages/safegres/src/adapters.ts
@@ -9,5 +9,8 @@ export {
   BUILTIN_ADAPTERS,
   constructiveAdapter,
   definePlanes,
+  graphileAdapter,
+  hasuraAdapter,
+  postgrestAdapter,
   resolveAdapters
 } from './exposure/adapters';

--- a/packages/safegres/src/cli/audit.ts
+++ b/packages/safegres/src/cli/audit.ts
@@ -57,7 +57,9 @@ Connection (priority order, top wins):
 Configuration:
   --config <path>          Explicit config file (else discovered: safegres.config.{ts,js,mjs,cjs},
                            .safegresrc{,.json,.yaml,.yml,.js}, safegres.json, package.json "safegres")
-  --preset <name>          Apply a built-in preset (recommended|strict|constructive|minimal)
+  --preset <name>          Apply a built-in preset. Posture: recommended, strict, minimal.
+                           Stack: constructive, postgrest, supabase, graphile, hasura.
+                           Composable: multi-tenant, oltp (extends: [stack, posture]).
   --rule <CODE=SETTING>    Retune a rule (repeatable), e.g. --rule A3=off --rule A5=high
 
 Exposure (what the score is computed against):

--- a/packages/safegres/src/config/presets.ts
+++ b/packages/safegres/src/config/presets.ts
@@ -38,8 +38,10 @@ export const strict: SafegresConfig = {
  *   so only what the exposed APIs can reach drives the score;
  * - untrusted-role rules watch `anonymous`; anything that can leak rows
  *   across the role boundary is critical;
- * - A3 is off — API roles never own tables in the Constructive model, so
- *   non-FORCEd RLS is not an exposure;
+ * - A3 is demoted to `info` rather than switched off — API roles never own
+ *   tables in the Constructive model, so non-FORCEd RLS is not an exposure
+ *   here, but the finding stays visible (info carries zero weight, so the
+ *   score is identical to switching it off) and re-tunable;
  * - `pg_partman`'s schema is skipped: it creates child partitions and
  *   templates at runtime with no dependency on the extension, so ownership
  *   alone leaves them looking like unsecured application tables.
@@ -50,7 +52,7 @@ export const constructive: SafegresConfig = {
   extensions: { ignore: ['pg_partman'] },
   rules: {
     A2: 'critical',
-    A3: 'off',
+    A3: 'info',
     P5: 'critical',
     R1: ['critical', { roles: ['anonymous'] }],
     R2: ['high', { roles: ['anonymous'] }],
@@ -70,9 +72,154 @@ export const minimal: SafegresConfig = {
   }
 };
 
+/**
+ * PostgREST: the exposed schemas come from `pgrst.db_schemas` in the catalog,
+ * and `anon` is the role an unauthenticated request runs as — so anything it
+ * can write, or any policy that lets it through, is the whole threat model.
+ *
+ * The connecting role (`authenticator`) is graded as a secondary plane rather
+ * than folded into the headline: it can `SET ROLE`, so its own grants are a
+ * separate question from what the API serves.
+ */
+export const postgrest: SafegresConfig = {
+  extends: 'safegres:recommended',
+  exposure: { adapters: ['postgrest'] },
+  rules: {
+    R1: ['critical', { roles: ['anon'] }],
+    R2: ['critical', { roles: ['anon'] }],
+    R3: 'high',
+    L5: ['high', { roles: ['anon'] }]
+  },
+  scoring: { floorOnCritical: 'C' }
+};
+
+/**
+ * Supabase is PostgREST with a fixed role vocabulary: `anon` (unauthenticated)
+ * and `authenticated` (any signed-up user — a much weaker boundary than it
+ * reads, since anyone can sign up) are both untrusted; `service_role` bypasses
+ * RLS by design, so its plane reports as skipped rather than F.
+ *
+ * `auth`, `storage`, `realtime`, `vault` and friends are Supabase's own
+ * schemas: they ship with their own policies and are not the developer's to
+ * fix, so they are scoped out of the score while staying in the report.
+ */
+export const supabase: SafegresConfig = {
+  extends: 'safegres:postgrest',
+  exposure: { adapters: ['supabase'] },
+  rules: {
+    R1: ['critical', { roles: ['anon', 'authenticated'] }],
+    R2: ['critical', { roles: ['anon', 'authenticated'] }],
+    L5: ['high', { roles: ['anon', 'authenticated'] }]
+  },
+  overrides: [
+    // Supabase-managed schemas: their policies ship with the platform, not
+    // with your migrations. Demoted, not excluded — still in the report.
+    {
+      tables: [
+        'auth.*',
+        'storage.*',
+        'realtime.*',
+        'vault.*',
+        'extensions.*',
+        'graphql.*',
+        'supabase_migrations.*'
+      ],
+      rules: { '*': 'info' }
+    }
+  ]
+};
+
+/**
+ * PostGraphile / graphile-starter: `app_public` is served, `app_hidden` is
+ * reachable through it, `app_private` is not exposed. The role vocabulary is
+ * the starter's (`*_visitor` is the request role, anonymous or not).
+ *
+ * A3 stays at its default: in this layout the API role is *not* the table
+ * owner, so a missing FORCE genuinely is an owner-bypass hole.
+ */
+export const graphile: SafegresConfig = {
+  extends: 'safegres:recommended',
+  exposure: { adapters: ['graphile'] },
+  rules: {
+    R1: ['high', { roles: ['visitor', 'app_visitor'] }],
+    R2: ['high', { roles: ['visitor', 'app_visitor'] }],
+    R3: 'high',
+    L5: ['medium', { roles: ['visitor', 'app_visitor'] }]
+  }
+};
+
+/** Hasura: the surface is whatever is *tracked* in `hdb_catalog`. */
+export const hasura: SafegresConfig = {
+  extends: 'safegres:recommended',
+  exposure: { adapters: ['hasura'] },
+  rules: {
+    R1: ['critical', { roles: ['anonymous', 'public'] }],
+    R2: ['critical', { roles: ['anonymous', 'public'] }],
+    R3: 'high'
+  },
+  overrides: [
+    // Hasura's own metadata catalog, managed by the engine.
+    { tables: ['hdb_catalog.*'], rules: { '*': 'info' } }
+  ]
+};
+
+/**
+ * Tenancy posture, independent of stack: in a shared-table multi-tenant
+ * database every RLS gap is a cross-tenant read, not a self-service leak, so
+ * the row-visibility rules are escalated and a single critical caps the grade
+ * at D. Owner-bypass hygiene is *not* escalated — it is a deployment property,
+ * and drowning the report in it hides the boundary findings.
+ *
+ * Compose it: `"extends": ["safegres:supabase", "safegres:multi-tenant"]`.
+ */
+export const multiTenant: SafegresConfig = {
+  rules: {
+    A1: 'critical',
+    A2: 'critical',
+    A4: 'high',
+    L1: 'critical',
+    L2: 'critical',
+    L3: 'high',
+    L5: 'high',
+    P5: 'high'
+  },
+  scoring: { floorOnCritical: 'D' },
+  failOn: { severity: 'critical' }
+};
+
+/**
+ * Perf posture for a read-heavy OLTP database, where a sequential scan behind
+ * an RLS policy is a production incident rather than a slow report. Security
+ * stays at whatever the composed preset says; this only retunes the P/X axis
+ * and gates on the perf grade, which is only meaningful once a baseline
+ * exists — see `--write-baseline`.
+ */
+export const oltp: SafegresConfig = {
+  rules: {
+    // The four that turn a policy into a per-row function call or defeat the
+    // index it should be using — the difference between an index scan and a
+    // seq scan per request.
+    X2: 'critical',
+    X3: 'critical',
+    X4: 'high',
+    X9: 'high',
+    X1: 'high',
+    X6: 'high',
+    P1b: 'high',
+    P5: 'high'
+  },
+  failOn: { perfGrade: 'C' }
+};
+
 export const PRESETS: Record<string, SafegresConfig> = {
   'safegres:recommended': recommended,
   'safegres:strict': strict,
   'safegres:constructive': constructive,
-  'safegres:minimal': minimal
+  'safegres:minimal': minimal,
+  'safegres:postgrest': postgrest,
+  'safegres:supabase': supabase,
+  'safegres:graphile': graphile,
+  'safegres:hasura': hasura,
+  'safegres:multi-tenant': multiTenant,
+  'safegres:oltp': oltp
 };

--- a/packages/safegres/src/exposure/adapters.ts
+++ b/packages/safegres/src/exposure/adapters.ts
@@ -137,10 +137,187 @@ export const constructiveAdapter: ExposureAdapter = {
   }
 };
 
+/**
+ * PostgREST exposure, read from the catalog rather than inferred from a
+ * schema name: PostgREST serves exactly `pgrst.db_schemas`, which is set as a
+ * role or database GUC (`ALTER ROLE authenticator SET pgrst.db_schemas = …`)
+ * and therefore lands in `pg_db_role_setting`. `pgrst.db_anon_role` names the
+ * role an unauthenticated request runs as, and the connecting role
+ * (`authenticator` by convention) is the one that can `SET ROLE` to it.
+ *
+ * Supabase is PostgREST underneath, so this covers it too; the difference is
+ * the role vocabulary, which the `supabase` preset supplies.
+ */
+export const postgrestAdapter: ExposureAdapter = {
+  name: 'postgrest',
+
+  async detect(exec: QueryExecutor): Promise<boolean> {
+    return (await postgrestSettings(exec)).size > 0;
+  },
+
+  async resolve(exec: QueryExecutor): Promise<PlaneInput[]> {
+    const settings = await postgrestSettings(exec);
+    const schemas = splitList(settings.get('pgrst.db_schemas'));
+    if (schemas.length === 0) return [];
+
+    const anon = settings.get('pgrst.db_anon_role');
+    const { rows } = await exec.query<{ rolname: string }>(
+      `SELECT r.rolname::text
+         FROM pg_db_role_setting s
+         JOIN pg_roles r ON r.oid = s.setrole
+        WHERE array_to_string(s.setconfig, ',') LIKE '%pgrst.%'`
+    );
+    // The authenticator is the connecting role, not an API-edge role: it holds
+    // no data privileges of its own, so grading it would grade nothing.
+    const authenticators = rows.map((r) => r.rolname);
+
+    return [
+      {
+        name: 'api',
+        kind: 'api',
+        primary: true,
+        schemas,
+        roles: anon ? [anon] : []
+      },
+      ...authenticators.map((role): PlaneInput => ({
+        name: `direct:${role}`,
+        kind: 'role',
+        roles: [role]
+      }))
+    ];
+  }
+};
+
+/**
+ * Hasura reads its exposed surface out of its own metadata: v2+ keeps one
+ * JSON document in `hdb_catalog.hdb_metadata`, older versions a row per
+ * tracked table in `hdb_catalog.hdb_table`. Only *tracked* tables are served,
+ * so the schemas that contain them are the surface.
+ */
+export const hasuraAdapter: ExposureAdapter = {
+  name: 'hasura',
+
+  async detect(exec: QueryExecutor): Promise<boolean> {
+    const { rows } = await exec.query<{ ok: boolean }>(
+      `SELECT to_regclass('hdb_catalog.hdb_metadata') IS NOT NULL
+              OR to_regclass('hdb_catalog.hdb_table') IS NOT NULL AS ok`
+    );
+    return rows[0]?.ok === true;
+  },
+
+  async resolve(exec: QueryExecutor): Promise<PlaneInput[]> {
+    const schemas = new Set<string>();
+
+    const { rows: modern } = await exec.query<{ ok: boolean }>(
+      `SELECT to_regclass('hdb_catalog.hdb_metadata') IS NOT NULL AS ok`
+    );
+    if (modern[0]?.ok) {
+      const { rows } = await exec.query<{ schema_name: string }>(
+        `SELECT DISTINCT t.value -> 'table' ->> 'schema' AS schema_name
+           FROM hdb_catalog.hdb_metadata m
+           CROSS JOIN LATERAL jsonb_array_elements(m.metadata -> 'sources') AS s(value)
+           CROSS JOIN LATERAL jsonb_array_elements(s.value -> 'tables') AS t(value)`
+      );
+      for (const r of rows) if (r.schema_name) schemas.add(r.schema_name);
+    } else {
+      const { rows } = await exec.query<{ schema_name: string }>(
+        'SELECT DISTINCT table_schema::text AS schema_name FROM hdb_catalog.hdb_table'
+      );
+      for (const r of rows) if (r.schema_name) schemas.add(r.schema_name);
+    }
+    if (schemas.size === 0) return [];
+
+    return [{ name: 'api', kind: 'api', primary: true, schemas: sorted(schemas) }];
+  }
+};
+
+/**
+ * PostGraphile publishes whatever schemas it was started with — a CLI/library
+ * argument, invisible from inside the database. So this adapter resolves the
+ * `graphile-starter` layout (`app_public` served, `app_hidden`/`app_private`
+ * not) and nothing else.
+ *
+ * That is naming-as-intent, which safegres otherwise refuses. The difference
+ * is consent: listing this adapter *is* the declaration that the convention
+ * holds here. When it doesn't, list `exposure.schemas` instead — explicit
+ * always wins.
+ */
+export const graphileAdapter: ExposureAdapter = {
+  name: 'graphile',
+
+  async detect(exec: QueryExecutor): Promise<boolean> {
+    const { rows } = await exec.query<{ ok: boolean }>(
+      "SELECT to_regnamespace('app_public') IS NOT NULL AS ok"
+    );
+    return rows[0]?.ok === true;
+  },
+
+  async resolve(exec: QueryExecutor): Promise<PlaneInput[]> {
+    const { rows } = await exec.query<{ nspname: string }>(
+      `SELECT nspname::text
+         FROM pg_namespace
+        WHERE nspname IN ('app_public', 'app_hidden', 'app_private')`
+    );
+    const present = new Set(rows.map((r) => r.nspname));
+    if (!present.has('app_public')) return [];
+
+    const planes: PlaneInput[] = [
+      {
+        name: 'api',
+        kind: 'api',
+        primary: true,
+        // app_hidden is reachable through app_public's views and functions —
+        // served indirectly, so it belongs to the surface.
+        schemas: ['app_public', ...(present.has('app_hidden') ? ['app_hidden'] : [])]
+      }
+    ];
+    if (present.has('app_private')) {
+      planes.push({ name: 'internal', kind: 'schema', schemas: ['app_private'] });
+    }
+    return planes;
+  }
+};
+
 /** Every adapter a config may name with a string. */
 export const BUILTIN_ADAPTERS: Record<string, ExposureAdapter> = {
-  constructive: constructiveAdapter
+  constructive: constructiveAdapter,
+  graphile: graphileAdapter,
+  hasura: hasuraAdapter,
+  postgrest: postgrestAdapter,
+  // Supabase *is* PostgREST; the preset supplies the role vocabulary.
+  supabase: postgrestAdapter
 };
+
+/**
+ * `pgrst.*` GUCs from `pg_db_role_setting`, whichever role or database they
+ * were set on. Reading the catalog rather than `current_setting()` is what
+ * makes this work from an audit connection that is not the API's.
+ */
+async function postgrestSettings(exec: QueryExecutor): Promise<Map<string, string>> {
+  const { rows } = await exec.query<{ setting: string }>(
+    `SELECT unnest(setconfig) AS setting FROM pg_db_role_setting`
+  );
+  const settings = new Map<string, string>();
+  for (const { setting } of rows) {
+    const eq = setting.indexOf('=');
+    if (eq < 0) continue;
+    const key = setting.slice(0, eq).trim().toLowerCase();
+    if (key.startsWith('pgrst.')) settings.set(key, setting.slice(eq + 1).trim());
+  }
+  return settings;
+}
+
+function splitList(value: string | undefined): string[] {
+  if (!value) return [];
+  return [
+    ...new Set(
+      value
+        .split(',')
+        .map((s) => s.trim().replace(/^"|"$/g, ''))
+        .filter(Boolean)
+    )
+  ].sort();
+}
 
 /**
  * Wrap a fixed set of planes as an adapter — the escape hatch for a surface

--- a/packages/safegres/src/index.ts
+++ b/packages/safegres/src/index.ts
@@ -79,7 +79,19 @@ export type { DoctorCheck, DoctorOptions, DoctorReport, DoctorStatus } from './c
 export { doctor } from './commands/doctor';
 export type { LoadConfigParams } from './config/loader';
 export { loadConfig, safegresConfigLoader } from './config/loader';
-export { constructive, minimal, PRESETS, recommended, strict } from './config/presets';
+export {
+  constructive,
+  graphile,
+  hasura,
+  minimal,
+  multiTenant,
+  oltp,
+  postgrest,
+  PRESETS,
+  recommended,
+  strict,
+  supabase
+} from './config/presets';
 export type { ResolvedRule, ResolvedRules } from './config/resolve';
 export {
   allAstRulesDisabled,
@@ -113,6 +125,9 @@ export {
   BUILTIN_ADAPTERS,
   constructiveAdapter,
   definePlanes,
+  graphileAdapter,
+  hasuraAdapter,
+  postgrestAdapter,
   resolveAdapters
 } from './exposure/adapters';
 export type { PlaneReach } from './exposure/planes';


### PR DESCRIPTION
## Summary

Packages the plane/adapter machinery from #1599 into presets you can name, split along the axis that actually varies: a **stack** preset knows how your framework declares exposure and what its role names mean, a **posture** preset says how harshly to read what it finds. They compose, because they are just partial configs:

```jsonc
{ "extends": ["safegres:supabase", "safegres:multi-tenant"] }
```

| Stack | Resolves exposure from | Untrusted |
| --- | --- | --- |
| `constructive` | `routing_public.apis` → `api_schemas` | `anonymous` |
| `postgrest` | `pgrst.db_schemas` in `pg_db_role_setting` | `anon` |
| `supabase` | same (Supabase *is* PostgREST) | `anon`, `authenticated` |
| `hasura` | tracked tables in `hdb_catalog` | `anonymous`, `public` |
| `graphile` | the `graphile-starter` layout | `visitor` |

| Posture | Behavior |
| --- | --- |
| `multi-tenant` | A1/A2, L1–L3, L5 escalated — in a shared-table database an RLS gap is a *cross-tenant* read; one critical floors the grade at D |
| `oltp` | X2–X4/X9 escalated — the policy shapes that turn an index scan into a per-row function call; `failOn: perfGrade C` |

**Nothing is switched off.** Per your note: a rule that doesn't apply to a stack is demoted to `info` — zero weight, so the score is byte-identical to disabling it — instead of deleted, so it stays in the report and stays re-tunable. That also flips the existing `constructive` preset's `A3: 'off'` → `'info'` (score unchanged; the finding becomes visible). Supabase's and Hasura's platform-managed schemas are scoped the same way, by demotion rather than exclusion. `minimal` is the one deliberate exception — being a smoke check is its whole job. A test enforces the invariant across every preset, and another asserts every string adapter a preset names exists in `BUILTIN_ADAPTERS`.

**Adapters read catalog state, not schema names.** PostgREST publishes its own surface as a GUC, so `postgrestAdapter` reads `pg_db_role_setting` rather than guessing — which also means it works from an audit connection that isn't the API's:

```sql
SELECT unnest(setconfig) FROM pg_db_role_setting   -- 'pgrst.db_schemas=app,api'
```
It emits the API plane plus a `direct:<authenticator>` role plane, because a role that can `SET ROLE` is a separate question from what the API serves. Hasura reads tracked tables out of `hdb_catalog.hdb_metadata` (v2 JSON, with the v1 `hdb_table` fallback) — untracked tables are not served, so they are not the surface.

`graphileAdapter` is the deliberate exception and is documented as one: PostGraphile's schema list is a *process argument* that leaves no trace in the database, so the adapter resolves the `graphile-starter` layout (`app_public` + `app_hidden` served, `app_private` its own internal plane). That is naming-as-intent, which safegres otherwise refuses; the difference is consent — naming the adapter *is* the declaration. When the convention doesn't hold, `exposure.schemas` still wins.

**Also:** dropped the hand-written `MIT © Constructive` line from the README. Every package here gets the shared `FOOTER.md` appended at build time (credits, license, disclaimer), so safegres was the only one ending in a duplicate, half-size footer.

## Verification

`pnpm lint`, `pnpm build`, `pnpm test` in `packages/safegres` — 23 suites / 243 tests, 10 of them new. The adapter tests run against a fixture that reproduces each stack's one catalog signal (`__tests__/fixtures/stacks.sql`), and include a negative: the `constructive` adapter must stay quiet in a database that isn't Constructive. Confirmed `dist/README.md` renders with the shared footer and no duplicate.


Link to Devin session: https://app.devin.ai/sessions/b7874ecee0c7471ea271e6e7193869dc
Requested by: @pyramation