### PR TITLE
feat(safegres): drive source, outputs and baselines from the config file

### DIFF
--- a/.agents/skills/safegres/SKILL.md
+++ b/.agents/skills/safegres/SKILL.md
@@ -232,6 +232,7 @@ score = 100 · exp(−k · riskPoints / exposedTables)
 
 ```bash
 safegres audit                     # audit the connected DB (default command)
+safegres lint                      # alias for audit, for a package.json script
 safegres perf                      # audit + index-hygiene dimension (= audit --perf)
 safegres audit --perf --fail-on-perf-grade B
 safegres audit --perf-baseline .safegres-perf.json --fail-on-new-perf   # ratchet: only new debt fails
@@ -269,7 +270,20 @@ console.log(perfReport.perf?.score);   // separate 0-100 perf axis (undefined un
 
 ## CI integration
 
-Report-only first, gate after a week of stable scores. In this monorepo's DB repos the pattern is: start Postgres → install `pgpm` + `safegres` → deploy the schema → `safegres audit` → write to `$GITHUB_STEP_SUMMARY`. Commit `.safegresrc.json` (`{ "extends": "safegres:constructive" }`) as the source of truth so local and CI agree. Add `--fail-on-grade B` only once the baseline is stable.
+Report-only first, gate after a week of stable scores. Never write a bespoke audit script: everything a job repeats belongs in `.safegresrc.json`, so the job is `safegres audit` (or a `"lint": "safegres lint"` package.json script). Paths in the file are relative to it.
+
+```jsonc
+{
+  "extends": "safegres:constructive",
+  "source":  { "pgpm": "application/app" },   // deploy into an ephemeral DB — no connection needed
+  "callGraph": { "enabled": true },
+  "perf":    { "enabled": true, "baseline": "ci/safegres-perf-baseline.json", "failOnNew": true },
+  "outputs": { "json": "safegres-reports/safegres.json", "sarif": "safegres-reports/safegres.sarif" },
+  "failOn":  { "grade": "B" }
+}
+```
+
+Inside Actions the job summary, annotations and PR comment are emitted automatically (`report.github` configures them). Add `failOn.grade` only once the baseline is stable.
 
 ## Guardrails
 

--- a/.agents/skills/safegres/SKILL.md
+++ b/.agents/skills/safegres/SKILL.md
@@ -278,7 +278,7 @@ Report-only first, gate after a week of stable scores. Never write a bespoke aud
   "source":  { "pgpm": "application/app" },   // deploy into an ephemeral DB — no connection needed
   "callGraph": { "enabled": true },
   "perf":    { "enabled": true, "baseline": "ci/safegres-perf-baseline.json", "failOnNew": true },
-  "outputs": { "json": "safegres-reports/safegres.json", "sarif": "safegres-reports/safegres.sarif" },
+  "outputs": { "dir": "safegres-reports" },   // safegres.json + .md + .sarif; or name files individually
   "failOn":  { "grade": "B" }
 }
 ```

--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -402,7 +402,9 @@ deploys it into an ephemeral one:
 
 `outputs.dir` writes `safegres.json`, `safegres.md` and `safegres.sarif` into one directory — name
 an individual file (`outputs.json`) only when the name matters. Directories are created as needed,
-and a flag still wins over the file for a one-off run (`safegres audit --out reports`).
+and a flag still wins over the file for a one-off run (`safegres audit --out reports`). Naming a
+connection wins too, so the same config audits a database you already have:
+`safegres audit --database staging`.
 
 Scores lead the markdown, then severity counts, then a table per dimension; internal advisories
 and accepted baseline debt fold into `<details>`. Pipe it to `gh pr comment --body-file -` to post

