### PR TITLE
feat(safegres): L13 — column-level ACLs, the grants relacl never showed

### DIFF
--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -148,6 +148,7 @@ family, **not** the dimension: `P1`/`P1b` are performance, `P5` is security.
 | L10 | info | fail-open | **Rewrite-rule bypass** — a rule on a view writes a relation as the view's owner, `security_invoker` notwithstanding † |
 | L11 | info | fail-open | **Materialized-view snapshot** — stored rows serve an untrusted role what the base relation's grants and policies would not † |
 | L12 | info | fail-open | **Non-barrier filtering view** — a view is an untrusted role's only path to a relation, but its row filter is not a boundary † |
+| L13 | info | fail-open | **Column-level grant** — an untrusted role reaches a relation through `pg_attribute.attacl`, which no relation ACL shows † |
 | W1 | medium | — | **No exposure surface configured** — whole database assumed reachable, score capped |
 
 † R1/R2/L5 are no-ops until you name the untrusted roles:

--- a/packages/safegres/__tests__/column-grants.test.ts
+++ b/packages/safegres/__tests__/column-grants.test.ts
@@ -1,0 +1,225 @@
+import { checkUntrustedColumnGrants } from '../src/checks/column-grants';
+import {
+  checkDeadPolicies,
+  checkDeadSchemaUsage,
+  computeRoleAccess,
+  effectiveColumnGrants,
+  type RoleGraph
+} from '../src/checks/lattice';
+import type { RoleAttributes, SchemaAclInfo } from '../src/pg/acl';
+import type { ColumnGrantInfo, GrantInfo, PolicyInfo, TableSnapshot } from '../src/pg/introspect';
+
+function table(partial: Partial<TableSnapshot> = {}): TableSnapshot {
+  return {
+    schema: 'app',
+    name: 'people',
+    oid: 1,
+    rlsEnabled: false,
+    rlsForced: false,
+    isPartitioned: false,
+    owner: 'app_owner',
+    grants: [],
+    columnGrants: [],
+    policies: [],
+    ...partial
+  };
+}
+
+function grant(role: string, privilege: GrantInfo['privilege']): GrantInfo {
+  return { role, privilege, grantable: false, bypassRls: false };
+}
+
+function colGrant(
+  role: string,
+  column: string,
+  privilege: GrantInfo['privilege'] = 'SELECT'
+): ColumnGrantInfo {
+  return { role, column, privilege, grantable: false, bypassRls: false };
+}
+
+function policy(partial: Partial<PolicyInfo> = {}): PolicyInfo {
+  return {
+    name: 'p',
+    cmd: 'ALL',
+    permissive: true,
+    roles: ['anonymous'],
+    using: 'true',
+    withCheck: 'true',
+    ...partial
+  };
+}
+
+function role(name: string, partial: Partial<RoleAttributes> = {}): [string, RoleAttributes] {
+  return [name, { name, bypassRls: false, isSuper: false, inheritsFrom: [], canSetRole: [], ...partial }];
+}
+
+const GRAPH: RoleGraph = new Map([
+  role('anonymous'),
+  role('authenticated'),
+  role('app_owner'),
+  role('app_admin', { inheritsFrom: ['authenticated'] }),
+  role('superrole', { bypassRls: true, isSuper: true })
+]);
+
+const ANON = { roles: ['anonymous'] };
+
+describe('effectiveColumnGrants', () => {
+  it('groups columns per privilege with direct provenance', () => {
+    const t = table({
+      columnGrants: [
+        colGrant('anonymous', 'name'),
+        colGrant('anonymous', 'avatar_url'),
+        colGrant('anonymous', 'bio', 'UPDATE')
+      ]
+    });
+    expect(effectiveColumnGrants(t, 'anonymous', GRAPH)).toEqual([
+      { privilege: 'SELECT', via: 'direct', columns: ['avatar_url', 'name'] },
+      { privilege: 'UPDATE', via: 'direct', columns: ['bio'] }
+    ]);
+  });
+
+  it('expands PUBLIC and inherited column grants', () => {
+    const t = table({
+      columnGrants: [colGrant('PUBLIC', 'name'), colGrant('authenticated', 'email')]
+    });
+    expect(effectiveColumnGrants(t, 'app_admin', GRAPH)).toEqual([
+      { privilege: 'SELECT', via: 'PUBLIC', columns: ['email', 'name'] }
+    ]);
+  });
+
+  it('drops privileges the role already holds on the whole relation', () => {
+    const t = table({
+      grants: [grant('anonymous', 'SELECT')],
+      columnGrants: [colGrant('anonymous', 'name'), colGrant('anonymous', 'bio', 'UPDATE')]
+    });
+    expect(effectiveColumnGrants(t, 'anonymous', GRAPH)).toEqual([
+      { privilege: 'UPDATE', via: 'direct', columns: ['bio'] }
+    ]);
+  });
+
+  it('ignores column grants to unrelated roles', () => {
+    const t = table({ columnGrants: [colGrant('authenticated', 'email')] });
+    expect(effectiveColumnGrants(t, 'anonymous', GRAPH)).toEqual([]);
+  });
+});
+
+describe('L13 — untrusted column-level grants', () => {
+  it('fires on a column grant no relation ACL shows, and says RLS is not mediating it', () => {
+    const t = table({ columnGrants: [colGrant('anonymous', 'email')] });
+    const findings = checkUntrustedColumnGrants(t, GRAPH, ANON);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      code: 'L13',
+      severity: 'info',
+      schema: 'app',
+      table: 'people',
+      role: 'anonymous',
+      privilege: 'SELECT'
+    });
+    expect(findings[0].message).toContain('(email)');
+    expect(findings[0].message).toContain('no RLS to mediate it');
+    expect(findings[0].context).toMatchObject({ columns: ['email'], rlsMediated: false });
+  });
+
+  it('reports the access as mediated when RLS applies to the role', () => {
+    const t = table({
+      rlsEnabled: true,
+      policies: [policy()],
+      columnGrants: [colGrant('anonymous', 'email')]
+    });
+    const findings = checkUntrustedColumnGrants(t, GRAPH, ANON);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].message).toContain('mediated by RLS');
+    expect(findings[0].context).toMatchObject({ rlsMediated: true });
+  });
+
+  it('treats a BYPASSRLS role as unmediated even with RLS on', () => {
+    const t = table({ rlsEnabled: true, columnGrants: [colGrant('superrole', 'email')] });
+    const findings = checkUntrustedColumnGrants(t, GRAPH, { roles: ['superrole'] });
+    expect(findings[0].context).toMatchObject({ rlsMediated: false, rlsEnabled: true });
+  });
+
+  it('stays silent when the role already holds the privilege on the whole relation', () => {
+    const t = table({
+      grants: [grant('anonymous', 'SELECT')],
+      columnGrants: [colGrant('anonymous', 'email')]
+    });
+    expect(checkUntrustedColumnGrants(t, GRAPH, ANON)).toEqual([]);
+  });
+
+  it('stays silent for roles that are not configured as untrusted', () => {
+    const t = table({ columnGrants: [colGrant('authenticated', 'email')] });
+    expect(checkUntrustedColumnGrants(t, GRAPH, ANON)).toEqual([]);
+    expect(checkUntrustedColumnGrants(t, GRAPH)).toEqual([]);
+  });
+
+  it('ignores REFERENCES, which grants no read of the data', () => {
+    const t = table({ columnGrants: [colGrant('anonymous', 'id', 'REFERENCES')] });
+    expect(checkUntrustedColumnGrants(t, GRAPH, ANON)).toEqual([]);
+  });
+
+  it('never recommends revoking the grant', () => {
+    const t = table({ columnGrants: [colGrant('anonymous', 'email')] });
+    const [finding] = checkUntrustedColumnGrants(t, GRAPH, ANON);
+    expect(finding.hint).toContain('Do not revoke the grant');
+    expect(finding.hint).toContain('nothing here proves it unused');
+  });
+});
+
+describe('column grants as reach', () => {
+  const usageAcl: SchemaAclInfo = {
+    schema: 'app',
+    owner: 'app_owner',
+    grants: [{ role: 'anonymous', privilege: 'USAGE' }],
+    executeRoles: []
+  };
+
+  it('L4 does not call schema USAGE dead when the only reach is column-scoped', () => {
+    const t = table({ columnGrants: [colGrant('anonymous', 'email')] });
+    expect(checkDeadSchemaUsage([usageAcl], [t], GRAPH)).toEqual([]);
+  });
+
+  it('L4 still fires when nothing at all is reachable', () => {
+    const findings = checkDeadSchemaUsage([usageAcl], [table()], GRAPH);
+    expect(findings.map((f) => f.code)).toEqual(['L4']);
+  });
+
+  it('L2 does not call a policy dead when the grant it mediates is column-scoped', () => {
+    const t = table({
+      rlsEnabled: true,
+      policies: [policy({ cmd: 'SELECT' })],
+      columnGrants: [colGrant('anonymous', 'email')]
+    });
+    expect(checkDeadPolicies(t, GRAPH)).toEqual([]);
+  });
+
+  it('L2 still fires when the role holds no grant of any kind', () => {
+    const t = table({ rlsEnabled: true, policies: [policy({ cmd: 'SELECT' })] });
+    expect(checkDeadPolicies(t, GRAPH).map((f) => f.code)).toEqual(['L2']);
+  });
+
+  it('the role access report counts a column-only relation and names the columns', () => {
+    const t = table({ columnGrants: [colGrant('anonymous', 'email'), colGrant('anonymous', 'name')] });
+    const [entry] = computeRoleAccess([t], GRAPH, ['anonymous']);
+    expect(entry.accessibleTables).toBe(1);
+    expect(entry.unmediated).toEqual([
+      {
+        schema: 'app',
+        table: 'people',
+        privileges: ['SELECT'],
+        via: 'direct',
+        columns: ['email', 'name'],
+        access: 'unmediated'
+      }
+    ]);
+  });
+
+  it('does not report columns when the whole relation is reachable anyway', () => {
+    const t = table({
+      grants: [grant('anonymous', 'SELECT')],
+      columnGrants: [colGrant('anonymous', 'email')]
+    });
+    const [entry] = computeRoleAccess([t], GRAPH, ['anonymous']);
+    expect(entry.unmediated[0].columns).toBeUndefined();
+  });
+});

