### PR TITLE
feat(safegres): anon-role split, sealed runs, and an evaluation corpus

### DIFF
--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -408,12 +408,21 @@ Untrusted roles are usually *resolved*, not named. `pgrst.db_anon_role` and grap
 guessing a name:
 
 ```jsonc
-{ "rules": { "R1": ["critical", { "rolesFrom": "exposure" }] } }
+{ "rules": { "R1": ["critical", { "rolesFrom": "anon" }] } }
 ```
 
-`rolesFrom: "exposure"` hands R1/R2/L5 whatever roles the adapter resolved, and unions with any
-explicit `roles`. Rules that ask for neither stay inert — resolved roles never leak into a rule
-that didn't opt in.
+An adapter resolves two role sets, because "at the API edge" and "reachable without credentials"
+are different questions:
+
+| `rolesFrom` | Roles | Use when |
+| --- | --- | --- |
+| `anon` | Only what an unauthenticated caller arrives as — `apis.anon_role`, `pgrst.db_anon_role`, Supabase's `anon`, graphile's visitor | Almost always. A signed-in role holding a write grant is the product; the anon role holding one is the bug. |
+| `exposure` | Every role at the edge, signed-in ones included | A surface where no role should be writing directly. |
+
+Both union with any explicit `roles`, so a preset can name a platform default *and* pick up a
+custom one. Rules that ask for neither stay inert — resolved roles never leak into a rule that
+didn't opt in. `report.exposure.anonRoles` carries the anonymous subset, and the pretty renderer
+marks it inline (`api roles: authenticated, anonymous (anon)`).
 
 | Posture | Behavior |
 | --- | --- |

--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -380,6 +380,28 @@ non-zero rather than let one be read as if it were.
 None of this constrains ordinary use: an unsealed run still gets a fingerprint, and `sealed: false`
 is simply the honest statement that local configuration participated.
 
+## The evaluation corpus
+
+A sealed score says the ruler did not move. It does not say the ruler is right. That is what the
+corpus in [`corpus/`](corpus/README.md) is for: ~20 small schemas, each with one deliberate flaw
+and a written-down answer — the findings a correct audit must produce, the false positives it must
+not, and the one-sentence fix.
+
+```ts
+import { audit, gradeCase, loadConfig, loadCorpus } from 'safegres';
+
+const { config } = loadConfig({ sealed: true, preset: 'recommended' });
+for (const c of loadCorpus()) {
+  await client.query(c.sql);
+  const { missed, falsePositives } = gradeCase(await audit(client, { config, ...c }), c);
+}
+```
+
+Cases are data — `schema.sql` plus a `case.json` answer key — so a harness that never runs safegres
+can still use them. Three uses: safegres's own regression suite, worked examples short enough to
+read, and an agent evaluation — hand the agent a case, ask for a fix, and require the expected
+findings to be *gone* with the dimension back at 100 rather than merely a better number.
+
 ## Configuration
 
 Configured like a linter. Discovered by walking up from the current directory:

--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -344,6 +344,42 @@ gate it on a grade you can hold today and raise it as the score climbs.
 The same mechanism exists for call-graph trust boundaries (`--write-baseline`, `--baseline`,
 `--fail-on-new-boundaries`).
 
+## Sealed runs
+
+Every knob above is deliberate when a team declares its intent in CI, and is the cheapest possible
+cheat when a *score* is the thing being evaluated — of an agent's migration, of a template, of a
+submission. Turning off the rule and re-baselining the debt both raise the number without touching
+the database.
+
+So every report carries the ruler it was measured with:
+
+```jsonc
+"provenance": {
+  "version": "1.17.0",
+  "fingerprint": "sha256:8f14e45fceea167a…",   // over the *resolved* rules, overrides,
+  "sealed": true,                              // scoring weights, exposure and ignores
+  "preset": "strict"
+}
+```
+
+`--sealed` grades under a built-in preset alone: no config-file discovery, and `--config`,
+`--rule`, `--exposure-schemas` and every baseline flag are *refused* rather than ignored — a run
+that silently dropped a flag would report a number for rules nobody chose. A harness pins the
+answer it expects:
+
+```bash
+safegres audit --sealed --preset strict --verify-fingerprint sha256:8f14e45fceea167a… --format json
+```
+
+The fingerprint covers the resolved rule set rather than the config text, so it is invariant to how
+a posture was spelled (preset vs. explicit rules, key order) and sensitive to anything that changes
+it — including the safegres version, because a rule's meaning can change without its configuration
+changing. Reports whose fingerprints differ are not comparable, and `--verify-fingerprint` exits
+non-zero rather than let one be read as if it were.
+
+None of this constrains ordinary use: an unsealed run still gets a fingerprint, and `sealed: false`
+is simply the honest statement that local configuration participated.
+
 ## Configuration
 
 Configured like a linter. Discovered by walking up from the current directory:

--- a/packages/safegres/__tests__/config.test.ts
+++ b/packages/safegres/__tests__/config.test.ts
@@ -160,12 +160,14 @@ describe('presets', () => {
     const { rules } = resolveRules(config);
     expect(rules.get('A2')!.severity).toBe('critical');
     expect(rules.get('P5')!.severity).toBe('critical');
+    // `anonymous` is the platform default, kept explicit; `rolesFrom` picks up
+    // an API that declares a custom `anon_role` instead of missing it.
     expect(rules.get('R1')).toEqual({
       enabled: true,
       severity: 'critical',
-      options: { roles: ['anonymous'] }
+      options: { roles: ['anonymous'], rolesFrom: 'anon' }
     });
-    expect(rules.get('R2')!.options).toEqual({ roles: ['anonymous'] });
+    expect(rules.get('R2')!.options).toEqual({ roles: ['anonymous'], rolesFrom: 'anon' });
     expect(config.scoring?.floorOnCritical).toBe('C');
   });
 });

--- a/packages/safegres/__tests__/corpus.test.ts
+++ b/packages/safegres/__tests__/corpus.test.ts
@@ -1,0 +1,82 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { getConnections, PgTestClient } from 'pgsql-test';
+
+import { audit } from '../src/commands/audit';
+import { loadConfig } from '../src/config/loader';
+import { type CorpusCase, gradeCase, loadCorpus } from '../src/corpus';
+import { SEVERITY_ORDER } from '../src/types';
+
+jest.setTimeout(300000);
+
+let pg: PgTestClient;
+let teardown: () => Promise<void>;
+
+const CORPUS = loadCorpus();
+/** Sealed: the corpus is graded by the shipped preset, never by a local file. */
+const { config } = loadConfig({ sealed: true, preset: 'recommended' });
+
+beforeAll(async () => {
+  ({ pg, teardown } = await getConnections());
+  await pg.any(fs.readFileSync(path.resolve(__dirname, '..', 'corpus', 'bootstrap.sql'), 'utf8'));
+  for (const c of CORPUS) await pg.any(c.sql);
+});
+
+afterAll(async () => {
+  if (teardown) await teardown();
+});
+
+async function auditCase(c: CorpusCase) {
+  return audit(pg.client, {
+    config,
+    exposure: c.exposure,
+    schemas: c.exposure.schemas,
+    perf: true,
+    sealed: true,
+    preset: 'recommended'
+  });
+}
+
+describe('evaluation corpus', () => {
+  it('ships cases covering both dimensions', () => {
+    expect(CORPUS.length).toBeGreaterThanOrEqual(20);
+    expect(CORPUS.some((c) => c.dimension === 'security')).toBe(true);
+    expect(CORPUS.some((c) => c.dimension === 'perf')).toBe(true);
+    // Every case must document its answer: an unexplained fixture is a
+    // regression test, not an evaluation.
+    for (const c of CORPUS) {
+      expect(`${c.id}:${c.expect.length > 0 && c.fix.length > 0}`).toBe(`${c.id}:true`);
+    }
+  });
+
+  it.each(CORPUS.map((c) => [c.id, c] as const))('%s produces its documented findings', async (_id, c) => {
+    const report = await auditCase(c);
+    const result = gradeCase(report, c);
+    expect({
+      id: result.id,
+      missed: result.missed.map((e) => `${e.code}${e.relation ? ` @ ${e.relation}` : ''}`),
+      falsePositives: result.falsePositives
+    }).toEqual({ id: c.id, missed: [], falsePositives: [] });
+
+    if (c.worstSeverity) {
+      const worst = report.findings
+        .filter((f) => f.exposed)
+        .reduce((acc, f) => Math.max(acc, SEVERITY_ORDER[f.severity]), 0);
+      expect(`${c.id}:${worst}`).toBe(`${c.id}:${SEVERITY_ORDER[c.worstSeverity]}`);
+    }
+  });
+
+  it('costs points wherever the flaw carries weight', async () => {
+    for (const c of CORPUS) {
+      const report = await auditCase(c);
+      const score = c.dimension === 'perf' ? report.perf?.score : report.score;
+      const codes = new Set(c.expect.map((e) => e.code));
+      // Some findings are weightless by construction — `info` severities and
+      // fail-closed rules, which report a locked door rather than an open one.
+      // A case made only of those must score 100; any case that deducts must
+      // not, and the score must agree with its own deduction list either way.
+      const weighted = (score?.deductions ?? []).some((d) => codes.has(d.code) && d.points > 0);
+      expect(`${c.id}:${(score?.value ?? 100) < 100}`).toBe(`${c.id}:${weighted}`);
+    }
+  });
+});

--- a/packages/safegres/__tests__/fingerprint.test.ts
+++ b/packages/safegres/__tests__/fingerprint.test.ts
@@ -1,0 +1,78 @@
+import { configFingerprint } from '../src/config/fingerprint';
+import { loadConfig } from '../src/config/loader';
+import type { SafegresConfig } from '../src/config/types';
+
+const V = '1.0.0';
+
+describe('configFingerprint', () => {
+  it('is stable across key order and equivalent spellings of the same posture', () => {
+    const a: SafegresConfig = { rules: { A3: 'off', A5: 'high' }, scoring: { densityK: 0.2 } };
+    const b: SafegresConfig = { scoring: { densityK: 0.2 }, rules: { A5: 'high', A3: 'off' } };
+    expect(configFingerprint(a, V)).toBe(configFingerprint(b, V));
+  });
+
+  it('moves when any knob that can move the score moves', () => {
+    const base: SafegresConfig = { rules: { A3: 'high' } };
+    const variants: SafegresConfig[] = [
+      { rules: { A3: 'off' } },
+      { rules: { A3: 'high' }, scoring: { densityK: 0.3 } },
+      { rules: { A3: 'high' }, perf: { ignore: ['app.*'] } },
+      { rules: { A3: 'high' }, public: { read: ['app.posts'] } },
+      { rules: { A3: 'high' }, overrides: [{ tables: ['app.*'], rules: { A3: 'info' } }] },
+      { rules: { A3: 'high' }, exposure: { schemas: ['app_public'] } }
+    ];
+    const seen = new Set([configFingerprint(base, V)]);
+    for (const v of variants) seen.add(configFingerprint(v, V));
+    expect(seen.size).toBe(variants.length + 1);
+  });
+
+  it('moves when the analyzer version moves — the same rule can mean something new', () => {
+    const config: SafegresConfig = { rules: { A3: 'high' } };
+    expect(configFingerprint(config, '1.0.0')).not.toBe(configFingerprint(config, '1.1.0'));
+  });
+
+  it('ignores everything that cannot move the score', () => {
+    const bare: SafegresConfig = { rules: { A3: 'high' } };
+    const noisy: SafegresConfig = {
+      rules: { A3: 'high' },
+      report: { github: { badges: false, annotations: 'none' } },
+      failOn: { severity: 'critical' }
+    };
+    expect(configFingerprint(noisy, V)).toBe(configFingerprint(bare, V));
+  });
+
+  it('identifies an adapter by name, not by its (unhashable) implementation', () => {
+    const withObject: SafegresConfig = {
+      exposure: { adapters: [{ name: 'mine', detect: async () => true, resolve: async () => [] }] }
+    };
+    const withName: SafegresConfig = { exposure: { adapters: ['mine'] } };
+    expect(configFingerprint(withObject, V)).toBe(configFingerprint(withName, V));
+  });
+});
+
+describe('sealed config loading', () => {
+  it('grades under the named preset alone, ignoring any config file in the tree', () => {
+    // __dirname sits under the safegres package, which has its own config;
+    // a sealed load must not see it.
+    const sealed = loadConfig({ cwd: __dirname, sealed: true, preset: 'strict' });
+    const open = loadConfig({ cwd: __dirname, preset: 'strict' });
+    expect(sealed.filepath).toBeUndefined();
+    expect(configFingerprint(sealed.config, V)).toBe(
+      configFingerprint(loadConfig({ cwd: '/', sealed: true, preset: 'strict' }).config, V)
+    );
+    expect(open).toBeDefined();
+  });
+
+  it('defaults to recommended and rejects a preset that does not exist', () => {
+    expect(loadConfig({ sealed: true }).config).toEqual(
+      loadConfig({ sealed: true, preset: 'recommended' }).config
+    );
+    expect(() => loadConfig({ sealed: true, preset: 'nope' })).toThrow(/Unknown preset/);
+  });
+
+  it('gives every stack preset a distinct fingerprint', () => {
+    const presets = ['recommended', 'strict', 'minimal', 'constructive', 'postgrest', 'supabase'];
+    const prints = presets.map((p) => configFingerprint(loadConfig({ sealed: true, preset: p }).config, V));
+    expect(new Set(prints).size).toBe(presets.length);
+  });
+});

--- a/packages/safegres/__tests__/fixtures/stacks.sql
+++ b/packages/safegres/__tests__/fixtures/stacks.sql
@@ -17,6 +17,10 @@ BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'fx_authenticator') THEN
     CREATE ROLE fx_authenticator NOLOGIN;
   END IF;
