### PR TITLE
feat(safegres): add L21 revocable-grant rule (granted − reachable)

### DIFF
--- a/packages/safegres/__tests__/revocable-grants.test.ts
+++ b/packages/safegres/__tests__/revocable-grants.test.ts
@@ -1,0 +1,274 @@
+import { getConnections, PgTestClient } from 'pgsql-test';
+
+import type { RoleRevocable } from '../src/checks/revocable-grants';
+import { audit } from '../src/commands/audit';
+import { loadConfig } from '../src/config/loader';
+
+jest.setTimeout(300000);
+
+let pg: PgTestClient;
+let teardown: () => Promise<void>;
+
+const { config } = loadConfig({ sealed: true, preset: 'recommended' });
+
+/**
+ * The constructive-db shape: an exposed API schema (`l21_app`) whose policies,
+ * triggers and write-time expressions call check functions living in a private
+ * schema (`l21_priv`) the API does not expose. The private schema is *audited*
+ * — it is in `schemas` — but it is not part of the exposure surface, so its
+ * functions are never direct-call entrypoints: the only way EXECUTE on one is
+ * load-bearing is if a policy/trigger/expression closure lands on it.
+ *
+ * `l21_anon` holds a blanket EXECUTE on every private function, the way
+ * `ALTER DEFAULT PRIVILEGES ... GRANT ALL ON FUNCTIONS TO anonymous` hands it
+ * out. The rule must sort those grants into the ones a path exercises and the
+ * ones nothing does.
+ */
+const SETUP = `
+DROP SCHEMA IF EXISTS l21_app CASCADE;
+DROP SCHEMA IF EXISTS l21_priv CASCADE;
+CREATE SCHEMA l21_app;
+CREATE SCHEMA l21_priv;
+
+DO $$ BEGIN
+  CREATE ROLE l21_anon NOLOGIN;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+DO $$ BEGIN
+  CREATE ROLE l21_owner NOLOGIN;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+GRANT USAGE ON SCHEMA l21_app, l21_priv TO l21_anon, l21_owner;
+
+-- Reached only through perm_check's body — but perm_check is SECURITY DEFINER,
+-- so the closure stops at its boundary and never follows into here. Revocable.
+CREATE FUNCTION l21_priv.definer_inner()
+RETURNS boolean LANGUAGE sql STABLE AS $$ SELECT true $$;
+ALTER FUNCTION l21_priv.definer_inner() OWNER TO l21_owner;
+
+-- The policy predicate. SECURITY DEFINER: l21_anon needs EXECUTE on it
+-- (retained), but not on what its body calls.
+CREATE FUNCTION l21_priv.perm_check(owner_id bigint)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER
+AS $$ SELECT l21_priv.definer_inner() $$;
+ALTER FUNCTION l21_priv.perm_check(bigint) OWNER TO l21_owner;
+
+-- Reached through the trigger body (which runs as l21_anon). Retained.
+CREATE FUNCTION l21_priv.limit_check()
+RETURNS void LANGUAGE plpgsql AS $$ BEGIN RETURN; END; $$;
+ALTER FUNCTION l21_priv.limit_check() OWNER TO l21_owner;
+
+-- An ordinary (SECURITY INVOKER) trigger function. EXECUTE on it is never
+-- checked when the trigger fires, so the grant itself is revocable — but its
+-- body runs as l21_anon, so what it calls (limit_check) is retained.
+CREATE FUNCTION l21_priv.stamp()
+RETURNS trigger LANGUAGE plpgsql
+AS $$ BEGIN PERFORM l21_priv.limit_check(); RETURN NEW; END; $$;
+ALTER FUNCTION l21_priv.stamp() OWNER TO l21_owner;
+
+-- CHECK constraint predicate — runs as the writing role. Retained.
+CREATE FUNCTION l21_priv.valid_body(b text)
+RETURNS boolean LANGUAGE sql IMMUTABLE AS $$ SELECT length(b) >= 0 $$;
+ALTER FUNCTION l21_priv.valid_body(text) OWNER TO l21_owner;
+
+-- Column default expression — runs as the inserting role. Retained.
+CREATE FUNCTION l21_priv.default_owner()
+RETURNS text LANGUAGE sql STABLE AS $$ SELECT 'anon'::text $$;
+ALTER FUNCTION l21_priv.default_owner() OWNER TO l21_owner;
+
+-- Nothing names it anywhere. Revocable.
+CREATE FUNCTION l21_priv.dead_fn()
+RETURNS void LANGUAGE sql AS $$ SELECT $$;
+ALTER FUNCTION l21_priv.dead_fn() OWNER TO l21_owner;
+
+CREATE TABLE l21_app.docs (
+  id bigserial PRIMARY KEY,
+  owner_id bigint NOT NULL,
+  owner text NOT NULL DEFAULT l21_priv.default_owner(),
+  body text NOT NULL CHECK (l21_priv.valid_body(body))
+);
+ALTER TABLE l21_app.docs OWNER TO l21_owner;
+ALTER TABLE l21_app.docs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE l21_app.docs FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY docs_visible ON l21_app.docs
+  FOR SELECT TO l21_anon USING (l21_priv.perm_check(owner_id));
+CREATE POLICY docs_insert ON l21_app.docs
+  FOR INSERT TO l21_anon WITH CHECK (true);
+
+CREATE TRIGGER stamp_docs BEFORE INSERT ON l21_app.docs
+  FOR EACH ROW EXECUTE FUNCTION l21_priv.stamp();
+
+GRANT SELECT, INSERT ON l21_app.docs TO l21_anon;
+GRANT EXECUTE ON FUNCTION
+  l21_priv.definer_inner(),
+  l21_priv.perm_check(bigint),
+  l21_priv.limit_check(),
+  l21_priv.stamp(),
+  l21_priv.valid_body(text),
+  l21_priv.default_owner(),
+  l21_priv.dead_fn()
+TO l21_anon;
+`;
+
+/** The opaque-node schema: a policy predicate that runs dynamic SQL. */
+const SETUP_OPAQUE = `
+DROP SCHEMA IF EXISTS l21o_app CASCADE;
+DROP SCHEMA IF EXISTS l21o_priv CASCADE;
+CREATE SCHEMA l21o_app;
+CREATE SCHEMA l21o_priv;
+
+DO $$ BEGIN
+  CREATE ROLE l21o_anon NOLOGIN;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+DO $$ BEGIN
+  CREATE ROLE l21o_owner NOLOGIN;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+GRANT USAGE ON SCHEMA l21o_app, l21o_priv TO l21o_anon, l21o_owner;
+
+-- The policy predicate runs dynamic SQL: the closure cannot see what it
+-- touches, so every candidate it could plausibly reach must be retained.
+CREATE FUNCTION l21o_priv.opaque_check(owner_id bigint)
+RETURNS boolean LANGUAGE plpgsql STABLE AS $$
+DECLARE ok boolean;
+BEGIN
+  EXECUTE 'SELECT ' || owner_id::text || ' > 0' INTO ok;
+  RETURN ok;
+END;
+$$;
+ALTER FUNCTION l21o_priv.opaque_check(bigint) OWNER TO l21o_owner;
+
+-- Looks dead. Must NOT be reported revocable: the opaque predicate above could
+-- reach it, so it is suppressed, not revoked.
+CREATE FUNCTION l21o_priv.maybe_dead()
+RETURNS void LANGUAGE sql AS $$ SELECT $$;
+ALTER FUNCTION l21o_priv.maybe_dead() OWNER TO l21o_owner;
+
+CREATE TABLE l21o_app.docs (
+  id bigserial PRIMARY KEY,
+  owner_id bigint NOT NULL
+);
+ALTER TABLE l21o_app.docs OWNER TO l21o_owner;
+ALTER TABLE l21o_app.docs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE l21o_app.docs FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY docs_visible ON l21o_app.docs
+  FOR SELECT TO l21o_anon USING (l21o_priv.opaque_check(owner_id));
+
+GRANT SELECT ON l21o_app.docs TO l21o_anon;
+GRANT EXECUTE ON FUNCTION
+  l21o_priv.opaque_check(bigint),
+  l21o_priv.maybe_dead()
+TO l21o_anon;
+`;
+
+beforeAll(async () => {
+  ({ pg, teardown } = await getConnections());
+  await pg.any(SETUP);
+  await pg.any(SETUP_OPAQUE);
+});
+
+afterAll(async () => {
+  if (teardown) await teardown();
+});
+
+function objects(grants: Array<{ schema: string; object: string }>): string[] {
+  return grants.map((g) => `${g.schema}.${g.object}`).sort();
+}
+
+function reasonsFor(role: RoleRevocable, object: string): string[] {
+  const key = object.split('.');
+  const hit = role.retained.find((g) => g.schema === key[0] && g.object === key[1]);
+  return hit ? hit.reasons : [];
+}
+
+describe('L21 revocable grants — reachability closure', () => {
+  it('separates revocable grants from the paths that retain them', async () => {
+    const report = await audit(pg.client, {
+      config,
+      schemas: ['l21_app', 'l21_priv'],
+      exposure: {
+        schemas: ['l21_app'],
+        roles: ['l21_anon'],
+        anonRoles: ['l21_anon']
+      },
+      perf: false,
+      sealed: true,
+      preset: 'recommended'
+    });
+
+    const role = report.revocableGrants?.roles.find((r) => r.role === 'l21_anon');
+    expect(role).toBeDefined();
+    if (!role) return;
+
+    // Nothing opaque here — the analysis is complete.
+    expect(role.taint).toEqual([]);
+    expect(role.suppressed).toEqual([]);
+
+    // Revocable: the trigger function (its EXECUTE is never checked), the
+    // function behind a SECURITY DEFINER boundary, and the genuinely dead one.
+    expect(objects(role.revocable)).toEqual([
+      'l21_priv.dead_fn',
+      'l21_priv.definer_inner',
+      'l21_priv.stamp'
+    ]);
+
+    // Retained, each by the path that proves it load-bearing.
+    expect(objects(role.retained)).toEqual([
+      'l21_priv.default_owner',
+      'l21_priv.limit_check',
+      'l21_priv.perm_check',
+      'l21_priv.valid_body'
+    ]);
+    expect(reasonsFor(role, 'l21_priv.perm_check')).toEqual(['policy-predicate']);
+    expect(reasonsFor(role, 'l21_priv.limit_check')).toEqual(['trigger']);
+    expect(reasonsFor(role, 'l21_priv.valid_body')).toEqual(['check-constraint']);
+    expect(reasonsFor(role, 'l21_priv.default_owner')).toEqual(['default-expression']);
+
+    expect(role.summary.retainedByPolicy).toBe(1);
+    expect(role.summary.retainedByTrigger).toBe(1);
+
+    // The finding stream carries one L21 per revocable grant, never for a
+    // retained one.
+    const l21 = report.findings.filter((f) => f.code === 'L21');
+    expect(l21.map((f) => `${f.schema}.${f.table}`).sort()).toEqual([
+      'l21_priv.dead_fn',
+      'l21_priv.definer_inner',
+      'l21_priv.stamp'
+    ]);
+    expect(l21.every((f) => f.severity === 'info')).toBe(true);
+  });
+
+  it('suppresses — never revokes — behind an opaque node, and records why', async () => {
+    const report = await audit(pg.client, {
+      config,
+      schemas: ['l21o_app', 'l21o_priv'],
+      exposure: {
+        schemas: ['l21o_app'],
+        roles: ['l21o_anon'],
+        anonRoles: ['l21o_anon']
+      },
+      perf: false,
+      sealed: true,
+      preset: 'recommended'
+    });
+
+    const role = report.revocableGrants?.roles.find((r) => r.role === 'l21o_anon');
+    expect(role).toBeDefined();
+    if (!role) return;
+
+    // The dynamic-SQL predicate is recorded as the reason the closure is
+    // incomplete.
+    expect(role.taint.length).toBeGreaterThan(0);
+    expect(role.taint.some((t) => /dynamic SQL/i.test(t.reason))).toBe(true);
+
+    // maybe_dead is not proven unused — it is suppressed, not revoked.
+    expect(objects(role.suppressed)).toContain('l21o_priv.maybe_dead');
+    expect(role.revocable).toEqual([]);
+    expect(report.findings.filter((f) => f.code === 'L21')).toEqual([]);
+  });
+});