--- a/packages/safegres/__tests__/column-introspect.test.ts
+++ b/packages/safegres/__tests__/column-introspect.test.ts
@@ -1,0 +1,76 @@
+import { getConnections, PgTestClient } from 'pgsql-test';
+
+import { introspectTables } from '../src/pg/introspect';
+
+jest.setTimeout(120000);
+
+let pg: PgTestClient;
+let teardown: () => Promise<void>;
+
+beforeAll(async () => {
+  ({ pg, teardown } = await getConnections());
+  // A column grant writes `pg_attribute.attacl` and leaves `pg_class.relacl`
+  // untouched, which is exactly why relacl-only introspection saw nothing.
+  await pg.any(`
+    CREATE SCHEMA fx_colacl;
+    CREATE TABLE fx_colacl.people (id int, name text, email text, ssn text);
+    CREATE TABLE fx_colacl.plain (id int, name text);
+    CREATE ROLE fx_col_anon;
+    CREATE ROLE fx_col_app;
+
+    GRANT SELECT (name, email) ON fx_colacl.people TO fx_col_anon;
+    GRANT UPDATE (email) ON fx_colacl.people TO fx_col_anon;
+    GRANT SELECT (name) ON fx_colacl.people TO PUBLIC;
+    GRANT SELECT ON fx_colacl.plain TO fx_col_app;
+  `);
+});
+
+afterAll(async () => {
+  await pg.any(`
+    DROP SCHEMA fx_colacl CASCADE;
+    DROP ROLE fx_col_anon;
+    DROP ROLE fx_col_app;
+  `);
+  await teardown();
+});
+
+/** Owner ACL rows appear as soon as a relation has any explicit grant. */
+const granted = <T extends { role: string }>(rows: T[] | undefined): T[] =>
+  (rows ?? []).filter((r) => r.role.startsWith('fx_col_') || r.role === 'PUBLIC');
+
+describe('column ACL introspection', () => {
+  it('reads column grants per role, column and privilege', async () => {
+    const tables = await introspectTables(pg as never, { schemas: ['fx_colacl'] });
+    const people = tables.find((t) => t.name === 'people');
+
+    expect(granted(people?.grants)).toEqual([]);
+    expect(granted(people?.columnGrants)).toEqual([
+      { role: 'PUBLIC', column: 'name', privilege: 'SELECT', grantable: false, bypassRls: false },
+      { role: 'fx_col_anon', column: 'email', privilege: 'SELECT', grantable: false, bypassRls: false },
+      { role: 'fx_col_anon', column: 'email', privilege: 'UPDATE', grantable: false, bypassRls: false },
+      { role: 'fx_col_anon', column: 'name', privilege: 'SELECT', grantable: false, bypassRls: false }
+    ]);
+  });
+
+  it('leaves a table-level grant out of the column list', async () => {
+    const tables = await introspectTables(pg as never, { schemas: ['fx_colacl'] });
+    const plain = tables.find((t) => t.name === 'plain');
+
+    expect(granted(plain?.columnGrants)).toEqual([]);
+    expect(granted(plain?.grants)).toEqual([
+      { role: 'fx_col_app', privilege: 'SELECT', grantable: false, bypassRls: false }
+    ]);
+  });
+
+  it('applies the role filter to column grants, but never to PUBLIC', async () => {
+    const tables = await introspectTables(pg as never, {
+      schemas: ['fx_colacl'],
+      roles: ['fx_col_app']
+    });
+    const people = tables.find((t) => t.name === 'people');
+
+    expect(granted(people?.columnGrants)).toEqual([
+      { role: 'PUBLIC', column: 'name', privilege: 'SELECT', grantable: false, bypassRls: false }
+    ]);
+  });
+});