--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -381,6 +381,27 @@ jobs:
             --perf-baseline ci/safegres-perf-baseline.json --fail-on-new-perf
 ```
 
+Everything a job repeats every run belongs in the config file instead, so the job is one word. A
+repository whose schema is a pgpm workspace does not need a database at all — `source.pgpm`
+deploys it into an ephemeral one:
+
+```jsonc
+// .safegresrc.json — paths are relative to this file
+{
+  "extends": "safegres:constructive",
+  "source":  { "pgpm": "application/app" },
+  "perf":    { "enabled": true, "baseline": "ci/perf-baseline.json", "failOnNew": true },
+  "outputs": { "json": "reports/safegres.json", "sarif": "reports/safegres.sarif" },
+  "failOn":  { "grade": "B" }
+}
+```
+
+```yaml
+      - run: npx safegres audit   # or: "audit": "safegres lint" in package.json
+```
+
+Output directories are created as needed, and a flag still wins over the file for a one-off run.
+
 Scores lead the markdown, then severity counts, then a table per dimension; internal advisories
 and accepted baseline debt fold into `<details>`. Pipe it to `gh pr comment --body-file -` to post
 it on the pull request instead. Library callers get the same renderer as `renderMarkdown(report)`.
@@ -622,6 +643,7 @@ score would move if that rule's findings went away. Gate with `--fail-on <severi
 
 ```bash
 safegres audit          # audit the connected database (default command)
+safegres lint           # alias for audit, for a package.json script
 safegres perf           # audit + the performance dimension (= audit --perf)
 safegres doctor         # diagnose config, parser, connection, catalog visibility, exposure
 safegres eval           # grade the auditor against a corpus with known answers
@@ -639,6 +661,10 @@ safegres print-config   # the resolved effective config (--explain for per-key p
 | Call graph | `--call-graph`, `--baseline <f>`, `--write-baseline <f>`, `--fail-on-new-boundaries` |
 | Gating | `--fail-on <severity>`, `--fail-on-score <n>`, `--fail-on-grade <g>`, `--fail-on-perf-score`, `--fail-on-perf-grade` |
 | Misc | `--skip-ast`, `--no-color`, `--help`, `--version` |
+
+The paths among those — `--pgpm`, the two baselines, and every `--write-*` — have config-file
+equivalents (`source.pgpm`, `perf.baseline`, `callGraph.baseline`, `outputs.*`), so CI can carry
+them in version control rather than in a command line.
 
 ## Going further
 

--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -36,6 +36,20 @@ executed and nothing written — safe to point at a production replica.
 *No database handy? See [CI](#ci-in-one-job): one service container plus the migration command you
 already have.*
 
+## Features
+
+* 🛡️ **Complete RLS Auditing** – Grants, RLS enforcement, policy coverage and policy behavior, across every schema and role in the database
+* 🎯 **Operation-Level Coverage** – Every granted `SELECT`/`INSERT`/`UPDATE`/`DELETE` checked against the policies that actually cover it, per role
+* 🔍 **Risky Policy Detection** – Permissive checks, volatile and session-dependent predicates, definer escalation and role bypass, found in the parsed AST rather than by regex
+* ⚡ **Performance on Its Own Axis** – Policy predicates that no index can serve, per-row function calls, missing foreign-key indexes — scored separately, so hardening never reads as a regression
+* 🧭 **Exposure Planes** – The declared API surface is the headline grade; direct-connection and per-role planes are graded beside it, so "what can an anonymous caller reach?" is a number
+* 📊 **Security Scoring & Grades** – Scores, grades, severity counts and per-rule deductions with the payoff of fixing each one
+* 🐘 **Pure PostgreSQL Analysis** – Reads the catalog and parses SQL; no agent, no traffic, no ORM, no application changes, nothing executed
+* ⚙️ **Built for CI** – Summaries, Markdown, JSON and SARIF, GitHub job summaries, annotations and a sticky PR comment, with configurable failure thresholds
+* Δ **Change-Aware Audits** – Compare two reports to show exactly what a branch introduced, fixed or worsened; baselines accept inherited debt and gate only what's new
+* 🧪 **Graded Against a Corpus** – `safegres eval` scores the auditor itself on fixtures with known answers, sealed against config that could game the number
+* 📦 **CLI and Library APIs** – Run it from the command line, or import the analysis, report and renderers into your own tooling
+
 ## What you get
 
 ```

--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -391,7 +391,7 @@ deploys it into an ephemeral one:
   "extends": "safegres:constructive",
   "source":  { "pgpm": "application/app" },
   "perf":    { "enabled": true, "baseline": "ci/perf-baseline.json", "failOnNew": true },
-  "outputs": { "json": "reports/safegres.json", "sarif": "reports/safegres.sarif" },
+  "outputs": { "dir": "safegres-reports" },
   "failOn":  { "grade": "B" }
 }
 ```
@@ -400,7 +400,9 @@ deploys it into an ephemeral one:
       - run: npx safegres audit   # or: "audit": "safegres lint" in package.json
 ```
 
-Output directories are created as needed, and a flag still wins over the file for a one-off run.
+`outputs.dir` writes `safegres.json`, `safegres.md` and `safegres.sarif` into one directory — name
+an individual file (`outputs.json`) only when the name matters. Directories are created as needed,
+and a flag still wins over the file for a one-off run (`safegres audit --out reports`).
 
 Scores lead the markdown, then severity counts, then a table per dimension; internal advisories
 and accepted baseline debt fold into `<details>`. Pipe it to `gh pr comment --body-file -` to post
@@ -657,13 +659,13 @@ safegres print-config   # the resolved effective config (--explain for per-key p
 | Exposure | `--exposure-schemas <csv>`, `--exposed-only` |
 | Scope | `--schemas`, `--exclude-schemas`, `--roles`, `--exclude-roles`, `--ignore-extensions`, `--audit-extension-owned` |
 | Performance | `--perf`, `--stats`, `--explain`, `--perf-baseline <f>`, `--write-perf-baseline <f>`, `--fail-on-new-perf` |
-| Reporting | `--format pretty\|json\|json-pretty\|markdown\|sarif`, `--sarif-sources <dir>`, `--summary`/`-q`, `--verbose`, `--compare <f>`, `--compare-ref <label>`, `--write-snapshot <f>` |
+| Reporting | `--format pretty\|json\|json-pretty\|markdown\|sarif`, `--out <dir>`, `--sarif-sources <dir>`, `--summary`/`-q`, `--verbose`, `--compare <f>`, `--compare-ref <label>`, `--write-snapshot <f>` |
 | Call graph | `--call-graph`, `--baseline <f>`, `--write-baseline <f>`, `--fail-on-new-boundaries` |
 | Gating | `--fail-on <severity>`, `--fail-on-score <n>`, `--fail-on-grade <g>`, `--fail-on-perf-score`, `--fail-on-perf-grade` |
 | Misc | `--skip-ast`, `--no-color`, `--help`, `--version` |
 
 The paths among those — `--pgpm`, the two baselines, and every `--write-*` — have config-file
-equivalents (`source.pgpm`, `perf.baseline`, `callGraph.baseline`, `outputs.*`), so CI can carry
+equivalents (`source.pgpm`, `perf.baseline`, `callGraph.baseline`, `outputs.dir`/`outputs.*`), so CI can carry
 them in version control rather than in a command line.
 
 ## Going further

--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -663,7 +663,7 @@ safegres print-config   # the resolved effective config (--explain for per-key p
 | Performance | `--perf`, `--stats`, `--explain`, `--perf-baseline <f>`, `--write-perf-baseline <f>`, `--fail-on-new-perf` |
 | Reporting | `--format pretty\|json\|json-pretty\|markdown\|sarif`, `--out <dir>`, `--sarif-sources <dir>`, `--summary`/`-q`, `--verbose`, `--compare <f>`, `--compare-ref <label>`, `--write-snapshot <f>` |
 | Call graph | `--call-graph`, `--baseline <f>`, `--write-baseline <f>`, `--fail-on-new-boundaries` |
