### PR TITLE
feat(pgpm): non-pgpm database adoption (migrate baseline / import --baseline) + tag resolution at the ingestion seam

### DIFF
--- a/pgpm/cli/__tests__/import-e2e.test.ts
+++ b/pgpm/cli/__tests__/import-e2e.test.ts
@@ -185,6 +185,73 @@ describe('pgpm import e2e', () => {
     expect(bundle.changes.length).toBeGreaterThan(0);
   });
 
+  it('--baseline writes an idempotent log-only pgpm_migrate backfill', async () => {
+    await fixture.runTerminalCommands(
+      `
+      cd ${WS}
+      pgpm import dump.sql --pkg imp-baseline-file --baseline
+      `,
+      {}
+    );
+
+    const baselinePath = path.join(wsDir, 'imp-baseline-file', 'baseline.sql');
+    expect(fs.existsSync(baselinePath)).toBe(true);
+    const backfill = fs.readFileSync(baselinePath, 'utf-8');
+    // Every recorded change is log-only (p_log_only => TRUE, empty DDL body).
+    expect(backfill).toMatch(/CALL pgpm_migrate\.deploy\(/);
+    expect(backfill).toContain('TRUE');
+    expect(backfill).not.toMatch(/CREATE SCHEMA/);
+    expect(backfill).toContain('BEGIN;');
+    expect(backfill).toContain('COMMIT;');
+  });
+
+  it('migrate baseline adopts a non-pgpm database so deploy runs nothing', async () => {
+    // A database that already carries the schema but was never pgpm-managed:
+    // apply the raw dump (no pgpm_migrate ledger), exactly like a restore.
+    const adopted = await fixture.setupTestDatabase();
+    const { sql } = preprocessDumpText(fs.readFileSync(DUMP_PATH, 'utf-8'));
+    await adopted.query(sql);
+
+    // Import the dump into a pgpm module (files only; no DB contact).
+    await fixture.runTerminalCommands(
+      `
+      cd ${WS}
+      pgpm import dump.sql --pkg imp-adopt
+      `,
+      {}
+    );
+
+    // Baseline: record every change as deployed (log-only) — no DDL re-run.
+    await fixture.runTerminalCommands(
+      `
+      cd ${WS}/imp-adopt
+      pgpm migrate baseline --database ${adopted.name} --yes
+      `,
+      { database: adopted.name }
+    );
+
+    const planCount = fs
+      .readFileSync(path.join(wsDir, 'imp-adopt', 'pgpm.plan'), 'utf-8')
+      .split('\n')
+      .filter(line => line.trim() && !line.startsWith('%') && !line.startsWith('@')).length;
+    const recorded = await adopted.query(
+      `SELECT COUNT(*)::int AS count FROM pgpm_migrate.changes WHERE package = 'imp-adopt'`
+    );
+    expect(recorded.rows[0].count).toBe(planCount);
+
+    // The schema is untouched and a subsequent deploy is a no-op.
+    const before = await snapshotCatalog(adopted);
+    await fixture.runTerminalCommands(
+      `
+      cd ${WS}/imp-adopt
+      pgpm deploy --database ${adopted.name} --package imp-adopt --yes
+      `,
+      { database: adopted.name }
+    );
+    const after = await snapshotCatalog(adopted);
+    expect(diffCatalogSnapshots(before, after)).toEqual([]);
+  });
+
   it('--with-data deploys COPY/INSERT data as seed fixtures', async () => {
     await fixture.runTerminalCommands(
       `

--- a/pgpm/cli/src/commands/import.ts
+++ b/pgpm/cli/src/commands/import.ts
@@ -1,3 +1,4 @@
+import { buildBaselineBackfill } from '@pgpmjs/core';
 import {
   dumpCompatibilityWarnings,
   importDumpRows,
@@ -17,6 +18,7 @@ import {
   PartitionCycleError,
   partitionExportRows
 } from '@pgpmjs/transform';
+import { writeFileSync } from 'fs';
 import { cliExitWithError, CLIOptions, Inquirerer, ParsedArgs } from 'inquirerer';
 import * as path from 'path';
 
@@ -77,6 +79,12 @@ Options:
   --emit-bundle <file>     Also project the imported module into a
                           content-addressed .bundle.tar.gz. Same single-package
                           requirement as --emit-sql.
+  --baseline              After writing each package, also write a
+                          <pkg>/baseline.sql: an idempotent, log-only
+                          pgpm_migrate backfill recording every generated
+                          change as already deployed. Adopts the source
+                          database — apply the script (after 'pgpm migrate
+                          init'), then 'pgpm deploy' runs only real changes.
   --cwd <directory>       Working directory (default: current directory)
   --dry-run               Print the resulting plan/paths without writing
 
@@ -89,6 +97,7 @@ Examples:
   pgpm import ./sql-files --pkg my-app --out ./packages --with-data
   pgpm import dump.sql --pkg my-app --partition partition.json
   pgpm import dump.sql --pkg my-app --emit-sql my-app.sql
+  pgpm import dump.sql --pkg my-app --baseline
 `;
 
 const NAMING_STYLES = ['directory', 'flat'] as const;
@@ -150,9 +159,13 @@ export default async (
   const emit = parseEmitProjectionTargets(argv, cwd);
   const emitRequested = hasEmitProjection(emit);
   const sqlToStdout = emit.emitSql === STDOUT_TARGET;
+  const baseline = Boolean(argv.baseline);
 
   if (emitRequested && dryRun) {
     await cliExitWithError('--emit-sql/--emit-bundle cannot be combined with --dry-run.');
+  }
+  if (baseline && dryRun) {
+    await cliExitWithError('--baseline cannot be combined with --dry-run.');
   }
 
   let source;
@@ -222,15 +235,25 @@ export default async (
       }
     }
     let firstDir: string | undefined;
+    const writtenDirs: string[] = [];
     for (const pkg of packages) {
       const dir = writePackage(outBase, pkg);
       firstDir ??= dir;
+      writtenDirs.push(dir);
       if (!sqlToStdout) {
         log.success(`wrote ${pkg.rows.length} changes to ${dir}`);
       }
     }
     if (emitRequested && firstDir) {
       await projectModule(firstDir, emit, sqlToStdout ? undefined : msg => log.success(msg));
+    }
+    if (baseline) {
+      for (const dir of writtenDirs) {
+        const { entries, backfillSql } = await buildBaselineBackfill(dir);
+        const baselinePath = path.join(dir, 'baseline.sql');
+        writeFileSync(baselinePath, backfillSql);
+        log.success(`wrote baseline backfill for ${entries.length} change(s) to ${baselinePath}`);
+      }
     }
   }
 

--- a/pgpm/cli/src/commands/migrate.ts
+++ b/pgpm/cli/src/commands/migrate.ts
@@ -1,5 +1,6 @@
 import { CLIOptions, extractFirst,Inquirerer, ParsedArgs } from 'inquirerer';
 
+import baseline from './migrate/baseline';
 import deps from './migrate/deps';
 // Migrate subcommands
 import init from './migrate/init';
@@ -10,7 +11,8 @@ const subcommandMap: Record<string, Function> = {
   init,
   status,
   list,
-  deps
+  deps,
+  baseline
 };
 
 const migrateUsageText = `
@@ -20,6 +22,7 @@ Migrate Commands:
   pgpm migrate status    Show current migration status
   pgpm migrate list      List all changes (deployed and pending)
   pgpm migrate deps      Show change dependencies
+  pgpm migrate baseline  Record a plan as already deployed (log-only), adopting an existing database
 
 Options:
   --help, -h     Show this help message
@@ -68,7 +71,8 @@ function getSubcommandDescription(cmd: string): string {
     init: 'Initialize migration tracking in database',
     status: 'Show current migration status',
     list: 'List all changes (deployed and pending)',
-    deps: 'Show change dependencies'
+    deps: 'Show change dependencies',
+    baseline: 'Record a plan as already deployed (log-only), adopting an existing database'
   };
   return descriptions[cmd] || '';
 }

--- a/pgpm/cli/src/commands/migrate/baseline.ts
+++ b/pgpm/cli/src/commands/migrate/baseline.ts
@@ -1,0 +1,128 @@
+import {
+  baselineBackfillEntries,
+  loadPlanSideModules,
+  PgpmMigrate
+} from '@pgpmjs/core';
+import { emitLedgerBackfill } from '@pgpmjs/diff';
+import { Logger } from '@pgpmjs/logger';
+import { writeFileSync } from 'fs';
+import { CLIOptions, Inquirerer, ParsedArgs, Question } from 'inquirerer';
+import * as path from 'path';
+import { getPgEnvOptions } from 'pg-env';
+
+import { getTargetDatabase } from '../../utils/database';
+
+const log = new Logger('migrate-baseline');
+
+const STDOUT_TARGET = '-';
+
+export const baselineUsageText = `
+Migrate Baseline Command:
+
+  pgpm migrate baseline [<workspace|module>] [OPTIONS]
+
+  Record a plan's changes as already deployed WITHOUT executing any DDL, so a
+  database that already carries the schema (imported from a dump, restored, or
+  otherwise adopted from outside pgpm) is brought to the plan's head in the
+  pgpm_migrate ledger. A subsequent 'pgpm deploy' then runs only genuinely new
+  changes.
+
+  Each change is recorded through the same pgpm_migrate.deploy procedure a real
+  deploy uses, with log-only mode (empty script, p_log_only => TRUE), in plan
+  order.
+
+Options:
+  --help, -h              Show this help message
+  --emit-ledger <file|->  Write the log-only backfill SQL instead of applying
+                          it (- for stdout). Offline; no database is touched.
+                          The target must already have the pgpm_migrate schema
+                          (run 'pgpm migrate init' first).
+  --database <name>       Database to apply the baseline to (skips the prompt)
+  -y, --yes               Skip the confirmation prompt when applying
+  --no-tx                 Apply without wrapping each module in a transaction
+  --cwd <directory>       Working directory (default: current directory)
+
+Examples:
+  pgpm migrate baseline ./my-app --emit-ledger baseline.sql
+  pgpm migrate baseline --database mydb
+  pgpm migrate baseline ./ws --emit-ledger -
+`;
+
+export default async (
+  argv: Partial<ParsedArgs>,
+  prompter: Inquirerer,
+  _options: CLIOptions
+) => {
+  if (argv.help || argv.h) {
+    console.log(baselineUsageText);
+    process.exit(0);
+  }
+
+  const cwd = (argv.cwd as string) || process.cwd();
+  const spec = (argv._ as string[] | undefined)?.filter(Boolean)[0] ?? cwd;
+
+  const modules = await loadPlanSideModules(spec, cwd);
+  const entries = await baselineBackfillEntries(modules);
+
+  if (entries.length === 0) {
+    log.warn('No plan changes with deploy scripts found; nothing to baseline.');
+    return argv;
+  }
+
+  const emitTarget = argv['emit-ledger'] ?? argv.emitLedger;
+
+  // Offline emit: write the log-only backfill SQL, touch no database.
+  if (typeof emitTarget === 'string' && emitTarget) {
+    const sql = emitLedgerBackfill(entries);
+    if (emitTarget === STDOUT_TARGET) {
+      process.stdout.write(sql);
+    } else {
+      const outPath = path.resolve(cwd, emitTarget);
+      writeFileSync(outPath, sql);
+      log.success(`Wrote baseline backfill for ${entries.length} change(s) to ${outPath}`);
+    }
+    return argv;
+  }
+
+  // Apply: record every change log-only against the target database.
+  const database = await getTargetDatabase(argv, prompter, {
+    message: 'Select database to baseline'
+  });
+
+  const { yes } = await prompter.prompt(argv, [
+    {
+      name: 'yes',
+      type: 'confirm',
+      message: `Record ${entries.length} change(s) as deployed (log-only) in "${database}"?`,
+      required: true
+    } as Question
+  ]);
+  if (!yes) {
+    log.info('Operation cancelled.');
+    return argv;
+  }
+
+  const config = getPgEnvOptions({ database });
+  const useTransaction = argv.tx !== false;
+  const client = new PgpmMigrate(config);
+  try {
+    let recorded = 0;
+    let skipped = 0;
+    for (const mod of modules) {
+      const result = await client.deploy({
+        modulePath: mod.modulePath,
+        logOnly: true,
+        useTransaction
+      });
+      recorded += result.deployed.length;
+      skipped += result.skipped.length;
+    }
+    log.success(
+      `Baseline complete in "${database}": ${recorded} change(s) recorded, ${skipped} already present.`
+    );
+  } finally {
+    await client.close();
+  }
+
+  return argv;
+};

--- a/pgpm/core/__tests__/diff/baseline.test.ts
+++ b/pgpm/core/__tests__/diff/baseline.test.ts
@@ -1,0 +1,78 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { baselineBackfillEntries, buildBaselineBackfill } from '../../src/diff/ledger';
+import { loadPlanSideModules } from '../../src/diff/sides';
+
+describe('baseline backfill (whole-plan ledger adoption)', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'pgpm-baseline-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const writeModule = () => {
+    writeFileSync(
+      join(dir, 'pgpm.plan'),
+      [
+        '%syntax-version=1.0.0',
+        '%project=my-mod',
+        '%uri=my-mod',
+        '',
+        'schemas/app/schema 2017-08-11T08:11:51Z t <t@x> # schema',
+        'schemas/app/tables/users/table [schemas/app/schema] 2017-08-11T08:11:51Z t <t@x> # table',
+        ''
+      ].join('\n')
+    );
+    mkdirSync(join(dir, 'deploy', 'schemas', 'app', 'tables', 'users'), { recursive: true });
+    writeFileSync(
+      join(dir, 'deploy', 'schemas', 'app', 'schema.sql'),
+      '-- Deploy: schemas/app/schema to pg\nCREATE SCHEMA app;\n'
+    );
+    writeFileSync(
+      join(dir, 'deploy', 'schemas', 'app', 'tables', 'users', 'table.sql'),
+      '-- Deploy: schemas/app/tables/users/table to pg\nCREATE TABLE app.users (id int);\n'
+    );
+  };
+
+  it('emits a backfill row for every plan change, in plan order', async () => {
+    writeModule();
+    const modules = await loadPlanSideModules(dir);
+    const entries = await baselineBackfillEntries(modules);
+
+    expect(entries.map(e => e.changeName)).toEqual([
+      'schemas/app/schema',
+      'schemas/app/tables/users/table'
+    ]);
+    expect(entries.every(e => e.package === 'my-mod')).toBe(true);
+    expect(entries.every(e => e.scriptHash.length > 0)).toBe(true);
+    expect(entries[1].requires).toEqual(['schemas/app/schema']);
+  });
+
+  it('builds an idempotent, log-only backfill script', async () => {
+    writeModule();
+    const { entries, backfillSql } = await buildBaselineBackfill(dir);
+
+    expect(entries).toHaveLength(2);
+    // Every change is recorded log-only (p_log_only => TRUE), no DDL body.
+    const calls = backfillSql.match(/CALL pgpm_migrate\.deploy\(/g) ?? [];
+    expect(calls).toHaveLength(2);
+    expect(backfillSql).toContain("'schemas/app/schema'");
+    expect(backfillSql).toContain("'schemas/app/tables/users/table'");
+    expect(backfillSql).toContain('TRUE');
+    expect(backfillSql).toContain('BEGIN;');
+    expect(backfillSql).toContain('COMMIT;');
+  });
+
+  it('skips changes whose deploy script is missing (no candidate hash)', async () => {
+    writeModule();
+    rmSync(join(dir, 'deploy', 'schemas', 'app', 'tables'), { recursive: true });
+    const { entries } = await buildBaselineBackfill(dir);
+    expect(entries.map(e => e.changeName)).toEqual(['schemas/app/schema']);
+  });
+});

--- a/pgpm/core/src/diff/ledger.ts
+++ b/pgpm/core/src/diff/ledger.ts
@@ -12,6 +12,7 @@
  */
 import type {
   BackfillSelection,
+  LedgerBackfillEntry,
   LedgerChangeRecord,
   LedgerClassification,
   PlanChangeRef
@@ -107,4 +108,55 @@ export const buildLedgerReport = async (options: LedgerReportOptions): Promise<L
     coverage,
     backfillSql: selection.entries.length > 0 ? emitLedgerBackfill(selection.entries) : undefined
   };
+};
+
+/**
+ * Every plan entry of a set of modules as a backfill row, in plan order — the
+ * whole plan, not the satisfied subset. This is the "baseline" input: a
+ * database that already carries a plan's schema (e.g. one imported from a
+ * dump, or one adopted from outside pgpm) can record the entire plan as
+ * deployed without re-executing any DDL. Entries with no candidate hash
+ * (deploy script missing) are skipped, mirroring {@link selectBackfillEntries}.
+ */
+export const baselineBackfillEntries = async (
+  modules: ModuleSource[]
+): Promise<LedgerBackfillEntry[]> => {
+  const refs = await planChangeRefs(modules);
+  const entries: LedgerBackfillEntry[] = [];
+  for (const ref of refs) {
+    const scriptHash = ref.hashes[0];
+    if (!scriptHash) continue;
+    entries.push({
+      package: ref.package,
+      changeName: ref.name,
+      scriptHash,
+      requires: ref.dependencies
+    });
+  }
+  return entries;
+};
+
+/** A whole-plan baseline backfill for a plan-bearing side. */
+export interface BaselineBackfill {
+  /** Backfill rows for every plan entry, in plan order. */
+  entries: LedgerBackfillEntry[];
+  /** Idempotent log-only backfill script for {@link entries}. */
+  backfillSql: string;
+}
+
+/**
+ * Build a whole-plan baseline backfill for a workspace or module directory:
+ * record every change as already deployed, log-only, so a `pgpm deploy`
+ * afterward is a no-op and the database is adopted at the plan's head. The
+ * target database must already have the `pgpm_migrate` schema
+ * (`pgpm migrate init` or any prior deploy creates it, and applying the
+ * baseline through `PgpmMigrate.deploy({ logOnly: true })` initializes it).
+ */
+export const buildBaselineBackfill = async (
+  spec: string,
+  cwd?: string
+): Promise<BaselineBackfill> => {
+  const modules = await loadPlanSideModules(spec, cwd);
+  const entries = await baselineBackfillEntries(modules);
+  return { entries, backfillSql: emitLedgerBackfill(entries) };
 };

--- a/pgpm/transform/__tests__/module-source.test.ts
+++ b/pgpm/transform/__tests__/module-source.test.ts
@@ -86,6 +86,63 @@ describe('loadModuleSource', () => {
   it('throws on a missing plan', () => {
     expect(() => loadModuleSource(join(dir, 'nope'))).toThrow();
   });
+
+  const writeTaggedModule = (dep: string) => {
+    writeFileSync(
+      join(dir, 'pgpm.plan'),
+      [
+        '%syntax-version=1.0.0',
+        '%project=my-mod',
+        '%uri=my-mod',
+        '',
+        'schemas/app/schema 2017-08-11T08:11:51Z tester <tester@x> # add schema',
+        '@v1 schemas/app/schema 2017-08-11T08:11:51Z tester <tester@x> # release v1',
+        `schemas/app/tables/users/table [${dep}] 2017-08-11T08:11:51Z tester <tester@x> # add table`,
+        ''
+      ].join('\n')
+    );
+    mkdirSync(join(dir, 'deploy', 'schemas', 'app', 'tables', 'users'), { recursive: true });
+    writeFileSync(
+      join(dir, 'deploy', 'schemas', 'app', 'schema.sql'),
+      '-- Deploy: schemas/app/schema to pg\nCREATE SCHEMA app;\n'
+    );
+    writeFileSync(
+      join(dir, 'deploy', 'schemas', 'app', 'tables', 'users', 'table.sql'),
+      '-- Deploy: schemas/app/tables/users/table to pg\nCREATE TABLE app.users (id int);\n'
+    );
+  };
+
+  it('resolves a local tag dependency to its change name', () => {
+    writeTaggedModule('@v1');
+    const source = loadModuleSource(dir);
+    const table = source.changes.find(c => c.name === 'schemas/app/tables/users/table')!;
+    expect(table.dependencies).toEqual(['schemas/app/schema']);
+    expect(source.warnings).toEqual([]);
+  });
+
+  it('leaves plain (non-tag) dependencies untouched', () => {
+    writeTaggedModule('schemas/app/schema');
+    const source = loadModuleSource(dir);
+    const table = source.changes.find(c => c.name === 'schemas/app/tables/users/table')!;
+    expect(table.dependencies).toEqual(['schemas/app/schema']);
+    expect(source.warnings).toEqual([]);
+  });
+
+  it('warns and keeps an unknown tag dependency verbatim', () => {
+    writeTaggedModule('@nope');
+    const source = loadModuleSource(dir);
+    const table = source.changes.find(c => c.name === 'schemas/app/tables/users/table')!;
+    expect(table.dependencies).toEqual(['@nope']);
+    expect(source.warnings.some(w => w.includes('@nope'))).toBe(true);
+  });
+
+  it('leaves a cross-package tag dependency unresolved with a warning', () => {
+    writeTaggedModule('other:@v1');
+    const source = loadModuleSource(dir);
+    const table = source.changes.find(c => c.name === 'schemas/app/tables/users/table')!;
+    expect(table.dependencies).toEqual(['other:@v1']);
+    expect(source.warnings.some(w => w.includes('cross-package'))).toBe(true);
+  });
 });
 
 describe('parsePartitionConfig', () => {

--- a/pgpm/transform/src/module-source.ts
+++ b/pgpm/transform/src/module-source.ts
@@ -4,7 +4,8 @@
  * consume. `pgpm transform` uses this today; a future `pgpm import` (dumps)
  * and `pgpm diff` are expected to reuse the same seam.
  */
-import { parsePgpmHeader, parsePlanFile, readScript } from '@pgpmjs/ast';
+import type { ExtendedPlanFile } from '@pgpmjs/ast';
+import { parsePgpmHeader, parsePlanFile, readScript, resolveReference } from '@pgpmjs/ast';
 import * as path from 'path';
 
 /** One change of a loaded module: headerless, unwrapped deploy SQL. */
@@ -44,6 +45,40 @@ export const stripTransactionWrapper = (sql: string): string =>
     .trim();
 
 /**
+ * Resolve a plan dependency token to a concrete change name.
+ *
+ * Non-tag tokens (a bare change name, or a `pkg:change` cross-package name)
+ * pass through unchanged — they are already the identity the ledger and
+ * generated plans record. A tag token (`@tag`) is resolved to its change via
+ * the plan that defines it, so a dependency written against a tag is not
+ * re-emitted verbatim into a generated plan or a ledger row. Cross-package
+ * tags (`pkg:@tag`) cannot be resolved from a single module's plan and are
+ * left as-is with a warning; the resolver returns them unchanged. Anything
+ * that fails to resolve is kept verbatim (never dropped) with a warning.
+ */
+const resolveDependencyToken = (
+  token: string,
+  plan: ExtendedPlanFile,
+  warnings: string[],
+  changeName: string
+): string => {
+  if (!token.includes('@')) return token;
+  const resolved = resolveReference(token, plan, plan.package);
+  if (resolved.error || !resolved.change) {
+    warnings.push(
+      `${changeName}: could not resolve dependency tag "${token}" (${resolved.error ?? 'no matching change'}); left as-is`
+    );
+    return token;
+  }
+  if (resolved.change === token) {
+    warnings.push(
+      `${changeName}: dependency tag "${token}" is cross-package; left unresolved (resolve it in workspace context)`
+    );
+  }
+  return resolved.change;
+};
+
+/**
  * Load a pgpm module from disk: parse pgpm.plan and read each change's
  * deploy script, stripping pgpm headers and transaction wrappers so the
  * result can be flattened straight into the dials pipeline
@@ -56,11 +91,12 @@ export const loadModuleSource = (moduleDir: string): ModuleSource => {
     const reasons = planResult.errors.map(e => e.message).join(', ');
     throw new Error(`Failed to parse pgpm.plan in ${modulePath}: ${reasons}`);
   }
+  const plan = planResult.data;
 
   const warnings: string[] = [];
   const changes: ModuleSourceChange[] = [];
 
-  for (const change of planResult.data.changes) {
+  for (const change of plan.changes) {
     const raw = readScript(modulePath, 'deploy', change.name);
     if (!raw) {
       warnings.push(`${change.name}: no deploy script found, skipping`);
@@ -69,7 +105,9 @@ export const loadModuleSource = (moduleDir: string): ModuleSource => {
     const { body } = parsePgpmHeader(raw);
     changes.push({
       name: change.name,
-      dependencies: change.dependencies ?? [],
+      dependencies: (change.dependencies ?? []).map(dep =>
+        resolveDependencyToken(dep, plan, warnings, change.name)
+      ),
       deploy: stripTransactionWrapper(body)
     });
   }


### PR DESCRIPTION
## Summary

Two follow-ups to the ledger-aware diff work (#1630), in one PR.

**1. Adopt a database that was never pgpm-managed.** Given a database that already carries a schema (restored from a dump, or imported), record its entire plan as *already deployed* — log-only, no DDL re-run — so it lands at the plan's head in the `pgpm_migrate` ledger and a subsequent `pgpm deploy` runs only genuinely new changes. Where #1630's `selectBackfillEntries` only backfilled the subset a *second* side proved semantically satisfied, adoption feeds the **whole plan**:

```ts
// pgpm/core/src/diff/ledger.ts
baselineBackfillEntries(modules)        // every plan change -> a log-only backfill row (plan order)
buildBaselineBackfill(spec, cwd?)       // -> { entries, backfillSql }  (reuses loadPlanSideModules + planChangeRefs + emitLedgerBackfill)
```

Two CLI entry points, both reusing that core seam (no duplicated DSN/plan/SQL logic):

- `pgpm migrate baseline [<workspace|module>] [--emit-ledger <file|->] [--database <db>] [-y]`
  - `--emit-ledger` writes the idempotent log-only backfill script offline (no DB).
  - apply mode records every change via `PgpmMigrate.deploy({ logOnly: true })` per module in dependency order — the same procedure a real deploy uses, so hashing / dep-resolution / skip-already-deployed are identical, and `initialize()` creates `pgpm_migrate` on a never-managed DB.
- `pgpm import ... --baseline` — after writing each generated package, also writes `<pkg>/baseline.sql`, completing the dump → workspace → recorded-as-deployed flow.

**2. Resolve tags once at the ingestion seam.** `loadModuleSource` (the shared seam transform / diff / import / export all read) passed plan `requires` through verbatim, so a dependency written against a tag (`@v1`) could be re-emitted into a generated plan or a ledger `requires` array as an unresolved token. It now resolves tag tokens to concrete change names via `@pgpmjs/ast`'s existing `resolveReference` (no new dep, no transform→core cycle):

```ts
dependencies: change.dependencies.map(dep => resolveDependencyToken(dep, plan, warnings, change.name))
// '@v1'        -> 'schemas/app/schema'   (local tag resolved against this plan)
// 'schemas/..' -> unchanged              (non-tag tokens untouched — zero behavior change)
// 'other:@v1'  -> left as-is + warning   (cross-package tag needs workspace context)
// '@nope'      -> left as-is + warning    (never dropped)
```

Only tokens containing `@` are touched, so non-tag dependencies are byte-for-byte unchanged.

## Notes
- Additive and opt-in: `migrate baseline` / `import --baseline` are new; existing `deploy`/`import`/`diff` behavior is unchanged. `deploy --logOnly` remains the imperative equivalent; `baseline` is the declarative/emit-a-file adoption form.
- Cross-package tags-in-`requires` (`pkg:@tag`) are surfaced with a warning rather than silently mis-recorded; resolving them needs the workspace and is left as a documented follow-up.

## Test plan
- `pgpm/transform` — `loadModuleSource` tag resolution: local tag resolved, non-tag untouched, unknown/cross-package left verbatim with a warning.
- `pgpm/core` — `baselineBackfillEntries` / `buildBaselineBackfill`: whole-plan rows in plan order, log-only SQL, missing-deploy-script skip.
- `pgpm/cli` (live PG) — `import --baseline` writes an idempotent log-only backfill; **adoption e2e**: apply a raw dump to a fresh DB (no ledger) → `pgpm import` → `pgpm migrate baseline --database` records 13 changes → `pgpm deploy` is a no-op with an identical catalog.
- Regression: full core suite (479), transform (116), diff (18), and the #1630 ledger e2e (with container `pg_dump`) all green.


Link to Devin session: https://app.devin.ai/sessions/34f64615befa49d7b807f3467a07e726
Requested by: @pyramation