--- a/packages/safegres/__tests__/definer-view.test.ts
+++ b/packages/safegres/__tests__/definer-view.test.ts
@@ -15,6 +15,7 @@ function table(partial: Partial<TableSnapshot> = {}): TableSnapshot {
     isPartitioned: false,
     owner: 'app_owner',
     grants: [],
+    columnGrants: [],
     policies: [],
     ...partial
   };

--- a/packages/safegres/__tests__/lattice.test.ts
+++ b/packages/safegres/__tests__/lattice.test.ts
@@ -21,6 +21,7 @@ function table(partial: Partial<TableSnapshot> = {}): TableSnapshot {
     isPartitioned: false,
     owner: 'app_owner',
     grants: [],
+    columnGrants: [],
     policies: [],
     ...partial
   };

--- a/packages/safegres/__tests__/role-trust.test.ts
+++ b/packages/safegres/__tests__/role-trust.test.ts
@@ -15,6 +15,7 @@ function table(partial: Partial<TableSnapshot> = {}): TableSnapshot {
     isPartitioned: false,
     owner: 'app_owner',
     grants: [],
+    columnGrants: [],
     policies: [],
     ...partial
   };

--- a/packages/safegres/__tests__/set-role.test.ts
+++ b/packages/safegres/__tests__/set-role.test.ts
@@ -14,6 +14,7 @@ function table(partial: Partial<TableSnapshot> = {}): TableSnapshot {
     isPartitioned: false,
     owner: 'app_owner',
     grants: [],
+    columnGrants: [],
     policies: [],
     ...partial
   };

--- a/packages/safegres/__tests__/view-exposure.test.ts
+++ b/packages/safegres/__tests__/view-exposure.test.ts
@@ -18,6 +18,7 @@ function table(partial: Partial<TableSnapshot> = {}): TableSnapshot {
     isPartitioned: false,
     owner: 'app_owner',
     grants: [],
+    columnGrants: [],
     policies: [],
     ...partial
   };

--- a/packages/safegres/__tests__/view-writes.test.ts
+++ b/packages/safegres/__tests__/view-writes.test.ts
@@ -19,6 +19,7 @@ function table(partial: Partial<TableSnapshot> = {}): TableSnapshot {
     isPartitioned: false,
     owner: 'app_owner',
     grants: [],
+    columnGrants: [],
     policies: [],
     ...partial
   };

--- a/packages/safegres/corpus/cases/35-column-grant-projection/case.json
+++ b/packages/safegres/corpus/cases/35-column-grant-projection/case.json
@@ -1,0 +1,27 @@
+{
+  "title": "A column grant is reach that lives only in pg_attribute.attacl",
+  "dimension": "security",
+  "exposure": {
+    "schemas": [
+      "c_column_grant"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "L13",
+      "relation": "c_column_grant.profiles",
+      "role": "corpus_anon",
+      "note": "column-level SELECT on an RLS-off table: every row of handle and display_name, and until this rule existed the audit reported the relation as unreachable"
+    }
+  ],
+  "worstSeverity": "info",
+  "fix": "Not a revoke. Either the projection is intended and public — in which case this is correct as written — or the relation needs RLS, because a column grant restricts which columns, never which rows.",
+  "id": "35-column-grant-projection"
+}

--- a/packages/safegres/corpus/cases/35-column-grant-projection/schema.sql
+++ b/packages/safegres/corpus/cases/35-column-grant-projection/schema.sql
@@ -1,0 +1,21 @@
+DROP SCHEMA IF EXISTS c_column_grant CASCADE;
+CREATE SCHEMA c_column_grant;
+
+GRANT USAGE ON SCHEMA c_column_grant TO corpus_anon, corpus_user;
+
+CREATE TABLE c_column_grant.profiles (
+  id bigserial PRIMARY KEY,
+  handle text NOT NULL,
+  display_name text NOT NULL,
+  email text NOT NULL,
+  password_reset_token text
+);
+
+-- The flaw is not the projection — exposing a handle and a display name
+-- anonymously is a reasonable thing to want. The flaw is that this grant is
+-- written to `pg_attribute.attacl` and nothing at all appears in the table's
+-- `relacl`, so every relacl-only rule concludes corpus_anon reaches nothing
+-- here. RLS is off, so the grant reads every row of those columns.
+GRANT SELECT (handle, display_name) ON c_column_grant.profiles TO corpus_anon;
+GRANT SELECT (handle, display_name, email) ON c_column_grant.profiles TO corpus_user;
+GRANT UPDATE (display_name) ON c_column_grant.profiles TO corpus_user;

