### PR TITLE
feat(safegres): L8 — DEFINER-view bypass as an AST reach edge

### DIFF
--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -129,6 +129,7 @@ are performance, `P5` is security.
 | L4 | info | neutral | **Dead schema `USAGE`** — reaches no relation and no function |
 | L5 | info | fail-open | An untrusted role reaches an **RLS-off table** via PUBLIC/inheritance † |
 | L6 | info | neutral | **Unaddressable grant** — an API role holds privileges on a relation its API cannot name ‡ |
+| L8 | info | fail-open | **DEFINER view bypass** — an untrusted role reads a base relation as the view's owner † |
 | W1 | medium | — | **No exposure surface configured** — whole database assumed reachable, score capped |
 
 † R1/R2/L5 are no-ops until you name the untrusted roles:

--- a/packages/safegres/__tests__/definer-view.test.ts
+++ b/packages/safegres/__tests__/definer-view.test.ts
@@ -1,0 +1,237 @@
+import { analyzeViewBodies, checkDefinerViewBypass } from '../src/checks/definer-view';
+import { type RoleGraph } from '../src/checks/lattice';
+import { computeViewReach } from '../src/checks/role-reach';
+import type { RoleAttributes } from '../src/pg/acl';
+import type { ViewSnapshot } from '../src/pg/indexes';
+import type { GrantInfo, TableSnapshot } from '../src/pg/introspect';
+
+function table(partial: Partial<TableSnapshot> = {}): TableSnapshot {
+  return {
+    schema: 'app',
+    name: 'orders',
+    oid: 1,
+    rlsEnabled: true,
+    rlsForced: true,
+    isPartitioned: false,
+    owner: 'app_owner',
+    grants: [],
+    policies: [],
+    ...partial
+  };
+}
+
+function view(partial: Partial<ViewSnapshot> = {}): ViewSnapshot {
+  return {
+    schema: 'app',
+    name: 'order_totals',
+    owner: 'app_owner',
+    materialized: false,
+    securityInvoker: false,
+    ownerBypassesRls: false,
+    grants: [grant('anon', 'SELECT')],
+    definition: 'SELECT id, total FROM app.orders',
+    ...partial
+  };
+}
+
+function grant(role: string, privilege: GrantInfo['privilege']): GrantInfo {
+  return { role, privilege, grantable: false, bypassRls: false };
+}
+
+function role(name: string, partial: Partial<RoleAttributes> = {}): [string, RoleAttributes] {
+  return [name, { name, bypassRls: false, isSuper: false, inheritsFrom: [], canSetRole: [], ...partial }];
+}
+
+function graph(...entries: Array<[string, RoleAttributes]>): RoleGraph {
+  return new Map(entries);
+}
+
+const GRAPH = graph(role('anon'), role('app_owner'), role('member'));
+
+describe('analyzeViewBodies', () => {
+  it('resolves the base relations a definer view reads', async () => {
+    const { views, suppressed } = await analyzeViewBodies([view()], [table()]);
+    expect(suppressed).toEqual([]);
+    expect(views).toHaveLength(1);
+    expect(views[0].baseRelations).toEqual([
+      { schema: 'app', table: 'orders', hops: [{ view: 'app.order_totals', owner: 'app_owner' }] }
+    ]);
+  });
+
+  it('resolves an unqualified reference against the view own schema', async () => {
+    const { views } = await analyzeViewBodies(
+      [view({ definition: 'SELECT id FROM orders' })],
+      [table()]
+    );
+    expect(views[0].baseRelations.map((b) => `${b.schema}.${b.table}`)).toEqual(['app.orders']);
+  });
+
+  it('ignores an invoker view: it executes as the caller, so it confers nothing', async () => {
+    const { views } = await analyzeViewBodies([view({ securityInvoker: true })], [table()]);
+    expect(views).toEqual([]);
+  });
+
+  it('ignores a materialized view: reading stored rows touches no base relation', async () => {
+    const { views } = await analyzeViewBodies([view({ materialized: true })], [table()]);
+    expect(views).toEqual([]);
+  });
+
+  it('follows a view on a view, re-owning the read at each definer hop', async () => {
+    const inner = view({ name: 'orders_inner', owner: 'inner_owner' });
+    const outer = view({
+      name: 'orders_outer',
+      owner: 'outer_owner',
+      definition: 'SELECT id FROM app.orders_inner'
+    });
+    const { views } = await analyzeViewBodies([outer, inner], [table()]);
+    const outerReach = views.find((v) => v.name === 'orders_outer')!;
+    expect(outerReach.baseRelations).toEqual([
+      {
+        schema: 'app',
+        table: 'orders',
+        hops: [
+          { view: 'app.orders_outer', owner: 'outer_owner' },
+          { view: 'app.orders_inner', owner: 'inner_owner' }
+        ]
+      }
+    ]);
+  });
+
+  it('keeps the outer owner in force through a nested invoker view', async () => {
+    const inner = view({ name: 'orders_inner', owner: 'inner_owner', securityInvoker: true });
+    const outer = view({
+      name: 'orders_outer',
+      owner: 'outer_owner',
+      definition: 'SELECT id FROM app.orders_inner'
+    });
+    const { views } = await analyzeViewBodies([outer, inner], [table()]);
+    const outerReach = views.find((v) => v.name === 'orders_outer')!;
+    expect(outerReach.baseRelations[0].hops.map((h) => h.owner)).toEqual([
+      'outer_owner',
+      'outer_owner'
+    ]);
+  });
+
+  it('suppresses a view whose body it cannot read, rather than reporting an empty one', async () => {
+    const { views, suppressed } = await analyzeViewBodies(
+      [view({ definition: 'SELECT ((( FROM nowhere' })],
+      [table()]
+    );
+    expect(views).toEqual([]);
+    expect(suppressed).toEqual([
+      { view: 'app.order_totals', reason: 'SQL fragment failed to parse' }
+    ]);
+  });
+
+  it('does not pin an ambiguous unqualified name to a relation nobody named', async () => {
+    const { views } = await analyzeViewBodies(
+      [view({ schema: 'other', definition: 'SELECT id FROM orders' })],
+      [table({ schema: 'app' }), table({ schema: 'archive', oid: 2 })]
+    );
+    expect(views).toEqual([]);
+  });
+});
+
+describe('computeViewReach', () => {
+  it('projects the base relation under the view owner, proven by AST', async () => {
+    const { views } = await analyzeViewBodies([view()], [table()]);
+    const [reach] = computeViewReach(views, GRAPH, ['anon']);
+    expect(reach.cells).toHaveLength(1);
+    expect(reach.cells[0]).toMatchObject({
+      schema: 'app',
+      table: 'orders',
+      privileges: ['SELECT'],
+      effectiveRole: 'app_owner',
+      proof: 'ast'
+    });
+    expect(reach.cells[0].path).toEqual([
+      { kind: 'grant', via: 'direct', privilege: 'SELECT' },
+      { kind: 'view', view: 'app.order_totals', owner: 'app_owner' }
+    ]);
+  });
+
+  it('needs SELECT on the view itself — an unreadable view reaches nothing', async () => {
+    const { views } = await analyzeViewBodies([view({ grants: [] })], [table()]);
+    const [reach] = computeViewReach(views, GRAPH, ['anon']);
+    expect(reach.cells).toEqual([]);
+  });
+
+  it('follows a grant on the view that arrives via PUBLIC', async () => {
+    const { views } = await analyzeViewBodies([view({ grants: [grant('PUBLIC', 'SELECT')] })], [table()]);
+    const [reach] = computeViewReach(views, GRAPH, ['anon']);
+    expect(reach.cells[0].path[0]).toEqual({ kind: 'grant', via: 'PUBLIC', privilege: 'SELECT' });
+  });
+});
+
+describe('checkDefinerViewBypass (L8)', () => {
+  async function check(views: ViewSnapshot[], tables: TableSnapshot[], roles: string[]) {
+    const analyzed = await analyzeViewBodies(views, tables);
+    return checkDefinerViewBypass(analyzed.views, tables, GRAPH, { roles });
+  }
+
+  it('is a no-op with no untrusted roles configured', async () => {
+    expect(await check([view()], [table()], [])).toEqual([]);
+  });
+
+  it('flags a base relation the role reads only as the view owner', async () => {
+    const findings = await check([view()], [table()], ['anon']);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      code: 'L8',
+      severity: 'info',
+      schema: 'app',
+      table: 'orders',
+      role: 'anon',
+      privilege: 'SELECT'
+    });
+    expect(findings[0].context).toMatchObject({
+      view: 'app.order_totals',
+      effectiveRole: 'app_owner',
+      proof: 'ast',
+      rlsBypassed: false
+    });
+  });
+
+  it('never recommends revoking a grant', async () => {
+    const [finding] = await check([view()], [table()], ['anon']);
+    expect(finding.hint).toContain('security_invoker');
+    expect(finding.hint).toContain('Do not revoke');
+  });
+
+  it('stays silent when the role can read the base relation anyway', async () => {
+    const base = table({ grants: [grant('anon', 'SELECT')] });
+    expect(await check([view()], [base], ['anon'])).toEqual([]);
+  });
+
+  it('stays silent for a security_invoker view over the same shape', async () => {
+    expect(await check([view({ securityInvoker: true })], [table()], ['anon'])).toEqual([]);
+  });
+
+  it('stays silent when the view owner is the untrusted role itself', async () => {
+    const owned = view({ owner: 'anon' });
+    expect(await check([owned], [table()], ['anon'])).toEqual([]);
+  });
+
+  it('says so when the owner is also exempt from the base table policies', async () => {
+    const base = table({ rlsForced: false, owner: 'app_owner' });
+    const [finding] = await check([view()], [base], ['anon']);
+    expect(finding.context).toMatchObject({ rlsBypassed: true });
+    expect(finding.message).toContain('not subject to its RLS policies');
+  });
+
+  it('reports nothing for a view whose body is opaque', async () => {
+    const opaque = view({ definition: 'SELECT ((( FROM nowhere' });
+    expect(await check([opaque], [table()], ['anon'])).toEqual([]);
+  });
+
+  it('sees a grant on the view the role holds by inheritance', async () => {
+    const inheriting = graph(
+      role('anon', { inheritsFrom: ['member'] }),
+      role('member'),
+      role('app_owner')
+    );
+    const analyzed = await analyzeViewBodies([view({ grants: [grant('member', 'SELECT')] })], [table()]);
+    const findings = checkDefinerViewBypass(analyzed.views, [table()], inheriting, { roles: ['anon'] });
+    expect(findings).toHaveLength(1);
+  });
+});

