### PR TITLE
feat(safegres): a first-party GitHub Action wrapping the config-driven audit

### DIFF
--- a/.agents/skills/safegres/SKILL.md
+++ b/.agents/skills/safegres/SKILL.md
@@ -336,7 +336,7 @@ Report-only first, gate after a week of stable scores. Never write a bespoke aud
 }
 ```
 
-Inside Actions the job summary, annotations and PR comment are emitted automatically (`report.github` configures them). Add `failOn.grade` only once the baseline is stable. A second job that needs the same surface but different gates extends this file rather than copying it — `{ "extends": "../../.safegresrc.json", "failOn": { "grade": "D" } }`.
+Inside Actions the job summary, annotations and PR comment are emitted automatically (`report.github` configures them). The step itself can be the first-party composite action, `uses: constructive-io/constructive/packages/safegres@main` (`packages/safegres/action.yml`): it installs the CLI, runs that config with `--github`, and takes only the inputs that legitimately differ between jobs sharing one config (`database`/`pgpm`, `fail-on-grade`, `report-only`, `out`, `comment`, `upload-sarif`, `compare`), exporting `security-score`/`security-grade`/`perf-score` as step outputs even on a gate failure. Anything you would pass every run belongs in the config file, not in `with:`. Add `failOn.grade` only once the baseline is stable. A second job that needs the same surface but different gates extends this file rather than copying it — `{ "extends": "../../.safegresrc.json", "failOn": { "grade": "D" } }`.
 
 ## Guardrails
 

--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -421,6 +421,21 @@ deploys it into an ephemeral one:
       - run: npx safegres audit   # or: "audit": "safegres lint" in package.json
 ```
 
+Or the first-party action, which installs the CLI, runs that config, and turns the report into a
+job summary, annotations and a sticky PR comment:
+
+```yaml
+      - uses: constructive-io/constructive/packages/safegres@main
+        with:
+          out: safegres-reports
+          comment: true          # sticky PR comment (needs pull-requests: write)
+          upload-sarif: true     # code scanning (needs security-events: write)
+```
+
+It exposes `security-score`, `security-grade` and `perf-score` as step outputs — on a failing run
+too, which is when they get read. Everything else stays in the config file; see
+**[docs/reporting.md](https://github.com/constructive-io/constructive/blob/main/packages/safegres/docs/reporting.md#the-action)**.
+
 `outputs.dir` writes `safegres.json`, `safegres.md` and `safegres.sarif` into one directory — name
 an individual file (`outputs.json`) only when the name matters. Directories are created as needed,
 and a flag still wins over the file for a one-off run (`safegres audit --out reports`). Naming a

--- a/packages/safegres/__tests__/action.test.ts
+++ b/packages/safegres/__tests__/action.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * The action is a wrapper around flags that live somewhere else, which is
+ * exactly the thing that rots silently: a renamed flag keeps the YAML valid
+ * and breaks every consumer of the action at runtime. These tests pin the two
+ * couplings — flags to the CLI, outputs to the report shape — and one bash
+ * hazard that a composite step makes easy to reintroduce.
+ */
+const action = readFileSync(join(__dirname, '..', 'action.yml'), 'utf8');
+const cli = readFileSync(join(__dirname, '..', 'src', 'cli', 'audit.ts'), 'utf8');
+
+describe('action.yml', () => {
+  it('passes only flags the CLI accepts', () => {
+    const flags = new Set(action.match(/--[a-z][a-z-]+/g) ?? []);
+    // The action's own YAML keys (`--report-only` is a flag; `upload-sarif` is
+    // an input) are not flags, so compare against what the run block emits.
+    const emitted = [...flags].filter((f) => action.includes(`args+=(${f}`) || action.includes(`add ${f} `));
+    expect(emitted.length).toBeGreaterThan(5);
+    for (const flag of emitted) {
+      expect(cli).toContain(flag);
+    }
+  });
+
+  it('reads the report fields the report actually has', () => {
+    // `score.value`/`score.grade`/`perf.score.value` — asserted here so a
+    // rename of the Report shape fails a test rather than an Actions run.
+    expect(action).toContain('score?.value');
+    expect(action).toContain('score?.grade');
+    expect(action).toContain('perf?.score?.value');
+  });
+
+  it('never appends an argument with a bare test, which `set -e` would abort on', () => {
+    expect(action).not.toMatch(/^\s*\[[^\]]*\]\s*&&\s*args\+=/m);
+  });
+});

