### PR TITLE
feat(safegres): extends a local file, a config schema, and a negative perf corpus

### DIFF
--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -499,9 +499,11 @@ is simply the honest statement that local configuration participated.
 ## The evaluation corpus
 
 A sealed score says the ruler did not move. It does not say the ruler is right. That is what the
-corpus in [`corpus/`](corpus/README.md) is for: ~20 small schemas, each with one deliberate flaw
-and a written-down answer — the findings a correct audit must produce, the false positives it must
-not, and the one-sentence fix.
+corpus in [`corpus/`](corpus/README.md) is for: small schemas, each with one deliberate flaw and a
+written-down answer — the findings a correct audit must produce, the false positives it must not,
+and the one-sentence fix. Many come in pairs: 18 cases pin what must *not* fire, and six of those
+are the earlier case with its flaw fixed — an answer key consisting entirely of silence and a score
+of 100, because a rule that survives its own fix is worse than a rule that never existed.
 
 `safegres eval` is the whole loop in one command: it deploys each case into the connected
 database, audits it under a sealed preset, grades the report against the answer key, drops the
@@ -513,7 +515,7 @@ $ safegres eval --database scratch
   PASS  17-foreign-key-without-index     perf    71.2 (C )  X1
   FAIL  18-policy-column-unindexed       perf     100 (A+)  missed X2
 
-25/26 cases passed · recall 98% · precision 100%
+41/42 cases passed · recall 98% · precision 100%
 ```
 
 | Flag | |
@@ -635,6 +637,36 @@ marks it inline (`api roles: authenticated, anonymous (anon)`).
 Presets **retune**, they don't delete: a rule that doesn't apply to a stack is demoted to `info`
 (zero weight, so the score is unchanged) rather than switched off, so it stays in the report and
 stays re-tunable. `minimal` is the deliberate exception — being a smoke check is its whole job.
+
+`extends` also takes a **path**, which is how a repository with more than one audit job keeps one
+copy of its rules. The gated PR job and the nightly advisory run against a deployed database
+differ by their gates and their baseline, not by their 19-entry `public.read` list:
+
+```jsonc
+// ci/nightly/.safegresrc.json
+{ "extends": "../../safegres.base.json",
+  "perf":    { "baseline": "ci/nightly/perf.json" },
+  "failOn":  { "grade": "D" } }
+```
+
+A path in an inherited file resolves against **the file that wrote it**, so a base file's
+`"baseline": "ci/perf.json"` keeps meaning the base file's `ci/`, whichever job inherits it —
+the same rule as a discovered config, applied per key. Objects merge per key and arrays replace,
+except `overrides`, which is a list of scoped exceptions and so unions across the chain:
+inheriting a config can't silently drop the exceptions that came with it. `--sealed` reaches none
+of this — it does no discovery at all, so there is no file to extend from.
+
+The file is **validated on load**, against a schema derived from the same declaration the editor
+completes against — an unknown key is an error naming the key it thinks you meant, not a silent
+no-op, because `"failon": { "grade": "B" }` otherwise reads as a passing build rather than as a
+typo. Point an editor at the schema for completion and inline documentation:
+
+```jsonc
+{ "$schema": "https://raw.githubusercontent.com/constructive-io/constructive/main/packages/safegres/schema/safegres.schema.json" }
+```
+
+It also ships in the package (`safegres/schema/safegres.schema.json`), and
+`safegres print-config --schema` writes it to stdout for an offline copy.
 
 CLI: `--config <path>`, `--preset <name>`, `--rule CODE=off|severity` (repeatable).
 

--- a/packages/safegres/__tests__/config-extends.test.ts
+++ b/packages/safegres/__tests__/config-extends.test.ts
@@ -1,0 +1,88 @@
+import * as fs from 'fs';
+import type { ParsedArgs } from 'inquirerer';
+import * as os from 'os';
+import * as path from 'path';
+
+import { resolveRunPaths } from '../src/cli/shared';
+import { configPathBase, loadConfig } from '../src/config/loader';
+import { resolveRules } from '../src/config/resolve';
+import type { SafegresConfig } from '../src/config/types';
+
+const argv = (values: Record<string, unknown> = {}): ParsedArgs => values as ParsedArgs;
+
+/** A repo whose shared rules live in one file and whose jobs each extend it. */
+function repo(base: SafegresConfig, job: SafegresConfig): { root: string; jobDir: string } {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'safegres-extends-')));
+  const jobDir = path.join(root, 'ci', 'nightly');
+  fs.mkdirSync(jobDir, { recursive: true });
+  fs.writeFileSync(path.join(root, 'safegres.base.json'), JSON.stringify(base));
+  fs.writeFileSync(
+    path.join(jobDir, '.safegresrc.json'),
+    JSON.stringify({ extends: '../../safegres.base.json', ...job })
+  );
+  return { root, jobDir };
+}
+
+describe('extends a local file', () => {
+  it('inherits through the file, and through the file to a preset', () => {
+    const { jobDir } = repo(
+      { extends: 'safegres:constructive', failOn: { grade: 'B' }, public: { read: ['app_public.posts'] } },
+      { failOn: { grade: 'D' } }
+    );
+
+    const { config } = loadConfig({ cwd: jobDir });
+
+    expect(config.public?.read).toEqual(['app_public.posts']); // from the base file
+    expect(config.failOn?.grade).toBe('D'); // the job's own gate wins
+    expect(resolveRules(config).rules.get('A2')!.severity).toBe('critical'); // from the preset
+  });
+
+  it('unions overrides rather than replacing them, as a preset chain does', () => {
+    const { jobDir } = repo(
+      { overrides: [{ tables: ['app_public.audit'], rules: { A1: 'off' } }] },
+      { overrides: [{ tables: ['app_public.jobs'], rules: { A5: 'off' } }] }
+    );
+
+    const { config } = loadConfig({ cwd: jobDir });
+
+    expect(config.overrides).toEqual([
+      { tables: ['app_public.audit'], rules: { A1: 'off' } },
+      { tables: ['app_public.jobs'], rules: { A5: 'off' } }
+    ]);
+  });
+
+  it('resolves each path against the file that declared it', () => {
+    const { root, jobDir } = repo(
+      { perf: { baseline: 'ci/perf.json' }, source: { pgpm: 'application/app' } },
+      { outputs: { dir: 'reports' } }
+    );
+
+    const loaded = loadConfig({ cwd: jobDir });
+    const paths = resolveRunPaths(argv(), loaded.config, configPathBase(loaded));
+
+    // Inherited: the base file's directory, not the one that inherited it.
+    expect(paths.perfBaseline).toBe(path.join(root, 'ci/perf.json'));
+    expect(paths.pgpm).toBe(path.join(root, 'application/app'));
+    // Declared here: this file's directory.
+    expect(paths.outputs.json).toBe(path.join(jobDir, 'reports', 'safegres.json'));
+  });
+
+  it('names the mistake when the target cannot be read', () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'safegres-extends-'));
+    fs.writeFileSync(path.join(cwd, '.safegresrc.json'), JSON.stringify({ extends: './nope.json' }));
+
+    expect(() => loadConfig({ cwd })).toThrow(/an "extends" target could not be read/);
+  });
+
+  it('cannot reach a sealed run: no discovery, so no file to extend from', () => {
+    const { jobDir } = repo(
+      { extends: 'safegres:minimal', failOn: { grade: 'F' } },
+      {}
+    );
+
+    const { config, isEmpty } = loadConfig({ cwd: jobDir, sealed: true, preset: 'recommended' });
+
+    expect(isEmpty).toBe(true);
+    expect(config.failOn?.grade).toBeUndefined();
+  });
+});

--- a/packages/safegres/__tests__/config-schema.test.ts
+++ b/packages/safegres/__tests__/config-schema.test.ts
@@ -1,0 +1,89 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { loadConfig } from '../src/config/loader';
+import { PRESETS } from '../src/config/presets';
+import { toJsonSchema } from '../src/config/schema';
+import { validateConfigShape } from '../src/config/validate';
+
+const SCHEMA_FILE = path.join(__dirname, '..', 'schema', 'safegres.schema.json');
+
+function load(config: unknown): ReturnType<typeof loadConfig> {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'safegres-schema-'));
+  fs.writeFileSync(path.join(cwd, '.safegresrc.json'), JSON.stringify(config));
+  return loadConfig({ cwd });
+}
+
+describe('config shape', () => {
+  it('rejects a typo\u2019d key and names the one it means', () => {
+    expect(() => load({ failon: { grade: 'B' } })).toThrow(/unknown key "failon" — did you mean "failOn"\?/);
+    expect(() => load({ outputs: { sarrif: 'out.sarif' } })).toThrow(
+      /unknown key "outputs.sarrif" — did you mean "sarif"\?/
+    );
+  });
+
+  it('rejects a value of the wrong kind, and an unknown enum member', () => {
+    expect(() => load({ perf: { enabled: 'yes' } })).toThrow(/"perf.enabled" is a string; expected a boolean/);
+    expect(() => load({ report: { github: { annotations: 'some' } } })).toThrow(
+      /"report.github.annotations" is "some"; expected one of "all", "gate-failures", "none"/
+    );
+  });
+
+  it('accepts $schema, so a file can point an editor at the schema', () => {
+    expect(() => load({ $schema: '../schema/safegres.schema.json', failOn: { grade: 'B' } })).not.toThrow();
+  });
+
+  it('accepts every shipped preset', () => {
+    for (const [name, preset] of Object.entries(PRESETS)) {
+      expect(() => validateConfigShape(preset)).not.toThrow(new RegExp(name));
+      validateConfigShape(preset);
+    }
+  });
+
+  it('accepts a full config using every top-level key', () => {
+    expect(() =>
+      validateConfigShape({
+        extends: ['safegres:supabase', 'safegres:multi-tenant'],
+        exposure: {
+          schemas: ['app_public'],
+          roles: ['anon'],
+          planes: [{ name: 'direct:app', kind: 'role', roles: ['app'] }]
+        },
+        public: { read: ['app_public.plans*'] },
+        extensions: { skipOwned: false, ignore: ['pg_partman'] },
+        perf: {
+          enabled: true,
+          rules: { X1: 'off' },
+          ignore: ['app_public.audit_*'],
+          scoring: { densityK: 0.2, includeStats: false },
+          stats: { enabled: true, minRows: 10 },
+          explain: { enabled: true },
+          baseline: 'ci/perf.json',
+          failOnNew: true,
+          paths: { infer: true, onWriteOncePointer: 'demote' }
+        },
+        schemas: ['app_public'],
+        excludeSchemas: ['audit'],
+        roles: ['anon'],
+        excludeRoles: ['postgres'],
+        rules: { 'A*': 'info', A3: ['high', { rolesFrom: 'anon' }] },
+        overrides: [{ tables: ['app_public.audit_*'], rules: { A2: 'off' } }],
+        scoring: { model: 'density', unknownExposureCap: false, floorOnCritical: 'C' },
+        failOn: { grade: 'B', planes: { 'direct:app': { grade: 'D' } } },
+        source: { pgpm: 'application/app' },
+        outputs: { dir: 'safegres-reports' },
+        callGraph: { enabled: true, baseline: 'ci/boundaries.json' },
+        report: { dimensions: ['security', 'perf'], github: { detail: 'summary', badges: false } },
+        eval: { corpus: 'corpus', preset: 'recommended', cases: ['01'] }
+      })
+    ).not.toThrow();
+  });
+});
+
+describe('schema/safegres.schema.json', () => {
+  it('is the described shape \u2014 regenerate with `node scripts/write-schema.js` after a build', () => {
+    const committed = JSON.parse(fs.readFileSync(SCHEMA_FILE, 'utf8'));
+    expect(committed).toEqual(toJsonSchema());
+  });
+});

--- a/packages/safegres/__tests__/corpus.test.ts
+++ b/packages/safegres/__tests__/corpus.test.ts
@@ -43,9 +43,11 @@ describe('evaluation corpus', () => {
     expect(CORPUS.some((c) => c.dimension === 'security')).toBe(true);
     expect(CORPUS.some((c) => c.dimension === 'perf')).toBe(true);
     // Every case must document its answer: an unexplained fixture is a
-    // regression test, not an evaluation.
+    // regression test, not an evaluation. A negative case answers with what
+    // must *not* fire, so `forbid` is an answer too.
     for (const c of CORPUS) {
-      expect(`${c.id}:${c.expect.length > 0 && c.fix.length > 0}`).toBe(`${c.id}:true`);
+      const answered = (c.expect.length > 0 || (c.forbid?.length ?? 0) > 0) && c.fix.length > 0;
+      expect(`${c.id}:${answered}`).toBe(`${c.id}:true`);
     }
   });
 

--- a/packages/safegres/corpus/README.md
+++ b/packages/safegres/corpus/README.md
@@ -42,6 +42,13 @@ Cases are **data, not code**: another tool can consume the corpus without runnin
 `expect` is a lower bound, not an equality check — a later release adding an unrelated advisory
 must not invalidate the corpus. What a case pins *negatively* goes in `forbid`.
 
+A **negative case** is one whose whole answer is negative: `expect` is empty and `forbid` names the
+rules that must stay quiet. It is the fixed form of a positive case — `38-foreign-key-with-index`
+is `17-foreign-key-without-index` with the index added — so the pair states both halves of what a
+rule means, and a rule that fires on the fix is caught by the corpus rather than by a user. A
+negative case must also score **100** on its dimension: precision is not just "the forbidden code
+didn't appear", it is "a correct schema costs nothing".
+
 ```ts
 import { audit, gradeCase, loadCorpus, loadConfig } from 'safegres';
 