--- a/packages/safegres/corpus/cases/36-column-grant-rls-mediated/case.json
+++ b/packages/safegres/corpus/cases/36-column-grant-rls-mediated/case.json
@@ -1,0 +1,27 @@
+{
+  "title": "A column grant under RLS is reported as reach, but as mediated reach",
+  "dimension": "security",
+  "exposure": {
+    "schemas": [
+      "c_column_grant_rls"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "L13",
+      "relation": "c_column_grant_rls.notes",
+      "role": "corpus_anon",
+      "note": "policies mediate the rows and the grant narrows the columns — reported because nothing else in the audit sees the grant at all, not because it is wrong"
+    }
+  ],
+  "worstSeverity": "info",
+  "fix": "Nothing. This case pins two things: that a mediated column grant is still surfaced, and that corpus_user — which holds SELECT on the whole relation — is not reported a second time for the redundant column grant.",
+  "id": "36-column-grant-rls-mediated"
+}

--- a/packages/safegres/corpus/cases/36-column-grant-rls-mediated/schema.sql
+++ b/packages/safegres/corpus/cases/36-column-grant-rls-mediated/schema.sql
@@ -1,0 +1,32 @@
+DROP SCHEMA IF EXISTS c_column_grant_rls CASCADE;
+CREATE SCHEMA c_column_grant_rls;
+
+GRANT USAGE ON SCHEMA c_column_grant_rls TO corpus_anon, corpus_user;
+
+CREATE TABLE c_column_grant_rls.notes (
+  id bigserial PRIMARY KEY,
+  author text NOT NULL,
+  title text NOT NULL,
+  body text NOT NULL
+);
+ALTER TABLE c_column_grant_rls.notes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_column_grant_rls.notes FORCE ROW LEVEL SECURITY;
+
+-- The column grant is mediated: only published rows are visible, and the
+-- column list narrows that further. The point of this case is the pairing —
+-- L13 still reports the reach, because nothing else in the audit can see it,
+-- but it reports it as mediated and recommends nothing.
+CREATE POLICY notes_published ON c_column_grant_rls.notes
+  FOR SELECT TO corpus_anon
+  USING (author = (SELECT current_setting('app.author', true)));
+CREATE INDEX notes_author_idx ON c_column_grant_rls.notes (author);
+
+GRANT SELECT (title) ON c_column_grant_rls.notes TO corpus_anon;
+
+-- The negative half: corpus_user holds the whole relation, so its column
+-- grant adds no reach and must not be reported twice.
+GRANT SELECT ON c_column_grant_rls.notes TO corpus_user;
+GRANT SELECT (title) ON c_column_grant_rls.notes TO corpus_user;
+CREATE POLICY notes_own ON c_column_grant_rls.notes
+  FOR SELECT TO corpus_user
+  USING (author = (SELECT current_setting('app.author', true)));

--- a/packages/safegres/docs/rules.md
+++ b/packages/safegres/docs/rules.md
@@ -95,6 +95,19 @@ Both inherit the same refusals, with one addition: a body safegres cannot parse 
 the remedies are `security_barrier = true`, an RLS policy on the base relation (policy quals already
 get barrier treatment), or not materializing rows that are not safe to hand out unconditionally.
 
+**L13** is not about views at all — it is about a place the catalog keeps privileges that nothing in
+this package used to read. `GRANT SELECT (email) ON t TO anon` writes `pg_attribute.attacl` and
+leaves `pg_class.relacl` untouched, so a role whose entire access to a relation is column-scoped was
+reported as reaching *nothing*: no A2, no R1, no L-series, and "0 relation(s) accessible" in the
+role access report. The privilege is real, and a column grant restricts *which columns*, never which
+rows — with RLS off it reads every row of the columns it names. Two consequences beyond the new
+finding: L4 no longer calls a role's schema `USAGE` dead when its only reach into that schema is a
+column grant (that was a recommend-a-revoke on a load-bearing grant), and L2 no longer calls a
+policy dead when the grant it mediates is column-scoped. What L13 does *not* do yet is feed the
+weighted rules: column-level SELECT for an anonymous role on an RLS-off table is the same exposure
+A2 grades `high`, and promoting it there is a scoring change to make once the rule has been
+validated against real schemas.
+
 Restrictive-only policies never count as coverage. `BYPASSRLS` and superuser roles are exempt from
 policy checks — they are not subject to RLS, so a "missing policy" finding for them would be
 noise. Policies are matched with `pg_has_role` semantics: a policy `TO authenticated` covers a