-| Gating | `--fail-on <severity>`, `--fail-on-score <n>`, `--fail-on-grade <g>`, `--fail-on-perf-score`, `--fail-on-perf-grade` |
+| Gating | `--fail-on <severity>`, `--fail-on-score <n>`, `--fail-on-grade <g>`, `--fail-on-perf-score`, `--fail-on-perf-grade`, `--report-only` |
 | Misc | `--skip-ast`, `--no-color`, `--help`, `--version` |
 
 The paths among those — `--pgpm`, the two baselines, and every `--write-*` — have config-file

--- a/packages/safegres/__tests__/run-paths.test.ts
+++ b/packages/safegres/__tests__/run-paths.test.ts
@@ -1,0 +1,74 @@
+import type { ParsedArgs } from 'inquirerer';
+import * as path from 'path';
+
+import { resolveRunPaths } from '../src/cli/shared';
+import type { SafegresConfig } from '../src/config/types';
+
+const CONFIG_DIR = '/repo';
+const argv = (values: Record<string, unknown> = {}): ParsedArgs => values as ParsedArgs;
+
+describe('resolveRunPaths', () => {
+  it('reads every path from the config file, resolved against it', () => {
+    const config: SafegresConfig = {
+      source: { pgpm: 'application/app' },
+      perf: { baseline: 'ci/perf.json' },
+      callGraph: { baseline: 'ci/boundaries.json' },
+      outputs: {
+        json: 'reports/safegres.json',
+        markdown: 'reports/safegres.md',
+        sarif: 'reports/safegres.sarif',
+        sarifSources: '.',
+        snapshot: 'reports/snapshot.json',
+        githubComment: 'reports/comment.md'
+      }
+    };
+
+    const paths = resolveRunPaths(argv(), config, CONFIG_DIR);
+
+    expect(paths.usePgpm).toBe(true);
+    expect(paths.pgpm).toBe(path.join(CONFIG_DIR, 'application/app'));
+    expect(paths.perfBaseline).toBe(path.join(CONFIG_DIR, 'ci/perf.json'));
+    expect(paths.callGraphBaseline).toBe(path.join(CONFIG_DIR, 'ci/boundaries.json'));
+    expect(paths.outputs.json).toBe(path.join(CONFIG_DIR, 'reports/safegres.json'));
+    expect(paths.outputs.sarifSources).toBe(CONFIG_DIR);
+    expect(paths.outputs.githubComment).toBe(path.join(CONFIG_DIR, 'reports/comment.md'));
+  });
+
+  it('lets a flag win, and keeps it relative to cwd rather than to the config', () => {
+    const config: SafegresConfig = {
+      source: { pgpm: 'application/app' },
+      perf: { baseline: 'ci/perf.json' },
+      outputs: { json: 'reports/safegres.json' }
+    };
+
+    const paths = resolveRunPaths(
+      argv({ pgpm: 'other/module', 'perf-baseline': 'tmp/perf.json', 'write-json': 'out.json' }),
+      config,
+      CONFIG_DIR
+    );
+
+    expect(paths.pgpm).toBe('other/module');
+    expect(paths.perfBaseline).toBe('tmp/perf.json');
+    expect(paths.outputs.json).toBe('out.json');
+  });
+
+  it('treats a bare --pgpm as "the nearest workspace"', () => {
+    const paths = resolveRunPaths(argv({ pgpm: true }), {}, CONFIG_DIR);
+    expect(paths.usePgpm).toBe(true);
+    expect(paths.pgpm).toBeUndefined();
+  });
+
+  it('asks for nothing when neither side says anything', () => {
+    const paths = resolveRunPaths(argv(), {}, CONFIG_DIR);
+    expect(paths.usePgpm).toBe(false);
+    expect(paths.perfBaseline).toBeUndefined();
+    expect(paths.outputs).toEqual({
+      json: undefined,
+      markdown: undefined,
+      sarif: undefined,
+      sarifSources: undefined,
+      snapshot: undefined,
+      githubComment: undefined
+    });
+  });
+});

--- a/packages/safegres/__tests__/run-paths.test.ts
+++ b/packages/safegres/__tests__/run-paths.test.ts
@@ -72,6 +72,15 @@ describe('resolveRunPaths', () => {
     expect(paths.outputs.sarif).toBe(path.join('tmp', 'safegres.sarif'));
   });
 