@@ -68,8 +75,9 @@ instead of leaving it to the number.
 
 ## Adding a case
 
-Keep it to one flaw. Anything the case does *not* mean to demonstrate — an unforced RLS table, an
-open read policy left in to make the SQL shorter — shows up as an extra finding and muddies the
-answer, so the surrounding schema should be otherwise correct. `__tests__/corpus.test.ts` runs
-every case and additionally checks that the flaw costs points exactly when the rule carries weight
-(`info` severities and fail-closed rules are weightless by construction).
+Keep it to one flaw, and add the negative alongside it. Anything the case does *not* mean to
+demonstrate — an unforced RLS table, an open read policy left in to make the SQL shorter — shows up
+as an extra finding and muddies the answer, so the surrounding schema should be otherwise correct.
+`__tests__/corpus.test.ts` runs every case and additionally checks that the flaw costs points
+exactly when the rule carries weight (`info` severities and fail-closed rules are weightless by
+construction).

--- a/packages/safegres/corpus/cases/35-policy-function-not-leakproof/case.json
+++ b/packages/safegres/corpus/cases/35-policy-function-not-leakproof/case.json
@@ -1,0 +1,24 @@
+{
+  "title": "Policy calls a non-LEAKPROOF function",
+  "dimension": "perf",
+  "exposure": {
+    "schemas": [
+      "c_policy_fn_leaky"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "X4",
+      "relation": "c_policy_fn_leaky.invoices",
+      "note": "a non-leakproof qual cannot be pushed below a join or subquery scan, so the security filter runs late and on more rows than it needs to"
+    }
+  ],
+  "fix": "Mark c_policy_fn_leaky.tenant_of LEAKPROOF — it raises no error carrying its argument — or inline the cast so the policy calls nothing at all."
+}

--- a/packages/safegres/corpus/cases/35-policy-function-not-leakproof/schema.sql
+++ b/packages/safegres/corpus/cases/35-policy-function-not-leakproof/schema.sql
@@ -1,0 +1,27 @@
+DROP SCHEMA IF EXISTS c_policy_fn_leaky CASCADE;
+CREATE SCHEMA c_policy_fn_leaky;
+GRANT USAGE ON SCHEMA c_policy_fn_leaky TO corpus_user, corpus_anon;
+
+-- IMMUTABLE, so this is not the per-row-evaluation flaw of case 20: the only
+-- thing wrong with it is that nothing has promised it doesn't leak its
+-- argument, and the planner takes that promise seriously.
+CREATE FUNCTION c_policy_fn_leaky.tenant_of(claim text) RETURNS uuid
+  LANGUAGE sql IMMUTABLE AS $$
+    SELECT nullif(claim, '')::uuid
+  $$;
+
+CREATE TABLE c_policy_fn_leaky.invoices (
+  id bigserial PRIMARY KEY,
+  tenant_id uuid NOT NULL,
+  amount numeric
+);
+CREATE INDEX invoices_tenant_idx ON c_policy_fn_leaky.invoices (tenant_id);
+ALTER TABLE c_policy_fn_leaky.invoices ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_policy_fn_leaky.invoices FORCE ROW LEVEL SECURITY;
+
+-- Hoisted into an InitPlan and comparing an indexed column: everything else
+-- about this predicate is right. The flaw is the missing LEAKPROOF.
+CREATE POLICY invoices_tenant ON c_policy_fn_leaky.invoices FOR SELECT TO corpus_user
+  USING (tenant_id = (SELECT c_policy_fn_leaky.tenant_of(current_setting('jwt.claims.tenant_id', true))));
+
+GRANT SELECT ON c_policy_fn_leaky.invoices TO corpus_user;

