### PR TITLE
feat(safegres): L14 — reach into an unaudited schema, and L8 down to the columns

### DIFF
--- a/.agents/skills/safegres/SKILL.md
+++ b/.agents/skills/safegres/SKILL.md
@@ -78,7 +78,7 @@ The score only improves by being **explicit** (declaring exposure and intent) or
 | L5 | high | fail-open | **Indirect coverage gap** — inherited/PUBLIC reach lands on a table with no covering policy |
 | L6 | low | fail-closed | **Unaddressable grant** — no exposed API can name the relation, and no policy references it |
 | L7 | info | fail-open | **`SET ROLE` reach** — a membership confers `set_option` without `INHERIT`, so a role assumes privileges it does not passively hold |
-| L8 | info | fail-open | **DEFINER-view bypass** — a non-`security_invoker` view reads its base relations as the *owner* |
+| L8 | info | fail-open | **DEFINER-view bypass** — a non-`security_invoker` view reads its base relations as the *owner*, naming the columns that escape |
 | L9 | info | fail-open | **DEFINER-view write** — an auto-updatable definer view writes a base relation as its owner |
 | L10 | info | fail-open | **Rewrite-rule bypass** — a rule's actions run as the view owner, `security_invoker` notwithstanding |
 | L11 | info | fail-open | **Materialized-view snapshot** — stored rows are served without consulting base ACLs or RLS |
@@ -97,6 +97,8 @@ The score only improves by being **explicit** (declaring exposure and intent) or
 Reach is modelled as cells in `checks/role-reach.ts`, each carrying the role the access **executes as** (`effectiveRole`), the **path** of edges it arrived by (`grant` / `setrole` / `view` / `matview` / `rule`), and a **proof** bit: `catalog` (an ACL row or `pg_auth_members`) or `ast` (read out of a SQL body). `opaque-tainted` exists for a chain that could not be followed; nothing produces it yet, because opacity is currently whole-body.
 
 **L8–L12 are the AST half: a view is not what its definition looks like.** A view without `security_invoker` runs as its owner, so a caller's SELECT on the view reads base relations under the *owner's* privileges (L8), and if the view is auto-updatable, writes land the same way (L9). Rewrite rules are worse: their actions are **not** governed by `security_invoker`, so L10 fires on invoker views where L9 does not. A materialized view stores rows computed at REFRESH time, so the bases are never consulted and their policies never run (L11). And a filtering view that is not `security_barrier` lets a leaky caller predicate be pushed below the filter (L12).
+
+**Which columns escape is a catalog fact, not a parsing problem.** `ViewSnapshot.columnDeps` reads the `pg_depend` rows the rewriter wrote for the view's `_RETURN` rule: `SELECT *` arrives expanded, a column used only in a `WHERE` counts as read, and a nested view depends on the *inner view's* columns. L8 puts that set in the message and in `context.columns`, and suppresses itself when every escaping column is one the role already holds by column grant **and** the base has no RLS — with RLS on, the owner reads rows the caller's policies hide, so the projection is beside the point. An absent column set is unknown, never narrow.
 
 **Conservatism is the rule, not a nicety.** A body safegres cannot see through — dynamic SQL, an unparseable definition, a chain deeper than the hop limit — **suppresses** the finding; it never becomes a weaker guess. L14 is the one place that reports the *absence* of knowledge: a qualified reference into a schema the audit never introspected is real reach with an ungraded far end, distinct from a name it simply could not resolve (a CTE, an alias), which is still dropped.
 

--- a/.agents/skills/safegres/SKILL.md
+++ b/.agents/skills/safegres/SKILL.md
@@ -71,11 +71,42 @@ The score only improves by being **explicit** (declaring exposure and intent) or
 | R1 | critical | fail-open | An **untrusted role** holds a write privilege |
 | R2 | high | fail-open | Permissive write policy applies to untrusted role or PUBLIC |
 | R3 | medium | fail-open | RLS table has grants **TO PUBLIC** |
+| L1 | medium | fail-open | **Indirect access** — an untrusted role reaches a table via PUBLIC or role inheritance, not a direct grant |
+| L2 | low | fail-closed | **Dead policy** — the policy's role holds no grant the policy could mediate |
+| L3 | low | fail-closed | **Unreachable grant** — the grant's role can never authenticate or be assumed |
+| L4 | low | fail-closed | **Dead schema `USAGE`** — the role reaches no table *or view* in the schema |
+| L5 | high | fail-open | **Indirect coverage gap** — inherited/PUBLIC reach lands on a table with no covering policy |
+| L6 | low | fail-closed | **Unaddressable grant** — no exposed API can name the relation, and no policy references it |
+| L7 | info | fail-open | **`SET ROLE` reach** — a membership confers `set_option` without `INHERIT`, so a role assumes privileges it does not passively hold |
+| L8 | info | fail-open | **DEFINER-view bypass** — a non-`security_invoker` view reads its base relations as the *owner* |
+| L9 | info | fail-open | **DEFINER-view write** — an auto-updatable definer view writes a base relation as its owner |
+| L10 | info | fail-open | **Rewrite-rule bypass** — a rule's actions run as the view owner, `security_invoker` notwithstanding |
+| L11 | info | fail-open | **Materialized-view snapshot** — stored rows are served without consulting base ACLs or RLS |
+| L12 | info | fail-open | **Non-barrier filtering view** — the row filter is not a boundary, so a leaky caller predicate reads below it |
+| L13 | info | fail-open | **Column-level grant** — reach through `pg_attribute.attacl`, which no relation ACL shows |
+| L14 | info | neutral | **Unaudited base relation** — a definer view reads a schema the audit never introspected |
 | W1 | medium | meta | No exposure surface configured — DB assumed reachable, score capped |
+
+**The L-series is the reachability lattice: what an untrusted role can make Postgres *do*, not what the ACL rows say.** Four things feed it, and they compose:
+
+- **Effective grants** (`checks/lattice.ts`) — the closure of direct grants, grants `TO PUBLIC`, and grants inherited through role membership; every cell carries its provenance (`direct` | `PUBLIC` | `member of <role>`). L13 adds the column-scoped closure from `pg_attribute.attacl`, suppressed where the whole-relation grant already covers the privilege.
+- **Schema `USAGE`** — a grant on a relation in a schema the role cannot enter is not reach (L4).
+- **Exposure** — which relations an API can actually name (L6), and which roles a request can arrive as (`exposure.anonRoles` drives every untrusted-role option).
+- **`SET ROLE`** — on PG16+ a membership can confer `set_option` without `INHERIT`, so a role that passively holds nothing still executes as its target (L7).
+
+Reach is modelled as cells in `checks/role-reach.ts`, each carrying the role the access **executes as** (`effectiveRole`), the **path** of edges it arrived by (`grant` / `setrole` / `view` / `matview` / `rule`), and a **proof** bit: `catalog` (an ACL row or `pg_auth_members`) or `ast` (read out of a SQL body). `opaque-tainted` exists for a chain that could not be followed; nothing produces it yet, because opacity is currently whole-body.
+
+**L8–L12 are the AST half: a view is not what its definition looks like.** A view without `security_invoker` runs as its owner, so a caller's SELECT on the view reads base relations under the *owner's* privileges (L8), and if the view is auto-updatable, writes land the same way (L9). Rewrite rules are worse: their actions are **not** governed by `security_invoker`, so L10 fires on invoker views where L9 does not. A materialized view stores rows computed at REFRESH time, so the bases are never consulted and their policies never run (L11). And a filtering view that is not `security_barrier` lets a leaky caller predicate be pushed below the filter (L12).
+
+**Conservatism is the rule, not a nicety.** A body safegres cannot see through — dynamic SQL, an unparseable definition, a chain deeper than the hop limit — **suppresses** the finding; it never becomes a weaker guess. L14 is the one place that reports the *absence* of knowledge: a qualified reference into a schema the audit never introspected is real reach with an ungraded far end, distinct from a name it simply could not resolve (a CTE, an alias), which is still dropped.
+
+**No rule may recommend revoking a grant it cannot prove unused.** The L-series remedies are *fix the view* (`security_invoker = true`, change the owner, add `security_barrier`), *bring the schema into scope*, or *narrow the role model* — never "revoke this grant", because the grant is usually what the API serves. L2/L3/L4/L6 are the exceptions that do recommend removal, and each carries an explicit veto (a policy reference, a live column grant, a reachable view) that suppresses the advice when anything is load-bearing.
+
+New L-rules ship `info` and **score-neutral** on purpose: the honest severity of a definer view handing an anonymous role a table is not informational, but a new rule earns its weight after it has been run against real schemas. Promoting one is a deliberate scoring change.
 
 Perf-dimension rules (only collected with `--perf`, scored on their own axis; `S*` additionally need `--stats`): **X1** FK with no covering index (medium), **X2** policy filters on a column that leads no index (medium), **X3** policy casts/wraps its own column with no matching expression index (medium), **X4** policy calls a non-LEAKPROOF function (low), **X5** redundant/duplicate index (low), **X6** no primary key and no usable replica identity (low), **X7** search column with no index the search can use — `tsvector` w/o GIN/GiST, `vector` w/o HNSW/IVFFlat (medium), **X8** sort-shaped `timestamptz`/`date` column leading no index (info, heuristic), **X9** policy calls a STABLE function per row because it is not wrapped in a scalar sub-select (medium), plus P1/P1b and the runtime-statistics rules **S1**-**S4**.
 
