### PR TITLE
feat(safegres): eval — grade the auditor against a corpus with known answers

### DIFF
--- a/.agents/skills/safegres/SKILL.md
+++ b/.agents/skills/safegres/SKILL.md
@@ -26,6 +26,7 @@ Use this skill when asked to:
 - **Audit the function call graph** — what exposed functions transitively reach: SECURITY DEFINER hops, RLS-bypass paths, auth-context mutations, dynamic SQL (`safegres audit --call-graph`).
 - **Wire safegres into CI** (per-push audit, grade gate) or a pgpm test.
 - **Diagnose** the environment/config (`safegres doctor`, `safegres print-config`).
+- **Calibrate or evaluate** — run the corpus of known-answer cases against a scratch database (`safegres eval`), as a regression check or as the harness scoring an agent's fix.
 
 ## Quick Start
 
@@ -243,6 +244,8 @@ safegres audit --write-snapshot scoreboard.json               # aggregates only,
 safegres audit --format sarif --sarif-sources ./deploy       # GitHub code scanning (upload-sarif)
 safegres audit --exposed-only      # hide internal advisories
 safegres doctor                    # config/parser/connection/catalog + exposure + stale public.read checks
+safegres eval                      # grade the auditor itself against the shipped corpus
+safegres eval --case 01 --json     # one case, machine-readable (recall/precision/fingerprint)
 safegres print-config              # resolved effective config
 safegres print-config --explain    # per-key provenance (which layer set each value)
 ```

--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -424,6 +424,32 @@ corpus in [`corpus/`](corpus/README.md) is for: ~20 small schemas, each with one
 and a written-down answer — the findings a correct audit must produce, the false positives it must
 not, and the one-sentence fix.
 
+`safegres eval` is the whole loop in one command: it deploys each case into the connected
+database, audits it under a sealed preset, grades the report against the answer key, drops the
+case's schemas again, and exits non-zero if any case fails.
+
+```console
+$ safegres eval --database scratch
+  PASS  01-anon-write-grant              security 1.2 (F )  R1
+  PASS  17-foreign-key-without-index     perf    71.2 (C )  X1
+  FAIL  18-policy-column-unindexed       perf     100 (A+)  missed X2
+
+25/26 cases passed · recall 98% · precision 100%
+```
+
+| Flag | |
+| --- | --- |
+| `--preset <name>` | the preset every case is graded under (default `recommended`) |
+| `--corpus <dir>` | your own corpus of `<id>/{case.json,schema.sql}` |
+| `--case <id>` | run one case, or an id prefix — comma-separated |
+| `--list` | print the corpus without touching a database |
+| `--json` | the `EvalReport`: per-case recall, precision, score, fingerprint |
+| `--keep` | leave the case schemas behind, to poke at one by hand |
+
+A config file may set `eval.corpus`, `eval.preset` and `eval.cases` — *what* to run. It cannot
+retune the rules for a run: cases are always graded by the named preset alone, or the corpus would
+be grading itself. The same loop is a library call (`runEval`), and its pieces are public:
+
 ```ts
 import { audit, gradeCase, loadConfig, loadCorpus } from 'safegres';
 
@@ -560,6 +586,7 @@ score would move if that rule's findings went away. Gate with `--fail-on <severi
 safegres audit          # audit the connected database (default command)
 safegres perf           # audit + the performance dimension (= audit --perf)
 safegres doctor         # diagnose config, parser, connection, catalog visibility, exposure