--- a/packages/safegres/corpus/cases/36-policy-function-leakproof/case.json
+++ b/packages/safegres/corpus/cases/36-policy-function-leakproof/case.json
@@ -1,0 +1,24 @@
+{
+  "title": "A LEAKPROOF policy function is not a planner obstacle",
+  "dimension": "perf",
+  "exposure": {
+    "schemas": [
+      "c_policy_fn_leakproof"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [],
+  "forbid": [
+    "X2",
+    "X3",
+    "X4",
+    "X9"
+  ],
+  "fix": "Nothing to fix — this is case 35 fixed, and a rule firing here would be telling you to undo the fix."
+}

--- a/packages/safegres/corpus/cases/36-policy-function-leakproof/schema.sql
+++ b/packages/safegres/corpus/cases/36-policy-function-leakproof/schema.sql
@@ -1,0 +1,22 @@
+DROP SCHEMA IF EXISTS c_policy_fn_leakproof CASCADE;
+CREATE SCHEMA c_policy_fn_leakproof;
+GRANT USAGE ON SCHEMA c_policy_fn_leakproof TO corpus_user, corpus_anon;
+
+CREATE FUNCTION c_policy_fn_leakproof.tenant_of(claim text) RETURNS uuid
+  LANGUAGE sql IMMUTABLE LEAKPROOF AS $$
+    SELECT nullif(claim, '')::uuid
+  $$;
+
+CREATE TABLE c_policy_fn_leakproof.invoices (
+  id bigserial PRIMARY KEY,
+  tenant_id uuid NOT NULL,
+  amount numeric
+);
+CREATE INDEX invoices_tenant_idx ON c_policy_fn_leakproof.invoices (tenant_id);
+ALTER TABLE c_policy_fn_leakproof.invoices ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_policy_fn_leakproof.invoices FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY invoices_tenant ON c_policy_fn_leakproof.invoices FOR SELECT TO corpus_user
+  USING (tenant_id = (SELECT c_policy_fn_leakproof.tenant_of(current_setting('jwt.claims.tenant_id', true))));
+
+GRANT SELECT ON c_policy_fn_leakproof.invoices TO corpus_user;

--- a/packages/safegres/corpus/cases/37-sort-column-unindexed/case.json
+++ b/packages/safegres/corpus/cases/37-sort-column-unindexed/case.json
@@ -1,0 +1,24 @@
+{
+  "title": "Sort-shaped column leading no index",
+  "dimension": "perf",
+  "exposure": {
+    "schemas": [
+      "c_sort_no_index"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "X8",
+      "relation": "c_sort_no_index.feed_items",
+      "note": "every page of a feed ordered by created_at sorts the whole RLS-filtered result; keyset pagination degenerates into scan-and-discard"
+    }
+  ],
+  "fix": "CREATE INDEX ON c_sort_no_index.feed_items (created_at DESC) — or turn X8 off if nothing orders by it, which is why the rule ships as info."
+}

--- a/packages/safegres/corpus/cases/37-sort-column-unindexed/schema.sql
+++ b/packages/safegres/corpus/cases/37-sort-column-unindexed/schema.sql
@@ -1,0 +1,14 @@
+DROP SCHEMA IF EXISTS c_sort_no_index CASCADE;
+CREATE SCHEMA c_sort_no_index;
+GRANT USAGE ON SCHEMA c_sort_no_index TO corpus_user, corpus_anon;
+
+CREATE TABLE c_sort_no_index.feed_items (
+  id bigserial PRIMARY KEY,
+  body text,
+  -- The flaw, such as it is: a timestamp column that leads no index. A
+  -- heuristic — nothing here proves anything orders by it — so the rule is
+  -- info and costs the score nothing.
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+GRANT SELECT ON c_sort_no_index.feed_items TO corpus_user;

--- a/packages/safegres/corpus/cases/38-foreign-key-with-index/case.json
+++ b/packages/safegres/corpus/cases/38-foreign-key-with-index/case.json
@@ -1,0 +1,22 @@
+{
+  "title": "A foreign key with a covering index is not a finding",
+  "dimension": "perf",
+  "exposure": {
+    "schemas": [
+      "c_fk_indexed"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [],
+  "forbid": [
+    "X1",
+    "X5"
+  ],
+  "fix": "Nothing to fix — this is case 17 fixed. X5 is forbidden too: a single-column index on a foreign key is not made redundant by the primary key it references."
+}

--- a/packages/safegres/corpus/cases/38-foreign-key-with-index/schema.sql
+++ b/packages/safegres/corpus/cases/38-foreign-key-with-index/schema.sql
@@ -1,0 +1,17 @@
+DROP SCHEMA IF EXISTS c_fk_indexed CASCADE;
+CREATE SCHEMA c_fk_indexed;
+GRANT USAGE ON SCHEMA c_fk_indexed TO corpus_user, corpus_anon;
+
+CREATE TABLE c_fk_indexed.authors (
+  id bigserial PRIMARY KEY,
+  name text NOT NULL
+);
+
+CREATE TABLE c_fk_indexed.books (
+  id bigserial PRIMARY KEY,
+  author_id bigint NOT NULL REFERENCES c_fk_indexed.authors (id) ON DELETE CASCADE,
+  title text NOT NULL
+);
+CREATE INDEX books_author_idx ON c_fk_indexed.books (author_id);
+
+GRANT SELECT ON c_fk_indexed.authors, c_fk_indexed.books TO corpus_user;

--- a/packages/safegres/corpus/cases/39-policy-cast-with-expression-index/case.json
+++ b/packages/safegres/corpus/cases/39-policy-cast-with-expression-index/case.json
@@ -1,0 +1,23 @@
+{
+  "title": "A cast in a policy is fine when a matching expression index exists",
+  "dimension": "perf",
+  "exposure": {
+    "schemas": [
+      "c_policy_cast_indexed"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [],
+  "forbid": [
+    "X2",
+    "X3",
+    "X9"
+  ],
+  "fix": "Nothing to fix — this is case 19 fixed with an expression index rather than by moving the cast, and X3 must recognize the index it asked for."
+}

--- a/packages/safegres/corpus/cases/39-policy-cast-with-expression-index/schema.sql
+++ b/packages/safegres/corpus/cases/39-policy-cast-with-expression-index/schema.sql
@@ -1,0 +1,19 @@
+DROP SCHEMA IF EXISTS c_policy_cast_indexed CASCADE;
+CREATE SCHEMA c_policy_cast_indexed;
+GRANT USAGE ON SCHEMA c_policy_cast_indexed TO corpus_user, corpus_anon;
+
+CREATE TABLE c_policy_cast_indexed.accounts (
+  id bigserial PRIMARY KEY,
+  tenant_id uuid NOT NULL,
+  email text
+);
+-- The expression index X3 asks for: it serves the cast comparison below,
+-- which a plain index on tenant_id could not.
+CREATE INDEX accounts_tenant_text_idx ON c_policy_cast_indexed.accounts ((tenant_id::text));
+ALTER TABLE c_policy_cast_indexed.accounts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_policy_cast_indexed.accounts FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY accounts_tenant ON c_policy_cast_indexed.accounts FOR SELECT TO corpus_user
+  USING (tenant_id::text = (SELECT current_setting('jwt.claims.tenant_id', true)));
+
+GRANT SELECT ON c_policy_cast_indexed.accounts TO corpus_user;

--- a/packages/safegres/corpus/cases/40-stable-function-hoisted/case.json
+++ b/packages/safegres/corpus/cases/40-stable-function-hoisted/case.json
@@ -1,0 +1,23 @@
+{
+  "title": "A STABLE policy function wrapped in a scalar sub-select is hoisted",
+  "dimension": "perf",
+  "exposure": {
+    "schemas": [
+      "c_stable_hoisted"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [],
+  "forbid": [
+    "X2",
+    "X4",
+    "X9"
+  ],
+  "fix": "Nothing to fix — this is case 20 fixed: the sub-select references no column, so the planner evaluates it once per query."
+}

--- a/packages/safegres/corpus/cases/40-stable-function-hoisted/schema.sql
+++ b/packages/safegres/corpus/cases/40-stable-function-hoisted/schema.sql
@@ -1,0 +1,25 @@
+DROP SCHEMA IF EXISTS c_stable_hoisted CASCADE;
+CREATE SCHEMA c_stable_hoisted;
+GRANT USAGE ON SCHEMA c_stable_hoisted TO corpus_user, corpus_anon;
+
+-- LEAKPROOF as well as STABLE: reading a GUC and casting it tells a caller
+-- nothing about any row, and without the marking X4 would fire here on top of
+-- the X9 this case is about.
+CREATE FUNCTION c_stable_hoisted.current_tenant() RETURNS uuid
+  LANGUAGE sql STABLE LEAKPROOF AS $$
+    SELECT nullif(current_setting('jwt.claims.tenant_id', true), '')::uuid
+  $$;
+
+CREATE TABLE c_stable_hoisted.ledger (
+  id bigserial PRIMARY KEY,
+  tenant_id uuid NOT NULL,
+  amount numeric
+);
+CREATE INDEX ledger_tenant_idx ON c_stable_hoisted.ledger (tenant_id);
+ALTER TABLE c_stable_hoisted.ledger ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_stable_hoisted.ledger FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY ledger_tenant ON c_stable_hoisted.ledger FOR SELECT TO corpus_user
+  USING (tenant_id = (SELECT c_stable_hoisted.current_tenant()));
+
+GRANT SELECT ON c_stable_hoisted.ledger TO corpus_user;

--- a/packages/safegres/corpus/cases/41-index-prefix-not-redundant/case.json
+++ b/packages/safegres/corpus/cases/41-index-prefix-not-redundant/case.json
@@ -1,0 +1,21 @@
+{
+  "title": "A single-column index is not redundant with a composite that ends in it",
+  "dimension": "perf",
+  "exposure": {
+    "schemas": [
+      "c_index_not_redundant"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [],
+  "forbid": [
+    "X5"
+  ],
+  "fix": "Nothing to fix — dropping either index costs a plan. X5 may only fire on a leading-column prefix, and (tenant_id) is not a prefix of (region, tenant_id)."
+}

--- a/packages/safegres/corpus/cases/41-index-prefix-not-redundant/schema.sql
+++ b/packages/safegres/corpus/cases/41-index-prefix-not-redundant/schema.sql
@@ -1,0 +1,15 @@
+DROP SCHEMA IF EXISTS c_index_not_redundant CASCADE;
+CREATE SCHEMA c_index_not_redundant;
+GRANT USAGE ON SCHEMA c_index_not_redundant TO corpus_user, corpus_anon;
+
+CREATE TABLE c_index_not_redundant.shipments (
+  id bigserial PRIMARY KEY,
+  tenant_id uuid NOT NULL,
+  region text NOT NULL
+);
+-- Neither index covers the other: tenant_id leads the first and trails the
+-- second, so only the first can serve a lookup by tenant alone.
+CREATE INDEX shipments_tenant_idx ON c_index_not_redundant.shipments (tenant_id);
+CREATE INDEX shipments_region_tenant_idx ON c_index_not_redundant.shipments (region, tenant_id);
+
+GRANT SELECT ON c_index_not_redundant.shipments TO corpus_user;

--- a/packages/safegres/corpus/cases/42-search-column-indexed/case.json
+++ b/packages/safegres/corpus/cases/42-search-column-indexed/case.json
@@ -1,0 +1,21 @@
+{
+  "title": "A tsvector column with a GIN index is not a finding",
+  "dimension": "perf",
+  "exposure": {
+    "schemas": [
+      "c_search_indexed"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [],
+  "forbid": [
+    "X7"
+  ],
+  "fix": "Nothing to fix — this is case 23 fixed, and the index is the one full-text search can actually use."
+}

--- a/packages/safegres/corpus/cases/42-search-column-indexed/schema.sql
+++ b/packages/safegres/corpus/cases/42-search-column-indexed/schema.sql
@@ -1,0 +1,12 @@
+DROP SCHEMA IF EXISTS c_search_indexed CASCADE;
+CREATE SCHEMA c_search_indexed;
+GRANT USAGE ON SCHEMA c_search_indexed TO corpus_user, corpus_anon;
+
+CREATE TABLE c_search_indexed.articles (
+  id bigserial PRIMARY KEY,
+  body text,
+  search_doc tsvector
+);
+CREATE INDEX articles_search_idx ON c_search_indexed.articles USING gin (search_doc);
+
+GRANT SELECT ON c_search_indexed.articles TO corpus_user;

--- a/packages/safegres/package.json
+++ b/packages/safegres/package.json
@@ -26,8 +26,9 @@
     "clean": "makage clean",
     "prepack": "npm run build",
     "version:sync": "node scripts/sync-version.js",
-    "build": "npm run version:sync && makage build && chmod +x dist/cli.js && mkdir -p dist/corpus && cp -r corpus/. dist/corpus/",
-    "build:dev": "makage build --dev && chmod +x dist/cli.js && mkdir -p dist/corpus && cp -r corpus/. dist/corpus/",
+    "build": "npm run version:sync && makage build && chmod +x dist/cli.js && mkdir -p dist/corpus dist/schema && cp -r corpus/. dist/corpus/ && cp schema/*.json dist/schema/",
+    "build:dev": "makage build --dev && chmod +x dist/cli.js && mkdir -p dist/corpus dist/schema && cp -r corpus/. dist/corpus/ && cp schema/*.json dist/schema/",
+    "schema": "npm run build:dev && node scripts/write-schema.js",
     "lint": "eslint . --fix",
     "test": "jest --passWithNoTests",
     "test:watch": "jest --watch"

--- a/packages/safegres/schema/safegres.schema.json
+++ b/packages/safegres/schema/safegres.schema.json
@@ -1,0 +1,837 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/constructive-io/constructive/main/packages/safegres/schema/safegres.schema.json",
+  "title": "safegres configuration",
+  "description": "Configuration for safegres, the PostgreSQL security and performance auditor. Discovered as safegres.config.{ts,js,mjs,cjs}, .safegresrc{,.json,.yaml,.yml,.js}, safegres.json, or the \"safegres\" key in package.json.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "JSON Schema reference, for editor completion."
+    },
+    "extends": {
+      "anyOf": [
+        {
+          "type": "string",
+          "description": "Preset name, path, or package"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Preset name, path, or package"
+          },
+          "description": "Several, lowest precedence first"
+        }
+      ],
+      "description": "Presets (safegres:recommended, …), relative file paths, or npm packages"
+    },
+    "exposure": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resolver": {
+          "type": "string",
+          "enum": [
+            "static",
+            "constructive",
+            "postgraphile"
+          ],
+          "description": "How to resolve the exposed surface"
+        },
+        "adapters": {
+          "type": "array",
+          "items": {
+            "description": "Built-in name or adapter object"
+          },
+          "description": "Exposure adapters: built-in names, or ExposureAdapter objects in a JS/TS config"
+        },
+        "schemas": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Schema name"
+          },
+          "description": "Schemas reachable from the exposed APIs"
+        },
+        "roles": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Role name"
+          },
+          "description": "Roles reachable at the API edge"
+        },
+        "anonRoles": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Role name"
+          },
+          "description": "The subset of roles an unauthenticated caller arrives as"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the primary plane. Default api."
+        },
+        "reach": {
+          "type": "boolean",
+          "description": "Let adapters narrow a plane to the relations the API can address. Default true."
+        },
+        "planes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Plane identifier, e.g. api, direct:app, internal"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "api",
+                  "role",
+                  "schema"
+                ],
+                "description": "What kind of access path this plane describes"
+              },
+              "primary": {
+                "type": "boolean",
+                "description": "Make this plane the headline score. At most one plane may claim it."
+              },
+              "schemas": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Schema name"
+                },
+                "description": "Schemas this plane reaches"
+              },
+              "roles": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Role name"
+                },
+                "description": "Roles this plane grants access as"
+              },
+              "anonRoles": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Role name"
+                },
+                "description": "The subset of roles reachable without authenticating"
+              }
+            },
+            "description": "One graded access plane"
+          },
+          "description": "Additional access planes to grade"
+        }
+      },
+      "description": "The exposed API surface — what the score is computed against"
+    },
+    "public": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "read": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "schema.table glob"
+          },
+          "description": "Table globs whose open SELECT policies are by design"
+        }
+      },
+      "description": "Declared-public surface: open reads that are deliberate"
+    },
+    "extensions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "skipOwned": {
+          "type": "boolean",
+          "description": "Skip relations an extension owns. Default true."
+        },
+        "ignore": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Extension name"
+          },
+          "description": "Extension names whose schemas are skipped wholesale"
+        }
+      },
+      "description": "How to treat objects belonging to installed extensions"
+    },
+    "perf": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Collect and score perf findings without passing --perf"
+        },
+        "rules": {
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "off",
+                  "critical",
+                  "high",
+                  "medium",
+                  "low",
+                  "info"
+                ],
+                "description": "Rule setting"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "description": "Severity or options object"
+                },
+                "description": "Severity plus rule options"
+              }
+            ],
+            "description": "off, a severity, or [severity, options]"
+          },
+          "description": "Rule settings by code or prefix wildcard (A*, P*, *). Exact codes win."
+        },
+        "ignore": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "schema.table glob"
+          },
+          "description": "Table globs whose perf findings are intentional"
+        },
+        "scoring": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "model": {
+              "type": "string",
+              "enum": [
+                "density",
+                "weighted"
+              ],
+              "description": "Scoring model. Default density."
+            },
+            "weights": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "number",
+                "description": "Points"
+              },
+              "description": "Points deducted per finding severity"
+            },
+            "perRuleWeights": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "number",
+                "description": "Points"
+              },
+              "description": "Per-rule weight, beating the severity weight"
+            },
+            "maxDeductionPerRule": {
+              "type": "number",
+              "description": "Cap on one rule’s total deduction (weighted model)"
+            },
+            "failClosedWeight": {
+              "type": "number",
+              "description": "Multiplier for fail-closed findings. Default 0."
+            },
+            "densityK": {
+              "type": "number",
+              "description": "Density falloff constant. Default 0.17."
+            },
+            "unknownExposureCap": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "description": "Cap"
+                },
+                {
+                  "type": "boolean",
+                  "description": "false to disable"
+                }
+              ],
+              "description": "Maximum score when no exposure surface resolves. Default 80; false disables the cap."
+            },
+            "floorOnCritical": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "A+",
+                    "A",
+                    "B",
+                    "C",
+                    "D",
+                    "F"
+                  ],
+                  "description": "Grade"
+                },
+                {
+                  "type": "boolean",
+                  "description": "false to disable"
+                }
+              ],
+              "description": "Grade any critical finding floors the score at. Default C; false disables."
+            },
+            "gradeBands": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "number",
+                "description": "Score"
+              },
+              "description": "Minimum score for each grade"
+            },
+            "includeStats": {
+              "type": "boolean",
+              "description": "Whether S* runtime-statistics findings count toward the perf score. Default true."
+            }
+          },
+          "description": "Scoring for the perf axis"
+        },
+        "stats": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Collect runtime statistics without passing --stats"
+            },
+            "minRows": {
+              "type": "number",
+              "description": "Ignore tables with fewer live rows than this. Default 1000."
+            },
+            "seqScanRatio": {
+              "type": "number",
+              "description": "S1 fires above this seq-scan/index-scan ratio. Default 10."
+            },
+            "minIndexBytes": {
+              "type": "number",
+              "description": "S2 ignores indexes smaller than this. Default 1048576."
+            },
+            "deadTupleRatio": {
+              "type": "number",
+              "description": "S3 fires above this dead/live tuple ratio. Default 0.2."
+            },
+            "minTimeShare": {
+              "type": "number",
+              "description": "S4 reports statements at or above this share of total time. Default 0.05."
+            },
+            "topStatements": {
+              "type": "number",
+              "description": "S4 reports at most this many statements. Default 5."
+            }
+          },
+          "description": "Runtime statistics (S*)"
+        },
+        "explain": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Probe findings with EXPLAIN without passing --explain"
+            },
+            "minRows": {
+              "type": "number",
+              "description": "Below this planner row estimate a seq scan is right. Default 1000."
+            }
+          },
+          "description": "Planner proof (--explain)"
+        },
+        "baseline": {
+          "type": "string",
+          "description": "Baseline of accepted perf debt; its presence enables the diff"
+        },
+        "failOnNew": {
+          "type": "boolean",
+          "description": "Exit non-zero on a perf finding absent from the baseline"
+        },
+        "paths": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "infer": {
+              "type": "boolean",
+              "description": "Collect access-path signals for every foreign key. Default true."
+            },
+            "minPointers": {
+              "type": "number",
+              "description": "Write-once pointers before the config-record signal fires. Default 2."
+            },
+            "onWriteOncePointer": {
+              "type": "string",
+              "enum": [
+                "report",
+                "demote",
+                "suppress"
+              ],
+              "description": "What X1 does with a shape-only write-once pointer"
+            }
+          },
+          "description": "Access-path classification, which decides whether X1 applies"
+        }
+      },
+      "description": "The optional performance dimension"
+    },
+    "schemas": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "Schema name"
+      },
+      "description": "Only audit these schemas"
+    },
+    "excludeSchemas": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "Schema name"
+      },
+      "description": "Never audit these schemas"
+    },
+    "roles": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "Role name"
+      },
+      "description": "Only audit these roles"
+    },
+    "excludeRoles": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "Role name"
+      },
+      "description": "Never audit these roles"
+    },
+    "rules": {
+      "type": "object",
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "string",
+            "enum": [
+              "off",
+              "critical",
+              "high",
+              "medium",
+              "low",
+              "info"
+            ],
+            "description": "Rule setting"
+          },
+          {
+            "type": "array",
+            "items": {
+              "description": "Severity or options object"
+            },
+            "description": "Severity plus rule options"
+          }
+        ],
+        "description": "off, a severity, or [severity, options]"
+      },
+      "description": "Rule settings by code or prefix wildcard (A*, P*, *). Exact codes win."
+    },
+    "overrides": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "tables": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "schema.table glob"
+            },
+            "description": "schema.table globs this entry applies to"
+          },
+          "rules": {
+            "type": "object",
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "off",
+                    "critical",
+                    "high",
+                    "medium",
+                    "low",
+                    "info"
+                  ],
+                  "description": "Rule setting"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "description": "Severity or options object"
+                  },
+                  "description": "Severity plus rule options"
+                }
+              ],
+              "description": "off, a severity, or [severity, options]"
+            },
+            "description": "Rule settings by code or prefix wildcard (A*, P*, *). Exact codes win."
+          }
+        },
+        "description": "One override"
+      },
+      "description": "Per-scope retuning, ESLint overrides-style"
+    },
+    "scoring": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "model": {
+          "type": "string",
+          "enum": [
+            "density",
+            "weighted"
+          ],
+          "description": "Scoring model. Default density."
+        },
+        "weights": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number",
+            "description": "Points"
+          },
+          "description": "Points deducted per finding severity"
+        },
+        "perRuleWeights": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number",
+            "description": "Points"
+          },
+          "description": "Per-rule weight, beating the severity weight"
+        },
+        "maxDeductionPerRule": {
+          "type": "number",
+          "description": "Cap on one rule’s total deduction (weighted model)"
+        },
+        "failClosedWeight": {
+          "type": "number",
+          "description": "Multiplier for fail-closed findings. Default 0."
+        },
+        "densityK": {
+          "type": "number",
+          "description": "Density falloff constant. Default 0.17."
+        },
+        "unknownExposureCap": {
+          "anyOf": [
+            {
+              "type": "number",
+              "description": "Cap"
+            },
+            {
+              "type": "boolean",
+              "description": "false to disable"
+            }
+          ],
+          "description": "Maximum score when no exposure surface resolves. Default 80; false disables the cap."
+        },
+        "floorOnCritical": {
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "A+",
+                "A",
+                "B",
+                "C",
+                "D",
+                "F"
+              ],
+              "description": "Grade"
+            },
+            {
+              "type": "boolean",
+              "description": "false to disable"
+            }
+          ],
+          "description": "Grade any critical finding floors the score at. Default C; false disables."
+        },
+        "gradeBands": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number",
+            "description": "Score"
+          },
+          "description": "Minimum score for each grade"
+        }
+      },
+      "description": "The security scoring model"
+    },
+    "failOn": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "severity": {
+          "type": "string",
+          "enum": [
+            "critical",
+            "high",
+            "medium",
+            "low",
+            "info"
+          ],
+          "description": "Exit non-zero on any finding at or above this severity"
+        },
+        "score": {
+          "type": "number",
+          "description": "Exit non-zero below this security score"
+        },
+        "grade": {
+          "type": "string",
+          "enum": [
+            "A+",
+            "A",
+            "B",
+            "C",
+            "D",
+            "F"
+          ],
+          "description": "Exit non-zero below this security grade"
+        },
+        "perfScore": {
+          "type": "number",
+          "description": "Exit non-zero below this perf score"
+        },
+        "perfGrade": {
+          "type": "string",
+          "enum": [
+            "A+",
+            "A",
+            "B",
+            "C",
+            "D",
+            "F"
+          ],
+          "description": "Exit non-zero below this perf grade"
+        },
+        "planes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "score": {
+                "type": "number",
+                "description": "Exit non-zero below this plane score"
+              },
+              "grade": {
+                "type": "string",
+                "enum": [
+                  "A+",
+                  "A",
+                  "B",
+                  "C",
+                  "D",
+                  "F"
+                ],
+                "description": "Exit non-zero below this plane grade"
+              }
+            },
+            "description": "One plane gate"
+          },
+          "description": "Per-plane gates, keyed by plane name. A floor is the useful shape."
+        }
+      },
+      "description": "Gates — what makes the run exit non-zero"
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "pgpm": {
+          "type": "string",
+          "description": "Deploy the pgpm workspace at this path into an ephemeral database and audit it"
+        }
+      },
+      "description": "Where the database to audit comes from"
+    },
+    "outputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "dir": {
+          "type": "string",
+          "description": "Write safegres.{json,md,sarif} into this directory"
+        },
+        "json": {
+          "type": "string",
+          "description": "Path for the JSON report"
+        },
+        "markdown": {
+          "type": "string",
+          "description": "Path for the Markdown report"
+        },
+        "sarif": {
+          "type": "string",
+          "description": "Path for the SARIF report"
+        },
+        "sarifSources": {
+          "type": "string",
+          "description": "Root scanned to resolve SARIF findings to SQL source lines"
+        },
+        "snapshot": {
+          "type": "string",
+          "description": "Path for the aggregate-only snapshot, for a later compare"
+        },
+        "githubComment": {
+          "type": "string",
+          "description": "Path for the rendered sticky PR comment"
+        }
+      },
+      "description": "Files a single run writes"
+    },
+    "callGraph": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Build the call-graph audit without passing --call-graph"
+        },
+        "baseline": {
+          "type": "string",
+          "description": "Baseline of accepted trust boundaries; enables the diff"
+        },
+        "failOnNew": {
+          "type": "boolean",
+          "description": "Exit non-zero on a boundary absent from the baseline"
+        }
+      },
+      "description": "The unscored call-graph audit and its baseline"
+    },
+    "report": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "planes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Plane name or glob"
+          },
+          "description": "Planes to render, by name or glob"
+        },
+        "dimensions": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "security",
+              "perf"
+            ],
+            "description": "Dimension"
+          },
+          "description": "Dimensions to render. Default both."
+        },
+        "github": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "summary": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "description": "Score"
+              },
+              "description": "Scores in the job summary, in order (security, perf, planes:<glob>)"
+            },
+            "comment": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "sticky": {
+                  "type": "boolean",
+                  "description": "Reuse one comment per PR instead of appending. Default true."
+                },
+                "sections": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "scores",
+                      "delta",
+                      "new-findings",
+                      "findings",
+                      "planes"
+                    ],
+                    "description": "Section"
+                  },
+                  "description": "Sections to include. Default scores, delta, new-findings."
+                }
+              },
+              "description": "Sticky PR comment"
+            },
+            "annotations": {
+              "type": "string",
+              "enum": [
+                "all",
+                "gate-failures",
+                "none"
+              ],
+              "description": "Which findings become annotations. Default gate-failures."
+            },
+            "detail": {
+              "type": "string",
+              "enum": [
+                "summary",
+                "normal",
+                "verbose"
+              ],
+              "description": "How much of the report goes in the job summary. Default normal."
+            },
+            "badges": {
+              "type": "boolean",
+              "description": "Render scores as colored shields.io badges. Default true."
+            }
+          },
+          "description": "GitHub Actions output"
+        }
+      },
+      "description": "What a rendered report shows — selection, not analysis"
+    },
+    "eval": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "corpus": {
+          "type": "string",
+          "description": "Corpus directory of <id>/{case.json,schema.sql}"
+        },
+        "preset": {
+          "type": "string",
+          "description": "Preset every case is graded under. Default recommended."
+        },
+        "cases": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Case id"
+          },
+          "description": "Case ids (or id prefixes) to run"
+        }
+      },
+      "description": "Defaults for safegres eval"
+    }
+  }
+}

