### PR TITLE
refactor(pgpm/transform): import statement facts from @pgsql/semantics

### DIFF
--- a/packages/csv-to-pg/package.json
+++ b/packages/csv-to-pg/package.json
@@ -44,7 +44,7 @@
   ],
   "dependencies": {
     "@pgsql/types": "^18.0.0",
-    "@pgsql/utils": "^18.2.1",
+    "@pgsql/utils": "^18.2.2",
     "csv-parser": "^3.2.1",
     "inquirerer": "^4.9.1",
     "js-yaml": "^4.1.0",

--- a/packages/node-type-registry/package.json
+++ b/packages/node-type-registry/package.json
@@ -34,7 +34,7 @@
     "@babel/generator": "^7.29.0",
     "@babel/types": "^7.29.0",
     "@pgsql/types": "^18.0.0",
-    "@pgsql/utils": "^18.2.1",
+    "@pgsql/utils": "^18.2.2",
     "pgsql-deparser": "^18.3.1",
     "schema-typescript": "^0.14.3"
   },

--- a/pgpm/slice/src/refs.ts
+++ b/pgpm/slice/src/refs.ts
@@ -8,7 +8,7 @@ export { loadModule } from 'plpgsql-parser';
 
 /**
  * A (possibly schema-qualified) database object name extracted from SQL.
- * Alias of `@pgsql/transform`'s `QualifiedName` — one name type across the
+ * Alias of `@pgsql/semantics`'s `QualifiedName` — one name type across the
  * facts substrate and the slice layer.
  */
 export type SqlObjectRef = QualifiedName;
@@ -45,7 +45,7 @@ function pushUnique(list: SqlObjectRef[], r: SqlObjectRef): void {
  * including references reached inside PL/pgSQL function bodies (which are
  * opaque strings in `CREATE FUNCTION` and invisible to a plain SQL parse).
  *
- * A thin change-level adapter over `@pgsql/transform`: `classifyStatements`
+ * A thin change-level adapter over the facts layer: `classifyStatements`
  * produces the per-statement facts and `buildStatementGraph`'s producer index
  * decides which references are internal — a reference with an in-script
  * producer is satisfied by the change itself, so only external references

--- a/pgpm/transform/__tests__/sub-object.test.ts
+++ b/pgpm/transform/__tests__/sub-object.test.ts
@@ -1,4 +1,4 @@
-import { classifyStatements } from '@pgsql/transform';
+import { classifyStatements } from '@pgsql/semantics';
 import { loadModule } from 'plpgsql-parser';
 
 import { nameUnnamedConstraints, subObjectIdentityOf } from '../src/sub-object';

--- a/pgpm/transform/package.json
+++ b/pgpm/transform/package.json
@@ -45,8 +45,9 @@
   "dependencies": {
     "@pgpmjs/ast": "workspace:^",
     "@pgpmjs/naming-spec": "workspace:^",
-    "@pgsql/scripts": "^18.3.1",
-    "@pgsql/transform": "^18.14.1",
+    "@pgsql/scripts": "^18.3.2",
+    "@pgsql/semantics": "^18.1.0",
+    "@pgsql/transform": "^18.15.0",
     "plpgsql-parser": "^18.5.1"
   }
 }

--- a/pgpm/transform/src/bundle-driver.ts
+++ b/pgpm/transform/src/bundle-driver.ts
@@ -8,7 +8,7 @@
  * stays a pure function factory over `transformSql` and `classifyStatements`.
  */
 