+  -- A signed-in API role: at the edge, but never reached anonymously.
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'fx_signed_in') THEN
+    CREATE ROLE fx_signed_in NOLOGIN;
+  END IF;
 END
 $$;
 

--- a/packages/safegres/__tests__/github.test.ts
+++ b/packages/safegres/__tests__/github.test.ts
@@ -93,6 +93,23 @@ describe('renderGithubSummary', () => {
     });
     expect(out.split('\n')[0]).toContain('badge/direct%3Aapp-');
   });
+
+  it('drops the finding tables at detail: summary, keeping the ratchet verdict', () => {
+    // A job summary is capped at 1 MB; a database with thousands of baselined
+    // findings needs the scores and the delta, not every row.
+    const report = makeReport();
+    report.perf = {
+      score: computeScore([], undefined, { exposedTables: 10, exposureKnown: true }),
+      findings: [],
+      diff: { added: [finding({ code: 'X1', dimension: 'perf' })], accepted: [], removed: [] }
+    } as never;
+
+    const full = renderGithubSummary(report);
+    const brief = renderGithubSummary(report, { config: { detail: 'summary' } });
+    expect(full).toContain('### Security findings');
+    expect(brief).not.toContain('### Security findings');
+    expect(brief).toContain('Perf baseline: **1 new**, 0 accepted, 0 resolved.');
+  });
 });
 
 describe('renderGithubComment', () => {

--- a/packages/safegres/__tests__/presets.test.ts
+++ b/packages/safegres/__tests__/presets.test.ts
@@ -155,6 +155,43 @@ describe('stack adapters', () => {
     }
   });
 
+  it("separates the anon role from the API edge's other roles", async () => {
+    const planes = await postgrestAdapter.resolve(pg.client as never);
+    const primary = planes.find((p) => p.primary);
+    // fx_anon is pgrst.db_anon_role; fx_authenticator holds the config but is
+    // a connecting role, not an API-edge one.
+    expect(primary!.anonRoles).toEqual(['fx_anon']);
+    expect(planes.find((p) => p.name === 'direct:fx_authenticator')!.anonRoles).toBeUndefined();
+  });
+
+  it("rolesFrom 'anon' targets only what an unauthenticated caller reaches", async () => {
+    // The distinction that keeps the constructive preset usable: a signed-in
+    // role writing is the product; the anon role writing is the bug.
+    await pg.any('GRANT INSERT ON fx_pgrst_api.notes TO fx_anon, fx_signed_in');
+    try {
+      const forAnon = await audit(pg.client as never, {
+        schemas: ['fx_pgrst_api'],
+        exposure: { adapters: ['postgrest'], roles: ['fx_signed_in'] },
+        config: { rules: { R1: ['critical', { rolesFrom: 'anon' }] } }
+      });
+      expect(forAnon.findings.filter((f) => f.code === 'R1').map((f) => f.role)).toEqual([
+        'fx_anon'
+      ]);
+
+      // The stricter reading still available for a surface that wants it.
+      const forAll = await audit(pg.client as never, {
+        schemas: ['fx_pgrst_api'],
+        exposure: { adapters: ['postgrest'], roles: ['fx_signed_in'] },
+        config: { rules: { R1: ['critical', { rolesFrom: 'exposure' }] } }
+      });
+      expect(
+        forAll.findings.filter((f) => f.code === 'R1').map((f) => f.role).sort()
+      ).toEqual(['fx_anon', 'fx_signed_in']);
+    } finally {
+      await pg.any('REVOKE INSERT ON fx_pgrst_api.notes FROM fx_anon, fx_signed_in');
+    }
+  });
+
   it('leaves rules inert when a preset names no roles and none resolve', async () => {
     // Without `rolesFrom` and without explicit roles, R1 stays a no-op —
     // adapter-resolved roles must never leak into rules that did not ask.

--- a/packages/safegres/corpus/README.md
+++ b/packages/safegres/corpus/README.md
@@ -1,0 +1,75 @@
+# The safegres evaluation corpus
+
+Small schemas with a deliberate flaw and a written-down answer.
+
+"The score went up" is not evidence of anything on its own. A corpus with known answers turns
+safegres into an instrument you can calibrate: every case names the findings a correct audit must
+produce, so a run is graded on *recall* — did it find the flaw? — rather than on a number whose
+provenance nobody can check.
+
+## Layout
+
+```
+corpus/
+  bootstrap.sql          # corpus_anon / corpus_user: the two roles every case is graded against
+  cases/<id>/
+    schema.sql           # the case, as SQL
+    case.json            # the answer key
+```
+
+`case.json`:
+
+```jsonc
+{
+  "title": "The anonymous role holds a write grant",
+  "dimension": "security",                       // which axis the flaw is on
+  "exposure": {                                  // the surface it is graded against
+    "schemas": ["c_anon_write_grant"],
+    "roles": ["corpus_anon", "corpus_user"],
+    "anonRoles": ["corpus_anon"]                 // reachable without credentials
+  },
+  "expect": [{ "code": "R1", "relation": "c_anon_write_grant.posts", "note": "…" }],
+  "forbid": ["R2"],                              // false positives this case guards against
+  "worstSeverity": "critical",
+  "fix": "REVOKE INSERT … — writes belong to the signed-in role."
+}
+```
+
+Cases are **data, not code**: another tool can consume the corpus without running ours.
+
+## Grading
+
+`expect` is a lower bound, not an equality check — a later release adding an unrelated advisory
+must not invalidate the corpus. What a case pins *negatively* goes in `forbid`.
+
+```ts
+import { audit, gradeCase, loadCorpus, loadConfig } from 'safegres';
+
+const { config } = loadConfig({ sealed: true, preset: 'recommended' });
+for (const c of loadCorpus()) {
+  await client.query(c.sql);
+  const report = await audit(client, { config, exposure: c.exposure, perf: true, sealed: true });
+  const { missed, falsePositives, passed } = gradeCase(report, c);
+}
+```
+
+Runs sealed, so the corpus is graded by the shipped preset and never by a config file in the tree —
+see `--sealed` and `report.provenance` in the main README.
+
+## Using it to evaluate an agent
+
+1. Deploy a case and audit it.
+2. Hand the agent the findings (or just the schema) and ask for a fix.
+3. Re-audit. The expected findings must be **gone**, no `forbid` code may appear, and the score on
+   the case's dimension must reach 100.
+
+Step 3 is why every case carries a one-sentence `fix`: the corpus states what "solved" means
+instead of leaving it to the number.
+
+## Adding a case
+
+Keep it to one flaw. Anything the case does *not* mean to demonstrate — an unforced RLS table, an
+open read policy left in to make the SQL shorter — shows up as an extra finding and muddies the
+answer, so the surrounding schema should be otherwise correct. `__tests__/corpus.test.ts` runs
+every case and additionally checks that the flaw costs points exactly when the rule carries weight
+(`info` severities and fail-closed rules are weightless by construction).

--- a/packages/safegres/corpus/bootstrap.sql
+++ b/packages/safegres/corpus/bootstrap.sql
@@ -1,0 +1,14 @@
+-- Roles every corpus case is graded against.
+--
+-- Two, because the whole model turns on the difference: `corpus_anon` is the
+-- role an unauthenticated request arrives as, `corpus_user` the role a
+-- signed-in one does. A case that grants `corpus_user` a write is a working
+-- application; the same grant to `corpus_anon` is a critical.
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'corpus_anon') THEN
+    CREATE ROLE corpus_anon NOLOGIN;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'corpus_user') THEN
+    CREATE ROLE corpus_user NOLOGIN;
+  END IF;
+END $$;

--- a/packages/safegres/corpus/cases/01-anon-write-grant/case.json
+++ b/packages/safegres/corpus/cases/01-anon-write-grant/case.json
@@ -1,0 +1,26 @@
+{
+  "title": "The anonymous role holds a write grant",
+  "dimension": "security",
+  "exposure": {
+    "schemas": [
+      "c_anon_write_grant"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "R1",
+      "relation": "c_anon_write_grant.posts",
+      "note": "an unauthenticated caller can INSERT; RLS narrows which rows, not whether it may write at all"
+    }
+  ],
+  "worstSeverity": "critical",
+  "fix": "REVOKE INSERT ON c_anon_write_grant.posts FROM corpus_anon \u2014 writes belong to the signed-in role.",
+  "id": "01-anon-write-grant"
+}

--- a/packages/safegres/corpus/cases/01-anon-write-grant/schema.sql
+++ b/packages/safegres/corpus/cases/01-anon-write-grant/schema.sql
@@ -1,0 +1,19 @@
+DROP SCHEMA IF EXISTS c_anon_write_grant CASCADE;
+CREATE SCHEMA c_anon_write_grant;
+GRANT USAGE ON SCHEMA c_anon_write_grant TO corpus_user, corpus_anon;
+
+CREATE TABLE c_anon_write_grant.posts (
+  id bigserial PRIMARY KEY,
+  author_id uuid NOT NULL,
+  body text NOT NULL
+);
+ALTER TABLE c_anon_write_grant.posts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_anon_write_grant.posts FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY posts_read ON c_anon_write_grant.posts FOR SELECT TO corpus_anon USING (true);
+CREATE POLICY posts_write ON c_anon_write_grant.posts FOR INSERT TO corpus_user
+  WITH CHECK (author_id = nullif(current_setting('jwt.claims.user_id', true), '')::uuid);
+
+GRANT SELECT ON c_anon_write_grant.posts TO corpus_anon;
+-- The flaw: the anonymous role can write, not just read.
+GRANT INSERT ON c_anon_write_grant.posts TO corpus_anon;

--- a/packages/safegres/corpus/cases/02-grant-to-public/case.json
+++ b/packages/safegres/corpus/cases/02-grant-to-public/case.json
@@ -1,0 +1,25 @@
+{
+  "title": "Grant to PUBLIC on an RLS table",
+  "dimension": "security",
+  "exposure": {
+    "schemas": [
+      "c_public_grant"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "R3",
+      "relation": "c_public_grant.invoices",
+      "note": "PUBLIC includes roles created after this grant, so the surface grows on its own"
+    }
+  ],
+  "fix": "REVOKE SELECT ON c_public_grant.invoices FROM PUBLIC and grant to the named API role instead.",
+  "id": "02-grant-to-public"
+}

--- a/packages/safegres/corpus/cases/02-grant-to-public/schema.sql
+++ b/packages/safegres/corpus/cases/02-grant-to-public/schema.sql
@@ -1,0 +1,18 @@
+DROP SCHEMA IF EXISTS c_public_grant CASCADE;
+CREATE SCHEMA c_public_grant;
+GRANT USAGE ON SCHEMA c_public_grant TO corpus_user, corpus_anon;
+
+CREATE TABLE c_public_grant.invoices (
+  id bigserial PRIMARY KEY,
+  tenant_id uuid NOT NULL,
+  total numeric NOT NULL
+);
+CREATE INDEX invoices_tenant_idx ON c_public_grant.invoices (tenant_id);
+ALTER TABLE c_public_grant.invoices ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_public_grant.invoices FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY invoices_tenant ON c_public_grant.invoices
+  USING (tenant_id = (SELECT nullif(current_setting('jwt.claims.tenant_id', true), '')::uuid));
+
+-- The flaw: PUBLIC is every role that exists and every role that ever will.
+GRANT SELECT ON c_public_grant.invoices TO PUBLIC;

--- a/packages/safegres/corpus/cases/03-rls-off-reachable-by-anon/case.json
+++ b/packages/safegres/corpus/cases/03-rls-off-reachable-by-anon/case.json
@@ -1,0 +1,30 @@
+{
+  "title": "RLS-off table reachable by the anonymous role via PUBLIC",
+  "dimension": "security",
+  "exposure": {
+    "schemas": [
+      "c_rls_off_public"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "A2",
+      "relation": "c_rls_off_public.audit_log",
+      "note": "grants exist and RLS is off: every granted role sees every row"
+    },
+    {
+      "code": "L5",
+      "relation": "c_rls_off_public.audit_log",
+      "note": "the reach is indirect \u2014 nothing names corpus_anon"
+    }
+  ],
+  "fix": "ENABLE ROW LEVEL SECURITY with a scoped policy, and revoke the PUBLIC grant.",
+  "id": "03-rls-off-reachable-by-anon"
+}

--- a/packages/safegres/corpus/cases/03-rls-off-reachable-by-anon/schema.sql
+++ b/packages/safegres/corpus/cases/03-rls-off-reachable-by-anon/schema.sql
@@ -1,0 +1,13 @@
+DROP SCHEMA IF EXISTS c_rls_off_public CASCADE;
+CREATE SCHEMA c_rls_off_public;
+GRANT USAGE ON SCHEMA c_rls_off_public TO corpus_user, corpus_anon;
+
+CREATE TABLE c_rls_off_public.audit_log (
+  id bigserial PRIMARY KEY,
+  actor_id uuid,
+  detail text
+);
+-- The flaw: no RLS at all. The named grant is the one a reviewer sees; the
+-- PUBLIC grant is the one that also hands the table to the anonymous role.
+GRANT SELECT ON c_rls_off_public.audit_log TO corpus_user;
+GRANT SELECT ON c_rls_off_public.audit_log TO PUBLIC;

--- a/packages/safegres/corpus/cases/04-permissive-write-policy/case.json
+++ b/packages/safegres/corpus/cases/04-permissive-write-policy/case.json
@@ -1,0 +1,30 @@
+{
+  "title": "Trivially-permissive write policy",
+  "dimension": "security",
+  "exposure": {
+    "schemas": [
+      "c_permissive_write"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "A7",
+      "relation": "c_permissive_write.documents",
+      "note": "USING (true) on a write policy: any signed-in tenant can rewrite another tenant's rows"
+    }
+  ],
+  "forbid": [
+    "R1",
+    "R2"
+  ],
+  "worstSeverity": "critical",
+  "fix": "Scope the write policy to the caller's tenant, or make it RESTRICTIVE.",
+  "id": "04-permissive-write-policy"
+}

--- a/packages/safegres/corpus/cases/04-permissive-write-policy/schema.sql
+++ b/packages/safegres/corpus/cases/04-permissive-write-policy/schema.sql
@@ -1,0 +1,21 @@
+DROP SCHEMA IF EXISTS c_permissive_write CASCADE;
+CREATE SCHEMA c_permissive_write;
+GRANT USAGE ON SCHEMA c_permissive_write TO corpus_user, corpus_anon;
+
+CREATE TABLE c_permissive_write.documents (
+  id bigserial PRIMARY KEY,
+  tenant_id uuid NOT NULL,
+  body text
+);
+CREATE INDEX documents_tenant_idx ON c_permissive_write.documents (tenant_id);
+ALTER TABLE c_permissive_write.documents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_permissive_write.documents FORCE ROW LEVEL SECURITY;
+
+-- The flaw: a permissive FOR ALL policy whose body is the literal `true`.
+-- Permissive policies OR together, so this defeats every scoped policy below.
+CREATE POLICY documents_all ON c_permissive_write.documents FOR ALL TO corpus_user
+  USING (true) WITH CHECK (true);
+CREATE POLICY documents_tenant ON c_permissive_write.documents FOR SELECT TO corpus_user
+  USING (tenant_id = (SELECT nullif(current_setting('jwt.claims.tenant_id', true), '')::uuid));
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON c_permissive_write.documents TO corpus_user;

--- a/packages/safegres/corpus/cases/05-public-read-policy/case.json
+++ b/packages/safegres/corpus/cases/05-public-read-policy/case.json
@@ -1,0 +1,25 @@
+{
+  "title": "USING (true) SELECT policy on a table with private columns",
+  "dimension": "security",
+  "exposure": {
+    "schemas": [
+      "c_public_read_policy"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "A8",
+      "relation": "c_public_read_policy.profiles",
+      "note": "public-read is sometimes intended, which is why this is a low, not a critical"
+    }
+  ],
+  "fix": "Expose a view with the public columns, or scope the policy to the owner.",
+  "id": "05-public-read-policy"
+}

--- a/packages/safegres/corpus/cases/05-public-read-policy/schema.sql
+++ b/packages/safegres/corpus/cases/05-public-read-policy/schema.sql
@@ -1,0 +1,16 @@
+DROP SCHEMA IF EXISTS c_public_read_policy CASCADE;
+CREATE SCHEMA c_public_read_policy;
+GRANT USAGE ON SCHEMA c_public_read_policy TO corpus_user, corpus_anon;
+
+CREATE TABLE c_public_read_policy.profiles (
+  id bigserial PRIMARY KEY,
+  email text NOT NULL,
+  display_name text
+);
+ALTER TABLE c_public_read_policy.profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_public_read_policy.profiles FORCE ROW LEVEL SECURITY;
+
+-- The flaw: every row is world-readable, including the email column.
+CREATE POLICY profiles_read ON c_public_read_policy.profiles FOR SELECT TO corpus_anon USING (true);
+
+GRANT SELECT ON c_public_read_policy.profiles TO corpus_anon;

--- a/packages/safegres/corpus/cases/06-update-without-with-check/case.json
+++ b/packages/safegres/corpus/cases/06-update-without-with-check/case.json
@@ -1,0 +1,25 @@
+{
+  "title": "UPDATE policy with USING but no WITH CHECK",
+  "dimension": "security",
+  "exposure": {
+    "schemas": [
+      "c_update_no_check"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "A6",
+      "relation": "c_update_no_check.tasks",
+      "note": "row smuggling: the row can be updated out of the caller's own scope"
+    }
+  ],
+  "fix": "Add WITH CHECK with the same predicate as USING.",
+  "id": "06-update-without-with-check"
+}

--- a/packages/safegres/corpus/cases/06-update-without-with-check/schema.sql
+++ b/packages/safegres/corpus/cases/06-update-without-with-check/schema.sql
@@ -1,0 +1,19 @@
+DROP SCHEMA IF EXISTS c_update_no_check CASCADE;
+CREATE SCHEMA c_update_no_check;
+GRANT USAGE ON SCHEMA c_update_no_check TO corpus_user, corpus_anon;
+
+CREATE TABLE c_update_no_check.tasks (
+  id bigserial PRIMARY KEY,
+  owner_id uuid NOT NULL,
+  title text
+);
+CREATE INDEX tasks_owner_idx ON c_update_no_check.tasks (owner_id);
+ALTER TABLE c_update_no_check.tasks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_update_no_check.tasks FORCE ROW LEVEL SECURITY;
+
+-- The flaw: USING controls which rows may be updated; without WITH CHECK
+-- the new row is unchecked, so a caller can reassign owner_id to someone else.
+CREATE POLICY tasks_update ON c_update_no_check.tasks FOR UPDATE TO corpus_user
+  USING (owner_id = (SELECT nullif(current_setting('jwt.claims.user_id', true), '')::uuid));
+
+GRANT UPDATE ON c_update_no_check.tasks TO corpus_user;

--- a/packages/safegres/corpus/cases/07-rls-enabled-no-policies/case.json
+++ b/packages/safegres/corpus/cases/07-rls-enabled-no-policies/case.json
@@ -1,0 +1,29 @@
+{
+  "title": "RLS enabled with no policies \u2014 a silent deny-all",
+  "dimension": "security",
+  "exposure": {
+    "schemas": [
+      "c_rls_no_policies"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "A1",
+      "relation": "c_rls_no_policies.settings"
+    },
+    {
+      "code": "A5",
+      "relation": "c_rls_no_policies.settings",
+      "note": "the SELECT grant is dead: no policy can admit it"
+    }
+  ],
+  "fix": "Add the policy that was meant to exist, or drop the grant and say the lock is deliberate.",
+  "id": "07-rls-enabled-no-policies"
+}

--- a/packages/safegres/corpus/cases/07-rls-enabled-no-policies/schema.sql
+++ b/packages/safegres/corpus/cases/07-rls-enabled-no-policies/schema.sql
@@ -1,0 +1,14 @@
+DROP SCHEMA IF EXISTS c_rls_no_policies CASCADE;
+CREATE SCHEMA c_rls_no_policies;
+GRANT USAGE ON SCHEMA c_rls_no_policies TO corpus_user, corpus_anon;
+
+CREATE TABLE c_rls_no_policies.settings (
+  id bigserial PRIMARY KEY,
+  key text NOT NULL,
+  value text
+);
+-- The flaw (or the intent — the finding is fail-closed): RLS is on and no
+-- policy exists, so every query returns zero rows for every non-owner.
+ALTER TABLE c_rls_no_policies.settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_rls_no_policies.settings FORCE ROW LEVEL SECURITY;
+GRANT SELECT ON c_rls_no_policies.settings TO corpus_user;

--- a/packages/safegres/corpus/cases/08-select-grant-no-policy/case.json
+++ b/packages/safegres/corpus/cases/08-select-grant-no-policy/case.json
@@ -1,0 +1,25 @@
+{
+  "title": "SELECT grant with no covering policy",
+  "dimension": "security",
+  "exposure": {
+    "schemas": [
+      "c_select_no_policy"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "A5",
+      "relation": "c_select_no_policy.orders",
+      "note": "fail-closed: nothing leaks, but the feature silently does not work"
+    }
+  ],
+  "fix": "Add a FOR SELECT policy scoped to the caller.",
+  "id": "08-select-grant-no-policy"
+}

--- a/packages/safegres/corpus/cases/08-select-grant-no-policy/schema.sql
+++ b/packages/safegres/corpus/cases/08-select-grant-no-policy/schema.sql
@@ -1,0 +1,20 @@
+DROP SCHEMA IF EXISTS c_select_no_policy CASCADE;
+CREATE SCHEMA c_select_no_policy;
+GRANT USAGE ON SCHEMA c_select_no_policy TO corpus_user, corpus_anon;
+
+CREATE TABLE c_select_no_policy.orders (
+  id bigserial PRIMARY KEY,
+  customer_id uuid NOT NULL,
+  total numeric
+);
+CREATE INDEX orders_customer_idx ON c_select_no_policy.orders (customer_id);
+ALTER TABLE c_select_no_policy.orders ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_select_no_policy.orders FORCE ROW LEVEL SECURITY;
+
+-- Only the write path has a policy.
+CREATE POLICY orders_insert ON c_select_no_policy.orders FOR INSERT TO corpus_user
+  WITH CHECK (customer_id = (SELECT nullif(current_setting('jwt.claims.user_id', true), '')::uuid));
+
+-- The flaw: reads are granted but no policy covers SELECT, so the API
+-- returns an empty list and looks like a data bug.
+GRANT SELECT, INSERT ON c_select_no_policy.orders TO corpus_user;

--- a/packages/safegres/corpus/cases/09-write-grant-no-policy/case.json
+++ b/packages/safegres/corpus/cases/09-write-grant-no-policy/case.json
@@ -1,0 +1,24 @@
+{
+  "title": "Write grant with no covering policy",
+  "dimension": "security",
+  "exposure": {
+    "schemas": [
+      "c_write_no_policy"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "A4",
+      "relation": "c_write_no_policy.comments"
+    }
+  ],
+  "fix": "Add FOR INSERT / FOR UPDATE policies, or revoke the grants.",
+  "id": "09-write-grant-no-policy"
+}

--- a/packages/safegres/corpus/cases/09-write-grant-no-policy/schema.sql
+++ b/packages/safegres/corpus/cases/09-write-grant-no-policy/schema.sql
@@ -1,0 +1,18 @@
+DROP SCHEMA IF EXISTS c_write_no_policy CASCADE;
+CREATE SCHEMA c_write_no_policy;
+GRANT USAGE ON SCHEMA c_write_no_policy TO corpus_user, corpus_anon;
+
+CREATE TABLE c_write_no_policy.comments (
+  id bigserial PRIMARY KEY,
+  author_id uuid NOT NULL,
+  body text
+);
+CREATE INDEX comments_author_idx ON c_write_no_policy.comments (author_id);
+ALTER TABLE c_write_no_policy.comments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_write_no_policy.comments FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY comments_read ON c_write_no_policy.comments FOR SELECT TO corpus_user
+  USING (author_id = (SELECT nullif(current_setting('jwt.claims.user_id', true), '')::uuid));
+
+-- The flaw: INSERT/UPDATE are granted with no policy covering them.
+GRANT SELECT, INSERT, UPDATE ON c_write_no_policy.comments TO corpus_user;

--- a/packages/safegres/corpus/cases/10-rls-not-forced/case.json
+++ b/packages/safegres/corpus/cases/10-rls-not-forced/case.json
@@ -1,0 +1,24 @@
+{
+  "title": "RLS enabled without FORCE \u2014 the owner bypasses every policy",
+  "dimension": "security",
+  "exposure": {
+    "schemas": [
+      "c_owner_bypass"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "A3",
+      "relation": "c_owner_bypass.secrets"
+    }
+  ],
+  "fix": "ALTER TABLE c_owner_bypass.secrets FORCE ROW LEVEL SECURITY.",
+  "id": "10-rls-not-forced"
+}

--- a/packages/safegres/corpus/cases/10-rls-not-forced/schema.sql
+++ b/packages/safegres/corpus/cases/10-rls-not-forced/schema.sql
@@ -1,0 +1,18 @@
+DROP SCHEMA IF EXISTS c_owner_bypass CASCADE;
+CREATE SCHEMA c_owner_bypass;
+GRANT USAGE ON SCHEMA c_owner_bypass TO corpus_user, corpus_anon;
+
+CREATE TABLE c_owner_bypass.secrets (
+  id bigserial PRIMARY KEY,
+  owner_id uuid NOT NULL,
+  token text NOT NULL
+);
+CREATE INDEX secrets_owner_idx ON c_owner_bypass.secrets (owner_id);
+-- The flaw: RLS is enabled but not FORCEd, so the table owner — and anything
+-- running as it, including a SECURITY DEFINER function — bypasses every policy.
+ALTER TABLE c_owner_bypass.secrets ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY secrets_owner ON c_owner_bypass.secrets FOR SELECT TO corpus_user
+  USING (owner_id = (SELECT nullif(current_setting('jwt.claims.user_id', true), '')::uuid));
+
+GRANT SELECT ON c_owner_bypass.secrets TO corpus_user;

--- a/packages/safegres/corpus/cases/11-session-user-in-policy/case.json
+++ b/packages/safegres/corpus/cases/11-session-user-in-policy/case.json
@@ -1,0 +1,24 @@
+{
+  "title": "Policy authorizes on current_user rather than on request identity",
+  "dimension": "security",
+  "exposure": {
+    "schemas": [
+      "c_session_user"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "P5",
+      "relation": "c_session_user.reports"
+    }
+  ],
+  "fix": "Authorize on the request claim (current_setting('jwt.claims.user_id')), not the connection role.",
+  "id": "11-session-user-in-policy"
+}

--- a/packages/safegres/corpus/cases/11-session-user-in-policy/schema.sql
+++ b/packages/safegres/corpus/cases/11-session-user-in-policy/schema.sql
@@ -1,0 +1,18 @@
+DROP SCHEMA IF EXISTS c_session_user CASCADE;
+CREATE SCHEMA c_session_user;
+GRANT USAGE ON SCHEMA c_session_user TO corpus_user, corpus_anon;
+
+CREATE TABLE c_session_user.reports (
+  id bigserial PRIMARY KEY,
+  owner_name name NOT NULL,
+  body text
+);
+ALTER TABLE c_session_user.reports ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_session_user.reports FORCE ROW LEVEL SECURITY;
+
+-- The flaw: identity is taken from the *database* role, but every API request
+-- arrives as the same role. current_user is a constant here, not a user.
+CREATE POLICY reports_owner ON c_session_user.reports FOR SELECT TO corpus_user
+  USING (owner_name = current_user);
+
+GRANT SELECT ON c_session_user.reports TO corpus_user;

--- a/packages/safegres/corpus/cases/12-volatile-function-in-policy/case.json
+++ b/packages/safegres/corpus/cases/12-volatile-function-in-policy/case.json
@@ -1,0 +1,24 @@
+{
+  "title": "Policy calls a VOLATILE function (per-row evaluation)",
+  "dimension": "perf",
+  "exposure": {
+    "schemas": [
+      "c_volatile_policy"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "P1",
+      "relation": "c_volatile_policy.events"
+    }
+  ],
+  "fix": "Mark the function STABLE and wrap the call in a scalar sub-select so it becomes an InitPlan.",
+  "id": "12-volatile-function-in-policy"
+}

--- a/packages/safegres/corpus/cases/12-volatile-function-in-policy/schema.sql
+++ b/packages/safegres/corpus/cases/12-volatile-function-in-policy/schema.sql
@@ -1,0 +1,21 @@
+DROP SCHEMA IF EXISTS c_volatile_policy CASCADE;
+CREATE SCHEMA c_volatile_policy;
+GRANT USAGE ON SCHEMA c_volatile_policy TO corpus_user, corpus_anon;
+
+CREATE FUNCTION c_volatile_policy.current_actor() RETURNS uuid
+  LANGUAGE sql VOLATILE AS $$ SELECT gen_random_uuid() $$;
+
+CREATE TABLE c_volatile_policy.events (
+  id bigserial PRIMARY KEY,
+  actor_id uuid NOT NULL
+);
+CREATE INDEX events_actor_idx ON c_volatile_policy.events (actor_id);
+ALTER TABLE c_volatile_policy.events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_volatile_policy.events FORCE ROW LEVEL SECURITY;
+
+-- The flaw: a VOLATILE function cannot be hoisted, so it runs once per row
+-- scanned — not once per query.
+CREATE POLICY events_actor ON c_volatile_policy.events FOR SELECT TO corpus_user
+  USING (actor_id = c_volatile_policy.current_actor());
+
+GRANT SELECT ON c_volatile_policy.events TO corpus_user;

--- a/packages/safegres/corpus/cases/13-security-definer-policy-wrapper/case.json
+++ b/packages/safegres/corpus/cases/13-security-definer-policy-wrapper/case.json
@@ -1,0 +1,24 @@
+{
+  "title": "Policy calls a SECURITY DEFINER wrapper",
+  "dimension": "perf",
+  "exposure": {
+    "schemas": [
+      "c_definer_wrapper"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "P1b",
+      "relation": "c_definer_wrapper.memberships"
+    }
+  ],
+  "fix": "Inline the predicate, or hoist the definer call out of the per-row path.",
+  "id": "13-security-definer-policy-wrapper"
+}

--- a/packages/safegres/corpus/cases/13-security-definer-policy-wrapper/schema.sql
+++ b/packages/safegres/corpus/cases/13-security-definer-policy-wrapper/schema.sql
@@ -1,0 +1,21 @@
+DROP SCHEMA IF EXISTS c_definer_wrapper CASCADE;
+CREATE SCHEMA c_definer_wrapper;
+GRANT USAGE ON SCHEMA c_definer_wrapper TO corpus_user, corpus_anon;
+
+CREATE FUNCTION c_definer_wrapper.is_member(tenant uuid) RETURNS boolean
+  LANGUAGE sql STABLE SECURITY DEFINER AS $$ SELECT tenant IS NOT NULL $$;
+
+CREATE TABLE c_definer_wrapper.memberships (
+  id bigserial PRIMARY KEY,
+  tenant_id uuid NOT NULL
+);
+CREATE INDEX memberships_tenant_idx ON c_definer_wrapper.memberships (tenant_id);
+ALTER TABLE c_definer_wrapper.memberships ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_definer_wrapper.memberships FORCE ROW LEVEL SECURITY;
+
+-- The flaw: a SECURITY DEFINER function is a plan fence — it cannot be
+-- inlined, so the qual never reaches the index.
+CREATE POLICY memberships_member ON c_definer_wrapper.memberships FOR SELECT TO corpus_user
+  USING (c_definer_wrapper.is_member(tenant_id));
+
+GRANT SELECT ON c_definer_wrapper.memberships TO corpus_user;

--- a/packages/safegres/corpus/cases/14-dead-policy/case.json
+++ b/packages/safegres/corpus/cases/14-dead-policy/case.json
@@ -1,0 +1,24 @@
+{
+  "title": "Dead policy \u2014 written for a role that holds no grant",
+  "dimension": "security",
+  "exposure": {
+    "schemas": [
+      "c_dead_policy"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "L2",
+      "relation": "c_dead_policy.drafts"
+    }
+  ],
+  "fix": "Grant SELECT to the role the policy names, or point the policy at the role that has the grant.",
+  "id": "14-dead-policy"
+}

--- a/packages/safegres/corpus/cases/14-dead-policy/schema.sql
+++ b/packages/safegres/corpus/cases/14-dead-policy/schema.sql
@@ -1,0 +1,18 @@
+DROP SCHEMA IF EXISTS c_dead_policy CASCADE;
+CREATE SCHEMA c_dead_policy;
+GRANT USAGE ON SCHEMA c_dead_policy TO corpus_user, corpus_anon;
+
+CREATE TABLE c_dead_policy.drafts (
+  id bigserial PRIMARY KEY,
+  owner_id uuid NOT NULL
+);
+CREATE INDEX drafts_owner_idx ON c_dead_policy.drafts (owner_id);
+ALTER TABLE c_dead_policy.drafts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_dead_policy.drafts FORCE ROW LEVEL SECURITY;
+
+-- The flaw: the policy names a role that holds no grant on the table, so it
+-- can never admit a row. Usually a rename that only got applied on one side.
+CREATE POLICY drafts_owner ON c_dead_policy.drafts FOR SELECT TO corpus_anon
+  USING (owner_id = (SELECT nullif(current_setting('jwt.claims.user_id', true), '')::uuid));
+
+GRANT SELECT ON c_dead_policy.drafts TO corpus_user;

--- a/packages/safegres/corpus/cases/15-unreachable-grant/case.json
+++ b/packages/safegres/corpus/cases/15-unreachable-grant/case.json
@@ -1,0 +1,24 @@
+{
+  "title": "Table grant without USAGE on the schema",
+  "dimension": "security",
+  "exposure": {
+    "schemas": [
+      "c_unreachable_grant"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "L3",
+      "relation": "c_unreachable_grant.attachments"
+    }
+  ],
+  "fix": "GRANT USAGE ON SCHEMA c_unreachable_grant TO corpus_anon, or drop the table grant.",
+  "id": "15-unreachable-grant"
+}

--- a/packages/safegres/corpus/cases/15-unreachable-grant/schema.sql
+++ b/packages/safegres/corpus/cases/15-unreachable-grant/schema.sql
@@ -1,0 +1,18 @@
+DROP SCHEMA IF EXISTS c_unreachable_grant CASCADE;
+CREATE SCHEMA c_unreachable_grant;
+GRANT USAGE ON SCHEMA c_unreachable_grant TO corpus_user;
+
+CREATE TABLE c_unreachable_grant.attachments (
+  id bigserial PRIMARY KEY,
+  owner_id uuid NOT NULL
+);
+CREATE INDEX attachments_owner_idx ON c_unreachable_grant.attachments (owner_id);
+ALTER TABLE c_unreachable_grant.attachments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_unreachable_grant.attachments FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY attachments_read ON c_unreachable_grant.attachments FOR SELECT TO corpus_anon
+  USING (owner_id = (SELECT nullif(current_setting('jwt.claims.user_id', true), '')::uuid));
+
+-- The flaw: the table privilege exists, but the role has no USAGE on the
+-- schema, so the grant can never be exercised.
+GRANT SELECT ON c_unreachable_grant.attachments TO corpus_anon;

--- a/packages/safegres/corpus/cases/16-anon-permissive-write-policy/case.json
+++ b/packages/safegres/corpus/cases/16-anon-permissive-write-policy/case.json
@@ -1,0 +1,34 @@
+{
+  "title": "Open write policy applying to the anonymous role",
+  "dimension": "security",
+  "exposure": {
+    "schemas": [
+      "c_anon_permissive_write"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "A7",
+      "relation": "c_anon_permissive_write.signups"
+    },
+    {
+      "code": "R1",
+      "relation": "c_anon_permissive_write.signups"
+    },
+    {
+      "code": "R2",
+      "relation": "c_anon_permissive_write.signups",
+      "note": "the policy, not just the grant, lets the anonymous role through"
+    }
+  ],
+  "worstSeverity": "critical",
+  "fix": "Constrain the WITH CHECK (approved = false), or take signups through a SECURITY DEFINER function.",
+  "id": "16-anon-permissive-write-policy"
+}

--- a/packages/safegres/corpus/cases/16-anon-permissive-write-policy/schema.sql
+++ b/packages/safegres/corpus/cases/16-anon-permissive-write-policy/schema.sql
@@ -1,0 +1,17 @@
+DROP SCHEMA IF EXISTS c_anon_permissive_write CASCADE;
+CREATE SCHEMA c_anon_permissive_write;
+GRANT USAGE ON SCHEMA c_anon_permissive_write TO corpus_user, corpus_anon;
+
+CREATE TABLE c_anon_permissive_write.signups (
+  id bigserial PRIMARY KEY,
+  email text NOT NULL,
+  approved boolean NOT NULL DEFAULT false
+);
+ALTER TABLE c_anon_permissive_write.signups ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_anon_permissive_write.signups FORCE ROW LEVEL SECURITY;
+
+-- The flaw: the open write policy applies to the *anonymous* role. Accepting
+-- an anonymous signup row is fine; accepting `approved = true` is not.
+CREATE POLICY signups_insert ON c_anon_permissive_write.signups FOR INSERT TO corpus_anon WITH CHECK (true);
+
+GRANT INSERT ON c_anon_permissive_write.signups TO corpus_anon;

--- a/packages/safegres/corpus/cases/17-foreign-key-without-index/case.json
+++ b/packages/safegres/corpus/cases/17-foreign-key-without-index/case.json
@@ -1,0 +1,24 @@
+{
+  "title": "Foreign key with no covering index",
+  "dimension": "perf",
+  "exposure": {
+    "schemas": [
+      "c_fk_no_index"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "X1",
+      "relation": "c_fk_no_index.books"
+    }
+  ],
+  "fix": "CREATE INDEX ON c_fk_no_index.books (author_id).",
+  "id": "17-foreign-key-without-index"
+}

--- a/packages/safegres/corpus/cases/17-foreign-key-without-index/schema.sql
+++ b/packages/safegres/corpus/cases/17-foreign-key-without-index/schema.sql
@@ -1,0 +1,18 @@
+DROP SCHEMA IF EXISTS c_fk_no_index CASCADE;
+CREATE SCHEMA c_fk_no_index;
+GRANT USAGE ON SCHEMA c_fk_no_index TO corpus_user, corpus_anon;
+
+CREATE TABLE c_fk_no_index.authors (
+  id bigserial PRIMARY KEY,
+  name text NOT NULL
+);
+
+CREATE TABLE c_fk_no_index.books (
+  id bigserial PRIMARY KEY,
+  -- The flaw: no index on the referencing column. Every DELETE on authors
+  -- seq-scans books, and the join has no index either.
+  author_id bigint NOT NULL REFERENCES c_fk_no_index.authors (id) ON DELETE CASCADE,
+  title text NOT NULL
+);
+
+GRANT SELECT ON c_fk_no_index.authors, c_fk_no_index.books TO corpus_user;

--- a/packages/safegres/corpus/cases/18-policy-column-unindexed/case.json
+++ b/packages/safegres/corpus/cases/18-policy-column-unindexed/case.json
@@ -1,0 +1,24 @@
+{
+  "title": "RLS predicate column leads no index",
+  "dimension": "perf",
+  "exposure": {
+    "schemas": [
+      "c_policy_unindexed"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "X2",
+      "relation": "c_policy_unindexed.documents"
+    }
+  ],
+  "fix": "CREATE INDEX ON c_policy_unindexed.documents (tenant_id) \u2014 the policy column belongs first.",
+  "id": "18-policy-column-unindexed"
+}

--- a/packages/safegres/corpus/cases/18-policy-column-unindexed/schema.sql
+++ b/packages/safegres/corpus/cases/18-policy-column-unindexed/schema.sql
@@ -1,0 +1,23 @@
+DROP SCHEMA IF EXISTS c_policy_unindexed CASCADE;
+CREATE SCHEMA c_policy_unindexed;
+GRANT USAGE ON SCHEMA c_policy_unindexed TO corpus_user, corpus_anon;
+
+CREATE FUNCTION c_policy_unindexed.current_tenant() RETURNS uuid
+  LANGUAGE sql STABLE AS $$
+    SELECT nullif(current_setting('jwt.claims.tenant_id', true), '')::uuid
+  $$;
+
+CREATE TABLE c_policy_unindexed.documents (
+  id bigserial PRIMARY KEY,
+  -- The flaw: every query against this table carries the policy's
+  -- tenant_id predicate, and no index leads with tenant_id.
+  tenant_id uuid NOT NULL,
+  title text
+);
+ALTER TABLE c_policy_unindexed.documents ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_policy_unindexed.documents FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY documents_tenant ON c_policy_unindexed.documents FOR SELECT TO corpus_user
+  USING (tenant_id = (SELECT c_policy_unindexed.current_tenant()));
+
+GRANT SELECT ON c_policy_unindexed.documents TO corpus_user;

--- a/packages/safegres/corpus/cases/19-policy-column-cast/case.json
+++ b/packages/safegres/corpus/cases/19-policy-column-cast/case.json
@@ -1,0 +1,24 @@
+{
+  "title": "Policy casts its own column, defeating the index",
+  "dimension": "perf",
+  "exposure": {
+    "schemas": [
+      "c_policy_cast"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "X3",
+      "relation": "c_policy_cast.accounts"
+    }
+  ],
+  "fix": "Cast the parameter instead: tenant_id = current_setting(...)::uuid.",
+  "id": "19-policy-column-cast"
+}

--- a/packages/safegres/corpus/cases/19-policy-column-cast/schema.sql
+++ b/packages/safegres/corpus/cases/19-policy-column-cast/schema.sql
@@ -1,0 +1,19 @@
+DROP SCHEMA IF EXISTS c_policy_cast CASCADE;
+CREATE SCHEMA c_policy_cast;
+GRANT USAGE ON SCHEMA c_policy_cast TO corpus_user, corpus_anon;
+
+CREATE TABLE c_policy_cast.accounts (
+  id bigserial PRIMARY KEY,
+  tenant_id uuid NOT NULL,
+  email text
+);
+CREATE INDEX accounts_tenant_idx ON c_policy_cast.accounts (tenant_id);
+ALTER TABLE c_policy_cast.accounts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_policy_cast.accounts FORCE ROW LEVEL SECURITY;
+
+-- The flaw: casting the *column* (rather than the parameter) makes the
+-- b-tree index above unusable. The index exists and is never chosen.
+CREATE POLICY accounts_tenant ON c_policy_cast.accounts FOR SELECT TO corpus_user
+  USING (tenant_id::text = current_setting('jwt.claims.tenant_id', true));
+
+GRANT SELECT ON c_policy_cast.accounts TO corpus_user;

--- a/packages/safegres/corpus/cases/20-stable-function-per-row/case.json
+++ b/packages/safegres/corpus/cases/20-stable-function-per-row/case.json
@@ -1,0 +1,24 @@
+{
+  "title": "STABLE function evaluated per row (no InitPlan)",
+  "dimension": "perf",
+  "exposure": {
+    "schemas": [
+      "c_stable_per_row"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "X9",
+      "relation": "c_stable_per_row.ledger"
+    }
+  ],
+  "fix": "USING (tenant_id = (SELECT current_tenant())) \u2014 the sub-select is what makes it an InitPlan.",
+  "id": "20-stable-function-per-row"
+}

--- a/packages/safegres/corpus/cases/20-stable-function-per-row/schema.sql
+++ b/packages/safegres/corpus/cases/20-stable-function-per-row/schema.sql
@@ -1,0 +1,25 @@
+DROP SCHEMA IF EXISTS c_stable_per_row CASCADE;
+CREATE SCHEMA c_stable_per_row;
+GRANT USAGE ON SCHEMA c_stable_per_row TO corpus_user, corpus_anon;
+
+CREATE FUNCTION c_stable_per_row.current_tenant() RETURNS uuid
+  LANGUAGE sql STABLE AS $$
+    SELECT nullif(current_setting('jwt.claims.tenant_id', true), '')::uuid
+  $$;
+
+CREATE TABLE c_stable_per_row.ledger (
+  id bigserial PRIMARY KEY,
+  tenant_id uuid NOT NULL,
+  amount numeric
+);
+CREATE INDEX ledger_tenant_idx ON c_stable_per_row.ledger (tenant_id);
+ALTER TABLE c_stable_per_row.ledger ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_stable_per_row.ledger FORCE ROW LEVEL SECURITY;
+
+-- The flaw: the call is row-independent but not wrapped in a scalar
+-- sub-select, so the planner re-evaluates it per row instead of hoisting it
+-- into an InitPlan. Same predicate, one extra pair of parentheses apart.
+CREATE POLICY ledger_tenant ON c_stable_per_row.ledger FOR SELECT TO corpus_user
+  USING (tenant_id = c_stable_per_row.current_tenant());
+
+GRANT SELECT ON c_stable_per_row.ledger TO corpus_user;

--- a/packages/safegres/corpus/cases/21-table-without-primary-key/case.json
+++ b/packages/safegres/corpus/cases/21-table-without-primary-key/case.json
@@ -1,0 +1,24 @@
+{
+  "title": "Table with no primary key",
+  "dimension": "perf",
+  "exposure": {
+    "schemas": [
+      "c_no_pk"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "X6",
+      "relation": "c_no_pk.click_events"
+    }
+  ],
+  "fix": "Add a primary key, or set an explicit REPLICA IDENTITY.",
+  "id": "21-table-without-primary-key"
+}

--- a/packages/safegres/corpus/cases/21-table-without-primary-key/schema.sql
+++ b/packages/safegres/corpus/cases/21-table-without-primary-key/schema.sql
@@ -1,0 +1,14 @@
+DROP SCHEMA IF EXISTS c_no_pk CASCADE;
+CREATE SCHEMA c_no_pk;
+GRANT USAGE ON SCHEMA c_no_pk TO corpus_user, corpus_anon;
+
+CREATE TABLE c_no_pk.click_events (
+  -- The flaw: no primary key and no replica identity. Rows cannot be
+  -- addressed individually, and logical replication of updates fails.
+  session_id uuid NOT NULL,
+  occurred_at timestamptz NOT NULL DEFAULT now(),
+  path text
+);
+CREATE INDEX click_events_session_idx ON c_no_pk.click_events (session_id);
+
+GRANT SELECT ON c_no_pk.click_events TO corpus_user;

--- a/packages/safegres/corpus/cases/22-redundant-index/case.json
+++ b/packages/safegres/corpus/cases/22-redundant-index/case.json
@@ -1,0 +1,24 @@
+{
+  "title": "Redundant index \u2014 a prefix of another index",
+  "dimension": "perf",
+  "exposure": {
+    "schemas": [
+      "c_redundant_index"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "X5",
+      "relation": "c_redundant_index.shipments"
+    }
+  ],
+  "fix": "DROP INDEX c_redundant_index.shipments_tenant_idx.",
+  "id": "22-redundant-index"
+}

--- a/packages/safegres/corpus/cases/22-redundant-index/schema.sql
+++ b/packages/safegres/corpus/cases/22-redundant-index/schema.sql
@@ -1,0 +1,16 @@
+DROP SCHEMA IF EXISTS c_redundant_index CASCADE;
+CREATE SCHEMA c_redundant_index;
+GRANT USAGE ON SCHEMA c_redundant_index TO corpus_user, corpus_anon;
+
+CREATE TABLE c_redundant_index.shipments (
+  id bigserial PRIMARY KEY,
+  tenant_id uuid NOT NULL,
+  status text NOT NULL
+);
+
+-- The flaw: the first index is a leading-column prefix of the second, so it
+-- serves no query the second cannot — it only costs write throughput.
+CREATE INDEX shipments_tenant_idx ON c_redundant_index.shipments (tenant_id);
+CREATE INDEX shipments_tenant_status_idx ON c_redundant_index.shipments (tenant_id, status);
+
+GRANT SELECT ON c_redundant_index.shipments TO corpus_user;

--- a/packages/safegres/corpus/cases/23-tsvector-without-index/case.json
+++ b/packages/safegres/corpus/cases/23-tsvector-without-index/case.json
@@ -1,0 +1,24 @@
+{
+  "title": "Search column with no index the search can use",
+  "dimension": "perf",
+  "exposure": {
+    "schemas": [
+      "c_search_no_index"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "X7",
+      "relation": "c_search_no_index.articles"
+    }
+  ],
+  "fix": "CREATE INDEX ON c_search_no_index.articles USING gin (search_doc).",
+  "id": "23-tsvector-without-index"
+}

--- a/packages/safegres/corpus/cases/23-tsvector-without-index/schema.sql
+++ b/packages/safegres/corpus/cases/23-tsvector-without-index/schema.sql
@@ -1,0 +1,13 @@
+DROP SCHEMA IF EXISTS c_search_no_index CASCADE;
+CREATE SCHEMA c_search_no_index;
+GRANT USAGE ON SCHEMA c_search_no_index TO corpus_user, corpus_anon;
+
+CREATE TABLE c_search_no_index.articles (
+  id bigserial PRIMARY KEY,
+  body text,
+  -- The flaw: a tsvector column with no GIN/GiST index. Every full-text
+  -- query is a sequential scan that recomputes nothing and reads everything.
+  search_doc tsvector
+);
+
+GRANT SELECT ON c_search_no_index.articles TO corpus_user;

--- a/packages/safegres/package.json
+++ b/packages/safegres/package.json
@@ -26,8 +26,8 @@
     "clean": "makage clean",
     "prepack": "npm run build",
     "version:sync": "node scripts/sync-version.js",
-    "build": "npm run version:sync && makage build && chmod +x dist/cli.js",
-    "build:dev": "makage build --dev && chmod +x dist/cli.js",
+    "build": "npm run version:sync && makage build && chmod +x dist/cli.js && mkdir -p dist/corpus && cp -r corpus/. dist/corpus/",
+    "build:dev": "makage build --dev && chmod +x dist/cli.js && mkdir -p dist/corpus && cp -r corpus/. dist/corpus/",
     "lint": "eslint . --fix",
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch"

--- a/packages/safegres/src/checks/anti-patterns.ts
+++ b/packages/safegres/src/checks/anti-patterns.ts
@@ -46,6 +46,26 @@ export function checkVolatileFunctions(
     const info = volatility.get(qualified) ?? volatility.get(lookupKey) ?? volatility.get(name);
 
     if (!info) continue; // unknown function (e.g. operator expansion) — skip silently
+
+    // A SECURITY DEFINER call is a plan fence whatever its volatility: the
+    // planner cannot inline it, so the qual never reaches an index. Checked
+    // before the volatility filter below, which would otherwise let every
+    // STABLE wrapper — the common shape — through unreported.
+    if (info.isSecurityDefiner) {
+      out.push({
+        code: 'P1b',
+        severity: 'medium',
+        category: 'anti-pattern',
+        schema: table.schema,
+        table: table.name,
+        policy: policyName,
+        message:
+          `Policy "${policyName}" on ${table.schema}.${table.name} calls SECURITY DEFINER function ${info.name}`,
+        hint: 'SECURITY DEFINER wrappers can\'t be inlined by the planner — every row forces a function call. Convert to a STABLE SQL function or replace with a direct expression.',
+        context: { function: info.name }
+      });
+    }
+
     if (info.volatility !== 'v') continue;
     if (SAFE_VOLATILE_ALLOWLIST.has(info.name.split('.').pop() ?? '')) continue;
     if (info.isSystem && SAFE_VOLATILE_ALLOWLIST.has(name)) continue;
@@ -63,21 +83,6 @@ export function checkVolatileFunctions(
         'Volatile functions re-execute for every row considered by the planner. Mark the function STABLE if safe, or precompute the result in a CTE / subquery.',
       context: { function: info.name, securityDefiner: info.isSecurityDefiner }
     });
-
-    if (info.isSecurityDefiner) {
-      out.push({
-        code: 'P1b',
-        severity: 'medium',
-        category: 'anti-pattern',
-        schema: table.schema,
-        table: table.name,
-        policy: policyName,
-        message:
-          `Policy "${policyName}" on ${table.schema}.${table.name} calls SECURITY DEFINER function ${info.name}`,
-        hint: 'SECURITY DEFINER wrappers can\'t be inlined by the planner — every row forces a function call. Convert to a STABLE SQL function or replace with a direct expression.',
-        context: { function: info.name }
-      });
-    }
   }
 
   return out;