--- a/packages/safegres/scripts/write-schema.js
+++ b/packages/safegres/scripts/write-schema.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+/**
+ * Regenerate `schema/safegres.schema.json` from the described config shape.
+ * The committed file is what an editor fetches, so it is checked in; the test
+ * suite fails if it drifts from the shape.
+ *
+ * Usage: pnpm build:dev && node scripts/write-schema.js
+ */
+const fs = require('fs');
+const path = require('path');
+
+const { toJsonSchema } = require('../dist/config/schema');
+
+const out = path.join(__dirname, '..', 'schema', 'safegres.schema.json');
+fs.mkdirSync(path.dirname(out), { recursive: true });
+fs.writeFileSync(out, `${JSON.stringify(toJsonSchema(), null, 2)}\n`);
+process.stdout.write(`wrote ${out}\n`);

--- a/packages/safegres/src/cli/audit.ts
+++ b/packages/safegres/src/cli/audit.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 
 import { diffCallGraph, parseBaseline, serializeBaseline, toBaseline } from '../callgraph/baseline';
 import { audit, type AuditOptions } from '../commands/audit';
-import { loadConfig } from '../config/loader';
+import { configPathBase, loadConfig } from '../config/loader';
 import type { Grade } from '../config/types';
 import { diffPerf, parsePerfBaseline, serializePerfBaseline, toPerfBaseline } from '../perf/baseline';
 import { compareReports, parseSnapshot, serializeSnapshot, toSnapshot } from '../report/compare';