+  it('lets an explicit connection beat a configured pgpm source', () => {
+    const config: SafegresConfig = { source: { pgpm: 'application/app' } };
+
+    expect(resolveRunPaths(argv({ database: 'live' }), config, CONFIG_DIR).usePgpm).toBe(false);
+    expect(resolveRunPaths(argv({ connection: 'postgres://…' }), config, CONFIG_DIR).usePgpm).toBe(false);
+    // …but the environment doesn't: PGDATABASE is set on every CI runner.
+    expect(resolveRunPaths(argv(), config, CONFIG_DIR).usePgpm).toBe(true);
+  });
+
   it('treats a bare --pgpm as "the nearest workspace"', () => {
     const paths = resolveRunPaths(argv({ pgpm: true }), {}, CONFIG_DIR);
     expect(paths.usePgpm).toBe(true);

--- a/packages/safegres/__tests__/run-paths.test.ts
+++ b/packages/safegres/__tests__/run-paths.test.ts
@@ -52,6 +52,26 @@ describe('resolveRunPaths', () => {
     expect(paths.outputs.json).toBe('out.json');
   });
 
+  it('expands a directory into the conventional file names', () => {
+    const paths = resolveRunPaths(argv(), { outputs: { dir: 'reports' } }, CONFIG_DIR);
+
+    expect(paths.outputs.json).toBe(path.join(CONFIG_DIR, 'reports/safegres.json'));
+    expect(paths.outputs.markdown).toBe(path.join(CONFIG_DIR, 'reports/safegres.md'));
+    expect(paths.outputs.sarif).toBe(path.join(CONFIG_DIR, 'reports/safegres.sarif'));
+    // The directory is the report set, not every artifact: a snapshot and a PR
+    // comment are asked for by name or not at all.
+    expect(paths.outputs.snapshot).toBeUndefined();
+    expect(paths.outputs.githubComment).toBeUndefined();
+  });
+
+  it('lets a named file beat the directory, and --out beat the config', () => {
+    const config: SafegresConfig = { outputs: { dir: 'reports', json: 'reports/full.json' } };
+    const paths = resolveRunPaths(argv({ out: 'tmp' }), config, CONFIG_DIR);
+
+    expect(paths.outputs.json).toBe(path.join(CONFIG_DIR, 'reports/full.json'));
+    expect(paths.outputs.sarif).toBe(path.join('tmp', 'safegres.sarif'));
+  });
+
   it('treats a bare --pgpm as "the nearest workspace"', () => {
     const paths = resolveRunPaths(argv({ pgpm: true }), {}, CONFIG_DIR);
     expect(paths.usePgpm).toBe(true);

--- a/packages/safegres/src/cli.ts
+++ b/packages/safegres/src/cli.ts
@@ -46,6 +46,7 @@ const options: Partial<CLIOptions> = {
       'exclude-roles',
       'format',
       'fail-on',
+      'out',
       'preset',
       'corpus',
       'case'

--- a/packages/safegres/src/cli/audit.ts
+++ b/packages/safegres/src/cli/audit.ts
@@ -159,6 +159,8 @@ Audit options:
                            (critical|high|medium|low|info; default: none)
   --fail-on-score <n>      Exit non-zero if the score is below n (0-100)
   --fail-on-grade <g>      Exit non-zero if the grade is below g (A+|A|B|C|D)
+  --report-only            Evaluate and report every gate, then exit 0 anyway —
+                           the way to run a gated config as an advisory job
   --skip-ast               Skip AST-level anti-pattern checks (faster)
   --no-color               Disable ANSI colors in pretty output
   --help, -h               Show this help message
@@ -535,7 +537,8 @@ export default async (
     else log.warn(`--github-comment: not posted — ${result.reason}`);
   }
 
-  if (failed) process.exit(1);
+  if (failed && argv['report-only'] !== true) process.exit(1);
+  if (failed) log.warn('--report-only: gates failed, exiting 0');
 };
 
 /** Write an output file, creating its directory: CI should not have to mkdir. */

--- a/packages/safegres/src/cli/audit.ts
+++ b/packages/safegres/src/cli/audit.ts
@@ -1,6 +1,7 @@
 import { Logger } from '@pgpmjs/logger';
 import * as fs from 'fs';
 import { CLIOptions, Inquirerer, ParsedArgs } from 'inquirerer';
+import * as path from 'path';
 
 import { diffCallGraph, parseBaseline, serializeBaseline, toBaseline } from '../callgraph/baseline';
 import { audit, type AuditOptions } from '../commands/audit';
@@ -17,7 +18,13 @@ import { matchPlane, type ViewConfig, viewConfigFromReportConfig } from '../repo
 import { meetsGrade } from '../score/score';
 import type { Finding, Report, Severity } from '../types';
 import { meetsThreshold, SEVERITY_ORDER, summarize } from '../types';
-import { buildClient, configParamsFromArgv, csvList, extensionScopeFromArgv } from './shared';
+import {
+  buildClient,
+  configParamsFromArgv,
+  csvList,
+  extensionScopeFromArgv,
+  resolveRunPaths
+} from './shared';
 
 const log = new Logger('safegres');
 
@@ -163,6 +170,18 @@ GitHub Actions:
   --write-github-comment <file>
                            Write the PR-comment markdown to <file> instead of
                            posting it
+
+Everything a CI job repeats every run belongs in the config file instead, so
+the job is just \`safegres audit\` (paths are relative to the config file):
+
+  {
+    "extends": "safegres:constructive",
+    "source":  { "pgpm": "application/app" },
+    "callGraph": { "enabled": true },
+    "perf":    { "enabled": true, "baseline": "ci/perf-baseline.json", "failOnNew": true },
+    "outputs": { "json": "reports/safegres.json", "sarif": "reports/safegres.sarif" },
+    "failOn":  { "grade": "B" }
+  }
 `;
 
 export default async (
@@ -199,7 +218,14 @@ export default async (
       process.exit(2);
     }
   }
-  const { config } = loadConfig({ cwd: pgpmCwd, ...configParamsFromArgv(argv) });
+  const loaded = loadConfig({ cwd: pgpmCwd, ...configParamsFromArgv(argv) });
+  const config = loaded.config;
+
+  const { pgpm: pgpmSource, usePgpm, perfBaseline, callGraphBaseline, outputs } = resolveRunPaths(
+    argv,
+    config,
+    loaded.filepath ? path.dirname(loaded.filepath) : process.cwd()
+  );
 
   const exposureSchemas = csvList(argv['exposure-schemas']);
   const auditOptions: AuditOptions = {
@@ -211,7 +237,7 @@ export default async (
     skipAstChecks: argv['skip-ast'] === true,
     perf:
       argv.perf === true
-      || typeof argv['perf-baseline'] === 'string'
+      || perfBaseline !== undefined
       || typeof argv['write-perf-baseline'] === 'string'
         ? true
         : undefined,
@@ -219,7 +245,8 @@ export default async (
     explain: argv.explain === true ? true : undefined,
     callGraph:
       argv['call-graph'] === true
-      || typeof argv.baseline === 'string'
+      || config.callGraph?.enabled === true
+      || callGraphBaseline !== undefined
       || typeof argv['write-baseline'] === 'string',
     exposure: exposureSchemas
       ? { ...config.exposure, schemas: exposureSchemas }
@@ -230,9 +257,9 @@ export default async (
   };
 
   let report: Report;
-  if (argv.pgpm) {
+  if (usePgpm) {
     const { auditPgpmWorkspace } = importPgpmTest();
-    report = await auditPgpmWorkspace({ ...auditOptions, cwd: pgpmCwd });
+    report = await auditPgpmWorkspace({ ...auditOptions, cwd: pgpmSource });
   } else {
     const client = buildClient(argv);
     await client.connect();
@@ -256,27 +283,27 @@ export default async (
     log.info(`wrote perf baseline: ${argv['write-perf-baseline']}`);
   }
 
-  if (typeof argv['perf-baseline'] === 'string' && report.perf) {
+  if (perfBaseline !== undefined && report.perf) {
     let raw: string;
     try {
-      raw = fs.readFileSync(argv['perf-baseline'], 'utf8');
+      raw = fs.readFileSync(perfBaseline, 'utf8');
     } catch {
       log.error(
-        `cannot read --perf-baseline file: ${argv['perf-baseline']} (create one with --write-perf-baseline)`
+        `cannot read perf baseline: ${perfBaseline} (create one with --write-perf-baseline)`
       );
       process.exit(2);
     }
     report.perf.diff = diffPerf(report.perf.findings, parsePerfBaseline(raw));
   }
 
-  if (typeof argv['write-snapshot'] === 'string') {
-    fs.writeFileSync(
-      argv['write-snapshot'],
+  if (outputs.snapshot !== undefined) {
+    writeOut(
+      outputs.snapshot,
       serializeSnapshot(
         toSnapshot(report, typeof argv['compare-ref'] === 'string' ? { ref: argv['compare-ref'] } : {})
       )
     );
-    log.info(`wrote snapshot: ${argv['write-snapshot']}`);
+    log.info(`wrote snapshot: ${outputs.snapshot}`);
   }
 
   if (typeof argv.compare === 'string') {
@@ -301,12 +328,12 @@ export default async (
     report.comparison = compareReports(previous, report);
   }
 
-  if (typeof argv.baseline === 'string' && report.callGraph) {
+  if (callGraphBaseline !== undefined && report.callGraph) {
     let raw: string;
     try {
-      raw = fs.readFileSync(argv.baseline, 'utf8');
+      raw = fs.readFileSync(callGraphBaseline, 'utf8');
     } catch {
-      log.error(`cannot read --baseline file: ${argv.baseline} (create one with --write-baseline)`);
+      log.error(`cannot read call-graph baseline: ${callGraphBaseline} (create one with --write-baseline)`);
       process.exit(2);
     }
     report.callGraphDiff = diffCallGraph(report.callGraph, parseBaseline(raw));
@@ -335,9 +362,7 @@ export default async (
     break;
   case 'sarif':
     output = renderSarif(report, {
-      sources: typeof argv['sarif-sources'] === 'string'
-        ? buildSourceIndex(argv['sarif-sources'])
-        : undefined
+      sources: outputs.sarifSources ? buildSourceIndex(outputs.sarifSources) : undefined
     });
     break;
   case 'markdown':
@@ -364,27 +389,25 @@ export default async (
   process.stdout.write('\n');
 
   // One audit, as many renderings as CI asked for.
-  if (typeof argv['write-json'] === 'string') {
-    fs.writeFileSync(argv['write-json'], `${renderJson(report, { pretty: true })}\n`);
-    log.info(`wrote json report: ${argv['write-json']}`);
+  if (outputs.json !== undefined) {
+    writeOut(outputs.json, `${renderJson(report, { pretty: true })}\n`);
+    log.info(`wrote json report: ${outputs.json}`);
   }
-  if (typeof argv['write-markdown'] === 'string') {
-    fs.writeFileSync(
-      argv['write-markdown'],
+  if (outputs.markdown !== undefined) {
+    writeOut(
+      outputs.markdown,
       `${renderMarkdown(report, { verbose: argv.verbose === true, view: viewConfig })}\n`
     );
-    log.info(`wrote markdown report: ${argv['write-markdown']}`);
+    log.info(`wrote markdown report: ${outputs.markdown}`);
   }
-  if (typeof argv['write-sarif'] === 'string') {
-    fs.writeFileSync(
-      argv['write-sarif'],
+  if (outputs.sarif !== undefined) {
+    writeOut(
+      outputs.sarif,
       `${renderSarif(report, {
-        sources: typeof argv['sarif-sources'] === 'string'
-          ? buildSourceIndex(argv['sarif-sources'])
-          : undefined
+        sources: outputs.sarifSources ? buildSourceIndex(outputs.sarifSources) : undefined
       })}\n`
     );
-    log.info(`wrote sarif report: ${argv['write-sarif']}`);
+    log.info(`wrote sarif report: ${outputs.sarif}`);
   }
 
   // Gates are evaluated before anything exits, so the GitHub renderers can
@@ -463,7 +486,8 @@ export default async (
     }
   }
 
-  if (argv['fail-on-new-perf'] === true && report.perf?.diff && report.perf.diff.added.length > 0) {
+  const failOnNewPerf = argv['fail-on-new-perf'] === true || config.perf?.failOnNew === true;
+  if (failOnNewPerf && report.perf?.diff && report.perf.diff.added.length > 0) {
     const count = report.perf.diff.added.length;
     gateFailures.push(...report.perf.diff.added);
     fail(
@@ -472,7 +496,7 @@ export default async (
   }
 
   if (
-    argv['fail-on-new-boundaries'] === true
+    (argv['fail-on-new-boundaries'] === true || config.callGraph?.failOnNew === true)
     && report.callGraphDiff
     && report.callGraphDiff.added.length > 0
   ) {
@@ -498,12 +522,9 @@ export default async (
     }
   }
 
-  if (typeof argv['write-github-comment'] === 'string') {
-    fs.writeFileSync(
-      argv['write-github-comment'],
-      `${renderGithubComment(report, githubOptions)}\n`
-    );
-    log.info(`wrote github comment: ${argv['write-github-comment']}`);
+  if (outputs.githubComment !== undefined) {
+    writeOut(outputs.githubComment, `${renderGithubComment(report, githubOptions)}\n`);
+    log.info(`wrote github comment: ${outputs.githubComment}`);
   }
 
   if (argv['github-comment'] === true) {
@@ -514,6 +535,12 @@ export default async (
 
   if (failed) process.exit(1);
 };
+
+/** Write an output file, creating its directory: CI should not have to mkdir. */
+function writeOut(file: string, contents: string): void {
+  fs.mkdirSync(path.dirname(path.resolve(file)), { recursive: true });
+  fs.writeFileSync(file, contents);
+}
 
 /** A repeatable flag: `--plane a --plane b` (minimist gives an array). */
 function listArg(value: unknown): string[] {

--- a/packages/safegres/src/cli/audit.ts
+++ b/packages/safegres/src/cli/audit.ts
@@ -147,6 +147,8 @@ Audit options:
   --sarif-sources <dir>    With --format sarif: scan <dir> for the CREATE TABLE /
                            CREATE POLICY that defines each object, so alerts point
                            at the SQL that produced the finding
+  --out <dir>              Write safegres.json, safegres.md and safegres.sarif
+                           into <dir> (created as needed)
   --write-json <file>      Also write the JSON report to <file>
   --write-markdown <file>  Also write the markdown report to <file>
   --write-sarif <file>     Also write the SARIF report to <file>
@@ -179,7 +181,7 @@ the job is just \`safegres audit\` (paths are relative to the config file):
     "source":  { "pgpm": "application/app" },
     "callGraph": { "enabled": true },
     "perf":    { "enabled": true, "baseline": "ci/perf-baseline.json", "failOnNew": true },
-    "outputs": { "json": "reports/safegres.json", "sarif": "reports/safegres.sarif" },
+    "outputs": { "dir": "safegres-reports" },
     "failOn":  { "grade": "B" }
   }
 `;

--- a/packages/safegres/src/cli/commands.ts
+++ b/packages/safegres/src/cli/commands.ts
@@ -16,6 +16,7 @@ Usage:
 
 Commands:
   audit           Audit grants, RLS flags, policy coverage, and anti-patterns
+  lint            Alias for audit, for a package.json script
   perf            Audit index hygiene and policy cost (audit --perf)
   doctor          Diagnose environment, connection, and configuration
   eval            Grade the auditor against a corpus with known answers
@@ -30,6 +31,7 @@ const commandMap: Record<
   (argv: ParsedArgs, prompter: Inquirerer, options: CLIOptions) => unknown
 > = {
   audit,
+  lint: audit,
   perf: (argv, prompter, options) => audit({ ...argv, perf: true }, prompter, options),
   doctor,
   eval: evalCommand,

--- a/packages/safegres/src/cli/shared.ts
+++ b/packages/safegres/src/cli/shared.ts
@@ -63,6 +63,11 @@ export function parseRuleFlags(value: unknown): RulesConfig | undefined {
   return Object.keys(rules).length > 0 ? rules : undefined;
 }
 
+/** Did the caller name a database on the command line, rather than in the environment? */
+function hasConnectionFlag(argv: ParsedArgs): boolean {
+  return ['connection', 'database', 'host', 'port'].some((flag) => typeof argv[flag] === 'string' || typeof argv[flag] === 'number');
+}
+
 /** Every file a run reads or writes, after flags and config have been merged. */
 export interface RunPaths {
   /** The pgpm workspace to deploy, when `usePgpm`. Undefined means "nearest". */
@@ -100,7 +105,10 @@ export function resolveRunPaths(
 
   return {
     pgpm: pick(argv.pgpm, config.source?.pgpm),
-    usePgpm: argv.pgpm !== undefined || config.source?.pgpm !== undefined,
+    // An explicit connection on the command line beats a configured source:
+    // pointing the same config at a database you already have is the whole
+    // reason to type one, and deploying a throwaway copy instead would ignore it.
+    usePgpm: argv.pgpm !== undefined || (config.source?.pgpm !== undefined && !hasConnectionFlag(argv)),
     perfBaseline: pick(argv['perf-baseline'], config.perf?.baseline),
     callGraphBaseline: pick(argv.baseline, config.callGraph?.baseline),
     outputs: {

--- a/packages/safegres/src/cli/shared.ts
+++ b/packages/safegres/src/cli/shared.ts
@@ -1,4 +1,5 @@
 import type { ParsedArgs } from 'inquirerer';
+import * as path from 'path';
 import { Client } from 'pg';
 import { getPgEnvOptions, type PgConfig } from 'pg-env';
 
@@ -60,6 +61,52 @@ export function parseRuleFlags(value: unknown): RulesConfig | undefined {
     rules[code] = setting as RulesConfig[string];
   }
   return Object.keys(rules).length > 0 ? rules : undefined;
+}
+
+/** Every file a run reads or writes, after flags and config have been merged. */
+export interface RunPaths {
+  /** The pgpm workspace to deploy, when `usePgpm`. Undefined means "nearest". */
+  pgpm?: string;
+  usePgpm: boolean;
+  perfBaseline?: string;
+  callGraphBaseline?: string;
+  outputs: {
+    json?: string;
+    markdown?: string;
+    sarif?: string;
+    sarifSources?: string;
+    snapshot?: string;
+    githubComment?: string;
+  };
+}
+
+/**
+ * Flags win over the config file. A path from the config file is resolved
+ * against that file, so a CI job can run from any directory; a path on the
+ * command line stays relative to cwd, like every other command's arguments.
+ */
+export function resolveRunPaths(
+  argv: ParsedArgs,
+  config: SafegresConfig,
+  configDir: string
+): RunPaths {
+  const pick = (flag: unknown, configured?: string): string | undefined =>
+    typeof flag === 'string' ? flag : configured && path.resolve(configDir, configured);
+
+  return {
+    pgpm: pick(argv.pgpm, config.source?.pgpm),
+    usePgpm: argv.pgpm !== undefined || config.source?.pgpm !== undefined,
+    perfBaseline: pick(argv['perf-baseline'], config.perf?.baseline),
+    callGraphBaseline: pick(argv.baseline, config.callGraph?.baseline),
+    outputs: {
+      json: pick(argv['write-json'], config.outputs?.json),
+      markdown: pick(argv['write-markdown'], config.outputs?.markdown),
+      sarif: pick(argv['write-sarif'], config.outputs?.sarif),
+      sarifSources: pick(argv['sarif-sources'], config.outputs?.sarifSources),
+      snapshot: pick(argv['write-snapshot'], config.outputs?.snapshot),
+      githubComment: pick(argv['write-github-comment'], config.outputs?.githubComment)
+    }
+  };
 }
 
 /** Build config-loading params from shared CLI flags. */

--- a/packages/safegres/src/cli/shared.ts
+++ b/packages/safegres/src/cli/shared.ts
@@ -93,15 +93,20 @@ export function resolveRunPaths(
   const pick = (flag: unknown, configured?: string): string | undefined =>
     typeof flag === 'string' ? flag : configured && path.resolve(configDir, configured);
 
+  // A directory is the common case: one path, conventional names, no remembering
+  // which extension goes with which renderer. A named file still wins.
+  const dir = pick(argv.out, config.outputs?.dir);
+  const inDir = (name: string): string | undefined => dir && path.join(dir, name);
+
   return {
     pgpm: pick(argv.pgpm, config.source?.pgpm),
     usePgpm: argv.pgpm !== undefined || config.source?.pgpm !== undefined,
     perfBaseline: pick(argv['perf-baseline'], config.perf?.baseline),
     callGraphBaseline: pick(argv.baseline, config.callGraph?.baseline),
     outputs: {
-      json: pick(argv['write-json'], config.outputs?.json),
-      markdown: pick(argv['write-markdown'], config.outputs?.markdown),
-      sarif: pick(argv['write-sarif'], config.outputs?.sarif),
+      json: pick(argv['write-json'], config.outputs?.json) ?? inDir('safegres.json'),
+      markdown: pick(argv['write-markdown'], config.outputs?.markdown) ?? inDir('safegres.md'),
+      sarif: pick(argv['write-sarif'], config.outputs?.sarif) ?? inDir('safegres.sarif'),
       sarifSources: pick(argv['sarif-sources'], config.outputs?.sarifSources),
       snapshot: pick(argv['write-snapshot'], config.outputs?.snapshot),
       githubComment: pick(argv['write-github-comment'], config.outputs?.githubComment)

--- a/packages/safegres/src/config/types.ts
+++ b/packages/safegres/src/config/types.ts
@@ -336,6 +336,12 @@ export interface SourceConfig {
  * `safegres audit`, with the artifact list versioned alongside the rules.
  */
 export interface OutputsConfig {
+  /**
+   * Write the whole set into one directory as `safegres.json`, `safegres.md`
+   * and `safegres.sarif`. The usual case, and nobody has to remember three
+   * paths; the keys below still override an individual file.
+   */
+  dir?: string;
   json?: string;
   markdown?: string;
   sarif?: string;

--- a/packages/safegres/src/config/types.ts
+++ b/packages/safegres/src/config/types.ts
@@ -326,6 +326,8 @@ export interface SourceConfig {
    * Deploy the pgpm workspace or module at this path (relative to the config
    * file) into an ephemeral test database and audit that. Equivalent to
    * `--pgpm <dir>`; requires the optional peer dependency `pgsql-test`.
+   * A connection named on the command line (`--connection`, `--database`,
+   * `--host`, `--port`) wins: the same config then audits that database.
    */
   pgpm?: string;
 }

--- a/packages/safegres/src/config/types.ts
+++ b/packages/safegres/src/config/types.ts
@@ -186,6 +186,14 @@ export interface PerfConfig {
   stats?: PerfStatsConfig;
   /** Planner proof (`--explain`). Off unless enabled here or by flag. */
   explain?: PerfExplainConfig;
+  /**
+   * Baseline of accepted perf debt. Present → the run diffs against it, the
+   * same as `--perf-baseline`. Writing one stays a flag (`--write-perf-baseline`):
+   * accepting debt is an act, not a setting.
+   */
+  baseline?: string;
+  /** Exit non-zero on a perf finding that isn't in the baseline. */
+  failOnNew?: boolean;
   /** Access-path classification, which decides whether X1 applies to a key. */
   paths?: PerfPathsConfig;
 }
@@ -308,6 +316,46 @@ export interface PlaneFailOnConfig {
 }
 
 /** Which scores and sections a rendered report shows. */
+/**
+ * The database under audit. A repository that always audits the same thing —
+ * a pgpm workspace deployed into an ephemeral database — should say so once,
+ * in the file, rather than in every invocation.
+ */
+export interface SourceConfig {
+  /**
+   * Deploy the pgpm workspace or module at this path (relative to the config
+   * file) into an ephemeral test database and audit that. Equivalent to
+   * `--pgpm <dir>`; requires the optional peer dependency `pgsql-test`.
+   */
+  pgpm?: string;
+}
+
+/**
+ * Files one run writes. Paths are relative to the config file, and the
+ * directories are created as needed: the point is that a CI job is
+ * `safegres audit`, with the artifact list versioned alongside the rules.
+ */
+export interface OutputsConfig {
+  json?: string;
+  markdown?: string;
+  sarif?: string;
+  /** Root scanned to resolve SARIF findings to their SQL source lines. */
+  sarifSources?: string;
+  /** Aggregate-only snapshot, for a later run's `compare`. */
+  snapshot?: string;
+  /** The rendered sticky PR comment, for a workflow that posts it itself. */
+  githubComment?: string;
+}
+
+export interface CallGraphConfig {
+  /** Build the call-graph audit without passing `--call-graph`. */
+  enabled?: boolean;
+  /** Baseline of accepted trust boundaries; enables the diff. */
+  baseline?: string;
+  /** Exit non-zero on a boundary that isn't in the baseline. */
+  failOnNew?: boolean;
+}
+
 export interface ReportConfig {
   /**
    * Planes to render, by name or glob (`primary`, `*`, `direct:*`). Default:
@@ -379,6 +427,12 @@ export interface SafegresConfig {
   overrides?: OverrideEntry[];
   scoring?: ScoringConfig;
   failOn?: FailOnConfig;
+  /** Where the database to audit comes from, when it isn't a live connection. */
+  source?: SourceConfig;
+  /** Files a single run writes, so CI doesn't have to spell them as flags. */
+  outputs?: OutputsConfig;
+  /** The unscored call-graph audit (`--call-graph`) and its baseline. */
+  callGraph?: CallGraphConfig;
   /** What a rendered report shows — selection, not analysis. */
   report?: ReportConfig;
   /** Defaults for `safegres eval` — which corpus, graded by which preset. */

--- a/packages/safegres/src/index.ts
+++ b/packages/safegres/src/index.ts
@@ -116,12 +116,14 @@ export {
   rulesForTable
 } from './config/resolve';
 export type {
+  CallGraphConfig,
   EvalConfig,
   ExposureConfig,
   FailOnConfig,
   GithubCommentConfig,
   GithubReportConfig,
   Grade,
+  OutputsConfig,
   OverrideEntry,
   PerfConfig,
   PlaneConfig,
@@ -131,7 +133,8 @@ export type {
   RulesConfig,
   RuleSetting,
   SafegresConfig,
-  ScoringConfig
+  ScoringConfig,
+  SourceConfig
 } from './config/types';
 export type { CaseResult, CorpusCase, ExpectedFinding } from './corpus';
 export { corpusBootstrap, corpusDir, gradeCase, loadCase, loadCorpus } from './corpus';


### PR DESCRIPTION
## Summary

Everything a CI job needs already exists as a flag, which is why every repo that uses safegres ends up with a wrapper script holding the flag string (`constructive-db/bin/safegres-check.cjs` is 181 lines of exactly that). The four things a job repeats every run had no config-file equivalent: where the database comes from, where artifacts go, which baseline to diff, and whether to gate on new debt. They do now, so the job is one word:

```jsonc
// .safegresrc.json — paths are relative to this file
{ "extends": "safegres:constructive",
  "source":  { "pgpm": "application/app" },
  "callGraph": { "enabled": true },
  "perf":    { "enabled": true, "baseline": "ci/perf-baseline.json", "failOnNew": true },
  "outputs": { "dir": "safegres-reports" },
  "failOn":  { "grade": "B" } }
```
```console
$ safegres audit          # or `safegres lint`, the new alias, in a package.json script
```

`outputs.dir` (and `--out <dir>`) writes `safegres.{json,md,sarif}`, so nobody has to remember which extension goes with which renderer; a named `outputs.json` still overrides its own file. Directories are created — CI should not have to `mkdir -p`.

**Path semantics, the one decision here.** A path from the config file resolves against *that file*; a path from a flag stays relative to cwd. Otherwise a job that `cd`s into a package reads a different baseline than the one committed next to the rules, and `--write-json out.json` stops meaning what every other CLI means by it. Flags win when both are given.

Merging is one pure function, `resolveRunPaths(argv, config, configDir)` in `cli/shared.ts`, so the precedence is unit-tested rather than asserted eight times inline in the command.

**Two escapes, now that a committed file can gate.** The same file is read by more than one job, so both directions need a way out:

- a connection named on the command line beats `source.pgpm` — `safegres audit --database staging` audits staging instead of deploying a throwaway copy of the same schema. `PGDATABASE` does not count: it is set on every runner.
- `--report-only` evaluates and reports every gate, then exits 0 — how to run a gated config as an advisory job against a second database, where the file's baseline doesn't apply.

Nothing about analysis or scoring moves: the new keys aren't in the fingerprint's scoring surface (it's a whitelist), so an identical database still fingerprints identically. Sealed runs are unaffected — they don't read a config file, so they can't pick up a `baseline` or a `source` either.

Also a `## Features` list near the top of the README, placed like pgsql-parser's.

Next: this unblocks cutting a release and deleting `bin/safegres-check.cjs` in constructive-db (planning #1370).

Link to Devin session: https://app.devin.ai/sessions/b7874ecee0c7471ea271e6e7193869dc
Requested by: @pyramation