### PR TITLE
feat(safegres): named scorecards — one report, several graded questions

### DIFF
--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -732,6 +732,47 @@ Every report carries its own arithmetic: per-rule points, grade, and the **payof
 score would move if that rule's findings went away. Gate with `--fail-on <severity>`,
 `--fail-on-score <n>`, `--fail-on-grade <g>` and their `--fail-on-perf-*` counterparts.
 
+### Scorecards: one report, several questions
+
+"How secure is this database" is not one question, and a single grade answers it for at most one
+reader. A platform team gates on what an unauthenticated caller reaches; an application team gates
+on house style; a reviewer wants the number no preset softened. A **scorecard** is that question
+written down — a selector over the findings, plus the weighting to grade what it selects:
+
+```jsonc
+{
+  "scorecards": {
+    "anon-surface": {
+      "description": "What an unauthenticated caller reaches.",
+      "select": { "roles": ["anonymous"], "direction": "fail-open", "exposure": "all" },
+      "perRuleWeights": { "L19": 10 },
+      "floorOnCritical": "C"
+    },
+    "sql-conventions": {
+      "select": { "rules": ["C*"], "exposure": "all", "denominator": "all" }
+    }
+  },
+  "failOn": { "scorecards": { "anon-surface": { "grade": "A" } } }
+}
+```
+
+Selectors narrow on `rules` (with `C*` wildcards) and `exclude`, `dimension`, `roles`, `planes`,
+`schemas`, `direction`, `minSeverity`, `exposure`, `acknowledged`, `severities` and `denominator`.
+Every scoring key is available per card, and `failOn.scorecards` gates on the one that matters to
+you rather than on somebody else's headline.
+
+Two cards always run and cannot be redefined into something flattering:
+
+- **`default`** — the Safegres score: the headline, exposure-scoped and preset-tuned, i.e. graded
+  the way you actually use the database. Naming it in the config cannot move it.
+- **`raw`** — every finding at its *declared* (registry) severity, exposure ignored,
+  acknowledgements included, fail-closed findings weighted like anything else. Not flattering, and
+  not meant to be: it is the number that is comparable between two databases and that no
+  configuration talked down.
+
+A scorecard decides what a number is *about* — never what is reported. `report.findings` is always
+the complete set, so the JSON is the raw data and the scores are queries over it.
+
 ## Commands
 
 ```bash

--- a/packages/safegres/__tests__/audit.test.ts
+++ b/packages/safegres/__tests__/audit.test.ts
@@ -150,6 +150,30 @@ describe('audit — Script A', () => {
     expect(p5?.severity).toBe('high');
   });
 
+  it('carries scorecards without narrowing the findings they score', async () => {
+    // Over the fixtures already applied above: an `A*` card must not become
+    // the whole report just because it is the card being read.
+    const report = await audit(pg.client as never, {
+      schemas: ['fx_a2', 'fx_p5'],
+      config: {
+        scorecards: {
+          'flags-only': { select: { rules: ['A*'], exposure: 'all' } }
+        }
+      }
+    });
+
+    const names = (report.scorecards ?? []).map((c) => c.name);
+    expect(names).toEqual(['default', 'raw', 'flags-only']);
+
+    const card = report.scorecards!.find((c) => c.name === 'flags-only')!;
+    expect(card.findings).toBeGreaterThan(0);
+    expect(card.score.deductions.every((d) => d.code.startsWith('A'))).toBe(true);
+
+    // The selector grades a slice; the report still carries everything.
+    expect(report.findings.length).toBeGreaterThanOrEqual(card.findings);
+    expect(report.findings.some((f) => !f.code.startsWith('A'))).toBe(true);
+  });
+
   it('clean table produces no findings', async () => {
     await applyFixture('clean-table.sql');
     const report = await audit(pg.client as never, { schemas: ['fx_clean'] });

--- a/packages/safegres/__tests__/scorecards.test.ts
+++ b/packages/safegres/__tests__/scorecards.test.ts
@@ -1,0 +1,155 @@
+import { computeScore } from '../src/score/score';
+import {
+  computeScorecards,
+  RESERVED_SCORECARDS,
+  selectFindings
+} from '../src/score/scorecards';
+import type { Finding } from '../src/types';
+
+function finding(over: Partial<Finding> = {}): Finding {
+  return {
+    code: 'A2',
+    severity: 'high',
+    category: 'flags',
+    direction: 'fail-open',
+    exposed: true,
+    schema: 'app_public',
+    table: 'widgets',
+    message: 'test',
+    ...over
+  };
+}
+
+const context = { exposedTables: 100, totalTables: 200, exposureKnown: true };
+
+function cards(findings: Finding[], config = {}) {
+  const headline = computeScore(findings, {}, context);
+  const report = computeScorecards(
+    findings,
+    headline,
+    { ...RESERVED_SCORECARDS, ...config },
+    context
+  );
+  return Object.fromEntries(report.map((c) => [c.name, c]));
+}
+
+describe('scorecards', () => {
+  it('always carries default and raw, whatever the config says', () => {
+    const byName = cards([finding()]);
+    expect(Object.keys(byName)).toEqual(['default', 'raw']);
+    expect(byName.default.reserved).toBe(true);
+    expect(byName.raw.reserved).toBe(true);
+  });
+
+  it('default is the headline verbatim — a scorecard block cannot move the badge', () => {
+    const findings = [finding(), finding({ code: 'A5', severity: 'critical' })];
+    const headline = computeScore(findings, {}, context);
+    const byName = cards(findings, {
+      // A card that would love the headline to be a 100.
+      default: { weights: { critical: 0, high: 0 } }
+    });
+    expect(byName.default.score).toEqual(headline);
+    expect(byName.default.score.value).toBeLessThan(100);
+  });
+
+  it('raw ignores exposure, acknowledgement and preset severities', () => {
+    const findings = [
+      // Everything the headline discounts, one of each.
+      finding({ code: 'A2', exposed: false }),
+      finding({ code: 'A5', acknowledged: true }),
+      // A preset quieted A3 to info; the registry declares it `low`.
+      finding({ code: 'A3', severity: 'info' }),
+      finding({ code: 'A4', direction: 'fail-closed' })
+    ];
+    const byName = cards(findings);
+
+    expect(byName.default.score.value).toBe(100);
+    expect(byName.raw.findings).toBe(4);
+    expect(byName.raw.score.value).toBeLessThan(100);
+    expect(byName.raw.score.deductions.find((d) => d.code === 'A3')?.points).toBeGreaterThan(0);
+  });
+
+  it('grades a team question: one rule set, its own weighting and gate', () => {
+    const findings = [
+      ...Array.from({ length: 12 }, (_, i) => finding({ code: 'C4', severity: 'low', table: `t${i}` })),
+      finding({ code: 'A2', severity: 'critical' })
+    ];
+    const byName = cards(findings, {
+      'sql-conventions': {
+        description: 'House style.',
+        select: { rules: ['C*'] },
+        weights: { low: 8 },
+        floorOnCritical: false
+      }
+    });
+
+    const card = byName['sql-conventions'];
+    expect(card.findings).toBe(12);
+    expect(card.description).toBe('House style.');
+    // The critical is somebody else's problem: this card grades C* only.
+    expect(card.score.deductions.map((d) => d.code)).toEqual(['C4']);
+    expect(card.score.value).toBeLessThan(byName.default.score.value);
+  });
+
+  it('selects by role, wherever the finding recorded it', () => {
+    const findings = [
+      finding({ code: 'R1', role: 'anonymous' }),
+      finding({ code: 'L19', context: { role: 'anonymous', function: 'p.f' } }),
+      finding({ code: 'L1', context: { roles: ['authenticated', 'anonymous'] } }),
+      finding({ code: 'A2', role: 'authenticated' })
+    ];
+    expect(selectFindings(findings, { roles: ['anonymous'] }).map((f) => f.code))
+      .toEqual(['R1', 'L19', 'L1']);
+  });
+
+  it('narrows on planes, schemas, direction and severity', () => {
+    const findings = [
+      finding({ code: 'A2', planes: ['api'], schema: 'app_public' }),
+      finding({ code: 'A5', planes: ['direct:app'], schema: 'app_public' }),
+      finding({ code: 'A4', planes: ['api'], schema: 'private', direction: 'fail-closed' }),
+      finding({ code: 'A6', planes: ['api'], schema: 'app_public', severity: 'low' })
+    ];
+    expect(selectFindings(findings, { planes: ['api'] }).map((f) => f.code))
+      .toEqual(['A2', 'A4', 'A6']);
+    expect(selectFindings(findings, { schemas: ['private'] }).map((f) => f.code)).toEqual(['A4']);
+    expect(selectFindings(findings, { direction: 'fail-closed' }).map((f) => f.code)).toEqual(['A4']);
+    expect(selectFindings(findings, { minSeverity: 'high' }).map((f) => f.code))
+      .toEqual(['A2', 'A5', 'A4']);
+  });
+
+  it('excludes after including, so a wildcard can carve out one rule', () => {
+    const findings = ['C1', 'C2', 'C3', 'C4', 'A2'].map((code) => finding({ code }));
+    expect(selectFindings(findings, { rules: ['C*'], exclude: ['C3'] }).map((f) => f.code))
+      .toEqual(['C1', 'C2', 'C4']);
+  });
+
+  it('never mutates the findings it re-severities', () => {
+    const original = finding({ code: 'A3', severity: 'info' });
+    const [selected] = selectFindings([original], { severities: 'declared' });
+    expect(original.severity).toBe('info');
+    expect(selected.severity).not.toBe('info');
+  });
+
+  it('normalizes an exposure-ignoring card by every relation, not just the exposed ones', () => {
+    const findings = Array.from({ length: 40 }, (_, i) =>
+      finding({ code: 'A2', exposed: false, table: `t${i}` }));
+    const byName = cards(findings, {
+      wide: { select: { exposure: 'all', denominator: 'all' } },
+      narrow: { select: { exposure: 'all' } }
+    });
+    // Same numerator, denominator twice the size: dividing the wider set by
+    // the narrower surface would penalize a card for asking a wider question.
+    expect(byName.wide.score.value).toBeGreaterThan(byName.narrow.score.value);
+    expect(byName.wide.score.exposedTables).toBe(200);
+  });
+
+  it('can grade both dimensions in one number when a team wants one', () => {
+    const findings = [
+      finding({ code: 'A2', dimension: 'security' }),
+      finding({ code: 'X1', dimension: 'perf', category: 'index' })
+    ];
+    expect(selectFindings(findings, {}).map((f) => f.code)).toEqual(['A2']);
+    expect(selectFindings(findings, { dimension: 'perf' }).map((f) => f.code)).toEqual(['X1']);
+    expect(selectFindings(findings, { dimension: 'all' }).map((f) => f.code)).toEqual(['A2', 'X1']);
+  });
+});

--- a/packages/safegres/schema/safegres.schema.json
+++ b/packages/safegres/schema/safegres.schema.json
@@ -604,6 +604,225 @@
       },
       "description": "The security scoring model"
     },
+    "scorecards": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "model": {
+            "type": "string",
+            "enum": [
+              "density",
+              "weighted"
+            ],
+            "description": "Scoring model. Default density."
+          },
+          "weights": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number",
+              "description": "Points"
+            },
+            "description": "Points deducted per finding severity"
+          },
+          "perRuleWeights": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number",
+              "description": "Points"
+            },
+            "description": "Per-rule weight, beating the severity weight"
+          },
+          "maxDeductionPerRule": {
+            "type": "number",
+            "description": "Cap on one rule’s total deduction (weighted model)"
+          },
+          "maxRuleDensity": {
+            "anyOf": [
+              {
+                "type": "number",
+                "description": "Fraction"
+              },
+              {
+                "type": "boolean",
+                "description": "false to disable"
+              }
+            ],
+            "description": "Cap on one rule’s contribution, as a fraction of the points that fail an audit alone. Default 0.5; false disables the cap."
+          },
+          "failClosedWeight": {
+            "type": "number",
+            "description": "Multiplier for fail-closed findings. Default 0."
+          },
+          "densityK": {
+            "type": "number",
+            "description": "Density falloff constant. Default 0.17."
+          },
+          "unknownExposureCap": {
+            "anyOf": [
+              {
+                "type": "number",
+                "description": "Cap"
+              },
+              {
+                "type": "boolean",
+                "description": "false to disable"
+              }
+            ],
+            "description": "Maximum score when no exposure surface resolves. Default 80; false disables the cap."
+          },
+          "floorOnCritical": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "A+",
+                  "A",
+                  "B",
+                  "C",
+                  "D",
+                  "F"
+                ],
+                "description": "Grade"
+              },
+              {
+                "type": "boolean",
+                "description": "false to disable"
+              }
+            ],
+            "description": "Grade any critical finding floors the score at. Default C; false disables."
+          },
+          "gradeBands": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number",
+              "description": "Score"
+            },
+            "description": "Minimum score for each grade"
+          },
+          "title": {
+            "type": "string",
+            "description": "Heading for reports. Defaults to the config key."
+          },
+          "description": {
+            "type": "string",
+            "description": "What decision this score informs. Rendered with it."
+          },
+          "select": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "rules": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Rule code or wildcard"
+                },
+                "description": "Rule codes or C* prefix wildcards to grade"
+              },
+              "exclude": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Rule code or wildcard"
+                },
+                "description": "Rule codes or wildcards to drop after rules selected"
+              },
+              "dimension": {
+                "type": "string",
+                "enum": [
+                  "security",
+                  "perf",
+                  "all"
+                ],
+                "description": "Which axis: security (default), perf, or all"
+              },
+              "roles": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Role name"
+                },
+                "description": "Only findings about these roles"
+              },
+              "planes": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Plane name"
+                },
+                "description": "Only findings reachable on these access planes"
+              },
+              "schemas": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Schema name"
+                },
+                "description": "Only findings in these schemas"
+              },
+              "direction": {
+                "type": "string",
+                "enum": [
+                  "fail-open",
+                  "fail-closed",
+                  "none",
+                  "any"
+                ],
+                "description": "fail-open leaks, fail-closed denials, or any"
+              },
+              "minSeverity": {
+                "type": "string",
+                "enum": [
+                  "critical",
+                  "high",
+                  "medium",
+                  "low",
+                  "info"
+                ],
+                "description": "Drop findings below this severity before scoring"
+              },
+              "exposure": {
+                "type": "string",
+                "enum": [
+                  "exposed",
+                  "all"
+                ],
+                "description": "exposed (default) grades the API surface; all ignores exposure"
+              },
+              "acknowledged": {
+                "type": "string",
+                "enum": [
+                  "skip",
+                  "include"
+                ],
+                "description": "include grades acknowledged findings too. Default skip."
+              },
+              "severities": {
+                "type": "string",
+                "enum": [
+                  "configured",
+                  "declared"
+                ],
+                "description": "configured (default) uses this config’s severities; declared uses each rule’s registry default"
+              },
+              "denominator": {
+                "type": "string",
+                "enum": [
+                  "exposed",
+                  "all"
+                ],
+                "description": "Density denominator: exposed relations (default) or all"
+              }
+            },
+            "description": "Which findings it grades"
+          }
+        },
+        "description": "One scorecard"
+      },
+      "description": "Named scores over slices of the same findings, keyed by name"
+    },
     "failOn": {
       "type": "object",
       "additionalProperties": false,
@@ -677,6 +896,33 @@
             "description": "One plane gate"
           },
           "description": "Per-plane gates, keyed by plane name. A floor is the useful shape."
+        },
+        "scorecards": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "score": {
+                "type": "number",
+                "description": "Exit non-zero below this plane score"
+              },
+              "grade": {
+                "type": "string",
+                "enum": [
+                  "A+",
+                  "A",
+                  "B",
+                  "C",
+                  "D",
+                  "F"
+                ],
+                "description": "Exit non-zero below this plane grade"
+              }
+            },
+            "description": "One scorecard gate"
+          },
+          "description": "Per-scorecard gates, keyed by scorecard name."
         }
       },
       "description": "Gates — what makes the run exit non-zero"

--- a/packages/safegres/src/cli/audit.ts
+++ b/packages/safegres/src/cli/audit.ts
@@ -490,6 +490,21 @@ export default async (
     }
   }
 
+  // Per-scorecard gates. The point of a scorecard is that a team gates on
+  // its own question, so this is the gate that matters to them and the
+  // headline is someone else's number.
+  for (const [pattern, gate] of Object.entries(config.failOn?.scorecards ?? {})) {
+    const cards = (report.scorecards ?? []).filter((c) => matchPlane(pattern, c.name));
+    for (const card of cards) {
+      if (gate.score != null && card.score.value < gate.score) {
+        fail(`scorecard ${card.name} score ${card.score.value} is below failOn.scorecards["${pattern}"].score ${gate.score}`);
+      }
+      if (gate.grade && !meetsGrade(card.score.grade, gate.grade)) {
+        fail(`scorecard ${card.name} grade ${card.score.grade} is below failOn.scorecards["${pattern}"].grade ${gate.grade}`);
+      }
+    }
+  }
+
   const failOnNewPerf = argv['fail-on-new-perf'] === true || config.perf?.failOnNew === true;
   if (failOnNewPerf && report.perf?.diff && report.perf.diff.added.length > 0) {
     const count = report.perf.diff.added.length;

--- a/packages/safegres/src/commands/audit.ts
+++ b/packages/safegres/src/commands/audit.ts
@@ -102,6 +102,7 @@ import { listAuditableRoles, resolveRoles } from '../pg/roles';
 import { introspectStats, type StatsSnapshot } from '../pg/stats';
 import { dimensionOf, RULES_BY_CODE, subjectOf } from '../rules/registry';
 import { computeScore } from '../score/score';
+import { computeScorecards, RESERVED_SCORECARDS } from '../score/scorecards';
 import type { ExposureReport, Finding, PerfReport, PerfStatsReport, Report, RoleAccessReport } from '../types';
 import { summarize } from '../types';
 import { version as PKG_VERSION } from '../version';
@@ -864,6 +865,16 @@ export async function audit(
 
     report.perf = perf;
   }
+
+  // Scorecards last: they are named questions asked of the finished finding
+  // set, so every stamp a scorecard can select on (exposure, planes, perf
+  // dimension) is already on the findings by now.
+  report.scorecards = computeScorecards(
+    findings,
+    report.score!,
+    { ...RESERVED_SCORECARDS, ...(config.scorecards ?? {}) },
+    { exposedTables, totalTables: snapshot.length, exposureKnown: exposure.known }
+  );
 
   if (options.callGraph) {
     const functions = await getFunctions();

--- a/packages/safegres/src/config/loader.ts
+++ b/packages/safegres/src/config/loader.ts
@@ -185,6 +185,11 @@ function mergePreset(preset: SafegresConfig, over: SafegresConfig): SafegresConf
     rules: { ...(base.rules ?? {}), ...(over.rules ?? {}) },
     scoring: { ...(base.scoring ?? {}), ...(over.scoring ?? {}) },
     failOn: { ...(base.failOn ?? {}), ...(over.failOn ?? {}) },
+    // Per name: a project adds its own card without dropping the preset's,
+    // and redefines one by naming it.
+    ...(base.scorecards || over.scorecards
+      ? { scorecards: { ...(base.scorecards ?? {}), ...(over.scorecards ?? {}) } }
+      : {}),
     overrides: [...(base.overrides ?? []), ...(over.overrides ?? [])],
     // Merged per-key so retuning `skipOwned` doesn't silently drop the
     // preset's `ignore` list. Omitted entirely when neither side sets it.

--- a/packages/safegres/src/config/presets.ts
+++ b/packages/safegres/src/config/presets.ts
@@ -131,7 +131,34 @@ export const constructive: SafegresConfig = {
     C3: 'low',
     C4: 'high'
   },
-  scoring: { floorOnCritical: 'C' }
+  scoring: { floorOnCritical: 'C' },
+  // The headline grades the API surface, which is the product's own question.
+  // These are the two other questions this codebase actually gates on, and
+  // neither is well served by being averaged into the first.
+  scorecards: {
+    'anon-surface': {
+      title: 'Anonymous surface',
+      description: 'What an unauthenticated caller reaches — exposure ignored, leaks only.',
+      select: {
+        roles: ['anonymous'],
+        direction: 'fail-open',
+        exposure: 'all',
+        denominator: 'all',
+        severities: 'declared'
+      },
+      // Nothing about the anonymous surface is informational. The L-series
+      // ships at `info` because each rule is new, not because "an
+      // unauthenticated caller reaches this" is a matter of interest — so on
+      // the card that asks exactly that question, a finding costs a point.
+      weights: { info: 1 },
+      floorOnCritical: 'C'
+    },
+    'sql-conventions': {
+      title: 'SQL conventions',
+      description: 'House style in function bodies — reachable or not, it is still the codebase.',
+      select: { rules: ['C*'], exposure: 'all', denominator: 'all' }
+    }
+  }
 };
 
 /** Structural flags only — a fast CI smoke check. */

--- a/packages/safegres/src/config/schema.ts
+++ b/packages/safegres/src/config/schema.ts
@@ -18,6 +18,8 @@ import type {
   PublicConfig,
   ReportConfig,
   SafegresConfig,
+  ScorecardConfig,
+  ScorecardSelector,
   ScoringConfig,
   SourceConfig
 } from './types';
@@ -165,6 +167,31 @@ const PERF: Shape<PerfConfig> = {
   paths: obj('Access-path classification, which decides whether X1 applies', PERF_PATHS)
 };
 
+const SCORECARD_SELECT: Shape<ScorecardSelector> = {
+  rules: list('Rule codes or C* prefix wildcards to grade', str('Rule code or wildcard')),
+  exclude: list('Rule codes or wildcards to drop after rules selected', str('Rule code or wildcard')),
+  dimension: str('Which axis: security (default), perf, or all', ['security', 'perf', 'all']),
+  roles: list('Only findings about these roles', str('Role name')),
+  planes: list('Only findings reachable on these access planes', str('Plane name')),
+  schemas: list('Only findings in these schemas', str('Schema name')),
+  direction: str('fail-open leaks, fail-closed denials, or any', ['fail-open', 'fail-closed', 'none', 'any']),
+  minSeverity: str('Drop findings below this severity before scoring', SEVERITIES),
+  exposure: str('exposed (default) grades the API surface; all ignores exposure', ['exposed', 'all']),
+  acknowledged: str('include grades acknowledged findings too. Default skip.', ['skip', 'include']),
+  severities: str(
+    'configured (default) uses this config\u2019s severities; declared uses each rule\u2019s registry default',
+    ['configured', 'declared']
+  ),
+  denominator: str('Density denominator: exposed relations (default) or all', ['exposed', 'all'])
+};
+
+const SCORECARD: Shape<ScorecardConfig> = {
+  ...SCORING,
+  title: str('Heading for reports. Defaults to the config key.'),
+  description: str('What decision this score informs. Rendered with it.'),
+  select: obj('Which findings it grades', SCORECARD_SELECT)
+};
+
 const FAIL_ON_PLANE: Shape<PlaneFailOnConfig> = {
   score: num('Exit non-zero below this plane score'),
   grade: str('Exit non-zero below this plane grade', GRADES)
@@ -180,6 +207,11 @@ const FAIL_ON: Shape<FailOnConfig> = {
     type: 'record',
     description: 'Per-plane gates, keyed by plane name. A floor is the useful shape.',
     values: obj('One plane gate', FAIL_ON_PLANE)
+  },
+  scorecards: {
+    type: 'record',
+    description: 'Per-scorecard gates, keyed by scorecard name.',
+    values: obj('One scorecard gate', FAIL_ON_PLANE)
   }
 };
 
@@ -271,6 +303,11 @@ export const CONFIG_SHAPE: Shape<SafegresConfig> = {
   rules: RULES,
   overrides: list('Per-scope retuning, ESLint overrides-style', obj('One override', OVERRIDE)),
   scoring: obj('The security scoring model', SCORING),
+  scorecards: {
+    type: 'record',
+    description: 'Named scores over slices of the same findings, keyed by name',
+    values: obj('One scorecard', SCORECARD)
+  },
   failOn: obj('Gates \u2014 what makes the run exit non-zero', FAIL_ON),
   source: obj('Where the database to audit comes from', SOURCE),
   outputs: obj('Files a single run writes', OUTPUTS),

--- a/packages/safegres/src/config/types.ts
+++ b/packages/safegres/src/config/types.ts
@@ -1,5 +1,5 @@
 import type { ExposureAdapter } from '../exposure/adapters';
-import type { Severity } from '../types';
+import type { Dimension, Direction, Severity } from '../types';
 
 /**
  * `'off'` disables a rule; a severity retunes it; `[severity, options]`
@@ -172,6 +172,86 @@ export interface ScoringConfig {
 }
 
 /**
+ * A named score over a slice of the findings: a selector plus the weighting
+ * to grade what it selects with. Every scoring key is available per card, so
+ * a scorecard is a full `ScoringConfig` with a question attached.
+ *
+ * The point is that "how secure is this database" is not one question. A
+ * platform team gates on what `anonymous` reaches; an application team gates
+ * on house style; a compliance reviewer wants the number that no preset
+ * softened. Collapsing those into a single grade means at least two of them
+ * are reading a number that does not answer their question — and the first
+ * time it disagrees with their judgement, they stop reading it at all.
+ *
+ * ```jsonc
+ * "scorecards": {
+ *   "anon-surface": {
+ *     "description": "What an unauthenticated caller reaches.",
+ *     "select": { "roles": ["anonymous"], "direction": "fail-open" },
+ *     "perRuleWeights": { "L19": 10 },
+ *     "floorOnCritical": "C"
+ *   },
+ *   "sql-conventions": { "select": { "rules": ["C*"], "exposure": "all" } }
+ * }
+ * ```
+ *
+ * Findings are never filtered by a scorecard — only *scored* by one. The
+ * report always carries every finding, so no configuration of this block can
+ * hide anything; it can only decide what a given number is about.
+ */
+export interface ScorecardConfig extends ScoringConfig {
+  /** Heading for reports. Defaults to the config key. */
+  title?: string;
+  /** What decision this score informs. Rendered with it. */
+  description?: string;
+  /** Which findings it grades. An empty selector grades what the headline does. */
+  select?: ScorecardSelector;
+}
+
+/**
+ * Which findings a scorecard grades. Every clause narrows; omitting one
+ * means "don't care", and an empty selector is the headline's own slice
+ * (exposed, non-acknowledged, security-dimension).
+ */
+export interface ScorecardSelector {
+  /** Rule codes or `C*` prefix wildcards to include. Default: all. */
+  rules?: string[];
+  /** Rule codes or wildcards to drop after `rules` has selected. */
+  exclude?: string[];
+  /** `security` (default), `perf`, or `all` — the two axes in one number. */
+  dimension?: Dimension | 'all';
+  /** Only findings about these roles (the finding's role, grantee, or reach context). */
+  roles?: string[];
+  /** Only findings reachable on these access planes. */
+  planes?: string[];
+  /** Only findings in these schemas. */
+  schemas?: string[];
+  /** `fail-open` leaks, `fail-closed` denials, or `any`. Default: any. */
+  direction?: Direction | 'any';
+  /** Drop findings below this severity before scoring. */
+  minSeverity?: Severity;
+  /**
+   * `exposed` (default) grades only what the API surface reaches; `all`
+   * ignores exposure entirely — the honest, database-to-database number.
+   */
+  exposure?: 'exposed' | 'all';
+  /** `include` grades acknowledged findings too. Default: skip them. */
+  acknowledged?: 'skip' | 'include';
+  /**
+   * `configured` (default) uses the severities this config resolved;
+   * `declared` uses each rule's registry default, so a preset that quiets a
+   * rule cannot quiet the score that is supposed to catch it.
+   */
+  severities?: 'configured' | 'declared';
+  /**
+   * Density denominator: `exposed` relations (default) or `all` of them.
+   * A card that ignores exposure should normalize by everything, or it
+   * divides a wider numerator by a narrower denominator.
+   */
+  denominator?: 'exposed' | 'all';
+}
+
+/**
  * The optional performance dimension: index-hygiene and policy-cost rules
  * (`X*`, plus P1/P1b), scored on their own axis against the same exposure
  * surface. Off by default — `safegres perf` / `--perf` / `enabled: true`.
@@ -317,6 +397,12 @@ export interface FailOnConfig {
    * not become an F.
    */
   planes?: Record<string, PlaneFailOnConfig>;
+  /**
+   * Per-scorecard gates, keyed by scorecard name. This is where a team's own
+   * question becomes its own build failure — `{ "anon-surface": { "grade": "A" } }`
+   * gates on that and nothing else.
+   */
+  scorecards?: Record<string, PlaneFailOnConfig>;
 }
 
 export interface PlaneFailOnConfig {
@@ -455,6 +541,11 @@ export interface SafegresConfig {
   rules?: RulesConfig;
   overrides?: OverrideEntry[];
   scoring?: ScoringConfig;
+  /**
+   * Named scores over slices of the same findings — see `ScorecardConfig`.
+   * Merged with the reserved `default` and `raw` cards, which always run.
+   */
+  scorecards?: Record<string, ScorecardConfig>;
   failOn?: FailOnConfig;
   /** Where the database to audit comes from, when it isn't a live connection. */
   source?: SourceConfig;

--- a/packages/safegres/src/report/markdown.ts
+++ b/packages/safegres/src/report/markdown.ts
@@ -74,6 +74,8 @@ export function renderMarkdown(report: Report, options: RenderMarkdownOptions = 
     );
   }
 
+  if (view.has('scorecards')) out.push(...scorecardSection(view), '');
+
   if (view.has('planes')) out.push(...planeSection(view), '');
 
   out.push(countsTable(report), '');
@@ -158,6 +160,31 @@ export function renderMarkdown(report: Report, options: RenderMarkdownOptions = 
  * working as designed — so they read as context under the headline rather
  * than as a second verdict competing with it.
  */
+/**
+ * The other named scores. Same findings, different questions — which is the
+ * point: a team that gates on `anon-surface` is not being asked to care
+ * about the headline, and `raw` is there so nobody has to trust that the
+ * config was written in good faith.
+ */
+function scorecardSection(view: ReportView): string[] {
+  const out: string[] = [
+    '### Scorecards',
+    '',
+    '_The same findings, scored by question. Nothing here filters the report — '
+      + 'a scorecard decides what a number is *about*, never what is reported._',
+    '',
+    '| Scorecard | Score | Grade | Findings | Question |',
+    '| --- | ---: | --- | ---: | --- |'
+  ];
+  for (const card of view.scorecards) {
+    out.push(
+      `| \`${card.name}\` | ${card.score.value} | **${card.score.grade}** | ${card.findings} `
+        + `| ${card.description ?? card.title ?? ''} |`
+    );
+  }
+  return out;
+}
+
 function planeSection(view: ReportView): string[] {
   const out: string[] = [
     '### Other access planes',

--- a/packages/safegres/src/report/pretty.ts
+++ b/packages/safegres/src/report/pretty.ts
@@ -104,6 +104,10 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
     lines.push('');
   }
 
+  if (view.has('scorecards')) {
+    lines.push(...scorecardLines(view, colorEnabled), '');
+  }
+
   if (view.has('planes')) {
     lines.push(...planeLines(view, colorEnabled), '');
   }
@@ -269,6 +273,26 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
   }
 
   return lines.join('\n');