@@ -228,7 +228,7 @@ export default async (
   const { pgpm: pgpmSource, usePgpm, perfBaseline, callGraphBaseline, outputs } = resolveRunPaths(
     argv,
     config,
-    loaded.filepath ? path.dirname(loaded.filepath) : process.cwd()
+    configPathBase(loaded)
   );
 
   const exposureSchemas = csvList(argv['exposure-schemas']);

--- a/packages/safegres/src/cli/eval.ts
+++ b/packages/safegres/src/cli/eval.ts
@@ -1,9 +1,10 @@
 import { CLIOptions, Inquirerer, ParsedArgs } from 'inquirerer';
+import * as path from 'path';
 import type { Client } from 'pg';
 import yanse from 'yanse';
 
 import { type EvalCaseResult, type EvalReport, runEval } from '../commands/eval';
-import { loadConfig } from '../config/loader';
+import { configPathBase, loadConfig } from '../config/loader';
 import type { EvalConfig } from '../config/types';
 import { loadCorpus } from '../corpus';
 import { buildClient, csvList } from './shared';
@@ -44,7 +45,12 @@ graded by the named preset alone, or the corpus would be measuring itself.
  */
 function evalDefaults(configFile?: string): EvalConfig {
   try {
-    return loadConfig({ configFile }).config.eval ?? {};
+    const loaded = loadConfig({ configFile });
+    const config = loaded.config.eval ?? {};
+    if (config.corpus === undefined) return config;
+    // Like every other configured path: relative to the file that declared it,
+    // so a corpus committed next to the config is found from any cwd.
+    return { ...config, corpus: path.resolve(configPathBase(loaded).dirFor('eval.corpus'), config.corpus) };
   } catch {
     return {};
   }

--- a/packages/safegres/src/cli/print-config.ts
+++ b/packages/safegres/src/cli/print-config.ts
@@ -2,6 +2,7 @@ import { CLIOptions, Inquirerer, ParsedArgs } from 'inquirerer';
 
 import { loadConfig, safegresConfigLoader } from '../config/loader';
 import { resolveRules } from '../config/resolve';
+import { toJsonSchema } from '../config/schema';
 import { RULES } from '../rules/registry';
 import { configParamsFromArgv } from './shared';
 
@@ -15,6 +16,7 @@ Options:
   --preset <name>          Apply a built-in preset
   --rule <CODE=SETTING>    Retune a rule (repeatable)
   --explain                Show per-key provenance (which layer set each value)
+  --schema                 Print the config JSON Schema instead, for an editor
   --help, -h               Show this help message
 `;
 
@@ -25,6 +27,11 @@ export default async (
 ): Promise<void> => {
   if (argv.help || argv.h) {
     process.stdout.write(usage);
+    return;
+  }
+
+  if (argv.schema === true) {
+    process.stdout.write(`${JSON.stringify(toJsonSchema(), null, 2)}\n`);
     return;
   }
 

--- a/packages/safegres/src/cli/shared.ts
+++ b/packages/safegres/src/cli/shared.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { Client } from 'pg';
 import { getPgEnvOptions, type PgConfig } from 'pg-env';
 
-import type { LoadConfigParams } from '../config/loader';
+import type { ConfigPathBase, LoadConfigParams } from '../config/loader';
 import type { ExtensionsConfig, RulesConfig, SafegresConfig } from '../config/types';
 
 export function csvList(value: unknown): string[] | undefined {
@@ -86,38 +86,48 @@ export interface RunPaths {
 }
 
 /**
- * Flags win over the config file. A path from the config file is resolved
- * against that file, so a CI job can run from any directory; a path on the
- * command line stays relative to cwd, like every other command's arguments.
+ * Flags win over the config file. A path from a config file is resolved
+ * against *the file that declared it* — which is not always the discovered
+ * one, since a file can extend another — so a CI job can run from any
+ * directory; a path on the command line stays relative to cwd, like every
+ * other command's arguments.
  */
 export function resolveRunPaths(
   argv: ParsedArgs,
   config: SafegresConfig,
-  configDir: string
+  base: ConfigPathBase | string
 ): RunPaths {
-  const pick = (flag: unknown, configured?: string): string | undefined =>
-    typeof flag === 'string' ? flag : configured && path.resolve(configDir, configured);
+  const dirFor = typeof base === 'string' ? () => base : (key: string): string => base.dirFor(key);
+  const pick = (flag: unknown, key: string, configured?: string): string | undefined =>
+    typeof flag === 'string' ? flag : configured && path.resolve(dirFor(key), configured);
 
   // A directory is the common case: one path, conventional names, no remembering
   // which extension goes with which renderer. A named file still wins.
-  const dir = pick(argv.out, config.outputs?.dir);
+  const dir = pick(argv.out, 'outputs.dir', config.outputs?.dir);
   const inDir = (name: string): string | undefined => dir && path.join(dir, name);
 
   return {
-    pgpm: pick(argv.pgpm, config.source?.pgpm),
+    pgpm: pick(argv.pgpm, 'source.pgpm', config.source?.pgpm),
     // An explicit connection on the command line beats a configured source:
     // pointing the same config at a database you already have is the whole
     // reason to type one, and deploying a throwaway copy instead would ignore it.
     usePgpm: argv.pgpm !== undefined || (config.source?.pgpm !== undefined && !hasConnectionFlag(argv)),
-    perfBaseline: pick(argv['perf-baseline'], config.perf?.baseline),
-    callGraphBaseline: pick(argv.baseline, config.callGraph?.baseline),
+    perfBaseline: pick(argv['perf-baseline'], 'perf.baseline', config.perf?.baseline),
+    callGraphBaseline: pick(argv.baseline, 'callGraph.baseline', config.callGraph?.baseline),
     outputs: {
-      json: pick(argv['write-json'], config.outputs?.json) ?? inDir('safegres.json'),
-      markdown: pick(argv['write-markdown'], config.outputs?.markdown) ?? inDir('safegres.md'),
-      sarif: pick(argv['write-sarif'], config.outputs?.sarif) ?? inDir('safegres.sarif'),
-      sarifSources: pick(argv['sarif-sources'], config.outputs?.sarifSources),
-      snapshot: pick(argv['write-snapshot'], config.outputs?.snapshot),
-      githubComment: pick(argv['write-github-comment'], config.outputs?.githubComment)
+      json: pick(argv['write-json'], 'outputs.json', config.outputs?.json) ?? inDir('safegres.json'),
+      markdown:
+        pick(argv['write-markdown'], 'outputs.markdown', config.outputs?.markdown)
+        ?? inDir('safegres.md'),
+      sarif:
+        pick(argv['write-sarif'], 'outputs.sarif', config.outputs?.sarif) ?? inDir('safegres.sarif'),
+      sarifSources: pick(argv['sarif-sources'], 'outputs.sarifSources', config.outputs?.sarifSources),
+      snapshot: pick(argv['write-snapshot'], 'outputs.snapshot', config.outputs?.snapshot),
+      githubComment: pick(
+        argv['write-github-comment'],
+        'outputs.githubComment',
+        config.outputs?.githubComment
+      )
     }
   };
 }

--- a/packages/safegres/src/config/loader.ts
+++ b/packages/safegres/src/config/loader.ts
@@ -1,8 +1,10 @@
 import { type ConfigLoader, createConfigLoader, type ExplainedValue, type LoadResult } from 'confstash';
+import * as path from 'path';
 
 import { PRESETS } from './presets';
 import { resolveRules } from './resolve';
-import type { SafegresConfig } from './types';
+import type { OverrideEntry, SafegresConfig } from './types';
+import { validateConfigShape } from './validate';
 
 export type { ConfigLoader, ExplainedValue, LoadResult };
 
@@ -18,6 +20,7 @@ export function safegresConfigLoader(): ConfigLoader<SafegresConfig> {
     presets: PRESETS,
     defaults: {},
     validate: (config) => {
+      validateConfigShape(config); // unknown keys, wrong value kinds
       resolveRules(config); // throws ConfigValidationError on bad rules/overrides
     }
   });
@@ -39,6 +42,17 @@ export interface LoadConfigParams {
   sealed?: boolean;
 }
 
+/**
+ * Where a configured *path* should resolve from. A repository that splits its
+ * config into a shared base and a per-job file has two directories in play,
+ * and `ci/baseline.json` written in the base means the base's `ci/`, whichever
+ * file inherited it.
+ */
+export interface ConfigPathBase {
+  /** Directory to resolve a value declared at this dotted key against. */
+  dirFor(key: string): string;
+}
+
 /** Load and merge the effective safegres config. */
 export function loadConfig(params: LoadConfigParams = {}): LoadResult<SafegresConfig> {
   if (params.sealed) return loadSealedConfig(params.preset);
@@ -54,16 +68,95 @@ export function loadConfig(params: LoadConfigParams = {}): LoadResult<SafegresCo
   }
   // `extends` in overrides isn't expanded by confstash (it only expands file
   // layers), so a CLI --preset is merged in as a layer *below* the file config.
-  const result = loader.loadSync({
-    cwd: params.cwd,
-    configFile: params.configFile,
-    overrides: stripExtends(overrides)
-  });
+  const result = describeExtendsFailure(() =>
+    loader.loadSync({
+      cwd: params.cwd,
+      configFile: params.configFile,
+      overrides: stripExtends(overrides)
+    })
+  );
+  const config = withUnionedOverrides(result);
   if (params.preset) {
     const presetConfig = PRESETS[overrides.extends as string];
-    return { ...result, config: mergePreset(presetConfig, result.config) };
+    return { ...result, config: mergePreset(presetConfig, config) };
   }
-  return result;
+  return { ...result, config };
+}
+
+/**
+ * A missing `extends` target surfaces from the loader as a bare `ENOENT` on a
+ * path nobody typed — the resolved one. Say what it was reached from, and that
+ * a name is a preset while a path is a file, which is the actual mistake.
+ */
+function describeExtendsFailure(load: () => LoadResult<SafegresConfig>): LoadResult<SafegresConfig> {
+  try {
+    return load();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.includes('ENOENT')) throw error;
+    throw new Error(
+      `${message}\nsafegres: an "extends" target could not be read. A built-in preset is a name `
+        + `(${Object.keys(PRESETS).join(', ')}); anything else is resolved as a path relative to `
+        + 'the file that declared it, or as an npm package.'
+    );
+  }
+}
+
+/**
+ * `overrides` is a list of scoped exceptions, so inheriting one file from
+ * another has to *add* to it. Array-typed keys otherwise replace — a child
+ * that narrows `exposure.schemas` means the narrower list — but replacing here
+ * would silently drop the base file's exceptions, which is how a shared config
+ * turns into two divergent copies. Preset chains have always unioned it; this
+ * makes a file chain agree.
+ */
+function withUnionedOverrides(result: LoadResult<SafegresConfig>): SafegresConfig {
+  const seen = new Set<string>();
+  const unioned: OverrideEntry[] = [];
+  for (const layer of result.layers) {
+    for (const override of layer.config.overrides ?? []) {
+      const key = JSON.stringify(override);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      unioned.push(override);
+    }
+  }
+  if (unioned.length === 0) return result.config;
+  return { ...result.config, overrides: unioned };
+}
+
+/**
+ * Resolve each configured path against the file that declared it, so an
+ * inherited `perf.baseline` keeps pointing at the base file's directory.
+ * Values that came from a preset or from CLI overrides have no directory of
+ * their own and fall back to the discovered config file, then to `cwd`.
+ */
+export function configPathBase(
+  result: LoadResult<SafegresConfig>,
+  cwd: string = process.cwd()
+): ConfigPathBase {
+  const fallback = result.filepath ? path.dirname(result.filepath) : cwd;
+  return {
+    dirFor(key: string): string {
+      // Highest precedence first: the layer that won the merge is the layer
+      // whose directory the value is written relative to.
+      for (let i = result.layers.length - 1; i >= 0; i--) {
+        const layer = result.layers[i];
+        if (valueAt(layer.config, key) === undefined) continue;
+        return layer.source === 'file' && layer.origin ? path.dirname(layer.origin) : fallback;
+      }
+      return fallback;
+    }
+  };
+}
+
+function valueAt(config: Partial<SafegresConfig>, key: string): unknown {
+  let node: unknown = config;
+  for (const part of key.split('.')) {
+    if (node == null || typeof node !== 'object') return undefined;
+    node = (node as Record<string, unknown>)[part];
+  }
+  return node;
 }
 
 /**

--- a/packages/safegres/src/config/schema.ts
+++ b/packages/safegres/src/config/schema.ts
@@ -1,0 +1,328 @@
+import type {
+  CallGraphConfig,
+  EvalConfig,
+  ExposureConfig,
+  ExtensionsConfig,
+  FailOnConfig,
+  GithubCommentConfig,
+  GithubReportConfig,
+  OutputsConfig,
+  OverrideEntry,
+  PerfConfig,
+  PerfExplainConfig,
+  PerfPathsConfig,
+  PerfScoringConfig,
+  PerfStatsConfig,
+  PlaneConfig,
+  PlaneFailOnConfig,
+  PublicConfig,
+  ReportConfig,
+  SafegresConfig,
+  ScoringConfig,
+  SourceConfig
+} from './types';
+
+/**
+ * The shape of the config file, as data: what an editor completes against
+ * (JSON Schema, via `toJsonSchema`) and what a load validates against, from
+ * one declaration.
+ *
+ * Drift is a compile error, not a stale file. `Shape<T>` maps over
+ * `Required<T>`, so a key added to `SafegresConfig` that nobody described
+ * here fails to typecheck — which is the only reason a hand-written schema
+ * for a growing interface is defensible at all.
+ */
+export type Shape<T> = { [K in keyof Required<T>]: Node };
+
+/** One described value. `any` is the honest answer for a live JS object. */
+export type Node =
+  | { type: 'any'; description: string }
+  | { type: 'string'; description: string; enum?: readonly string[] }
+  | { type: 'number'; description: string }
+  | { type: 'boolean'; description: string }
+  | { type: 'array'; description: string; items: Node }
+  | { type: 'object'; description: string; properties: Record<string, Node> }
+  /** A map with arbitrary keys — `rules`, `failOn.planes`, … */
+  | { type: 'record'; description: string; values: Node }
+  /** A key whose value may be more than one of the above. */
+  | { type: 'union'; description: string; of: Node[] };
+
+const str = (description: string, values?: readonly string[]): Node =>
+  values ? { type: 'string', description, enum: values } : { type: 'string', description };
+const num = (description: string): Node => ({ type: 'number', description });
+const bool = (description: string): Node => ({ type: 'boolean', description });
+const list = (description: string, items: Node): Node => ({ type: 'array', description, items });
+const obj = <T>(description: string, properties: Shape<T>): Node => ({
+  type: 'object',
+  description,
+  properties: properties as Record<string, Node>
+});
+const oneOf = (description: string, ...of: Node[]): Node => ({ type: 'union', description, of });
+
+const GRADES = ['A+', 'A', 'B', 'C', 'D', 'F'] as const;
+const SEVERITIES = ['critical', 'high', 'medium', 'low', 'info'] as const;
+
+/** `'off' | Severity | [Severity, options]`. */
+const RULE_SETTING: Node = oneOf(
+  'off, a severity, or [severity, options]',
+  str('Rule setting', ['off', ...SEVERITIES]),
+  list('Severity plus rule options', { type: 'any', description: 'Severity or options object' })
+);
+
+const RULES: Node = {
+  type: 'record',
+  description: 'Rule settings by code or prefix wildcard (A*, P*, *). Exact codes win.',
+  values: RULE_SETTING
+};
+
+const PLANE: Shape<PlaneConfig> = {
+  name: str('Plane identifier, e.g. api, direct:app, internal'),
+  kind: str('What kind of access path this plane describes', ['api', 'role', 'schema']),
+  primary: bool('Make this plane the headline score. At most one plane may claim it.'),
+  schemas: list('Schemas this plane reaches', str('Schema name')),
+  roles: list('Roles this plane grants access as', str('Role name')),
+  anonRoles: list('The subset of roles reachable without authenticating', str('Role name'))
+};
+
+const EXPOSURE: Shape<ExposureConfig> = {
+  resolver: str('How to resolve the exposed surface', ['static', 'constructive', 'postgraphile']),
+  adapters: list(
+    'Exposure adapters: built-in names, or ExposureAdapter objects in a JS/TS config',
+    { type: 'any', description: 'Built-in name or adapter object' }
+  ),
+  schemas: list('Schemas reachable from the exposed APIs', str('Schema name')),
+  roles: list('Roles reachable at the API edge', str('Role name')),
+  anonRoles: list('The subset of roles an unauthenticated caller arrives as', str('Role name')),
+  name: str('Name of the primary plane. Default api.'),
+  reach: bool('Let adapters narrow a plane to the relations the API can address. Default true.'),
+  planes: list('Additional access planes to grade', obj('One graded access plane', PLANE))
+};
+
+const SCORING: Shape<ScoringConfig> = {
+  model: str('Scoring model. Default density.', ['density', 'weighted']),
+  weights: { type: 'record', description: 'Points deducted per finding severity', values: num('Points') },
+  perRuleWeights: { type: 'record', description: 'Per-rule weight, beating the severity weight', values: num('Points') },
+  maxDeductionPerRule: num('Cap on one rule\u2019s total deduction (weighted model)'),
+  failClosedWeight: num('Multiplier for fail-closed findings. Default 0.'),
+  densityK: num('Density falloff constant. Default 0.17.'),
+  unknownExposureCap: oneOf(
+    'Maximum score when no exposure surface resolves. Default 80; false disables the cap.',
+    num('Cap'),
+    bool('false to disable')
+  ),
+  floorOnCritical: oneOf(
+    'Grade any critical finding floors the score at. Default C; false disables.',
+    str('Grade', GRADES),
+    bool('false to disable')
+  ),
+  gradeBands: { type: 'record', description: 'Minimum score for each grade', values: num('Score') }
+};
+
+const PERF_SCORING: Shape<PerfScoringConfig> = {
+  ...SCORING,
+  includeStats: bool('Whether S* runtime-statistics findings count toward the perf score. Default true.')
+};
+
+const PERF_STATS: Shape<PerfStatsConfig> = {
+  enabled: bool('Collect runtime statistics without passing --stats'),
+  minRows: num('Ignore tables with fewer live rows than this. Default 1000.'),
+  seqScanRatio: num('S1 fires above this seq-scan/index-scan ratio. Default 10.'),
+  minIndexBytes: num('S2 ignores indexes smaller than this. Default 1048576.'),
+  deadTupleRatio: num('S3 fires above this dead/live tuple ratio. Default 0.2.'),
+  minTimeShare: num('S4 reports statements at or above this share of total time. Default 0.05.'),
+  topStatements: num('S4 reports at most this many statements. Default 5.')
+};
+
+const PERF_EXPLAIN: Shape<PerfExplainConfig> = {
+  enabled: bool('Probe findings with EXPLAIN without passing --explain'),
+  minRows: num('Below this planner row estimate a seq scan is right. Default 1000.')
+};
+
+const PERF_PATHS: Shape<PerfPathsConfig> = {
+  infer: bool('Collect access-path signals for every foreign key. Default true.'),
+  minPointers: num('Write-once pointers before the config-record signal fires. Default 2.'),
+  onWriteOncePointer: str('What X1 does with a shape-only write-once pointer', [
+    'report',
+    'demote',
+    'suppress'
+  ])
+};
+
+const PERF: Shape<PerfConfig> = {
+  enabled: bool('Collect and score perf findings without passing --perf'),
+  rules: RULES,
+  ignore: list('Table globs whose perf findings are intentional', str('schema.table glob')),
+  scoring: obj('Scoring for the perf axis', PERF_SCORING),
+  stats: obj('Runtime statistics (S*)', PERF_STATS),
+  explain: obj('Planner proof (--explain)', PERF_EXPLAIN),
+  baseline: str('Baseline of accepted perf debt; its presence enables the diff'),
+  failOnNew: bool('Exit non-zero on a perf finding absent from the baseline'),
+  paths: obj('Access-path classification, which decides whether X1 applies', PERF_PATHS)
+};
+
+const FAIL_ON_PLANE: Shape<PlaneFailOnConfig> = {
+  score: num('Exit non-zero below this plane score'),
+  grade: str('Exit non-zero below this plane grade', GRADES)
+};
+
+const FAIL_ON: Shape<FailOnConfig> = {
+  severity: str('Exit non-zero on any finding at or above this severity', SEVERITIES),
+  score: num('Exit non-zero below this security score'),
+  grade: str('Exit non-zero below this security grade', GRADES),
+  perfScore: num('Exit non-zero below this perf score'),
+  perfGrade: str('Exit non-zero below this perf grade', GRADES),
+  planes: {
+    type: 'record',
+    description: 'Per-plane gates, keyed by plane name. A floor is the useful shape.',
+    values: obj('One plane gate', FAIL_ON_PLANE)
+  }
+};
+
+const GITHUB_COMMENT: Shape<GithubCommentConfig> = {
+  sticky: bool('Reuse one comment per PR instead of appending. Default true.'),
+  sections: list(
+    'Sections to include. Default scores, delta, new-findings.',
+    str('Section', ['scores', 'delta', 'new-findings', 'findings', 'planes'])
+  )
+};
+
+const GITHUB: Shape<GithubReportConfig> = {
+  summary: list('Scores in the job summary, in order (security, perf, planes:<glob>)', str('Score')),
+  comment: obj('Sticky PR comment', GITHUB_COMMENT),
+  annotations: str('Which findings become annotations. Default gate-failures.', [
+    'all',
+    'gate-failures',
+    'none'
+  ]),
+  detail: str('How much of the report goes in the job summary. Default normal.', [
+    'summary',
+    'normal',
+    'verbose'
+  ]),
+  badges: bool('Render scores as colored shields.io badges. Default true.')
+};
+
+const REPORT: Shape<ReportConfig> = {
+  planes: list('Planes to render, by name or glob', str('Plane name or glob')),
+  dimensions: list('Dimensions to render. Default both.', str('Dimension', ['security', 'perf'])),
+  github: obj('GitHub Actions output', GITHUB)
+};
+
+const OVERRIDE: Shape<OverrideEntry> = {
+  tables: list('schema.table globs this entry applies to', str('schema.table glob')),
+  rules: RULES
+};
+
+const OUTPUTS: Shape<OutputsConfig> = {
+  dir: str('Write safegres.{json,md,sarif} into this directory'),
+  json: str('Path for the JSON report'),
+  markdown: str('Path for the Markdown report'),
+  sarif: str('Path for the SARIF report'),
+  sarifSources: str('Root scanned to resolve SARIF findings to SQL source lines'),
+  snapshot: str('Path for the aggregate-only snapshot, for a later compare'),
+  githubComment: str('Path for the rendered sticky PR comment')
+};
+
+const SOURCE: Shape<SourceConfig> = {
+  pgpm: str('Deploy the pgpm workspace at this path into an ephemeral database and audit it')
+};
+
+const CALL_GRAPH: Shape<CallGraphConfig> = {
+  enabled: bool('Build the call-graph audit without passing --call-graph'),
+  baseline: str('Baseline of accepted trust boundaries; enables the diff'),
+  failOnNew: bool('Exit non-zero on a boundary absent from the baseline')
+};
+
+const EVAL: Shape<EvalConfig> = {
+  corpus: str('Corpus directory of <id>/{case.json,schema.sql}'),
+  preset: str('Preset every case is graded under. Default recommended.'),
+  cases: list('Case ids (or id prefixes) to run', str('Case id'))
+};
+
+const PUBLIC: Shape<PublicConfig> = {
+  read: list('Table globs whose open SELECT policies are by design', str('schema.table glob'))
+};
+
+const EXTENSIONS: Shape<ExtensionsConfig> = {
+  skipOwned: bool('Skip relations an extension owns. Default true.'),
+  ignore: list('Extension names whose schemas are skipped wholesale', str('Extension name'))
+};
+
+/** The config file, described. */
+export const CONFIG_SHAPE: Shape<SafegresConfig> = {
+  extends: oneOf(
+    'Presets (safegres:recommended, \u2026), relative file paths, or npm packages',
+    str('Preset name, path, or package'),
+    list('Several, lowest precedence first', str('Preset name, path, or package'))
+  ),
+  exposure: obj('The exposed API surface \u2014 what the score is computed against', EXPOSURE),
+  public: obj('Declared-public surface: open reads that are deliberate', PUBLIC),
+  extensions: obj('How to treat objects belonging to installed extensions', EXTENSIONS),
+  perf: obj('The optional performance dimension', PERF),
+  schemas: list('Only audit these schemas', str('Schema name')),
+  excludeSchemas: list('Never audit these schemas', str('Schema name')),
+  roles: list('Only audit these roles', str('Role name')),
+  excludeRoles: list('Never audit these roles', str('Role name')),
+  rules: RULES,
+  overrides: list('Per-scope retuning, ESLint overrides-style', obj('One override', OVERRIDE)),
+  scoring: obj('The security scoring model', SCORING),
+  failOn: obj('Gates \u2014 what makes the run exit non-zero', FAIL_ON),
+  source: obj('Where the database to audit comes from', SOURCE),
+  outputs: obj('Files a single run writes', OUTPUTS),
+  callGraph: obj('The unscored call-graph audit and its baseline', CALL_GRAPH),
+  report: obj('What a rendered report shows \u2014 selection, not analysis', REPORT),
+  eval: obj('Defaults for safegres eval', EVAL)
+};
+
+export const SCHEMA_ID = 'https://raw.githubusercontent.com/constructive-io/constructive/main/packages/safegres/schema/safegres.schema.json';
+
+/** The described shape as a draft-07 JSON Schema, for editors. */
+export function toJsonSchema(): Record<string, unknown> {
+  return {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    $id: SCHEMA_ID,
+    title: 'safegres configuration',
+    description:
+      'Configuration for safegres, the PostgreSQL security and performance auditor. '
+      + 'Discovered as safegres.config.{ts,js,mjs,cjs}, .safegresrc{,.json,.yaml,.yml,.js}, '
+      + 'safegres.json, or the "safegres" key in package.json.',
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      $schema: { type: 'string', description: 'JSON Schema reference, for editor completion.' },
+      ...objectProperties(CONFIG_SHAPE as Record<string, Node>)
+    }
+  };
+}
+
+function objectProperties(shape: Record<string, Node>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, node] of Object.entries(shape)) out[key] = jsonNode(node);
+  return out;
+}
+
+function jsonNode(node: Node): Record<string, unknown> {
+  const description = node.description;
+  switch (node.type) {
+  case 'any':
+    return { description };
+  case 'string':
+    return node.enum ? { type: 'string', enum: [...node.enum], description } : { type: 'string', description };
+  case 'number':
+  case 'boolean':
+    return { type: node.type, description };
+  case 'array':
+    return { type: 'array', items: jsonNode(node.items), description };
+  case 'object':
+    return {
+      type: 'object',
+      additionalProperties: false,
+      properties: objectProperties(node.properties),
+      description
+    };
+  case 'record':
+    return { type: 'object', additionalProperties: jsonNode(node.values), description };
+  case 'union':
+    return { anyOf: node.of.map(jsonNode), description };
+  }
+}

--- a/packages/safegres/src/config/types.ts
+++ b/packages/safegres/src/config/types.ts
@@ -417,7 +417,17 @@ export interface GithubCommentConfig {
  * key in package.json.
  */
 export interface SafegresConfig {
-  /** Presets (`safegres:recommended`, …), relative paths, or npm packages. */
+  /**
+   * Presets (`safegres:recommended`, …), relative paths (`./safegres.base.json`),
+   * or npm packages — recursively, lowest precedence first.
+   *
+   * A path is resolved against the file that declared it, and so is every
+   * *path-valued* key inherited from it (`source.pgpm`, `perf.baseline`,
+   * `outputs.*`, `eval.corpus`): a baseline written in a shared base file means
+   * that file's directory, whichever job inherited it. Objects merge per key
+   * and arrays replace, except `overrides`, which is a list of scoped
+   * exceptions and so unions across the chain.
+   */
   extends?: string | string[];
   /** The exposed API surface — what the score is computed against. */
   exposure?: ExposureConfig;

--- a/packages/safegres/src/config/validate.ts
+++ b/packages/safegres/src/config/validate.ts
@@ -1,0 +1,130 @@
+import { ConfigValidationError } from './resolve';
+import { CONFIG_SHAPE, type Node } from './schema';
+
+/**
+ * Check a config against the described shape: unknown keys, and values of the
+ * wrong kind.
+ *
+ * A typo'd key used to be *silently ignored*, which for a file that decides
+ * whether CI fails is the worst possible outcome — `failon: { grade: 'B' }`
+ * reads as a passing build rather than as a mistake. So this rejects rather
+ * than warns, and names the key it thinks you meant.
+ *
+ * Value checks stay shallow on purpose: rule settings, severities and grades
+ * are validated by `resolveRules` and by the gate code, which know the rule
+ * registry. This is the shape, not the semantics.
+ */
+export function validateConfigShape(config: unknown): void {
+  const problems: string[] = [];
+  checkObject(config, CONFIG_SHAPE as Record<string, Node>, '', problems, ['$schema', 'extends']);
+  if (problems.length === 0) return;
+  throw new ConfigValidationError(
+    `Invalid safegres configuration:\n${problems.map((p) => `  - ${p}`).join('\n')}`
+  );
+}
+
+function checkObject(
+  value: unknown,
+  properties: Record<string, Node>,
+  path: string,
+  problems: string[],
+  extraKeys: string[] = []
+): void {
+  if (!isPlainObject(value)) return;
+  for (const [key, entry] of Object.entries(value)) {
+    if (extraKeys.includes(key)) continue;
+    const node = properties[key];
+    if (!node) {
+      problems.push(`unknown key ${quote(path, key)}${suggestion(key, Object.keys(properties))}`);
+      continue;
+    }
+    checkNode(entry, node, path ? `${path}.${key}` : key, problems);
+  }
+}
+
+function checkNode(value: unknown, node: Node, path: string, problems: string[]): void {
+  if (value === undefined || value === null) return;
+  switch (node.type) {
+  case 'any':
+    return;
+  case 'string':
+    if (typeof value !== 'string') return void problems.push(wrongType(path, 'a string', value));
+    if (node.enum && !node.enum.includes(value)) {
+      problems.push(`"${path}" is "${value}"; expected one of ${node.enum.map((v) => `"${v}"`).join(', ')}`);
+    }
+    return;
+  case 'number':
+    if (typeof value !== 'number') problems.push(wrongType(path, 'a number', value));
+    return;
+  case 'boolean':
+    if (typeof value !== 'boolean') problems.push(wrongType(path, 'a boolean', value));
+    return;
+  case 'array':
+    if (!Array.isArray(value)) return void problems.push(wrongType(path, 'an array', value));
+    value.forEach((item, i) => checkNode(item, node.items, `${path}[${i}]`, problems));
+    return;
+  case 'object':
+    if (!isPlainObject(value)) return void problems.push(wrongType(path, 'an object', value));
+    checkObject(value, node.properties, path, problems);
+    return;
+  case 'record':
+    if (!isPlainObject(value)) return void problems.push(wrongType(path, 'an object', value));
+    for (const [key, entry] of Object.entries(value)) {
+      checkNode(entry, node.values, `${path}.${key}`, problems);
+    }
+    return;
+  case 'union': {
+    // A union is satisfied by any branch, so only report when every branch
+    // rejects — and then report the branch that complained least.
+    const attempts = node.of.map((branch) => {
+      const branchProblems: string[] = [];
+      checkNode(value, branch, path, branchProblems);
+      return branchProblems;
+    });
+    if (attempts.some((a) => a.length === 0)) return;
+    const best = attempts.reduce((a, b) => (b.length < a.length ? b : a));
+    problems.push(...best);
+  }
+  }
+}
+
+function wrongType(path: string, expected: string, value: unknown): string {
+  return `"${path}" is ${describe(value)}; expected ${expected}`;
+}
+
+function describe(value: unknown): string {
+  if (Array.isArray(value)) return 'an array';
+  if (value === null) return 'null';
+  return `a ${typeof value}`;
+}
+
+function quote(path: string, key: string): string {
+  return `"${path ? `${path}.${key}` : key}"`;
+}
+
+/** "did you mean" for one edit's worth of typo, which is the common case. */
+function suggestion(key: string, known: string[]): string {
+  const lower = key.toLowerCase();
+  const near = known.find((k) => k.toLowerCase() === lower)
+    ?? known.find((k) => distance(k.toLowerCase(), lower) <= Math.max(1, Math.floor(key.length / 4)));
+  return near ? ` — did you mean "${near}"?` : '';
+}
+
+function distance(a: string, b: string): number {
+  const rows: number[][] = [Array.from({ length: b.length + 1 }, (_, j) => j)];
+  for (let i = 1; i <= a.length; i++) {
+    rows[i] = [i];
+    for (let j = 1; j <= b.length; j++) {
+      rows[i][j] = Math.min(
+        rows[i - 1][j] + 1,
+        rows[i][j - 1] + 1,
+        rows[i - 1][j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1)
+      );
+    }
+  }
+  return rows[a.length][b.length];
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/safegres/src/index.ts
+++ b/packages/safegres/src/index.ts
@@ -121,6 +121,7 @@ export {
   ruleCodesForDimension,
   rulesForTable
 } from './config/resolve';
+export { CONFIG_SHAPE, SCHEMA_ID, toJsonSchema } from './config/schema';
 export type {
   CallGraphConfig,
   EvalConfig,
@@ -142,6 +143,7 @@ export type {
   ScoringConfig,
   SourceConfig
 } from './config/types';
+export { validateConfigShape } from './config/validate';
 export type { CaseResult, CorpusCase, ExpectedFinding } from './corpus';
 export { corpusBootstrap, corpusDir, gradeCase, loadCase, loadCorpus } from './corpus';
 export type { ExposureAdapter, PlaneInput, ReachContext } from './exposure/adapters';


### PR DESCRIPTION
## Summary

P1, P6 and P5 off [#1377](https://github.com/constructive-io/constructive-planning/issues/1377). No rules changed; `src/pg/introspect.ts` and `src/checks/lattice.ts` untouched.

**P1 — `extends` resolves a local file.** `"extends": "../../safegres.base.json"` now works alongside built-in presets, which is what two CI jobs sharing a 19-entry `public.read` list needed. The non-obvious part is *whose* directory a relative path belongs to. A baseline written in a shared base file means that file's directory, whichever job inherited it — so path resolution is per-declaring-layer, not per-discovered-config:

```ts
// before: every path resolved against dirname(discovered config)
resolveRunPaths(argv, config, path.dirname(loaded.filepath))

// after: each path-valued key resolves against the layer that declared it
resolveRunPaths(argv, config, configPathBase(loaded))
configPathBase(loaded).dirFor('perf.baseline')  // → dirname of the file that wrote it
```

Applies to `source.pgpm`, `perf.baseline`, `callGraph.baseline`, `outputs.*`, `eval.corpus`. Objects merge per key and arrays replace, except `overrides` — a list of scoped exceptions, so it unions across the chain rather than letting a child silently drop the exceptions it inherited. `--sealed` does no discovery and so reaches none of this, by construction.

**P6 — one description, two consumers.** `src/config/schema.ts` declares the config shape as data (`Shape<SafegresConfig>`, so a new config key that isn't described fails to compile). `toJsonSchema()` generates the checked-in `schema/safegres.schema.json` for editor completion, and `validateConfigShape()` runs the same description at load time — because today `"failon": { "grade": "B" }` is silently ignored and reads as a passing build:

```
$ safegres audit
Invalid safegres config: unknown key "failon" — did you mean "failOn"?
```

Also `safegres print-config --schema`, and `pnpm schema` to regenerate (a test fails if the committed file drifts).

**P5 — the perf axis gets negatives.** Two positives for the last uncovered perf rules (X4 non-LEAKPROOF policy function, X8 sort-shaped column), and six **negative** cases: the earlier case with its flaw fixed, whose answer key is empty `expect` plus `forbid`. `38-foreign-key-with-index` is case 17 with the index added; `36`, `39`, `40` are 35/19/20 fixed. The corpus test already asserted that a case with no weighted finding scores exactly 100, so these pin something stronger than "the code didn't appear": a correct schema costs nothing. `corpus.test.ts`'s "every case documents its answer" check now accepts `forbid` as an answer.

42 cases, all passing; `pnpm build`, `pnpm lint`, `pnpm test` green.


Link to Devin session: https://app.devin.ai/sessions/b7874ecee0c7471ea271e6e7193869dc
Requested by: @pyramation