--- a/packages/safegres/corpus/cases/25-definer-view-bypass/case.json
+++ b/packages/safegres/corpus/cases/25-definer-view-bypass/case.json
@@ -1,0 +1,30 @@
+{
+  "title": "Anonymous role reads a locked table through a DEFINER view",
+  "dimension": "security",
+  "exposure": {
+    "schemas": [
+      "c_definer_view_bypass"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "L8",
+      "relation": "c_definer_view_bypass.orders",
+      "note": "the view is not security_invoker, so corpus_anon's SELECT on it reads `orders` as c_definer_view_owner — a grant no ACL row on `orders` gives it"
+    }
+  ],
+  "forbid": [
+    "A2",
+    "R1"
+  ],
+  "worstSeverity": "info",
+  "fix": "Recreate c_definer_view_bypass.order_totals WITH (security_invoker = true) so the caller's own grants and policies apply, or give it an owner whose reach matches what the view is meant to expose. Revoking corpus_anon's SELECT on the view is not the fix — that grant is what the API serves.",
+  "id": "25-definer-view-bypass"
+}

--- a/packages/safegres/corpus/cases/25-definer-view-bypass/schema.sql
+++ b/packages/safegres/corpus/cases/25-definer-view-bypass/schema.sql
@@ -1,0 +1,36 @@
+DROP SCHEMA IF EXISTS c_definer_view_bypass CASCADE;
+CREATE SCHEMA c_definer_view_bypass;
+
+-- The role the view executes as. It owns the base table, so its reach is
+-- everything the table's policies were written to constrain.
+DO $$ BEGIN
+  CREATE ROLE c_definer_view_owner NOLOGIN;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+GRANT USAGE ON SCHEMA c_definer_view_bypass TO corpus_anon, corpus_user, c_definer_view_owner;
+
+CREATE TABLE c_definer_view_bypass.orders (
+  id bigserial PRIMARY KEY,
+  customer text NOT NULL,
+  total numeric NOT NULL
+);
+ALTER TABLE c_definer_view_bypass.orders OWNER TO c_definer_view_owner;
+ALTER TABLE c_definer_view_bypass.orders ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_definer_view_bypass.orders FORCE ROW LEVEL SECURITY;
+
+-- The table is correctly locked down: only the signed-in role can read it, and
+-- only its own rows. corpus_anon holds no grant on it at all.
+CREATE POLICY orders_own_rows ON c_definer_view_bypass.orders
+  FOR SELECT TO corpus_user USING (customer = (SELECT current_setting('app.customer', true)));
+CREATE INDEX orders_customer_idx ON c_definer_view_bypass.orders (customer);
+GRANT SELECT ON c_definer_view_bypass.orders TO corpus_user;
+
+-- The flaw: the view is not `security_invoker`, so it executes as its owner —
+-- who owns the base table. corpus_anon holds nothing but SELECT on the view,
+-- and reads every order through it. No ACL row on `orders` names corpus_anon,
+-- so every catalog-only check sees a table the anonymous role cannot reach.
+CREATE VIEW c_definer_view_bypass.order_totals AS
+  SELECT id, customer, total FROM c_definer_view_bypass.orders;
+ALTER VIEW c_definer_view_bypass.order_totals OWNER TO c_definer_view_owner;
+GRANT SELECT ON c_definer_view_bypass.order_totals TO corpus_anon;

