### PR TITLE
fix(safegres): L4 counts views, so a view-only read path is not dead schema USAGE

### DIFF
--- a/packages/safegres/__tests__/lattice.test.ts
+++ b/packages/safegres/__tests__/lattice.test.ts
@@ -230,6 +230,15 @@ describe('L4 checkDeadSchemaUsage', () => {
     const t = table({ grants: [grant('PUBLIC', 'SELECT')] });
     expect(checkDeadSchemaUsage([aclRel], [t], BASE_GRAPH)).toEqual([]);
   });
+
+  it('counts a view: USAGE is load-bearing when a view is all the role reaches', () => {
+    const acl = schemaAcl({ grants: [{ role: 'anonymous', privilege: 'USAGE' }] });
+    const view = { schema: 'app', grants: [grant('anonymous', 'SELECT')] };
+    expect(checkDeadSchemaUsage([acl], [table()], BASE_GRAPH, [view])).toEqual([]);
+    // A view in another schema says nothing about this one.
+    const elsewhere = { schema: 'other', grants: [grant('anonymous', 'SELECT')] };
+    expect(checkDeadSchemaUsage([acl], [table()], BASE_GRAPH, [elsewhere])).toHaveLength(1);
+  });
 });
 
 describe('L5 checkUntrustedIndirectAccess', () => {

--- a/packages/safegres/corpus/cases/25-definer-view-bypass/case.json
+++ b/packages/safegres/corpus/cases/25-definer-view-bypass/case.json
@@ -22,7 +22,8 @@
   ],
   "forbid": [
     "A2",
-    "R1"
+    "R1",
+    "L4"
   ],
   "worstSeverity": "info",
   "fix": "Recreate c_definer_view_bypass.order_totals WITH (security_invoker = true) so the caller's own grants and policies apply, or give it an owner whose reach matches what the view is meant to expose. Revoking corpus_anon's SELECT on the view is not the fix — that grant is what the API serves.",

--- a/packages/safegres/docs/rules.md
+++ b/packages/safegres/docs/rules.md
@@ -29,7 +29,10 @@ cell each `(relation, role, privilege)` triple lands in:
 | no | — | yes | dead policy (L2) |
 
 plus schema composition: an object grant is unreachable without `USAGE` on its schema (L3), and
-`USAGE` that reaches no relation and no function is dead surface (L4).
+`USAGE` that reaches no relation and no function is dead surface (L4). Views count as relations
+for L4: a role whose only reachable object is a view holds `USAGE` the API depends on — and by L8
+that view may be its entire read path — so counting tables alone would recommend revoking a
+load-bearing grant.
 
 L6 composes the lattice with [API reach](../README.md#api-reach--the-relations-the-api-can-actually-name):
 an API-edge role holding privileges on a relation the generated API cannot address. It is not a

--- a/packages/safegres/src/checks/lattice.ts
+++ b/packages/safegres/src/checks/lattice.ts
@@ -23,7 +23,7 @@
  */
 
 import type { RoleAttributes, SchemaAclInfo } from '../pg/acl';
-import type { PgPrivilege, PolicyInfo, TableSnapshot } from '../pg/introspect';
+import type { GrantInfo, PgPrivilege, PolicyInfo, TableSnapshot } from '../pg/introspect';
 import type { Finding } from '../types';
 import { CLAUSE_REQUIRED, POLICY_CMDS } from './coverage';
 
@@ -273,15 +273,26 @@ export function checkUnreachableGrants(
  * relation (directly, via PUBLIC, or by inheritance) and can EXECUTE no
  * function in the schema. Advisory only: sequences, types and future objects
  * are not modeled, so this is a review candidate, not a proof.
+ *
+ * `views` matters more than its optionality suggests: a role whose only
+ * reachable object in the schema is a view holds USAGE that is load-bearing,
+ * and L8 exists precisely because that view can be the role's entire read
+ * path. Called without them, L4 sees a table-only schema and reports a grant
+ * the API depends on as revokable — so pass them wherever they are available.
  */
 export function checkDeadSchemaUsage(
   schemaAcls: SchemaAclInfo[],
   tables: TableSnapshot[],
-  graph: RoleGraph
+  graph: RoleGraph,
+  views: Array<{ schema: string; grants: GrantInfo[] }> = []
 ): Finding[] {
   const tablesBySchema = new Map<string, TableSnapshot[]>();
   for (const t of tables) {
     tablesBySchema.set(t.schema, [...(tablesBySchema.get(t.schema) ?? []), t]);
+  }
+  const viewsBySchema = new Map<string, Array<{ grants: GrantInfo[] }>>();
+  for (const v of views) {
+    viewsBySchema.set(v.schema, [...(viewsBySchema.get(v.schema) ?? []), v]);
   }
 
   const out: Finding[] = [];
@@ -295,8 +306,8 @@ export function checkDeadSchemaUsage(
       if (!attrs || attrs.isSuper) continue;
       if (g.role === acl.owner) continue;
 
-      const reachesRelation = schemaTables.some(
-        (t) => effectiveGrants(t, g.role, graph).length > 0
+      const reachesRelation = [...schemaTables, ...(viewsBySchema.get(acl.schema) ?? [])].some(
+        (r) => effectiveGrants(r, g.role, graph).length > 0
       );
       if (reachesRelation) continue;
 

--- a/packages/safegres/src/commands/audit.ts
+++ b/packages/safegres/src/commands/audit.ts
@@ -221,15 +221,18 @@ export async function audit(
     indexSnapshot.map((t) => [`${t.schema}.${t.name}`, t])
   );
 
-  // Views are read for two independent reasons: their bodies refute "nothing
-  // queries this column" for the perf paths, and their owners carry the L8
-  // reach edge. One introspection serves both.
+  // Views are read for three independent reasons: their bodies refute "nothing
+  // queries this column" for the perf paths, their owners carry the L8 reach
+  // edge, and their ACLs keep L4 from calling schema USAGE dead when a view is
+  // the only thing in the schema the role can reach. One introspection serves
+  // all three.
   const definerViewRoles = withExposedRoles(
     resolved.rules.get('L8')?.options as LatticeRoleOptions,
     exposure
   )?.roles ?? [];
   const needsViews =
     (perfEnabled && config.perf?.paths?.infer !== false)
+    || resolved.rules.get('L4')?.enabled !== false
     || (!skipAst && definerViewRoles.length > 0 && resolved.rules.get('L8')?.enabled !== false);
   const viewSnapshot = needsViews
     ? await introspectViews(exec, {
@@ -324,7 +327,7 @@ export async function audit(
     }
   }
 
-  findings.push(...checkDeadSchemaUsage(schemaAcls, snapshot, roleGraph));
+  findings.push(...checkDeadSchemaUsage(schemaAcls, snapshot, roleGraph, viewSnapshot));
 
   // L8 is per-view, not per-table: a view body names its own base relations.
   if (!skipAst && definerViewRoles.length > 0 && resolved.rules.get('L8')?.enabled !== false) {


### PR DESCRIPTION
## Summary

Reconciles the L4/L8 interaction surfaced by #1606: on corpus case `25-definer-view-bypass`, L8 reported that `corpus_anon` reads a table through a view in a schema while **L4 reported, on the same run, that the role's `USAGE` on that schema is dead and revokable**. `checkDeadSchemaUsage` counted only `TableSnapshot`s, so a role whose only reachable object in a schema is a view looked like it reached nothing — a recommend-a-revoke on a grant the API is actively serving through, which is exactly what the lattice is not allowed to do.

```diff
 export function checkDeadSchemaUsage(
   schemaAcls: SchemaAclInfo[],
   tables: TableSnapshot[],
-  graph: RoleGraph
+  graph: RoleGraph,
+  views: Array<{ schema: string; grants: GrantInfo[] }> = []
 ): Finding[]

-  const reachesRelation = schemaTables.some((t) => effectiveGrants(t, g.role, graph).length > 0);
+  const reachesRelation = [...schemaTables, ...(viewsBySchema.get(acl.schema) ?? [])]
+    .some((r) => effectiveGrants(r, g.role, graph).length > 0);
```

The parameter is optional so existing callers keep compiling, but the audit always passes it: `needsViews` now includes L4, so the single `introspectViews` call added by #1606 (already shared by the perf paths and L8) also feeds L4. The view ACL composes through the same PUBLIC/inheritance closure as a table's — `effectiveGrants` was widened to `Pick<TableSnapshot, 'grants'>` in #1606, so no new closure logic.

Pinned negatively where it was found: corpus case 25 now carries `"L4"` in `forbid`, so the false positive cannot come back silently. Unit test covers both directions (a view in the schema clears L4; a view in another schema does not).

`pnpm build`, `pnpm lint`, `pnpm test` (336) pass in `packages/safegres`.


Link to Devin session: https://app.devin.ai/sessions/f340c08768814b278a179aea7994f924
Requested by: @pyramation