-**Direction is the key idea:** `fail-open` = real exposure (untrusted side reaches more than intended). `fail-closed` = denied at runtime (hygiene/availability, not a leak) — contributes **0** to the score by default. R1/R2 are no-ops until you configure a role list; `safegres:constructive` sets them for `anonymous`.
+**Direction is the key idea:** `fail-open` = real exposure (untrusted side reaches more than intended). `fail-closed` = denied at runtime (hygiene/availability, not a leak) — contributes **0** to the score by default. R1/R2 and the untrusted-role L-rules are no-ops until you configure a role list: `"L8": ["info", { "roles": ["anonymous"] }]`, or `{ "rolesFrom": "anon" }` to take them from `exposure.anonRoles`, which is what `safegres:recommended` does for L5 and L7–L14. `safegres:constructive` sets R1/R2 for `anonymous`.
 
 ## Configuration (confstash)
 

--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -143,7 +143,7 @@ family, **not** the dimension: `P1`/`P1b` are performance, `P5` is security.
 | L4 | info | neutral | **Dead schema `USAGE`** — reaches no relation and no function |
 | L5 | info | fail-open | An untrusted role reaches an **RLS-off table** via PUBLIC/inheritance † |
 | L6 | info | neutral | **Unaddressable grant** — an API role holds privileges on a relation its API cannot name ‡ |
-| L8 | info | fail-open | **DEFINER view bypass** — an untrusted role reads a base relation as the view's owner † |
+| L8 | info | fail-open | **DEFINER view bypass** — an untrusted role reads a base relation, and named columns of it, as the view's owner † |
 | L9 | info | fail-open | **DEFINER view write** — an auto-updatable definer view writes a base relation as its owner † |
 | L10 | info | fail-open | **Rewrite-rule bypass** — a rule on a view writes a relation as the view's owner, `security_invoker` notwithstanding † |
 | L11 | info | fail-open | **Materialized-view snapshot** — stored rows serve an untrusted role what the base relation's grants and policies would not † |

--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -149,6 +149,7 @@ family, **not** the dimension: `P1`/`P1b` are performance, `P5` is security.
 | L11 | info | fail-open | **Materialized-view snapshot** — stored rows serve an untrusted role what the base relation's grants and policies would not † |
 | L12 | info | fail-open | **Non-barrier filtering view** — a view is an untrusted role's only path to a relation, but its row filter is not a boundary † |
 | L13 | info | fail-open | **Column-level grant** — an untrusted role reaches a relation through `pg_attribute.attacl`, which no relation ACL shows † |
+| L14 | info | neutral | **Unaudited base relation** — a definer view reads a relation in a schema the audit never introspected † |
 | W1 | medium | — | **No exposure surface configured** — whole database assumed reachable, score capped |
 
 † R1/R2/L5 are no-ops until you name the untrusted roles:

--- a/packages/safegres/__tests__/unaudited-reach.test.ts
+++ b/packages/safegres/__tests__/unaudited-reach.test.ts
@@ -1,0 +1,146 @@
+import {
+  analyzeViewBodies,
+  checkUnauditedViewReach
+} from '../src/checks/definer-view';
+import { type RoleGraph } from '../src/checks/lattice';
+import type { RoleAttributes } from '../src/pg/acl';
+import type { ViewSnapshot } from '../src/pg/indexes';
+import type { GrantInfo, TableSnapshot } from '../src/pg/introspect';
+
+function table(partial: Partial<TableSnapshot> = {}): TableSnapshot {
+  return {
+    schema: 'app',
+    name: 'orders',
+    oid: 1,
+    rlsEnabled: true,
+    rlsForced: true,
+    isPartitioned: false,
+    owner: 'app_owner',
+    grants: [],
+    columnGrants: [],
+    policies: [],
+    ...partial
+  };
+}
+
+function view(partial: Partial<ViewSnapshot> = {}): ViewSnapshot {
+  return {
+    schema: 'app',
+    name: 'role_report',
+    owner: 'app_owner',
+    materialized: false,
+    securityInvoker: false,
+    securityBarrier: false,
+    ownerBypassesRls: false,
+    grants: [{ role: 'anon', privilege: 'SELECT', grantable: false, bypassRls: false }],
+    definition: 'SELECT rolname FROM private.secrets',
+    writable: [],
+    insteadOfTriggers: false,
+    rules: [],
+    ...partial
+  };
+}
+
+function role(name: string, partial: Partial<RoleAttributes> = {}): [string, RoleAttributes] {
+  return [name, { name, bypassRls: false, isSuper: false, inheritsFrom: [], canSetRole: [], ...partial }];
+}
+
+const GRAPH: RoleGraph = new Map([role('anon'), role('app_owner')]);
+const ANON = { roles: ['anon'] };
+
+describe('base relations outside the audited schemas', () => {
+  it('resolves a qualified reference into an unaudited schema as external', async () => {
+    const { views } = await analyzeViewBodies([view()], [table()], ['app']);
+    expect(views[0].baseRelations).toEqual([
+      {
+        schema: 'private',
+        table: 'secrets',
+        hops: [{ view: 'app.role_report', owner: 'app_owner' }],
+        external: true
+      }
+    ]);
+  });
+
+  it('still drops an unqualified name it cannot pin down', async () => {
+    const { views } = await analyzeViewBodies(
+      [view({ definition: 'WITH secrets AS (SELECT 1 AS id) SELECT id FROM secrets' })],
+      [table()],
+      ['app']
+    );
+    expect(views).toEqual([]);
+  });
+
+  it('treats a reference into an audited schema as a miss, not as external', async () => {
+    // `app.missing` is not in the snapshot but `app` was audited: the audit
+    // read that schema and found no such relation, so the name is unresolved.
+    const { views } = await analyzeViewBodies(
+      [view({ definition: 'SELECT id FROM app.missing' })],
+      [table()],
+      ['app']
+    );
+    expect(views).toEqual([]);
+  });
+
+  it('defaults the audited set to the schemas of the snapshot', async () => {
+    const { views } = await analyzeViewBodies([view()], [table()]);
+    expect(views[0].baseRelations[0]).toMatchObject({ schema: 'private', external: true });
+  });
+});
+
+describe('L14 — unaudited base relation', () => {
+  it('reports the reach and names the schema that was never introspected', async () => {
+    const { views } = await analyzeViewBodies([view()], [table()], ['app']);
+    const findings = checkUnauditedViewReach(views, GRAPH, ANON);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      code: 'L14',
+      severity: 'info',
+      schema: 'private',
+      table: 'secrets',
+      role: 'anon'
+    });
+    expect(findings[0].message).toContain('outside the audited schemas');
+    expect(findings[0].context).toMatchObject({
+      view: 'app.role_report',
+      effectiveRole: 'app_owner',
+      unauditedSchema: 'private',
+      proof: 'ast'
+    });
+  });
+
+  it('says nothing about an audited base relation — that is L8 territory', async () => {
+    const { views } = await analyzeViewBodies(
+      [view({ definition: 'SELECT id FROM app.orders' })],
+      [table()],
+      ['app']
+    );
+    expect(checkUnauditedViewReach(views, GRAPH, ANON)).toEqual([]);
+  });
+
+  it('stays silent on an invoker view: the caller needs its own grant', async () => {
+    const { views } = await analyzeViewBodies([view({ securityInvoker: true })], [table()], ['app']);
+    expect(checkUnauditedViewReach(views, GRAPH, ANON)).toEqual([]);
+  });
+
+  it('stays silent when the untrusted role cannot read the view', async () => {
+    const { views } = await analyzeViewBodies(
+      [view({ grants: [] as GrantInfo[] })],
+      [table()],
+      ['app']
+    );
+    expect(checkUnauditedViewReach(views, GRAPH, ANON)).toEqual([]);
+  });
+
+  it('is a no-op until untrusted roles are configured', async () => {
+    const { views } = await analyzeViewBodies([view()], [table()], ['app']);
+    expect(checkUnauditedViewReach(views, GRAPH)).toEqual([]);
+  });
+
+  it('recommends bringing the schema into scope, never a revoke', async () => {
+    const { views } = await analyzeViewBodies([view()], [table()], ['app']);
+    const [finding] = checkUnauditedViewReach(views, GRAPH, ANON);
+    expect(finding.hint).toContain('Add the schema to the audit');
+    expect(finding.hint).toContain('do not revoke anything');
+  });
+});