--- a/packages/safegres/src/checks/column-grants.ts
+++ b/packages/safegres/src/checks/column-grants.ts
@@ -1,0 +1,92 @@
+/**
+ * L13: reach that exists only in `pg_attribute.attacl`.
+ *
+ * `GRANT SELECT (secret) ON t TO anonymous` writes nothing to the relation's
+ * ACL. Every grant query in this package read `relacl` alone, so a role whose
+ * entire access to a table is column-scoped was reported as reaching *nothing*
+ * — no A2, no R1, no L-series, and "0 relation(s) accessible" in the role
+ * access report. The privilege is real: the role selects those columns, and
+ * when the table has no RLS it selects every row of them.
+ *
+ * The finding is deliberately about the *invisibility* as much as the access.
+ * A column grant is a legitimate and often good way to expose a projection;
+ * what is not fine is that nothing else in the audit grades it. So L13 reports
+ * the reach, states whether RLS mediates it, and — as everywhere else — never
+ * recommends revoking the grant it cannot prove unused.
+ */
+
+import type { PgPrivilege, TableSnapshot } from '../pg/introspect';
+import type { Finding } from '../types';
+import {
+  effectiveColumnGrants,
+  type LatticeRoleOptions,
+  type RoleGraph
+} from './lattice';
+
+/** SELECT/INSERT/UPDATE are the column privileges RLS has anything to say about. */
+const MEDIATED: PgPrivilege[] = ['SELECT', 'INSERT', 'UPDATE'];
+
+export function checkUntrustedColumnGrants(
+  table: TableSnapshot,
+  graph: RoleGraph,
+  options: LatticeRoleOptions = {}
+): Finding[] {
+  const roles = options.roles ?? [];
+  if (roles.length === 0 || table.columnGrants.length === 0) return [];
+
+  const out: Finding[] = [];
+  for (const role of roles) {
+    const grants = effectiveColumnGrants(table, role, graph).filter((g) =>
+      MEDIATED.includes(g.privilege)
+    );
+    if (grants.length === 0) continue;
+
+    const attrs = graph.get(role);
+    // Same exemption test the rest of the lattice uses: a role RLS does not
+    // apply to reads every row of the columns it is granted.
+    const rlsApplies =
+      table.rlsEnabled
+      && !attrs?.bypassRls
+      && !attrs?.isSuper
+      && !(role === table.owner && !table.rlsForced);
+
+    const columns = [...new Set(grants.flatMap((g) => g.columns))].sort();
+    const privileges = grants.map((g) => g.privilege).sort();
+    const via = grants[0].via;
+
+    out.push({
+      code: 'L13',
+      severity: 'info',
+      category: 'anti-pattern',
+      schema: table.schema,
+      table: table.name,
+      role,
+      privilege: privileges.join(', '),
+      message:
+        `Untrusted role ${role} holds column-level ${privileges.join(', ')} on `
+        + `${table.schema}.${table.name} (${columns.join(', ')})`
+        + (via === 'direct' ? '' : ` via ${via}`)
+        + (rlsApplies
+          ? ' — mediated by RLS, but invisible to every rule that reads the relation ACL'
+          : ' — with no RLS to mediate it, so every row of those columns is readable'),
+      hint:
+        `Column grants live in \`pg_attribute.attacl\`, not \`relacl\`: \`\\dp\` shows them in `
+        + `the "Column privileges" column and nothing else in this audit graded them until now. `
+        + (rlsApplies
+          ? 'Confirm the policies that mediate this relation are the ones you would want applied '
+            + 'to a projection of it.'
+          : 'If the projection is meant to be public this is correct as written; if not, enable '
+            + 'RLS on the relation — the column grant restricts *which columns*, never which rows.')
+        + ' Do not revoke the grant on the strength of this finding alone: nothing here proves it '
+        + 'unused.',
+      context: {
+        columns,
+        via,
+        rlsMediated: rlsApplies,
+        rlsEnabled: table.rlsEnabled
+      }
+    });
+  }
+
+  return out;
+}

--- a/packages/safegres/src/checks/lattice.ts
+++ b/packages/safegres/src/checks/lattice.ts
@@ -75,6 +75,56 @@ export function effectiveGrants(
     .sort((a, b) => a.privilege.localeCompare(b.privilege));
 }
 
+/** A privilege `role` holds on some, but not all, of a relation's columns. */
+export interface EffectiveColumnGrant extends EffectiveGrant {
+  /** The columns it covers, sorted. */
+  columns: string[];
+}
+
+/**
+ * Every privilege `role` effectively holds on individual *columns* of `table`,
+ * composed exactly like {@link effectiveGrants} — direct, PUBLIC, inherited.
+ *
+ * A column grant lives in `pg_attribute.attacl` and never appears in the
+ * relation's ACL, so a role can hold nothing at all by `effectiveGrants` and
+ * still read the columns that matter. Privileges the role already holds on the
+ * whole relation are dropped: the column grant then adds no reach, and
+ * reporting it would double-count the same access.
+ */
+export function effectiveColumnGrants(
+  table: Pick<TableSnapshot, 'grants' | 'columnGrants'>,
+  role: string,
+  graph: RoleGraph
+): EffectiveColumnGrant[] {
+  if (table.columnGrants.length === 0) return [];
+  const wholeRelation = new Set(effectiveGrants(table, role, graph).map((g) => g.privilege));
+
+  const rank = (via: GrantVia): number => (via === 'direct' ? 0 : via === 'PUBLIC' ? 1 : 2);
+  const ancestors = new Set(graph.get(role)?.inheritsFrom ?? []);
+  const byPrivilege = new Map<PgPrivilege, { via: GrantVia; columns: Set<string> }>();
+
+  for (const g of table.columnGrants) {
+    if (wholeRelation.has(g.privilege)) continue;
+    const via: GrantVia | null =
+      g.role === role ? 'direct'
+        : g.role === 'PUBLIC' ? 'PUBLIC'
+          : ancestors.has(g.role) ? `member of ${g.role}`
+            : null;
+    if (!via) continue;
+
+    const entry = byPrivilege.get(g.privilege);
+    if (!entry) byPrivilege.set(g.privilege, { via, columns: new Set([g.column]) });
+    else {
+      entry.columns.add(g.column);
+      if (rank(via) < rank(entry.via)) entry.via = via;
+    }
+  }
+
+  return [...byPrivilege.entries()]
+    .map(([privilege, e]) => ({ privilege, via: e.via, columns: [...e.columns].sort() }))
+    .sort((a, b) => a.privilege.localeCompare(b.privilege));
+}
+
 /**
  * Whether a policy applies to `role` at runtime: named directly, via PUBLIC,
  * or via a role it inherits from (`pg_has_role(..., 'member')` semantics).
@@ -181,7 +231,9 @@ export function checkDeadPolicies(table: TableSnapshot, graph: RoleGraph): Findi
   if (!table.rlsEnabled) return [];
   const out: Finding[] = [];
 
-  const anyGrantee = table.grants.some((g) => g.role !== table.owner);
+  const anyGrantee =
+    table.grants.some((g) => g.role !== table.owner)
+    || table.columnGrants.some((g) => g.role !== table.owner);
 
   for (const policy of table.policies) {
     if (!policy.permissive) continue;
@@ -198,7 +250,12 @@ export function checkDeadPolicies(table: TableSnapshot, graph: RoleGraph): Findi
     for (const role of policy.roles) {
       const attrs = graph.get(role);
       if (attrs?.bypassRls) continue; // policies never apply to it anyway
-      const held = effectiveGrants(table, role, graph).map((e) => e.privilege);
+      // A column grant is a grant: the policy it mediates is not dead just
+      // because the privilege is scoped to a projection of the relation.
+      const held = [
+        ...effectiveGrants(table, role, graph),
+        ...effectiveColumnGrants(table, role, graph)
+      ].map((e) => e.privilege);
       if (privileges.some((p) => held.includes(p))) continue;
       out.push(deadPolicyFinding(table, policy, role,
         `Permissive ${policy.cmd} policy ${policy.name} on ${table.schema}.${table.name} applies to ${role}, but ${role} holds no ${privileges.join('/')} grant (directly, via PUBLIC, or by inheritance)`));
@@ -306,9 +363,13 @@ export function checkDeadSchemaUsage(
       if (!attrs || attrs.isSuper) continue;
       if (g.role === acl.owner) continue;
 
-      const reachesRelation = [...schemaTables, ...(viewsBySchema.get(acl.schema) ?? [])].some(
-        (r) => effectiveGrants(r, g.role, graph).length > 0
-      );
+      const reachesRelation =
+        [...schemaTables, ...(viewsBySchema.get(acl.schema) ?? [])].some(
+          (r) => effectiveGrants(r, g.role, graph).length > 0
+        )
+        // A column grant is reach the relation's own ACL does not show, and
+        // the USAGE it needs is every bit as load-bearing.
+        || schemaTables.some((t) => effectiveColumnGrants(t, g.role, graph).length > 0);
       if (reachesRelation) continue;
 
       const reachesFunction =
@@ -440,6 +501,12 @@ export interface RoleAccessRelation {
   privileges: PgPrivilege[];
   /** Most direct provenance across the privileges. */
   via: GrantVia;