-import { classifyStatements } from '@pgsql/transform';
+import { classifyStatements } from '@pgsql/semantics';
 import {
   createExtensionResult,
   createRoleResult,

--- a/pgpm/transform/src/categorize.ts
+++ b/pgpm/transform/src/categorize.ts
@@ -1,4 +1,4 @@
-import { classifyStatements, StatementFacts } from '@pgsql/transform';
+import { classifyStatements, StatementFacts } from '@pgsql/semantics';
 
 /**
  * A category is a chunk-seam key a change is assigned to. Free-form string; the

--- a/pgpm/transform/src/fixture-closure.ts
+++ b/pgpm/transform/src/fixture-closure.ts
@@ -1,4 +1,4 @@
-import { classifyStatements, QualifiedName, StatementFacts } from '@pgsql/transform';
+import { classifyStatements, QualifiedName, StatementFacts } from '@pgsql/semantics';
 
 import {
   CategoryProfile,

--- a/pgpm/transform/src/granularity-driver.ts
+++ b/pgpm/transform/src/granularity-driver.ts
@@ -20,10 +20,11 @@
 import type { ObjectIdentity as NamingIdentity } from '@pgpmjs/naming-spec';
 import { pathFor } from '@pgpmjs/naming-spec';
 import { revertFor, verifyFor } from '@pgsql/scripts';
-import type { Granularity, StatementFacts } from '@pgsql/transform';
+import type { StatementFacts } from '@pgsql/semantics';
+import { classifyStatements } from '@pgsql/semantics';
+import type { Granularity } from '@pgsql/transform';
 import {
   buildStatementGraph,
-  classifyStatements,
   identityOf,
   restructureSql
 } from '@pgsql/transform';

--- a/pgpm/transform/src/partition-driver.ts
+++ b/pgpm/transform/src/partition-driver.ts
@@ -1,7 +1,7 @@
 /**
  * Partition dial: project one deploy surface into a set of pgpm packages.
  *
- * The object graph (statements classified by `@pgsql/transform`, grouped
+ * The object graph (statements classified by `@pgsql/semantics`, grouped
  * into identity-keyed units) is the source of truth; which package a unit
  * lives in is a *derived projection* of a declarative partition config.
  * Units can be assigned by schema, by object kind, by explicit cherry-pick
@@ -21,14 +21,12 @@
  * pgpm.plan + deploy trees, feed a bundle, ...).
  */
 import { pathFor, PathStyle } from '@pgpmjs/naming-spec';
+import { classifyStatements, StatementFacts, StatementKind } from '@pgsql/semantics';
 import {
   buildStatementGraph,
-  classifyStatements,
   identityOf,
   ObjectIdentity,
-  ObjectIdentityKind,
-  StatementFacts,
-  StatementKind
+  ObjectIdentityKind
 } from '@pgsql/transform';
 
 /** One deployable unit: an object (by identity) and the statements that build it. */

--- a/pgpm/transform/src/program.ts
+++ b/pgpm/transform/src/program.ts
@@ -9,8 +9,8 @@
  * untouched statements). A program with no dirty statements emits its source
  * byte-identically, so content-addressed hashes are preserved.
  */
-import type { StatementFacts } from '@pgsql/transform';
-import { classifyStatements } from '@pgsql/transform';
+import type { StatementFacts } from '@pgsql/semantics';
+import { classifyStatements } from '@pgsql/semantics';
 import { Deparser, parseSql } from 'plpgsql-parser';
 
 /** A statement's location in the source script (byte offsets). */

--- a/pgpm/transform/src/regen.ts
+++ b/pgpm/transform/src/regen.ts
@@ -13,8 +13,8 @@
  */
 import type { GeneratedScript } from '@pgsql/scripts';
 import { revertFor, verifyFor } from '@pgsql/scripts';
-import type { StatementFacts } from '@pgsql/transform';
-import { classifyStatements } from '@pgsql/transform';
+import type { StatementFacts } from '@pgsql/semantics';
+import { classifyStatements } from '@pgsql/semantics';
 
 export type { GeneratedScript } from '@pgsql/scripts';
 

--- a/pgpm/transform/src/restructure.ts
+++ b/pgpm/transform/src/restructure.ts
@@ -7,7 +7,8 @@
  */
 import { PgpmRow } from '@pgpmjs/ast';
 import { alterationPathFor, pathFor, PathStyle } from '@pgpmjs/naming-spec';
-import { Granularity, identityOf, StatementFacts } from '@pgsql/transform';
+import { StatementFacts } from '@pgsql/semantics';
+import { Granularity, identityOf } from '@pgsql/transform';
 import { loadModule } from 'plpgsql-parser';
 
 import { ChangeGranularity, restructureChanges } from './granularity-driver';

--- a/pgpm/transform/src/semantic-diff-driver.ts
+++ b/pgpm/transform/src/semantic-diff-driver.ts
@@ -28,10 +28,11 @@
  */
 import { pathFor, PathStyle } from '@pgpmjs/naming-spec';
 import { existenceCheck, invertStatement, revertFor, verifyFor } from '@pgsql/scripts';
