### PR TITLE
fix(safegres): read security_invoker as a boolean, not the string 'true'

### DIFF
--- a/packages/safegres/__tests__/view-introspect.test.ts
+++ b/packages/safegres/__tests__/view-introspect.test.ts
@@ -1,0 +1,47 @@
+import { getConnections, PgTestClient } from 'pgsql-test';
+
+import { introspectViews } from '../src/pg/indexes';
+
+jest.setTimeout(120000);
+
+let pg: PgTestClient;
+let teardown: () => Promise<void>;
+
+beforeAll(async () => {
+  ({ pg, teardown } = await getConnections());
+  // `security_invoker` is a boolean reloption, so every spelling Postgres
+  // accepts for a boolean is legal here and is stored verbatim in reloptions.
+  await pg.any(`
+    CREATE SCHEMA fx_viewopt;
+    CREATE TABLE fx_viewopt.t (id int);
+    CREATE VIEW fx_viewopt.v_true  WITH (security_invoker = true)   AS SELECT id FROM fx_viewopt.t;
+    CREATE VIEW fx_viewopt.v_quoted WITH (security_invoker = 'true') AS SELECT id FROM fx_viewopt.t;
+    CREATE VIEW fx_viewopt.v_on    WITH (security_invoker = on)     AS SELECT id FROM fx_viewopt.t;
+    CREATE VIEW fx_viewopt.v_one   WITH (security_invoker = 1)      AS SELECT id FROM fx_viewopt.t;
+    CREATE VIEW fx_viewopt.v_yes   WITH (security_invoker = 'yes')  AS SELECT id FROM fx_viewopt.t;
+    CREATE VIEW fx_viewopt.v_bare  WITH (security_invoker)          AS SELECT id FROM fx_viewopt.t;
+    CREATE VIEW fx_viewopt.v_off   WITH (security_invoker = off)    AS SELECT id FROM fx_viewopt.t;
+    CREATE VIEW fx_viewopt.v_none                                   AS SELECT id FROM fx_viewopt.t;
+  `);
+});
+
+afterAll(async () => {
+  if (teardown) await teardown();
+});
+
+describe('introspectViews — security_invoker spellings', () => {
+  it('reads every boolean spelling, not just the literal string "true"', async () => {
+    const views = await introspectViews(pg.client as never, { schemas: ['fx_viewopt'] });
+    const invoker = Object.fromEntries(views.map((v) => [v.name, v.securityInvoker]));
+    expect(invoker).toEqual({
+      v_true: true,
+      v_quoted: true,
+      v_on: true,
+      v_one: true,
+      v_yes: true,
+      v_bare: true,
+      v_off: false,
+      v_none: false
+    });
+  });
+});

--- a/packages/safegres/corpus/cases/26-invoker-view-no-bypass/schema.sql
+++ b/packages/safegres/corpus/cases/26-invoker-view-no-bypass/schema.sql
@@ -32,3 +32,13 @@ CREATE VIEW c_invoker_view_no_bypass.order_totals
   SELECT id, customer, total FROM c_invoker_view_no_bypass.orders;
 ALTER VIEW c_invoker_view_no_bypass.order_totals OWNER TO c_invoker_view_owner;
 GRANT SELECT ON c_invoker_view_no_bypass.order_totals TO corpus_anon;
+
+-- `security_invoker` is a boolean reloption, and Postgres stores whichever
+-- spelling was written: `on` here is exactly as invoker as `true` above. A
+-- reader that string-matches 'true' calls this view a definer view and tells
+-- the author to fix a schema that is already correct.
+CREATE VIEW c_invoker_view_no_bypass.order_totals_on
+  WITH (security_invoker = on) AS
+  SELECT id, customer, total FROM c_invoker_view_no_bypass.orders;
+ALTER VIEW c_invoker_view_no_bypass.order_totals_on OWNER TO c_invoker_view_owner;
+GRANT SELECT ON c_invoker_view_no_bypass.order_totals_on TO corpus_anon;

--- a/packages/safegres/src/pg/indexes.ts
+++ b/packages/safegres/src/pg/indexes.ts
@@ -276,11 +276,15 @@ export async function introspectViews(
          c.relkind = 'm'                          AS materialized,
          pg_catalog.pg_get_userbyid(c.relowner)   AS owner,
          COALESCE(o.rolsuper OR o.rolbypassrls, false) AS owner_bypasses_rls,
+         -- Postgres stores a boolean reloption verbatim, so this is any of
+         -- true/on/1/yes/t/y depending on how the view was written; the cast
+         -- accepts every spelling the option itself accepts, and reloption
+         -- validation at CREATE time guarantees it parses.
          COALESCE(
            (SELECT option_value FROM pg_options_to_table(c.reloptions)
             WHERE option_name = 'security_invoker'),
            'false'
-         ) = 'true'                               AS security_invoker,
+         )::boolean                               AS security_invoker,
          c.relacl                                 AS relacl,
          pg_get_viewdef(c.oid)                    AS definition
        FROM pg_class c


### PR DESCRIPTION
## Summary

`security_invoker` is a **boolean** reloption, and Postgres stores whichever spelling the author wrote. L8's introspection compared it to the literal string `'true'`, so every other legal spelling read as `false` — i.e. a correct, invoker view was reported as a DEFINER-view bypass and the author was told to "recreate it `WITH (security_invoker = true)`" on a view that already is one.

```sql
CREATE VIEW v WITH (security_invoker = on) ...  -- reloptions: {security_invoker=on}
-- before: option_value = 'true'  → false → L8 fires (false positive)
-- after:  option_value::boolean  → true  → silent
```

Verified against PG 18: `true`/`'true'`/bare `security_invoker` normalize to `true`, but `on`, `1`, `yes` (and `t`/`y`) are stored verbatim. The cast accepts exactly the set the reloption itself accepts, and reloption validation at `CREATE` time (`security_invoker=100` is rejected by Postgres) guarantees it parses.

Found by running L8 against real schemas: constructive-db writes `security_invoker = 'true'` (fine) in generated SQL, but hand-written SQL in that family uses the bare and `on` forms too, and a false positive that says "fix this correct view" is the worst failure mode for a new rule.

Corpus case 26 (the negative case) grows a second view spelled `security_invoker = on` so the `forbid: L8` there pins the regression; `__tests__/view-introspect.test.ts` asserts all eight spellings through `introspectViews` against a live database.

Scope: `src/pg/indexes.ts` only — no rule logic, no signature changes, nothing in `audit.ts` or `index.ts`.


Link to Devin session: https://app.devin.ai/sessions/f340c08768814b278a179aea7994f924
Requested by: @pyramation