### PR TITLE
fix(safegres): grade routine findings by callability, charge per repair unit

### DIFF
--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -165,6 +165,13 @@ untrusted-role model; the `safegres:constructive` preset configures them for `an
 ‡ L6 needs an adapter that can compute [API reach](#api-reach--the-relations-the-api-can-actually-name);
 without one nothing is unaddressable and it never fires.
 
+**Exposure is asked per subject.** A relation finding is exposed when the API can address the
+relation. A *routine* finding — the convention rules, L19, L20 — is exposed when an untrusted role
+can **call the function**: `USAGE` on its schema and `EXECUTE` on the function, directly, by
+inheritance, or through Postgres's default `EXECUTE TO PUBLIC`. Grading a definer function by the
+schema it sits in is not conservative, it is wrong in the dangerous direction: the function is
+private precisely so that calling it is the only way in.
+
 **Direction is the load-bearing idea.** `fail-open` findings are exposure — the untrusted side
 reaches more than intended. `fail-closed` findings are *denied by Postgres at runtime*: an
 availability and hygiene concern, not a leak. They contribute **zero** to the score by default
@@ -594,7 +601,7 @@ Precedence: **CLI > project config > preset > built-in defaults**.
     { "tables": ["app_public.audit_*"], "rules": { "A2": "off" } }
   ],
   "perf": { "enabled": true, "ignore": ["app_public.audit_*"], "rules": { "X6": "off" } },
-  "scoring": { "densityK": 0.17, "unknownExposureCap": 80 },
+  "scoring": { "densityK": 0.17, "maxRuleDensity": 0.5, "unknownExposureCap": 80 },
   "failOn": { "grade": "B", "perfGrade": "B" }
 }
 ```
@@ -709,6 +716,17 @@ exposed tables lands at a C). Non-exposed findings score 0; fail-closed findings
 `scoring.failClosedWeight` is raised; unknown exposure caps the score; any exposed critical floors
 the grade at C (`scoring.floorOnCritical`). Grades: A+ 97 · A 90 · B 80 · C 65 · D 50 · F below.
 The legacy flat-deduction model is `scoring.model: "weighted"`.
+
+Two corrections keep a rule's **shape** out of the arithmetic, because a rule's fan-out is a
+property of how it reports, not of how much risk it found.
+
+- **Points are charged per unit of repair.** A rule that emits one finding per (relation ×
+  function) pair — L19 does, and on one real database that is 853 findings over 166 functions —
+  costs what fixing it costs: 166 revokes. The finding count is unchanged in the report; the
+  deduction reads `−664 (×853 → 166 fixes)`.
+- **No single rule can decide the grade.** Each rule's contribution is capped at
+  `scoring.maxRuleDensity` (default 0.5) of the points that would score an F alone, so one rule
+  at its ceiling costs two grade bands and an F still takes breadth. `false` disables it.
 
 Every report carries its own arithmetic: per-rule points, grade, and the **payoff** — how far the
 score would move if that rule's findings went away. Gate with `--fail-on <severity>`,

--- a/packages/safegres/__tests__/config.test.ts
+++ b/packages/safegres/__tests__/config.test.ts
@@ -337,6 +337,54 @@ describe('computeScore', () => {
     expect(x1.potential / x4.potential).toBeGreaterThan(8);
   });
 