-import type { ObjectIdentity, StatementFacts } from '@pgsql/transform';
+import type { StatementFacts } from '@pgsql/semantics';
+import { classifyStatements } from '@pgsql/semantics';
+import type { ObjectIdentity } from '@pgsql/transform';
 import {
   buildStatementGraph,
-  classifyStatements,
   cleanTree,
   Granularity,
   identityOf

--- a/pgpm/transform/src/sub-object.ts
+++ b/pgpm/transform/src/sub-object.ts
@@ -10,7 +10,7 @@
  * every alteration.
  */
 import type { ObjectIdentity } from '@pgpmjs/naming-spec';
-import type { StatementFacts } from '@pgsql/transform';
+import type { StatementFacts } from '@pgsql/semantics';
 import { Deparser, parseSync } from 'plpgsql-parser';
 
 import { ConstraintNode, defaultConstraintName } from './constraint-names';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2469,8 +2469,8 @@ importers:
         specifier: ^18.0.0
         version: 18.0.0
       '@pgsql/utils':
-        specifier: ^18.2.1
-        version: 18.2.1
+        specifier: ^18.2.2
+        version: 18.2.2
       csv-parser:
         specifier: ^3.2.1
         version: 3.2.1
@@ -2571,8 +2571,8 @@ importers:
         specifier: ^18.0.0
         version: 18.0.0
       '@pgsql/utils':
-        specifier: ^18.2.1
-        version: 18.2.1
+        specifier: ^18.2.2
+        version: 18.2.2
       pgsql-deparser:
         specifier: ^18.3.1
         version: 18.3.1
@@ -3162,11 +3162,14 @@ importers:
         specifier: workspace:^
         version: link:../naming-spec/dist
       '@pgsql/scripts':
-        specifier: ^18.3.1
-        version: 18.3.1
+        specifier: ^18.3.2
+        version: 18.3.2
+      '@pgsql/semantics':
+        specifier: ^18.1.0
+        version: 18.1.0
       '@pgsql/transform':
-        specifier: ^18.14.1
-        version: 18.14.1
+        specifier: ^18.15.0
+        version: 18.15.0
       plpgsql-parser:
         specifier: ^18.5.1
         version: 18.5.1
@@ -6519,16 +6522,22 @@ packages:
         integrity: sha512-iAbNljBqhOu1zwcCGrZlS+5asih64d5QZwle6fVOVK6KqPYP6byw59xa8+tSGH/wj+PWrA0GzMB1ak6OWzEcBA==,
       }
 
-  '@pgsql/scripts@18.3.1':
+  '@pgsql/scripts@18.3.2':
     resolution:
       {
-        integrity: sha512-Nk7GTySEc2cgHc8tGSjMq37W56l/YnHENRE6kZDcIFbRQ3Yc1/km4ytHZdGPvhwRWfNbdXMeslgZkW3zWsCsYw==,
+        integrity: sha512-qZMcAk4jDBixiPjYH0+sxiXGcrpm9YI33RedAQELYGRa1idI9vqVevQ89x8TKmR3Qgegw9mMjyMAt3jLFLzEQQ==,
       }
 
-  '@pgsql/transform@18.14.1':
+  '@pgsql/semantics@18.1.0':
     resolution:
       {
-        integrity: sha512-jqzJjKRLyoW/orD/78Qa+nXpZhxZ1vY9meDLEimbv75cuD4cyNOBABybrQD7FRewpdgbEUJ3affAlcuRCuTmDg==,
+        integrity: sha512-7QewtC6GgnSy8lLWeZUfKfurz7V3YdVWgKPkwlFOiSaDoinwVbmyfZxyK1qtTE8//wUW1gVoybc0ARNnBMyH8w==,
+      }
+
+  '@pgsql/transform@18.15.0':
+    resolution:
+      {
+        integrity: sha512-JSdPCUPuRWQ/gE1qyZtQHv2MGXf0Yz97d/4qoTuSemIHnXruKH4VPIBFElfbZqHAGTnBDu43s6Av+1SeMkgWGQ==,
       }
 
   '@pgsql/traverse@18.7.1':
@@ -6543,10 +6552,10 @@ packages:
         integrity: sha512-jtAY4JU7jdVYZ/Vv3zlZqVP+FRWZokyCLKPPCnAApiaJAElpyyiMC3HRiquBu29kSrVs+rkqZD50SUIb/zyEGw==,
       }
 