+}
+
+/**
+ * The other named scores. One line each: the headline answers the question
+ * the preset was written for, and these answer the ones a particular team
+ * actually gates on. `raw` sits among them deliberately — a number no
+ * configuration softened, next to the one that was.
+ */
+function scorecardLines(view: ReportView, colorEnabled: boolean): string[] {
+  const lines = ['scorecards — the same findings, scored by question:'];
+  for (const card of view.scorecards) {
+    const grade = colorEnabled
+      ? gradePaintFor(card.score)(`${card.score.value} (${card.score.grade})`)
+      : `${card.score.value} (${card.score.grade})`;
+    lines.push(
+      `  ${card.name}: ${grade}  — ${card.findings} finding(s)`
+        + (card.description ? `  ${card.description}` : '')
+    );
+  }
+  return lines;
 }
 
 /**

--- a/packages/safegres/src/report/view.ts
+++ b/packages/safegres/src/report/view.ts
@@ -10,6 +10,7 @@
  */
 
 import type { ReportConfig } from '../config/types';
+import type { ScorecardReport } from '../score/scorecards';
 import type { Finding, PlaneReport, Report } from '../types';
 import type { ScoreDelta } from './compare';
 
@@ -18,6 +19,7 @@ export type ViewSection =
   | 'delta'
   | 'findings'
   | 'planes'