+safegres eval           # grade the auditor against a corpus with known answers
 safegres print-config   # the resolved effective config (--explain for per-key provenance)
 ```
 

--- a/packages/safegres/__tests__/eval.test.ts
+++ b/packages/safegres/__tests__/eval.test.ts
@@ -1,0 +1,61 @@
+import { getConnections, PgTestClient } from 'pgsql-test';
+
+import { runEval } from '../src/commands/eval';
+import { loadConfig } from '../src/config/loader';
+import { loadCorpus } from '../src/corpus';
+
+jest.setTimeout(300000);
+
+let pg: PgTestClient;
+let teardown: () => Promise<void>;
+
+const { config } = loadConfig({ sealed: true, preset: 'recommended' });
+/** A security case and a perf case: enough to prove both axes are graded. */
+const CASES = ['01-anon-write-grant', '17-foreign-key-without-index'];
+
+beforeAll(async () => {
+  ({ pg, teardown } = await getConnections());
+});
+
+afterAll(async () => {
+  if (teardown) await teardown();
+});
+
+describe('runEval', () => {
+  it('grades the selected cases and leaves the database as it found it', async () => {
+    const report = await runEval(pg.client, { config, preset: 'recommended', cases: CASES });
+
+    expect(report.results.map((r) => r.id)).toEqual(CASES);
+    expect({ passed: report.passed, total: report.total }).toEqual({ passed: 2, total: 2 });
+    expect({ recall: report.recall, precision: report.precision }).toEqual({ recall: 1, precision: 1 });
+    expect(report.sealed).toBe(true);
+    expect(report.fingerprint).toMatch(/^sha256:[0-9a-f]{64}$/);
+    // Each case's flaw costs points on its own axis.
+    for (const r of report.results) expect(`${r.id}:${r.score < 100}`).toBe(`${r.id}:true`);
+
+    const schemas = loadCorpus()
+      .filter((c) => CASES.includes(c.id))
+      .flatMap((c) => c.exposure.schemas ?? []);
+    const { rows } = await pg.client.query(
+      'SELECT nspname FROM pg_namespace WHERE nspname = ANY($1)',
+      [schemas]
+    );
+    expect(rows).toEqual([]);
+  });
+
+  it('keeps the schemas when asked, and accepts an id prefix', async () => {
+    const report = await runEval(pg.client, { config, cases: ['01'], keep: true });
+    expect(report.results.map((r) => r.id)).toEqual(['01-anon-write-grant']);
+
+    const { rows } = await pg.client.query(
+      'SELECT nspname FROM pg_namespace WHERE nspname = $1',
+      ['c_anon_write_grant']
+    );
+    expect(rows).toHaveLength(1);
+    await pg.client.query('DROP SCHEMA c_anon_write_grant CASCADE');
+  });
+
+  it('refuses a selection that matches nothing', async () => {
+    await expect(runEval(pg.client, { config, cases: ['nope'] })).rejects.toThrow(/No corpus case/);
+  });
+});

--- a/packages/safegres/src/cli.ts
+++ b/packages/safegres/src/cli.ts
@@ -15,7 +15,19 @@ if (process.argv.includes('--version') || process.argv.includes('-v')) {
 const options: Partial<CLIOptions> = {
   minimistOpts: {
     alias: { v: 'version', h: 'help', q: 'summary' },
-    boolean: ['skip-ast', 'color', 'help', 'version', 'summary', 'verbose', 'call-graph', 'fail-on-new-boundaries'],
+    boolean: [
+      'skip-ast',
+      'color',
+      'help',
+      'version',
+      'summary',
+      'verbose',
+      'call-graph',
+      'fail-on-new-boundaries',
+      'keep',
+      'list',
+      'json'
+    ],
     string: [
       'baseline',
       'write-baseline',
@@ -33,7 +45,10 @@ const options: Partial<CLIOptions> = {
       'roles',
       'exclude-roles',
       'format',
-      'fail-on'
+      'fail-on',
+      'preset',
+      'corpus',
+      'case'
     ]
   }
 };

--- a/packages/safegres/src/cli/commands.ts
+++ b/packages/safegres/src/cli/commands.ts
@@ -3,6 +3,7 @@ import { CLIOptions, extractFirst, Inquirerer, ParsedArgs } from 'inquirerer';
 
 import audit from './audit';
 import doctor from './doctor';
+import evalCommand from './eval';
 import printConfig from './print-config';
 
 const log = new Logger('safegres');
@@ -17,6 +18,7 @@ Commands:
   audit           Audit grants, RLS flags, policy coverage, and anti-patterns
   perf            Audit index hygiene and policy cost (audit --perf)
   doctor          Diagnose environment, connection, and configuration
+  eval            Grade the auditor against a corpus with known answers
   print-config    Show the resolved effective configuration
   help            Show this help message
 
@@ -30,6 +32,7 @@ const commandMap: Record<
   audit,
   perf: (argv, prompter, options) => audit({ ...argv, perf: true }, prompter, options),
   doctor,
+  eval: evalCommand,
   'print-config': printConfig
 };
 

--- a/packages/safegres/src/cli/eval.ts
+++ b/packages/safegres/src/cli/eval.ts
@@ -1,0 +1,123 @@
+import { CLIOptions, Inquirerer, ParsedArgs } from 'inquirerer';
+import type { Client } from 'pg';
+import yanse from 'yanse';
+
+import { type EvalCaseResult, type EvalReport, runEval } from '../commands/eval';
+import { loadConfig } from '../config/loader';
+import type { EvalConfig } from '../config/types';
+import { loadCorpus } from '../corpus';
+import { buildClient, csvList } from './shared';
+
+const usage = `
+safegres eval — grade the auditor against a corpus with known answers
+
+  safegres eval [OPTIONS]
+
+Deploys each corpus case into the connected database, audits it under a sealed
+preset, and grades the report against the case's answer key: every expected
+finding present (recall), nothing the case forbids (precision). Exits non-zero
+if any case fails. Each case's schemas are dropped afterwards.
+
+Connection (same flags as \`safegres audit\`):
+  --connection <url>       Full PostgreSQL connection string
+  --host / --port / --user / --password / --database
+
+Options:
+  --preset <name>          Preset every case is graded under (default: recommended)
+  --corpus <dir>           Corpus directory of <id>/{case.json,schema.sql}
+  --case <id>              Run only these cases; id or id prefix, comma-separated
+  --list                   List the corpus without connecting to a database
+  --keep                   Leave the case schemas in the database
+  --json                   Emit the machine-readable result instead of a table
+  --no-color               Disable ANSI colors
+  --help, -h               Show this help message
+
+Config: a discovered safegres config may set \`eval.corpus\`, \`eval.preset\` and
+\`eval.cases\` — what to run. It cannot retune the rules: cases are always
+graded by the named preset alone, or the corpus would be measuring itself.
+`;
+
+/**
+ * Discovery is used for *selection only* (which corpus, which preset, which
+ * cases). Grading always loads the preset sealed, so nothing in the working
+ * tree can change the answers.
+ */
+function evalDefaults(configFile?: string): EvalConfig {
+  try {
+    return loadConfig({ configFile }).config.eval ?? {};
+  } catch {
+    return {};
+  }
+}
+
+function line(r: EvalCaseResult, color: boolean): string {
+  const paint = (s: string): string => (!color ? s : r.passed ? yanse.green(s) : yanse.bold(yanse.red(s)));
+  const detail = r.passed
+    ? r.found.map((e) => e.code).join(' ')
+    : [
+      ...r.missed.map((e) => `missed ${e.code}${e.relation ? `@${e.relation}` : ''}`),
+      ...r.falsePositives.map((code) => `false positive ${code}`)
+    ].join(', ');
+  return `  ${paint(r.passed ? 'PASS' : 'FAIL')}  ${r.id.padEnd(32)} ${r.dimension.padEnd(8)} `
+    + `${String(r.score).padStart(3)} (${r.grade.padEnd(2)})  ${detail}\n`;
+}
+
+function summary(report: EvalReport, color: boolean): string {
+  const pct = (n: number): string => `${Math.round(n * 100)}%`;
+  const ok = report.passed === report.total;
+  const headline = `${report.passed}/${report.total} cases passed`;
+  return `\n${color ? (ok ? yanse.green(headline) : yanse.bold(yanse.red(headline))) : headline}`
+    + ` · recall ${pct(report.recall)} · precision ${pct(report.precision)}\n`;
+}
+
+export default async (
+  argv: ParsedArgs,
+  _prompter: Inquirerer,
+  _options: CLIOptions
+): Promise<void> => {
+  if (argv.help || argv.h) {
+    process.stdout.write(usage);
+    return;
+  }
+
+  const defaults = evalDefaults(typeof argv.config === 'string' ? argv.config : undefined);
+  const corpus = typeof argv.corpus === 'string' ? argv.corpus : defaults.corpus;
+  const preset = typeof argv.preset === 'string' ? argv.preset : (defaults.preset ?? 'recommended');
+  const cases = csvList(argv.case) ?? defaults.cases;
+  const color = argv.color !== false && argv.json !== true;
+
+  if (argv.list === true) {
+    for (const c of loadCorpus(corpus)) {
+      process.stdout.write(`${c.id.padEnd(32)} ${c.dimension.padEnd(8)} ${c.title}\n`);
+    }
+    return;
+  }
+
+  const { config } = loadConfig({ sealed: true, preset });
+  const client: Client = buildClient(argv);
+  await client.connect();
+
+  try {
+    const report = await runEval(client, {
+      config,
+      preset,
+      corpus,
+      cases,
+      keep: argv.keep === true,
+      onResult: argv.json === true ? undefined : (r) => process.stdout.write(line(r, color))
+    });
+
+    if (argv.json === true) {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    } else {
+      process.stdout.write(summary(report, color));
+      for (const r of report.results.filter((x) => !x.passed)) {
+        process.stdout.write(`\n${r.id}: ${r.title}\n  fix: ${r.fix}\n`);
+      }
+    }
+
+    if (report.passed !== report.total) process.exit(1);
+  } finally {
+    await client.end();
+  }
+};

--- a/packages/safegres/src/commands/eval.ts
+++ b/packages/safegres/src/commands/eval.ts
@@ -1,0 +1,148 @@
+/**
+ * `safegres eval` — grade the auditor against a corpus with known answers.
+ *
+ * The audit answers "what is wrong with this database". Eval answers the
+ * question one level up: *is the auditor right?* It deploys each corpus case
+ * into a live database, audits it under a sealed preset, and grades the report
+ * against the case's answer key — recall (every expected finding present) and
+ * precision (nothing the case forbids).
+ *
+ * That makes it three things with one implementation: safegres's own
+ * calibration check, a harness an agent can be scored against (fix the case,
+ * re-run, require the findings to disappear), and a demonstration that the
+ * rules mean what the docs say.
+ */
+
+import type { Grade, SafegresConfig } from '../config/types';
+import { type CaseResult, corpusBootstrap, type CorpusCase, gradeCase, loadCorpus } from '../corpus';
+import { asExecutor, type QueryExecutor } from '../pg/introspect';
+import { audit } from './audit';
+
+export interface EvalOptions {
+  /**
+   * The configuration cases are graded under. Normally a sealed preset: the
+   * corpus measures the rules, so a local config file editing them would be
+   * measuring the wrong thing.
+   */
+  config?: SafegresConfig;
+  /** The preset name, recorded in each report's provenance. */
+  preset?: string;
+  /** Corpus directory. Defaults to the corpus shipped with the package. */
+  corpus?: string;
+  /** Case ids (or id prefixes) to run. Defaults to all of them. */
+  cases?: string[];
+  /** Skip the role bootstrap — for a database that already has the roles. */
+  skipBootstrap?: boolean;
+  /** Leave each case's schemas in the database instead of dropping them. */
+  keep?: boolean;
+  /** Called as each case finishes, for streaming progress. */
+  onResult?: (result: EvalCaseResult) => void;
+}
+
+export interface EvalCaseResult extends CaseResult {
+  title: string;
+  dimension: CorpusCase['dimension'];
+  /** The score on the case's own dimension, after its flaw is accounted for. */
+  score: number;
+  grade: Grade;
+  /** The answer key, so a failing case reads as an instruction. */
+  fix: string;
+}
+
+export interface EvalReport {
+  generatedAt: string;
+  /** The preset every case was graded under. */
+  preset?: string;
+  /** Configuration fingerprint shared by every case's report. */
+  fingerprint?: string;
+  sealed: boolean;
+  total: number;
+  passed: number;
+  /** Expected findings produced / expected findings total. */
+  recall: number;
+  /** Cases that produced no forbidden finding / cases total. */
+  precision: number;
+  results: EvalCaseResult[];
+}
+
+function selectCases(all: CorpusCase[], ids?: string[]): CorpusCase[] {
+  if (!ids || ids.length === 0) return all;
+  const selected = all.filter((c) => ids.some((id) => c.id === id || c.id.startsWith(id)));
+  if (selected.length === 0) {
+    throw new Error(`No corpus case matches ${ids.join(', ')}. Available: ${all.map((c) => c.id).join(', ')}`);
+  }
+  return selected;
+}
+
+/**
+ * Deploy, audit and grade every selected case. Each case owns its schemas —
+ * its SQL drops them first — so cases neither see nor disturb each other, and
+ * the database is left as it was found unless `keep` says otherwise.
+ */
+export async function runEval(
+  client: QueryExecutor,
+  options: EvalOptions = {}
+): Promise<EvalReport> {
+  const exec = asExecutor(client);
+  const cases = selectCases(loadCorpus(options.corpus), options.cases);
+
+  if (!options.skipBootstrap) await exec.query(corpusBootstrap());
+
+  const results: EvalCaseResult[] = [];
+  let fingerprint: string | undefined;
+  let sealed = false;
+
+  for (const c of cases) {
+    await exec.query(c.sql);
+    try {
+      const report = await audit(exec, {
+        config: options.config,
+        exposure: c.exposure,
+        schemas: c.exposure.schemas,
+        perf: true,
+        sealed: true,
+        ...(options.preset ? { preset: options.preset } : {})
+      });
+      fingerprint ??= report.provenance?.fingerprint;
+      sealed = report.provenance?.sealed ?? false;
+
+      const score = c.dimension === 'perf' ? report.perf?.score : report.score;
+      const result: EvalCaseResult = {
+        ...gradeCase(report, c),
+        title: c.title,
+        dimension: c.dimension,
+        score: score?.value ?? 100,
+        grade: score?.grade ?? 'A+',
+        fix: c.fix
+      };
+      results.push(result);
+      options.onResult?.(result);
+    } finally {
+      if (!options.keep) {
+        for (const schema of c.exposure.schemas ?? []) {
+          await exec.query(`DROP SCHEMA IF EXISTS ${quoteIdent(schema)} CASCADE`);
+        }
+      }
+    }
+  }
+
+  const expected = results.reduce((n, r) => n + r.found.length + r.missed.length, 0);
+  const found = results.reduce((n, r) => n + r.found.length, 0);
+  const clean = results.filter((r) => r.falsePositives.length === 0).length;
+
+  return {
+    generatedAt: new Date().toISOString(),
+    ...(options.preset ? { preset: options.preset } : {}),
+    ...(fingerprint ? { fingerprint } : {}),
+    sealed,
+    total: results.length,
+    passed: results.filter((r) => r.passed).length,
+    recall: expected === 0 ? 1 : found / expected,
+    precision: results.length === 0 ? 1 : clean / results.length,
+    results
+  };
+}
+
+function quoteIdent(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}

--- a/packages/safegres/src/config/types.ts
+++ b/packages/safegres/src/config/types.ts
@@ -381,4 +381,20 @@ export interface SafegresConfig {
   failOn?: FailOnConfig;
   /** What a rendered report shows — selection, not analysis. */
   report?: ReportConfig;
+  /** Defaults for `safegres eval` — which corpus, graded by which preset. */
+  eval?: EvalConfig;
+}
+
+/**
+ * `safegres eval` defaults. Deliberately only says *what* to run: a case is
+ * graded by a named preset, never by the rest of this file, so a project can
+ * point eval at its own corpus without also being able to move the answers.
+ */
+export interface EvalConfig {
+  /** Corpus directory of `<id>/{case.json,schema.sql}`. Defaults to the shipped one. */
+  corpus?: string;
+  /** Preset every case is graded under. Defaults to `recommended`. */
+  preset?: string;
+  /** Case ids (or id prefixes) to run. Defaults to all of them. */
+  cases?: string[];
 }

--- a/packages/safegres/src/corpus/index.ts
+++ b/packages/safegres/src/corpus/index.ts
@@ -70,6 +70,14 @@ export function corpusDir(): string {
   return found;
 }
 
+/**
+ * The SQL creating the roles every case is graded against (`corpus_anon`,
+ * `corpus_user`). Idempotent, so a harness can run it before every case.
+ */
+export function corpusBootstrap(dir: string = corpusDir()): string {
+  return fs.readFileSync(path.resolve(dir, '..', 'bootstrap.sql'), 'utf8');
+}
+
 /** Load every case in `dir` (default: the shipped corpus), ordered by id. */
 export function loadCorpus(dir: string = corpusDir()): CorpusCase[] {
   return fs

--- a/packages/safegres/src/index.ts
+++ b/packages/safegres/src/index.ts
@@ -79,6 +79,8 @@ export type { AuditOptions } from './commands/audit';
 export { audit } from './commands/audit';
 export type { DoctorCheck, DoctorOptions, DoctorReport, DoctorStatus } from './commands/doctor';
 export { doctor } from './commands/doctor';
+export type { EvalCaseResult, EvalOptions, EvalReport } from './commands/eval';
+export { runEval } from './commands/eval';
 export type { Provenance } from './config/fingerprint';
 export { configFingerprint } from './config/fingerprint';
 export type { LoadConfigParams } from './config/loader';
@@ -108,6 +110,7 @@ export {
   rulesForTable
 } from './config/resolve';
 export type {
+  EvalConfig,
   ExposureConfig,
   FailOnConfig,
   GithubCommentConfig,
@@ -125,7 +128,7 @@ export type {
   ScoringConfig
 } from './config/types';
 export type { CaseResult, CorpusCase, ExpectedFinding } from './corpus';
-export { corpusDir, gradeCase, loadCase, loadCorpus } from './corpus';
+export { corpusBootstrap, corpusDir, gradeCase, loadCase, loadCorpus } from './corpus';
 export type { ExposureAdapter, PlaneInput, ReachContext } from './exposure/adapters';
 export {
   BUILTIN_ADAPTERS,


### PR DESCRIPTION
## Summary

The corpus landed in #1604 as a Jest suite, which means the only way to run it is to check out the repo. `safegres eval` makes it a command: deploy each case into the connected database, audit it under a **sealed** preset, grade the report against the case's answer key, drop the case's schemas again, exit non-zero if any case fails.

```console
$ safegres eval --database scratch
  PASS  01-anon-write-grant              security 1.2 (F )  R1
  PASS  17-foreign-key-without-index     perf    71.2 (C )  X1
  ...
26/26 cases passed · recall 100% · precision 100%
```

Deliberately narrow, since two other agents are in this package: no rule, check, scoring or report-shape changes. New files (`src/commands/eval.ts`, `src/cli/eval.ts`, `__tests__/eval.test.ts`) plus one-line registrations in `cli/commands.ts`, `cli.ts` and `index.ts`.

**The one design decision.** Config discovery says *what* to run; the preset says *how* it is graded, and nothing else can reach the second:

```ts
const defaults = loadConfig({ configFile }).config.eval ?? {};   // corpus, preset, cases
const { config } = loadConfig({ sealed: true, preset });         // the ruler — preset alone
```

So a project can point `eval.corpus` at its own cases without also being able to move the answers — a corpus graded by a local `rules` block would be grading itself. Every case's report therefore carries the same `provenance.fingerprint`, which is surfaced in the `--json` output.

**Isolation.** Each case's `schema.sql` drops its own schemas first, and `runEval` drops them again in a `finally` (`--keep` opts out), so cases neither see each other nor leave anything behind — asserted in the test.

New public API: `runEval`, `EvalOptions`, `EvalReport`, `EvalCaseResult`, `corpusBootstrap()` (the role-bootstrap SQL, previously only readable by knowing the path), and `EvalConfig` on `SafegresConfig`.


Link to Devin session: https://app.devin.ai/sessions/b7874ecee0c7471ea271e6e7193869dc
Requested by: @pyramation