### PR TITLE
chore(fixtures): bump @constructive-db/* plane packages to 4.4.0 / routing 5.4.0

### DIFF
--- a/pgpm.json
+++ b/pgpm.json
@@ -3,10 +3,10 @@
     "testing/*"
   ],
   "dependencies": {
-    "@constructive-db/apps": "4.2.0",
-    "@constructive-db/catalog": "4.2.0",
-    "@constructive-db/routing": "5.2.0",
-    "@constructive-db/routing-platform": "4.2.0",
+    "@constructive-db/apps": "4.4.0",
+    "@constructive-db/catalog": "4.4.0",
+    "@constructive-db/routing": "5.4.0",
+    "@constructive-db/routing-platform": "4.4.0",
     "@pgpm/database-jobs": "0.33.1",
     "@pgpm/function-resolution": "0.33.1",
     "@pgpm/jwt-claims": "0.33.0",


### PR DESCRIPTION
## Summary
Picks up the newly published constructive-db plane packages in the root `pgpm.json` fixture pins:

```diff
-"@constructive-db/apps": "4.2.0",            +"4.4.0"
-"@constructive-db/catalog": "4.2.0",         +"4.4.0"
-"@constructive-db/routing": "5.2.0",         +"5.4.0"
-"@constructive-db/routing-platform": "4.2.0",+"4.4.0"
```

These are the modules `pnpm fixtures:install` pulls into `extensions/` for the server-test integration suites. Verified by reinstalling the fixtures at the new versions and running `graphql/server-test/__tests__/scoped-routing.integration.test.ts` (7/7 pass, both the SQL-level `resolve_route` cases and the GraphQL e2e path).

Link to Devin session: https://app.devin.ai/sessions/d4c550e515bb48e9a384b67d3fefb574
Requested by: @pyramation