--- a/packages/safegres/src/checks/lattice.ts
+++ b/packages/safegres/src/checks/lattice.ts
@@ -321,7 +321,7 @@ export interface LatticeRoleOptions {
   /** Role names considered untrusted (exact match). */
   roles?: string[];
   /** Take the untrusted roles from the resolved exposure surface. See `RoleTrustOptions`. */
-  rolesFrom?: 'exposure';
+  rolesFrom?: 'exposure' | 'anon';
 }
 
 /**

--- a/packages/safegres/src/checks/role-trust.ts
+++ b/packages/safegres/src/checks/role-trust.ts
@@ -12,13 +12,20 @@ import type { Finding } from '../types';
 export interface RoleTrustOptions {
   /** Role names considered untrusted (exact match). */
   roles?: string[];
-  /**
+   /**
    * Take the untrusted roles from the resolved exposure surface instead of
-   * naming them. The API-edge roles an adapter resolves *are* the untrusted
-   * ones, and their names are per-deployment (`myapp_visitor`, a Constructive
-   * API's `anon_role`), so a preset cannot hardcode them. Unions with `roles`.
+   * naming them — their names are per-deployment (`myapp_visitor`, a
+   * Constructive API's `anon_role`), so a preset cannot hardcode them.
+   *
+   * - `anon`: only the roles an *unauthenticated* caller arrives as. The right
+   *   default for a stack whose signed-in role legitimately writes: flagging
+   *   `authenticated` for holding an INSERT grant would flag the product.
+   * - `exposure`: every role at the API edge, signed-in ones included. The
+   *   stricter reading, for a surface where no role should write directly.
+   *
+   * Unions with `roles`.
    */