--- a/packages/safegres/corpus/cases/26-invoker-view-no-bypass/case.json
+++ b/packages/safegres/corpus/cases/26-invoker-view-no-bypass/case.json
@@ -1,0 +1,31 @@
+{
+  "title": "A security_invoker view over the same shape is not a bypass",
+  "dimension": "security",
+  "exposure": {
+    "schemas": [
+      "c_invoker_view_no_bypass"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "A3",
+      "relation": "c_invoker_view_no_bypass.orders",
+      "note": "the only real finding left: RLS is not FORCEd, so the table owner still reads every row"
+    }
+  ],
+  "forbid": [
+    "L8",
+    "L5",
+    "A2"
+  ],
+  "worstSeverity": "low",
+  "fix": "ALTER TABLE c_invoker_view_no_bypass.orders FORCE ROW LEVEL SECURITY. The view needs no fix — `security_invoker` is what the definer-view bypass (case 25) is fixed *into*, and a rule that reported L8 here would be flagging a correct schema.",
+  "id": "26-invoker-view-no-bypass"
+}

--- a/packages/safegres/corpus/cases/26-invoker-view-no-bypass/schema.sql
+++ b/packages/safegres/corpus/cases/26-invoker-view-no-bypass/schema.sql
@@ -1,0 +1,34 @@
+DROP SCHEMA IF EXISTS c_invoker_view_no_bypass CASCADE;
+CREATE SCHEMA c_invoker_view_no_bypass;
+
+-- The same shape as 25-definer-view-bypass, with the one difference that
+-- decides it: the view is `security_invoker`, so it executes as the caller.
+DO $$ BEGIN
+  CREATE ROLE c_invoker_view_owner NOLOGIN;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+GRANT USAGE ON SCHEMA c_invoker_view_no_bypass TO corpus_anon, corpus_user, c_invoker_view_owner;
+
+CREATE TABLE c_invoker_view_no_bypass.orders (
+  id bigserial PRIMARY KEY,
+  customer text NOT NULL,
+  total numeric NOT NULL
+);
+ALTER TABLE c_invoker_view_no_bypass.orders OWNER TO c_invoker_view_owner;
+ALTER TABLE c_invoker_view_no_bypass.orders ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY orders_own_rows ON c_invoker_view_no_bypass.orders
+  FOR SELECT TO corpus_user USING (customer = (SELECT current_setting('app.customer', true)));
+CREATE INDEX orders_customer_idx ON c_invoker_view_no_bypass.orders (customer);
+GRANT SELECT ON c_invoker_view_no_bypass.orders TO corpus_user;
+
+-- corpus_anon can SELECT the view and nothing else, exactly as in case 25 —
+-- but `security_invoker` means Postgres checks *corpus_anon's* privileges on
+-- `orders`, which are none, so the read is denied. There is no bypass here and
+-- a rule that reported one would be recommending a change to a correct schema.
+CREATE VIEW c_invoker_view_no_bypass.order_totals
+  WITH (security_invoker = true) AS
+  SELECT id, customer, total FROM c_invoker_view_no_bypass.orders;
+ALTER VIEW c_invoker_view_no_bypass.order_totals OWNER TO c_invoker_view_owner;
+GRANT SELECT ON c_invoker_view_no_bypass.order_totals TO corpus_anon;

--- a/packages/safegres/docs/rules.md
+++ b/packages/safegres/docs/rules.md
@@ -40,6 +40,23 @@ policy predicate anywhere may reference the relation. The second is the importan
 can subquery a table under the querying role, so the grant is load-bearing however invisible it is
 to the API, and a naive recommendation to revoke it would break authorization at runtime.
 
+L8 is the first rule whose evidence is a SQL body rather than the catalog. A view that was not
+created `WITH (security_invoker = true)` executes as its **owner**, so a role holding nothing but
+SELECT on the view reads the view's base relations under the owner's privileges — tables no ACL
+row names it on, and, when the owner owns the table or holds `BYPASSRLS`, without the row filter
+the table's policies would have applied. No amount of catalog closure can see that edge: it exists
+only inside the view definition, which is why the reach cells it produces carry `proof: 'ast'`
+rather than `proof: 'catalog'`, and why the effective role on them is the view's owner.
+
+Three things gate it, and all three are refusals to guess. A body safegres cannot read — dynamic
+SQL, an unparseable definition, a chain of views deeper than it will follow — suppresses the view
+entirely, because an unread body is *unknown*, not empty. A reference it cannot pin to exactly one
+relation resolves to nothing rather than to a plausible candidate. And the remedy is never a
+revoke: the SELECT on the view is what the API serves, so L8 recommends `security_invoker = true`
+or a different owner, and says so explicitly. Only SELECT is modelled — an auto-updatable view can
+carry writes the same way, but proving which write reaches which base relation needs more than the
+body's relation set.
+
 Restrictive-only policies never count as coverage. `BYPASSRLS` and superuser roles are exempt from
 policy checks — they are not subject to RLS, so a "missing policy" finding for them would be
 noise. Policies are matched with `pg_has_role` semantics: a policy `TO authenticated` covers a

--- a/packages/safegres/src/callgraph/extract.ts
+++ b/packages/safegres/src/callgraph/extract.ts
@@ -5,6 +5,9 @@
  * (read vs write), and auth-context mutations it contains. Dynamic SQL
  * (`EXECUTE format(...)`) and unparseable bodies are surfaced as `opaque`
  * rather than silently dropped — static analysis ends there.
+ *
+ * A view body is the same question asked of a different object, so
+ * {@link extractQuery} exposes the plain-SQL half directly.
  */
 
 import { parsePlPgSQL } from 'libpg-query';
@@ -46,7 +49,7 @@ export async function extractBody(fn: FunctionSnapshot): Promise<ExtractedBody> 
 
   if (fn.language === 'sql') {
     if (!fn.source || fn.source.trim() === '') return EMPTY;
-    return extractFromSql(fn.source, 'statement');
+    return extractQuery(fn.source);
   }
 
   // plpgsql: parse the full CREATE FUNCTION, then analyze every embedded
@@ -74,7 +77,7 @@ export async function extractBody(fn: FunctionSnapshot): Promise<ExtractedBody> 
       q = q.replace(/^\s*[a-zA-Z_"][\w$".]*(\[[^\]]*\])*\s*:?=\s*/, '');
     }
     const sql = e.parseMode === 0 ? q : `SELECT ${q}`;
-    const part = await extractFromSql(sql, 'statement');
+    const part = await extractQuery(sql);
     mergeBody(out, part);
   }
 