--- a/packages/safegres/action.yml
+++ b/packages/safegres/action.yml
@@ -1,0 +1,160 @@
+name: safegres
+description: >-
+  Audit a PostgreSQL database for security and performance, and report the
+  result as a job summary, annotations, a sticky PR comment and SARIF.
+author: Constructive
+branding:
+  icon: shield
+  color: blue
+
+# Everything a run repeats belongs in the committed config file, so the common
+# case is no inputs at all. The inputs below are the things that legitimately
+# differ *between jobs sharing one config*: which database, whether the gates
+# bite, and which artifacts leave the runner.
+inputs:
+  version:
+    description: 'npm version of the safegres CLI to install (dist-tag or exact version).'
+    required: false
+    default: 'latest'
+  config:
+    description: >-
+      Path to the config file. Omit to let safegres discover it
+      (safegres.config.{ts,js,mjs,cjs}, .safegresrc{,.json,.yaml,.yml,.js},
+      safegres.json, or package.json "safegres").
+    required: false
+    default: ''
+  working-directory:
+    description: 'Directory to run the audit from. Config discovery starts here.'
+    required: false
+    default: '.'
+  database:
+    description: >-
+      Audit this existing database instead of the config file's `source.pgpm`
+      workspace. Beats the file; the PG* environment variables supply the rest
+      of the connection.
+    required: false
+    default: ''
+  pgpm:
+    description: >-
+      Deploy this pgpm workspace into an ephemeral database and audit that.
+      Overrides `source.pgpm`; needs no connection.
+    required: false
+    default: ''
+  preset:
+    description: 'Built-in preset to apply (constructive, postgrest, supabase, graphile, hasura, strict, …).'
+    required: false
+    default: ''
+  out:
+    description: 'Directory to write safegres.json, safegres.md and safegres.sarif into.'
+    required: false
+    default: ''
+  fail-on-grade:
+    description: 'Fail the job below this security grade (A+|A|B|C|D). Overrides `failOn.grade`.'
+    required: false
+    default: ''
+  report-only:
+    description: >-
+      Evaluate every gate, report what would have failed, and exit 0 anyway —
+      how to run a gated config as an advisory job.
+    required: false
+    default: 'false'
+  comment:
+    description: 'Upsert the sticky PR comment. Needs `github-token` and `pull-requests: write`.'
+    required: false
+    default: 'false'
+  compare:
+    description: 'A previous run''s JSON report to diff this one against (renders the delta).'
+    required: false
+    default: ''
+  compare-ref:
+    description: 'What to call the previous run in the delta (e.g. "main", a commit sha).'
+    required: false
+    default: ''
+  upload-sarif:
+    description: >-
+      Upload the SARIF report to GitHub code scanning. Requires `out` (or an
+      `outputs.sarif`/`outputs.dir` in the config) and `security-events: write`.
+    required: false
+    default: 'false'
+  github-token:
+    description: 'Token used for the PR comment. Defaults to the workflow token.'
+    required: false
+    default: ${{ github.token }}
+  args:
+    description: 'Extra CLI arguments, appended verbatim. The escape hatch; prefer the config file.'
+    required: false
+    default: ''
+
+outputs:
+  security-score:
+    description: 'The security score (0-100) of the primary exposure plane.'
+    value: ${{ steps.audit.outputs.security-score }}
+  security-grade:
+    description: 'The security grade (A+|A|B|C|D|F).'
+    value: ${{ steps.audit.outputs.security-grade }}
+  perf-score:
+    description: 'The performance score (0-100), empty when the perf dimension is off.'
+    value: ${{ steps.audit.outputs.perf-score }}
+  report:
+    description: 'Path to the JSON report, when the run wrote one.'
+    value: ${{ steps.audit.outputs.report }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install safegres
+      shell: bash
+      run: npm install -g safegres@${{ inputs.version }}
+
+    - name: Audit
+      id: audit
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        args=(audit --github)
+        # `if` rather than `test && append`: the composite shell runs with
+        # `-e`, and a false test is the last command on its line.
+        add() { if [ -n "$2" ]; then args+=("$1" "$2"); fi; }
+        add --config        "${{ inputs.config }}"
+        add --database      "${{ inputs.database }}"
+        add --pgpm          "${{ inputs.pgpm }}"
+        add --preset        "${{ inputs.preset }}"
+        add --out           "${{ inputs.out }}"
+        add --fail-on-grade "${{ inputs.fail-on-grade }}"
+        add --compare       "${{ inputs.compare }}"
+        add --compare-ref   "${{ inputs.compare-ref }}"
+        if [ "${{ inputs.report-only }}" = "true" ]; then args+=(--report-only); fi
+        if [ "${{ inputs.comment }}" = "true" ]; then args+=(--github-comment); fi
+        # Unquoted on purpose: this is the verbatim-arguments escape hatch.
+        read -r -a extra <<< "${{ inputs.args }}"
+        # The gate's exit code is the job's, but the outputs below are worth
+        # having on a failing run too — that is when someone reads them.
+        status=0
+        safegres "${args[@]}" "${extra[@]}" || status=$?
+
+        report=""
+        if [ -n "${{ inputs.out }}" ] && [ -f "${{ inputs.out }}/safegres.json" ]; then
+          report="${{ inputs.out }}/safegres.json"
+        fi
+        if [ -n "$report" ]; then
+          node -e '
+            const r = require("path").resolve(process.argv[1]);
+            const { score, perf } = require(r);
+            const out = [
+              `security-score=${score?.value ?? ""}`,
+              `security-grade=${score?.grade ?? ""}`,
+              `perf-score=${perf?.score?.value ?? ""}`,
+              `report=${process.argv[1]}`
+            ].join("\n");
+            require("fs").appendFileSync(process.env.GITHUB_OUTPUT, out + "\n");
+          ' "$report"
+        fi
+        exit $status
+
+    - name: Upload SARIF
+      if: ${{ inputs.upload-sarif == 'true' && always() }}
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: ${{ inputs.working-directory }}/${{ inputs.out }}/safegres.sarif

--- a/packages/safegres/docs/reporting.md
+++ b/packages/safegres/docs/reporting.md
@@ -134,6 +134,42 @@ What appears is configuration, not code:
 GitHub Markdown has no text color, so a genuinely colored score has to be an image; `badges: false`
 falls back to emoji for air-gapped runners that cannot reach shields.io.
 
+## The action
+
+`packages/safegres/action.yml` is the same run as a composite action — it installs the CLI, runs the
+audit with `--github`, and optionally posts the comment and uploads the SARIF:
+
+```yaml
+- uses: constructive-io/constructive/packages/safegres@main
+  with:
+    out: safegres-reports
+    comment: true
+    upload-sarif: true
+```
+
+Its inputs are deliberately only the things that differ *between jobs sharing one config* —
+`database`/`pgpm` (what to audit), `fail-on-grade` and `report-only` (whether the gates bite),
+`out`/`comment`/`upload-sarif` (what leaves the runner), `compare`/`compare-ref` (the delta), plus
+`version`, `config`, `preset`, `working-directory` and an `args` escape hatch. Everything a run
+repeats belongs in the committed config file, so the common case passes nothing at all.
+
+Two jobs can then share one config and differ only where they should: a gated merge check
+(`safegres audit`, the file's `failOn` in force) and an advisory scan of a deployed database
+(`database: staging`, `report-only: true`). The step exports `security-score`, `security-grade`,
+`perf-score` and `report` as outputs on failing runs too — a gate failure is exactly when the score
+is worth reading:
+
+```yaml
+- uses: constructive-io/constructive/packages/safegres@main
+  id: audit
+  with: { out: safegres-reports, fail-on-grade: B }
+- if: always()
+  run: echo "graded ${{ steps.audit.outputs.security-grade }}"
+```
+
+Permissions are the caller's: `pull-requests: write` for `comment`, `security-events: write` for
+`upload-sarif`, `actions: read` if the job downloads a base-branch report for `compare`.
+
 ## What changed (`--compare`)
 
 A report says what the database *is*; on a pull request the only question is what the branch *did*


### PR DESCRIPTION
## Summary

P7 off #1377, and the last piece of "no bespoke script": `--github` already does the work, but every consumer still hand-writes the install step, the flag string and the SARIF upload. `packages/safegres/action.yml` is a composite action, so it needs no new repository — `uses: constructive-io/constructive/packages/safegres@main` resolves a path inside this one:

```yaml
- uses: constructive-io/constructive/packages/safegres@main
  with:
    out: safegres-reports
    comment: true          # sticky PR comment
    upload-sarif: true     # code scanning
```

The design constraint is the one the config work established: **the action must not become a second configuration surface.** Its inputs are only the things that legitimately differ *between jobs sharing one config file* — `database`/`pgpm` (what to audit), `fail-on-grade`/`report-only` (whether the gates bite), `out`/`comment`/`upload-sarif` (what leaves the runner), `compare`/`compare-ref`, plus `version`, `config`, `preset`, `working-directory` and an `args` escape hatch. Anything passed every run belongs in `.safegresrc.json`, so the common case is `with:`-less. That is exactly constructive-db's two jobs: one gated on `application/app`, one advisory on the deployed stack (`database:` + `report-only: true`), off one file.

Two details worth the diff:

```bash
# the composite shell runs with `-e`, so `[ -n "$x" ] && args+=(…)` aborts the
# step the first time an input is empty — the failing test *is* the last command
add() { if [ -n "$2" ]; then args+=("$1" "$2"); fi; }
...
status=0
safegres "${args[@]}" "${extra[@]}" || status=$?   # outputs first, gate exit second
```

Outputs (`security-score`, `security-grade`, `perf-score`, `report`) are written **before** the gate's exit code is re-raised, because a gate failure is precisely when a downstream step wants the grade.

`__tests__/action.test.ts` pins the two couplings that rot silently — every flag the run block emits must exist in `cli/audit.ts`, and the output extraction must match the `Report` shape (`score.value`/`score.grade`/`perf.score.value`) — plus a regression test for the `set -e` hazard above. README and `docs/reporting.md` gain the action; the skill file gains the "inputs are not a config surface" rule. `pnpm build`, `pnpm lint` (2 pre-existing warnings) and `pnpm test` are green.


Link to Devin session: https://app.devin.ai/sessions/b7874ecee0c7471ea271e6e7193869dc
Requested by: @pyramation