+  it('density model: charges a rule per unit of repair, not per finding', () => {
+    // L19 emits one finding per (relation × function) pair; two functions
+    // reaching five relations each is ten findings and two revokes.
+    const findings = ['f_one', 'f_two'].flatMap((fn) =>
+      Array.from({ length: 5 }, (_, i) =>
+        finding({
+          code: 'L19',
+          severity: 'medium',
+          table: `t${i}`,
+          context: { function: `private.${fn}` }
+        }))
+    );
+    const score = computeScore(findings, {}, { exposedTables: 100, exposureKnown: true });
+    const [l19] = score.deductions;
+
+    expect(l19.count).toBe(10);
+    expect(l19.units).toBe(2);
+    // Two units at medium, not ten findings: 8 points rather than 40.
+    expect(l19.points).toBe(8);
+  });
+
+  it('density model: caps one rule at half the points that would fail an audit', () => {
+    // 300 criticals over 100 tables is 7500 raw points — an F many times
+    // over on one rule's say-so. The cap is 0.5·ln(100/50)/k·tables ≈ 203.9.
+    const findings = Array.from({ length: 300 }, (_, i) =>
+      finding({ code: 'A7', severity: 'critical', table: `t${i}` }));
+    const score = computeScore(findings, { floorOnCritical: false }, {
+      exposedTables: 100,
+      exposureKnown: true
+    });
+    const [a7] = score.deductions;
+
+    expect(a7.count).toBe(300);
+    expect(a7.capped).toBe(true);
+    expect(a7.points).toBeCloseTo(203.9, 1);
+    // One rule alone lands a C, never an F: breadth is what fails an audit.
+    expect(score.value).toBe(70.7);
+    expect(score.grade).toBe('C');
+
+    // Opt out and the raw arithmetic is back.
+    const uncapped = computeScore(findings, { maxRuleDensity: false, floorOnCritical: false }, {
+      exposedTables: 100,
+      exposureKnown: true
+    });
+    expect(uncapped.deductions[0].points).toBe(7500);
+    expect(uncapped.grade).toBe('F');
+  });
+
   it('density model: lists zero-weight rules as unscored rather than dropping them', () => {
     const findings = [
       finding({ code: 'A2', severity: 'high' }),

--- a/packages/safegres/__tests__/extensions.test.ts
+++ b/packages/safegres/__tests__/extensions.test.ts
@@ -91,6 +91,38 @@ describe('extension-owned relations', () => {
     expect(tables(report.findings)).toContain('fx_ext.app_widget');
   });
 
+  it('applies the same exclusions to routines, which the convention linter reads', async () => {
+    // The linter reads function bodies, and an extension's bodies are not the
+    // application's to fix. Before this, `extensions.ignore` filtered
+    // relations only, so partman's 300-odd functions arrived as house-style
+    // violations against a house that did not write them.
+    const fns = (findings: Finding[]) =>
+      [...new Set(
+        findings
+          .filter((f) => f.category === 'convention')
+          .map((f) => (f.context as { function?: string }).function?.replace(/\(.*$/, ''))
+      )];
+
+    const report = await audit(pg.client as never, {
+      schemas: SCHEMAS,
+      extensions: { ignore: ['pg_trgm'] },
+      config: { rules: { C1: 'high', C4: 'high' } }
+    });
+    const found = fns(report.findings);
+
+    expect(found).toContain('fx_ext.app_helper');
+    expect(found).not.toContain('fx_ext.ext_helper');       // extension-owned
+    expect(found).not.toContain('fx_ext_runtime.runtime_helper'); // ignored schema
+
+    // Ask for them and they arrive: the extension author is the audience.
+    const audited = await audit(pg.client as never, {
+      schemas: SCHEMAS,
+      extensions: { skipOwned: false },
+      config: { rules: { C1: 'high', C4: 'high' } }
+    });
+    expect(fns(audited.findings)).toContain('fx_ext.ext_helper');
+  });
+
   it('the constructive preset ships pg_partman in the ignore list', () => {
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'safegres-'));
     const { config } = loadConfig({ cwd, preset: 'constructive' });

--- a/packages/safegres/__tests__/fixtures/ext-owned.sql
+++ b/packages/safegres/__tests__/fixtures/ext-owned.sql
@@ -56,3 +56,23 @@ CREATE TABLE fx_ext_runtime.runtime_child (
   label text
 );
 GRANT SELECT ON fx_ext_runtime.runtime_child TO PUBLIC;
+
+-- The same distinction for routines, which the convention linter reads. All
+-- three use dynamic SQL (C4) and pin search_path (C1); only `app_helper` is
+-- the application's to fix.
+CREATE FUNCTION fx_ext.ext_helper() RETURNS void
+LANGUAGE plpgsql SET search_path = public AS $$
+BEGIN EXECUTE 'SELECT 1'; END;
+$$;
+ALTER EXTENSION hstore ADD FUNCTION fx_ext.ext_helper();
+
+CREATE FUNCTION fx_ext.app_helper() RETURNS void
+LANGUAGE plpgsql SET search_path = public AS $$
+BEGIN EXECUTE 'SELECT 1'; END;
+$$;
+
+-- Unregistered, but inside an extension's schema — the pg_partman shape.
+CREATE FUNCTION fx_ext_runtime.runtime_helper() RETURNS void
+LANGUAGE plpgsql SET search_path = public AS $$
+BEGIN EXECUTE 'SELECT 1'; END;
+$$;

--- a/packages/safegres/__tests__/lint-audit.test.ts
+++ b/packages/safegres/__tests__/lint-audit.test.ts
@@ -60,6 +60,34 @@ beforeAll(async () => {
     $$;
   `);
 
+  // An internal schema no API serves, holding a function anonymous can call.
+  // Relation reach says unexposed; callability says otherwise, and the
+  // second is the question a routine finding is about.
+  await pg.any('CREATE SCHEMA fx_lint_private');
+  await pg.any(`
+    CREATE FUNCTION fx_lint_private.reachable() RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+    BEGIN
+      EXECUTE 'SELECT 1';
+    END;
+    $$;
+  `);
+  await pg.any(`
+    CREATE FUNCTION fx_lint_private.locked() RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+    BEGIN
+      EXECUTE 'SELECT 1';
+    END;
+    $$;
+  `);
+  await pg.any(
+    'DO $$ BEGIN CREATE ROLE fx_anon NOLOGIN; EXCEPTION WHEN duplicate_object THEN NULL; END $$;'
+  );
+  await pg.any('GRANT USAGE ON SCHEMA fx_lint_private TO fx_anon');
+  await pg.any('REVOKE EXECUTE ON FUNCTION fx_lint_private.locked() FROM PUBLIC');
+
   // Clean: fully-qualified, no search_path, no dynamic SQL.
   await pg.any(`
     CREATE FUNCTION fx_lint.clean() RETURNS bigint
@@ -128,6 +156,28 @@ describe('audit: convention linter wiring (C*)', () => {
       (f) => (f.context as { function?: string }).function?.startsWith('fx_lint.clean(')
     );
     expect(onClean).toEqual([]);
+  });
+
+  it('grades a routine finding by who can call the function, not by its schema', async () => {
+    const report = await audit(pg.client as never, {
+      schemas: ['fx_lint', 'fx_lint_private'],
+      config: {
+        rules: { C4: 'high' },
+        exposure: { schemas: ['fx_lint'], roles: ['fx_anon'], anonRoles: ['fx_anon'] }
+      }
+    });
+    const c4 = (name: string) =>
+      report.findings.find(
+        (f) =>
+          f.code === 'C4'
+          && (f.context as { function?: string }).function?.startsWith(`fx_lint_private.${name}(`)
+      );
+
+    // Off the API surface, but `fx_anon` holds USAGE and the default
+    // EXECUTE-to-PUBLIC: it can call the body, so the finding scores.
+    expect(c4('reachable')?.exposed).toBe(true);
+    // Same schema, EXECUTE revoked from PUBLIC — genuinely out of reach.
+    expect(c4('locked')?.exposed).toBe(false);
   });
 
   it('runs the linter under the constructive preset but not under recommended', () => {

--- a/packages/safegres/__tests__/routine-reach.test.ts
+++ b/packages/safegres/__tests__/routine-reach.test.ts
@@ -1,0 +1,132 @@
+import type { RoleGraph } from '../src/checks/lattice';
+import { resolveRoutineReach } from '../src/exposure/routines';
+import type { RoleAttributes, SchemaAclInfo } from '../src/pg/acl';
+import type { FunctionSnapshot } from '../src/pg/functions';
+
+function role(name: string, extra: Partial<RoleAttributes> = {}): RoleAttributes {
+  return { name, bypassRls: false, isSuper: false, inheritsFrom: [], canSetRole: [], ...extra };
+}
+
+function fn(partial: Partial<FunctionSnapshot> & { schema: string; name: string }): FunctionSnapshot {
+  return {
+    oid: 1,
+    args: '',
+    owner: 'app_owner',
+    ownerBypassesRls: false,
+    isSecurityDefiner: true,
+    searchPathPinned: false,
+    returnsTrigger: false,
+    language: 'plpgsql',
+    source: null,
+    definition: null,
+    grants: [],
+    defaultAcl: false,
+    ...partial
+  };
+}
+
+function acl(schema: string, usage: string[]): SchemaAclInfo {
+  return {
+    schema,
+    owner: 'app_owner',
+    grants: usage.map((r) => ({ role: r, privilege: 'USAGE' as const })),
+    executeRoles: []
+  };
+}
+
+const graph: RoleGraph = new Map([
+  ['anonymous', role('anonymous')],
+  ['authenticated', role('authenticated', { inheritsFrom: ['app_reader'] })]
+]);
+
+const schemaAcls = new Map([
+  ['app_private', acl('app_private', ['anonymous', 'authenticated'])],
+  ['app_locked', acl('app_locked', [])],
+  ['app_public', acl('app_public', ['anonymous'])]
+]);
+
+const options = {
+  roles: ['anonymous'],
+  graph,
+  schemaAcls,
+  exposedSchemas: new Set(['app_public'])
+};
+
+describe('resolveRoutineReach', () => {
+  it('reaches a function in an unexposed schema the role can execute', () => {
+    // The whole point: `app_private` is off the API surface, so relation
+    // reach says no — but anonymous holds USAGE and EXECUTE, so it can call
+    // the definer function and get its owner's privileges.
+    const reach = resolveRoutineReach(
+      [fn({ schema: 'app_private', name: 'perm_check', grants: [{ role: 'anonymous', grantable: false }] })],
+      options
+    );
+    expect([...reach]).toEqual(['app_private.perm_check']);
+  });
+
+  it('counts the default EXECUTE-to-PUBLIC ACL as reach', () => {
+    const reach = resolveRoutineReach(
+      [fn({
+        schema: 'app_private',
+        name: 'helper',
+        grants: [{ role: 'PUBLIC', grantable: false }],
+        defaultAcl: true
+      })],
+      options
+    );
+    expect(reach.has('app_private.helper')).toBe(true);
+  });
+
+  it('does not reach past a schema the role has no USAGE on', () => {
+    // EXECUTE without USAGE names nothing — the same gate L3 applies to a
+    // table grant. Without it, Postgres's default ACL would make every
+    // function in every internal schema look reachable by everyone.
+    const reach = resolveRoutineReach(
+      [fn({ schema: 'app_locked', name: 'helper', grants: [{ role: 'PUBLIC', grantable: false }] })],
+      options
+    );
+    expect(reach.size).toBe(0);
+  });
+
+  it('does not reach a function the role holds no EXECUTE on', () => {
+    const reach = resolveRoutineReach(
+      [fn({ schema: 'app_private', name: 'admin_only', grants: [{ role: 'administrator', grantable: false }] })],
+      options
+    );
+    expect(reach.size).toBe(0);
+  });
+
+  it('follows role inheritance', () => {
+    const reach = resolveRoutineReach(
+      [fn({ schema: 'app_private', name: 'reader', grants: [{ role: 'app_reader', grantable: false }] })],
+      { ...options, roles: ['authenticated'] }
+    );
+    expect(reach.has('app_private.reader')).toBe(true);
+  });
+
+  it('judges a trigger function by its schema, not its ACL', () => {
+    // Postgres refuses a direct call however wide the ACL is, so EXECUTE on
+    // one confers nothing. What reaches the body is a write that fires it.
+    const reach = resolveRoutineReach(
+      [
+        fn({
+          schema: 'app_private',
+          name: 'on_write',
+          returnsTrigger: true,
+          grants: [{ role: 'PUBLIC', grantable: false }]
+        }),
+        fn({ schema: 'app_public', name: 'on_write', returnsTrigger: true, grants: [] })
+      ],
+      options
+    );
+    expect([...reach]).toEqual(['app_public.on_write']);
+  });
+
+  it('reaches nothing when no untrusted role is resolved', () => {
+    const reach = resolveRoutineReach(
+      [fn({ schema: 'app_private', name: 'helper', grants: [{ role: 'PUBLIC', grantable: false }] })],
+      { ...options, roles: [] }
+    );
+    expect(reach.size).toBe(0);
+  });
+});

--- a/packages/safegres/schema/safegres.schema.json
+++ b/packages/safegres/schema/safegres.schema.json
@@ -244,6 +244,19 @@
               "type": "number",
               "description": "Cap on one rule’s total deduction (weighted model)"
             },
+            "maxRuleDensity": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "description": "Fraction"
+                },
+                {
+                  "type": "boolean",
+                  "description": "false to disable"
+                }
+              ],
+              "description": "Cap on one rule’s contribution, as a fraction of the points that fail an audit alone. Default 0.5; false disables the cap."
+            },
             "failClosedWeight": {
               "type": "number",
               "description": "Multiplier for fail-closed findings. Default 0."
@@ -524,6 +537,19 @@
         "maxDeductionPerRule": {
           "type": "number",
           "description": "Cap on one rule’s total deduction (weighted model)"
+        },
+        "maxRuleDensity": {
+          "anyOf": [
+            {
+              "type": "number",
+              "description": "Fraction"
+            },
+            {
+              "type": "boolean",
+              "description": "false to disable"
+            }
+          ],
+          "description": "Cap on one rule’s contribution, as a fraction of the points that fail an audit alone. Default 0.5; false disables the cap."
         },
         "failClosedWeight": {
           "type": "number",

--- a/packages/safegres/src/checks/definer-function.ts
+++ b/packages/safegres/src/checks/definer-function.ts
@@ -32,7 +32,7 @@
  */
 
 import { extractBody, extractFunctionAccess } from '../callgraph/extract';
-import type { SchemaAclInfo } from '../pg/acl';
+import { canEnterSchema, type SchemaAclInfo } from '../pg/acl';
 import type { FunctionSnapshot } from '../pg/functions';
 import type { ViewSnapshot } from '../pg/indexes';
 import type { PgPrivilege, TableSnapshot } from '../pg/introspect';
@@ -550,30 +550,6 @@ export function checkUnreadableFunctionReach(
   }
 
   return out;
-}
-
-/**
- * The role can enter the schema, so a grant on something inside it is reach.
- *
- * The same gate L3 applies to a table grant, applied to EXECUTE: without
- * `USAGE` the function cannot be named, and Postgres's default
- * EXECUTE-to-PUBLIC would otherwise make every definer function in an
- * internal schema look reachable by every role in the database.
- */
-function canEnterSchema(
-  schema: string,
-  role: string,
-  graph: RoleGraph,
-  schemaAcls: Map<string, SchemaAclInfo>
-): boolean {
-  const acl = schemaAcls.get(schema);
-  if (!acl) return true; // not introspected: assume reachable rather than silently drop
-  const attrs = graph.get(role);
-  if (attrs?.isSuper) return true;
-  if (role === acl.owner) return true;
-  const usage = new Set(acl.grants.filter((g) => g.privilege === 'USAGE').map((g) => g.role));
-  if (usage.has('PUBLIC') || usage.has(role)) return true;
-  return (attrs?.inheritsFrom ?? []).some((a) => usage.has(a) || a === acl.owner);
 }
 
 /** The owner is exempt from the relation's policies on this path. */

--- a/packages/safegres/src/commands/audit.ts
+++ b/packages/safegres/src/commands/audit.ts
@@ -86,6 +86,7 @@ import { configFingerprint } from '../config/fingerprint';
 import { allAstRulesDisabled, applyRulesToFindings, matchTablePattern, resolveRules, rulesForTable } from '../config/resolve';
 import type { ExposureConfig, SafegresConfig } from '../config/types';
 import { resolvePlaneReach, scorePlane, stampPlanes } from '../exposure/planes';
+import { resolveRoutineReach } from '../exposure/routines';
 import { LINT_RULES, LINT_RULES_BY_ID, lintDefinition, type LintProblem, type SuppressedProblem } from '../lint';
 import { type ExplainReport, proveFindings } from '../perf/explain';
 import { introspectRoleGraph, introspectSchemaAcls } from '../pg/acl';
@@ -99,7 +100,7 @@ import { type AccessPath, classifyPaths } from '../pg/paths';
 import { lookupVolatility, type ProcVolatility } from '../pg/proc';
 import { listAuditableRoles, resolveRoles } from '../pg/roles';
 import { introspectStats, type StatsSnapshot } from '../pg/stats';
-import { dimensionOf, RULES_BY_CODE } from '../rules/registry';
+import { dimensionOf, RULES_BY_CODE, subjectOf } from '../rules/registry';
 import { computeScore } from '../score/score';
 import type { ExposureReport, Finding, PerfReport, PerfStatsReport, Report, RoleAccessReport } from '../types';
 import { summarize } from '../types';
@@ -170,6 +171,8 @@ export async function audit(
   const config = options.config ?? {};
   const resolved = resolveRules(config);
 
+  const extensions = options.extensions ?? config.extensions;
+
   // Function definitions are read by two independent features (the convention
   // linter and the call graph); introspect them at most once.
   let functionsCache: FunctionSnapshot[] | undefined;
@@ -177,7 +180,8 @@ export async function audit(
     if (!functionsCache) {
       functionsCache = await introspectFunctions(exec, {
         schemas: options.schemas ?? config.schemas,
-        excludeSchemas: options.excludeSchemas ?? config.excludeSchemas
+        excludeSchemas: options.excludeSchemas ?? config.excludeSchemas,
+        extensions
       });
     }
     return functionsCache;
@@ -215,8 +219,6 @@ export async function audit(
   const unaddressable = new Set(
     (apiReach?.unreachable ?? []).map((r) => `${r.schema}.${r.table}`)
   );
-
-  const extensions = options.extensions ?? config.extensions;
 
   const snapshot = await introspectTables(exec, {
     schemas: options.schemas ?? config.schemas,
@@ -612,6 +614,24 @@ export async function audit(
 
   findings = applyRulesToFindings(resolved, findings);
 
+  // Routine findings are graded by whether an untrusted role can *call the
+  // function*, not by whether its schema is on the API surface — see
+  // `RuleMeta.subject`. Resolved only when such a finding exists, so an audit
+  // with the routine rules off still costs one query less.
+  const routineRoles = [...new Set([...apiRoles, ...(exposure.anonRoles ?? [])])];
+  let routineReach: Set<string> | undefined;
+  const isRoutineExposed = async (schema: string, name: string): Promise<boolean> => {
+    if (!routineReach) {
+      routineReach = resolveRoutineReach(await getFunctions(), {
+        roles: routineRoles,
+        graph: roleGraph,
+        schemaAcls: schemaAclsByName,
+        exposedSchemas
+      });
+    }
+    return routineReach.has(`${schema}.${name}`);
+  };
+
   // Stamp direction (from the registry) and exposure on every finding.
   const publicRead = config.public?.read ?? [];
   const perfIgnore = config.perf?.ignore ?? [];
@@ -626,9 +646,25 @@ export async function audit(
       const viewRef = f.code === 'L14'
         ? (f.context as { view?: string } | undefined)?.view
         : undefined;
-      f.exposed = viewRef
-        ? isExposed(viewRef.slice(0, viewRef.lastIndexOf('.')), viewRef.slice(viewRef.lastIndexOf('.') + 1))
-        : isExposed(f.schema, f.table);
+      // A routine finding names a function somewhere in the finding — in
+      // `context.function` for the reach rules, in `schema`/`table` for the
+      // convention linter, which files a function under the fields a relation
+      // finding uses.
+      const routineRef = meta && subjectOf(meta) === 'routine'
+        ? (f.context as { function?: string } | undefined)?.function?.replace(/\(.*$/, '')
+          ?? (f.table ? `${f.schema}.${f.table}` : undefined)
+        : undefined;
+      if (routineRef) {
+        const dot = routineRef.lastIndexOf('.');
+        f.exposed = await isRoutineExposed(routineRef.slice(0, dot), routineRef.slice(dot + 1));
+      } else if (viewRef) {
+        f.exposed = isExposed(
+          viewRef.slice(0, viewRef.lastIndexOf('.')),
+          viewRef.slice(viewRef.lastIndexOf('.') + 1)
+        );
+      } else {
+        f.exposed = isExposed(f.schema, f.table);
+      }
     }
 
     // A key that looks like a write-once provisioning pointer, where the

--- a/packages/safegres/src/config/schema.ts
+++ b/packages/safegres/src/config/schema.ts
@@ -103,6 +103,11 @@ const SCORING: Shape<ScoringConfig> = {
   weights: { type: 'record', description: 'Points deducted per finding severity', values: num('Points') },
   perRuleWeights: { type: 'record', description: 'Per-rule weight, beating the severity weight', values: num('Points') },
   maxDeductionPerRule: num('Cap on one rule\u2019s total deduction (weighted model)'),
+  maxRuleDensity: oneOf(
+    'Cap on one rule\u2019s contribution, as a fraction of the points that fail an audit alone. Default 0.5; false disables the cap.',
+    num('Fraction'),
+    bool('false to disable')
+  ),
   failClosedWeight: num('Multiplier for fail-closed findings. Default 0.'),
   densityK: num('Density falloff constant. Default 0.17.'),
   unknownExposureCap: oneOf(

--- a/packages/safegres/src/config/types.ts
+++ b/packages/safegres/src/config/types.ts
@@ -143,6 +143,17 @@ export interface ScoringConfig {
   /** Cap on total deduction any single rule can contribute (weighted model). */
   maxDeductionPerRule?: number;
   /**
+   * Cap on any single rule's contribution (density model), as a fraction of
+   * the points that would take the score to F on their own. Default 0.5 — one
+   * rule at its cap costs two grade bands, and an F still takes breadth.
+   *
+   * The density curve has no natural ceiling, so before this a rule's weight
+   * and its *fan-out* were indistinguishable: L19 emitting one finding per
+   * (relation × function) pair took a real audit from A+ to F on one severity
+   * notch. `false` removes the cap.
+   */
+  maxRuleDensity?: number | false;
+  /**
    * Multiplier applied to fail-closed findings' weights (density model).
    * Default 0 — denied-at-runtime hygiene findings don't reduce the score.
    */

--- a/packages/safegres/src/exposure/routines.ts
+++ b/packages/safegres/src/exposure/routines.ts
@@ -1,0 +1,77 @@
+/**
+ * Routine exposure: which functions an untrusted role can actually call.
+ *
+ * The exposure surface answers "which relations can the API address?", and
+ * every finding was graded by that question — including the ones that are not
+ * about a relation at all. A definer function lives in a private schema, so by
+ * relation reach it is unexposed; but `anonymous` holds `EXECUTE` on it, so it
+ * is one call away from whatever its owner can touch. Grading it by its schema
+ * is not conservative, it is wrong in the dangerous direction.
+ *
+ * The question a routine finding is graded by is therefore the callability
+ * one: can an untrusted role reach the function itself — `USAGE` on its
+ * schema, and `EXECUTE` on the function, directly, by inheritance, or through
+ * Postgres's default `EXECUTE TO PUBLIC`.
+ */
+
+import type { RoleGraph } from '../checks/lattice';
+import { canEnterSchema, type SchemaAclInfo } from '../pg/acl';
+import type { FunctionSnapshot } from '../pg/functions';
+
+export interface RoutineReachOptions {
+  /** Roles a request can arrive as — the API edge, plus its anonymous roles. */
+  roles: string[];
+  graph: RoleGraph;
+  schemaAcls: Map<string, SchemaAclInfo>;
+  /**
+   * Schemas on the API surface. A trigger function is not directly callable
+   * whatever its ACL says, so it is judged the way its firing is: reachable
+   * when a write that fires it is.
+   */
+  exposedSchemas: Set<string>;
+}
+
+/**
+ * Every `schema.name` an untrusted role can execute. Overloads collapse: the
+ * finding names a function, not a signature, and a role that can call one
+ * overload can reach the body the rule is talking about.
+ */
+export function resolveRoutineReach(
+  functions: FunctionSnapshot[],
+  options: RoutineReachOptions
+): Set<string> {
+  const reachable = new Set<string>();
+  if (options.roles.length === 0) return reachable;
+
+  for (const fn of functions) {
+    const key = `${fn.schema}.${fn.name}`;
+    if (reachable.has(key)) continue;
+    if (fn.returnsTrigger) {
+      // Postgres refuses a direct call however wide the ACL is. What reaches
+      // the body is a write to the table the trigger is attached to, so the
+      // API surface is the right question after all.
+      if (options.exposedSchemas.has(fn.schema)) reachable.add(key);
+      continue;
+    }
+    if (options.roles.some((role) => canExecute(fn, role, options))) reachable.add(key);
+  }
+
+  return reachable;
+}
+
+function canExecute(
+  fn: FunctionSnapshot,
+  role: string,
+  { graph, schemaAcls }: RoutineReachOptions
+): boolean {
+  if (!canEnterSchema(fn.schema, role, graph, schemaAcls)) return false;
+  const attrs = graph.get(role);
+  if (attrs?.isSuper) return true;
+  if (role === fn.owner) return true;
+  return fn.grants.some(
+    (g) =>
+      g.role === 'PUBLIC'
+      || g.role === role
+      || (attrs?.inheritsFrom ?? []).includes(g.role)
+  );
+}

--- a/packages/safegres/src/pg/acl.ts
+++ b/packages/safegres/src/pg/acl.ts
@@ -231,3 +231,27 @@ export async function introspectSchemaAcls(
     executeRoles: r.execute_roles
   }));
 }
+
+/**
+ * The role can enter the schema, so a grant on something inside it is reach.
+ *
+ * The same gate L3 applies to a table grant, applied to a schema's contents:
+ * without `USAGE` the object cannot be named, and Postgres's default
+ * EXECUTE-to-PUBLIC would otherwise make every function in an internal schema
+ * look reachable by every role in the database.
+ */
+export function canEnterSchema(
+  schema: string,
+  role: string,
+  graph: Map<string, RoleAttributes>,
+  schemaAcls: Map<string, SchemaAclInfo>
+): boolean {
+  const acl = schemaAcls.get(schema);
+  if (!acl) return true; // not introspected: assume reachable rather than silently drop
+  const attrs = graph.get(role);
+  if (attrs?.isSuper) return true;
+  if (role === acl.owner) return true;
+  const usage = new Set(acl.grants.filter((g) => g.privilege === 'USAGE').map((g) => g.role));
+  if (usage.has('PUBLIC') || usage.has(role)) return true;
+  return (attrs?.inheritsFrom ?? []).some((a) => usage.has(a) || a === acl.owner);
+}

--- a/packages/safegres/src/pg/functions.ts
+++ b/packages/safegres/src/pg/functions.ts
@@ -7,7 +7,7 @@
  * is pinned, the language, the body source, and EXECUTE grants per role.
  */
 
-import type { QueryExecutor } from './introspect';
+import type { ExtensionScopeOptions, QueryExecutor } from './introspect';
 
 export interface FunctionGrant {
   role: string;
@@ -53,6 +53,39 @@ const DEFAULT_EXCLUDES = ['pg_catalog', 'information_schema', 'pg_toast'];
 export interface IntrospectFunctionOptions {
   schemas?: string[];
   excludeSchemas?: string[];
+  extensions?: ExtensionScopeOptions;
+}
+
+/**
+ * Extension scoping for routines. The table-side filter reads ownership off
+ * `pg_class`; a function's is on `pg_proc`, and nothing about a routine is
+ * inherited the way a partition inherits its parent's dependency — so this is
+ * the same rule expressed against the other catalog, not a shared helper.
+ *
+ * Without it `extensions.ignore` narrowed the relation rules and left the
+ * routine rules reading the extension's own bodies: `pg_partman` alone
+ * accounted for every C1 finding and 60% of C4 on a real audit.
+ */
+function routineExtensionFilter(
+  options: ExtensionScopeOptions | undefined,
+  paramIndex: number
+): string {
+  const clauses: string[] = [];
+  if (options?.skipOwned ?? true) {
+    clauses.push(`
+        AND NOT EXISTS (
+          SELECT 1 FROM pg_depend d
+          WHERE d.classid = 'pg_proc'::regclass
+            AND d.refclassid = 'pg_extension'::regclass
+            AND d.deptype = 'e'
+            AND d.objid = p.oid
+        )`);
+  }
+  clauses.push(`
+        AND NOT (n.oid = ANY (
+          SELECT e.extnamespace FROM pg_extension e WHERE e.extname = ANY($${paramIndex}::text[])
+        ))`);
+  return clauses.join('');
 }
 
 export async function introspectFunctions(
@@ -63,10 +96,12 @@ export async function introspectFunctions(
   const schemaFilter = options.schemas && options.schemas.length > 0
     ? `AND n.nspname = ANY($1::text[])`
     : `AND NOT (n.nspname = ANY($2::text[]))`;
+  const extFilter = routineExtensionFilter(options.extensions, 3);
 
   const sql = `
     WITH _params AS (
-      SELECT $1::text[] AS include_schemas, $2::text[] AS exclude_schemas
+      SELECT $1::text[] AS include_schemas, $2::text[] AS exclude_schemas,
+             $3::text[] AS ignore_extensions
     ),
     procs AS (
       SELECT
@@ -93,7 +128,7 @@ export async function introspectFunctions(
       JOIN pg_language l  ON l.oid = p.prolang
       LEFT JOIN pg_roles o ON o.oid = p.proowner
       WHERE p.prokind IN ('f', 'p')
-        ${schemaFilter}
+        ${schemaFilter}${extFilter}
     ),
     grants AS (
       SELECT
@@ -144,7 +179,7 @@ export async function introspectFunctions(
     definition: string | null;
     grants: Array<{ role: string; grantable: boolean }>;
     default_acl: boolean;
-  }>(sql, [options.schemas ?? [], excludes]);
+  }>(sql, [options.schemas ?? [], excludes, options.extensions?.ignore ?? []]);
 
   return rows.map((r) => ({
     oid: r.oid,

--- a/packages/safegres/src/report/markdown.ts
+++ b/packages/safegres/src/report/markdown.ts
@@ -10,7 +10,7 @@
  */
 
 import type { RoleAccessEntry } from '../checks/lattice';
-import type { Score } from '../score/score';
+import type { Score, ScoreDeduction } from '../score/score';
 import type { Finding, PlaneReport, Report, Severity } from '../types';
 import { formatDelta, type ReportComparison, type RuleDelta, type ScoreDelta } from './compare';
 import { type ReportView, selectView, type ViewConfig } from './view';
@@ -177,11 +177,7 @@ function planeSection(view: ReportView): string[] {
       '',
       '| Rule | Findings | Points | Grade | Payoff |',
       '| --- | ---: | ---: | --- | ---: |',
-      ...plane.score.deductions.map((d) =>
-        d.unscored
-          ? `| \`${d.code}\` | ${d.count} | — | — | *unscored* |`
-          : `| \`${d.code}\` | ${d.count} | −${d.points} | **${d.grade}** | +${d.potential.toFixed(1)} |`
-      )
+      ...plane.score.deductions.map(deductionRow)
     );
   }
   return out;
@@ -337,16 +333,24 @@ function comparisonSection(cmp: ReportComparison): string[] {
  * rule alone goes to zero — the number worth ranking work by, and not
  * proportional to the finding count, because the curve is exponential.
  */
+/**
+ * One rule's row. Findings and fixes are different numbers when a rule fans
+ * out over a single repair, and points are charged on the second.
+ */
+function deductionRow(d: ScoreDeduction): string {
+  const found = d.units === undefined ? `${d.count}` : `${d.count} (${d.units} fixes)`;
+  const points = d.capped ? `−${d.points} (capped)` : `−${d.points}`;
+  return d.unscored
+    ? `| \`${d.code}\` | ${found} | — | — | *unscored* |`
+    : `| \`${d.code}\` | ${found} | ${points} | **${d.grade}** | +${d.potential.toFixed(1)} |`;
+}
+
 function ruleTable(label: string, score: Score | undefined, options: RenderMarkdownOptions): string[] {
   if (!score || score.deductions.length === 0) return [];
   const table = [
     '| Rule | Findings | Points | Grade | Payoff |',
     '| --- | ---: | ---: | --- | ---: |',
-    ...score.deductions.map((d) =>
-      d.unscored
-        ? `| \`${d.code}\` | ${d.count} | — | — | *unscored* |`
-        : `| \`${d.code}\` | ${d.count} | −${d.points} | **${d.grade}** | +${d.potential.toFixed(1)} |`
-    )
+    ...score.deductions.map(deductionRow)
   ];
   return options.verbose
     ? [`### ${label} by rule`, '', ...table, '']

--- a/packages/safegres/src/report/pretty.ts
+++ b/packages/safegres/src/report/pretty.ts
@@ -1,6 +1,6 @@
 import yanse from 'yanse';
 
-import type { Score } from '../score/score';
+import type { Score, ScoreDeduction } from '../score/score';
 import type { Finding, PlaneReport, Report, Severity } from '../types';
 import { renderCallGraph, renderCallGraphDiff } from './callgraph';
 import { formatDelta, type ScoreDelta } from './compare';
@@ -320,13 +320,20 @@ function scoreLines(label: string, score: Score, colorEnabled: boolean): string[
   const top = scored.slice(0, 3);
   if (top.length > 0) {
     lines.push(
-      `  top deductions: ${top.map((d) => `${d.code} −${d.points} (×${d.count})`).join('  ')}`
+      `  top deductions: ${top.map(deductionLabel).join('  ')}`
     );
     // Payoff, not points: what the score becomes if the rule goes to zero.
     lines.push(
       `  by rule: ${scored
         .map((d) => `${d.code} ${d.grade} (+${d.potential.toFixed(1)})`)
         .join('  ')}`
+    );
+  }
+  const capped = scored.filter((d) => d.capped);
+  if (capped.length > 0) {
+    lines.push(
+      `  capped: ${capped.map((d) => d.code).join(', ')}`
+        + '  — one rule cannot decide the grade; the finding count is unchanged'
     );
   }
   const unscored = score.deductions.filter((d) => d.unscored);
@@ -337,6 +344,17 @@ function scoreLines(label: string, score: Score, colorEnabled: boolean): string[
     );
   }
   return lines;
+}
+
+/**
+ * `L19 −664 (×568 → 166 fixes)` — the finding count and what it costs to
+ * clear are different numbers, and only the second one is charged.
+ */
+function deductionLabel(d: ScoreDeduction): string {
+  const count = d.units === undefined
+    ? `×${d.count}`
+    : `×${d.count} → ${d.units} fix${d.units === 1 ? '' : 'es'}`;
+  return `${d.code} −${d.points} (${count})`;
 }
 
 function deltaLine(d: ScoreDelta, ref: string | undefined, colorEnabled: boolean): string {

--- a/packages/safegres/src/rules/registry.ts
+++ b/packages/safegres/src/rules/registry.ts
@@ -30,11 +30,41 @@ export interface RuleMeta {
    * read function definitions rather than the catalog, and run their own pass.
    */
   scope: 'table' | 'policy-ast' | 'index' | 'stats' | 'function-src';
+  /**
+   * What the finding is *about*, which decides how its exposure is judged.
+   *
+   * A `relation` finding is exposed when its table is on the API surface. A
+   * `routine` finding is exposed when an untrusted role can *call the
+   * function* — schema USAGE plus EXECUTE — which is a different question and
+   * frequently a different answer: a definer function in a private schema is
+   * off the API surface and still one grant away from anonymous.
+   *
+   * Judging routine findings by relation reach is why a real audit reported
+   * every `C*` and `L19` finding as `exposed: false`, and therefore scored
+   * them at zero. Defaults to `relation`.
+   */
+  subject?: 'relation' | 'routine';
+  /**
+   * The finding's unit of repair, as a dotted path into the finding
+   * (`context.function`). The score counts *distinct* units, not findings,
+   * so a rule that emits one finding per (relation × function) pair moves the
+   * score by how much work it represents rather than by its own fan-out.
+   *
+   * L19 is the case that forced this: 568 findings over 166 functions, where
+   * promoting the rule one notch took the audit from A+ to F on multiplicity
+   * alone. Omitted means one finding is one unit.
+   */
+  dedupBy?: string;
 }
 
 /** The scoring axis a rule belongs to (`security` unless declared otherwise). */
 export function dimensionOf(meta: RuleMeta): Dimension {
   return meta.dimension ?? 'security';
+}
+
+/** What a rule's findings are about (`relation` unless declared otherwise). */
+export function subjectOf(meta: RuleMeta): 'relation' | 'routine' {
+  return meta.subject ?? 'relation';
 }
 
 export const RULES: RuleMeta[] = [
@@ -369,7 +399,12 @@ export const RULES: RuleMeta[] = [
     defaultSeverity: 'info',
     direction: 'fail-open',
     title: 'Definer-function reach — an untrusted role touches a relation by executing a SECURITY DEFINER function (options: { roles: [...] })',
-    scope: 'table'
+    scope: 'table',
+    // The reach is the function's, not the relation's: a definer function in
+    // an unexposed schema still runs as its owner for whoever holds EXECUTE.
+    subject: 'routine',
+    // One finding per (relation × function) pair, but one revoke per function.
+    dedupBy: 'context.function'
   },
   {
     code: 'L20',
@@ -381,7 +416,9 @@ export const RULES: RuleMeta[] = [
     defaultSeverity: 'info',
     direction: 'fail-open',
     title: 'INSTEAD OF trigger write — an untrusted role writes a relation through a trigger function that runs as its owner (options: { roles: [...] })',
-    scope: 'table'
+    scope: 'table',
+    subject: 'routine',
+    dedupBy: 'context.function'
   },
   {
     code: 'W1',
@@ -514,7 +551,8 @@ export const RULES: RuleMeta[] = [
     defaultSeverity: 'high',
     direction: 'fail-open',
     title: 'Function sets search_path (house rule: never set it — fully-qualify instead)',
-    scope: 'function-src'
+    scope: 'function-src',
+    subject: 'routine'
   },
   {
     code: 'C2',
@@ -522,7 +560,8 @@ export const RULES: RuleMeta[] = [
     defaultSeverity: 'medium',
     direction: 'neutral',
     title: 'Function uses a #variable_conflict directive',
-    scope: 'function-src'
+    scope: 'function-src',
+    subject: 'routine'
   },
   {
     code: 'C3',
@@ -530,7 +569,10 @@ export const RULES: RuleMeta[] = [
     defaultSeverity: 'low',
     direction: 'neutral',
     title: 'Function has an unqualified relation reference (relies on search_path)',
-    scope: 'function-src'
+    scope: 'function-src',
+    subject: 'routine',
+    // Every unqualified reference in one body is one edit to that body.
+    dedupBy: 'context.function'
   },
   {
     code: 'C4',
@@ -538,7 +580,9 @@ export const RULES: RuleMeta[] = [
     defaultSeverity: 'high',
     direction: 'fail-open',
     title: 'Function uses dynamic SQL (waivable with a categorized reason)',
-    scope: 'function-src'
+    scope: 'function-src',
+    subject: 'routine',
+    dedupBy: 'context.function'
   }
 ];
 

--- a/packages/safegres/src/score/score.ts
+++ b/packages/safegres/src/score/score.ts
@@ -1,4 +1,5 @@
 import type { Grade, ScoringConfig } from '../config/types';
+import { RULES_BY_CODE } from '../rules/registry';
 import type { Finding, Severity } from '../types';
 import { meetsThreshold } from '../types';
 
@@ -26,6 +27,18 @@ export interface ScoreDeduction {
    * fixing them would move the score; it cannot.
    */
   unscored?: boolean;
+  /**
+   * The rule's raw points exceeded `maxRuleDensity` and were cut to it. The
+   * finding count is unchanged: what is capped is the rule's influence on the
+   * score, not the size of the problem it reports.
+   */
+  capped?: boolean;
+  /**
+   * Distinct units of repair behind `count`, when a rule declares one
+   * (`RuleMeta.dedupBy`). Points are charged per unit, so a rule that emits
+   * one finding per (relation × function) pair costs what fixing it costs.
+   */
+  units?: number;
 }
 
 export interface Score {
@@ -75,6 +88,7 @@ export const DEFAULT_GRADE_BANDS: Record<Exclude<Grade, 'F'>, number> = {
 };
 
 const DEFAULT_MAX_DEDUCTION_PER_RULE = 40;
+const DEFAULT_MAX_RULE_DENSITY = 0.5;
 const DEFAULT_DENSITY_K = 0.17;
 const DEFAULT_UNKNOWN_EXPOSURE_CAP = 80;
 const DEFAULT_FAIL_CLOSED_WEIGHT = 0;
@@ -106,6 +120,12 @@ export function computeScore(
  * `failClosedWeight`, default 0 — denied-at-runtime hygiene doesn't reduce
  * the score). With the default k, one critical per ~10 exposed tables lands
  * around a C; one critical per table is an F.
+ *
+ * Two things keep a rule's *shape* out of the arithmetic. Points are charged
+ * per unit of repair, not per finding, for rules that declare one — a rule
+ * emitting a row per (relation × function) pair costs what fixing it costs.
+ * And each rule's total is capped at a fraction of the points that would fail
+ * an audit alone (`maxRuleDensity`), so no single rule can decide the grade.
  */
 function computeDensityScore(
   findings: Finding[],
@@ -123,38 +143,66 @@ function computeDensityScore(
   // unknown-exposure cap is their penalty, not weighted points.
   const scorable = findings.filter((f) => f.exposed !== false && !f.acknowledged && f.category !== 'meta');
 
-  const byRule = new Map<string, { count: number; points: number }>();
+  const exposedTables = Math.max(1, context.exposedTables ?? 1);
+
+  const byRule = new Map<string, RuleTally>();
   for (const f of scorable) {
     let weight = perRule[f.code] ?? weights[f.severity] ?? 0;
     if (f.direction === 'fail-closed') weight *= failClosedWeight;
-    const entry = byRule.get(f.code) ?? { count: 0, points: 0 };
+    const entry = byRule.get(f.code) ?? { count: 0, points: 0, units: new Set<string>() };
     entry.count += 1;
-    entry.points += Math.max(0, weight);
+    // A rule with a declared unit of repair is charged once per unit: the
+    // second finding against the same function is the same fix, and letting
+    // it charge again grades fan-out rather than risk.
+    const unit = repairUnit(f);
+    if (unit === undefined || !entry.units.has(unit)) {
+      entry.points += Math.max(0, weight);
+      if (unit !== undefined) entry.units.add(unit);
+    }
     byRule.set(f.code, entry);
   }
 
-  const riskPoints = [...byRule.values()].reduce((sum, r) => sum + r.points, 0);
-  const exposedTables = Math.max(1, context.exposedTables ?? 1);
+  // No single rule may contribute more than `maxRuleDensity` of the points
+  // that would take the score to F alone — at the default half, one rule can
+  // cost two grade bands but an F still takes breadth. Solved from the curve
+  // rather than fixed, so retuning `k` or the bands moves the cap with them.
+  const maxRuleDensity = config.maxRuleDensity ?? DEFAULT_MAX_RULE_DENSITY;
+  const pointsToF = (Math.log(100 / (bands.D || 50)) / k) * exposedTables;
+  const ruleCap = maxRuleDensity === false ? Infinity : maxRuleDensity * pointsToF;
+
+  const capped = new Map<string, { count: number; points: number; raw: number; units?: number }>();
+  for (const [code, tally] of byRule) {
+    capped.set(code, {
+      count: tally.count,
+      points: Math.min(tally.points, ruleCap),
+      raw: tally.points,
+      ...(tally.units.size > 0 ? { units: tally.units.size } : {})
+    });
+  }
+
+  const riskPoints = [...capped.values()].reduce((sum, r) => sum + r.points, 0);
   const density = riskPoints / exposedTables;
   const curve = (points: number) => round1(100 * Math.exp((-k * points) / exposedTables));
 
   let value = round1(100 * Math.exp(-k * density));
 
-  const deductions: ScoreDeduction[] = [...byRule.entries()]
-    .map(([code, { count, points }]) => ({
+  const deductions: ScoreDeduction[] = [...capped.entries()]
+    .map(([code, { count, points, raw, units }]) => ({
       code,
       count,
       points,
       score: curve(points),
       grade: gradeFor(curve(points), bands),
       potential: round1(curve(riskPoints - points) - value),
+      ...(units !== undefined && units !== count ? { units } : {}),
+      ...(raw > points ? { capped: true } : {}),
       ...(points === 0 ? { unscored: true } : {})
     }))
     .sort(byPayoff);
 
-  const cap = config.unknownExposureCap ?? DEFAULT_UNKNOWN_EXPOSURE_CAP;
-  const capped = context.exposureKnown === false && cap !== false && value > cap;
-  if (capped) value = cap;
+  const unknownCap = config.unknownExposureCap ?? DEFAULT_UNKNOWN_EXPOSURE_CAP;
+  const cappedByUnknown = context.exposureKnown === false && unknownCap !== false && value > unknownCap;
+  if (cappedByUnknown) value = unknownCap;
 
   let grade = gradeFor(value, bands);
   if (
@@ -173,8 +221,30 @@ function computeDensityScore(
     deductions,
     density: Math.round(density * 1000) / 1000,
     exposedTables,
-    ...(capped ? { cappedByUnknownExposure: true } : {})
+    ...(cappedByUnknown ? { cappedByUnknownExposure: true } : {})
   };
+}
+
+interface RuleTally {
+  count: number;
+  points: number;
+  /** Distinct repair units seen, for rules that declare one. */
+  units: Set<string>;
+}
+
+/**
+ * The finding's unit of repair, from the rule's declared `dedupBy` path.
+ * `undefined` when the rule declares none — one finding, one unit.
+ */
+function repairUnit(finding: Finding): string | undefined {
+  const path = RULES_BY_CODE.get(finding.code)?.dedupBy;
+  if (!path) return undefined;
+  let value: unknown = finding;
+  for (const key of path.split('.')) {
+    if (value === null || typeof value !== 'object') return undefined;
+    value = (value as Record<string, unknown>)[key];
+  }
+  return typeof value === 'string' ? value : undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

constructive-db scores **100 (A+)** with 7 critical and 366 high findings in the same report, and one info rule promoted a single notch takes it to **F**. Both facts have the same cause: the score measures the wrong things. Three defects, fixed here. Measured against constructive-db, the same database now scores **88.9 (B)** — with the count of `high` findings *down* from 366 to 113, because a chunk of them were an extension's.

Details in constructive-io/constructive-planning#1385.

**1. Every finding was graded as if it were about a relation.**

`Finding.exposed` came from one question — can the API address `schema.table`? For a definer function in a private schema the answer is no, so `C1`, `C4`, `L19` and `L20` were `exposed: false` **by construction** and could never score. `"C1": "high"` in the constructive preset was decorative. That grading is not conservative, it is wrong in the dangerous direction: the function is private precisely so that *calling* it is the only way in.

Exposure is now asked per subject, declared on the rule:

```ts
// rules/registry.ts
{ code: 'L19', subject: 'routine', dedupBy: 'context.function' }

// commands/audit.ts
f.exposed = subjectOf(meta) === 'routine'
  ? routineReach.has(`${schema}.${fn}`)   // can an untrusted role CALL it?
  : isExposed(f.schema, f.table);         // can the API address it?
```

`resolveRoutineReach()` (new, `exposure/routines.ts`) answers the first: schema `USAGE` plus effective `EXECUTE` — direct, inherited, or Postgres's default `EXECUTE TO PUBLIC` — for any role in `exposure.roles ∪ anonRoles`. A trigger function is judged by its schema instead, since Postgres refuses a direct call however wide its ACL is; what reaches that body is a write that fires it. `canEnterSchema` moves to `pg/acl.ts` from its private home in `checks/definer-function.ts`, unchanged.

**2. A rule's fan-out and its severity were indistinguishable.**

`maxDeductionPerRule` only ever applied to the legacy `weighted` model, so under `density` a rule's points were unbounded. L19 emits one finding per (relation × function) pair — 853 findings over 166 functions on constructive-db — which is why promoting it one notch swung A+ → F. Two changes:

```
points = Σ over distinct RuleMeta.dedupBy values, not over findings
       = min(points, maxRuleDensity · pointsToF)      # default 0.5
```

The cap is solved from the curve (`pointsToF = ln(100/gradeBands.D)/k · exposedTables`) rather than fixed, so retuning `k` or the bands moves it too. At the default, one rule at its ceiling costs two grade bands and an F still takes breadth. Reports show both numbers — `C4 −320 (×80 → 32 fixes)` — because the finding count is not the size of the fix, and neither is a lie.

**3. `extensions.ignore` filtered relations but not routines.**

`introspectFunctions` took no `extensions` option, so pg_partman's function bodies arrived as house-style violations against a house that didn't write them: 38/38 C1 and 194/325 C4 findings on constructive-db were partman's. It now applies the same two exclusions the relation path does (`pg_depend` extension membership, and named extensions' schemas). With them, **C1 and C2 are clean on constructive-db** — free to make hard errors whenever we want.

### Measured

```
before:  score 100 (A+)    7 critical  366 high   74 medium  567 low
after:   score 88.9 (B)    7 critical  113 high   74 medium  521 low
         top deductions: C4 −320 (×80 → 32 fixes)  C3 −18 (×45 → 18 fixes)
```

L19 is still `info` and still unscored — deliberately. What the 853 findings mean, and which of those 166 functions anonymous should be able to call, is L10's job (constructive-io/constructive-planning#1386); this PR only makes sure the answer can no longer be hidden by the scoreboard.

### Tests

`__tests__/routine-reach.test.ts` (7 cases: USAGE gate, PUBLIC default ACL, inheritance, trigger functions), an end-to-end exposure case in `lint-audit.test.ts` where two functions in the same unexposed schema grade differently on their ACLs alone, a routine case in `extensions.test.ts`, and dedup/cap cases in `config.test.ts`. 570 pass.


Link to Devin session: https://app.devin.ai/sessions/ec06ef6eabae4872ae5ec3926f037c85
Requested by: @pyramation