+  | 'scorecards'
   | 'role-access'
   | 'call-graph';
 
@@ -26,6 +28,7 @@ export const ALL_SECTIONS: ViewSection[] = [
   'delta',
   'findings',
   'planes',
+  'scorecards',
   'role-access',
   'call-graph'
 ];
@@ -78,6 +81,12 @@ export interface ReportView {
   planes: PlaneReport[];
   /** Planes the view config asked to see in full. */
   expandedPlanes: PlaneReport[];
+  /**
+   * Named scores other than `default`, which is the headline and is already
+   * rendered as the score. Kept in config order so the file decides what a
+   * reader sees first.
+   */
+  scorecards: ScorecardReport[];
   security: ViewFindings;
   perf?: ViewFindings;
   has(section: ViewSection): boolean;
@@ -144,6 +153,8 @@ export function selectView(report: Report, config: ViewConfig = {}): ReportView 
     });
   }
 
+  const scorecards = (report.scorecards ?? []).filter((c) => c.name !== 'default');
+
   const securityAll = report.perf
     ? report.findings.filter((f) => f.dimension !== 'perf')
     : report.findings;
@@ -154,6 +165,7 @@ export function selectView(report: Report, config: ViewConfig = {}): ReportView 
     scores,
     planes: secondary,
     expandedPlanes,