--- a/packages/safegres/corpus/cases/52-revocable-execute-grant/case.json
+++ b/packages/safegres/corpus/cases/52-revocable-execute-grant/case.json
@@ -1,0 +1,30 @@
+{
+  "title": "A role holds EXECUTE on a trigger function it can neither call nor fire — revocable",
+  "dimension": "security",
+  "exposure": {
+    "schemas": [
+      "c_revocable"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [
+    {
+      "code": "L21",
+      "relation": "c_revocable.stamp_created_by",
+      "role": "corpus_anon",
+      "note": "corpus_anon's EXECUTE arrives from a blanket default-privileges grant, but the reachability closure never lands on the function: a trigger function is not directly callable, and corpus_anon holds no write grant on `events` to fire the trigger. Granted minus reachable is non-empty, so the grant is revocable."
+    }
+  ],
+  "forbid": [
+    "L19",
+    "L20"
+  ],
+  "fix": "REVOKE EXECUTE ON FUNCTION c_revocable.stamp_created_by() FROM corpus_anon. No path exercises the grant — corpus_anon cannot call a trigger function directly, and cannot fire the trigger without a write grant on c_revocable.events — so dropping it changes nothing corpus_anon can do.",
+  "id": "52-revocable-execute-grant"
+}

--- a/packages/safegres/corpus/cases/52-revocable-execute-grant/schema.sql
+++ b/packages/safegres/corpus/cases/52-revocable-execute-grant/schema.sql
@@ -1,0 +1,45 @@
+DROP SCHEMA IF EXISTS c_revocable CASCADE;
+CREATE SCHEMA c_revocable;
+
+DO $$ BEGIN
+  CREATE ROLE c_revocable_owner NOLOGIN;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+GRANT USAGE ON SCHEMA c_revocable TO corpus_anon, corpus_user, c_revocable_owner;
+
+CREATE TABLE c_revocable.events (
+  id bigserial PRIMARY KEY,
+  body text NOT NULL
+);
+ALTER TABLE c_revocable.events OWNER TO c_revocable_owner;
+ALTER TABLE c_revocable.events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_revocable.events FORCE ROW LEVEL SECURITY;
+
+-- corpus_anon may read, nothing more.
+CREATE POLICY events_read ON c_revocable.events
+  FOR SELECT TO corpus_anon USING (id > 0);
+GRANT SELECT ON c_revocable.events TO corpus_anon;
+
+-- A SECURITY DEFINER trigger function. It fires only on write, and corpus_anon
+-- holds no write grant on `events`, so it can never make the trigger run. A
+-- trigger function is not directly callable either: Postgres refuses a direct
+-- call however wide its EXECUTE ACL is.
+CREATE FUNCTION c_revocable.stamp_created_by()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN NEW;
+END;
+$$;
+ALTER FUNCTION c_revocable.stamp_created_by() OWNER TO c_revocable_owner;
+
+CREATE TRIGGER stamp_created_by BEFORE INSERT ON c_revocable.events
+  FOR EACH ROW EXECUTE FUNCTION c_revocable.stamp_created_by();
+
+-- The blanket grant: corpus_anon gets EXECUTE the way a schema created with
+-- `ALTER DEFAULT PRIVILEGES ... GRANT ALL ON FUNCTIONS TO anonymous` hands it
+-- out. corpus_anon now holds EXECUTE on a trigger function it can neither call
+-- nor fire — a grant `granted − reachable` should prove revocable.
+GRANT EXECUTE ON FUNCTION c_revocable.stamp_created_by() TO corpus_anon;

--- a/packages/safegres/corpus/cases/53-policy-predicate-retains-execute/case.json
+++ b/packages/safegres/corpus/cases/53-policy-predicate-retains-execute/case.json
@@ -1,0 +1,23 @@
+{
+  "title": "A grant that looks dead but is reached through an RLS policy predicate — retained, not revocable",
+  "dimension": "security",
+  "exposure": {
+    "schemas": [
+      "c_policy_reach",
+      "c_policy_priv"
+    ],
+    "roles": [
+      "corpus_anon",
+      "corpus_user"
+    ],
+    "anonRoles": [
+      "corpus_anon"
+    ]
+  },
+  "expect": [],
+  "forbid": [
+    "L21"
+  ],
+  "fix": "Do not revoke. corpus_anon's EXECUTE on c_policy_priv.can_read(bigint) is exercised by the docs_visible policy predicate on every read of c_policy_reach.docs, which evaluates as the querying role. Revoking it makes the policy raise `permission denied for function can_read` and fails authorization closed for every anonymous read — the load-bearing grant the rule is built to protect.",
+  "id": "53-policy-predicate-retains-execute"
+}

--- a/packages/safegres/corpus/cases/53-policy-predicate-retains-execute/schema.sql
+++ b/packages/safegres/corpus/cases/53-policy-predicate-retains-execute/schema.sql
@@ -1,0 +1,49 @@
+DROP SCHEMA IF EXISTS c_policy_reach CASCADE;
+DROP SCHEMA IF EXISTS c_policy_priv CASCADE;
+CREATE SCHEMA c_policy_reach;
+CREATE SCHEMA c_policy_priv;
+
+DO $$ BEGIN
+  CREATE ROLE c_policy_owner NOLOGIN;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- corpus_anon can reach the API schema, but holds no USAGE on the private one —
+-- exactly the constructive-db shape, where the `*_private` schemas hold the
+-- check functions the policies call. The private schema is still audited (it is
+-- in scope), it is simply not part of the surface corpus_anon addresses.
+GRANT USAGE ON SCHEMA c_policy_reach TO corpus_anon, c_policy_owner;
+GRANT USAGE ON SCHEMA c_policy_priv TO c_policy_owner;
+
+CREATE TABLE c_policy_reach.docs (
+  id bigserial PRIMARY KEY,
+  owner_id bigint NOT NULL,
+  body text NOT NULL
+);
+ALTER TABLE c_policy_reach.docs OWNER TO c_policy_owner;
+ALTER TABLE c_policy_reach.docs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE c_policy_reach.docs FORCE ROW LEVEL SECURITY;
+
+-- The load-bearing check. It looks dead: corpus_anon never calls it, holds no
+-- USAGE on its schema, and no ACL on `docs` names it. But it is the SELECT
+-- policy's predicate, which evaluates as corpus_anon on every read of `docs`.
+CREATE FUNCTION c_policy_priv.can_read(owner_id bigint)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT owner_id = NULLIF(current_setting('app.uid', true), '')::bigint;
+$$;
+ALTER FUNCTION c_policy_priv.can_read(bigint) OWNER TO c_policy_owner;
+
+CREATE POLICY docs_visible ON c_policy_reach.docs
+  FOR SELECT TO corpus_anon
+  USING (c_policy_priv.can_read(owner_id));
+
+GRANT SELECT ON c_policy_reach.docs TO corpus_anon;
+
+-- The blanket grant again: corpus_anon holds EXECUTE on the private check
+-- function. `granted − reachable` must NOT report it revocable — the policy
+-- predicate is a reachable path, and losing EXECUTE would break authorization
+-- silently, for every anonymous read. This is the case the rule exists for.
+GRANT EXECUTE ON FUNCTION c_policy_priv.can_read(bigint) TO corpus_anon;

--- a/packages/safegres/src/checks/revocable-grants.ts
+++ b/packages/safegres/src/checks/revocable-grants.ts
@@ -1,0 +1,493 @@
+/**
+ * L21: `granted − reachable`, the revocable-grant rule.
+ *
+ * For a role R, {@link analyzeRevocableGrants} computes the set of EXECUTE
+ * grants R holds that no path can exercise, so a human never has to guess which
+ * of R's grants are safe to drop. It is the reachability proof the rest of the
+ * L-series only approximates: L1 asks whether an indirect *relation* grant is
+ * admitted by current policy coverage, L3 asks whether an object grant is
+ * blocked by missing schema USAGE, and L6 suppresses an unaddressable relation
+ * finding whenever a policy predicate merely *names* the relation. L21 asks the
+ * broader question — "can this grant be exercised at all?" — across object
+ * kinds and every execution path a grant can travel, and only claims a grant
+ * revocable when it can prove the answer is no.
+ *
+ * Reach(R) is closed over, at minimum:
+ *
+ *   1. **Direct call targets** — functions in an exposed schema R can EXECUTE
+ *      and reach through schema USAGE.
+ *   2. **RLS policy predicates.** For every policy on a relation R can address,
+ *      the `USING`/`WITH CHECK` expressions and the functions and relations
+ *      they name, closed over transitively. These evaluate as R.
+ *   3. **Trigger bodies.** For every ordinary trigger on a relation R can
+ *      write, the trigger function's body — when it is not SECURITY DEFINER,
+ *      it runs as R. (EXECUTE on the trigger function itself is *not* reach:
+ *      Postgres never checks it when firing a trigger, so such a grant is
+ *      genuinely revocable, which is the whole point of the constructive-db
+ *      audit.)
+ *   4. **Write-time expressions** — column defaults, generated columns and
+ *      CHECK constraints on relations R can insert into or update. They run as
+ *      the writing role.
+ *   5. **Views and their bodies**, so a grant exercised only through an
+ *      `security_invoker` view survives.
+ *
+ * A SECURITY DEFINER boundary **stops** the closure: inside it the owner's
+ * privileges apply, not R's, so R needs EXECUTE on the definer function
+ * (retained) but not on anything the body goes on to call.
+ *
+ * **Fail-closed, bounded by USAGE.** Nothing is reported revocable that the
+ * analysis cannot prove unused. If any node reached as R runs SQL this analysis
+ * cannot read — dynamic `EXECUTE`, a body that fails to parse, a C/internal
+ * function — the role's closure is incomplete: that opaque node, running as R,
+ * could construct a call to any function R can *actually name and execute*. But
+ * Postgres still enforces schema USAGE at call time, so an opaque node running
+ * as R can only reach functions in schemas R holds USAGE on. A candidate whose
+ * schema R cannot even name is therefore out of an opaque node's reach: it can
+ * only be exercised through a reference this analysis *does* follow (a policy
+ * predicate, trigger body, write-time expression or view), so if none landed on
+ * it, it is revocable. Only unreached candidates in a USAGE-reachable schema are
+ * moved from `revocable` to `suppressed`, with the reason recorded. This is what
+ * lets the constructive-db audit prove the blanket EXECUTE on private-schema
+ * functions revocable — anonymous cannot name those schemas — while never
+ * revoking a grant an opaque node could plausibly exercise.
+ */
+
+import { extractBody, extractQuery } from '../callgraph/extract';
+import type { SchemaAclInfo } from '../pg/acl';
+import type { FunctionSnapshot } from '../pg/functions';
+import type { ViewSnapshot } from '../pg/indexes';
+import type { PgPrivilege, TableSnapshot } from '../pg/introspect';
+import type { ReachInputs } from '../pg/reach-inputs';
+import type { Finding } from '../types';
+import { effectiveExecute, effectiveGrants, type GrantVia, type RoleGraph } from './lattice';
+
+/** Which execution path retained a grant — the proof a human reviews. */
+export type RetainReason =
+  | 'direct-call'
+  | 'policy-predicate'
+  | 'trigger'
+  | 'default-expression'
+  | 'generated-column'
+  | 'check-constraint'
+  | 'view';
+
+/** A `(role, object, kind)` grant, the machine-consumable unit of the rule. */
+export interface GrantTuple {
+  role: string;
+  schema: string;
+  object: string;
+  /** Argument signature, for the function overload the grant is on. */
+  args: string;
+  kind: 'function';
+  privilege: 'EXECUTE';
+  /** How R comes to hold it — `direct` or `member of <role>` (never PUBLIC). */
+  via: GrantVia;
+}
+
+/** A grant the analysis proved reachable, with the path(s) that retained it. */
+export interface RetainedGrant extends GrantTuple {
+  reasons: RetainReason[];
+  proof: string[];
+}
+
+/** A grant the analysis could not prove unused, and why. */
+export interface SuppressedGrant extends GrantTuple {
+  reason: string;
+}
+
+/** A node in R's closure that ran SQL the analysis could not read. */
+export interface TaintNode {
+  node: string;
+  reason: string;
+}
+
+export interface RoleRevocable {
+  role: string;
+  summary: {
+    candidates: number;
+    revocable: number;
+    retained: number;
+    retainedByPolicy: number;
+    retainedByTrigger: number;
+    suppressed: number;
+  };
+  /** Grants that can be dropped without changing what R can do. */
+  revocable: GrantTuple[];
+  /** Grants that must be kept, each with the path(s) proving it load-bearing. */
+  retained: RetainedGrant[];
+  /** Grants left retained only because the closure was incomplete. */
+  suppressed: SuppressedGrant[];
+  /** The opaque nodes that forced the suppressions above. */
+  taint: TaintNode[];
+}
+
+export interface RevocableGrantsReport {
+  roles: RoleRevocable[];
+}
+
+export interface RevocableGrantsInput {
+  roles: string[];
+  functions: FunctionSnapshot[];
+  tables: TableSnapshot[];
+  views: ViewSnapshot[];
+  graph: RoleGraph;
+  schemaAcls: Map<string, SchemaAclInfo>;
+  reachInputs: ReachInputs;
+  /** Schemas the exposed API surface can reach; empty when the surface is unknown. */
+  exposedSchemas: Set<string>;
+  /** True when an exposure surface was resolved — otherwise all schemas are reachable. */
+  exposureKnown: boolean;
+  /** Relations the generated API declares it cannot address (`schema.table`). */
+  unaddressable: Set<string>;
+}
+
+const WRITE_PRIVILEGES: PgPrivilege[] = ['INSERT', 'UPDATE', 'DELETE'];
+const ACCESS_PRIVILEGES: PgPrivilege[] = ['SELECT', 'INSERT', 'UPDATE', 'DELETE'];
+/** Languages whose bodies can be read; anything else is opaque for this rule. */
+const READABLE_LANGUAGES = new Set(['sql', 'plpgsql']);
+
+/**
+ * The revocable, retained and suppressed EXECUTE grants for each configured
+ * role. One reachability closure is walked per role; the candidate set is R's
+ * own EXECUTE grants (direct or inherited — a grant TO PUBLIC is not R's to
+ * revoke on its own, so it is never a candidate).
+ */
+export async function analyzeRevocableGrants(
+  input: RevocableGrantsInput
+): Promise<RevocableGrantsReport> {
+  const functionsByName = new Map<string, FunctionSnapshot[]>();
+  for (const fn of input.functions) {
+    const key = `${fn.schema}.${fn.name}`;
+    functionsByName.set(key, [...(functionsByName.get(key) ?? []), fn]);
+  }
+  const tablesByKey = new Map(input.tables.map((t) => [`${t.schema}.${t.name}`, t]));
+  const viewsByKey = new Map(input.views.map((v) => [`${v.schema}.${v.name}`, v]));
+
+  const roles: RoleRevocable[] = [];
+  for (const role of input.roles) {
+    roles.push(
+      await analyzeRole(role, input, { functionsByName, tablesByKey, viewsByKey })
+    );
+  }
+  return { roles };
+}
+
+interface Indexes {
+  functionsByName: Map<string, FunctionSnapshot[]>;
+  tablesByKey: Map<string, TableSnapshot>;
+  viewsByKey: Map<string, ViewSnapshot>;
+}
+
+async function analyzeRole(
+  role: string,
+  input: RevocableGrantsInput,
+  idx: Indexes
+): Promise<RoleRevocable> {
+  const { graph, schemaAcls, reachInputs, functions, tables, views } = input;
+
+  const fnId = (fn: FunctionSnapshot): string => `${fn.schema}.${fn.name}(${fn.args})`;
+
+  const reached = new Map<string, { reasons: Set<RetainReason>; proof: string }>();
+  const taint: TaintNode[] = [];
+  const framesWalked = new Set<string>();
+  const viewsWalked = new Set<string>();
+  const relationsClosed = new Set<string>();
+
+  const resolve = (ref: { schema?: string; name: string }, contextSchema: string): FunctionSnapshot[] =>
+    idx.functionsByName.get(`${ref.schema ?? contextSchema}.${ref.name}`) ?? [];
+
+  const hasUsage = (schema: string): boolean => {
+    const acl = schemaAcls.get(schema);
+    if (!acl) return true; // schema not introspected — assume reachable, never revoke on a guess
+    if (role === acl.owner) return true;
+    const usage = new Set(acl.grants.filter((g) => g.privilege === 'USAGE').map((g) => g.role));
+    if (usage.has('PUBLIC') || usage.has(role)) return true;
+    const ancestors = graph.get(role)?.inheritsFrom ?? [];
+    return ancestors.some((a) => usage.has(a) || a === acl.owner);
+  };
+
+  const markReached = (fn: FunctionSnapshot, reason: RetainReason, proof: string): void => {
+    const id = fnId(fn);
+    const entry = reached.get(id);
+    if (entry) entry.reasons.add(reason);
+    else reached.set(id, { reasons: new Set([reason]), proof });
+  };
+
+  // `readBody` re-classifies C/internal (and any other non-SQL) function as
+  // opaque. `extractBody` treats those as known-empty for the call graph,
+  // which is safe there but would let this rule prove a grant unused off a
+  // body it never read — the one thing it must not do.
+  const readBody = async (fn: FunctionSnapshot): ReturnType<typeof extractBody> => {
+    if (!READABLE_LANGUAGES.has(fn.language)) {
+      return {
+        calls: [],
+        tables: [],
+        settings: [],
+        opaque: true,
+        opaqueReason: `language "${fn.language}" is not statically analyzable`
+      };
+    }
+    return extractBody(fn);
+  };
+
+  // A function body running as R: its callees run as R too, so each is a grant
+  // R must hold. The function itself is marked reached by its caller, not here.
+  const walkFrame = async (fn: FunctionSnapshot, reason: RetainReason, proof: string): Promise<void> => {
+    const id = fnId(fn);
+    if (framesWalked.has(id)) return;
+    framesWalked.add(id);
+    const body = await readBody(fn);
+    if (body.opaque) {
+      taint.push({ node: id, reason: body.opaqueReason ?? 'body could not be read' });
+      return;
+    }
+    if (body.tainted) taint.push({ node: id, reason: body.tainted });
+    for (const call of body.calls) {
+      for (const callee of resolve(call, fn.schema)) {
+        await seedFunction(callee, reason, `${proof} → ${fnId(callee)}`);
+      }
+    }
+  };
+
+  // R invokes `fn` as itself: R needs EXECUTE on it (retained). Follow the body
+  // only when it runs as R — a SECURITY DEFINER boundary stops the closure.
+  const seedFunction = async (fn: FunctionSnapshot, reason: RetainReason, proof: string): Promise<void> => {
+    markReached(fn, reason, proof);
+    if (!fn.isSecurityDefiner) await walkFrame(fn, reason, proof);
+  };
+
+  // A standalone SQL expression evaluated as R: a policy predicate, a column
+  // default, a CHECK. Wrapped in `SELECT` so the parser accepts a bare
+  // expression; the functions it calls and the relations it reads close over.
+  const seedExpr = async (
+    exprSql: string,
+    reason: RetainReason,
+    contextSchema: string,
+    proof: string
+  ): Promise<void> => {
+    const parsed = await extractQuery(`SELECT ${exprSql}`);
+    if (parsed.opaque) {
+      taint.push({ node: proof, reason: parsed.opaqueReason ?? 'expression could not be read' });
+      return;
+    }
+    if (parsed.tainted) taint.push({ node: proof, reason: parsed.tainted });
+    for (const call of parsed.calls) {
+      for (const callee of resolve(call, contextSchema)) {
+        await seedFunction(callee, reason, `${proof} → ${fnId(callee)}`);
+      }
+    }
+    for (const t of parsed.tables) {
+      await closeRelationPolicies(`${t.schema ?? contextSchema}.${t.name}`, reason);
+    }
+  };
+
+  // The policies of a relation read within a running-as-R context also run as
+  // R, so their predicates close over too — this is the load-bearing path the
+  // constructive-db audit is about.
+  const closeRelationPolicies = async (relKey: string, reason: RetainReason): Promise<void> => {
+    if (relationsClosed.has(relKey)) return;
+    relationsClosed.add(relKey);
+    const table = idx.tablesByKey.get(relKey);
+    if (!table) return;
+    for (const p of table.policies) {
+      if (p.using) await seedExpr(p.using, reason, table.schema, `policy ${p.name} USING on ${relKey}`);
+      if (p.withCheck) {
+        await seedExpr(p.withCheck, reason, table.schema, `policy ${p.name} WITH CHECK on ${relKey}`);
+      }
+    }
+  };
+
+  const walkView = async (view: ViewSnapshot, reason: RetainReason): Promise<void> => {
+    const key = `${view.schema}.${view.name}`;
+    if (viewsWalked.has(key)) return;
+    viewsWalked.add(key);
+    if (!view.securityInvoker) return; // definer view: body runs as the owner
+    const parsed = await extractQuery(view.definition);
+    if (parsed.opaque) {
+      taint.push({ node: key, reason: parsed.opaqueReason ?? 'view body could not be read' });
+      return;
+    }
+    if (parsed.tainted) taint.push({ node: key, reason: parsed.tainted });
+    for (const call of parsed.calls) {
+      for (const callee of resolve(call, view.schema)) {
+        await seedFunction(callee, reason, `view ${key} → ${fnId(callee)}`);
+      }
+    }
+    for (const t of parsed.tables) {
+      const tk = `${t.schema ?? view.schema}.${t.name}`;
+      await closeRelationPolicies(tk, reason);
+      const nested = idx.viewsByKey.get(tk);
+      if (nested) await walkView(nested, reason);
+    }
+  };
+
+  const reachable = (schema: string): boolean =>
+    !input.exposureKnown || input.exposedSchemas.has(schema);
+
+  // 1. Direct call entrypoints.
+  for (const fn of functions) {
+    if (fn.returnsTrigger) continue; // not directly callable, whatever its ACL
+    if (!reachable(fn.schema)) continue;
+    if (effectiveExecute(fn, role, graph) === null) continue;
+    if (!hasUsage(fn.schema)) continue;
+    await seedFunction(fn, 'direct-call', `direct EXECUTE entrypoint ${fnId(fn)}`);
+  }
+
+  // 2/3/4. Per-relation closures: policy predicates, trigger bodies and
+  // write-time expressions, for the relations R can actually address.
+  for (const table of tables) {
+    const key = `${table.schema}.${table.name}`;
+    if (input.exposureKnown && input.unaddressable.has(key)) continue;
+    if (!hasUsage(table.schema)) continue;
+    const held = new Set(effectiveGrants(table, role, graph).map((g) => g.privilege));
+    if (!ACCESS_PRIVILEGES.some((p) => held.has(p))) continue;
+
+    await closeRelationPolicies(key, 'policy-predicate');
+
+    const writes = WRITE_PRIVILEGES.filter((p) => held.has(p));
+    if (writes.length === 0) continue;
+
+    for (const trig of reachInputs.triggers.get(key) ?? []) {
+      if (trig.instead) continue; // INSTEAD OF is a view trigger, reached via walkView
+      if (!trig.events.some((e) => writes.includes(e))) continue;
+      for (const fn of resolve({ schema: trig.functionSchema, name: trig.functionName }, trig.functionSchema)) {
+        // EXECUTE on the trigger function is never needed; only what its body
+        // calls, and only when the body runs as R (not SECURITY DEFINER).
+        if (!fn.isSecurityDefiner) {
+          await walkFrame(fn, 'trigger', `trigger ${trig.name} on ${key} → ${fnId(fn)}`);
+        }
+      }
+    }
+
+    for (const expr of reachInputs.expressions.get(key) ?? []) {
+      const reason: RetainReason =
+        expr.kind === 'check' ? 'check-constraint'
+          : expr.kind === 'generated' ? 'generated-column'
+            : 'default-expression';
+      await seedExpr(expr.expr, reason, table.schema, `${reason} ${expr.name} on ${key}`);
+    }
+  }
+
+  // 5. Views R can read (or write): an invoker view's body runs as R.
+  for (const view of views) {
+    if (view.materialized) continue;
+    if (!reachable(view.schema)) continue;
+    if (!hasUsage(view.schema)) continue;
+    const held = new Set(effectiveGrants({ grants: view.grants }, role, graph).map((g) => g.privilege));
+    if (!ACCESS_PRIVILEGES.some((p) => held.has(p))) continue;
+    await walkView(view, 'view');
+  }
+
+  return classify(role, functions, graph, fnId, reached, taint, hasUsage);
+}
+
+function classify(
+  role: string,
+  functions: FunctionSnapshot[],
+  graph: RoleGraph,
+  fnId: (fn: FunctionSnapshot) => string,
+  reached: Map<string, { reasons: Set<RetainReason>; proof: string }>,
+  taint: TaintNode[],
+  hasUsage: (schema: string) => boolean
+): RoleRevocable {
+  const revocable: GrantTuple[] = [];
+  const retained: RetainedGrant[] = [];
+  const suppressed: SuppressedGrant[] = [];
+  // An opaque node reached as R can construct a dynamic call to any function R
+  // can name — but only in a schema R holds USAGE on. Candidates outside those
+  // schemas are beyond its reach, so opacity does not protect them.
+  const opaqueReached = taint.length > 0;
+
+  for (const fn of functions) {
+    const via = effectiveExecute(fn, role, graph);
+    if (via === null || via === 'PUBLIC') continue; // not a grant R can revoke on its own
+    const tuple: GrantTuple = {
+      role,
+      schema: fn.schema,
+      object: fn.name,
+      args: fn.args,
+      kind: 'function',
+      privilege: 'EXECUTE',
+      via
+    };
+    const hit = reached.get(fnId(fn));
+    if (hit) {
+      retained.push({ ...tuple, reasons: [...hit.reasons].sort(), proof: [hit.proof] });
+    } else if (opaqueReached && hasUsage(fn.schema)) {
+      suppressed.push({
+        ...tuple,
+        reason:
+          'analysis incomplete — an opaque node reached as this role could construct a dynamic call '
+          + 'to any function in a schema the role holds USAGE on, including this one, so the grant '
+          + 'cannot be proven unused'
+      });
+    } else {
+      revocable.push(tuple);
+    }
+  }
+
+  const byReason = (r: RetainReason): number =>
+    retained.filter((g) => g.reasons.includes(r)).length;
+
+  return {
+    role,
+    summary: {
+      candidates: revocable.length + retained.length + suppressed.length,
+      revocable: revocable.length,
+      retained: retained.length,
+      retainedByPolicy: byReason('policy-predicate'),
+      retainedByTrigger: byReason('trigger'),
+      suppressed: suppressed.length
+    },
+    revocable: sortTuples(revocable),
+    retained: sortTuples(retained),
+    suppressed: sortTuples(suppressed),
+    taint
+  };
+}
+
+function sortTuples<T extends GrantTuple>(tuples: T[]): T[] {
+  return [...tuples].sort((a, b) =>
+    `${a.schema}.${a.object}(${a.args})`.localeCompare(`${b.schema}.${b.object}(${b.args})`)
+  );
+}
+
+/**
+ * L21 findings: one per revocable grant. The proof of every *retained* grant
+ * lives in `report.revocableGrants`, not in the finding stream — a retained
+ * grant is not a problem, and the finding stream is problems. The revocable
+ * recommendation carries its own tuple in `context` so a caller can act on it
+ * without re-deriving it.
+ */
+export function revocableGrantFindings(report: RevocableGrantsReport): Finding[] {
+  const out: Finding[] = [];
+  for (const role of report.roles) {
+    for (const g of role.revocable) {
+      const object = `${g.schema}.${g.object}(${g.args})`;
+      out.push({
+        code: 'L21',
+        severity: 'info',
+        category: 'coverage',
+        schema: g.schema,
+        table: g.object,
+        role: g.role,
+        privilege: 'EXECUTE',
+        message:
+          `Role ${g.role} holds EXECUTE on ${object} (${g.via}) but no reachable path exercises it — `
+          + 'the grant is revocable',
+        hint:
+          'The reachability closure — direct calls, RLS policy predicates, trigger bodies, write-time '
+          + 'expressions and the views this role can reach — never lands on this function, so revoking '
+          + 'EXECUTE from the role changes nothing it can do. Review `report.revocableGrants` for the '
+          + 'retained grants and their proof paths before applying a batch revoke.',
+        context: {
+          object,
+          kind: g.kind,
+          via: g.via,
+          revocable: true
+        }
+      });
+    }
+  }
+  return out;
+}

--- a/packages/safegres/src/commands/audit.ts
+++ b/packages/safegres/src/commands/audit.ts
@@ -59,6 +59,11 @@ import {
   type PredicateColumn
 } from '../checks/policy-index';
 import {
+  analyzeRevocableGrants,
+  revocableGrantFindings,
+  type RevocableGrantsReport
+} from '../checks/revocable-grants';
+import {
   checkGrantsWithoutRls,
   checkRlsEnabledNoPolicies,
   checkRlsNotForced
@@ -97,6 +102,7 @@ import { asExecutor, type IntrospectOptions, introspectTables, type QueryExecuto
 import { introspectObjectAcls } from '../pg/objects';
 import { type AccessPath, classifyPaths } from '../pg/paths';
 import { lookupVolatility, type ProcVolatility } from '../pg/proc';
+import { introspectReachInputs } from '../pg/reach-inputs';
 import { listAuditableRoles, resolveRoles } from '../pg/roles';
 import { introspectStats, type StatsSnapshot } from '../pg/stats';
 import { dimensionOf, RULES_BY_CODE } from '../rules/registry';
@@ -325,6 +331,17 @@ export async function audit(
     resolved.rules.get('L17')?.options as LatticeRoleOptions,
     exposure
   )?.roles ?? [];
+  // L21 (`granted − reachable`) runs on the untrusted roles by default — its
+  // question is precisely "which of anonymous's grants are load-bearing?" — so
+  // it reads its role list from `exposure.anonRoles` unless the config overrides
+  // it. It reads function/view bodies, so it is gated on `skipAst` like the
+  // other body rules.
+  const revocableRoles = withExposedRoles(
+    { rolesFrom: 'anon', ...(resolved.rules.get('L21')?.options as LatticeRoleOptions) },
+    exposure
+  )?.roles ?? [];
+  const revocableEnabled =
+    !skipAst && revocableRoles.length > 0 && resolved.rules.get('L21')?.enabled !== false;
   // L8 and L14 are two answers from one body pass: the base relations that
   // were graded, and the ones that could not be because they are out of scope.
   const viewBodiesEnabled =
@@ -352,7 +369,8 @@ export async function audit(
     || viewBodiesEnabled
     || viewWritesEnabled
     || viewExposureEnabled
-    || functionBodiesEnabled;
+    || functionBodiesEnabled
+    || revocableEnabled;
   const viewSnapshot = needsViews
     ? await introspectViews(exec, {
       schemas: options.schemas ?? config.schemas,
@@ -564,6 +582,32 @@ export async function audit(
         ...checkLeakyFilterView(exposureViews.leaky, snapshot, roleGraph, { roles: leakyViewRoles })
       );
     }
+  }
+
+  // L21: the EXECUTE grants each untrusted role holds that no reachable path
+  // exercises. Its own reachability closure — policy predicates, trigger
+  // bodies, write-time expressions and views — needs the trigger/expression
+  // inputs no other rule reads. The revocable recommendations enter the finding
+  // stream; the retained-and-suppressed proof lists ride on the report.
+  let revocableGrants: RevocableGrantsReport | undefined;
+  if (revocableEnabled) {
+    const reachInputs = await introspectReachInputs(exec, {
+      schemas: options.schemas ?? config.schemas,
+      excludeSchemas: options.excludeSchemas ?? config.excludeSchemas
+    });
+    revocableGrants = await analyzeRevocableGrants({
+      roles: revocableRoles,
+      functions: await getFunctions(),
+      tables: snapshot,
+      views: viewSnapshot,
+      graph: roleGraph,
+      schemaAcls: schemaAclsByName,
+      reachInputs,
+      exposedSchemas,
+      exposureKnown: exposure.known,
+      unaddressable
+    });
+    findings.push(...revocableGrantFindings(revocableGrants));
   }
 
   const statsSnapshot: StatsSnapshot | null = statsEnabled
@@ -778,6 +822,8 @@ export async function audit(
     };
     report.roleAccess = roleAccess;
   }
+
+  if (revocableGrants) report.revocableGrants = revocableGrants;
 
   if (perfEnabled) {
     // `S*` findings are scored by default — opting into `--stats` is the

--- a/packages/safegres/src/pg/reach-inputs.ts
+++ b/packages/safegres/src/pg/reach-inputs.ts
@@ -1,0 +1,214 @@
+/**
+ * Extra catalog inputs the revocable-grant rule (L21) needs and no other rule
+ * reads: the ordinary triggers on a relation, and the SQL expressions a write
+ * to it evaluates — column defaults, generated columns and CHECK constraints.
+ *
+ * All three matter for one reason: they run as the *querying* role, not the
+ * table owner. A function called from a column default or a trigger body is a
+ * function the writing role must be able to EXECUTE, exactly as if it had
+ * called it directly — so a grant reached only that way is load-bearing and
+ * must not be reported revocable. The per-table policy predicates L21 also
+ * closes over already live on {@link TableSnapshot.policies}; only these three
+ * were missing.
+ */
+
+import type { QueryExecutor } from './introspect';
+
+/** A non-internal trigger on a relation, and the function it fires. */
+export interface RelationTrigger {
+  name: string;
+  /** The write commands that fire it (TRUNCATE is dropped — it grants nothing). */
+  events: Array<'INSERT' | 'UPDATE' | 'DELETE'>;
+  /** `INSTEAD OF` (view) vs an ordinary BEFORE/AFTER trigger. */
+  instead: boolean;
+  functionSchema: string;
+  functionName: string;
+}
+
+/** A SQL expression a write to the relation evaluates, as the querying role. */
+export interface RelationExpr {
+  kind: 'default' | 'generated' | 'check';
+  /** Column name for default/generated; constraint name for check. */
+  name: string;
+  expr: string;
+}
+
+export interface ReachInputs {
+  /** Triggers per relation, keyed `schema.table`. */
+  triggers: Map<string, RelationTrigger[]>;
+  /** Write-time expressions per relation, keyed `schema.table`. */
+  expressions: Map<string, RelationExpr[]>;
+}
+
+export interface ReachInputsOptions {
+  schemas?: string[];
+  excludeSchemas?: string[];
+}
+
+const DEFAULT_EXCLUDES = ['pg_catalog', 'information_schema', 'pg_toast'];
+
+/**
+ * The triggers and write-time expressions of every relation in scope, in two
+ * cheap queries. Keyed the same way the table snapshot is (`schema.table`), so
+ * the engine can look inputs up by the relation it is already iterating.
+ */
+export async function introspectReachInputs(
+  exec: QueryExecutor,
+  options: ReachInputsOptions = {}
+): Promise<ReachInputs> {
+  const excludes = [...DEFAULT_EXCLUDES, ...(options.excludeSchemas ?? [])];
+  const include = options.schemas ?? [];
+  // Both params are referenced unconditionally so the prepared statement's
+  // parameter count never depends on which branch of the include/exclude
+  // choice applies (`pg` binds by count, not by name).
+  const schemaFilter =
+    'AND CASE WHEN cardinality($1::text[]) > 0'
+    + ' THEN n.nspname = ANY($1::text[])'
+    + ' ELSE NOT (n.nspname = ANY($2::text[])) END';
+
+  const triggers = await introspectTriggers(exec, schemaFilter, include, excludes);
+  const expressions = await introspectExpressions(exec, schemaFilter, include, excludes);
+  return { triggers, expressions };
+}
+
+async function introspectTriggers(
+  exec: QueryExecutor,
+  schemaFilter: string,
+  include: string[],
+  excludes: string[]
+): Promise<Map<string, RelationTrigger[]>> {
+  // tgtype bits (see access/tableam / commands/trigger.h): 1 ROW, 2 BEFORE,
+  // 4 INSERT, 8 DELETE, 16 UPDATE, 32 TRUNCATE, 64 INSTEAD OF. Decoded here so
+  // the engine gets event names, not a bitmask.
+  const { rows } = await exec.query<{
+    schema: string;
+    relation: string;
+    name: string;
+    fires_insert: boolean;
+    fires_update: boolean;
+    fires_delete: boolean;
+    instead: boolean;
+    fn_schema: string;
+    fn_name: string;
+  }>(
+    `
+    SELECT
+      n.nspname                      AS schema,
+      c.relname                      AS relation,
+      t.tgname                       AS name,
+      (t.tgtype & 4)  <> 0           AS fires_insert,
+      (t.tgtype & 16) <> 0           AS fires_update,
+      (t.tgtype & 8)  <> 0           AS fires_delete,
+      (t.tgtype & 64) <> 0           AS instead,
+      fn.nspname                     AS fn_schema,
+      p.proname                      AS fn_name
+    FROM pg_trigger t
+    JOIN pg_class c ON c.oid = t.tgrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    JOIN pg_proc p ON p.oid = t.tgfoid
+    JOIN pg_namespace fn ON fn.oid = p.pronamespace
+    WHERE NOT t.tgisinternal
+      AND n.nspname NOT LIKE 'pg\\_%'
+      ${schemaFilter}
+    ORDER BY n.nspname, c.relname, t.tgname
+    `,
+    [include, excludes]
+  );
+
+  const out = new Map<string, RelationTrigger[]>();
+  for (const r of rows) {
+    const events: RelationTrigger['events'] = [];
+    if (r.fires_insert) events.push('INSERT');
+    if (r.fires_update) events.push('UPDATE');
+    if (r.fires_delete) events.push('DELETE');
+    const key = `${r.schema}.${r.relation}`;
+    const list = out.get(key) ?? [];
+    list.push({
+      name: r.name,
+      events,
+      instead: r.instead,
+      functionSchema: r.fn_schema,
+      functionName: r.fn_name
+    });
+    out.set(key, list);
+  }
+  return out;
+}
+
+async function introspectExpressions(
+  exec: QueryExecutor,
+  schemaFilter: string,
+  include: string[],
+  excludes: string[]
+): Promise<Map<string, RelationExpr[]>> {
+  const out = new Map<string, RelationExpr[]>();
+  const add = (key: string, expr: RelationExpr): void => {
+    const list = out.get(key) ?? [];
+    list.push(expr);
+    out.set(key, list);
+  };
+
+  // Column defaults and generated-column expressions both live in pg_attrdef;
+  // a generated column is flagged by pg_attribute.attgenerated.
+  const { rows: defaults } = await exec.query<{
+    schema: string;
+    relation: string;
+    column: string;
+    generated: boolean;
+    expr: string | null;
+  }>(
+    `
+    SELECT
+      n.nspname                              AS schema,
+      c.relname                              AS relation,
+      a.attname                              AS column,
+      a.attgenerated <> ''                   AS generated,
+      pg_get_expr(ad.adbin, ad.adrelid)      AS expr
+    FROM pg_attrdef ad
+    JOIN pg_class c ON c.oid = ad.adrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    JOIN pg_attribute a ON a.attrelid = ad.adrelid AND a.attnum = ad.adnum
+    WHERE n.nspname NOT LIKE 'pg\\_%'
+      ${schemaFilter}
+    ORDER BY n.nspname, c.relname, a.attnum
+    `,
+    [include, excludes]
+  );
+  for (const r of defaults) {
+    if (!r.expr) continue;
+    add(`${r.schema}.${r.relation}`, {
+      kind: r.generated ? 'generated' : 'default',
+      name: r.column,
+      expr: r.expr
+    });
+  }
+
+  const { rows: checks } = await exec.query<{
+    schema: string;
+    relation: string;
+    name: string;
+    expr: string | null;
+  }>(
+    `
+    SELECT
+      n.nspname                              AS schema,
+      c.relname                              AS relation,
+      con.conname                            AS name,
+      pg_get_expr(con.conbin, con.conrelid)  AS expr
+    FROM pg_constraint con
+    JOIN pg_class c ON c.oid = con.conrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE con.contype = 'c'
+      AND n.nspname NOT LIKE 'pg\\_%'
+      ${schemaFilter}
+    ORDER BY n.nspname, c.relname, con.conname
+    `,
+    [include, excludes]
+  );
+  for (const r of checks) {
+    if (!r.expr) continue;
+    add(`${r.schema}.${r.relation}`, { kind: 'check', name: r.name, expr: r.expr });
+  }
+
+  return out;
+}

--- a/packages/safegres/src/rules/registry.ts
+++ b/packages/safegres/src/rules/registry.ts
@@ -384,6 +384,29 @@ export const RULES: RuleMeta[] = [
     scope: 'table'
   },
   {
+    code: 'L21',
+    // `granted − reachable`. The user asked for "L10", but L10 has been the
+    // rewrite-rule bypass rule since it shipped; this takes the next free
+    // L-code and keeps every existing identity intact.
+    //
+    // `coverage`, not `anti-pattern`: like L1/L3/L6 the finding is about what a
+    // grant can and cannot reach, not a leak — and it is `fail-closed`, so it
+    // is weightless and never moves the score. It ships `info` because it is
+    // new and, uniquely, its verdict is a *revoke recommendation*: the cost of
+    // a wrong one is an outage, so it stays advisory until the reachability
+    // proof has earned trust in the field. Its honest severity once proven is
+    // `low` — a revocable grant is latent surface, not an active leak, and the
+    // value is the retained-grant proof list, which is emitted whatever the
+    // severity. The rule is fail-closed by construction: it recommends a revoke
+    // only for a grant it proved unreachable, and suppresses (retains) every
+    // grant whose closure it could not fully read.
+    category: 'coverage',
+    defaultSeverity: 'info',
+    direction: 'fail-closed',
+    title: 'Revocable grant — a role holds EXECUTE no reachable path exercises (options: { roles: [...] })',
+    scope: 'table'
+  },
+  {
     code: 'W1',
     category: 'meta',
     defaultSeverity: 'medium',

--- a/packages/safegres/src/types.ts
+++ b/packages/safegres/src/types.ts
@@ -268,6 +268,14 @@ export interface Report {
   /** Effective per-role access, for the configured untrusted roles. */
   roleAccess?: RoleAccessReport;
   /**
+   * L21's `granted − reachable` result: per role, the EXECUTE grants that are
+   * revocable, the ones retained (each with the reachability path that proves
+   * it load-bearing), and the ones suppressed because the closure could not be
+   * fully read. The retained-and-suppressed lists are the point of the rule —
+   * they are what a human reviews before dropping anything.
+   */
+  revocableGrants?: import('./checks/revocable-grants').RevocableGrantsReport;
+  /**
    * Unscored call-graph audit (`--call-graph`): trust boundaries reachable
    * from the exposed entry points, for human review.
    */


### PR DESCRIPTION
## Summary

Adds **L21 — the revocable-grant rule**: for a role `R`, compute the EXECUTE grants
`R` holds that **no reachable path exercises**, so a human never has to guess which of
`R`'s grants are safe to drop. This is `G(R) − Reach(R)`, with a **proof path** attached
to every *retained* grant (that list is the point — it is what a reviewer reads before a
batch revoke) and a recorded reason for everything the analysis could not prove.

> **Naming.** This was requested as "L10", but `L10` has been the rewrite-rule-bypass
> rule since it shipped. To keep every existing rule identity intact, this takes the next
> free L-code, **L21**, and documents the collision in the registry note.

### What `Reach(R)` closes over

```
Reach(R) ⊇
  1. direct calls        — functions in an exposed schema R can EXECUTE and reach via USAGE
  2. policy predicates   — USING / WITH CHECK of every policy on a relation R can address,
                           and the functions/relations they name, closed transitively (run as R)
  3. trigger bodies      — ordinary (non-DEFINER) trigger fns on a relation R can write (run as R)
  4. write-time exprs    — column defaults, generated columns, CHECK constraints (run as writer)
  5. views + their bodies — a grant exercised only through a security_invoker view survives
```

A **SECURITY DEFINER boundary stops the closure**: `R` needs EXECUTE on the definer
function itself (retained), but the body runs as the *owner*, so nothing the body calls
is an `R`-grant. Crucially, **EXECUTE on a trigger function is never checked by Postgres
when the trigger fires** — so such a grant is genuinely revocable even though the body is
load-bearing. That asymmetry is exactly what the constructive-db audit is about.

### Fail-closed, bounded by USAGE

Nothing is reported revocable that the analysis cannot prove unused. If any node reached
as `R` runs SQL the analyzer cannot read — dynamic `EXECUTE`, a body that fails to parse,
a C/internal function — that opaque node could construct a dynamic call to any function
`R` can **name and execute**. But Postgres still enforces schema `USAGE` at call time, so
an opaque node running as `R` can only reach functions in schemas `R` holds `USAGE` on.

```
unreached candidate, opaque node present, R has USAGE on its schema  → suppressed (retain, record why)
unreached candidate, R cannot even name the schema                   → revocable  (opacity can't reach it)
reached by a followed path                                           → retained   (with proof path)
```

That USAGE bound is what makes the rule *useful* instead of collapsing to "suppress
everything the moment one opaque node exists anywhere".

### Relationship to L1 / L3 / L6

L21 is the reachability proof the rest of the L-series only approximates:

- **L1** asks whether an indirect *relation* grant is admitted by current policy coverage.
- **L3** asks whether an object grant is blocked by missing schema `USAGE`.
- **L6** *suppresses* an unaddressable-relation finding whenever a policy predicate merely
  **names** the relation — a heuristic. L21 subsumes that question by actually modelling the
  policy-predicate path (parse `USING`/`WITH CHECK`, close over the call graph as `R`) and
  only claims a grant unused when it can prove it.

L21 does not duplicate them: it answers the broader "can this grant be exercised at all?"
across object kinds and every execution path, and emits a machine-consumable report
(`report.revocableGrants`): revocable `(role, object, kind)` tuples, retained grants with
their proof paths, suppressed grants with reasons, and the taint nodes that forced the
suppressions.

### Severity / shipping posture

Ships at **`info`, score-neutral** (`fail-closed`, weightless — fixing it can never move
the grade). `info` is the *shipping* posture, not the verdict: uniquely among the
L-series, L21's output is a *revoke recommendation*, and the cost of a wrong one is an
outage, so it stays advisory until the reachability proof has earned trust in the field.
Its honest severity once proven is **`low`** — a revocable grant is latent surface, not an
active leak, and the value is the retained-grant proof list, which is emitted at any
severity.

## Files

- **`src/checks/revocable-grants.ts`** *(new)* — the closure engine, the machine-readable
  report types, and `revocableGrantFindings()` (one `L21` finding per revocable grant;
  retained/suppressed evidence lives on the report, not the finding stream).
- **`src/pg/reach-inputs.ts`** *(new)* — introspects the inputs closures 3/4 need:
  non-internal triggers (`pg_trigger` + event bits), column defaults / generated columns
  (`pg_attrdef` / `pg_attribute`), and CHECK constraints (`pg_constraint`).
- **`src/rules/registry.ts`**, **`src/types.ts`** — register L21; add
  `Report.revocableGrants`.
- **`src/commands/audit.ts`** — **minimal dispatch only** (flagging per the file-lane
  agreement — I stayed out of `src/score/` and `src/config/`). L21's roles default to the
  exposed/anonymous set (`rolesFrom: 'anon'`), its body analysis is gated on `skipAst`, and
  the existing `L10` dispatch is untouched:
  ```ts
  // unchanged:
  const ruleBypassRoles = withExposedRoles(resolved.rules.get('L10')?.options as LatticeRoleOptions, exposure)?.roles ?? [];
  // new, separate lookup:
  const revocableRoles = withExposedRoles({ rolesFrom: 'anon', ...(resolved.rules.get('L21')?.options as LatticeRoleOptions) }, exposure)?.roles ?? [];
  ```
- **`corpus/cases/52-revocable-execute-grant/`** *(new, positive)* — an ordinary trigger
  function whose EXECUTE the trigger never checks: provably revocable.
- **`corpus/cases/53-policy-predicate-retains-execute/`** *(new, negative — the point of
  the rule)* — a helper that *looks* dead but is reached only through a policy predicate;
  asserts L21 stays silent.
- **`__tests__/revocable-grants.test.ts`** *(new)* — a constructive-db-shaped integration
  test: an exposed API schema whose policies/triggers/defaults/CHECKs call functions in a
  private schema, plus an opaque-dynamic-SQL case. Asserts the exact revocable/retained
  partition, each retained grant's reason, and that the opaque case suppresses (never
  revokes) and emits zero findings.

## Result against constructive-db `application/app`

Deployed `application/app` (constructive preset, exposure resolved from the routing plane)
and ran L21 for `anonymous`. **Headline: with the schema exactly as deployed, L21 proves
0 of `anonymous`'s 595 EXECUTE grants blanket-revocable — and that refusal is the finding.**

| bucket | count | why |
|---|---:|---|
| candidates (anon EXECUTE grants) | **595** | direct + inherited; PUBLIC-only excluded |
| retained — direct-call | **125** | anon can call these directly (EXECUTE + USAGE, exposed schema) |
| retained — policy predicate | **0** | see below |
| retained — trigger | **0** | see below |
| **suppressed (fail-closed)** | **470** | anon holds USAGE on their schema **and** the closure reaches an opaque node |
| **revocable (proven)** | **0** | — |

Taint nodes that force the 470 suppressions: **13** — 6 genuine dynamic `EXECUTE`
(`metaschema.resolve_membership_type`, `metaschema_generators.event_tracker`,
`rls_parser.parse_policy_sprt_permission`, …) and 7 PL/pgSQL bodies the parser could not
read (`constructive_auth_public.check_password`, several `ast_helpers.*`). Any one of
these, running as anon, could name any function in a schema anon has USAGE on.

**Why policy/trigger retention is 0 here (and why that is correct, not a bug):** in this
deployment `anonymous` can `SELECT` **0** RLS-protected tables, so the policy-, trigger-
and write-expression closures never start — there is no relation anon can address. The
perm/limit checks the issue cites (`constructive_memberships_private.org_memberships_perm_check`,
`constructive_limits_private.app_limits_check`) are all `SECURITY DEFINER` and are **not
named by any policy predicate** in this schema. So for `anonymous` specifically, the only
reach is direct calls plus the opaque taint. (Those checks are load-bearing for the
*querying/authenticated* roles — analyzed separately, per role — not for anon here.)

### What actually unblocks the revoke (honest, and actionable)

The blanket EXECUTE is entangled with a blanket **USAGE**: `anonymous` holds USAGE on 75
of 91 schemas, including every `*_private` schema. As long as it can *name* those schemas
and reach one opaque function, a fail-closed analyzer must retain everything. Remove the
USAGE it has no API reason to hold and the set collapses to a concrete revoke list. I ran
the counterfactual (revoke anon + PUBLIC USAGE on the 27 `*_private` schemas, re-audit):

| | revocable | retained | suppressed |
|---|---:|---:|---:|
| as deployed | 0 | 125 | 470 |
| **after revoking USAGE on `*_private`** | **401** | 125 | 69 |

The 401 that become provably revocable are exactly the private-schema EXECUTE grants —
`constructive_app_private` (128), `compute_private` (47),
`constructive_memberships_private` (41), `constructive_limits_private` (35), … — i.e. the
blanket `ALTER DEFAULT PRIVILEGES … GRANT ALL ON FUNCTIONS TO anonymous` surface. The 69
still-suppressed are in public schemas anon keeps USAGE on; the 125 directly-callable stay
retained.

**Caveats (what the analysis could not prove):**
- 7 of the 13 taint nodes are **parser limitations**, not proven dynamic SQL — the
  suppression they cause is conservative and may be looser than reality. Improving the
  PL/pgSQL parser coverage would shrink the suppressed set further.
- Numbers are from the fixture deployment of `application/app` (constructive preset), not a
  production dump; the *shape* (blanket EXECUTE + blanket USAGE + no anon table access)
  matches the reported production audit, but exact counts will differ.
- The counterfactual is a **proposed remediation**, run to quantify the payoff — it is not
  applied by this PR.

## Verification

- `pnpm build` (full monorepo, serves as typecheck) — clean.
- `packages/safegres` `pnpm test` — **48 suites / 563 tests** pass (incl. the new
  integration test and corpus cases 52 & 53).
- `packages/safegres` `pnpm lint` and repo-wide `pnpm lint` — 0 errors (2 pre-existing
  warnings in `src/config/loader.ts`, not from this change).


Link to Devin session: https://app.devin.ai/sessions/ce8f9d0f4bf14e289b580f4dc22f7cee
Requested by: @pyramation