-  rolesFrom?: 'exposure';
+  rolesFrom?: 'exposure' | 'anon';
 }
 
 const WRITE_PRIVILEGES: PgPrivilege[] = ['INSERT', 'UPDATE', 'DELETE', 'TRUNCATE'];

--- a/packages/safegres/src/cli/audit.ts
+++ b/packages/safegres/src/cli/audit.ts
@@ -61,6 +61,15 @@ Configuration:
                            Stack: constructive, postgrest, supabase, graphile, hasura.
                            Composable: multi-tenant, oltp (extends: [stack, posture]).
   --rule <CODE=SETTING>    Retune a rule (repeatable), e.g. --rule A3=off --rule A5=high
+  --sealed                 Grade under a built-in preset ALONE: no config-file
+                           discovery, and --config/--rule/--exposure-schemas and
+                           every baseline flag are refused. For evaluating an
+                           agent, where editing the rules is the cheapest way to
+                           win. Pair with --preset; the resolved rule set is
+                           fingerprinted into report.provenance either way
+  --verify-fingerprint <f> Exit non-zero unless the run's configuration
+                           fingerprint is <f> — the harness's proof that the
+                           score it is reading was produced under its own rules
 
 Exposure (what the score is computed against):
   --exposure-schemas <csv> Declare the API-exposed schemas; findings outside