+    scorecards,
     security: partition(securityAll, config),
     ...(report.perf && dimensions.has('perf')
       ? { perf: partition(report.perf.findings, config) }
@@ -165,6 +177,8 @@ export function selectView(report: Report, config: ViewConfig = {}): ReportView 
         return report.comparison != null;
       case 'planes':
         return secondary.length > 0;
+      case 'scorecards':
+        return scorecards.length > 0;
       case 'role-access':
         return (report.roleAccess?.roles.length ?? 0) > 0;
       case 'call-graph':

--- a/packages/safegres/src/score/score.ts
+++ b/packages/safegres/src/score/score.ts
@@ -69,6 +69,13 @@ export interface ScoreContext {
   exposedTables?: number;
   /** Whether an exposure surface was configured/resolved. */
   exposureKnown?: boolean;
+  /**
+   * The caller has already decided which findings count (a scorecard's
+   * selector). Skips the built-in exposure/acknowledgement/meta filtering,
+   * which would otherwise silently overrule a selector that asked for
+   * unexposed findings.
+   */
+  prefiltered?: boolean;
 }
 
 export const DEFAULT_WEIGHTS: Record<Severity, number> = {
@@ -141,7 +148,9 @@ function computeDensityScore(
 
   // Meta findings (e.g. W1) are advisories about the audit itself — the
   // unknown-exposure cap is their penalty, not weighted points.
-  const scorable = findings.filter((f) => f.exposed !== false && !f.acknowledged && f.category !== 'meta');
+  const scorable = context.prefiltered
+    ? findings
+    : findings.filter((f) => f.exposed !== false && !f.acknowledged && f.category !== 'meta');
 
   const exposedTables = Math.max(1, context.exposedTables ?? 1);
 
@@ -264,7 +273,9 @@ function computeWeightedScore(
   const bands = { ...DEFAULT_GRADE_BANDS, ...(config.gradeBands ?? {}) };
   const floor = config.floorOnCritical === undefined ? 'C' : config.floorOnCritical;
 
-  const scorable = findings.filter((f) => f.exposed !== false && !f.acknowledged && f.category !== 'meta');
+  const scorable = context.prefiltered
+    ? findings
+    : findings.filter((f) => f.exposed !== false && !f.acknowledged && f.category !== 'meta');
 
   const byRule = new Map<string, { count: number; points: number }>();
   for (const f of scorable) {

--- a/packages/safegres/src/score/scorecards.ts
+++ b/packages/safegres/src/score/scorecards.ts
@@ -1,0 +1,205 @@
+import type { ScorecardConfig, ScorecardSelector } from '../config/types';
+import { RULES_BY_CODE } from '../rules/registry';
+import { type Finding, type Severity, summarize,type Summary } from '../types';
+import { computeScore, type Score, type ScoreContext } from './score';
+
+/**
+ * One named score over a selected slice of the findings.
+ *
+ * The headline score answers one question well and every other question
+ * badly: a platform team gating on what `anonymous` reaches and an
+ * application team gating on house style are not arguing about the same
+ * number, and forcing them to is how a single number becomes something
+ * nobody trusts. A scorecard is that question, written down — a selector
+ * over the findings plus the weighting to grade them with.
+ */
+export interface ScorecardReport {
+  /** Config key, e.g. `anon-surface`. */
+  name: string;
+  /** Human-readable heading for reports. */
+  title?: string;
+  /**
+   * Why this scorecard exists — what decision it informs. Rendered with the
+   * score, because a number whose question is unstated invites the reader to
+   * supply their own.
+   */
+  description?: string;
+  /** The findings it selected, graded by its own weighting. */
+  score: Score;
+  /** How many findings the selector matched. */
+  findings: number;
+  /** Severity counts over the selected findings. */
+  summary: Summary;
+  /** The resolved selector, so a report explains its own arithmetic. */
+  select: ScorecardSelector;
+  /**
+   * Reserved scorecards safegres computes itself: `default` is the headline
+   * (`report.score`, verbatim) and `raw` is every finding at its declared
+   * severity with no exposure filter. Neither can be redefined into
+   * something flattering.
+   */
+  reserved?: boolean;
+}
+
+export interface ScorecardContext extends ScoreContext {
+  /** Relations on the exposed surface — the default density denominator. */
+  exposedTables?: number;
+  /** Every relation in the audited schemas — the `all` denominator. */
+  totalTables?: number;
+}
+
+/**
+ * The two scorecards every run carries, whatever the config says.
+ *
+ * `raw` is the honest one: no exposure filter, no acknowledgements, no
+ * preset severity retuning, fail-closed findings weighted like anything
+ * else. It is not flattering and it is not meant to be — it is the number
+ * that is comparable between two databases, and the one a preset cannot
+ * talk down.
+ */
+export const RESERVED_SCORECARDS: Record<string, ScorecardConfig> = {
+  default: {
+    title: 'Safegres score',
+    description: 'The headline: exposed, fail-open findings at their configured severities.'
+  },
+  raw: {
+    title: 'Raw score',
+    description:
+      'Every finding at its declared severity, exposure ignored — comparable across databases.',
+    select: {
+      severities: 'declared',
+      exposure: 'all',
+      acknowledged: 'include',
+      denominator: 'all'
+    },
+    failClosedWeight: 1,
+    maxRuleDensity: false
+  }
+};
+
+/**
+ * Grade each configured scorecard. `default` is not recomputed — it is the
+ * headline score passed in, so a scorecard block can never move the number
+ * on the badge by redefining what `default` means.
+ */
+export function computeScorecards(
+  findings: Finding[],
+  headline: Score,
+  cards: Record<string, ScorecardConfig>,
+  context: ScorecardContext
+): ScorecardReport[] {
+  const out: ScorecardReport[] = [];
+  for (const [name, card] of Object.entries(cards)) {
+    const reserved = name in RESERVED_SCORECARDS;
+    const select = { ...(RESERVED_SCORECARDS[name]?.select ?? {}), ...(card.select ?? {}) };
+    if (name === 'default') {
+      out.push({
+        name,
+        ...titleOf(name, card),
+        score: headline,
+        findings: findings.filter((f) => f.exposed !== false && !f.acknowledged).length,
+        summary: summarize(findings.filter((f) => f.exposed !== false && !f.acknowledged)),
+        select,
+        reserved: true
+      });
+      continue;
+    }
+    const selected = selectFindings(findings, select);
+    const denominator = select.denominator === 'all'
+      ? (context.totalTables ?? context.exposedTables)
+      : context.exposedTables;
+    out.push({
+      name,
+      ...titleOf(name, card),
+      score: computeScore(selected, card, {
+        ...context,
+        exposedTables: denominator,
+        // The selector has already decided what counts; scoring must not
+        // filter again, or `exposure: 'all'` would be silently overruled.
+        prefiltered: true
+      }),
+      findings: selected.length,
+      summary: summarize(selected),
+      select,
+      ...(reserved ? { reserved: true } : {})
+    });
+  }
+  return out;
+}
+
+function titleOf(name: string, card: ScorecardConfig): { title?: string; description?: string } {
+  const base = RESERVED_SCORECARDS[name] ?? {};
+  const title = card.title ?? base.title;
+  const description = card.description ?? base.description;
+  return { ...(title ? { title } : {}), ...(description ? { description } : {}) };
+}
+
+/**
+ * The findings a scorecard grades. Every clause is a narrowing filter, so an
+ * empty selector selects what the headline does: exposed, non-acknowledged,
+ * security findings.
+ */
+export function selectFindings(findings: Finding[], select: ScorecardSelector): Finding[] {
+  const dimension = select.dimension ?? 'security';
+  const rules = select.rules?.map(matcher);
+  const exclude = select.exclude?.map(matcher);
+  const roles = select.roles ? new Set(select.roles) : undefined;
+  const planes = select.planes ? new Set(select.planes) : undefined;
+  const schemas = select.schemas ? new Set(select.schemas) : undefined;
+  const severity = select.minSeverity ? SEVERITY_RANK[select.minSeverity] : undefined;
+
+  const selected = findings.filter((f) => {
+    if (f.category === 'meta') return false;
+    if (dimension !== 'all' && (f.dimension ?? 'security') !== dimension) return false;
+    if (select.exposure !== 'all' && f.exposed === false) return false;
+    if (select.acknowledged !== 'include' && f.acknowledged) return false;
+    if (select.direction && select.direction !== 'any' && f.direction !== select.direction) {
+      return false;
+    }
+    if (rules && !rules.some((m) => m(f.code))) return false;
+    if (exclude?.some((m) => m(f.code))) return false;
+    if (schemas && (f.schema === undefined || !schemas.has(f.schema))) return false;
+    if (roles && !touchesRole(f, roles)) return false;
+    if (planes && !f.planes?.some((p) => planes.has(p))) return false;
+    if (severity !== undefined && SEVERITY_RANK[f.severity] < severity) return false;
+    return true;
+  });
+
+  // Declared severities answer "how bad is this really", independent of what
+  // a preset chose to quiet down. Copies, never mutation: the findings in
+  // the report keep the severity the config resolved.
+  return select.severities === 'declared'
+    ? selected.map((f) => {
+      const declared = RULES_BY_CODE.get(f.code)?.defaultSeverity;
+      return declared === undefined || declared === f.severity ? f : { ...f, severity: declared };
+    })
+    : selected;
+}
+
+const SEVERITY_RANK: Record<Severity, number> = {
+  info: 0,
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 4
+};
+
+/**
+ * A role clause asks "is this finding about one of these roles" — which the
+ * finding answers in one of three places: the graded `role` column, a
+ * grantee list, or the reachability context a lattice rule attached.
+ */
+function touchesRole(finding: Finding, roles: Set<string>): boolean {
+  if (finding.role && roles.has(finding.role)) return true;
+  const context = finding.context as { role?: string; roles?: unknown } | undefined;
+  if (context?.role && roles.has(context.role)) return true;
+  return Array.isArray(context?.roles)
+    && context.roles.some((r) => typeof r === 'string' && roles.has(r));
+}
+
+/** Rule code matcher: exact, or a `C*` prefix wildcard. */
+function matcher(pattern: string): (code: string) => boolean {
+  if (!pattern.endsWith('*')) return (code) => code === pattern;
+  const prefix = pattern.slice(0, -1);
+  return (code) => code.startsWith(prefix);
+}

--- a/packages/safegres/src/types.ts
+++ b/packages/safegres/src/types.ts
@@ -265,6 +265,13 @@ export interface Report {
    * into gating.
    */
   planes?: PlaneReport[];
+  /**
+   * Named scores over slices of the same findings (`scorecards` config), the
+   * reserved `default` and `raw` cards first. Different teams gate on
+   * different questions; this is where each one's answer lives, computed
+   * from the one set of findings so they can never disagree about the facts.
+   */
+  scorecards?: import('./score/scorecards').ScorecardReport[];
   /** Effective per-role access, for the configured untrusted roles. */
   roleAccess?: RoleAccessReport;
   /**


### PR DESCRIPTION
## Summary

The score definition was singular and baked in, so "how secure is this database" had exactly one answer and it was right for at most one reader. A **scorecard** makes the definition data: a selector over the findings plus the weighting to grade what it selects. `computeScore` was already pure over `(findings, config)`, so this is a selection layer, not a second scoring engine:

```ts
selectFindings(report.findings, card.select) → computeScore(selected, card, ctx)
```

Findings are never filtered by a scorecard, only *scored* by one — `report.findings` stays the complete set, so the JSON is the raw data and every score is a query over it. Nothing in this block can hide a row.

```jsonc
"scorecards": {
  "anon-surface": {
    "select": { "roles": ["anonymous"], "direction": "fail-open", "exposure": "all" },
    "weights": { "info": 1 }, "floorOnCritical": "C"
  }
},
"failOn": { "scorecards": { "anon-surface": { "grade": "A" } } }
```

Two cards always run and cannot be redefined into something flattering:

- **`default`** — the headline, passed through verbatim. Naming it in the config cannot move the badge (`computeScorecards` takes `headline: Score` and returns it as-is).
- **`raw`** — every finding at its **declared** (registry) severity, exposure ignored, acknowledgements included, `failClosedWeight: 1`, `maxRuleDensity: false`. The number no preset talked down, and the one comparable between two databases.

Selector clauses: `rules` (with `C*` wildcards) / `exclude` / `dimension` / `roles` / `planes` / `schemas` / `direction` / `minSeverity` / `exposure` / `acknowledged` / `severities` / `denominator`. Two are less obvious than they look:

- `severities: 'declared'` re-severities *copies* — the findings in the report keep what the config resolved, so a card cannot mutate the report it reads.
- `denominator: 'all'` normalizes by every relation rather than the exposed ones: a card that widens the numerator (`exposure: 'all'`) and keeps the narrow denominator is penalized for asking a wider question.

`ScoreContext.prefiltered` is the one change to the engine — without it `computeScore`'s built-in exposure/acknowledgement filter would silently overrule a selector that asked for unexposed findings.

The `constructive` preset ships two cards (`anon-surface`, `sql-conventions`), rendered in pretty and markdown output and gateable via `failOn.scorecards`.

## Measured on constructive-db

```
score: 88.9 (B)              — the headline, unchanged by this PR

scorecards — the same findings, scored by question:
  raw:             62.3 (D)  — 2110 findings
  anon-surface:    94.4 (A)  — 857 findings
  sql-conventions: 83.2 (B)  — 159 findings
```

Known understatement, and a follow-up rather than a fix here: `anon-surface` is overwhelmingly a *routine* surface (853 L19 findings over 166 functions), but the density denominator is relations. Dividing routine findings by table count flatters it. A subject-aware denominator is the next step.

## Tests

New `__tests__/scorecards.test.ts` (10 cases): reserved cards always present, `default` immune to redefinition, `raw` ignoring exposure/acknowledgement/preset severities, per-card weights and rule selection, role selection across all three places a finding records a role, plane/schema/direction/severity narrowing, wildcard + exclude, non-mutation, denominator behaviour, cross-dimension selection. Plus a live audit case asserting the report still carries findings the card did not select. 581 tests pass; lint clean (two pre-existing warnings); schema regenerated.

Stacked on #1627 — the routine-exposure/repair-unit scoring fix it builds on.


Link to Devin session: https://app.devin.ai/sessions/ec06ef6eabae4872ae5ec3926f037c85
Requested by: @pyramation