### PR TITLE
fix(presigned-url): keep the database claim across request-lane statements

### DIFF
--- a/graphile/graphile-presigned-url-plugin/__tests__/request-pg-client.test.ts
+++ b/graphile/graphile-presigned-url-plugin/__tests__/request-pg-client.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Regression tests for withRequestPgClient.
+ *
+ * The bug: the grafast context's `withPgClient(pgSettings, cb)` applies the
+ * request's jwt claims as transaction-LOCAL `set_config(key, value, is_local =>
+ * true)` but does NOT open an explicit transaction around `cb`. When `cb` runs
+ * more than one statement, each executes in its own implicit (autocommit)
+ * transaction, so a LOCAL setting applied for the set_config statement is gone
+ * by the next statement. `jwt_private.current_database_id()` then raised
+ * DATABASE_CLAIM_REQUIRED on presigned uploads even though the request carried
+ * `jwt.claims.database_id`.
+ *
+ * The fix: withRequestPgClient acquires the client WITHOUT settings, opens ONE
+ * explicit transaction, and applies the settings inside it — so every statement
+ * in `cb` observes the same claims.
+ *
+ * These tests use a small in-memory model of the node-postgres adaptor's
+ * transaction-LOCAL semantics so the regression needs no live database.
+ */
+
+import { type WithPgClient,withRequestPgClient } from '../src/request-pg-client';
+
+const SET_CONFIG_SQL_RE = /set_config\(el->>0, el->>1, true\)/;
+
+/**
+ * Faithful-enough model of the adaptor client around `set_config(..., is_local
+ * => true)`: a LOCAL setting lives for the enclosing transaction, or — with no
+ * open transaction — only for the single statement that set it (autocommit).
+ */
+class FakePg {
+  txDepth = 0;
+  calls: string[] = [];
+  private txLocal = new Map<string, string>();
+  private stmtLocal = new Map<string, string>();
+
+  private effective(key: string): string | null {
+    return this.txLocal.get(key) ?? this.stmtLocal.get(key) ?? null;
+  }
+
+  async query(opts: { text: string; values?: unknown[] }): Promise<{ rows: Array<Record<string, unknown>> }> {
+    this.calls.push(opts.text.replace(/\s+/g, ' ').trim());
+
+    if (SET_CONFIG_SQL_RE.test(opts.text)) {
+      const entries = JSON.parse(String(opts.values?.[0] ?? '[]')) as Array<[string, string]>;
+      for (const [key, value] of entries) {
+        if (this.txDepth > 0) this.txLocal.set(key, value);
+        else this.stmtLocal.set(key, value);
+      }
+      if (this.txDepth === 0) this.stmtLocal.clear();
+      return { rows: [{}] };
+    }
+
+    const match = /current_setting\('([^']+)'/.exec(opts.text);
+    const rows: Array<Record<string, unknown>> = match
+      ? [{ v: this.effective(match[1]) }]
+      : [{}];
+    if (this.txDepth === 0) this.stmtLocal.clear();
+    return { rows };
+  }
+
+  async withTransaction<T>(cb: (tx: FakePg) => Promise<T>): Promise<T> {
+    this.txDepth++;
+    this.calls.push('BEGIN');
+    try {
+      const result = await cb(this);
+      this.calls.push('COMMIT');
+      return result;
+    } catch (err) {
+      this.calls.push('ROLLBACK');
+      throw err;
+    } finally {
+      this.txDepth--;
+      if (this.txDepth === 0) this.txLocal.clear();
+    }
+  }
+}
+
+function makeWithPgClient(pg: FakePg): { withPgClient: WithPgClient; settingsSeen: Array<Record<string, string> | null> } {
+  const settingsSeen: Array<Record<string, string> | null> = [];
+  const withPgClient = (async (pgSettings, cb) => {
+    settingsSeen.push(pgSettings);
+    // The adaptor applies request pgSettings via a LOCAL set_config in the same
+    // lane WITHOUT opening an explicit transaction — this is the buggy path.
+    if (pgSettings) {
+      await pg.query({
+        text: 'SELECT set_config(el->>0, el->>1, true) FROM json_array_elements($1::json) el',
+        values: [JSON.stringify(Object.entries(pgSettings))],
+      });
+    }
+    return cb(pg as never);
+  }) as WithPgClient;
+  return { withPgClient, settingsSeen };
+}
+
+const readClaim = "SELECT current_setting('jwt.claims.database_id', true) AS v";
+
+describe('withRequestPgClient', () => {
+  it('reproduces the bug: a LOCAL claim is lost across autocommit statements', async () => {
+    const pg = new FakePg();
+    const { withPgClient } = makeWithPgClient(pg);
+
+    // Directly using withPgClient(pgSettings, cb) — no surrounding transaction.
+    const claim = await withPgClient({ 'jwt.claims.database_id': 'db-1' }, async (client) => {
+      const result = await client.query({ text: readClaim });
+      return result.rows[0]?.v ?? null;
+    });
+
+    expect(claim).toBeNull();
+  });
+
+  it('keeps the claim visible across every statement inside the transaction', async () => {
+    const pg = new FakePg();
+    const { withPgClient } = makeWithPgClient(pg);
+
+    const claim = await withRequestPgClient(
+      withPgClient,
+      { role: 'authenticated', 'jwt.claims.database_id': 'db-1' },
+      async (tx) => {
+        await tx.query({ text: 'SELECT 1' });
+        const result = await tx.query({ text: readClaim });
+        return result.rows[0]?.v ?? null;
+      },
+    );
+
+    expect(claim).toBe('db-1');
+  });
+
+  it('acquires the client in the system lane (null pgSettings) and wraps work in one transaction', async () => {
+    const pg = new FakePg();
+    const { withPgClient, settingsSeen } = makeWithPgClient(pg);
+
+    await withRequestPgClient(
+      withPgClient,
+      { 'jwt.claims.database_id': 'db-1' },
+      async (tx) => tx.query({ text: readClaim }),
+    );
+
+    // The helper must NOT pass request pgSettings to withPgClient — it applies
+    // them itself inside the transaction.
+    expect(settingsSeen).toEqual([null]);
+
+    // BEGIN → set_config → work → COMMIT, in that order.
+    expect(pg.calls[0]).toBe('BEGIN');
+    expect(pg.calls[1]).toMatch(SET_CONFIG_SQL_RE);
+    expect(pg.calls[2]).toBe(readClaim);
+    expect(pg.calls[pg.calls.length - 1]).toBe('COMMIT');
+  });
+
+  it('opens a transaction but issues no set_config when there are no settings', async () => {
+    for (const settings of [null, {}] as Array<Record<string, string> | null>) {
+      const pg = new FakePg();
+      const { withPgClient } = makeWithPgClient(pg);
+
+      await withRequestPgClient(withPgClient, settings, async (tx) => tx.query({ text: 'SELECT 1' }));
+
+      expect(pg.calls).toContain('BEGIN');
+      expect(pg.calls).toContain('COMMIT');
+      expect(pg.calls.filter((c) => SET_CONFIG_SQL_RE.test(c))).toHaveLength(0);
+    }
+  });
+
+  it('propagates callback errors (never swallows) and rolls back', async () => {
+    const pg = new FakePg();
+    const { withPgClient } = makeWithPgClient(pg);
+
+    await expect(
+      withRequestPgClient(withPgClient, { 'jwt.claims.database_id': 'db-1' }, async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    expect(pg.calls).toContain('ROLLBACK');
+    expect(pg.calls).not.toContain('COMMIT');
+  });
+});

--- a/graphile/graphile-presigned-url-plugin/src/download-url-field.ts
+++ b/graphile/graphile-presigned-url-plugin/src/download-url-field.ts
@@ -25,6 +25,7 @@ import { Logger } from '@pgpmjs/logger';
 import { context as grafastContext, lambda, object } from 'grafast';
 import type { GraphileConfig } from 'graphile-config';
 
+import { withRequestPgClient } from './request-pg-client';
 import { generatePresignedGetUrl } from './s3-signer';
 import { loadAllStorageModules, resolveStorageConfigFromCodec, storedPhysicalName } from './storage-module-cache';
 import type { PresignedUrlPluginOptions, S3Config, StorageModuleConfig } from './types';
@@ -149,11 +150,11 @@ export function createDownloadUrlPlugin(
                       let downloadUrlExpirySeconds = 3600;
                       try {
                         if (withPgClient && pgSettings) {
-                          const databaseId = await withPgClient(pgSettings, async (pgClient: any) => {
+                          const databaseId = await withRequestPgClient(withPgClient, pgSettings, async (pgClient) => {
                             const dbResult = await pgClient.query({
                               text: `SELECT jwt_private.current_database_id() AS id`,
                             });
-                            return dbResult.rows[0]?.id ?? null;
+                            return (dbResult.rows[0]?.id as string | undefined) ?? null;
                           });
                           // Module registration is server config, not user data:
                           // resolve it without the request role's pgSettings.
@@ -164,7 +165,7 @@ export function createDownloadUrlPlugin(
                             )
                             : null;
                           const resolved = config && bucketId
-                            ? await withPgClient(pgSettings, async (pgClient: any) => {
+                            ? await withRequestPgClient(withPgClient, pgSettings, async (pgClient) => {
                               // Look up the stored physical coordinate for scoped S3 resolution
                               const bucketResult = await pgClient.query({
                                 text: `SELECT key, physical_name FROM ${config.bucketsQualifiedName} WHERE id = $1 LIMIT 1`,

--- a/graphile/graphile-presigned-url-plugin/src/plugin.ts
+++ b/graphile/graphile-presigned-url-plugin/src/plugin.ts
@@ -23,6 +23,7 @@ import { Logger } from '@pgpmjs/logger';
 import { access, context as grafastContext, lambda, object } from 'grafast';
 import type { GraphileConfig } from 'graphile-config';
 
+import { type WithPgClient,withRequestPgClient } from './request-pg-client';
 import { deleteS3Object,generatePresignedPutUrl } from './s3-signer';
 import { getBucketConfig, isS3BucketProvisioned, loadAllStorageModules, markS3BucketProvisioned,resolveStorageConfigFromCodec, storedPhysicalName } from './storage-module-cache';
 import type { BucketConfig,PresignedUrlPluginOptions, S3Config, StorageModuleConfig } from './types';
@@ -143,14 +144,19 @@ function resolveS3ForDatabase(
  * value is the durable coordinate: route resolution and every later read use
  * it verbatim; nothing is recomputed.
  *
- * The record write runs in the system lane (`withPgClient(null, ...)`) — it is
- * server bookkeeping, not request data, and anonymous request roles cannot
- * UPDATE bucket rows under RLS. `bucket` (the cached config) is mutated in place
- * so subsequent reads observe the recorded name without a DB round-trip.
+ * The record write runs in the system lane (privileged role, so it bypasses the
+ * RLS that stops request roles from UPDATE-ing bucket rows) — it is server
+ * bookkeeping, not request data. It still carries the tenant `database_id`
+ * claim, because the buckets table's catalog-sync trigger calls
+ * `jwt_private.current_database_id()` and would otherwise raise
+ * DATABASE_CLAIM_REQUIRED; `withRequestPgClient` applies that claim inside the
+ * write's transaction without switching off the privileged role.
+ * `bucket` (the cached config) is mutated in place so subsequent reads observe
+ * the recorded name without a DB round-trip.
  */
 async function provisionAndRecordPhysicalBucket(
   options: PresignedUrlPluginOptions,
-  withPgClient: (pgSettings: null, cb: (client: any) => Promise<unknown>) => Promise<unknown>,
+  withPgClient: WithPgClient,
   storageConfig: StorageModuleConfig,
   databaseId: string,
   bucket: BucketConfig,
@@ -167,7 +173,9 @@ async function provisionAndRecordPhysicalBucket(
 
   // Record the physical coordinate on the source row. The `physical_name IS NULL`
   // guard keeps this idempotent and race-safe across concurrent first uploads.
-  await withPgClient(null, (client: any) =>
+  // The catalog-sync trigger on this UPDATE needs `jwt.claims.database_id`, so the
+  // write runs under the resolved database claim (privileged role preserved).
+  await withRequestPgClient(withPgClient, { 'jwt.claims.database_id': databaseId }, (client) =>
     client.query({
       text: `UPDATE ${storageConfig.bucketsQualifiedName}
              SET physical_name = $1