--- a/packages/safegres/__tests__/view-columns.test.ts
+++ b/packages/safegres/__tests__/view-columns.test.ts
@@ -1,0 +1,133 @@
+import { analyzeViewBodies, checkDefinerViewBypass } from '../src/checks/definer-view';
+import { type RoleGraph } from '../src/checks/lattice';
+import type { RoleAttributes } from '../src/pg/acl';
+import type { ViewSnapshot } from '../src/pg/indexes';
+import type { ColumnGrantInfo, TableSnapshot } from '../src/pg/introspect';
+
+function table(partial: Partial<TableSnapshot> = {}): TableSnapshot {
+  return {
+    schema: 'app',
+    name: 'people',
+    oid: 1,
+    rlsEnabled: false,
+    rlsForced: false,
+    isPartitioned: false,
+    owner: 'app_owner',
+    grants: [],
+    columnGrants: [],
+    policies: [],
+    ...partial
+  };
+}
+
+function view(partial: Partial<ViewSnapshot> = {}): ViewSnapshot {
+  return {
+    schema: 'app',
+    name: 'people_public',
+    owner: 'app_owner',
+    materialized: false,
+    securityInvoker: false,
+    securityBarrier: false,
+    ownerBypassesRls: false,
+    grants: [{ role: 'anon', privilege: 'SELECT', grantable: false, bypassRls: false }],
+    definition: 'SELECT id, email FROM app.people',
+    columnDeps: [{ schema: 'app', table: 'people', columns: ['email', 'id'] }],
+    writable: [],
+    insteadOfTriggers: false,
+    rules: [],
+    ...partial
+  };
+}
+
+function columnGrants(role: string, columns: string[]): ColumnGrantInfo[] {
+  return columns.map((column) => ({
+    role,
+    privilege: 'SELECT' as const,
+    column,
+    grantable: false,
+    bypassRls: false
+  }));
+}
+
+function role(name: string, partial: Partial<RoleAttributes> = {}): [string, RoleAttributes] {
+  return [
+    name,
+    { name, bypassRls: false, isSuper: false, inheritsFrom: [], canSetRole: [], ...partial }
+  ];
+}
+
+const GRAPH: RoleGraph = new Map([role('anon'), role('app_owner')]);
+
+async function findings(v: ViewSnapshot, t: TableSnapshot) {
+  const { views } = await analyzeViewBodies([v], [t]);
+  return checkDefinerViewBypass(views, [t], GRAPH, { roles: ['anon'] });
+}
+
+describe('view column dependencies', () => {
+  it('attaches the columns the catalog says the body reads to each base relation', async () => {
+    const { views } = await analyzeViewBodies([view()], [table()]);
+    expect(views[0].baseRelations).toEqual([
+      {
+        schema: 'app',
+        table: 'people',
+        hops: [{ view: 'app.people_public', owner: 'app_owner' }],
+        columns: ['email', 'id']
+      }
+    ]);
+  });
+
+  it('leaves columns absent when the snapshot carries no dependency rows', async () => {
+    const { views } = await analyzeViewBodies([view({ columnDeps: undefined })], [table()]);
+    expect(views[0].baseRelations[0].columns).toBeUndefined();
+  });
+
+  it('names the escaping columns in the L8 finding, not just the relation', async () => {
+    const [f] = await findings(view(), table());
+    expect(f.code).toBe('L8');
+    expect(f.message).toContain('app.people (email, id)');
+    expect(f.context).toMatchObject({ columns: ['email', 'id'] });
+  });
+});
+
+describe('L8 against a column-grant holder', () => {
+  const granted = table({ columnGrants: columnGrants('anon', ['email', 'id', 'note']) });
+
+  it('stays silent when the view exposes only columns the role could already read', async () => {
+    expect(await findings(view(), granted)).toEqual([]);
+  });
+
+  it('fires when a single column escapes beyond the grant', async () => {
+    const wide = view({
+      definition: 'SELECT id, email, ssn FROM app.people',
+      columnDeps: [{ schema: 'app', table: 'people', columns: ['email', 'id', 'ssn'] }]
+    });
+    const [f] = await findings(wide, granted);
+    expect(f?.code).toBe('L8');
+    expect(f.context).toMatchObject({ grantedColumns: ['email', 'id', 'note'] });
+  });
+
+  it('fires on the same projection when the base has RLS: the owner skips the policies', async () => {
+    const rls = table({
+      rlsEnabled: true,
+      columnGrants: columnGrants('anon', ['email', 'id', 'note'])
+    });
+    const [f] = await findings(view(), rls);
+    expect(f?.code).toBe('L8');
+  });
+
+  it('fires when the columns are unknown, rather than assuming the projection is narrow', async () => {
+    expect(await findings(view({ columnDeps: undefined }), granted)).toHaveLength(1);
+  });
+
+  it('recommends fixing the view, never revoking the column grant', async () => {
+    const [f] = await findings(
+      view({
+        definition: 'SELECT id, email, ssn FROM app.people',
+        columnDeps: [{ schema: 'app', table: 'people', columns: ['email', 'id', 'ssn'] }]
+      }),
+      granted
+    );
+    expect(f.hint).toMatch(/security_invoker/);
+    expect(f.hint).toMatch(/Do not revoke/i);
+  });
+});