+  /**
+   * Present when the reach is column-scoped: the columns reachable, and the
+   * privileges above are the column-level ones. Absent for whole-relation
+   * access.
+   */
+  columns?: string[];
   /** `unmediated` = RLS off or bypassed; `mediated` = at least one applicable policy; `dead` = RLS default-deny. */
   access: 'unmediated' | 'mediated' | 'dead';
 }
@@ -480,17 +547,35 @@ export function computeRoleAccess(
       const grants = effectiveGrants(table, role, graph).filter((e) =>
         RLS_PRIVILEGES.includes(e.privilege)
       );
-      if (grants.length === 0) continue;
+      // Column grants are reported only when the relation is reachable by
+      // nothing else — otherwise the whole-relation row already covers them.
+      const columnGrants = grants.length > 0
+        ? []
+        : effectiveColumnGrants(table, role, graph).filter((e) =>
+          RLS_PRIVILEGES.includes(e.privilege)
+        );
+      if (grants.length === 0 && columnGrants.length === 0) continue;
 
-      const privileges = grants.map((g) => g.privilege);
-      const via = grants.reduce<GrantVia>(
+      const columns = columnGrants.length > 0
+        ? [...new Set(columnGrants.flatMap((g) => g.columns))].sort()
+        : undefined;
+      const effective = grants.length > 0 ? grants : columnGrants;
+      const privileges = effective.map((g) => g.privilege);
+      const via = effective.reduce<GrantVia>(
         (best, g) => (rankVia(g.via) < rankVia(best) ? g.via : best),
-        grants[0].via
+        effective[0].via
       );
 
       if (!table.rlsEnabled || attrs?.bypassRls || (role === table.owner && !table.rlsForced)) {
         entry.accessibleTables += 1;
-        entry.unmediated.push({ schema: table.schema, table: table.name, privileges, via, access: 'unmediated' });
+        entry.unmediated.push({
+          schema: table.schema,
+          table: table.name,
+          privileges,
+          via,
+          ...(columns ? { columns } : {}),
+          access: 'unmediated'
+        });
         continue;
       }
 

--- a/packages/safegres/src/commands/audit.ts
+++ b/packages/safegres/src/commands/audit.ts
@@ -12,6 +12,7 @@ import {
   collectFunctionNames,
   parseOrNull
 } from '../checks/anti-patterns';
+import { checkUntrustedColumnGrants } from '../checks/column-grants';
 import {
   checkCoverageGaps,
   checkUpdateWithCheckCoverage
@@ -358,6 +359,13 @@ export async function audit(
         table,
         roleGraph,
         withExposedRoles(tableRules.get('L7')?.options as LatticeRoleOptions, exposure)
+      )
+    );
+    findings.push(
+      ...checkUntrustedColumnGrants(
+        table,
+        roleGraph,
+        withExposedRoles(tableRules.get('L13')?.options as LatticeRoleOptions, exposure)
       )
     );
 

--- a/packages/safegres/src/config/presets.ts
+++ b/packages/safegres/src/config/presets.ts
@@ -40,7 +40,11 @@ export const recommended: SafegresConfig = {
     // materialized view serves rows RLS never filtered, and a filtering view
     // without `security_barrier` is not a boundary. Same posture again.
     L11: ['info', { rolesFrom: 'anon' }],
-    L12: ['info', { rolesFrom: 'anon' }]
+    L12: ['info', { rolesFrom: 'anon' }],
+    // Reach that only `pg_attribute.attacl` shows. New, so zero weight — but
+    // note this one is catalog-derived, not body-derived: what was missing was
+    // the introspection, not the proof.
+    L13: ['info', { rolesFrom: 'anon' }]
   }
 };
 

--- a/packages/safegres/src/index.ts
+++ b/packages/safegres/src/index.ts
@@ -26,6 +26,7 @@ export type {
   ChecklistItem
 } from './callgraph/graph';
 export { buildCallGraph } from './callgraph/graph';
+export { checkUntrustedColumnGrants } from './checks/column-grants';
 export type { SuppressedView, ViewBodyAnalysis } from './checks/definer-view';
 export { analyzeViewBodies, checkDefinerViewBypass } from './checks/definer-view';
 export {
@@ -36,6 +37,7 @@ export {
   checkUnindexedSortColumns
 } from './checks/indexes';
 export type {
+  EffectiveColumnGrant,
   EffectiveGrant,
   GrantVia,
   LatticeRoleOptions,
@@ -50,6 +52,7 @@ export {
   checkUnreachableGrants,
   checkUntrustedIndirectAccess,
   computeRoleAccess,
+  effectiveColumnGrants,
   effectiveGrants
 } from './checks/lattice';
 export type { PolicyClause, PredicateColumn } from './checks/policy-index';
@@ -198,6 +201,8 @@ export { introspectFunctions } from './pg/functions';
 export type { ColumnInfo, ForeignKeyInfo, IndexInfo, TableIndexSnapshot, ViewSnapshot } from './pg/indexes';
 export { introspectIndexes, introspectViews } from './pg/indexes';
 export {
+  type ColumnGrantInfo,
+  type GrantInfo,
   type IntrospectOptions,
   introspectTables,
   type PgPrivilege,

--- a/packages/safegres/src/pg/introspect.ts
+++ b/packages/safegres/src/pg/introspect.ts
@@ -42,6 +42,18 @@ export interface GrantInfo {
   bypassRls: boolean;
 }
 
+/**
+ * A grant on one column (`pg_attribute.attacl`), which Postgres keeps entirely
+ * separate from the table's own ACL: `GRANT SELECT (secret) ON t TO anon`
+ * leaves `relacl` untouched, so any analysis that reads only `relacl`
+ * concludes the role reaches nothing.
+ *
+ * Only SELECT, INSERT, UPDATE and REFERENCES can be column-scoped.
+ */
+export interface ColumnGrantInfo extends GrantInfo {
+  column: string;
+}
+
 /** `pg_policy.polcmd` uses: `r` SELECT, `a` INSERT, `w` UPDATE, `d` DELETE, `*` ALL. */
 export type PolicyCmd = 'SELECT' | 'INSERT' | 'UPDATE' | 'DELETE' | 'ALL';
 
@@ -73,6 +85,12 @@ export interface TableSnapshot {
   isPartitioned: boolean;
   owner: string;
   grants: GrantInfo[];
+  /**
+   * Grants on individual columns. Disjoint from {@link TableSnapshot.grants}:
+   * a column grant never appears in `relacl`, and a table grant never appears
+   * in `attacl`, so a role can reach a relation through this list alone.
+   */
+  columnGrants: ColumnGrantInfo[];
   policies: PolicyInfo[];
 }
 
@@ -222,6 +240,37 @@ export async function introspectTables(
       WHERE true
         ${roleFilter}
     ),
+    -- Column ACLs live on pg_attribute, not pg_class: a column grant is
+    -- invisible to relacl, and this is the only place it surfaces.
+    col_grants_exploded AS (
+      SELECT
+        r.oid,
+        a.attname                             AS column_name,
+        (aclexplode(a.attacl)).grantee        AS grantee_oid,
+        (aclexplode(a.attacl)).privilege_type AS privilege_type,
+        (aclexplode(a.attacl)).is_grantable   AS is_grantable
+      FROM rels r
+      JOIN pg_attribute a ON a.attrelid = r.oid
+      WHERE a.attacl IS NOT NULL
+        AND a.attnum > 0
+        AND NOT a.attisdropped
+    ),
+    col_grants AS (
+      SELECT
+        g.oid,
+        g.column_name,
+        CASE WHEN g.grantee_oid = 0 THEN 'PUBLIC' ELSE rol.rolname END AS grantee,
+        g.privilege_type,
+        g.is_grantable,
+        CASE
+          WHEN g.grantee_oid = 0 THEN false
+          ELSE COALESCE(rol.rolsuper OR rol.rolbypassrls, false)
+        END AS bypass_rls
+      FROM col_grants_exploded g
+      LEFT JOIN pg_roles rol ON rol.oid = g.grantee_oid
+      WHERE true
+        ${roleFilter}
+    ),
     policies AS (
       SELECT
         p.polrelid                                  AS oid,
@@ -258,6 +307,17 @@ export async function introspectTables(
       )                                                   AS grants,
       COALESCE(
         (SELECT jsonb_agg(jsonb_build_object(
+          'role', g.grantee,
+          'column', g.column_name,
+          'privilege', g.privilege_type,
+          'grantable', g.is_grantable,
+          'bypassRls', g.bypass_rls
+        ) ORDER BY g.grantee, g.column_name, g.privilege_type)
+         FROM col_grants g WHERE g.oid = r.oid),
+        '[]'::jsonb
+      )                                                   AS column_grants,
+      COALESCE(
+        (SELECT jsonb_agg(jsonb_build_object(
           'name', p.name,
           'cmd', p.cmd::text,
           'permissive', p.permissive,
@@ -287,6 +347,13 @@ export async function introspectTables(
     is_partitioned: boolean;
     owner: string;
     grants: Array<{ role: string; privilege: string; grantable: boolean; bypassRls: boolean }>;
+    column_grants: Array<{
+      role: string;
+      column: string;
+      privilege: string;
+      grantable: boolean;
+      bypassRls: boolean;
+    }>;
     policies: Array<{
       name: string;
       cmd: string;
@@ -307,6 +374,13 @@ export async function introspectTables(
     owner: r.owner,
     grants: r.grants.map((g) => ({
       role: g.role,
+      privilege: normalizePrivilege(g.privilege),
+      grantable: g.grantable,
+      bypassRls: g.bypassRls === true
+    })),
+    columnGrants: r.column_grants.map((g) => ({
+      role: g.role,
+      column: g.column,
       privilege: normalizePrivilege(g.privilege),
       grantable: g.grantable,
       bypassRls: g.bypassRls === true

--- a/packages/safegres/src/report/markdown.ts
+++ b/packages/safegres/src/report/markdown.ts
@@ -217,7 +217,9 @@ function roleAccessSection(roles: RoleAccessEntry[]): string[] {
         '| Relation | Privileges | Via |',
         '| --- | --- | --- |',
         ...entry.unmediated.map(
-          (r) => `| \`${r.schema}.${r.table}\` | ${r.privileges.join(', ')} | ${r.via} |`
+          (r) =>
+            `| \`${r.schema}.${r.table}\` | ${r.privileges.join(', ')}`
+            + `${r.columns ? ` (${r.columns.join(', ')})` : ''} | ${r.via} |`
         ),
         ''
       );

--- a/packages/safegres/src/report/pretty.ts
+++ b/packages/safegres/src/report/pretty.ts
@@ -174,7 +174,11 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
       const shown = verbose ? entry.unmediated : entry.unmediated.slice(0, 20);
       for (const r of shown) {
         lines.push(
-          paint('medium', `    ${r.schema}.${r.table}  ${r.privileges.join(', ')}  (via ${r.via})`)
+          paint(
+            'medium',
+            `    ${r.schema}.${r.table}  ${r.privileges.join(', ')}`
+              + `${r.columns ? ` on (${r.columns.join(', ')})` : ''}  (via ${r.via})`
+          )
         );
       }
       if (shown.length < entry.unmediated.length) {

--- a/packages/safegres/src/rules/registry.ts
+++ b/packages/safegres/src/rules/registry.ts
@@ -288,6 +288,19 @@ export const RULES: RuleMeta[] = [
     scope: 'table'
   },
   {
+    code: 'L13',
+    category: 'anti-pattern',
+    // Ships `info` on the same new-rule posture. The honest severity depends
+    // entirely on the relation: column-level SELECT on an RLS-off table for an
+    // anonymous role is the same exposure A2 calls `high`, and until this rule
+    // existed nothing in the package saw it at all, because every grant query
+    // read `relacl` and a column grant lives in `pg_attribute.attacl`.
+    defaultSeverity: 'info',
+    direction: 'fail-open',
+    title: 'Column-level grant — an untrusted role reaches a relation through column privileges no relation ACL shows (options: { roles: [...] })',
+    scope: 'table'
+  },
+  {
     code: 'W1',
     category: 'meta',
     defaultSeverity: 'medium',


### PR DESCRIPTION
## Summary

Gap 2 from the constructive-db review, and the last one that is pure blindness rather than a missing rule: **every grant query in this package read `pg_class.relacl` and nothing read `pg_attribute.attacl`.**

```sql
GRANT SELECT (handle, email) ON app.profiles TO anonymous;
```

writes no ACL entry on the relation. So the audit reported `app.profiles` as unreachable by `anonymous` — no A2, no R1, no L-series, and "0 relation(s) accessible" in the role access report — while `anonymous` selected those two columns of every row in the table. A column grant restricts *which columns*, never which rows.

The fix is one new fact in the snapshot and one new composition function; the rule on top is small by comparison.

```ts
interface TableSnapshot {
  grants: GrantInfo[];            // pg_class.relacl        (unchanged)
  columnGrants: ColumnGrantInfo[]; // pg_attribute.attacl   (new — disjoint from the above)
}

// Same direct > PUBLIC > inherited closure as effectiveGrants, minus
// anything the role already holds on the whole relation.
effectiveColumnGrants(table, role, graph): Array<{ privilege, via, columns: string[] }>
```

**L13** (`info`, fail-open, score-neutral, `rolesFrom: 'anon'`) reports the reach and states whether RLS mediates it. It recommends no revoke: the projection is often exactly what was intended, and nothing here proves the grant unused.

### Two bugs that were consequences of the blindness, not new rules

Both are behavior changes to existing rules, pinned by tests:

- **L4** told a role its schema `USAGE` was dead and revokable when its only reach into that schema was a column grant. That is a recommend-a-revoke on a load-bearing grant — the same class of bug as the L4/L8 interaction fixed in #1607.
- **L2** called a policy dead — "applies to `anon`, but `anon` holds no SELECT grant" — when the grant it mediates is column-scoped. A straight false positive; corpus case 36 caught it.

`computeRoleAccess` now carries an optional `columns` on a relation reachable *only* column-wise, and both renderers show it (`app.profiles SELECT on (email, handle) (via direct)`). A relation reachable at table level is unaffected — no double-reporting.

### Severity posture

`info` is the new-rule posture, not the verdict. Column-level SELECT for an anonymous role on an RLS-off table is the same exposure A2 grades `high`. Promoting column grants into the weighted rules (A2/R1) is a scoring change and deliberately not in this PR; `docs/rules.md` says so explicitly.

### Corpus

- `35-column-grant-projection` — positive: anonymous projection, RLS off.
- `36-column-grant-rls-mediated` — the pairing: L13 still fires under RLS but reports the access as mediated, *and* the role holding the whole relation is not reported twice for its redundant column grant.

### Verification

`pnpm build` / `pnpm lint` (2 pre-existing `_extends` warnings) / `pnpm test` — 38 suites, 449 tests green. New DB integration test asserts `attacl` introspection against a live PG, including that the role filter applies to column grants but never to PUBLIC.

Full audit of constructive-db with this build: **zero L13 findings, score unchanged** (security 100 A+, perf 91.2 A). Its 59 column grants all target `authenticated`, which the preset does not grade as untrusted — latent, not live.

### Files touched outside the rule

`src/commands/audit.ts` (one dispatch block), `src/index.ts` (exports), `src/report/{markdown,pretty}.ts` (render the column list). Fixtures in six existing test files gained `columnGrants: []`.

### Remaining view-queue gaps

Tracked in constructive-io/constructive-planning#1377, which consolidates these with the product/tooling backlog. E5 (excluded schemas suppress findings), E7 (column-level reads *through* views — needs this PR first) and E8 (sequences, functions, FDWs) are the ones still in `pg/introspect.ts` and `checks/lattice.ts`.


Link to Devin session: https://app.devin.ai/sessions/f340c08768814b278a179aea7994f924
Requested by: @pyramation