-  '@pgsql/utils@18.2.1':
+  '@pgsql/utils@18.2.2':
     resolution:
       {
-        integrity: sha512-iwCN06r7zTY0frrr5O9jgIbsfnmaXlGiwqk47B8GCCyeHtcJlYqVGPF9t8efBmhqgDaJieaeNsLyRLnnpLbkbg==,
+        integrity: sha512-nZkLQfrYBDTzqczP9y3+XKYODe7Cs/Kk0/qoaftz/ikb17Oa0HVd91wVnfYFbvWElzUNnauslR3V52VAhH20tg==,
       }
 
   '@pkgjs/parseargs@0.11.0':
@@ -17834,17 +17843,25 @@ snapshots:
 
   '@pgsql/quotes@18.2.0': {}
 
-  '@pgsql/scripts@18.3.1':
+  '@pgsql/scripts@18.3.2':
     dependencies:
       '@pgsql/quotes': 18.2.0
-      '@pgsql/transform': 18.14.1
+      '@pgsql/transform': 18.15.0
       plpgsql-parser: 18.5.1
     transitivePeerDependencies:
       - supports-color
 
-  '@pgsql/transform@18.14.1':
+  '@pgsql/semantics@18.1.0':
+    dependencies:
+      '@pgsql/traverse': 18.7.1
+      plpgsql-parser: 18.5.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@pgsql/transform@18.15.0':
     dependencies:
       '@pgsql/quotes': 18.2.0
+      '@pgsql/semantics': 18.1.0
       '@pgsql/traverse': 18.7.1
       plpgsql-parser: 18.5.1
     transitivePeerDependencies:
@@ -17860,7 +17877,7 @@ snapshots:
 
   '@pgsql/types@18.0.0': {}
 
-  '@pgsql/utils@18.2.1':
+  '@pgsql/utils@18.2.2':
     dependencies:
       '@pgsql/types': 18.0.0
       nested-obj: 0.2.2


### PR DESCRIPTION
## Summary

`@pgsql/transform@18.15.0` moved its statement-classification layer out into the new `@pgsql/semantics@18.1.0` and now just re-exports it:

```ts
// @pgsql/transform/facts.ts (18.15.0)
export * from '@pgsql/semantics';
```

So `@pgpmjs/transform` was reaching the facts layer through a compatibility shim. This points those imports at the owning package and splits the mixed import sites along the new package seam — facts (`classifyStatements`, `StatementFacts`, `StatementKind`, `QualifiedName`) from `@pgsql/semantics`, transformation (`identityOf`, `buildStatementGraph`, `restructureSql`, `cleanTree`, `Granularity`, `ObjectIdentity`, the routers) still from `@pgsql/transform`:

```diff
-import type { ObjectIdentity, StatementFacts } from '@pgsql/transform';
-import { buildStatementGraph, classifyStatements, cleanTree, Granularity, identityOf } from '@pgsql/transform';
+import type { StatementFacts } from '@pgsql/semantics';
+import { classifyStatements } from '@pgsql/semantics';
+import type { ObjectIdentity } from '@pgsql/transform';
+import { buildStatementGraph, cleanTree, Granularity, identityOf } from '@pgsql/transform';
```

Behavior is identical — same code, same symbols, now imported from where they live.

`index.ts` keeps its single `export * from '@pgsql/transform'` (which still re-exports the facts symbols transitively), so downstream in-repo consumers of `@pgpmjs/transform` — `pgpm/import`, `pgpm/slice` — are unchanged.

Dependency versions come from `makage update-deps --from ../pgsql-parser`, which flagged four outdated pins: `@pgsql/transform` 18.14.1 → ^18.15.0 and `@pgsql/scripts` ^18.3.2 in `@pgpmjs/transform` (plus the new `@pgsql/semantics` ^18.1.0), and `@pgsql/utils` ^18.2.1 → ^18.2.2 in `csv-to-pg` and `node-type-registry`.

Verified: `pgpm/transform` build + lint + 107 tests, and build/test on the consumers `pgpm/slice` (59), `csv-to-pg`, `node-type-registry`.


Link to Devin session: https://app.devin.ai/sessions/f340c08768814b278a179aea7994f924
Requested by: @pyramation