@@ -112,7 +115,11 @@ function collectPlpgsql(node: unknown, exprs: Array<{ query: string; parseMode: 
   for (const value of Object.values(rec)) collectPlpgsql(value, exprs, out);
 }
 
-async function extractFromSql(sql: string, _mode: 'statement'): Promise<ExtractedBody> {
+/**
+ * The same extraction over a standalone SQL statement — a view body, a policy
+ * predicate, anything that is already plain SQL rather than a function.
+ */
+export async function extractQuery(sql: string): Promise<ExtractedBody> {
   let ast: unknown;
   try {
     ast = await parse(sql);

--- a/packages/safegres/src/checks/definer-view.ts
+++ b/packages/safegres/src/checks/definer-view.ts
@@ -1,0 +1,254 @@
+/**
+ * L8: a view that is not `security_invoker` hands its readers the owner's
+ * privileges on every relation its body touches.
+ *
+ * A view executes as its owner unless it was created `WITH (security_invoker
+ * = true)`. So a role holding nothing but SELECT on the view reads the base
+ * relations under the *owner's* rights — including tables it has no grant on,
+ * and, when the owner owns the base table or bypasses RLS, without the row
+ * filter the base table's policies would have applied.
+ *
+ * Nothing in the catalog-only effective-access layer can see this:
+ * `effectiveGrants` never names the calling role on the base relation, and
+ * the base relation's ACL never names it either. The edge only exists in the
+ * view's *body*, which makes this the first rule that reads SQL rather than
+ * pure catalog — the `proof: 'ast'` edge of the reach model in `role-reach.ts`.
+ *
+ * Two conservatism rules the rest of the analysis depends on:
+ *
+ *   - **A body we cannot read is unknown, not empty.** Dynamic SQL or an
+ *     unparseable body suppresses the view entirely rather than producing a
+ *     partial (and therefore misleading) base-relation set.
+ *   - **The fix is never a revoke.** The grant on the view is what the API
+ *     serves; the defect is the view executing as its owner. L8 recommends
+ *     `security_invoker = true` or a different owner, and nothing else.
+ */
+
+import { extractQuery } from '../callgraph/extract';
+import type { ViewSnapshot } from '../pg/indexes';
+import type { TableSnapshot } from '../pg/introspect';
+import type { Finding } from '../types';
+import { effectiveGrants, type LatticeRoleOptions, type RoleGraph } from './lattice';
+import { computeViewReach, type ViewBaseRelation, type ViewReachInput } from './role-reach';
+
+/** How deep a chain of views on views is followed before giving up. */
+const MAX_VIEW_DEPTH = 8;
+
+/** A view whose body did not yield a usable base-relation set. */
+export interface SuppressedView {
+  view: string;
+  reason: string;
+}
+
+export interface ViewBodyAnalysis {
+  /** Definer views whose bodies were read, as reach inputs. */
+  views: ViewReachInput[];
+  /** Views deliberately left out, with why — an unread body is not a clean bill. */
+  suppressed: SuppressedView[];
+}
+
+/**
+ * Read every definer view's body and resolve the base relations it reaches.
+ *
+ * Nested views are followed: a definer view over an invoker view still
+ * executes the inner body as the *outer* owner, while an inner definer view
+ * switches the executing role again. Each resolved relation therefore carries
+ * the hops it passed through and the owner of the last one.
+ */
+export async function analyzeViewBodies(
+  views: ViewSnapshot[],
+  tables: TableSnapshot[]
+): Promise<ViewBodyAnalysis> {
+  // A materialized view stores its rows: reading it touches no base relation,
+  // so it is a leaf here, never an edge.
+  const queryable = views.filter((v) => !v.materialized);
+  const tableKeys = new Set(tables.map((t) => `${t.schema}.${t.name}`));
+  const byName = new Map<string, ViewSnapshot[]>();
+  for (const v of queryable) {
+    byName.set(v.name, [...(byName.get(v.name) ?? []), v]);
+  }
+  const viewKeys = new Map(queryable.map((v) => [`${v.schema}.${v.name}`, v]));
+
+  const bodies = new Map<string, Awaited<ReturnType<typeof extractQuery>>>();
+  for (const v of queryable) {
+    bodies.set(`${v.schema}.${v.name}`, await extractQuery(v.definition));
+  }
+
+  const out: ViewReachInput[] = [];
+  const suppressed: SuppressedView[] = [];
+
+  for (const view of queryable) {
+    if (view.securityInvoker) continue;
+
+    const bases: ViewBaseRelation[] = [];
+    const seen = new Set<string>();
+    let opaque: string | undefined;
+
+    const walk = (current: ViewSnapshot, hops: Array<{ view: string; owner: string }>): void => {
+      const key = `${current.schema}.${current.name}`;
+      if (hops.length > MAX_VIEW_DEPTH) {
+        opaque ??= `view chain deeper than ${MAX_VIEW_DEPTH} hops`;
+        return;
+      }
+      const body = bodies.get(key);
+      if (!body) return;
+      if (body.opaque) {
+        opaque ??= body.opaqueReason ?? 'body could not be read';
+        return;
+      }
+
+      for (const ref of body.tables) {
+        const relation = resolve(ref, current.schema, tableKeys, viewKeys, byName);
+        if (!relation) continue; // a CTE, an alias, or a name we cannot pin down
+
+        if (relation.kind === 'view') {
+          const nested = relation.view;
+          if (`${nested.schema}.${nested.name}` === key) continue;
+          // An inner definer view re-owns the read; an inner invoker view runs
+          // under whichever owner is already in force.
+          const owner = nested.securityInvoker ? hops[hops.length - 1].owner : nested.owner;
+          walk(nested, [...hops, { view: `${nested.schema}.${nested.name}`, owner }]);
+          continue;
+        }
+
+        const relKey = `${relation.schema}.${relation.name}`;
+        const dedupe = `${relKey}::${hops[hops.length - 1].owner}`;
+        if (seen.has(dedupe)) continue;
+        seen.add(dedupe);
+        bases.push({ schema: relation.schema, table: relation.name, hops: [...hops] });
+      }
+    };
+
+    walk(view, [{ view: `${view.schema}.${view.name}`, owner: view.owner }]);
+
+    if (opaque) {
+      suppressed.push({ view: `${view.schema}.${view.name}`, reason: opaque });
+      continue;
+    }
+    if (bases.length === 0) continue;
+
+    out.push({
+      schema: view.schema,
+      name: view.name,
+      owner: view.owner,
+      grants: view.grants,
+      baseRelations: bases
+    });
+  }
+
+  return { views: out, suppressed };
+}
+
+type Resolved =
+  | { kind: 'table'; schema: string; name: string }
+  | { kind: 'view'; view: ViewSnapshot };
+
+/**
+ * Pin a body reference to a relation in the snapshot.
+ *
+ * `pg_get_viewdef` qualifies anything outside the creating `search_path` but
+ * leaves the rest bare, so an unqualified name is resolved against the view's
+ * own schema first and then against the snapshot as a whole — and only when
+ * exactly one relation answers to it. An ambiguous or unknown name (a CTE, a
+ * table alias, a relation outside the audited schemas) resolves to nothing:
+ * over-approximating here would attribute a read to a relation nobody named.
+ */
+function resolve(
+  ref: { schema?: string; name: string },
+  viewSchema: string,
+  tableKeys: Set<string>,
+  viewKeys: Map<string, ViewSnapshot>,
+  viewsByName: Map<string, ViewSnapshot[]>
+): Resolved | null {
+  const candidates = ref.schema ? [ref.schema] : [viewSchema];
+  for (const schema of candidates) {
+    const key = `${schema}.${ref.name}`;
+    const view = viewKeys.get(key);
+    if (view) return { kind: 'view', view };
+    if (tableKeys.has(key)) return { kind: 'table', schema, name: ref.name };
+  }
+  if (ref.schema) return null;
+
+  const matches = [
+    ...[...tableKeys]
+      .filter((k) => k.endsWith(`.${ref.name}`))
+      .map((k): Resolved => ({ kind: 'table', schema: k.slice(0, -(ref.name.length + 1)), name: ref.name })),
+    ...(viewsByName.get(ref.name) ?? []).map((v): Resolved => ({ kind: 'view', view: v }))
+  ];
+  return matches.length === 1 ? matches[0] : null;
+}
+
+/**
+ * L8: an untrusted role reads a base relation through a definer view.
+ *
+ * Fires once per (role, view, base relation) where the role can SELECT the
+ * view, the view executes as someone else, and the role holds no SELECT of
+ * its own on the relation the view reads. A `security_invoker` view over the
+ * same shape produces nothing — it executes as the caller, so the base
+ * relation's own ACL and policies apply and there is no edge to report.
+ */
+export function checkDefinerViewBypass(
+  views: ViewReachInput[],
+  tables: TableSnapshot[],
+  graph: RoleGraph,
+  options: LatticeRoleOptions = {}
+): Finding[] {
+  const untrusted = options.roles ?? [];
+  if (untrusted.length === 0 || views.length === 0) return [];
+
+  const byKey = new Map(tables.map((t) => [`${t.schema}.${t.name}`, t]));
+  const out: Finding[] = [];
+
+  for (const { role, cells } of computeViewReach(views, graph, untrusted)) {
+    for (const cell of cells) {
+      if (cell.effectiveRole === role) continue;
+
+      const base = byKey.get(`${cell.schema}.${cell.table}`);
+      if (!base) continue;
+      // Already reachable in its own right: the view launders nothing.
+      if (effectiveGrants(base, role, graph).some((g) => g.privilege === 'SELECT')) continue;
+
+      const hops = cell.path.filter((e): e is { kind: 'view'; view: string; owner: string } =>
+        e.kind === 'view'
+      );
+      const outermost = hops[0];
+      const owner = cell.effectiveRole;
+      const ownerAttrs = graph.get(owner);
+      // The owner is exempt from the base table's policies — either because
+      // it owns the table and FORCE is off, or because it bypasses RLS
+      // outright — so the rows the policies would have filtered come back.
+      const rlsBypassed =
+        base.rlsEnabled
+        && (!!ownerAttrs?.bypassRls || (base.owner === owner && !base.rlsForced));
+
+      out.push({
+        code: 'L8',
+        severity: 'info',
+        category: 'anti-pattern',
+        schema: base.schema,
+        table: base.name,
+        role,
+        privilege: 'SELECT',
+        message:
+          `Untrusted role ${role} reads ${base.schema}.${base.name} through view ${outermost.view}, `
+          + `which executes as its owner ${owner} — ${role} holds no SELECT on the base relation`
+          + (rlsBypassed ? `, and ${owner} is not subject to its RLS policies` : ''),
+        hint:
+          `The view is not \`security_invoker\`, so Postgres checks ${owner}'s privileges on the base `
+          + `relation, not ${role}'s. Recreate it \`WITH (security_invoker = true)\` so the caller's `
+          + `own grants and policies apply, or give it an owner whose reach matches what the view is `
+          + `meant to expose. Do not revoke the SELECT on the view — that grant is what the API serves.`,
+        context: {
+          view: outermost.view,
+          effectiveRole: owner,
+          viaViews: hops.map((h) => h.view),
+          baseRlsEnabled: base.rlsEnabled,
+          rlsBypassed,
+          proof: cell.proof
+        }
+      });
+    }
+  }
+
+  return out;
+}

--- a/packages/safegres/src/checks/lattice.ts
+++ b/packages/safegres/src/checks/lattice.ts
@@ -43,9 +43,13 @@ const RLS_PRIVILEGES: PgPrivilege[] = ['SELECT', 'INSERT', 'UPDATE', 'DELETE'];
  * Every privilege `role` effectively holds on `table`: direct grants, grants
  * TO PUBLIC, and grants to roles it inherits from. Deduplicated per privilege
  * with the most direct provenance winning (direct > PUBLIC > inherited).
+ *
+ * Takes anything carrying an ACL, not just a table: a view's own grants
+ * compose the same way, and the view-ownership reach edge asks this same
+ * question of them.
  */
 export function effectiveGrants(
-  table: TableSnapshot,
+  table: Pick<TableSnapshot, 'grants'>,
   role: string,
   graph: RoleGraph
 ): EffectiveGrant[] {

--- a/packages/safegres/src/checks/role-reach.ts
+++ b/packages/safegres/src/checks/role-reach.ts
@@ -14,14 +14,14 @@
  * #1358/#1361): it projects a role's reach into each relation as a set of
  * cells, each carrying the role the access actually *executes as*
  * (`effectiveRole`) and how that reach arrived (`path`). Stage 1 models two
- * edge kinds — passive grants and `SET ROLE` — and every fact is
- * catalog-proven (`proof: 'catalog'`). View-ownership and SECURITY DEFINER
- * edges (which need body analysis and carry `proof: 'ast' | 'opaque-tainted'`)
- * come in later stages; the types leave room for them without committing to
- * them now.
+ * edge kinds — passive grants and `SET ROLE` — both catalog-proven
+ * (`proof: 'catalog'`). Stage 2 adds the view-ownership edge: a read through a
+ * non-`security_invoker` view executes as the view's owner, and the base
+ * relations it touches are read out of the view body, so those cells carry
+ * `proof: 'ast'`. SECURITY DEFINER function edges come later.
  */
 
-import type { PgPrivilege, TableSnapshot } from '../pg/introspect';
+import type { GrantInfo, PgPrivilege, TableSnapshot } from '../pg/introspect';
 import { effectiveGrants, type GrantVia, type RoleGraph } from './lattice';
 
 /** One hop in the path by which a role reaches a relation. */
@@ -29,7 +29,12 @@ export type RoleReachEdge =
   /** A privilege held passively: directly, via PUBLIC, or via INHERIT. */
   | { kind: 'grant'; via: GrantVia; privilege: PgPrivilege }
   /** The caller assumed `to` with `SET ROLE` (`pg_auth_members.set_option`). */
-  | { kind: 'setrole'; to: string };
+  | { kind: 'setrole'; to: string }
+  /**
+   * The caller read through a view that executes as `owner` — every relation
+   * the body names is read under the owner's privileges, not the caller's.
+   */
+  | { kind: 'view'; view: string; owner: string };
 
 /**
  * How well-founded a reach cell is. Stage 1 is entirely `catalog` — every
@@ -115,6 +120,72 @@ export function computeRoleReach(
             ...assumed.map((g) => ({ kind: 'grant' as const, via: g.via, privilege: g.privilege }))
           ],
           proof: 'catalog'
+        });
+      }
+    }
+
+    return { role, cells };
+  });
+}
+
+/** One relation a view body reads, with the roles the hops execute as. */
+export interface ViewBaseRelation {
+  schema: string;
+  table: string;
+  /**
+   * The view hops the read passes through, outermost first. The last hop's
+   * owner is the role the base relation is actually read as.
+   */
+  hops: Array<{ view: string; owner: string }>;
+}
+
+/** A view, its own ACL, and the base relations its body was found to read. */
+export interface ViewReachInput {
+  schema: string;
+  name: string;
+  owner: string;
+  /** ACL rows on the view itself — who can SELECT the view at all. */
+  grants: GrantInfo[];
+  baseRelations: ViewBaseRelation[];
+}
+
+/**
+ * Project the view-ownership edge into the same reach model: for every role
+ * that can SELECT a view, one cell per base relation the view body reads,
+ * under the owner the hop executes as.
+ *
+ * Only SELECT is modelled. An auto-updatable or `INSTEAD OF`-triggered view
+ * can carry writes the same way, but proving *which* write reaches *which*
+ * base relation needs more than the body's relation set, and an unproven
+ * write edge is exactly the kind of guess this model refuses to make.
+ *
+ * A view whose body could not be read (dynamic SQL, an unparseable body) must
+ * not appear in `views`: an unreadable body is unknown, not empty.
+ */
+export function computeViewReach(
+  views: ViewReachInput[],
+  graph: RoleGraph,
+  roles: string[]
+): RoleReach[] {
+  return roles.map((role) => {
+    const cells: RoleReachCell[] = [];
+
+    for (const view of views) {
+      const select = effectiveGrants(view, role, graph).find((g) => g.privilege === 'SELECT');
+      if (!select) continue;
+
+      for (const base of view.baseRelations) {
+        if (base.hops.length === 0) continue;
+        cells.push({
+          schema: base.schema,
+          table: base.table,
+          privileges: ['SELECT'],
+          effectiveRole: base.hops[base.hops.length - 1].owner,
+          path: [
+            { kind: 'grant', via: select.via, privilege: 'SELECT' },
+            ...base.hops.map((h) => ({ kind: 'view' as const, view: h.view, owner: h.owner }))
+          ],
+          proof: 'ast'
         });
       }
     }

--- a/packages/safegres/src/commands/audit.ts
+++ b/packages/safegres/src/commands/audit.ts
@@ -16,6 +16,7 @@ import {
   checkCoverageGaps,
   checkUpdateWithCheckCoverage
 } from '../checks/coverage';
+import { analyzeViewBodies, checkDefinerViewBypass } from '../checks/definer-view';
 import {
   checkMissingPrimaryKey,
   checkRedundantIndexes,
@@ -63,7 +64,7 @@ import { introspectRoleGraph, introspectSchemaAcls } from '../pg/acl';
 import type { ResolvedExposure } from '../pg/exposure';
 import { resolveExposure, resolvePlanes, resolveReach } from '../pg/exposure';
 import { introspectFunctions } from '../pg/functions';
-import { introspectIndexes, introspectViewBodies, type TableIndexSnapshot } from '../pg/indexes';
+import { introspectIndexes, introspectViews, type TableIndexSnapshot } from '../pg/indexes';
 import { asExecutor, type IntrospectOptions, introspectTables, type QueryExecutor, type TableSnapshot } from '../pg/introspect';
 import { type AccessPath, classifyPaths } from '../pg/paths';
 import { lookupVolatility, type ProcVolatility } from '../pg/proc';
@@ -220,6 +221,23 @@ export async function audit(
     indexSnapshot.map((t) => [`${t.schema}.${t.name}`, t])
   );
 
+  // Views are read for two independent reasons: their bodies refute "nothing
+  // queries this column" for the perf paths, and their owners carry the L8
+  // reach edge. One introspection serves both.
+  const definerViewRoles = withExposedRoles(
+    resolved.rules.get('L8')?.options as LatticeRoleOptions,
+    exposure
+  )?.roles ?? [];
+  const needsViews =
+    (perfEnabled && config.perf?.paths?.infer !== false)
+    || (!skipAst && definerViewRoles.length > 0 && resolved.rules.get('L8')?.enabled !== false);
+  const viewSnapshot = needsViews
+    ? await introspectViews(exec, {
+      schemas: options.schemas ?? config.schemas,
+      excludeSchemas: options.excludeSchemas ?? config.excludeSchemas
+    })
+    : [];
+
   // Evidence about which foreign keys anything reads. Reported alongside the
   // findings; by default it changes neither, because no signal available on an
   // empty database proves a path is unreachable.
@@ -228,10 +246,7 @@ export async function audit(
     ? classifyPaths(
       indexSnapshot,
       snapshot,
-      await introspectViewBodies(exec, {
-        schemas: options.schemas ?? config.schemas,
-        excludeSchemas: options.excludeSchemas ?? config.excludeSchemas
-      }),
+      viewSnapshot.map((v) => v.definition),
       {
         minPointers: config.perf?.paths?.minPointers,
         hiddenBackwardRelations: new Set(apiReach?.hiddenBackwardRelations ?? [])
@@ -310,6 +325,14 @@ export async function audit(
   }
 
   findings.push(...checkDeadSchemaUsage(schemaAcls, snapshot, roleGraph));
+
+  // L8 is per-view, not per-table: a view body names its own base relations.
+  if (!skipAst && definerViewRoles.length > 0 && resolved.rules.get('L8')?.enabled !== false) {
+    const viewBodies = await analyzeViewBodies(viewSnapshot, snapshot);
+    findings.push(
+      ...checkDefinerViewBypass(viewBodies.views, snapshot, roleGraph, { roles: definerViewRoles })
+    );
+  }
 
   const statsSnapshot: StatsSnapshot | null = statsEnabled
     ? await introspectStats(exec, {

--- a/packages/safegres/src/config/presets.ts
+++ b/packages/safegres/src/config/presets.ts
@@ -22,7 +22,11 @@ export const recommended: SafegresConfig = {
     // Signal-only for now: an unauthenticated role that can SET ROLE to a role
     // with more reach is a real escalation, but the rule is new and unproven,
     // so it reports at zero weight until validated. See the registry entry.
-    L7: ['info', { rolesFrom: 'anon' }]
+    L7: ['info', { rolesFrom: 'anon' }],
+    // Same posture, same reason: a view that executes as its owner hands its
+    // readers that owner's reach, which is a real bypass, but the rule is new
+    // and body-derived, so it reports at zero weight until validated.
+    L8: ['info', { rolesFrom: 'anon' }]
   }
 };
 

--- a/packages/safegres/src/index.ts
+++ b/packages/safegres/src/index.ts
@@ -26,6 +26,8 @@ export type {
   ChecklistItem
 } from './callgraph/graph';
 export { buildCallGraph } from './callgraph/graph';
+export type { SuppressedView, ViewBodyAnalysis } from './checks/definer-view';
+export { analyzeViewBodies, checkDefinerViewBypass } from './checks/definer-view';
 export {
   checkMissingPrimaryKey,
   checkRedundantIndexes,
@@ -175,8 +177,8 @@ export {
 } from './pg/exposure';
 export type { FunctionGrant, FunctionSnapshot, IntrospectFunctionOptions } from './pg/functions';
 export { introspectFunctions } from './pg/functions';
-export type { ColumnInfo, ForeignKeyInfo, IndexInfo, TableIndexSnapshot } from './pg/indexes';
-export { introspectIndexes } from './pg/indexes';
+export type { ColumnInfo, ForeignKeyInfo, IndexInfo, TableIndexSnapshot, ViewSnapshot } from './pg/indexes';
+export { introspectIndexes, introspectViews } from './pg/indexes';
 export {
   type IntrospectOptions,
   introspectTables,

--- a/packages/safegres/src/pg/indexes.ts
+++ b/packages/safegres/src/pg/indexes.ts
@@ -6,7 +6,7 @@
  * pays for it.
  */
 
-import { extensionFilter, type IntrospectOptions, type QueryExecutor } from './introspect';
+import { extensionFilter, type GrantInfo, type IntrospectOptions, type QueryExecutor } from './introspect';
 
 export interface IndexInfo {
   name: string;
@@ -211,6 +211,137 @@ export async function introspectIndexes(
   }));
 }
 
+/** A view (or materialized view) with everything an access check needs. */
+export interface ViewSnapshot {
+  schema: string;
+  name: string;
+  /**
+   * The role a non-`security_invoker` view executes as. Postgres checks the
+   * base relations' ACLs and policies against *this* role, not the caller's.
+   */
+  owner: string;
+  /** `relkind = 'm'` — stored rows, so a query never touches the bases. */
+  materialized: boolean;
+  /**
+   * `reloptions.security_invoker`. When true the view executes as the caller
+   * and confers nothing; when false (the default) it executes as `owner`.
+   */
+  securityInvoker: boolean;
+  /** The owner is a superuser or has BYPASSRLS: the bases' policies never run. */
+  ownerBypassesRls: boolean;
+  /** ACL rows on the view itself, in the same shape as a table's. */
+  grants: GrantInfo[];
+  /** `pg_get_viewdef()` — the body, as SQL text. */
+  definition: string;
+}
+
+/**
+ * Every view and materialized view in scope, with its owner, its
+ * `security_invoker` setting and its own ACL.
+ *
+ * The definition alone answers "is this column read by anything" (see
+ * {@link classifyPaths}); the owner and `security_invoker` answer *whose*
+ * privileges the read runs under, which is what the view-ownership reach edge
+ * needs (L8).
+ */
+export async function introspectViews(
+  exec: QueryExecutor,
+  options: Pick<IntrospectOptions, 'schemas' | 'excludeSchemas'> = {}
+): Promise<ViewSnapshot[]> {
+  const excludes = [...DEFAULT_EXCLUDES, ...(options.excludeSchemas ?? [])];
+  const schemaFilter = options.schemas && options.schemas.length > 0
+    ? `AND n.nspname = ANY($1::text[])`
+    : `AND NOT (n.nspname = ANY($2::text[]))`;
+
+  const { rows } = await exec.query<{
+    schema_name: string;
+    view_name: string;
+    owner: string;
+    materialized: boolean;
+    security_invoker: boolean;
+    owner_bypasses_rls: boolean;
+    grants: Array<{ role: string; privilege: string; grantable: boolean; bypassRls: boolean }>;
+    definition: string;
+  }>(
+    // Both parameters are referenced (even when only one filters) so Postgres
+    // can infer their types — an unused $N errors out at bind time.
+    `WITH _params AS (
+       SELECT $1::text[] AS include_schemas, $2::text[] AS exclude_schemas
+     ),
+     views AS (
+       SELECT
+         n.nspname                                AS schema_name,
+         c.relname                                AS view_name,
+         c.oid                                    AS oid,
+         c.relkind = 'm'                          AS materialized,
+         pg_catalog.pg_get_userbyid(c.relowner)   AS owner,
+         COALESCE(o.rolsuper OR o.rolbypassrls, false) AS owner_bypasses_rls,
+         COALESCE(
+           (SELECT option_value FROM pg_options_to_table(c.reloptions)
+            WHERE option_name = 'security_invoker'),
+           'false'
+         ) = 'true'                               AS security_invoker,
+         c.relacl                                 AS relacl,
+         pg_get_viewdef(c.oid)                    AS definition
+       FROM pg_class c
+       JOIN pg_namespace n ON n.oid = c.relnamespace
+       LEFT JOIN pg_roles o ON o.oid = c.relowner
+       WHERE c.relkind IN ('v', 'm')
+         ${schemaFilter}
+     ),
+     grants AS (
+       SELECT
+         v.oid,
+         CASE WHEN a.grantee = 0 THEN 'PUBLIC' ELSE rol.rolname END AS grantee,
+         a.privilege_type,
+         a.is_grantable,
+         CASE
+           WHEN a.grantee = 0 THEN false
+           ELSE COALESCE(rol.rolsuper OR rol.rolbypassrls, false)
+         END AS bypass_rls
+       FROM views v, aclexplode(v.relacl) a
+       LEFT JOIN pg_roles rol ON rol.oid = a.grantee
+       WHERE v.relacl IS NOT NULL
+     )
+     SELECT
+       v.schema_name,
+       v.view_name,
+       v.owner,
+       v.materialized,
+       v.security_invoker,
+       v.owner_bypasses_rls,
+       v.definition,
+       COALESCE(
+         (SELECT jsonb_agg(jsonb_build_object(
+           'role', g.grantee,
+           'privilege', g.privilege_type,
+           'grantable', g.is_grantable,
+           'bypassRls', g.bypass_rls
+         )) FROM grants g WHERE g.oid = v.oid),
+         '[]'::jsonb
+       )                                          AS grants
+     FROM views v
+     ORDER BY v.schema_name, v.view_name`,
+    [options.schemas ?? [], excludes]
+  );
+
+  return rows.map((r) => ({
+    schema: r.schema_name,
+    name: r.view_name,
+    owner: r.owner,
+    materialized: r.materialized,
+    securityInvoker: r.security_invoker,
+    ownerBypassesRls: r.owner_bypasses_rls,
+    grants: r.grants.map((g) => ({
+      role: g.role,
+      privilege: g.privilege as GrantInfo['privilege'],
+      grantable: g.grantable,
+      bypassRls: g.bypassRls
+    })),
+    definition: r.definition
+  }));
+}
+
 /**
  * Every view and materialized-view body in scope, as SQL text.
  *
@@ -222,25 +353,7 @@ export async function introspectViewBodies(
   exec: QueryExecutor,
   options: Pick<IntrospectOptions, 'schemas' | 'excludeSchemas'> = {}
 ): Promise<string[]> {
-  const excludes = [...DEFAULT_EXCLUDES, ...(options.excludeSchemas ?? [])];
-  const schemaFilter = options.schemas && options.schemas.length > 0
-    ? `AND n.nspname = ANY($1::text[])`
-    : `AND NOT (n.nspname = ANY($2::text[]))`;
-
-  const { rows } = await exec.query<{ definition: string }>(
-    // Both parameters are referenced (even when only one filters) so Postgres
-    // can infer their types — an unused $N errors out at bind time.
-    `WITH _params AS (
-       SELECT $1::text[] AS include_schemas, $2::text[] AS exclude_schemas
-     )
-     SELECT pg_get_viewdef(c.oid) AS definition
-     FROM pg_class c
-     JOIN pg_namespace n ON n.oid = c.relnamespace
-     WHERE c.relkind IN ('v', 'm')
-       ${schemaFilter}`,
-    [options.schemas ?? [], excludes]
-  );
-  return rows.map((r) => r.definition);
+  return (await introspectViews(exec, options)).map((v) => v.definition);
 }
 
 /**

--- a/packages/safegres/src/rules/registry.ts
+++ b/packages/safegres/src/rules/registry.ts
@@ -212,6 +212,25 @@ export const RULES: RuleMeta[] = [
     scope: 'table'
   },
   {
+    code: 'L8',
+    category: 'anti-pattern',
+    // Ships `info` (signal-only, zero score weight) because the rule is new
+    // and, uniquely among the L rules, reads SQL bodies rather than pure
+    // catalog. The fact is not informational: a definer view handing an
+    // anonymous role a table it holds no grant on is A2/L5 laundered through
+    // a view, and it is `medium` on its own merits — `high` when the base
+    // table has RLS the view owner is exempt from (`context.rlsBypassed`),
+    // because then the view also deletes the row filter. Escalate via
+    // config/preset once the finding proves itself in the field.
+    defaultSeverity: 'info',
+    direction: 'fail-open',
+    title: 'DEFINER view bypass — an untrusted role reads a base relation as the view owner (options: { roles: [...] })',
+    // Reported against the base relation, and gated on `skipAstChecks` in the
+    // audit rather than on `policy-ast`: the body it parses is a view's, not a
+    // policy's, so turning the `P*` rules off does not turn this one off.
+    scope: 'table'
+  },
+  {
     code: 'W1',
     category: 'meta',
     defaultSeverity: 'medium',


### PR DESCRIPTION
## Summary

**L8 — DEFINER-view bypass**, the first safegres rule whose evidence is a SQL body rather than the catalog, and the first `proof: 'ast'` edge in the reach model landed by #1605.

A view that is not `security_invoker` executes as its **owner**. A role holding nothing but `SELECT` on the view therefore reads the view's base relations under the owner's privileges — tables no ACL row names it on, and, when the owner owns the table (and FORCE is off) or holds `BYPASSRLS`, without the row filter the table's policies would have applied. `effectiveGrants` cannot see this: it never names the calling role on the base relation, and the base relation's ACL never names it either. The edge exists only inside the view definition.

Modelled as an edge in the existing `RoleReach`, not a parallel mechanism:

```ts
export type RoleReachEdge =
  | { kind: 'grant'; via: GrantVia; privilege: PgPrivilege }
  | { kind: 'setrole'; to: string }
+ | { kind: 'view'; view: string; owner: string };

// checks/role-reach.ts
computeViewReach(views, graph, roles) -> RoleReach[]
//   cell = { schema, table, privileges: ['SELECT'],
//            effectiveRole: <owner of the last hop>,
//            path: [grant on the view, ...view hops],
//            proof: 'ast' }
```

A cell for `anon` on `app.orders` reached through `app.order_totals` owned by `app_owner` reads:

```ts
{ effectiveRole: 'app_owner', proof: 'ast',
  path: [{ kind: 'grant', via: 'direct', privilege: 'SELECT' },
         { kind: 'view', view: 'app.order_totals', owner: 'app_owner' }] }
```

`checks/definer-view.ts` supplies the inputs and the finding:

- `introspectViews` (extends `pg/indexes.ts`; `introspectViewBodies` is kept as a one-line wrapper over it) adds the facts the body cannot carry: `owner`, `securityInvoker`, `ownerBypassesRls`, `materialized`, the view's own `grants`, and `pg_get_viewdef`.
- `analyzeViewBodies` parses each body with safegres's own extractor. `extract.ts`'s private `extractFromSql` is exported as `extractQuery(sql)` — a view body is the same question asked of a different object — and the plpgsql path now calls it, so there is one extractor, not two.
- Nested views are followed, re-owning the read at each hop: an inner **definer** view switches the executing role again, an inner **invoker** view leaves the outer owner in force. Each resolved relation carries its hop list, so the effective role is the owner of the last hop, not the first.
- `effectiveGrants(table, ...)` is widened to `Pick<TableSnapshot, 'grants'>` so a view's own ACL composes through the same PUBLIC/inheritance closure. No behavior change.
- The finding fires per `(role, view, base relation)` only when the role has no SELECT of its own on the base relation — a view over a table the role can already read launders nothing.

**Three refusals to guess**, per the hard constraint:

- an unread body is *unknown*, not empty: dynamic SQL, an unparseable definition, or a chain deeper than 8 hops suppresses the view entirely (`ViewBodyAnalysis.suppressed` records why) rather than emitting a partial base-relation set;
- a reference that cannot be pinned to exactly one relation resolves to nothing, never to a plausible candidate;
- **the remedy is never a revoke.** The `SELECT` on the view is what the API serves; the defect is the view executing as its owner. The hint says `security_invoker = true` or a different owner, and says explicitly not to revoke. Materialized views are leaves (stored rows touch no base relation), and only SELECT is modelled — an auto-updatable view can carry writes the same way, but proving *which* write reaches *which* base relation needs more than the body's relation set.

### Severity

Shipping `info` / score-neutral, and that is a posture, not the verdict. On its own merits this is **medium**, and **high** when `context.rlsBypassed` is true — a definer view handing an anonymous role a table it holds no grant on is A2/L5 laundered through a view, and when the owner is exempt from the base table's policies the view also deletes the row filter. It ships weightless because the rule is new and is the first to derive a finding from a parsed body; escalate via config/preset once it is calibrated in the field. Score and fingerprint tests are unchanged and pass.

### Corpus

- `25-definer-view-bypass` — anonymous role reads a FORCEd-RLS table through a definer view; expects `L8 @ c_definer_view_bypass.orders`, scores 100 (weightless), worst severity `info`.
- `26-invoker-view-no-bypass` — **the negative**, the same shape with `WITH (security_invoker = true)`; `forbid: ["L8", "L5", "A2"]`. `forbid` is code-scoped, so the control needs its own case to mean anything: an L8 anywhere in it fails the corpus.

### Files flagged for the coordinating session

- `src/commands/audit.ts` — additive: one import, `introspectViews` replacing the `introspectViewBodies` call that already existed (its result feeds the perf paths unchanged, `.map(v => v.definition)`), and one gated dispatch block. Gated on `skipAst` and on L8 having untrusted roles, so nothing is introspected or parsed when the rule is off.
- `src/index.ts` — additive: exports for `analyzeViewBodies` / `checkDefinerViewBypass` / `introspectViews` and their types.
- `src/checks/lattice.ts` — one parameter type widened (`TableSnapshot` -> `Pick<TableSnapshot, 'grants'>`), no logic touched.
- `src/rules/registry.ts` — L8 has `scope: 'table'`, not `'policy-ast'`: the body it parses is a view's, not a policy's, so turning the `P*` rules off must not turn it off. It is gated on `skipAstChecks` in the audit instead.

Based on `origin/main` at 52079c65f (#1605 merged). `pnpm build`, `pnpm lint`, `pnpm test` (335 tests) all pass in `packages/safegres`.

### One interaction worth reconciling (not fixed here)

In case 25, **L4** reports that `corpus_anon` has dead `USAGE` on the schema and can have it revoked — while L8 reports, on the same run, that the role reads a table through a view *in that schema*. L4 counts only tables, so a role whose sole reachable relation is a view looks like it reaches nothing. That is a pre-existing L4 gap rather than an L8 regression, but it is a recommend-a-revoke on a load-bearing grant, so it belongs to whoever owns the lattice next; fixing it here would mean changing `checkDeadSchemaUsage`'s signature in code another session is working in.


Link to Devin session: https://app.devin.ai/sessions/f340c08768814b278a179aea7994f924
Requested by: @pyramation