### PR TITLE
chore(safegres): consume libpg-query@18.1.4 (VARIADIC + block-label PL/pgSQL parse fixes)

### DIFF
--- a/packages/safegres/package.json
+++ b/packages/safegres/package.json
@@ -65,7 +65,7 @@
     "@pgsql/types": "^18.0.0",
     "confstash": "^0.1.0",
     "inquirerer": "^4.9.1",
-    "libpg-query": "^18.1.3",
+    "libpg-query": "^18.1.4",
     "pg": "^8.21.0",
     "pg-env": "workspace:^",
     "pgsql-deparser": "^18.3.2",

--- a/packages/safegres/package.json
+++ b/packages/safegres/package.json
@@ -65,7 +65,7 @@
     "@pgsql/types": "^18.0.0",
     "confstash": "^0.1.0",
     "inquirerer": "^4.9.1",
-    "libpg-query": "^18.1.2",
+    "libpg-query": "^18.1.3",
     "pg": "^8.21.0",
     "pg-env": "workspace:^",
     "pgsql-deparser": "^18.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8854,17 +8854,8 @@ packages:
     resolution: {integrity: sha512-26zzwoBNAvX9AWOPiqqF6FG4HrSCPsHFkQm7nT+xU1ggAujL/eae81RnCv4CJ2In9q9fh10B88sYSzKCUh/Ghg==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
-  libpg-query@18.1.2:
-    resolution: {integrity: sha512-8epkLd4hMoUVfYu2RlXWiUTxnGw1S6adm6/rMgWqlUB6+KsVb5BmJrDY8CjaPB9NWbEt6OnvQnfGxol2iBxn4A==}
-
   libpg-query@18.1.4:
     resolution: {integrity: sha512-6jF9qn9ln4yLnmSF+bS/DBvAfNcPhGI05+pkQy+n3cRd3p9aO8LWjquEin8SLO0k7zYk745ZGBXYUiL9AUI7gA==}
-
-  libpg-query@18.1.4:
-    resolution:
-      {
-        integrity: sha512-6jF9qn9ln4yLnmSF+bS/DBvAfNcPhGI05+pkQy+n3cRd3p9aO8LWjquEin8SLO0k7zYk745ZGBXYUiL9AUI7gA==,
-      }
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -17067,10 +17058,6 @@ snapshots:
       ssri: 10.0.6
     transitivePeerDependencies:
       - supports-color
-
-  libpg-query@18.1.2:
-    dependencies:
-      '@pgsql/types': 18.0.0
 
   libpg-query@18.1.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2664,8 +2664,8 @@ importers:
         specifier: ^4.9.1
         version: 4.9.1
       libpg-query:
-        specifier: ^18.1.2
-        version: 18.1.2
+        specifier: ^18.1.3
+        version: 18.1.3
       pg:
         specifier: ^8.21.0
         version: 8.21.0
@@ -12006,6 +12006,12 @@ packages:
     resolution:
       {
         integrity: sha512-8epkLd4hMoUVfYu2RlXWiUTxnGw1S6adm6/rMgWqlUB6+KsVb5BmJrDY8CjaPB9NWbEt6OnvQnfGxol2iBxn4A==,
+      }
+
+  libpg-query@18.1.3:
+    resolution:
+      {
+        integrity: sha512-J1bTAp7PgOFB3tZSet0a7hNqmWOcNB6XmBsTNQbNXprUSZXT26QoOtFXqICFMTHli9HVRJxbjLe1qk75b7D6kA==,
       }
 
   lines-and-columns@1.2.4:
@@ -21713,6 +21719,10 @@ snapshots:
       - supports-color
 
   libpg-query@18.1.2:
+    dependencies:
+      '@pgsql/types': 18.0.0
+
+  libpg-query@18.1.3:
     dependencies:
       '@pgsql/types': 18.0.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2664,8 +2664,8 @@ importers:
         specifier: ^4.9.1
         version: 4.9.1
       libpg-query:
-        specifier: ^18.1.3
-        version: 18.1.3
+        specifier: ^18.1.4
+        version: 18.1.4
       pg:
         specifier: ^8.21.0
         version: 8.21.0
@@ -12008,10 +12008,10 @@ packages:
         integrity: sha512-8epkLd4hMoUVfYu2RlXWiUTxnGw1S6adm6/rMgWqlUB6+KsVb5BmJrDY8CjaPB9NWbEt6OnvQnfGxol2iBxn4A==,
       }
 