@@ -170,6 +179,26 @@ export default async (
   const colorEnabled = argv.color !== false;
 
   const pgpmCwd = typeof argv.pgpm === 'string' ? argv.pgpm : undefined;
+  const sealed = argv.sealed === true;
+  if (sealed) {
+    // Everything below is a way to change the score without changing the
+    // database. A sealed run refuses them outright rather than ignoring them:
+    // an evaluation that silently dropped the flag it was handed would be
+    // reporting a number for rules nobody chose.
+    const banned = [
+      'config',
+      'rule',
+      'baseline',
+      'write-baseline',
+      'perf-baseline',
+      'write-perf-baseline',
+      'exposure-schemas'
+    ].filter((flag) => argv[flag] !== undefined);
+    if (banned.length > 0) {
+      log.error(`--sealed refuses local configuration: remove ${banned.map((f) => `--${f}`).join(', ')}`);
+      process.exit(2);
+    }
+  }
   const { config } = loadConfig({ cwd: pgpmCwd, ...configParamsFromArgv(argv) });
 
   const exposureSchemas = csvList(argv['exposure-schemas']);
@@ -195,7 +224,9 @@ export default async (
     exposure: exposureSchemas
       ? { ...config.exposure, schemas: exposureSchemas }
       : undefined,
-    config
+    config,
+    sealed,
+    ...(typeof argv.preset === 'string' ? { preset: argv.preset } : {})
   };
 
   let report: Report;
@@ -364,6 +395,16 @@ export default async (
     log.error(message);
     failed = true;
   };
+
+  // Checked first: if the ruler is wrong, nothing measured with it is worth
+  // gating on.
+  const expected = argv['verify-fingerprint'];
+  if (typeof expected === 'string' && report.provenance?.fingerprint !== expected) {
+    fail(
+      `configuration fingerprint ${report.provenance?.fingerprint ?? 'unknown'} `
+        + `does not match --verify-fingerprint ${expected}`
+    );
+  }
 
   const failOnSeverity =
     typeof argv['fail-on'] === 'string' ? (argv['fail-on'] as Severity) : config.failOn?.severity;

--- a/packages/safegres/src/cli/shared.ts
+++ b/packages/safegres/src/cli/shared.ts
@@ -71,6 +71,7 @@ export function configParamsFromArgv(argv: ParsedArgs): LoadConfigParams {
   return {
     configFile: typeof argv.config === 'string' ? argv.config : undefined,
     preset: typeof argv.preset === 'string' ? argv.preset : undefined,
-    overrides: Object.keys(overrides).length > 0 ? overrides : undefined
+    overrides: Object.keys(overrides).length > 0 ? overrides : undefined,
+    sealed: argv.sealed === true
   };
 }

--- a/packages/safegres/src/commands/audit.ts
+++ b/packages/safegres/src/commands/audit.ts
@@ -57,6 +57,7 @@ import type { ExposureConfig, SafegresConfig } from '../config/types';
 import { resolvePlaneReach, scorePlane, stampPlanes } from '../exposure/planes';
 import { type ExplainReport, proveFindings } from '../perf/explain';
 import { introspectRoleGraph, introspectSchemaAcls } from '../pg/acl';
+import type { ResolvedExposure } from '../pg/exposure';
 import { resolveExposure, resolvePlanes } from '../pg/exposure';
 import { introspectFunctions } from '../pg/functions';
 import { introspectIndexes, introspectViewBodies, type TableIndexSnapshot } from '../pg/indexes';
@@ -219,13 +220,13 @@ export async function audit(
     findings.push(
       ...checkUntrustedRoleWrites(
         table,
-        withExposedRoles(tableRules.get('R1')?.options as RoleTrustOptions, exposure.roles)
+        withExposedRoles(tableRules.get('R1')?.options as RoleTrustOptions, exposure)
       )
     );
     findings.push(
       ...checkUntrustedRolePolicies(
         table,
-        withExposedRoles(tableRules.get('R2')?.options as RoleTrustOptions, exposure.roles)
+        withExposedRoles(tableRules.get('R2')?.options as RoleTrustOptions, exposure)
       )
     );
     findings.push(...checkPublicGrants(table));
@@ -238,7 +239,7 @@ export async function audit(
       ...checkUntrustedIndirectAccess(
         table,
         roleGraph,
-        withExposedRoles(tableRules.get('L5')?.options as LatticeRoleOptions, exposure.roles)
+        withExposedRoles(tableRules.get('L5')?.options as LatticeRoleOptions, exposure)
       )
     );
 
@@ -363,6 +364,9 @@ export async function audit(
     plane: planes[0].name,
     schemas: exposure.schemas,
     ...(exposure.roles ? { roles: exposure.roles } : {}),
+    ...(exposure.anonRoles && exposure.anonRoles.length > 0
+      ? { anonRoles: exposure.anonRoles }
+      : {}),
     exposedTables,
     totalTables: snapshot.length
   };
@@ -413,11 +417,11 @@ export async function audit(
   const untrustedRoles = [...new Set([
     ...(withExposedRoles(
       resolved.rules.get('L5')?.options as LatticeRoleOptions | undefined,
-      exposure.roles
+      exposure
     )?.roles ?? []),
     ...(withExposedRoles(
       resolved.rules.get('R1')?.options as RoleTrustOptions | undefined,
-      exposure.roles
+      exposure
     )?.roles ?? [])
   ])].sort();
   if (untrustedRoles.length > 0) {
@@ -499,12 +503,13 @@ export async function audit(
  * ones, and their names are per-deployment, so a preset names the *source*
  * instead of the roles. Explicit `roles` still apply — the two union.
  */
-function withExposedRoles<T extends { roles?: string[]; rolesFrom?: 'exposure' }>(
+function withExposedRoles<T extends { roles?: string[]; rolesFrom?: 'exposure' | 'anon' }>(
   options: T | undefined,
-  exposedRoles: string[] | undefined
+  exposure: ResolvedExposure
 ): T | undefined {
   if (!options?.rolesFrom) return options;
-  const roles = [...new Set([...(options.roles ?? []), ...(exposedRoles ?? [])])].sort();
+  const resolved = options.rolesFrom === 'anon' ? exposure.anonRoles : exposure.roles;
+  const roles = [...new Set([...(options.roles ?? []), ...(resolved ?? [])])].sort();
   return { ...options, roles };
 }
 

--- a/packages/safegres/src/commands/audit.ts
+++ b/packages/safegres/src/commands/audit.ts
@@ -52,6 +52,7 @@ import {
   type RoleTrustOptions
 } from '../checks/role-trust';
 import { checkStats, DEFAULT_STATS_THRESHOLDS, type StatsThresholds } from '../checks/stats';
+import { configFingerprint } from '../config/fingerprint';
 import { allAstRulesDisabled, applyRulesToFindings, matchTablePattern, resolveRules, rulesForTable } from '../config/resolve';
 import type { ExposureConfig, SafegresConfig } from '../config/types';
 import { resolvePlaneReach, scorePlane, stampPlanes } from '../exposure/planes';
@@ -117,6 +118,16 @@ export interface AuditOptions extends IntrospectOptions {
    * the config are used as fallbacks for the corresponding AuditOptions.
    */
   config?: SafegresConfig;
+  /**
+   * Record the run as sealed: produced under configuration the caller
+   * controls, with no local config file, rule overrides or baselines. The
+   * audit behaves identically — sealing is enforced by whoever assembles the
+   * config (the CLI's `--sealed`) — but the claim lands in
+   * `report.provenance` so a harness can require it.
+   */
+  sealed?: boolean;
+  /** The preset a sealed run was graded under, recorded in the provenance. */
+  preset?: string;
 }
 
 export async function audit(
@@ -377,6 +388,12 @@ export async function audit(
   const report: Report = {
     version: PKG_VERSION,
     generatedAt: new Date().toISOString(),
+    provenance: {
+      version: PKG_VERSION,
+      fingerprint: configFingerprint(config, PKG_VERSION),
+      sealed: options.sealed === true,
+      ...(options.preset ? { preset: options.preset } : {})
+    },
     summary: summarize(findings),
     findings,
     score: computeScore(securityFindings, config.scoring, {

--- a/packages/safegres/src/config/fingerprint.ts
+++ b/packages/safegres/src/config/fingerprint.ts
@@ -1,0 +1,91 @@
+/**
+ * Provenance: proving *which rules* produced a score.
+ *
+ * Every knob that moves the number — a rule's severity, an override, a perf
+ * ignore, the exposed surface, the scoring weights — is deliberate and useful
+ * to a developer declaring intent in CI. To an evaluation harness scoring an
+ * agent, the same knobs are the cheapest way to win: turn off the rule, or
+ * re-baseline the debt, and the score goes up without the database changing.
+ *
+ * So a report carries a fingerprint of the configuration it was produced
+ * under. Two runs with the same fingerprint were graded by the same rules and
+ * are comparable; a different fingerprint means the ruler changed, and a
+ * harness can reject the run instead of believing the number.
+ *
+ * The fingerprint covers the *resolved* rules rather than the config text, so
+ * it is invariant to how the same posture was expressed (preset vs. explicit
+ * rules, key order, whitespace) and sensitive to anything that changes it.
+ */
+
+import { createHash } from 'crypto';
+
+import type { ExposureAdapter } from '../exposure/adapters';
+import { resolveRules } from './resolve';
+import type { SafegresConfig } from './types';
+
+/** Everything about a run that a comparison must be able to trust. */
+export interface Provenance {
+  /** The safegres version that produced the report. */
+  version: string;
+  /** `sha256:<hex>` over the resolved, score-relevant configuration. */
+  fingerprint: string;
+  /**
+   * True when the run refused local configuration: no discovered config file,
+   * no rule overrides, no baselines. An evaluation harness should require it.
+   */
+  sealed: boolean;
+  /** The preset the sealed run was graded under, when one was named. */
+  preset?: string;
+}
+
+/**
+ * A canonical JSON encoding: object keys sorted at every depth, so two configs
+ * that mean the same thing hash the same regardless of how they were written.
+ */
+function canonical(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, v]) => v !== undefined)
+      .sort(([a], [b]) => a.localeCompare(b));
+    return Object.fromEntries(entries.map(([k, v]) => [k, canonical(v)]));
+  }
+  return value;
+}
+
+/**
+ * The score-relevant projection of a config. Deliberately *not* the whole
+ * config: connection parameters, output formats and renderer options cannot
+ * move the number, and hashing them would make every run look incomparable.
+ */
+function scoringSurface(config: SafegresConfig): unknown {
+  const { rules } = resolveRules(config);
+  return {
+    rules: [...rules.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([code, rule]) => [code, rule.enabled, rule.severity, canonical(rule.options ?? null)]),
+    overrides: (config.overrides ?? []).map((o) => canonical(o)),
+    scoring: canonical(config.scoring ?? {}),
+    publicRead: [...(config.public?.read ?? [])].sort(),
+    perfIgnore: [...(config.perf?.ignore ?? [])].sort(),
+    exposure: canonical({
+      ...config.exposure,
+      // An adapter is code, not data: identify it by name and let the version
+      // field carry the rest.
+      adapters: (config.exposure?.adapters ?? []).map((a: string | ExposureAdapter) =>
+        typeof a === 'string' ? a : a.name
+      )
+    })
+  };
+}
+
+/**
+ * `sha256:<hex>` over the resolved scoring surface and the safegres version.
+ * The version participates because a rule's *meaning* can change without its
+ * configuration changing, and two scores from different analyzers are no more
+ * comparable than two scores from different rule sets.
+ */
+export function configFingerprint(config: SafegresConfig, version: string): string {
+  const payload = JSON.stringify({ version, config: scoringSurface(config) });
+  return `sha256:${createHash('sha256').update(payload).digest('hex')}`;
+}

--- a/packages/safegres/src/config/loader.ts
+++ b/packages/safegres/src/config/loader.ts
@@ -31,10 +31,18 @@ export interface LoadConfigParams {
   preset?: string;
   /** Highest-precedence partial config (parsed CLI flags). */
   overrides?: Partial<SafegresConfig>;
+  /**
+   * Grade under a built-in preset alone: skip config-file discovery entirely,
+   * so nothing in the working tree can move the score. For an evaluation
+   * harness, where the configuration is part of what is being tested.
+   */
+  sealed?: boolean;
 }
 
 /** Load and merge the effective safegres config. */
 export function loadConfig(params: LoadConfigParams = {}): LoadResult<SafegresConfig> {
+  if (params.sealed) return loadSealedConfig(params.preset);
+
   const loader = safegresConfigLoader();
   const overrides: Partial<SafegresConfig> = { ...(params.overrides ?? {}) };
   if (params.preset) {
@@ -56,6 +64,19 @@ export function loadConfig(params: LoadConfigParams = {}): LoadResult<SafegresCo
     return { ...result, config: mergePreset(presetConfig, result.config) };
   }
   return result;
+}
+
+/**
+ * The sealed config: one named preset, expanded, and nothing else. No
+ * discovery, no overrides, no `extends` to a local file — so the only thing
+ * that can change the score is the database.
+ */
+function loadSealedConfig(preset = 'recommended'): LoadResult<SafegresConfig> {
+  const name = preset.includes(':') ? preset : `safegres:${preset}`;
+  if (!(name in PRESETS)) {
+    throw new Error(`Unknown preset "${preset}". Available: ${Object.keys(PRESETS).join(', ')}`);
+  }
+  return { config: expandPreset(PRESETS[name]), layers: [], isEmpty: true };
 }
 
 function stripExtends(config: Partial<SafegresConfig>): Partial<SafegresConfig> {

--- a/packages/safegres/src/config/presets.ts
+++ b/packages/safegres/src/config/presets.ts
@@ -6,9 +6,20 @@ import type { SafegresConfig } from './types';
  * or npm packages.
  */
 
-/** Today's default behavior: every rule at its registry default severity. */
+/**
+ * Today's default behavior: every rule at its registry default severity.
+ *
+ * The untrusted-role rules take whichever roles the surface says are reachable
+ * without credentials, so a declared `exposure.anonRoles` (or an adapter that
+ * resolves one) is enough to switch them on. With no such surface `anonRoles`
+ * is empty and they stay inert, exactly as before.
+ */
 export const recommended: SafegresConfig = {
-  rules: {}
+  rules: {
+    R1: ['critical', { rolesFrom: 'anon' }],
+    R2: ['high', { rolesFrom: 'anon' }],
+    L5: ['info', { rolesFrom: 'anon' }]
+  }
 };
 
 /**

--- a/packages/safegres/src/config/presets.ts
+++ b/packages/safegres/src/config/presets.ts
@@ -54,10 +54,15 @@ export const constructive: SafegresConfig = {
     A2: 'critical',
     A3: 'info',
     P5: 'critical',
-    R1: ['critical', { roles: ['anonymous'] }],
-    R2: ['high', { roles: ['anonymous'] }],
+    // Each API declares its own `anon_role`; the adapter reads it, so a
+    // custom one is picked up instead of being missed, with the platform
+    // default kept explicitly so an unresolved surface still checks it.
+    // `role_name` (`authenticated`) is deliberately *not* included: a
+    // signed-in user holding a write grant is the product, not a finding.
+    R1: ['critical', { roles: ['anonymous'], rolesFrom: 'anon' }],
+    R2: ['high', { roles: ['anonymous'], rolesFrom: 'anon' }],
     R3: 'medium',
-    L5: ['info', { roles: ['anonymous'] }]
+    L5: ['info', { roles: ['anonymous'], rolesFrom: 'anon' }]
   },
   scoring: { floorOnCritical: 'C' }
 };
@@ -87,10 +92,10 @@ export const postgrest: SafegresConfig = {
   rules: {
     // The anon role is `pgrst.db_anon_role`, so the adapter knows its name and
     // the rules take it from the resolved surface rather than assuming `anon`.
-    R1: ['critical', { rolesFrom: 'exposure' }],
-    R2: ['critical', { rolesFrom: 'exposure' }],
+    R1: ['critical', { rolesFrom: 'anon' }],
+    R2: ['critical', { rolesFrom: 'anon' }],
     R3: 'high',
-    L5: ['high', { rolesFrom: 'exposure' }]
+    L5: ['high', { rolesFrom: 'anon' }]
   },
   scoring: { floorOnCritical: 'C' }
 };
@@ -109,11 +114,13 @@ export const supabase: SafegresConfig = {
   extends: 'safegres:postgrest',
   exposure: { adapters: ['supabase'] },
   rules: {
-    // Named outright: these three are fixed by the platform, and unlike
-    // PostgREST's configurable anon role they are the same on every project.
-    R1: ['critical', { roles: ['anon', 'authenticated'] }],
-    R2: ['critical', { roles: ['anon', 'authenticated'] }],
-    L5: ['high', { roles: ['anon', 'authenticated'] }]
+    // Both are named outright, not just the anon one: on Supabase anyone can
+    // sign up, so `authenticated` is a boundary the internet crosses at will.
+    // Fixed by the platform, so unlike PostgREST's anon role they are safe to
+    // name — and the adapter's anon set unions in on a self-hosted project.
+    R1: ['critical', { roles: ['anon', 'authenticated'], rolesFrom: 'anon' }],
+    R2: ['critical', { roles: ['anon', 'authenticated'], rolesFrom: 'anon' }],
+    L5: ['high', { roles: ['anon', 'authenticated'], rolesFrom: 'anon' }]
   },
   overrides: [
     // Supabase-managed schemas: their policies ship with the platform, not
@@ -150,10 +157,12 @@ export const graphile: SafegresConfig = {
   extends: 'safegres:recommended',
   exposure: { adapters: ['graphile'] },
   rules: {
-    R1: ['high', { rolesFrom: 'exposure' }],
-    R2: ['high', { rolesFrom: 'exposure' }],
+    // Every request is the visitor role, signed in or not, so for graphile the
+    // anon set and the API-edge set are the same thing.
+    R1: ['high', { rolesFrom: 'anon' }],
+    R2: ['high', { rolesFrom: 'anon' }],
     R3: 'high',
-    L5: ['medium', { rolesFrom: 'exposure' }]
+    L5: ['medium', { rolesFrom: 'anon' }]
   }
 };
 

--- a/packages/safegres/src/config/types.ts
+++ b/packages/safegres/src/config/types.ts
@@ -322,6 +322,12 @@ export interface GithubReportConfig {
   /** Which findings become workflow annotations. Default `gate-failures`. */
   annotations?: 'all' | 'gate-failures' | 'none';
   /**
+   * How much of the report goes in the job summary. Default `normal`. Set
+   * `summary` on a database with thousands of findings: GitHub truncates a job
+   * summary at 1 MB, and a truncated report is worse than a short one.
+   */
+  detail?: 'summary' | 'normal' | 'verbose';
+  /**
    * Render scores as colored shields.io badges. Default `true`; `false` falls
    * back to 🟢/🟡/🔴 text, which needs no network fetch.
    */

--- a/packages/safegres/src/config/types.ts
+++ b/packages/safegres/src/config/types.ts
@@ -55,6 +55,12 @@ export interface ExposureConfig {
   schemas?: string[];
   /** Roles reachable from the API edge (static resolver). */
   roles?: string[];
+  /**
+   * The subset of `roles` an unauthenticated caller arrives as. Adapters
+   * resolve this themselves (`apis.anon_role`, `pgrst.db_anon_role`, ...);
+   * set it only for a surface you are declaring statically.
+   */
+  anonRoles?: string[];
   /** Name of the primary plane. Default `api`. */
   name?: string;
   /**
@@ -88,6 +94,8 @@ export interface PlaneConfig {
   primary?: boolean;
   schemas?: string[];
   roles?: string[];
+  /** The subset of `roles` reachable without authenticating. */
+  anonRoles?: string[];
 }
 
 /**

--- a/packages/safegres/src/corpus/index.ts
+++ b/packages/safegres/src/corpus/index.ts
@@ -1,0 +1,130 @@
+/**
+ * The evaluation corpus: small schemas with a deliberate flaw and a written-down
+ * answer.
+ *
+ * It exists because "the score went up" is not evidence of anything on its own.
+ * A corpus with known answers turns safegres into a measuring instrument you
+ * can calibrate: every case names the findings a correct audit must produce, so
+ * a run can be graded on recall (did it find the flaw?) rather than on a number
+ * whose provenance nobody can check. It is used three ways —
+ *
+ *   1. safegres's own regression suite (`__tests__/corpus.test.ts`);
+ *   2. an evaluation harness for an agent asked to *fix* the case: audit,
+ *      hand the findings over, re-audit, and require the expected findings to
+ *      be gone without new ones appearing;
+ *   3. worked examples — each case is short enough to read.
+ *
+ * Cases live in `corpus/cases/<id>/` as `schema.sql` plus `case.json`, i.e.
+ * data, not code: another tool can consume the corpus without running ours.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import type { ExposureConfig } from '../config/types';
+import type { Finding, Report, Severity } from '../types';
+
+/** One expected finding: a rule code, optionally pinned to a relation. */
+export interface ExpectedFinding {
+  code: string;
+  /** `schema.table`, when the case has more than one relation in play. */
+  relation?: string;
+  /** Why this is the right answer — the part a reader learns from. */
+  note?: string;
+}
+
+export interface CorpusCase {
+  id: string;
+  title: string;
+  /** Which axis the flaw is on. A case may be graded on both. */
+  dimension: 'security' | 'perf';
+  /** The SQL that builds the case, as committed. */
+  sql: string;
+  /** The surface the case is graded against — its whole point, for most cases. */
+  exposure: ExposureConfig;
+  /** Findings a correct audit must produce. */
+  expect: ExpectedFinding[];
+  /** Rule codes that must NOT fire: the false positives this case guards. */
+  forbid?: string[];
+  /** Worst severity the case should produce, as a coarse sanity check. */
+  worstSeverity?: Severity;
+  /** How the flaw is fixed, in one sentence — the answer key. */
+  fix: string;
+}
+
+interface CaseFile extends Omit<CorpusCase, 'sql' | 'id'> {
+  id?: string;
+}
+
+/**
+ * The corpus shipped with the package. Two candidates because the package
+ * publishes from `dist/`, where the corpus sits one directory closer.
+ */
+export function corpusDir(): string {
+  const candidates = [
+    path.resolve(__dirname, '..', 'corpus', 'cases'),
+    path.resolve(__dirname, '..', '..', 'corpus', 'cases')
+  ];
+  const found = candidates.find((dir) => fs.existsSync(dir));
+  if (!found) throw new Error(`Corpus not found. Looked in: ${candidates.join(', ')}`);
+  return found;
+}
+
+/** Load every case in `dir` (default: the shipped corpus), ordered by id. */
+export function loadCorpus(dir: string = corpusDir()): CorpusCase[] {
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => loadCase(path.join(dir, e.name)))
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/** Load a single case directory (`case.json` + `schema.sql`). */
+export function loadCase(dir: string): CorpusCase {
+  const meta = JSON.parse(fs.readFileSync(path.join(dir, 'case.json'), 'utf8')) as CaseFile;
+  return {
+    ...meta,
+    id: meta.id ?? path.basename(dir),
+    sql: fs.readFileSync(path.join(dir, 'schema.sql'), 'utf8')
+  };
+}
+
+export interface CaseResult {
+  id: string;
+  /** Expected findings the audit produced. */
+  found: ExpectedFinding[];
+  /** Expected findings the audit missed — recall failures. */
+  missed: ExpectedFinding[];
+  /** Forbidden rule codes the audit produced — precision failures. */
+  falsePositives: string[];
+  /** True when nothing was missed and nothing forbidden fired. */
+  passed: boolean;
+}
+
+function matches(finding: Finding, expected: ExpectedFinding): boolean {
+  if (finding.code !== expected.code) return false;
+  if (!expected.relation) return true;
+  return `${finding.schema}.${finding.table}` === expected.relation;
+}
+
+/**
+ * Grade a report against the case it was produced from. Deliberately not a
+ * strict equality check on the finding set: a case pins the findings that
+ * define it, and a later release adding an unrelated advisory should not
+ * invalidate the corpus. What a case *does* pin negatively goes in `forbid`.
+ */
+export function gradeCase(report: Report, testCase: CorpusCase): CaseResult {
+  const findings = report.findings;
+  const found = testCase.expect.filter((e) => findings.some((f) => matches(f, e)));
+  const missed = testCase.expect.filter((e) => !findings.some((f) => matches(f, e)));
+  const falsePositives = [...new Set(findings.map((f) => f.code))].filter((code) =>
+    (testCase.forbid ?? []).includes(code)
+  );
+  return {
+    id: testCase.id,
+    found,
+    missed,
+    falsePositives,
+    passed: missed.length === 0 && falsePositives.length === 0
+  };
+}

--- a/packages/safegres/src/exposure/adapters.ts
+++ b/packages/safegres/src/exposure/adapters.ts
@@ -29,7 +29,16 @@ export interface PlaneInput {
   kind?: PlaneKind;
   primary?: boolean;
   schemas?: string[];
+  /** Every role that reaches this plane, anonymous ones included. */
   roles?: string[];
+  /**
+   * The subset of `roles` an *unauthenticated* caller arrives as. Every stack
+   * knows which one this is — Constructive's `apis.anon_role`, PostgREST's
+   * `pgrst.db_anon_role`, Supabase's `anon`, graphile's visitor — and the
+   * distinction is the difference between "a signed-in user can write this"
+   * (usually the point) and "anyone on the internet can" (usually the bug).
+   */
+  anonRoles?: string[];
 }
 
 export interface ExposureAdapter {
@@ -94,12 +103,19 @@ export const constructiveAdapter: ExposureAdapter = {
       anon_role: string | null;
     }>(sources.join(' UNION ALL '));
 
-    const byApi = new Map<string, { schemas: Set<string>; roles: Set<string> }>();
-    const all = { schemas: new Set<string>(), roles: new Set<string>() };
+    type Entry = { schemas: Set<string>; roles: Set<string>; anonRoles: Set<string> };
+    const entryOf = (): Entry => ({
+      schemas: new Set<string>(),
+      roles: new Set<string>(),
+      anonRoles: new Set<string>()
+    });
+
+    const byApi = new Map<string, Entry>();
+    const all = entryOf();
     for (const r of rows) {
       if (!r.schema_name) continue;
       const key = r.api ?? 'api';
-      const entry = byApi.get(key) ?? { schemas: new Set<string>(), roles: new Set<string>() };
+      const entry = byApi.get(key) ?? entryOf();
       entry.schemas.add(r.schema_name);
       all.schemas.add(r.schema_name);
       for (const role of [r.role_name, r.anon_role]) {
@@ -107,6 +123,12 @@ export const constructiveAdapter: ExposureAdapter = {
           entry.roles.add(role);
           all.roles.add(role);
         }
+      }
+      // `role_name` is the signed-in role (`authenticated`); only `anon_role`
+      // is reachable without credentials.
+      if (r.anon_role) {
+        entry.anonRoles.add(r.anon_role);
+        all.anonRoles.add(r.anon_role);
       }
       byApi.set(key, entry);
     }
@@ -118,7 +140,8 @@ export const constructiveAdapter: ExposureAdapter = {
         kind: 'api',
         primary: true,
         schemas: sorted(all.schemas),
-        roles: sorted(all.roles)
+        roles: sorted(all.roles),
+        anonRoles: sorted(all.anonRoles)
       }
     ];
     // One plane per API, but only where there is more than one to tell apart:
@@ -129,7 +152,8 @@ export const constructiveAdapter: ExposureAdapter = {
           name: `api:${api}`,
           kind: 'api',
           schemas: sorted(entry.schemas),
-          roles: sorted(entry.roles)
+          roles: sorted(entry.roles),
+          anonRoles: sorted(entry.anonRoles)
         });
       }
     }
@@ -177,7 +201,9 @@ export const postgrestAdapter: ExposureAdapter = {
         kind: 'api',
         primary: true,
         schemas,
-        roles: anon ? [anon] : []
+        roles: anon ? [anon] : [],
+        // db_anon_role is by definition the unauthenticated one.
+        anonRoles: anon ? [anon] : []
       },
       ...authenticators.map((role): PlaneInput => ({
         name: `direct:${role}`,
@@ -232,7 +258,9 @@ export const supabaseAdapter: ExposureAdapter = {
         kind: 'api',
         primary: true,
         schemas,
-        roles: ['anon', 'authenticated']
+        roles: ['anon', 'authenticated'],
+        // `authenticated` still requires a sign-up; `anon` requires nothing.
+        anonRoles: ['anon']
       },
       // service_role bypasses RLS by design; planes.ts reports it as skipped
       // rather than inventing an ordinary grade for it.
@@ -324,7 +352,10 @@ export const graphileAdapter: ExposureAdapter = {
         // app_hidden is reachable through app_public's views and functions —
         // served indirectly, so it belongs to the surface.
         schemas: ['app_public', ...(present.has('app_hidden') ? ['app_hidden'] : [])],
-        roles: visitors
+        roles: visitors,
+        // PostGraphile runs *every* request as the visitor role, signed in or
+        // not — the caller is a JWT claim — so it is anonymous-reachable.
+        anonRoles: visitors
       }
     ];
     if (present.has('app_private')) {

--- a/packages/safegres/src/index.ts
+++ b/packages/safegres/src/index.ts
@@ -122,6 +122,8 @@ export type {
   SafegresConfig,
   ScoringConfig
 } from './config/types';
+export type { CaseResult, CorpusCase, ExpectedFinding } from './corpus';
+export { corpusDir, gradeCase, loadCase, loadCorpus } from './corpus';
 export type { ExposureAdapter, PlaneInput } from './exposure/adapters';
 export {
   BUILTIN_ADAPTERS,

--- a/packages/safegres/src/index.ts
+++ b/packages/safegres/src/index.ts
@@ -77,6 +77,8 @@ export type { AuditOptions } from './commands/audit';
 export { audit } from './commands/audit';
 export type { DoctorCheck, DoctorOptions, DoctorReport, DoctorStatus } from './commands/doctor';
 export { doctor } from './commands/doctor';
+export type { Provenance } from './config/fingerprint';
+export { configFingerprint } from './config/fingerprint';
 export type { LoadConfigParams } from './config/loader';
 export { loadConfig, safegresConfigLoader } from './config/loader';
 export {

--- a/packages/safegres/src/pg/exposure.ts
+++ b/packages/safegres/src/pg/exposure.ts
@@ -19,6 +19,8 @@ export interface ResolvedExposure {
   source: string;
   schemas: string[];
   roles?: string[];
+  /** The subset of `roles` reachable without authenticating. */
+  anonRoles?: string[];
 }
 
 /** A plane before its reach is computed against the table snapshot. */
@@ -31,6 +33,7 @@ export interface ResolvedPlane {
   source: string;
   schemas: string[];
   roles: string[];
+  anonRoles: string[];
 }
 
 export const UNKNOWN_EXPOSURE: ResolvedExposure = {
@@ -58,7 +61,8 @@ export async function resolveExposure(
       known: true,
       source: adapter.name,
       schemas: union(primary.schemas ?? [], config.schemas),
-      roles: union(primary.roles ?? [], config.roles)
+      roles: union(primary.roles ?? [], config.roles),
+      anonRoles: union(primary.anonRoles ?? [], config.anonRoles)
     };
   }
 
@@ -67,7 +71,8 @@ export async function resolveExposure(
       known: true,
       source: 'config',
       schemas: [...config.schemas].sort(),
-      roles: config.roles
+      roles: config.roles,
+      anonRoles: config.anonRoles
     };
   }
 
@@ -95,7 +100,8 @@ export async function resolvePlanes(
       primary: true,
       source: primary.source,
       schemas: primary.schemas,
-      roles: primary.roles ?? []
+      roles: primary.roles ?? [],
+      anonRoles: primary.anonRoles ?? []
     }
   ];
 
@@ -109,7 +115,8 @@ export async function resolvePlanes(
       primary: false,
       source,
       schemas: [...(input.schemas ?? [])].sort(),
-      roles: [...(input.roles ?? [])].sort()
+      roles: [...(input.roles ?? [])].sort(),
+      anonRoles: [...(input.anonRoles ?? [])].sort()
     });
   };
 
@@ -139,7 +146,8 @@ export async function resolvePlanes(
       primary: true,
       source: 'config',
       schemas: [...(override.schemas ?? [])].sort(),
-      roles: [...(override.roles ?? [])].sort()
+      roles: [...(override.roles ?? [])].sort(),
+      anonRoles: [...(override.anonRoles ?? [])].sort()
     };
   }
 

--- a/packages/safegres/src/report/github.ts
+++ b/packages/safegres/src/report/github.ts
@@ -73,10 +73,12 @@ export function renderGithubSummary(report: Report, options: GithubRenderOptions
   const config = options.config ?? {};
   const badges = config.badges !== false;
   const selectors = config.summary ?? ['security', 'perf'];
-  const view = selectView(report, {
+  const viewConfig: ViewConfig = {
     planes: planePatterns(selectors),
+    ...(config.detail ? { detail: config.detail } : {}),
     ...options.view
-  });
+  };
+  const view = selectView(report, viewConfig);
 
   const out: string[] = [];
   const line = selectedScores(view.scores, selectors)
@@ -84,7 +86,7 @@ export function renderGithubSummary(report: Report, options: GithubRenderOptions
     .join(' ');
   if (line) out.push(line, '');
 
-  out.push(renderMarkdown(report, { view: { planes: planePatterns(selectors), ...options.view } }));
+  out.push(renderMarkdown(report, { view: viewConfig }));
   return out.join('\n');
 }
 

--- a/packages/safegres/src/report/markdown.ts
+++ b/packages/safegres/src/report/markdown.ts
@@ -76,7 +76,19 @@ export function renderMarkdown(report: Report, options: RenderMarkdownOptions = 
 
   if (report.comparison) out.push(...comparisonSection(report.comparison), '');
 
-  if (view.detail === 'summary') return out.join('\n');
+  if (view.detail === 'summary') {
+    // The ratchet's verdict is the one perf number a summary reader needs:
+    // the absolute score is dominated by accepted debt, the delta is not.
+    const diff = report.perf?.diff;
+    if (diff) {
+      out.push(
+        `Perf baseline: **${diff.added.length} new**, ${diff.accepted.length} accepted, `
+          + `${diff.removed.length} resolved.`,
+        ''
+      );
+    }
+    return out.join('\n');
+  }
 
   out.push(
     ...findingSection('Security findings', [...view.security.exposed, ...view.security.internal], options),

--- a/packages/safegres/src/report/pretty.ts
+++ b/packages/safegres/src/report/pretty.ts
@@ -61,7 +61,11 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
           + `  — ${exposure.exposedTables}/${exposure.totalTables} tables exposed`
       );
       if (exposure.roles && exposure.roles.length > 0) {
-        lines.push(`  api roles: ${exposure.roles.join(', ')}`);
+        // Marking the anonymous ones answers the question a reader actually
+        // has: which of these does a caller reach with no credentials?
+        const anon = new Set(exposure.anonRoles ?? []);
+        const roles = exposure.roles.map((r) => (anon.has(r) ? `${r} (anon)` : r));
+        lines.push(`  api roles: ${roles.join(', ')}`);
       }
     } else {
       lines.push(

--- a/packages/safegres/src/report/pretty.ts
+++ b/packages/safegres/src/report/pretty.ts
@@ -51,6 +51,9 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
   const { summary: s, score, exposure } = report;
   const lines: string[] = [
     `safegres ${report.version}  (${report.generatedAt})`,
+    ...(report.provenance?.sealed
+      ? [`sealed: ${report.provenance.preset ?? 'recommended'}  ${report.provenance.fingerprint}`]
+      : []),
     ''
   ];
 

--- a/packages/safegres/src/types.ts
+++ b/packages/safegres/src/types.ts
@@ -228,6 +228,12 @@ export interface RoleAccessReport {
 export interface Report {
   version: string;
   generatedAt: string;
+  /**
+   * What ruler this score was measured with: a fingerprint of the resolved
+   * configuration, and whether the run refused local config entirely. Two
+   * reports are comparable when their fingerprints match.
+   */
+  provenance?: import('./config/fingerprint').Provenance;
   summary: Summary;
   findings: Finding[];
   /** Config-driven audit score (weighted deductions, 0-100 + grade). */

--- a/packages/safegres/src/types.ts
+++ b/packages/safegres/src/types.ts
@@ -146,6 +146,11 @@ export interface ExposureReport {
   schemas: string[];
   /** API-edge roles, when the resolver can discover them. */
   roles?: string[];
+  /**
+   * The subset of `roles` an unauthenticated caller arrives as — the answer to
+   * "what can someone with no credentials reach?". Omitted when none resolve.
+   */
+  anonRoles?: string[];
   /** Tables on the exposed surface (the score denominator). */
   exposedTables: number;
   /** All tables the audit introspected. */


### PR DESCRIPTION
## Summary

Three pieces, in the order they depend on each other: the exposure surface learns which roles are *anonymous*, a run learns to state which ruler it was measured with, and the package ships schemas whose answers are known.

**1. `anonRoles` — the surface's missing distinction.** The Constructive adapter reads both `role_name` and `anon_role` per API and flattened them into one `roles` list, so `rolesFrom: 'exposure'` would have pointed R1/R2 at `authenticated` and turned every ordinary signed-in write grant into a critical. A plane now carries both:

```ts
interface PlaneInput {
  roles?: string[];      // every role that reaches this plane
  anonRoles?: string[];  // the subset an *unauthenticated* caller arrives as
}
// rules choose: rolesFrom: 'anon' | 'exposure'
```

Per adapter: Constructive `anon_role` only; PostgREST `pgrst.db_anon_role` (never the authenticator); Supabase `anon` but not `authenticated`; Graphile's visitor role, which carries anonymous traffic by design. `recommended` now points R1/R2/L5 at `rolesFrom: 'anon'`, so a declared `exposure.anonRoles` switches them on and an undeclared surface leaves them inert exactly as before.

**2. Sealed runs.** Every configuration knob is deliberate in CI and is the cheapest possible cheat when a *score* is what's being evaluated — turning off the rule and re-baselining both raise the number without touching the database. So every report now carries `provenance: { version, fingerprint, sealed, preset }`, where the fingerprint is sha256 over the **resolved** score-relevant surface (rules × enabled × severity × options, overrides, scoring, public-read, perf ignores, exposure + adapter names, version) — invariant to how a posture was spelled, sensitive to anything that changes it. `--sealed` skips config discovery entirely and *refuses* `--config`/`--rule`/`--exposure-schemas`/baseline flags rather than ignoring them; `--verify-fingerprint <f>` exits non-zero unless the run matches the harness's expectation.

**3. The evaluation corpus** (`corpus/`). A sealed score says the ruler didn't move; it doesn't say the ruler is right. 23 small schemas, one deliberate flaw each, with an answer key as *data* (`schema.sql` + `case.json`: expected findings, forbidden false positives, worst severity, the one-sentence fix) so a harness can consume it without running safegres. `loadCorpus()` / `gradeCase(report, case)` grade recall and precision; `__tests__/corpus.test.ts` runs all of them and additionally pins that a flaw costs points exactly when the rule carries weight (`info` and fail-closed rules are weightless by construction).

Writing the corpus found two real bugs, both fixed here:

- **P1b never fired on the common shape.** It was emitted inside the `volatility === 'v'` branch, so only a *VOLATILE* `SECURITY DEFINER` function was reported — yet the rule is about inlining, and a STABLE definer wrapper is just as much a plan fence. Now checked before the volatility filter. This can surface new (medium, perf-dimension) findings on existing databases.
- **A5/A1 case authoring**, not a bug but worth knowing: fail-closed rules and `info` severities deduct nothing, which the corpus now asserts explicitly rather than leaving implicit.

Also: configurable job-summary detail (`report.github.detail: 'summary' | 'normal' | 'verbose'`) — GitHub truncates a job summary at 1 MB, and a truncated report is worse than a short one, so `summary` keeps the badges and the ratchet verdict and drops the finding tables.

Related: the deeper reachability work this unblocks is designed in constructive-io/constructive-planning#1361.


Link to Devin session: https://app.devin.ai/sessions/b7874ecee0c7471ea271e6e7193869dc
Requested by: @pyramation