@@ -322,7 +330,10 @@ export function createPresignedUrlPlugin(
                     });
 
                     return lambda($combined, async (vals: any) => {
-                      const databaseId = await vals.withPgClient(vals.pgSettings, (pgClient: any) =>
+                      // Request-lane reads/writes run under the request role's pgSettings
+                      // inside an explicit transaction so the jwt claims stay applied
+                      // across every statement (see withRequestPgClient).
+                      const databaseId = await withRequestPgClient(vals.withPgClient, vals.pgSettings, (pgClient) =>
                         resolveDatabaseId(pgClient),
                       );
                       if (!databaseId) throw new Error('DATABASE_NOT_FOUND');
@@ -336,7 +347,7 @@ export function createPresignedUrlPlugin(
                       if (!storageConfig) throw new Error('STORAGE_MODULE_NOT_FOUND');
 
                       // Bucket config read under the request role (RLS-gated visibility).
-                      const bucket = await vals.withPgClient(vals.pgSettings, (pgClient: any) =>
+                      const bucket = await withRequestPgClient(vals.withPgClient, vals.pgSettings, (pgClient) =>
                         getBucketConfig(pgClient, storageConfig, databaseId, vals.bucketKey, vals.ownerId || undefined),
                       );
                       if (!bucket) throw new Error('BUCKET_NOT_FOUND');
@@ -349,16 +360,14 @@ export function createPresignedUrlPlugin(
                       const s3ForDb = resolveS3ForDatabase(options, storageConfig, physicalName);
 
                       // File row INSERT under the request role (RLS enforced).
-                      return vals.withPgClient(vals.pgSettings, (pgClient: any) =>
-                        pgClient.withTransaction((txClient: any) =>
-                          processSingleFile(options, txClient, storageConfig, databaseId, bucket, s3ForDb, {
-                            contentHash: vals.contentHash,
-                            contentType: vals.contentType,
-                            size: vals.size,
-                            filename: vals.filename,
-                            key: vals.customKey,
-                          }),
-                        ),
+                      return withRequestPgClient(vals.withPgClient, vals.pgSettings, (txClient) =>
+                        processSingleFile(options, txClient, storageConfig, databaseId, bucket, s3ForDb, {
+                          contentHash: vals.contentHash,
+                          contentType: vals.contentType,
+                          size: vals.size,
+                          filename: vals.filename,
+                          key: vals.customKey,
+                        }),
                       );
                     });
                   },
@@ -435,7 +444,10 @@ export function createPresignedUrlPlugin(
                     });
 
                     return lambda($combined, async (vals: any) => {
-                      const databaseId = await vals.withPgClient(vals.pgSettings, (pgClient: any) =>
+                      // Request-lane reads/writes run under the request role's pgSettings
+                      // inside an explicit transaction so the jwt claims stay applied
+                      // across every statement (see withRequestPgClient).
+                      const databaseId = await withRequestPgClient(vals.withPgClient, vals.pgSettings, (pgClient) =>
                         resolveDatabaseId(pgClient),
                       );
                       if (!databaseId) throw new Error('DATABASE_NOT_FOUND');
@@ -449,7 +461,7 @@ export function createPresignedUrlPlugin(
                       if (!storageConfig) throw new Error('STORAGE_MODULE_NOT_FOUND');
 
                       // Bucket config read under the request role (RLS-gated visibility).
-                      const bucket = await vals.withPgClient(vals.pgSettings, (pgClient: any) =>
+                      const bucket = await withRequestPgClient(vals.withPgClient, vals.pgSettings, (pgClient) =>
                         getBucketConfig(pgClient, storageConfig, databaseId, vals.bucketKey, vals.ownerId || undefined),
                       );
                       if (!bucket) throw new Error('BUCKET_NOT_FOUND');
@@ -476,23 +488,21 @@ export function createPresignedUrlPlugin(
                       const s3ForDb = resolveS3ForDatabase(options, storageConfig, physicalName);
 
                       // File row INSERTs under the request role (RLS enforced).
-                      return vals.withPgClient(vals.pgSettings, (pgClient: any) =>
-                        pgClient.withTransaction(async (txClient: any) => {
-                          const results = [];
-                          for (const file of filesArray) {
-                            results.push(
-                              await processSingleFile(options, txClient, storageConfig, databaseId, bucket, s3ForDb, {
-                                contentHash: file.contentHash,
-                                contentType: file.contentType,
-                                size: file.size,
-                                filename: file.filename,
-                                key: file.key,
-                              }),
-                            );
-                          }
-                          return { files: results };
-                        }),
-                      );
+                      return withRequestPgClient(vals.withPgClient, vals.pgSettings, async (txClient) => {
+                        const results = [];
+                        for (const file of filesArray) {
+                          results.push(
+                            await processSingleFile(options, txClient, storageConfig, databaseId, bucket, s3ForDb, {
+                              contentHash: file.contentHash,
+                              contentType: file.contentType,
+                              size: file.size,
+                              filename: file.filename,
+                              key: file.key,
+                            }),
+                          );
+                        }
+                        return { files: results };
+                      });
                     });
                   },
                 },
@@ -557,7 +567,7 @@ export function createPresignedUrlPlugin(
 
                 if (withPgClient) {
                   try {
-                    const databaseId = await withPgClient(pgSettings, (pgClient: any) => resolveDatabaseId(pgClient));
+                    const databaseId = await withRequestPgClient(withPgClient, pgSettings, (pgClient) => resolveDatabaseId(pgClient));
                     // Module registration is server config, not user data:
                     // resolve it without the request role's pgSettings.
                     const allConfigs = databaseId
@@ -566,7 +576,7 @@ export function createPresignedUrlPlugin(
                     const storageConfig = resolveStorageConfigFromCodec(capturedCodec, allConfigs);
 
                     if (storageConfig) {
-                      await withPgClient(pgSettings, async (pgClient: any) => {
+                      await withRequestPgClient(withPgClient, pgSettings, async (pgClient) => {
                         // Read the file row (RLS enforced)
                         const result = await pgClient.query({
                           text: `SELECT key, bucket_id FROM ${storageConfig.filesQualifiedName} WHERE id = $1 LIMIT 1`,
@@ -593,7 +603,7 @@ export function createPresignedUrlPlugin(
 
                 if (withPgClient) {
                   try {
-                    const databaseId = await withPgClient(pgSettings, (pgClient: any) => resolveDatabaseId(pgClient));
+                    const databaseId = await withRequestPgClient(withPgClient, pgSettings, (pgClient) => resolveDatabaseId(pgClient));
                     // Module registration is server config, not user data:
                     // resolve it without the request role's pgSettings.
                     const allConfigs = databaseId
@@ -601,13 +611,13 @@ export function createPresignedUrlPlugin(
                       : [];
                     const storageConfig = resolveStorageConfigFromCodec(capturedCodec, allConfigs);
 
-                    if (storageConfig) await withPgClient(pgSettings, async (pgClient: any) => {
+                    if (storageConfig) await withRequestPgClient(withPgClient, pgSettings, async (pgClient) => {
                       // Check refcount: any other file with the same key in this bucket?
                       const refResult = await pgClient.query({
                         text: `SELECT COUNT(*)::int AS ref_count FROM ${storageConfig.filesQualifiedName} WHERE key = $1 AND bucket_id = $2`,
                         values: [fileRow!.key, fileRow!.bucket_id],
                       });
-                      const refCount = refResult.rows[0]?.ref_count ?? 0;
+                      const refCount = (refResult.rows[0]?.ref_count as number | undefined) ?? 0;
 
                       if (refCount > 0) {
                         log.info(`File deleted from DB; S3 key ${fileRow!.key} still referenced by ${refCount} file(s)`);

--- a/graphile/graphile-presigned-url-plugin/src/request-pg-client.ts
+++ b/graphile/graphile-presigned-url-plugin/src/request-pg-client.ts
@@ -1,0 +1,56 @@
+/**
+ * Run a callback under the request's pgSettings inside ONE explicit transaction.
+ *
+ * The grafast context's `withPgClient(pgSettings, cb)` applies pgSettings as
+ * transaction-LOCAL `set_config(key, value, is_local => true)`. When `cb` issues
+ * more than one statement WITHOUT an explicit surrounding transaction, each
+ * statement runs in its own implicit (autocommit) transaction, so a LOCAL
+ * setting applied for one statement is already gone by the next. The request
+ * role's jwt claims (notably `jwt.claims.database_id`) then vanish between
+ * statements, and `jwt_private.current_database_id()` raises
+ * DATABASE_CLAIM_REQUIRED even though the request carried the claim.
+ *
+ * This helper acquires the client without settings (`withPgClient(null, ...)`),
+ * opens a single explicit transaction, and applies the request settings inside
+ * it — so every statement in `cb` observes the same role and jwt claims. It
+ * mirrors the `pg-query-context` pattern used elsewhere in the codebase for
+ * manual, multi-statement RLS work.
+ */
+
+export interface RequestPgClient {
+  query(opts: { text: string; values?: unknown[] }): Promise<{ rows: Array<Record<string, unknown>> }>;
+  withTransaction<T>(cb: (tx: RequestPgClient) => Promise<T>): Promise<T>;
+}
+
+export type WithPgClient = <T>(
+  pgSettings: Record<string, string> | null,
+  cb: (client: RequestPgClient) => Promise<T>,
+) => Promise<T>;
+
+async function applyRequestSettings(
+  tx: RequestPgClient,
+  pgSettings: Record<string, string> | null,
+): Promise<void> {
+  if (!pgSettings) return;
+  const entries = Object.entries(pgSettings)
+    .filter(([, value]) => value != null)
+    .map(([key, value]) => [key, String(value)]);
+  if (entries.length === 0) return;
+  await tx.query({
+    text: 'SELECT set_config(el->>0, el->>1, true) FROM json_array_elements($1::json) el',
+    values: [JSON.stringify(entries)],
+  });
+}
+
+export function withRequestPgClient<T>(
+  withPgClient: WithPgClient,
+  pgSettings: Record<string, string> | null,
+  cb: (tx: RequestPgClient) => Promise<T>,
+): Promise<T> {
+  return withPgClient(null, (client) =>
+    client.withTransaction(async (tx) => {
+      await applyRequestSettings(tx, pgSettings);
+      return cb(tx);
+    }),
+  );
+}


### PR DESCRIPTION
## Summary

`uploadAppFile` (and the file `downloadUrl` resolver) failed over HTTP with `DATABASE_CLAIM_REQUIRED` even though the request carried `jwt.claims.database_id`.

Root cause: the presigned-url plugin ran multi-statement request work as

```ts
withPgClient(pgSettings, (client) => client.query(...) /* then another query */)
```

The `@dataplan/pg` adaptor applies `pgSettings` as **transaction-LOCAL** `set_config(key, value, is_local => true)` but does **not** open an explicit transaction around the callback. So each `client.query(...)` runs in its own implicit (autocommit) transaction, and the LOCAL claim set for one statement is already gone by the next — `jwt_private.current_database_id()` then raises `DATABASE_CLAIM_REQUIRED`. (Confirmed at runtime: the callback's first statement saw the claim, the next did not.)

Fix — a small helper that mirrors the existing `pg-query-context` pattern (new `src/request-pg-client.ts`):

```ts
export function withRequestPgClient(withPgClient, pgSettings, cb) {
  return withPgClient(null, (client) =>          // system lane: no settings on acquire
    client.withTransaction(async (tx) => {        // ONE explicit transaction
      await applyRequestSettings(tx, pgSettings);  // set_config(..., is_local) INSIDE it
      return cb(tx);                               // every statement sees the claim
    }),
  );
}
```

All request-lane reads/writes now go through it (`plugin.ts`, `download-url-field.ts`): `resolveDatabaseId`, bucket/file reads, single + bulk `processSingleFile`, and the delete-middleware pre-read/refcount reads. System-lane config reads (`loadAllStorageModules`) stay on `withPgClient(null, ...)`.

One extra case: `provisionAndRecordPhysicalBucket`'s `physical_name` `UPDATE` is intentionally a **system-lane** write (privileged role, so it bypasses the RLS that blocks request roles). But the buckets table's catalog-sync trigger calls `current_database_id()`, so a bare system-lane write hit the same claim error. It now runs through `withRequestPgClient(withPgClient, { 'jwt.claims.database_id': databaseId }, ...)` — the claim is applied inside the transaction **without** switching off the privileged role, so RLS stays bypassed and the trigger resolves.

## Verification

- Package `build` (tsc typecheck) + `lint` clean.
- New `__tests__/request-pg-client.test.ts` (no live DB; models the adaptor's transaction-LOCAL semantics): reproduces the bug (claim lost across autocommit statements), proves the fix (claim durable across statements in the transaction), asserts the system-lane acquire + `BEGIN → set_config → work → COMMIT` ordering, no `set_config` when there are no settings, and error propagation + `ROLLBACK` (no swallowing).
- End-to-end against a local `fun up --k8s` cluster (graphql-public rebuilt with this `dist/`): `uploadAppFile` returns a presigned URL, `PUT` → `200`, and a second upload of identical content returns `deduplicated: true` with `uploadUrl: null` and the same `fileId`.


Link to Devin session: https://app.devin.ai/sessions/2ffbeace70364c6aa00b2534a5eadd06
Requested by: @pyramation