--- a/packages/safegres/__tests__/view-introspect.test.ts
+++ b/packages/safegres/__tests__/view-introspect.test.ts
@@ -46,6 +46,17 @@ beforeAll(async () => {
     CREATE VIEW fx_viewbarrier.v_both WITH (security_barrier = on, security_invoker = 1) AS
       SELECT id FROM fx_viewbarrier.t;
     CREATE MATERIALIZED VIEW fx_viewbarrier.mv AS SELECT id FROM fx_viewbarrier.t;
+
+    CREATE SCHEMA fx_viewcols;
+    CREATE TABLE fx_viewcols.people (id int, email text, ssn text, note text);
+    CREATE VIEW fx_viewcols.v_narrow AS SELECT id, email FROM fx_viewcols.people;
+    CREATE VIEW fx_viewcols.v_star AS SELECT * FROM fx_viewcols.people;
+    -- A column used only in the WHERE clause never appears in the output,
+    -- but the view still reads it.
+    CREATE VIEW fx_viewcols.v_filtered AS
+      SELECT id FROM fx_viewcols.people WHERE ssn IS NOT NULL;
+    -- A nested view depends on the inner *view's* columns, not the table's.
+    CREATE VIEW fx_viewcols.v_nested AS SELECT email FROM fx_viewcols.v_narrow;
   `);
 });
 
@@ -89,6 +100,27 @@ describe('introspectViews — write paths', () => {
       ['v_ruled_ins', 'INSERT', true]
     ]);
     expect(byName.v_ruled.rules[0].definition).toContain('CREATE RULE');
+  });
+});
+
+describe('introspectViews — column dependencies', () => {
+  it('reads which columns of a base relation a view body actually touches', async () => {
+    const views = await introspectViews(pg.client as never, { schemas: ['fx_viewcols'] });
+    const deps = (name: string, table: string): string[] | undefined =>
+      views
+        .find((v) => v.name === name)
+        ?.columnDeps?.find((d) => d.schema === 'fx_viewcols' && d.table === table)?.columns;
+
+    expect(deps('v_narrow', 'people')).toEqual(['email', 'id']);
+    // `*` is expanded at CREATE time, so the catalog knows the real set.
+    expect(deps('v_star', 'people')).toEqual(['email', 'id', 'note', 'ssn']);
+    // Read is read: a qual column escapes as surely as a projected one.
+    expect(deps('v_filtered', 'people')).toEqual(['id', 'ssn']);
+
+    // Per hop: the outer view depends on the inner view, and the inner view
+    // is what depends on the table.
+    expect(deps('v_nested', 'people')).toBeUndefined();
+    expect(deps('v_nested', 'v_narrow')).toEqual(['email']);
   });
 });
 

--- a/packages/safegres/corpus/cases/37-unaudited-base-relation/case.json
+++ b/packages/safegres/corpus/cases/37-unaudited-base-relation/case.json
@@ -1,0 +1,30 @@
+{
+  "title": "A definer view reads a relation in a schema the audit never introspected",
+  "dimension": "security",
+  "exposure": {
+    "schemas": [
+      "c_unaudited_view"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "L14",
+      "relation": "c_unaudited_hidden.credentials",
+      "role": "corpus_anon",
+      "note": "the reach is proven from the view body; nothing on the far end was graded, because c_unaudited_hidden is outside the audited schemas"
+    }
+  ],
+  "forbid": [
+    "L8"
+  ],
+  "worstSeverity": "info",
+  "fix": "Bring c_unaudited_hidden into the audit (add it to `schemas`, or drop it from `excludeSchemas`) so the base relation's ACL and policies are graded — then L8 can answer whether this is a bypass. Excluding a schema scopes what is scored, never what is reachable.",
+  "id": "37-unaudited-base-relation"
+}

--- a/packages/safegres/corpus/cases/37-unaudited-base-relation/schema.sql
+++ b/packages/safegres/corpus/cases/37-unaudited-base-relation/schema.sql
@@ -1,0 +1,45 @@
+DROP SCHEMA IF EXISTS c_unaudited_view CASCADE;
+DROP SCHEMA IF EXISTS c_unaudited_hidden CASCADE;
+CREATE SCHEMA c_unaudited_view;
+CREATE SCHEMA c_unaudited_hidden;
+
+DO $$ BEGIN
+  CREATE ROLE c_unaudited_owner NOLOGIN;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+GRANT USAGE ON SCHEMA c_unaudited_view TO corpus_anon, corpus_user, c_unaudited_owner;
+
+-- Deliberately *not* in the case's exposure surface, so the audit never
+-- introspects it: no ACL, no policy and no owner of this table is ever read.
+CREATE TABLE c_unaudited_hidden.credentials (
+  id bigserial PRIMARY KEY,
+  subject text NOT NULL,
+  secret text NOT NULL
+);
+ALTER TABLE c_unaudited_hidden.credentials OWNER TO c_unaudited_owner;
+ALTER TABLE c_unaudited_hidden.credentials ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_unaudited_hidden.credentials FORCE ROW LEVEL SECURITY;
+
+-- A table in scope, so the case has an audited surface of its own and the
+-- finding below is clearly about the *other* schema.
+CREATE TABLE c_unaudited_view.sessions (
+  id bigserial PRIMARY KEY,
+  subject text NOT NULL
+);
+ALTER TABLE c_unaudited_view.sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_unaudited_view.sessions FORCE ROW LEVEL SECURITY;
+CREATE POLICY sessions_own ON c_unaudited_view.sessions
+  FOR SELECT TO corpus_user
+  USING (subject = (SELECT current_setting('app.subject', true)));
+CREATE INDEX sessions_subject_idx ON c_unaudited_view.sessions (subject);
+GRANT SELECT ON c_unaudited_view.sessions TO corpus_user;
+
+-- The flaw: the view is in scope and its body names a relation that is not.
+-- It executes as its owner, so corpus_anon reads a table the audit never
+-- graded — every rule that needs the base relation's ACL or policies drops
+-- the edge, and the view scans clean.
+CREATE VIEW c_unaudited_view.subject_directory AS
+  SELECT subject FROM c_unaudited_hidden.credentials;
+ALTER VIEW c_unaudited_view.subject_directory OWNER TO c_unaudited_owner;
+GRANT SELECT ON c_unaudited_view.subject_directory TO corpus_anon, corpus_user;

--- a/packages/safegres/corpus/cases/38-invoker-view-unaudited-base/case.json
+++ b/packages/safegres/corpus/cases/38-invoker-view-unaudited-base/case.json
@@ -1,0 +1,30 @@
+{
+  "title": "An invoker view over the same out-of-scope table confers nothing, so nothing is reported",
+  "dimension": "security",
+  "exposure": {
+    "schemas": [
+      "c_invoker_unaudited"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "A3",
+      "relation": "c_invoker_unaudited.sessions",
+      "note": "the only finding left, and it is about the in-scope table: RLS is not FORCEd, so the owner still reads every row"
+    }
+  ],
+  "forbid": [
+    "L14",
+    "L8"
+  ],
+  "worstSeverity": "low",
+  "fix": "Nothing on the view. This case pins the boundary: L14 reports an out-of-scope *reach*, not an out-of-scope *reference*. `security_invoker` means the caller reads with its own privileges, so no edge crosses the schema boundary and reporting one would be noise on every view that touches a system catalog.",
+  "id": "38-invoker-view-unaudited-base"
+}

--- a/packages/safegres/corpus/cases/38-invoker-view-unaudited-base/schema.sql
+++ b/packages/safegres/corpus/cases/38-invoker-view-unaudited-base/schema.sql
@@ -1,0 +1,39 @@
+DROP SCHEMA IF EXISTS c_invoker_unaudited CASCADE;
+DROP SCHEMA IF EXISTS c_invoker_hidden CASCADE;
+CREATE SCHEMA c_invoker_unaudited;
+CREATE SCHEMA c_invoker_hidden;
+
+DO $$ BEGIN
+  CREATE ROLE c_invoker_unaudited_owner NOLOGIN;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+GRANT USAGE ON SCHEMA c_invoker_unaudited TO corpus_anon, corpus_user, c_invoker_unaudited_owner;
+
+CREATE TABLE c_invoker_hidden.credentials (
+  id bigserial PRIMARY KEY,
+  subject text NOT NULL,
+  secret text NOT NULL
+);
+ALTER TABLE c_invoker_hidden.credentials OWNER TO c_invoker_unaudited_owner;
+
+CREATE TABLE c_invoker_unaudited.sessions (
+  id bigserial PRIMARY KEY,
+  subject text NOT NULL
+);
+ALTER TABLE c_invoker_unaudited.sessions ENABLE ROW LEVEL SECURITY;
+CREATE POLICY sessions_own ON c_invoker_unaudited.sessions
+  FOR SELECT TO corpus_user
+  USING (subject = (SELECT current_setting('app.subject', true)));
+CREATE INDEX sessions_subject_idx ON c_invoker_unaudited.sessions (subject);
+GRANT SELECT ON c_invoker_unaudited.sessions TO corpus_user;
+
+-- The same cross-schema shape as case 37, with `security_invoker`. The view
+-- confers nothing: corpus_anon reads the hidden table only if it holds its own
+-- grant on it (it does not, and it has no USAGE on the schema either), so
+-- there is no reach to report and L14 must stay silent. An out-of-scope
+-- *reference* is not a finding; an out-of-scope *reach* is.
+CREATE VIEW c_invoker_unaudited.subject_directory WITH (security_invoker = true) AS
+  SELECT subject FROM c_invoker_hidden.credentials;
+ALTER VIEW c_invoker_unaudited.subject_directory OWNER TO c_invoker_unaudited_owner;
+GRANT SELECT ON c_invoker_unaudited.subject_directory TO corpus_anon, corpus_user;

--- a/packages/safegres/corpus/cases/39-definer-view-column-subset/case.json
+++ b/packages/safegres/corpus/cases/39-definer-view-column-subset/case.json
@@ -1,0 +1,30 @@
+{
+  "title": "A definer view exposing only the columns the caller already holds is not a bypass",
+  "dimension": "security",
+  "exposure": {
+    "schemas": [
+      "c_view_columns"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "L13",
+      "relation": "c_view_columns.people",
+      "role": "corpus_anon",
+      "note": "the column grant itself is real reach, and L13 reports it — that is the baseline the definer view adds nothing to"
+    }
+  ],
+  "forbid": [
+    "L8"
+  ],
+  "worstSeverity": "info",
+  "fix": "Nothing. corpus_anon reads (id, handle) by column grant and the view returns exactly those columns of exactly those rows, so the owner's read launders nothing. Reporting L8 here would recommend rewriting a view that gives away nothing the ACL did not already give away.",
+  "id": "39-definer-view-column-subset"
+}

--- a/packages/safegres/corpus/cases/39-definer-view-column-subset/schema.sql
+++ b/packages/safegres/corpus/cases/39-definer-view-column-subset/schema.sql
@@ -1,0 +1,29 @@
+DROP SCHEMA IF EXISTS c_view_columns CASCADE;
+CREATE SCHEMA c_view_columns;
+
+DO $$ BEGIN
+  CREATE ROLE c_view_columns_owner NOLOGIN;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+GRANT USAGE ON SCHEMA c_view_columns TO corpus_anon, corpus_user, c_view_columns_owner;
+
+CREATE TABLE c_view_columns.people (
+  id bigserial PRIMARY KEY,
+  handle text NOT NULL,
+  email text NOT NULL,
+  ssn text NOT NULL
+);
+ALTER TABLE c_view_columns.people OWNER TO c_view_columns_owner;
+
+-- corpus_anon already reads these two columns, by column-level grant. No RLS,
+-- so the owner's read returns exactly the rows corpus_anon's own read would.
+GRANT SELECT (id, handle) ON c_view_columns.people TO corpus_anon;
+
+-- A definer view over the *same two columns* launders nothing: every value it
+-- returns was already readable by the caller. L8 must stay silent, which it
+-- can only do by knowing the projection, not just the relation.
+CREATE VIEW c_view_columns.handles AS
+  SELECT id, handle FROM c_view_columns.people;
+ALTER VIEW c_view_columns.handles OWNER TO c_view_columns_owner;
+GRANT SELECT ON c_view_columns.handles TO corpus_anon;

--- a/packages/safegres/corpus/cases/40-definer-view-column-overreach/case.json
+++ b/packages/safegres/corpus/cases/40-definer-view-column-overreach/case.json
@@ -1,0 +1,27 @@
+{
+  "title": "One column past the caller's grant, and the same shape is a definer-view bypass",
+  "dimension": "security",
+  "exposure": {
+    "schemas": [
+      "c_view_columns_wide"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "L8",
+      "relation": "c_view_columns_wide.people",
+      "role": "corpus_anon",
+      "note": "`email` is in no grant corpus_anon holds; the finding names the escaping columns, so the report says which ones"
+    }
+  ],
+  "worstSeverity": "info",
+  "fix": "Narrow c_view_columns_wide.contacts to the columns the caller is entitled to, recreate it `WITH (security_invoker = true)`, or give it an owner whose reach matches what it is meant to expose. Do not revoke the column grants — they are what the narrow projection legitimately serves.",
+  "id": "40-definer-view-column-overreach"
+}

--- a/packages/safegres/corpus/cases/40-definer-view-column-overreach/schema.sql
+++ b/packages/safegres/corpus/cases/40-definer-view-column-overreach/schema.sql
@@ -1,0 +1,29 @@
+DROP SCHEMA IF EXISTS c_view_columns_wide CASCADE;
+CREATE SCHEMA c_view_columns_wide;
+
+DO $$ BEGIN
+  CREATE ROLE c_view_columns_wide_owner NOLOGIN;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+GRANT USAGE ON SCHEMA c_view_columns_wide TO corpus_anon, corpus_user, c_view_columns_wide_owner;
+
+CREATE TABLE c_view_columns_wide.people (
+  id bigserial PRIMARY KEY,
+  handle text NOT NULL,
+  email text NOT NULL,
+  ssn text NOT NULL
+);
+ALTER TABLE c_view_columns_wide.people OWNER TO c_view_columns_wide_owner;
+
+-- corpus_anon already reads these two columns, by column-level grant. No RLS,
+-- so the owner's read returns exactly the rows corpus_anon's own read would.
+GRANT SELECT (id, handle) ON c_view_columns_wide.people TO corpus_anon;
+
+-- One column past the grant, and the view is a bypass: `email` escapes only
+-- because the read runs as the owner. The projection is the whole difference
+-- between this case and case 39.
+CREATE VIEW c_view_columns_wide.contacts AS
+  SELECT id, handle, email FROM c_view_columns_wide.people;
+ALTER VIEW c_view_columns_wide.contacts OWNER TO c_view_columns_wide_owner;
+GRANT SELECT ON c_view_columns_wide.contacts TO corpus_anon;

--- a/packages/safegres/docs/rules.md
+++ b/packages/safegres/docs/rules.md
@@ -58,6 +58,17 @@ relation resolves to nothing rather than to a plausible candidate. And the remed
 revoke: the SELECT on the view is what the API serves, so L8 recommends `security_invoker = true`
 or a different owner, and says so explicitly.
 
+What escapes through a view is a *projection*, not a relation, and the catalog says exactly which
+one: the rewriter records a `pg_depend` row per column the view body reads, so `SELECT *` arrives
+already expanded, a column used only in a `WHERE` counts as read, and a nested view depends on the
+inner view's columns rather than the table's. L8 carries that set into the finding — the message and
+`context.columns` name the columns, not just the relation — and uses it for one refusal: when every
+column that escapes is one the role could already read through its own column grants (L13's closure)
+*and* the base relation has no RLS, the view launders nothing and L8 stays silent. With RLS on, the
+projection is beside the point: the owner reads rows the caller's policies hide, so the finding
+stands. An unknown column set is unknown, never narrow — a snapshot without dependency rows reports
+as before.
+
 L9 and L10 are the write half of the same question, and neither is answerable from the view body
 alone. **L9** is auto-update: a simple view over one relation is updatable, so Postgres rewrites an
 INSERT/UPDATE/DELETE on the view onto that relation, and on a definer view the rewritten command is

--- a/packages/safegres/docs/rules.md
+++ b/packages/safegres/docs/rules.md
@@ -108,6 +108,26 @@ weighted rules: column-level SELECT for an anonymous role on an RLS-off table is
 A2 grades `high`, and promoting it there is a scoring change to make once the rule has been
 validated against real schemas.
 
+**L14** is the coverage half of L8, and the only rule here that reports an *absence of knowledge*.
+Excluding a schema — by `excludeSchemas`, by naming only some in `schemas`, or because it is a
+system catalog — is a statement about what gets *graded*, not about what is *reachable*. A definer
+view in an audited schema whose body reads `information_schema`, an extension's tables, or a private
+schema left out of the surface produced nothing at all: the base relation was not in the snapshot,
+so every rule that grades a base relation dropped the edge and the view scanned clean. The resolver
+now separates the two kinds of miss — a qualified reference into a schema the audit *did* read is
+still an unresolved name (a CTE, an alias) and is still dropped, while a qualified reference into a
+schema it never read is `external`: the reach is proven, its consequences are not.
+
+The finding is `info`/`neutral` and stays there however the reach is graded later, because an
+unknown is not a leak and scoring one would let an excluded schema move the number. It is exposure-
+stamped by the *view*, not by the out-of-scope relation, or every instance would file itself as an
+internal advisory and disappear from the report that matters. The remedy is to bring the schema into
+scope or to satisfy yourself the projection is safe — never a revoke. Note the boundary the negative
+corpus case pins: an out-of-scope *reference* is not a finding, only an out-of-scope *reach* is. An
+invoker view over the same table confers nothing, so it reports nothing, which is what keeps every
+view that touches a system catalog from becoming noise. L9–L12 take the conservative side of the
+same distinction: an external relation has no owner, ACL or RLS to reason about, so it suppresses.
+
 Restrictive-only policies never count as coverage. `BYPASSRLS` and superuser roles are exempt from
 policy checks — they are not subject to RLS, so a "missing policy" finding for them would be
 noise. Policies are matched with `pg_has_role` semantics: a policy `TO authenticated` covers a

--- a/packages/safegres/src/checks/definer-view.ts
+++ b/packages/safegres/src/checks/definer-view.ts
@@ -28,7 +28,12 @@ import { type ExtractedBody, extractQuery } from '../callgraph/extract';
 import type { ViewSnapshot } from '../pg/indexes';
 import type { TableSnapshot } from '../pg/introspect';
 import type { Finding } from '../types';
-import { effectiveGrants, type LatticeRoleOptions, type RoleGraph } from './lattice';
+import {
+  effectiveColumnGrants,
+  effectiveGrants,
+  type LatticeRoleOptions,
+  type RoleGraph
+} from './lattice';
 import { computeViewReach, type ViewBaseRelation, type ViewReachInput } from './role-reach';
 
 /** How deep a chain of views on views is followed before giving up. */
@@ -153,11 +158,17 @@ export function resolveViewBases(
       const dedupe = `${relKey}::${hops[hops.length - 1].owner}`;
       if (seen.has(dedupe)) continue;
       seen.add(dedupe);
+      // Which columns escape is the catalog's answer, not the body's: the
+      // rewriter recorded one dependency row per column the view reads.
+      const columns = current.columnDeps?.find(
+        (d) => d.schema === relation.schema && d.table === relation.name
+      )?.columns;
       bases.push({
         schema: relation.schema,
         table: relation.name,
         hops: [...hops],
-        ...(relation.kind === 'external' ? { external: true } : {})
+        ...(relation.kind === 'external' ? { external: true } : {}),
+        ...(columns ? { columns } : {})
       });
     }
   };
@@ -277,6 +288,17 @@ export function checkDefinerViewBypass(
       // Already reachable in its own right: the view launders nothing.
       if (effectiveGrants(base, role, graph).some((g) => g.privilege === 'SELECT')) continue;
 
+      // Nor does it when the columns that escape are ones the role could
+      // already read column-by-column (L13's closure) and the base has no RLS
+      // for the owner's read to skip. With RLS on, the projection matching is
+      // beside the point: the owner sees rows the caller's policies hide.
+      const granted = effectiveColumnGrants(base, role, graph)
+        .find((g) => g.privilege === 'SELECT');
+      if (
+        cell.columns && granted && !base.rlsEnabled
+        && cell.columns.every((c) => granted.columns.includes(c))
+      ) continue;
+
       const hops = cell.path.filter((e): e is { kind: 'view'; view: string; owner: string } =>
         e.kind === 'view'
       );
@@ -299,7 +321,9 @@ export function checkDefinerViewBypass(
         role,
         privilege: 'SELECT',
         message:
-          `Untrusted role ${role} reads ${base.schema}.${base.name} through view ${outermost.view}, `
+          `Untrusted role ${role} reads ${base.schema}.${base.name}`
+          + (cell.columns ? ` (${cell.columns.join(', ')})` : '')
+          + ` through view ${outermost.view}, `
           + `which executes as its owner ${owner} — ${role} holds no SELECT on the base relation`
           + (rlsBypassed ? `, and ${owner} is not subject to its RLS policies` : ''),
         hint:
@@ -313,6 +337,8 @@ export function checkDefinerViewBypass(
           viaViews: hops.map((h) => h.view),
           baseRlsEnabled: base.rlsEnabled,
           rlsBypassed,
+          ...(cell.columns ? { columns: cell.columns } : {}),
+          ...(granted ? { grantedColumns: granted.columns } : {}),
           proof: cell.proof
         }
       });

--- a/packages/safegres/src/checks/definer-view.ts
+++ b/packages/safegres/src/checks/definer-view.ts
@@ -57,12 +57,13 @@ export interface ViewBodyAnalysis {
  */
 export async function analyzeViewBodies(
   views: ViewSnapshot[],
-  tables: TableSnapshot[]
+  tables: TableSnapshot[],
+  auditedSchemas?: Iterable<string>
 ): Promise<ViewBodyAnalysis> {
   // A materialized view stores its rows: reading it touches no base relation,
   // so it is a leaf here, never an edge.
   const queryable = views.filter((v) => !v.materialized);
-  const index = buildRelationIndex(queryable, tables);
+  const index = buildRelationIndex(queryable, tables, auditedSchemas);
 
   const bodies = await readBodies(queryable);
 
@@ -152,7 +153,12 @@ export function resolveViewBases(
       const dedupe = `${relKey}::${hops[hops.length - 1].owner}`;
       if (seen.has(dedupe)) continue;
       seen.add(dedupe);
-      bases.push({ schema: relation.schema, table: relation.name, hops: [...hops] });
+      bases.push({
+        schema: relation.schema,
+        table: relation.name,
+        hops: [...hops],
+        ...(relation.kind === 'external' ? { external: true } : {})
+      });
     }
   };
 
@@ -163,22 +169,42 @@ export function resolveViewBases(
 
 export type Resolved =
   | { kind: 'table'; schema: string; name: string }
-  | { kind: 'view'; view: ViewSnapshot };
+  | { kind: 'view'; view: ViewSnapshot }
+  /**
+   * A schema-qualified relation in a schema the audit did not introspect —
+   * excluded by config, owned by an extension, or a system catalog. The
+   * reference is unambiguous, so dropping it would under-report the view's
+   * reach; nothing about the relation itself is known.
+   */
+  | { kind: 'external'; schema: string; name: string };
 
 /** The lookup tables {@link resolveRelation} needs, built once per snapshot. */
 export interface RelationIndex {
   tableKeys: Set<string>;
   viewKeys: Map<string, ViewSnapshot>;
   viewsByName: Map<string, ViewSnapshot[]>;
+  /**
+   * The schemas the snapshot covers. A qualified reference into a schema
+   * *not* in this set is external rather than unresolvable; a miss inside it
+   * is a name the audit genuinely could not pin down.
+   */
+  auditedSchemas: Set<string>;
 }
 
-export function buildRelationIndex(views: ViewSnapshot[], tables: TableSnapshot[]): RelationIndex {
+export function buildRelationIndex(
+  views: ViewSnapshot[],
+  tables: TableSnapshot[],
+  auditedSchemas?: Iterable<string>
+): RelationIndex {
   const viewsByName = new Map<string, ViewSnapshot[]>();
   for (const v of views) viewsByName.set(v.name, [...(viewsByName.get(v.name) ?? []), v]);
   return {
     tableKeys: new Set(tables.map((t) => `${t.schema}.${t.name}`)),
     viewKeys: new Map(views.map((v) => [`${v.schema}.${v.name}`, v])),
-    viewsByName
+    viewsByName,
+    auditedSchemas: new Set(
+      auditedSchemas ?? [...tables.map((t) => t.schema), ...views.map((v) => v.schema)]
+    )
   };
 }
 
@@ -195,7 +221,7 @@ export function buildRelationIndex(views: ViewSnapshot[], tables: TableSnapshot[
 export function resolveRelation(
   ref: { schema?: string; name: string },
   viewSchema: string,
-  { tableKeys, viewKeys, viewsByName }: RelationIndex
+  { tableKeys, viewKeys, viewsByName, auditedSchemas }: RelationIndex
 ): Resolved | null {
   const candidates = ref.schema ? [ref.schema] : [viewSchema];
   for (const schema of candidates) {
@@ -204,7 +230,13 @@ export function resolveRelation(
     if (view) return { kind: 'view', view };
     if (tableKeys.has(key)) return { kind: 'table', schema, name: ref.name };
   }
-  if (ref.schema) return null;
+  // Qualified and unknown: either a relation the audit skipped (external, and
+  // the reach is still real) or a genuine miss inside a schema it did read.
+  if (ref.schema) {
+    return auditedSchemas.has(ref.schema)
+      ? null
+      : { kind: 'external', schema: ref.schema, name: ref.name };
+  }
 
   const matches = [
     ...[...tableKeys]
@@ -281,6 +313,75 @@ export function checkDefinerViewBypass(
           viaViews: hops.map((h) => h.view),
           baseRlsEnabled: base.rlsEnabled,
           rlsBypassed,
+          proof: cell.proof
+        }
+      });
+    }
+  }
+
+  return out;
+}
+
+/**
+ * L14: a definer view hands an untrusted role a relation the audit never
+ * looked at.
+ *
+ * Excluding a schema is a statement about what is *graded*, not about what is
+ * *reachable*. A view in an audited schema can read `information_schema`,
+ * `pg_catalog`, an extension's tables, or any schema left out of
+ * `exposure.schemas` — and because that relation is not in the snapshot,
+ * every rule that grades a base relation silently drops the edge. The view
+ * looked clean because the audit could not see the far end.
+ *
+ * This is the one L-rule that reports an *absence of knowledge*. It says the
+ * read happens and that nothing was graded on the other side; it does not
+ * claim the relation is sensitive, and it recommends no revoke — the remedy
+ * is to bring the schema into scope, or to satisfy yourself that the
+ * projection is safe and leave it.
+ */
+export function checkUnauditedViewReach(
+  views: ViewReachInput[],
+  graph: RoleGraph,
+  options: LatticeRoleOptions = {}
+): Finding[] {
+  const untrusted = options.roles ?? [];
+  if (untrusted.length === 0 || views.length === 0) return [];
+
+  const out: Finding[] = [];
+
+  for (const { role, cells } of computeViewReach(views, graph, untrusted)) {
+    for (const cell of cells) {
+      if (!cell.external) continue;
+
+      const hops = cell.path.filter((e): e is { kind: 'view'; view: string; owner: string } =>
+        e.kind === 'view'
+      );
+      const outermost = hops[0];
+      if (!outermost) continue;
+      const owner = cell.effectiveRole;
+
+      out.push({
+        code: 'L14',
+        severity: 'info',
+        category: 'coverage',
+        schema: cell.schema,
+        table: cell.table,
+        role,
+        privilege: 'SELECT',
+        message:
+          `Untrusted role ${role} reads ${cell.schema}.${cell.table} through view ${outermost.view} `
+          + `as its owner ${owner}, and ${cell.schema} is outside the audited schemas — nothing `
+          + 'graded what that relation exposes',
+        hint:
+          `The read is proven from the view body; its consequences are not, because ${cell.schema} `
+          + 'was never introspected. Add the schema to the audit (`schemas`, or remove it from '
+          + '`excludeSchemas`) to grade the far end, or confirm the projection is safe to serve. '
+          + 'This is a gap in coverage, not a proven leak: do not revoke anything on its strength.',
+        context: {
+          view: outermost.view,
+          effectiveRole: owner,
+          viaViews: hops.map((h) => h.view),
+          unauditedSchema: cell.schema,
           proof: cell.proof
         }
       });

--- a/packages/safegres/src/checks/role-reach.ts
+++ b/packages/safegres/src/checks/role-reach.ts
@@ -78,6 +78,8 @@ export interface RoleReachCell {
    * `privileges` is what the path exercises, not what the relation permits.
    */
   external?: boolean;
+  /** The columns of the relation the path reaches, where they are known. */
+  columns?: string[];
 }
 
 /** Everything one role reaches, across the relations examined. */
@@ -161,6 +163,11 @@ export interface ViewBaseRelation {
    * not, and a consumer must not grade it as if the relation were in scope.
    */
   external?: boolean;
+  /**
+   * The columns of the relation that actually escape through the view, from
+   * the catalog's own dependency rows. Absent means unknown — never "none".
+   */
+  columns?: string[];
 }
 
 /** A view, its own ACL, and the base relations its body was found to read. */
@@ -219,7 +226,8 @@ export function computeViewReach(
             }))
           ],
           proof: 'ast',
-          ...(base.external ? { external: true } : {})
+          ...(base.external ? { external: true } : {}),
+          ...(base.columns ? { columns: base.columns } : {})
         });
       }
     }

--- a/packages/safegres/src/checks/role-reach.ts
+++ b/packages/safegres/src/checks/role-reach.ts
@@ -73,6 +73,11 @@ export interface RoleReachCell {
   /** The edges, caller-first, by which the reach arrived. */
   path: RoleReachEdge[];
   proof: ReachProof;
+  /**
+   * The relation was not introspected: it is outside the audited schemas.
+   * `privileges` is what the path exercises, not what the relation permits.
+   */
+  external?: boolean;
 }
 
 /** Everything one role reaches, across the relations examined. */
@@ -150,6 +155,12 @@ export interface ViewBaseRelation {
    * owner is the role the base relation is actually read as.
    */
   hops: Array<{ view: string; owner: string }>;
+  /**
+   * The relation lives outside the audited schemas, so nothing is known about
+   * its ACL, its RLS or its owner. The read is proven; its consequences are
+   * not, and a consumer must not grade it as if the relation were in scope.
+   */
+  external?: boolean;
 }
 
 /** A view, its own ACL, and the base relations its body was found to read. */
@@ -207,7 +218,8 @@ export function computeViewReach(
               owner: h.owner
             }))
           ],
-          proof: 'ast'
+          proof: 'ast',
+          ...(base.external ? { external: true } : {})
         });
       }
     }

--- a/packages/safegres/src/checks/view-exposure.ts
+++ b/packages/safegres/src/checks/view-exposure.ts
@@ -75,13 +75,16 @@ export async function analyzeViewExposure(
         suppressed.push({ view: label, reason: opaque });
         continue;
       }
-      if (bases.length === 0) continue;
+      // Relations outside the audited schemas carry no ACL or policy to
+      // compare the stored rows against; L14 reports the reach instead.
+      const graded = bases.filter((b) => !b.external);
+      if (graded.length === 0) continue;
       matviews.push({
         schema: view.schema,
         name: view.name,
         owner: view.owner,
         grants: view.grants,
-        baseRelations: bases,
+        baseRelations: graded,
         materialized: true
       });
       continue;
@@ -104,13 +107,14 @@ export async function analyzeViewExposure(
       suppressed.push({ view: label, reason: opaque });
       continue;
     }
-    if (bases.length === 0) continue;
+    const gradedBases = bases.filter((b) => !b.external);
+    if (gradedBases.length === 0) continue;
     leaky.push({
       schema: view.schema,
       name: view.name,
       owner: view.owner,
       grants: view.grants,
-      baseRelations: bases
+      baseRelations: gradedBases
     });
   }
 

--- a/packages/safegres/src/checks/view-writes.ts
+++ b/packages/safegres/src/checks/view-writes.ts
@@ -158,6 +158,9 @@ async function autoUpdateEdges(
     if (resolved.length !== 1) return [];
 
     const target = resolved[0];
+    // A relation outside the audited schemas cannot be graded: its owner, its
+    // ACL and its RLS are all unknown, so the write is not placeable here.
+    if (target.kind === 'external') return [];
     if (target.kind === 'table') {
       return view.writable.map((privilege) => ({
         schema: target.schema,
@@ -205,6 +208,7 @@ async function ruleEdges(
 
     const target = resolveRelation(access, view.schema, index);
     if (!target) continue;
+    if (target.kind === 'external') continue;
     if (target.kind === 'view') {
       // The write recurses into another view's rewrite path; proving where it
       // finally lands is more than this analysis can do.

--- a/packages/safegres/src/commands/audit.ts
+++ b/packages/safegres/src/commands/audit.ts
@@ -17,7 +17,11 @@ import {
   checkCoverageGaps,
   checkUpdateWithCheckCoverage
 } from '../checks/coverage';
-import { analyzeViewBodies, checkDefinerViewBypass } from '../checks/definer-view';
+import {
+  analyzeViewBodies,
+  checkDefinerViewBypass,
+  checkUnauditedViewReach
+} from '../checks/definer-view';
 import {
   checkMissingPrimaryKey,
   checkRedundantIndexes,
@@ -221,6 +225,10 @@ export async function audit(
     excludeSchemas: options.excludeSchemas ?? config.excludeSchemas
   });
   const schemaAclsByName = new Map(schemaAcls.map((a) => [a.schema, a]));
+  // Which schemas the audit actually looked at — the same include/exclude
+  // filters the table snapshot used. A view body naming anything outside this
+  // set reaches past the audit rather than reaching nothing (L14).
+  const auditedSchemas = new Set(schemaAcls.map((a) => a.schema));
 
   // Roles requests arrive as, and the relations some policy predicate names.
   // L6 needs both: the first is whose grants it is talking about, the second
@@ -267,6 +275,16 @@ export async function audit(
     resolved.rules.get('L12')?.options as LatticeRoleOptions,
     exposure
   )?.roles ?? [];
+  const unauditedReachRoles = withExposedRoles(
+    resolved.rules.get('L14')?.options as LatticeRoleOptions,
+    exposure
+  )?.roles ?? [];
+  // L8 and L14 are two answers from one body pass: the base relations that
+  // were graded, and the ones that could not be because they are out of scope.
+  const viewBodiesEnabled =
+    !skipAst
+    && ((definerViewRoles.length > 0 && resolved.rules.get('L8')?.enabled !== false)
+      || (unauditedReachRoles.length > 0 && resolved.rules.get('L14')?.enabled !== false));
   const viewExposureEnabled =
     !skipAst
     && ((matviewRoles.length > 0 && resolved.rules.get('L11')?.enabled !== false)
@@ -278,7 +296,7 @@ export async function audit(
   const needsViews =
     (perfEnabled && config.perf?.paths?.infer !== false)
     || resolved.rules.get('L4')?.enabled !== false
-    || (!skipAst && definerViewRoles.length > 0 && resolved.rules.get('L8')?.enabled !== false)
+    || viewBodiesEnabled
     || viewWritesEnabled
     || viewExposureEnabled;
   const viewSnapshot = needsViews
@@ -384,11 +402,18 @@ export async function audit(
   findings.push(...checkDeadSchemaUsage(schemaAcls, snapshot, roleGraph, viewSnapshot));
 
   // L8 is per-view, not per-table: a view body names its own base relations.
-  if (!skipAst && definerViewRoles.length > 0 && resolved.rules.get('L8')?.enabled !== false) {
-    const viewBodies = await analyzeViewBodies(viewSnapshot, snapshot);
-    findings.push(
-      ...checkDefinerViewBypass(viewBodies.views, snapshot, roleGraph, { roles: definerViewRoles })
-    );
+  if (viewBodiesEnabled) {
+    const viewBodies = await analyzeViewBodies(viewSnapshot, snapshot, auditedSchemas);
+    if (definerViewRoles.length > 0 && resolved.rules.get('L8')?.enabled !== false) {
+      findings.push(
+        ...checkDefinerViewBypass(viewBodies.views, snapshot, roleGraph, { roles: definerViewRoles })
+      );
+    }
+    if (unauditedReachRoles.length > 0 && resolved.rules.get('L14')?.enabled !== false) {
+      findings.push(
+        ...checkUnauditedViewReach(viewBodies.views, roleGraph, { roles: unauditedReachRoles })
+      );
+    }
   }
 
   // L9/L10 are the write half of the same question, and share one analysis.
@@ -475,7 +500,17 @@ export async function audit(
     const meta = RULES_BY_CODE.get(f.code);
     if (meta && f.direction === undefined) f.direction = meta.direction;
     if (meta && f.dimension === undefined) f.dimension = dimensionOf(meta);
-    if (exposure.known && f.schema) f.exposed = isExposed(f.schema, f.table);
+    if (exposure.known && f.schema) {
+      // L14 names a relation outside the audited schemas by construction, so
+      // grading it by its own schema would file every finding as an internal
+      // advisory. What is exposed is the view an API role reads it through.
+      const viewRef = f.code === 'L14'
+        ? (f.context as { view?: string } | undefined)?.view
+        : undefined;
+      f.exposed = viewRef
+        ? isExposed(viewRef.slice(0, viewRef.lastIndexOf('.')), viewRef.slice(viewRef.lastIndexOf('.') + 1))
+        : isExposed(f.schema, f.table);
+    }
 
     // A key that looks like a write-once provisioning pointer, where the
     // reviewer has chosen to read the finding rather than gate on it. Applied

--- a/packages/safegres/src/config/presets.ts
+++ b/packages/safegres/src/config/presets.ts
@@ -44,7 +44,10 @@ export const recommended: SafegresConfig = {
     // Reach that only `pg_attribute.attacl` shows. New, so zero weight — but
     // note this one is catalog-derived, not body-derived: what was missing was
     // the introspection, not the proof.
-    L13: ['info', { rolesFrom: 'anon' }]
+    L13: ['info', { rolesFrom: 'anon' }],
+    // The coverage half of L8: a body reference the audit could not follow
+    // because the schema was out of scope. Reports an unknown, never a leak.
+    L14: ['info', { rolesFrom: 'anon' }]
   }
 };
 

--- a/packages/safegres/src/index.ts
+++ b/packages/safegres/src/index.ts
@@ -28,7 +28,11 @@ export type {
 export { buildCallGraph } from './callgraph/graph';
 export { checkUntrustedColumnGrants } from './checks/column-grants';
 export type { SuppressedView, ViewBodyAnalysis } from './checks/definer-view';
-export { analyzeViewBodies, checkDefinerViewBypass } from './checks/definer-view';
+export {
+  analyzeViewBodies,
+  checkDefinerViewBypass,
+  checkUnauditedViewReach
+} from './checks/definer-view';
 export {
   checkMissingPrimaryKey,
   checkRedundantIndexes,

--- a/packages/safegres/src/pg/indexes.ts
+++ b/packages/safegres/src/pg/indexes.ts
@@ -240,6 +240,15 @@ export interface ViewSnapshot {
   /** `pg_get_viewdef()` — the body, as SQL text. */
   definition: string;
   /**
+   * The columns of each relation the view body actually reads, from the
+   * `pg_depend` rows on the view's `_RETURN` rule. The catalog answers this
+   * exactly — `SELECT *` is expanded at CREATE time, expressions and joins
+   * are accounted for, and a nested view depends on the *inner view's*
+   * columns, so the list is per hop. Absent when the caller built the
+   * snapshot without it.
+   */
+  columnDeps?: Array<{ schema: string; table: string; columns: string[] }>;
+  /**
    * The write commands Postgres accepts on the view, from
    * `pg_relation_is_updatable`. A simple view is *auto-updatable*: the write
    * is rewritten onto its single base relation, and on a definer view that
@@ -309,6 +318,7 @@ export async function introspectViews(
     owner_bypasses_rls: boolean;
     grants: Array<{ role: string; privilege: string; grantable: boolean; bypassRls: boolean }>;
     definition: string;
+    column_deps: Array<{ schema: string; table: string; columns: string[] }>;
     updatable_bits: number;
     instead_of_triggers: boolean;
     rules: Array<{ name: string; event: string; instead: boolean; definition: string }>;
@@ -373,6 +383,26 @@ export async function introspectViews(
        LEFT JOIN pg_roles rol ON rol.oid = a.grantee
        WHERE v.relacl IS NOT NULL
      ),
+     -- Which columns of which relation the view body reads. The rewriter
+     -- records one pg_depend row per referenced column, so this is the
+     -- catalog's own answer to "what escapes through this view" — no parsing,
+     -- no star expansion, no alias resolution.
+     column_deps AS (
+       SELECT DISTINCT
+         r.ev_class    AS view_oid,
+         dn.nspname    AS dep_schema,
+         dc.relname    AS dep_table,
+         a.attname     AS dep_column
+       FROM pg_depend d
+       JOIN pg_rewrite r ON r.oid = d.objid AND d.classid = 'pg_rewrite'::regclass
+       JOIN views v ON v.oid = r.ev_class
+       JOIN pg_class dc ON dc.oid = d.refobjid
+       JOIN pg_namespace dn ON dn.oid = dc.relnamespace
+       JOIN pg_attribute a ON a.attrelid = d.refobjid AND a.attnum = d.refobjsubid
+       WHERE d.refclassid = 'pg_class'::regclass
+         AND d.refobjsubid > 0
+         AND r.ev_class <> d.refobjid
+     ),
      rules AS (
        -- _RETURN is the SELECT rule that *is* the view; every other rule is
        -- behaviour pg_get_viewdef does not show.
@@ -404,6 +434,19 @@ export async function introspectViews(
          )) FROM grants g WHERE g.oid = v.oid),
          '[]'::jsonb
        )                                          AS grants,
+       COALESCE(
+         (SELECT jsonb_agg(t) FROM (
+           SELECT jsonb_build_object(
+             'schema', cd.dep_schema,
+             'table', cd.dep_table,
+             'columns', jsonb_agg(cd.dep_column ORDER BY cd.dep_column)
+           ) AS t
+           FROM column_deps cd
+           WHERE cd.view_oid = v.oid
+           GROUP BY cd.dep_schema, cd.dep_table
+         ) deps),
+         '[]'::jsonb
+       )                                          AS column_deps,
        v.updatable_bits,
        v.instead_of_triggers,
        COALESCE(
@@ -435,6 +478,7 @@ export async function introspectViews(
       bypassRls: g.bypassRls
     })),
     definition: r.definition,
+    columnDeps: r.column_deps,
     writable: [
       ...(r.updatable_bits & 8 ? ['INSERT' as const] : []),
       ...(r.updatable_bits & 4 ? ['UPDATE' as const] : []),

--- a/packages/safegres/src/rules/registry.ts
+++ b/packages/safegres/src/rules/registry.ts
@@ -301,6 +301,18 @@ export const RULES: RuleMeta[] = [
     scope: 'table'
   },
   {
+    code: 'L14',
+    // `coverage`, not `anti-pattern`: the finding is that the audit stopped at
+    // the schema boundary, not that the view is wrong. Severity stays `info`
+    // however the reach is graded later — an unknown is never a proven leak,
+    // and scoring one would let an excluded schema move the number.
+    category: 'coverage',
+    defaultSeverity: 'info',
+    direction: 'neutral',
+    title: 'Unaudited base relation — a definer view reads a relation in a schema the audit did not introspect (options: { roles: [...] })',
+    scope: 'table'
+  },
+  {
     code: 'W1',
     category: 'meta',
     defaultSeverity: 'medium',

--- a/packages/safegres/src/version.ts
+++ b/packages/safegres/src/version.ts
@@ -1,2 +1,2 @@
 // Auto-synced from package.json by scripts/sync-version.js.
-export const version = '1.16.1';
+export const version = '1.18.0';


### PR DESCRIPTION
## Summary

Excluding a schema is a statement about what gets **graded**, not about what is **reachable** — and until now the two were the same thing. A definer view in an audited schema whose body reads `information_schema`, an extension's tables, or a private schema left out of the surface produced *nothing at all*: `resolveRelation` returned `null`, the base relation never entered the reach model, and the view scanned clean because the audit could not see the far end. That is E5 on the [backlog](https://github.com/constructive-io/constructive-planning/issues/1377).

The fix is to separate the two kinds of resolution miss the resolver was conflating:

```ts
// definer-view.ts — resolveRelation, on a qualified ref it could not find
- if (ref.schema) return null;                       // a CTE and information_schema, alike
+ if (ref.schema) {
+   return auditedSchemas.has(ref.schema)
+     ? null                                          // the audit read that schema: unresolved name
+     : { kind: 'external', schema: ref.schema, name: ref.name };  // never read: real reach
+ }
```

`RelationIndex` gains `auditedSchemas` (from `introspectSchemaAcls`, i.e. exactly the include/exclude filters the table snapshot ran under; defaulted to the snapshot's own schemas for library callers), `ViewBaseRelation`/`RoleReachCell` gain `external`, and `checkUnauditedViewReach` emits **L14** for cells whose far end was never introspected.

**L14 is the one rule that reports an absence of knowledge**, which drives three deliberate choices:

- `info` / **`neutral`**, and it stays there however this is graded later. An unknown is not a leak, and scoring one would let an excluded schema move the number.
- Exposure is stamped by the **view**, not by the out-of-scope relation — otherwise every instance files itself as an internal advisory and vanishes from the report that matters. This is the one non-additive line in `audit.ts`:
  ```ts
  f.exposed = viewRef ? isExposed(schemaOf(viewRef), nameOf(viewRef)) : isExposed(f.schema, f.table);
  ```
- The remedy is *bring the schema into scope* or *confirm the projection*, never a revoke. Hard constraint intact.

The negative corpus case pins the boundary that keeps this from being noise on every view that touches a catalog: **an out-of-scope reference is not a finding, only an out-of-scope reach is.** An invoker view over the same table confers nothing, so it reports nothing. L9–L12 take the conservative side of the same distinction — an external relation has no owner, ACL or RLS to reason against, so it suppresses rather than guessing (`view-writes.ts` returns no edge, `view-exposure.ts` filters externals out of the graded bases). Behavior for those four rules is unchanged.

Also folds in the **skill update** the rule table had been missing since L6: `.agents/skills/safegres/SKILL.md` now documents L1–L14, the four inputs that compose into the lattice (effective grants incl. column ACLs, schema `USAGE`, exposure, `SET ROLE`), the reach-cell model with its `effectiveRole`/`path`/`proof`, the AST view rules, the opaque-suppression rule and the no-unsafe-revoke constraint. Skill updates ship with each rule PR from here on.

## Checks

- `pnpm build`, `pnpm lint` (0 errors, 2 pre-existing warnings), `pnpm test` → **39 suites / 461 tests**, including 10 new unit tests and corpus cases `37-unaudited-base-relation` (positive) and `38-invoker-view-unaudited-base` (negative, `forbid: L14`).
- Full constructive-db audit with this build: **zero L14**, security 100 (A+) and perf 91.2 (A), both unchanged. Its private views are not readable by `anonymous`, so nothing crosses the boundary for an untrusted role — an honest zero, not a silent one.
- `src/index.ts` and `src/commands/audit.ts` edits are one export and one dispatch branch, plus the exposure-stamp line quoted above.

Honest severity, once proven: an anonymous role reading a relation nobody graded is not informational — but the finding is *not knowing*, and no amount of validation turns an unknown into a scored leak. L14 should stay `info`/`neutral` even after the rule matures; what should change is that the schema gets audited and L8 answers the question properly.

---

## E7 — L8 reads the projection, not just the relation (second commit)

A view exposes *columns*, and the catalog already knows which: the rewriter writes one `pg_depend` row per column the `_RETURN` rule reads. `SELECT *` arrives expanded, a column used only in a `WHERE` counts as read, and a nested view depends on the **inner view's** columns — no parsing, no star expansion, no alias resolution. `ViewSnapshot.columnDeps` reads them, `ViewBaseRelation.columns`/`RoleReachCell.columns` carry them per hop, and L8 puts them in the message and in `context.columns`.

The reason to have them is a refusal, not a decoration:

```ts
// checkDefinerViewBypass, after the whole-relation SELECT check
const granted = effectiveColumnGrants(base, role, graph).find((g) => g.privilege === 'SELECT');
if (cell.columns && granted && !base.rlsEnabled
    && cell.columns.every((c) => granted.columns.includes(c))) continue;
```

A definer view over exactly the columns the caller already reads by column grant (L13's closure), on a table with no RLS, launders nothing — every value it returns was already reachable, so telling the author to rewrite the view is advice with nothing behind it. With RLS on the projection is beside the point: the owner reads rows the caller's policies hide, so the finding stands. And an absent column set is *unknown*, never narrow — a snapshot without dependency rows grades exactly as before.

Corpus cases `39-definer-view-column-subset` (`forbid: L8`; the granted columns only) and `40-definer-view-column-overreach` (one column wider, same shape, L8 fires) are the same schema either side of that line. Live-PG coverage for `columnDeps` is in `view-introspect.test.ts`.

Totals after both commits: **40 suites / 472 tests**, lint clean (same 2 pre-existing warnings), constructive-db unchanged at 100 (A+) / 91.2 (A) with zero L14 and zero new L8.


Link to Devin session: https://app.devin.ai/sessions/f340c08768814b278a179aea7994f924
Requested by: @pyramation