-  libpg-query@18.1.3:
+  libpg-query@18.1.4:
     resolution:
       {
-        integrity: sha512-J1bTAp7PgOFB3tZSet0a7hNqmWOcNB6XmBsTNQbNXprUSZXT26QoOtFXqICFMTHli9HVRJxbjLe1qk75b7D6kA==,
+        integrity: sha512-6jF9qn9ln4yLnmSF+bS/DBvAfNcPhGI05+pkQy+n3cRd3p9aO8LWjquEin8SLO0k7zYk745ZGBXYUiL9AUI7gA==,
       }
 
   lines-and-columns@1.2.4:
@@ -21722,7 +21722,7 @@ snapshots:
     dependencies:
       '@pgsql/types': 18.0.0
 
-  libpg-query@18.1.3:
+  libpg-query@18.1.4:
     dependencies:
       '@pgsql/types': 18.0.0
 


### PR DESCRIPTION
## Summary

Bumps safegres's direct `libpg-query` dependency `^18.1.2 → ^18.1.4` to pick up **two** upstream standalone-parser fixes, both published from `constructive-io/libpg_query`:

- **18.1.3** — [libpg_query#7](https://github.com/constructive-io/libpg_query/pull/7): `VARIADIC` array params (`text[]`/`jsonb[]`/`uuid[]`) threw `"VARIADIC parameter must be an array"`. The standalone syscache mock synthesized `pg_type` rows without `typelem`/`typsubscript`, so `get_element_type()` classified arrays as non-arrays.
- **18.1.4** — [libpg_query#8](https://github.com/constructive-io/libpg_query/pull/8): a schema-qualified function (`auth.check_password`) threw `"check_password.password is not a known variable"` on `SELECT ... INTO <funcname>.<param>`. The parser took the *first* component of the qualified name (the schema) as the function name via `linitial()`, so plpgsql's block label was the schema; fixed to `llast()` (last component), matching upstream `CreateFunction`.

**Why it matters here.** L21's reachability closure reads function bodies via `parsePlPgSQL` (imported directly from `libpg-query` in `src/callgraph/extract.ts`). Both bugs made valid bodies unreadable, so L21 (and every other body-walking rule) fail-closed and treated them as opaque **taint nodes**. The SQL itself is valid and Postgres runs it fine; only the out-of-backend parser mock was wrong.

```
# 18.1.2                                    # 18.1.4
parsePlPgSQL('… VARIADIC x text[] …')        THROWS  →  OK
parsePlPgSQL('… s.check_password … INTO …')  THROWS  →  OK
```

This is a dependency/lockfile change only — no safegres source change. The `parsePlPgSQL` path was never weakened; it simply parses the inputs it always should have.

## Relationship to #1634 (merged)

#1634 already bumped the **`@pgsql/*`/`pgsql-parser`** wrappers (which now sit on `libpg-query 18.1.4` transitively). This PR is the remaining **direct** `libpg-query` line in safegres, on a different dep entry. `main` has been merged in and the lockfile reconciled: net diff vs `main` is now just safegres's `libpg-query ^18.1.2 → ^18.1.4` plus dropping the now-unreferenced `18.1.2` from the lockfile (18.1.4 is already present via the ecosystem).

## Verification

- safegres: 48 suites / 563 tests green; lint 0 errors on 18.1.4.
- Direct `parsePlPgSQL` regression on `VARIADIC text[]`/`jsonb[]`/`uuid[]` **and** the schema-qualified `INTO <funcname>.<param>` case → all OK against the published 18.1.4 WASM.
- `pnpm install --frozen-lockfile` clean after the merge (deduped a merge-introduced `libpg-query@18.1.4` key collision).
- Re-ran the constructive-db `application/app` audit (L21, `anonymous`):

  | metric | 18.1.2 | 18.1.4 |
  |---|---|---|
  | taint nodes | 13 | **6** |
  | — dynamic SQL | 6 | 6 |
  | — parse failure | 7 | **0** |
  | candidates / retained / suppressed / revocable | 595 / 125 / 470 / 0 | 595 / 125 / 470 / 0 |

  All 7 former parse-failure nodes now parse and drop out of the taint set (6 VARIADIC builders in 18.1.3; `constructive_auth_public.check_password` in 18.1.4). The remaining **6 taint nodes are all genuine dynamic `EXECUTE`** — irreducible, correctly fail-closed. The revocable/suppressed totals are unchanged because they're gated by `anonymous`'s blanket USAGE on the `*_private` schemas plus those 6 dynamic-SQL nodes, not by the parse failures.


Link to Devin session: https://app.devin.ai/sessions/ce8f9d0f4bf14e289b580f4dc22f7cee
Requested by: @pyramation