### PR TITLE
fix(safegres): grade routine findings by callability, and name the scores (scorecards)

### DIFF
--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -165,6 +165,13 @@ untrusted-role model; the `safegres:constructive` preset configures them for `an
 ‡ L6 needs an adapter that can compute [API reach](#api-reach--the-relations-the-api-can-actually-name);
 without one nothing is unaddressable and it never fires.
 
+**Exposure is asked per subject.** A relation finding is exposed when the API can address the
+relation. A *routine* finding — the convention rules, L19, L20 — is exposed when an untrusted role
+can **call the function**: `USAGE` on its schema and `EXECUTE` on the function, directly, by
+inheritance, or through Postgres's default `EXECUTE TO PUBLIC`. Grading a definer function by the
+schema it sits in is not conservative, it is wrong in the dangerous direction: the function is
+private precisely so that calling it is the only way in.
+
 **Direction is the load-bearing idea.** `fail-open` findings are exposure — the untrusted side
 reaches more than intended. `fail-closed` findings are *denied by Postgres at runtime*: an
 availability and hygiene concern, not a leak. They contribute **zero** to the score by default
@@ -594,7 +601,7 @@ Precedence: **CLI > project config > preset > built-in defaults**.
     { "tables": ["app_public.audit_*"], "rules": { "A2": "off" } }
   ],
   "perf": { "enabled": true, "ignore": ["app_public.audit_*"], "rules": { "X6": "off" } },
-  "scoring": { "densityK": 0.17, "unknownExposureCap": 80 },
+  "scoring": { "densityK": 0.17, "maxRuleDensity": 0.5, "unknownExposureCap": 80 },
   "failOn": { "grade": "B", "perfGrade": "B" }
 }
 ```
@@ -709,6 +716,17 @@ exposed tables lands at a C). Non-exposed findings score 0; fail-closed findings
 `scoring.failClosedWeight` is raised; unknown exposure caps the score; any exposed critical floors
 the grade at C (`scoring.floorOnCritical`). Grades: A+ 97 · A 90 · B 80 · C 65 · D 50 · F below.
 The legacy flat-deduction model is `scoring.model: "weighted"`.
+
+Two corrections keep a rule's **shape** out of the arithmetic, because a rule's fan-out is a
+property of how it reports, not of how much risk it found.
+
+- **Points are charged per unit of repair.** A rule that emits one finding per (relation ×
+  function) pair — L19 does, and on one real database that is 853 findings over 166 functions —
+  costs what fixing it costs: 166 revokes. The finding count is unchanged in the report; the
+  deduction reads `−664 (×853 → 166 fixes)`.
+- **No single rule can decide the grade.** Each rule's contribution is capped at
+  `scoring.maxRuleDensity` (default 0.5) of the points that would score an F alone, so one rule
+  at its ceiling costs two grade bands and an F still takes breadth. `false` disables it.
 
 Every report carries its own arithmetic: per-rule points, grade, and the **payoff** — how far the
 score would move if that rule's findings went away. Gate with `--fail-on <severity>`,

--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -732,6 +732,47 @@ Every report carries its own arithmetic: per-rule points, grade, and the **payof
 score would move if that rule's findings went away. Gate with `--fail-on <severity>`,
 `--fail-on-score <n>`, `--fail-on-grade <g>` and their `--fail-on-perf-*` counterparts.
 
+### Scorecards: one report, several questions
+
+"How secure is this database" is not one question, and a single grade answers it for at most one
+reader. A platform team gates on what an unauthenticated caller reaches; an application team gates
+on house style; a reviewer wants the number no preset softened. A **scorecard** is that question
+written down — a selector over the findings, plus the weighting to grade what it selects:
+
+```jsonc
+{
+  "scorecards": {
+    "anon-surface": {
+      "description": "What an unauthenticated caller reaches.",
+      "select": { "roles": ["anonymous"], "direction": "fail-open", "exposure": "all" },
+      "perRuleWeights": { "L19": 10 },
+      "floorOnCritical": "C"
+    },
+    "sql-conventions": {
+      "select": { "rules": ["C*"], "exposure": "all", "denominator": "all" }
+    }
+  },
+  "failOn": { "scorecards": { "anon-surface": { "grade": "A" } } }
+}
+```
+
+Selectors narrow on `rules` (with `C*` wildcards) and `exclude`, `dimension`, `roles`, `planes`,
+`schemas`, `direction`, `minSeverity`, `exposure`, `acknowledged`, `severities` and `denominator`.
+Every scoring key is available per card, and `failOn.scorecards` gates on the one that matters to
+you rather than on somebody else's headline.
+
+Two cards always run and cannot be redefined into something flattering:
+
+- **`default`** — the Safegres score: the headline, exposure-scoped and preset-tuned, i.e. graded
+  the way you actually use the database. Naming it in the config cannot move it.
+- **`raw`** — every finding at its *declared* (registry) severity, exposure ignored,
+  acknowledgements included, fail-closed findings weighted like anything else. Not flattering, and
+  not meant to be: it is the number that is comparable between two databases and that no
+  configuration talked down.
+
+A scorecard decides what a number is *about* — never what is reported. `report.findings` is always
+the complete set, so the JSON is the raw data and the scores are queries over it.
+
 ## Commands
 
 ```bash

--- a/packages/safegres/__tests__/audit.test.ts
+++ b/packages/safegres/__tests__/audit.test.ts
@@ -150,6 +150,30 @@ describe('audit — Script A', () => {
     expect(p5?.severity).toBe('high');
   });
 
+  it('carries scorecards without narrowing the findings they score', async () => {
+    // Over the fixtures already applied above: an `A*` card must not become
+    // the whole report just because it is the card being read.
+    const report = await audit(pg.client as never, {
+      schemas: ['fx_a2', 'fx_p5'],
+      config: {
+        scorecards: {
+          'flags-only': { select: { rules: ['A*'], exposure: 'all' } }
+        }
+      }
+    });
+
+    const names = (report.scorecards ?? []).map((c) => c.name);
+    expect(names).toEqual(['default', 'raw', 'flags-only']);
+
+    const card = report.scorecards!.find((c) => c.name === 'flags-only')!;
+    expect(card.findings).toBeGreaterThan(0);
+    expect(card.score.deductions.every((d) => d.code.startsWith('A'))).toBe(true);
+
+    // The selector grades a slice; the report still carries everything.
+    expect(report.findings.length).toBeGreaterThanOrEqual(card.findings);
+    expect(report.findings.some((f) => !f.code.startsWith('A'))).toBe(true);
+  });
+
   it('clean table produces no findings', async () => {
     await applyFixture('clean-table.sql');
     const report = await audit(pg.client as never, { schemas: ['fx_clean'] });

--- a/packages/safegres/__tests__/config.test.ts
+++ b/packages/safegres/__tests__/config.test.ts
@@ -337,6 +337,54 @@ describe('computeScore', () => {
     expect(x1.potential / x4.potential).toBeGreaterThan(8);
   });
 
+  it('density model: charges a rule per unit of repair, not per finding', () => {
+    // L19 emits one finding per (relation × function) pair; two functions
+    // reaching five relations each is ten findings and two revokes.
+    const findings = ['f_one', 'f_two'].flatMap((fn) =>
+      Array.from({ length: 5 }, (_, i) =>
+        finding({
+          code: 'L19',
+          severity: 'medium',
+          table: `t${i}`,
+          context: { function: `private.${fn}` }
+        }))
+    );
+    const score = computeScore(findings, {}, { exposedTables: 100, exposureKnown: true });
+    const [l19] = score.deductions;
+
+    expect(l19.count).toBe(10);
+    expect(l19.units).toBe(2);
+    // Two units at medium, not ten findings: 8 points rather than 40.
+    expect(l19.points).toBe(8);
+  });
+
+  it('density model: caps one rule at half the points that would fail an audit', () => {
+    // 300 criticals over 100 tables is 7500 raw points — an F many times
+    // over on one rule's say-so. The cap is 0.5·ln(100/50)/k·tables ≈ 203.9.
+    const findings = Array.from({ length: 300 }, (_, i) =>
+      finding({ code: 'A7', severity: 'critical', table: `t${i}` }));
+    const score = computeScore(findings, { floorOnCritical: false }, {
+      exposedTables: 100,
+      exposureKnown: true
+    });
+    const [a7] = score.deductions;
+
+    expect(a7.count).toBe(300);
+    expect(a7.capped).toBe(true);
+    expect(a7.points).toBeCloseTo(203.9, 1);
+    // One rule alone lands a C, never an F: breadth is what fails an audit.
+    expect(score.value).toBe(70.7);
+    expect(score.grade).toBe('C');
+
+    // Opt out and the raw arithmetic is back.
+    const uncapped = computeScore(findings, { maxRuleDensity: false, floorOnCritical: false }, {
+      exposedTables: 100,
+      exposureKnown: true
+    });
+    expect(uncapped.deductions[0].points).toBe(7500);
+    expect(uncapped.grade).toBe('F');
+  });
+
   it('density model: lists zero-weight rules as unscored rather than dropping them', () => {
     const findings = [
       finding({ code: 'A2', severity: 'high' }),

--- a/packages/safegres/__tests__/extensions.test.ts
+++ b/packages/safegres/__tests__/extensions.test.ts
@@ -91,6 +91,38 @@ describe('extension-owned relations', () => {
     expect(tables(report.findings)).toContain('fx_ext.app_widget');
   });
 
+  it('applies the same exclusions to routines, which the convention linter reads', async () => {
+    // The linter reads function bodies, and an extension's bodies are not the
+    // application's to fix. Before this, `extensions.ignore` filtered
+    // relations only, so partman's 300-odd functions arrived as house-style
+    // violations against a house that did not write them.
+    const fns = (findings: Finding[]) =>
+      [...new Set(
+        findings
+          .filter((f) => f.category === 'convention')
+          .map((f) => (f.context as { function?: string }).function?.replace(/\(.*$/, ''))
+      )];
+
+    const report = await audit(pg.client as never, {
+      schemas: SCHEMAS,
+      extensions: { ignore: ['pg_trgm'] },
+      config: { rules: { C1: 'high', C4: 'high' } }
+    });
+    const found = fns(report.findings);
+
+    expect(found).toContain('fx_ext.app_helper');
+    expect(found).not.toContain('fx_ext.ext_helper');       // extension-owned
+    expect(found).not.toContain('fx_ext_runtime.runtime_helper'); // ignored schema
+
+    // Ask for them and they arrive: the extension author is the audience.
+    const audited = await audit(pg.client as never, {
+      schemas: SCHEMAS,
+      extensions: { skipOwned: false },
+      config: { rules: { C1: 'high', C4: 'high' } }
+    });
+    expect(fns(audited.findings)).toContain('fx_ext.ext_helper');
+  });
+
   it('the constructive preset ships pg_partman in the ignore list', () => {
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'safegres-'));
     const { config } = loadConfig({ cwd, preset: 'constructive' });

--- a/packages/safegres/__tests__/fixtures/ext-owned.sql
+++ b/packages/safegres/__tests__/fixtures/ext-owned.sql
@@ -56,3 +56,23 @@ CREATE TABLE fx_ext_runtime.runtime_child (
   label text
 );
 GRANT SELECT ON fx_ext_runtime.runtime_child TO PUBLIC;
+
+-- The same distinction for routines, which the convention linter reads. All
+-- three use dynamic SQL (C4) and pin search_path (C1); only `app_helper` is
+-- the application's to fix.
+CREATE FUNCTION fx_ext.ext_helper() RETURNS void
+LANGUAGE plpgsql SET search_path = public AS $$
+BEGIN EXECUTE 'SELECT 1'; END;
+$$;
+ALTER EXTENSION hstore ADD FUNCTION fx_ext.ext_helper();
+
+CREATE FUNCTION fx_ext.app_helper() RETURNS void
+LANGUAGE plpgsql SET search_path = public AS $$
+BEGIN EXECUTE 'SELECT 1'; END;
+$$;
+
+-- Unregistered, but inside an extension's schema — the pg_partman shape.
+CREATE FUNCTION fx_ext_runtime.runtime_helper() RETURNS void
+LANGUAGE plpgsql SET search_path = public AS $$
+BEGIN EXECUTE 'SELECT 1'; END;
+$$;

--- a/packages/safegres/__tests__/lint-audit.test.ts
+++ b/packages/safegres/__tests__/lint-audit.test.ts
@@ -60,6 +60,34 @@ beforeAll(async () => {
     $$;
   `);
 
+  // An internal schema no API serves, holding a function anonymous can call.
+  // Relation reach says unexposed; callability says otherwise, and the
+  // second is the question a routine finding is about.
+  await pg.any('CREATE SCHEMA fx_lint_private');
+  await pg.any(`
+    CREATE FUNCTION fx_lint_private.reachable() RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+    BEGIN
+      EXECUTE 'SELECT 1';
+    END;
+    $$;
+  `);
+  await pg.any(`
+    CREATE FUNCTION fx_lint_private.locked() RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+    BEGIN
+      EXECUTE 'SELECT 1';
+    END;
+    $$;
+  `);
+  await pg.any(
+    'DO $$ BEGIN CREATE ROLE fx_anon NOLOGIN; EXCEPTION WHEN duplicate_object THEN NULL; END $$;'
+  );
+  await pg.any('GRANT USAGE ON SCHEMA fx_lint_private TO fx_anon');
+  await pg.any('REVOKE EXECUTE ON FUNCTION fx_lint_private.locked() FROM PUBLIC');
+
   // Clean: fully-qualified, no search_path, no dynamic SQL.
   await pg.any(`
     CREATE FUNCTION fx_lint.clean() RETURNS bigint
@@ -128,6 +156,28 @@ describe('audit: convention linter wiring (C*)', () => {
       (f) => (f.context as { function?: string }).function?.startsWith('fx_lint.clean(')
     );
     expect(onClean).toEqual([]);
+  });
+
+  it('grades a routine finding by who can call the function, not by its schema', async () => {
+    const report = await audit(pg.client as never, {
+      schemas: ['fx_lint', 'fx_lint_private'],
+      config: {
+        rules: { C4: 'high' },
+        exposure: { schemas: ['fx_lint'], roles: ['fx_anon'], anonRoles: ['fx_anon'] }
+      }
+    });
+    const c4 = (name: string) =>
+      report.findings.find(
+        (f) =>
+          f.code === 'C4'
+          && (f.context as { function?: string }).function?.startsWith(`fx_lint_private.${name}(`)
+      );
+
+    // Off the API surface, but `fx_anon` holds USAGE and the default
+    // EXECUTE-to-PUBLIC: it can call the body, so the finding scores.
+    expect(c4('reachable')?.exposed).toBe(true);
+    // Same schema, EXECUTE revoked from PUBLIC — genuinely out of reach.
+    expect(c4('locked')?.exposed).toBe(false);
   });
 
   it('runs the linter under the constructive preset but not under recommended', () => {

--- a/packages/safegres/__tests__/routine-reach.test.ts
+++ b/packages/safegres/__tests__/routine-reach.test.ts
@@ -1,0 +1,132 @@
+import type { RoleGraph } from '../src/checks/lattice';
+import { resolveRoutineReach } from '../src/exposure/routines';
+import type { RoleAttributes, SchemaAclInfo } from '../src/pg/acl';
+import type { FunctionSnapshot } from '../src/pg/functions';
+
+function role(name: string, extra: Partial<RoleAttributes> = {}): RoleAttributes {
+  return { name, bypassRls: false, isSuper: false, inheritsFrom: [], canSetRole: [], ...extra };
+}
+
+function fn(partial: Partial<FunctionSnapshot> & { schema: string; name: string }): FunctionSnapshot {
+  return {
+    oid: 1,
+    args: '',
+    owner: 'app_owner',
+    ownerBypassesRls: false,
+    isSecurityDefiner: true,
+    searchPathPinned: false,
+    returnsTrigger: false,
+    language: 'plpgsql',
+    source: null,
+    definition: null,
+    grants: [],
+    defaultAcl: false,
+    ...partial
+  };
+}
+
+function acl(schema: string, usage: string[]): SchemaAclInfo {
+  return {
+    schema,
+    owner: 'app_owner',
+    grants: usage.map((r) => ({ role: r, privilege: 'USAGE' as const })),
+    executeRoles: []
+  };
+}
+
+const graph: RoleGraph = new Map([
+  ['anonymous', role('anonymous')],
+  ['authenticated', role('authenticated', { inheritsFrom: ['app_reader'] })]
+]);
+
+const schemaAcls = new Map([
+  ['app_private', acl('app_private', ['anonymous', 'authenticated'])],
+  ['app_locked', acl('app_locked', [])],
+  ['app_public', acl('app_public', ['anonymous'])]
+]);
+
+const options = {
+  roles: ['anonymous'],
+  graph,
+  schemaAcls,
+  exposedSchemas: new Set(['app_public'])
+};
+
+describe('resolveRoutineReach', () => {
+  it('reaches a function in an unexposed schema the role can execute', () => {
+    // The whole point: `app_private` is off the API surface, so relation
+    // reach says no — but anonymous holds USAGE and EXECUTE, so it can call
+    // the definer function and get its owner's privileges.
+    const reach = resolveRoutineReach(
+      [fn({ schema: 'app_private', name: 'perm_check', grants: [{ role: 'anonymous', grantable: false }] })],
+      options
+    );
+    expect([...reach]).toEqual(['app_private.perm_check']);
+  });
+
+  it('counts the default EXECUTE-to-PUBLIC ACL as reach', () => {
+    const reach = resolveRoutineReach(
+      [fn({
+        schema: 'app_private',
+        name: 'helper',
+        grants: [{ role: 'PUBLIC', grantable: false }],
+        defaultAcl: true
+      })],
+      options
+    );
+    expect(reach.has('app_private.helper')).toBe(true);
+  });
+
+  it('does not reach past a schema the role has no USAGE on', () => {
+    // EXECUTE without USAGE names nothing — the same gate L3 applies to a
+    // table grant. Without it, Postgres's default ACL would make every
+    // function in every internal schema look reachable by everyone.
+    const reach = resolveRoutineReach(
+      [fn({ schema: 'app_locked', name: 'helper', grants: [{ role: 'PUBLIC', grantable: false }] })],
+      options
+    );
+    expect(reach.size).toBe(0);
+  });
+
+  it('does not reach a function the role holds no EXECUTE on', () => {
+    const reach = resolveRoutineReach(
+      [fn({ schema: 'app_private', name: 'admin_only', grants: [{ role: 'administrator', grantable: false }] })],
+      options
+    );
+    expect(reach.size).toBe(0);
+  });
+
+  it('follows role inheritance', () => {
+    const reach = resolveRoutineReach(
+      [fn({ schema: 'app_private', name: 'reader', grants: [{ role: 'app_reader', grantable: false }] })],
+      { ...options, roles: ['authenticated'] }
+    );
+    expect(reach.has('app_private.reader')).toBe(true);
+  });
+
+  it('judges a trigger function by its schema, not its ACL', () => {
+    // Postgres refuses a direct call however wide the ACL is, so EXECUTE on
+    // one confers nothing. What reaches the body is a write that fires it.
+    const reach = resolveRoutineReach(
+      [
+        fn({
+          schema: 'app_private',
+          name: 'on_write',
+          returnsTrigger: true,
+          grants: [{ role: 'PUBLIC', grantable: false }]
+        }),
+        fn({ schema: 'app_public', name: 'on_write', returnsTrigger: true, grants: [] })
+      ],
+      options
+    );
+    expect([...reach]).toEqual(['app_public.on_write']);
+  });
+
+  it('reaches nothing when no untrusted role is resolved', () => {
+    const reach = resolveRoutineReach(
+      [fn({ schema: 'app_private', name: 'helper', grants: [{ role: 'PUBLIC', grantable: false }] })],
+      { ...options, roles: [] }
+    );
+    expect(reach.size).toBe(0);
+  });
+});

--- a/packages/safegres/__tests__/scorecards.test.ts
+++ b/packages/safegres/__tests__/scorecards.test.ts
@@ -1,0 +1,155 @@
+import { computeScore } from '../src/score/score';
+import {
+  computeScorecards,
+  RESERVED_SCORECARDS,
+  selectFindings
+} from '../src/score/scorecards';
+import type { Finding } from '../src/types';
+
+function finding(over: Partial<Finding> = {}): Finding {
+  return {
+    code: 'A2',
+    severity: 'high',
+    category: 'flags',
+    direction: 'fail-open',
+    exposed: true,
+    schema: 'app_public',
+    table: 'widgets',
+    message: 'test',
+    ...over
+  };
+}
+
+const context = { exposedTables: 100, totalTables: 200, exposureKnown: true };
+
+function cards(findings: Finding[], config = {}) {
+  const headline = computeScore(findings, {}, context);
+  const report = computeScorecards(
+    findings,
+    headline,
+    { ...RESERVED_SCORECARDS, ...config },
+    context
+  );
+  return Object.fromEntries(report.map((c) => [c.name, c]));
+}
+
+describe('scorecards', () => {
+  it('always carries default and raw, whatever the config says', () => {
+    const byName = cards([finding()]);
+    expect(Object.keys(byName)).toEqual(['default', 'raw']);
+    expect(byName.default.reserved).toBe(true);
+    expect(byName.raw.reserved).toBe(true);
+  });
+
+  it('default is the headline verbatim — a scorecard block cannot move the badge', () => {
+    const findings = [finding(), finding({ code: 'A5', severity: 'critical' })];
+    const headline = computeScore(findings, {}, context);
+    const byName = cards(findings, {
+      // A card that would love the headline to be a 100.
+      default: { weights: { critical: 0, high: 0 } }
+    });
+    expect(byName.default.score).toEqual(headline);
+    expect(byName.default.score.value).toBeLessThan(100);
+  });
+
+  it('raw ignores exposure, acknowledgement and preset severities', () => {
+    const findings = [
+      // Everything the headline discounts, one of each.
+      finding({ code: 'A2', exposed: false }),
+      finding({ code: 'A5', acknowledged: true }),
+      // A preset quieted A3 to info; the registry declares it `low`.
+      finding({ code: 'A3', severity: 'info' }),
+      finding({ code: 'A4', direction: 'fail-closed' })
+    ];
+    const byName = cards(findings);
+
+    expect(byName.default.score.value).toBe(100);
+    expect(byName.raw.findings).toBe(4);
+    expect(byName.raw.score.value).toBeLessThan(100);
+    expect(byName.raw.score.deductions.find((d) => d.code === 'A3')?.points).toBeGreaterThan(0);
+  });
+
+  it('grades a team question: one rule set, its own weighting and gate', () => {
+    const findings = [
+      ...Array.from({ length: 12 }, (_, i) => finding({ code: 'C4', severity: 'low', table: `t${i}` })),
+      finding({ code: 'A2', severity: 'critical' })
+    ];
+    const byName = cards(findings, {
+      'sql-conventions': {
+        description: 'House style.',
+        select: { rules: ['C*'] },
+        weights: { low: 8 },
+        floorOnCritical: false
+      }
+    });
+
+    const card = byName['sql-conventions'];
+    expect(card.findings).toBe(12);
+    expect(card.description).toBe('House style.');
+    // The critical is somebody else's problem: this card grades C* only.
+    expect(card.score.deductions.map((d) => d.code)).toEqual(['C4']);
+    expect(card.score.value).toBeLessThan(byName.default.score.value);
+  });
+
+  it('selects by role, wherever the finding recorded it', () => {
+    const findings = [
+      finding({ code: 'R1', role: 'anonymous' }),
+      finding({ code: 'L19', context: { role: 'anonymous', function: 'p.f' } }),
+      finding({ code: 'L1', context: { roles: ['authenticated', 'anonymous'] } }),
+      finding({ code: 'A2', role: 'authenticated' })
+    ];
+    expect(selectFindings(findings, { roles: ['anonymous'] }).map((f) => f.code))
+      .toEqual(['R1', 'L19', 'L1']);
+  });
+
+  it('narrows on planes, schemas, direction and severity', () => {
+    const findings = [
+      finding({ code: 'A2', planes: ['api'], schema: 'app_public' }),
+      finding({ code: 'A5', planes: ['direct:app'], schema: 'app_public' }),
+      finding({ code: 'A4', planes: ['api'], schema: 'private', direction: 'fail-closed' }),
+      finding({ code: 'A6', planes: ['api'], schema: 'app_public', severity: 'low' })
+    ];
+    expect(selectFindings(findings, { planes: ['api'] }).map((f) => f.code))
+      .toEqual(['A2', 'A4', 'A6']);
+    expect(selectFindings(findings, { schemas: ['private'] }).map((f) => f.code)).toEqual(['A4']);
+    expect(selectFindings(findings, { direction: 'fail-closed' }).map((f) => f.code)).toEqual(['A4']);
+    expect(selectFindings(findings, { minSeverity: 'high' }).map((f) => f.code))
+      .toEqual(['A2', 'A5', 'A4']);
+  });
+
+  it('excludes after including, so a wildcard can carve out one rule', () => {
+    const findings = ['C1', 'C2', 'C3', 'C4', 'A2'].map((code) => finding({ code }));
+    expect(selectFindings(findings, { rules: ['C*'], exclude: ['C3'] }).map((f) => f.code))
+      .toEqual(['C1', 'C2', 'C4']);
+  });
+
+  it('never mutates the findings it re-severities', () => {
+    const original = finding({ code: 'A3', severity: 'info' });
+    const [selected] = selectFindings([original], { severities: 'declared' });
+    expect(original.severity).toBe('info');
+    expect(selected.severity).not.toBe('info');
+  });
+
+  it('normalizes an exposure-ignoring card by every relation, not just the exposed ones', () => {
+    const findings = Array.from({ length: 40 }, (_, i) =>
+      finding({ code: 'A2', exposed: false, table: `t${i}` }));
+    const byName = cards(findings, {
+      wide: { select: { exposure: 'all', denominator: 'all' } },
+      narrow: { select: { exposure: 'all' } }
+    });
+    // Same numerator, denominator twice the size: dividing the wider set by
+    // the narrower surface would penalize a card for asking a wider question.
+    expect(byName.wide.score.value).toBeGreaterThan(byName.narrow.score.value);
+    expect(byName.wide.score.exposedTables).toBe(200);
+  });
+
+  it('can grade both dimensions in one number when a team wants one', () => {
+    const findings = [
+      finding({ code: 'A2', dimension: 'security' }),
+      finding({ code: 'X1', dimension: 'perf', category: 'index' })
+    ];
+    expect(selectFindings(findings, {}).map((f) => f.code)).toEqual(['A2']);
+    expect(selectFindings(findings, { dimension: 'perf' }).map((f) => f.code)).toEqual(['X1']);
+    expect(selectFindings(findings, { dimension: 'all' }).map((f) => f.code)).toEqual(['A2', 'X1']);
+  });
+});

--- a/packages/safegres/schema/safegres.schema.json
+++ b/packages/safegres/schema/safegres.schema.json
@@ -604,6 +604,225 @@
       },
       "description": "The security scoring model"
     },
+    "scorecards": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "model": {
+            "type": "string",
+            "enum": [
+              "density",
+              "weighted"
+            ],
+            "description": "Scoring model. Default density."
+          },
+          "weights": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number",
+              "description": "Points"
+            },
+            "description": "Points deducted per finding severity"
+          },
+          "perRuleWeights": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number",
+              "description": "Points"
+            },
+            "description": "Per-rule weight, beating the severity weight"
+          },
+          "maxDeductionPerRule": {
+            "type": "number",
+            "description": "Cap on one rule’s total deduction (weighted model)"
+          },
+          "maxRuleDensity": {
+            "anyOf": [
+              {
+                "type": "number",
+                "description": "Fraction"
+              },
+              {
+                "type": "boolean",
+                "description": "false to disable"
+              }
+            ],
+            "description": "Cap on one rule’s contribution, as a fraction of the points that fail an audit alone. Default 0.5; false disables the cap."
+          },
+          "failClosedWeight": {
+            "type": "number",
+            "description": "Multiplier for fail-closed findings. Default 0."
+          },
+          "densityK": {
+            "type": "number",
+            "description": "Density falloff constant. Default 0.17."
+          },
+          "unknownExposureCap": {
+            "anyOf": [
+              {
+                "type": "number",
+                "description": "Cap"
+              },
+              {
+                "type": "boolean",
+                "description": "false to disable"
+              }
+            ],
+            "description": "Maximum score when no exposure surface resolves. Default 80; false disables the cap."
+          },
+          "floorOnCritical": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "A+",
+                  "A",
+                  "B",
+                  "C",
+                  "D",
+                  "F"
+                ],
+                "description": "Grade"
+              },
+              {
+                "type": "boolean",
+                "description": "false to disable"
+              }
+            ],
+            "description": "Grade any critical finding floors the score at. Default C; false disables."
+          },
+          "gradeBands": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number",
+              "description": "Score"
+            },
+            "description": "Minimum score for each grade"
+          },
+          "title": {
+            "type": "string",
+            "description": "Heading for reports. Defaults to the config key."
+          },
+          "description": {
+            "type": "string",
+            "description": "What decision this score informs. Rendered with it."
+          },
+          "select": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "rules": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Rule code or wildcard"
+                },
+                "description": "Rule codes or C* prefix wildcards to grade"
+              },
+              "exclude": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Rule code or wildcard"
+                },
+                "description": "Rule codes or wildcards to drop after rules selected"
+              },
+              "dimension": {
+                "type": "string",
+                "enum": [
+                  "security",
+                  "perf",
+                  "all"
+                ],
+                "description": "Which axis: security (default), perf, or all"
+              },
+              "roles": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Role name"
+                },
+                "description": "Only findings about these roles"
+              },
+              "planes": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Plane name"
+                },
+                "description": "Only findings reachable on these access planes"
+              },
+              "schemas": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "description": "Schema name"
+                },
+                "description": "Only findings in these schemas"
+              },
+              "direction": {
+                "type": "string",
+                "enum": [
+                  "fail-open",
+                  "fail-closed",
+                  "none",
+                  "any"
+                ],
+                "description": "fail-open leaks, fail-closed denials, or any"
+              },
+              "minSeverity": {
+                "type": "string",
+                "enum": [
+                  "critical",
+                  "high",
+                  "medium",
+                  "low",
+                  "info"
+                ],
+                "description": "Drop findings below this severity before scoring"
+              },
+              "exposure": {
+                "type": "string",
+                "enum": [
+                  "exposed",
+                  "all"
+                ],
+                "description": "exposed (default) grades the API surface; all ignores exposure"
+              },
+              "acknowledged": {
+                "type": "string",
+                "enum": [
+                  "skip",
+                  "include"
+                ],
+                "description": "include grades acknowledged findings too. Default skip."
+              },
+              "severities": {
+                "type": "string",
+                "enum": [
+                  "configured",
+                  "declared"
+                ],
+                "description": "configured (default) uses this config’s severities; declared uses each rule’s registry default"
+              },
+              "denominator": {
+                "type": "string",
+                "enum": [
+                  "exposed",
+                  "all"
+                ],
+                "description": "Density denominator: exposed relations (default) or all"
+              }
+            },
+            "description": "Which findings it grades"
+          }
+        },
+        "description": "One scorecard"
+      },
+      "description": "Named scores over slices of the same findings, keyed by name"
+    },
     "failOn": {
       "type": "object",
       "additionalProperties": false,
@@ -677,6 +896,33 @@
             "description": "One plane gate"
           },
           "description": "Per-plane gates, keyed by plane name. A floor is the useful shape."
+        },
+        "scorecards": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "score": {
+                "type": "number",
+                "description": "Exit non-zero below this plane score"
+              },
+              "grade": {
+                "type": "string",
+                "enum": [
+                  "A+",
+                  "A",
+                  "B",
+                  "C",
+                  "D",
+                  "F"
+                ],
+                "description": "Exit non-zero below this plane grade"
+              }
+            },
+            "description": "One scorecard gate"
+          },
+          "description": "Per-scorecard gates, keyed by scorecard name."
         }
       },
       "description": "Gates — what makes the run exit non-zero"

--- a/packages/safegres/schema/safegres.schema.json
+++ b/packages/safegres/schema/safegres.schema.json
@@ -244,6 +244,19 @@
               "type": "number",
               "description": "Cap on one rule’s total deduction (weighted model)"
             },
+            "maxRuleDensity": {
+              "anyOf": [
+                {
+                  "type": "number",
+                  "description": "Fraction"
+                },
+                {
+                  "type": "boolean",
+                  "description": "false to disable"
+                }
+              ],
+              "description": "Cap on one rule’s contribution, as a fraction of the points that fail an audit alone. Default 0.5; false disables the cap."
+            },
             "failClosedWeight": {
               "type": "number",
               "description": "Multiplier for fail-closed findings. Default 0."
@@ -524,6 +537,19 @@
         "maxDeductionPerRule": {
           "type": "number",
           "description": "Cap on one rule’s total deduction (weighted model)"
+        },
+        "maxRuleDensity": {
+          "anyOf": [
+            {
+              "type": "number",
+              "description": "Fraction"
+            },
+            {
+              "type": "boolean",
+              "description": "false to disable"
+            }
+          ],
+          "description": "Cap on one rule’s contribution, as a fraction of the points that fail an audit alone. Default 0.5; false disables the cap."
         },
         "failClosedWeight": {
           "type": "number",

--- a/packages/safegres/src/checks/definer-function.ts
+++ b/packages/safegres/src/checks/definer-function.ts
@@ -32,7 +32,7 @@
  */
 
 import { extractBody, extractFunctionAccess } from '../callgraph/extract';
-import type { SchemaAclInfo } from '../pg/acl';
+import { canEnterSchema, type SchemaAclInfo } from '../pg/acl';
 import type { FunctionSnapshot } from '../pg/functions';
 import type { ViewSnapshot } from '../pg/indexes';
 import type { PgPrivilege, TableSnapshot } from '../pg/introspect';
@@ -550,30 +550,6 @@ export function checkUnreadableFunctionReach(
   }
 
   return out;
-}
-
-/**
- * The role can enter the schema, so a grant on something inside it is reach.
- *
- * The same gate L3 applies to a table grant, applied to EXECUTE: without
- * `USAGE` the function cannot be named, and Postgres's default
- * EXECUTE-to-PUBLIC would otherwise make every definer function in an
- * internal schema look reachable by every role in the database.
- */
-function canEnterSchema(
-  schema: string,
-  role: string,
-  graph: RoleGraph,
-  schemaAcls: Map<string, SchemaAclInfo>
-): boolean {
-  const acl = schemaAcls.get(schema);
-  if (!acl) return true; // not introspected: assume reachable rather than silently drop
-  const attrs = graph.get(role);
-  if (attrs?.isSuper) return true;
-  if (role === acl.owner) return true;
-  const usage = new Set(acl.grants.filter((g) => g.privilege === 'USAGE').map((g) => g.role));
-  if (usage.has('PUBLIC') || usage.has(role)) return true;
-  return (attrs?.inheritsFrom ?? []).some((a) => usage.has(a) || a === acl.owner);
 }
 
 /** The owner is exempt from the relation's policies on this path. */

--- a/packages/safegres/src/cli/audit.ts
+++ b/packages/safegres/src/cli/audit.ts
@@ -490,6 +490,21 @@ export default async (
     }
   }
 
+  // Per-scorecard gates. The point of a scorecard is that a team gates on
+  // its own question, so this is the gate that matters to them and the
+  // headline is someone else's number.
+  for (const [pattern, gate] of Object.entries(config.failOn?.scorecards ?? {})) {
+    const cards = (report.scorecards ?? []).filter((c) => matchPlane(pattern, c.name));
+    for (const card of cards) {
+      if (gate.score != null && card.score.value < gate.score) {
+        fail(`scorecard ${card.name} score ${card.score.value} is below failOn.scorecards["${pattern}"].score ${gate.score}`);
+      }
+      if (gate.grade && !meetsGrade(card.score.grade, gate.grade)) {
+        fail(`scorecard ${card.name} grade ${card.score.grade} is below failOn.scorecards["${pattern}"].grade ${gate.grade}`);
+      }
+    }
+  }
+
   const failOnNewPerf = argv['fail-on-new-perf'] === true || config.perf?.failOnNew === true;
   if (failOnNewPerf && report.perf?.diff && report.perf.diff.added.length > 0) {
     const count = report.perf.diff.added.length;

--- a/packages/safegres/src/commands/audit.ts
+++ b/packages/safegres/src/commands/audit.ts
@@ -108,6 +108,7 @@ import { listAuditableRoles, resolveRoles } from '../pg/roles';
 import { introspectStats, type StatsSnapshot } from '../pg/stats';
 import { dimensionOf, RULES_BY_CODE, subjectOf } from '../rules/registry';
 import { computeScore } from '../score/score';
+import { computeScorecards, RESERVED_SCORECARDS } from '../score/scorecards';
 import type { ExposureReport, Finding, PerfReport, PerfStatsReport, Report, RoleAccessReport } from '../types';
 import { summarize } from '../types';
 import { version as PKG_VERSION } from '../version';
@@ -910,6 +911,16 @@ export async function audit(
 
     report.perf = perf;
   }
+
+  // Scorecards last: they are named questions asked of the finished finding
+  // set, so every stamp a scorecard can select on (exposure, planes, perf
+  // dimension) is already on the findings by now.
+  report.scorecards = computeScorecards(
+    findings,
+    report.score!,
+    { ...RESERVED_SCORECARDS, ...(config.scorecards ?? {}) },
+    { exposedTables, totalTables: snapshot.length, exposureKnown: exposure.known }
+  );
 
   if (options.callGraph) {
     const functions = await getFunctions();

--- a/packages/safegres/src/commands/audit.ts
+++ b/packages/safegres/src/commands/audit.ts
@@ -91,6 +91,7 @@ import { configFingerprint } from '../config/fingerprint';
 import { allAstRulesDisabled, applyRulesToFindings, matchTablePattern, resolveRules, rulesForTable } from '../config/resolve';
 import type { ExposureConfig, SafegresConfig } from '../config/types';
 import { resolvePlaneReach, scorePlane, stampPlanes } from '../exposure/planes';
+import { resolveRoutineReach } from '../exposure/routines';
 import { LINT_RULES, LINT_RULES_BY_ID, lintDefinition, type LintProblem, type SuppressedProblem } from '../lint';
 import { type ExplainReport, proveFindings } from '../perf/explain';
 import { introspectRoleGraph, introspectSchemaAcls } from '../pg/acl';
@@ -105,7 +106,7 @@ import { lookupVolatility, type ProcVolatility } from '../pg/proc';
 import { introspectReachInputs } from '../pg/reach-inputs';
 import { listAuditableRoles, resolveRoles } from '../pg/roles';
 import { introspectStats, type StatsSnapshot } from '../pg/stats';
-import { dimensionOf, RULES_BY_CODE } from '../rules/registry';
+import { dimensionOf, RULES_BY_CODE, subjectOf } from '../rules/registry';
 import { computeScore } from '../score/score';
 import type { ExposureReport, Finding, PerfReport, PerfStatsReport, Report, RoleAccessReport } from '../types';
 import { summarize } from '../types';
@@ -176,6 +177,8 @@ export async function audit(
   const config = options.config ?? {};
   const resolved = resolveRules(config);
 
+  const extensions = options.extensions ?? config.extensions;
+
   // Function definitions are read by two independent features (the convention
   // linter and the call graph); introspect them at most once.
   let functionsCache: FunctionSnapshot[] | undefined;
@@ -183,7 +186,8 @@ export async function audit(
     if (!functionsCache) {
       functionsCache = await introspectFunctions(exec, {
         schemas: options.schemas ?? config.schemas,
-        excludeSchemas: options.excludeSchemas ?? config.excludeSchemas
+        excludeSchemas: options.excludeSchemas ?? config.excludeSchemas,
+        extensions
       });
     }
     return functionsCache;
@@ -221,8 +225,6 @@ export async function audit(
   const unaddressable = new Set(
     (apiReach?.unreachable ?? []).map((r) => `${r.schema}.${r.table}`)
   );
-
-  const extensions = options.extensions ?? config.extensions;
 
   const snapshot = await introspectTables(exec, {
     schemas: options.schemas ?? config.schemas,
@@ -656,6 +658,24 @@ export async function audit(
 
   findings = applyRulesToFindings(resolved, findings);
 
+  // Routine findings are graded by whether an untrusted role can *call the
+  // function*, not by whether its schema is on the API surface — see
+  // `RuleMeta.subject`. Resolved only when such a finding exists, so an audit
+  // with the routine rules off still costs one query less.
+  const routineRoles = [...new Set([...apiRoles, ...(exposure.anonRoles ?? [])])];
+  let routineReach: Set<string> | undefined;
+  const isRoutineExposed = async (schema: string, name: string): Promise<boolean> => {
+    if (!routineReach) {
+      routineReach = resolveRoutineReach(await getFunctions(), {
+        roles: routineRoles,
+        graph: roleGraph,
+        schemaAcls: schemaAclsByName,
+        exposedSchemas
+      });
+    }
+    return routineReach.has(`${schema}.${name}`);
+  };
+
   // Stamp direction (from the registry) and exposure on every finding.
   const publicRead = config.public?.read ?? [];
   const perfIgnore = config.perf?.ignore ?? [];
@@ -670,9 +690,25 @@ export async function audit(
       const viewRef = f.code === 'L14'
         ? (f.context as { view?: string } | undefined)?.view
         : undefined;
-      f.exposed = viewRef
-        ? isExposed(viewRef.slice(0, viewRef.lastIndexOf('.')), viewRef.slice(viewRef.lastIndexOf('.') + 1))
-        : isExposed(f.schema, f.table);
+      // A routine finding names a function somewhere in the finding — in
+      // `context.function` for the reach rules, in `schema`/`table` for the
+      // convention linter, which files a function under the fields a relation
+      // finding uses.
+      const routineRef = meta && subjectOf(meta) === 'routine'
+        ? (f.context as { function?: string } | undefined)?.function?.replace(/\(.*$/, '')
+          ?? (f.table ? `${f.schema}.${f.table}` : undefined)
+        : undefined;
+      if (routineRef) {
+        const dot = routineRef.lastIndexOf('.');
+        f.exposed = await isRoutineExposed(routineRef.slice(0, dot), routineRef.slice(dot + 1));
+      } else if (viewRef) {
+        f.exposed = isExposed(
+          viewRef.slice(0, viewRef.lastIndexOf('.')),
+          viewRef.slice(viewRef.lastIndexOf('.') + 1)
+        );
+      } else {
+        f.exposed = isExposed(f.schema, f.table);
+      }
     }
 
     // A key that looks like a write-once provisioning pointer, where the

--- a/packages/safegres/src/config/loader.ts
+++ b/packages/safegres/src/config/loader.ts
@@ -185,6 +185,11 @@ function mergePreset(preset: SafegresConfig, over: SafegresConfig): SafegresConf
     rules: { ...(base.rules ?? {}), ...(over.rules ?? {}) },
     scoring: { ...(base.scoring ?? {}), ...(over.scoring ?? {}) },
     failOn: { ...(base.failOn ?? {}), ...(over.failOn ?? {}) },
+    // Per name: a project adds its own card without dropping the preset's,
+    // and redefines one by naming it.
+    ...(base.scorecards || over.scorecards
+      ? { scorecards: { ...(base.scorecards ?? {}), ...(over.scorecards ?? {}) } }
+      : {}),
     overrides: [...(base.overrides ?? []), ...(over.overrides ?? [])],
     // Merged per-key so retuning `skipOwned` doesn't silently drop the
     // preset's `ignore` list. Omitted entirely when neither side sets it.

--- a/packages/safegres/src/config/presets.ts
+++ b/packages/safegres/src/config/presets.ts
@@ -131,7 +131,34 @@ export const constructive: SafegresConfig = {
     C3: 'low',
     C4: 'high'
   },
-  scoring: { floorOnCritical: 'C' }
+  scoring: { floorOnCritical: 'C' },
+  // The headline grades the API surface, which is the product's own question.
+  // These are the two other questions this codebase actually gates on, and
+  // neither is well served by being averaged into the first.
+  scorecards: {
+    'anon-surface': {
+      title: 'Anonymous surface',
+      description: 'What an unauthenticated caller reaches — exposure ignored, leaks only.',
+      select: {
+        roles: ['anonymous'],
+        direction: 'fail-open',
+        exposure: 'all',
+        denominator: 'all',
+        severities: 'declared'
+      },
+      // Nothing about the anonymous surface is informational. The L-series
+      // ships at `info` because each rule is new, not because "an
+      // unauthenticated caller reaches this" is a matter of interest — so on
+      // the card that asks exactly that question, a finding costs a point.
+      weights: { info: 1 },
+      floorOnCritical: 'C'
+    },
+    'sql-conventions': {
+      title: 'SQL conventions',
+      description: 'House style in function bodies — reachable or not, it is still the codebase.',
+      select: { rules: ['C*'], exposure: 'all', denominator: 'all' }
+    }
+  }
 };
 
 /** Structural flags only — a fast CI smoke check. */

--- a/packages/safegres/src/config/schema.ts
+++ b/packages/safegres/src/config/schema.ts
@@ -18,6 +18,8 @@ import type {
   PublicConfig,
   ReportConfig,
   SafegresConfig,
+  ScorecardConfig,
+  ScorecardSelector,
   ScoringConfig,
   SourceConfig
 } from './types';
@@ -165,6 +167,31 @@ const PERF: Shape<PerfConfig> = {
   paths: obj('Access-path classification, which decides whether X1 applies', PERF_PATHS)
 };
 
+const SCORECARD_SELECT: Shape<ScorecardSelector> = {
+  rules: list('Rule codes or C* prefix wildcards to grade', str('Rule code or wildcard')),
+  exclude: list('Rule codes or wildcards to drop after rules selected', str('Rule code or wildcard')),
+  dimension: str('Which axis: security (default), perf, or all', ['security', 'perf', 'all']),
+  roles: list('Only findings about these roles', str('Role name')),
+  planes: list('Only findings reachable on these access planes', str('Plane name')),
+  schemas: list('Only findings in these schemas', str('Schema name')),
+  direction: str('fail-open leaks, fail-closed denials, or any', ['fail-open', 'fail-closed', 'none', 'any']),
+  minSeverity: str('Drop findings below this severity before scoring', SEVERITIES),
+  exposure: str('exposed (default) grades the API surface; all ignores exposure', ['exposed', 'all']),
+  acknowledged: str('include grades acknowledged findings too. Default skip.', ['skip', 'include']),
+  severities: str(
+    'configured (default) uses this config\u2019s severities; declared uses each rule\u2019s registry default',
+    ['configured', 'declared']
+  ),
+  denominator: str('Density denominator: exposed relations (default) or all', ['exposed', 'all'])
+};
+
+const SCORECARD: Shape<ScorecardConfig> = {
+  ...SCORING,
+  title: str('Heading for reports. Defaults to the config key.'),
+  description: str('What decision this score informs. Rendered with it.'),
+  select: obj('Which findings it grades', SCORECARD_SELECT)
+};
+
 const FAIL_ON_PLANE: Shape<PlaneFailOnConfig> = {
   score: num('Exit non-zero below this plane score'),
   grade: str('Exit non-zero below this plane grade', GRADES)
@@ -180,6 +207,11 @@ const FAIL_ON: Shape<FailOnConfig> = {
     type: 'record',
     description: 'Per-plane gates, keyed by plane name. A floor is the useful shape.',
     values: obj('One plane gate', FAIL_ON_PLANE)
+  },
+  scorecards: {
+    type: 'record',
+    description: 'Per-scorecard gates, keyed by scorecard name.',
+    values: obj('One scorecard gate', FAIL_ON_PLANE)
   }
 };
 
@@ -271,6 +303,11 @@ export const CONFIG_SHAPE: Shape<SafegresConfig> = {
   rules: RULES,
   overrides: list('Per-scope retuning, ESLint overrides-style', obj('One override', OVERRIDE)),
   scoring: obj('The security scoring model', SCORING),
+  scorecards: {
+    type: 'record',
+    description: 'Named scores over slices of the same findings, keyed by name',
+    values: obj('One scorecard', SCORECARD)
+  },
   failOn: obj('Gates \u2014 what makes the run exit non-zero', FAIL_ON),
   source: obj('Where the database to audit comes from', SOURCE),
   outputs: obj('Files a single run writes', OUTPUTS),

--- a/packages/safegres/src/config/schema.ts
+++ b/packages/safegres/src/config/schema.ts
@@ -103,6 +103,11 @@ const SCORING: Shape<ScoringConfig> = {
   weights: { type: 'record', description: 'Points deducted per finding severity', values: num('Points') },
   perRuleWeights: { type: 'record', description: 'Per-rule weight, beating the severity weight', values: num('Points') },
   maxDeductionPerRule: num('Cap on one rule\u2019s total deduction (weighted model)'),
+  maxRuleDensity: oneOf(
+    'Cap on one rule\u2019s contribution, as a fraction of the points that fail an audit alone. Default 0.5; false disables the cap.',
+    num('Fraction'),
+    bool('false to disable')
+  ),
   failClosedWeight: num('Multiplier for fail-closed findings. Default 0.'),
   densityK: num('Density falloff constant. Default 0.17.'),
   unknownExposureCap: oneOf(

--- a/packages/safegres/src/config/types.ts
+++ b/packages/safegres/src/config/types.ts
@@ -1,5 +1,5 @@
 import type { ExposureAdapter } from '../exposure/adapters';
-import type { Severity } from '../types';
+import type { Dimension, Direction, Severity } from '../types';
 
 /**
  * `'off'` disables a rule; a severity retunes it; `[severity, options]`
@@ -172,6 +172,86 @@ export interface ScoringConfig {
 }
 
 /**
+ * A named score over a slice of the findings: a selector plus the weighting
+ * to grade what it selects with. Every scoring key is available per card, so
+ * a scorecard is a full `ScoringConfig` with a question attached.
+ *
+ * The point is that "how secure is this database" is not one question. A
+ * platform team gates on what `anonymous` reaches; an application team gates
+ * on house style; a compliance reviewer wants the number that no preset
+ * softened. Collapsing those into a single grade means at least two of them
+ * are reading a number that does not answer their question — and the first
+ * time it disagrees with their judgement, they stop reading it at all.
+ *
+ * ```jsonc
+ * "scorecards": {
+ *   "anon-surface": {
+ *     "description": "What an unauthenticated caller reaches.",
+ *     "select": { "roles": ["anonymous"], "direction": "fail-open" },
+ *     "perRuleWeights": { "L19": 10 },
+ *     "floorOnCritical": "C"
+ *   },
+ *   "sql-conventions": { "select": { "rules": ["C*"], "exposure": "all" } }
+ * }
+ * ```
+ *
+ * Findings are never filtered by a scorecard — only *scored* by one. The
+ * report always carries every finding, so no configuration of this block can
+ * hide anything; it can only decide what a given number is about.
+ */
+export interface ScorecardConfig extends ScoringConfig {
+  /** Heading for reports. Defaults to the config key. */
+  title?: string;
+  /** What decision this score informs. Rendered with it. */
+  description?: string;
+  /** Which findings it grades. An empty selector grades what the headline does. */
+  select?: ScorecardSelector;
+}
+
+/**
+ * Which findings a scorecard grades. Every clause narrows; omitting one
+ * means "don't care", and an empty selector is the headline's own slice
+ * (exposed, non-acknowledged, security-dimension).
+ */
+export interface ScorecardSelector {
+  /** Rule codes or `C*` prefix wildcards to include. Default: all. */
+  rules?: string[];
+  /** Rule codes or wildcards to drop after `rules` has selected. */
+  exclude?: string[];
+  /** `security` (default), `perf`, or `all` — the two axes in one number. */
+  dimension?: Dimension | 'all';
+  /** Only findings about these roles (the finding's role, grantee, or reach context). */
+  roles?: string[];
+  /** Only findings reachable on these access planes. */
+  planes?: string[];
+  /** Only findings in these schemas. */
+  schemas?: string[];
+  /** `fail-open` leaks, `fail-closed` denials, or `any`. Default: any. */
+  direction?: Direction | 'any';
+  /** Drop findings below this severity before scoring. */
+  minSeverity?: Severity;
+  /**
+   * `exposed` (default) grades only what the API surface reaches; `all`
+   * ignores exposure entirely — the honest, database-to-database number.
+   */
+  exposure?: 'exposed' | 'all';
+  /** `include` grades acknowledged findings too. Default: skip them. */
+  acknowledged?: 'skip' | 'include';
+  /**
+   * `configured` (default) uses the severities this config resolved;
+   * `declared` uses each rule's registry default, so a preset that quiets a
+   * rule cannot quiet the score that is supposed to catch it.
+   */
+  severities?: 'configured' | 'declared';
+  /**
+   * Density denominator: `exposed` relations (default) or `all` of them.
+   * A card that ignores exposure should normalize by everything, or it
+   * divides a wider numerator by a narrower denominator.
+   */
+  denominator?: 'exposed' | 'all';
+}
+
+/**
  * The optional performance dimension: index-hygiene and policy-cost rules
  * (`X*`, plus P1/P1b), scored on their own axis against the same exposure
  * surface. Off by default — `safegres perf` / `--perf` / `enabled: true`.
@@ -317,6 +397,12 @@ export interface FailOnConfig {
    * not become an F.
    */
   planes?: Record<string, PlaneFailOnConfig>;
+  /**
+   * Per-scorecard gates, keyed by scorecard name. This is where a team's own
+   * question becomes its own build failure — `{ "anon-surface": { "grade": "A" } }`
+   * gates on that and nothing else.
+   */
+  scorecards?: Record<string, PlaneFailOnConfig>;
 }
 
 export interface PlaneFailOnConfig {
@@ -455,6 +541,11 @@ export interface SafegresConfig {
   rules?: RulesConfig;
   overrides?: OverrideEntry[];
   scoring?: ScoringConfig;
+  /**
+   * Named scores over slices of the same findings — see `ScorecardConfig`.
+   * Merged with the reserved `default` and `raw` cards, which always run.
+   */
+  scorecards?: Record<string, ScorecardConfig>;
   failOn?: FailOnConfig;
   /** Where the database to audit comes from, when it isn't a live connection. */
   source?: SourceConfig;

--- a/packages/safegres/src/config/types.ts
+++ b/packages/safegres/src/config/types.ts
@@ -143,6 +143,17 @@ export interface ScoringConfig {
   /** Cap on total deduction any single rule can contribute (weighted model). */
   maxDeductionPerRule?: number;
   /**
+   * Cap on any single rule's contribution (density model), as a fraction of
+   * the points that would take the score to F on their own. Default 0.5 — one
+   * rule at its cap costs two grade bands, and an F still takes breadth.
+   *
+   * The density curve has no natural ceiling, so before this a rule's weight
+   * and its *fan-out* were indistinguishable: L19 emitting one finding per
+   * (relation × function) pair took a real audit from A+ to F on one severity
+   * notch. `false` removes the cap.
+   */
+  maxRuleDensity?: number | false;
+  /**
    * Multiplier applied to fail-closed findings' weights (density model).
    * Default 0 — denied-at-runtime hygiene findings don't reduce the score.
    */

--- a/packages/safegres/src/exposure/routines.ts
+++ b/packages/safegres/src/exposure/routines.ts
@@ -1,0 +1,77 @@
+/**
+ * Routine exposure: which functions an untrusted role can actually call.
+ *
+ * The exposure surface answers "which relations can the API address?", and
+ * every finding was graded by that question — including the ones that are not
+ * about a relation at all. A definer function lives in a private schema, so by
+ * relation reach it is unexposed; but `anonymous` holds `EXECUTE` on it, so it
+ * is one call away from whatever its owner can touch. Grading it by its schema
+ * is not conservative, it is wrong in the dangerous direction.
+ *
+ * The question a routine finding is graded by is therefore the callability
+ * one: can an untrusted role reach the function itself — `USAGE` on its
+ * schema, and `EXECUTE` on the function, directly, by inheritance, or through
+ * Postgres's default `EXECUTE TO PUBLIC`.
+ */
+
+import type { RoleGraph } from '../checks/lattice';
+import { canEnterSchema, type SchemaAclInfo } from '../pg/acl';
+import type { FunctionSnapshot } from '../pg/functions';
+
+export interface RoutineReachOptions {
+  /** Roles a request can arrive as — the API edge, plus its anonymous roles. */
+  roles: string[];
+  graph: RoleGraph;
+  schemaAcls: Map<string, SchemaAclInfo>;
+  /**
+   * Schemas on the API surface. A trigger function is not directly callable
+   * whatever its ACL says, so it is judged the way its firing is: reachable
+   * when a write that fires it is.
+   */
+  exposedSchemas: Set<string>;
+}
+
+/**
+ * Every `schema.name` an untrusted role can execute. Overloads collapse: the
+ * finding names a function, not a signature, and a role that can call one
+ * overload can reach the body the rule is talking about.
+ */
+export function resolveRoutineReach(
+  functions: FunctionSnapshot[],
+  options: RoutineReachOptions
+): Set<string> {
+  const reachable = new Set<string>();
+  if (options.roles.length === 0) return reachable;
+
+  for (const fn of functions) {
+    const key = `${fn.schema}.${fn.name}`;
+    if (reachable.has(key)) continue;
+    if (fn.returnsTrigger) {
+      // Postgres refuses a direct call however wide the ACL is. What reaches
+      // the body is a write to the table the trigger is attached to, so the
+      // API surface is the right question after all.
+      if (options.exposedSchemas.has(fn.schema)) reachable.add(key);
+      continue;
+    }
+    if (options.roles.some((role) => canExecute(fn, role, options))) reachable.add(key);
+  }
+
+  return reachable;
+}
+
+function canExecute(
+  fn: FunctionSnapshot,
+  role: string,
+  { graph, schemaAcls }: RoutineReachOptions
+): boolean {
+  if (!canEnterSchema(fn.schema, role, graph, schemaAcls)) return false;
+  const attrs = graph.get(role);
+  if (attrs?.isSuper) return true;
+  if (role === fn.owner) return true;
+  return fn.grants.some(
+    (g) =>
+      g.role === 'PUBLIC'
+      || g.role === role
+      || (attrs?.inheritsFrom ?? []).includes(g.role)
+  );
+}

--- a/packages/safegres/src/pg/acl.ts
+++ b/packages/safegres/src/pg/acl.ts
@@ -231,3 +231,27 @@ export async function introspectSchemaAcls(
     executeRoles: r.execute_roles
   }));
 }
+
+/**
+ * The role can enter the schema, so a grant on something inside it is reach.
+ *
+ * The same gate L3 applies to a table grant, applied to a schema's contents:
+ * without `USAGE` the object cannot be named, and Postgres's default
+ * EXECUTE-to-PUBLIC would otherwise make every function in an internal schema
+ * look reachable by every role in the database.
+ */
+export function canEnterSchema(
+  schema: string,
+  role: string,
+  graph: Map<string, RoleAttributes>,
+  schemaAcls: Map<string, SchemaAclInfo>
+): boolean {
+  const acl = schemaAcls.get(schema);
+  if (!acl) return true; // not introspected: assume reachable rather than silently drop
+  const attrs = graph.get(role);
+  if (attrs?.isSuper) return true;
+  if (role === acl.owner) return true;
+  const usage = new Set(acl.grants.filter((g) => g.privilege === 'USAGE').map((g) => g.role));
+  if (usage.has('PUBLIC') || usage.has(role)) return true;
+  return (attrs?.inheritsFrom ?? []).some((a) => usage.has(a) || a === acl.owner);
+}

--- a/packages/safegres/src/pg/functions.ts
+++ b/packages/safegres/src/pg/functions.ts
@@ -7,7 +7,7 @@
  * is pinned, the language, the body source, and EXECUTE grants per role.
  */
 
-import type { QueryExecutor } from './introspect';
+import type { ExtensionScopeOptions, QueryExecutor } from './introspect';
 
 export interface FunctionGrant {
   role: string;
@@ -53,6 +53,39 @@ const DEFAULT_EXCLUDES = ['pg_catalog', 'information_schema', 'pg_toast'];
 export interface IntrospectFunctionOptions {
   schemas?: string[];
   excludeSchemas?: string[];
+  extensions?: ExtensionScopeOptions;
+}
+
+/**
+ * Extension scoping for routines. The table-side filter reads ownership off
+ * `pg_class`; a function's is on `pg_proc`, and nothing about a routine is
+ * inherited the way a partition inherits its parent's dependency — so this is
+ * the same rule expressed against the other catalog, not a shared helper.
+ *
+ * Without it `extensions.ignore` narrowed the relation rules and left the
+ * routine rules reading the extension's own bodies: `pg_partman` alone
+ * accounted for every C1 finding and 60% of C4 on a real audit.
+ */
+function routineExtensionFilter(
+  options: ExtensionScopeOptions | undefined,
+  paramIndex: number
+): string {
+  const clauses: string[] = [];
+  if (options?.skipOwned ?? true) {
+    clauses.push(`
+        AND NOT EXISTS (
+          SELECT 1 FROM pg_depend d
+          WHERE d.classid = 'pg_proc'::regclass
+            AND d.refclassid = 'pg_extension'::regclass
+            AND d.deptype = 'e'
+            AND d.objid = p.oid
+        )`);
+  }
+  clauses.push(`
+        AND NOT (n.oid = ANY (
+          SELECT e.extnamespace FROM pg_extension e WHERE e.extname = ANY($${paramIndex}::text[])
+        ))`);
+  return clauses.join('');
 }
 
 export async function introspectFunctions(
@@ -63,10 +96,12 @@ export async function introspectFunctions(
   const schemaFilter = options.schemas && options.schemas.length > 0
     ? `AND n.nspname = ANY($1::text[])`
     : `AND NOT (n.nspname = ANY($2::text[]))`;
+  const extFilter = routineExtensionFilter(options.extensions, 3);
 
   const sql = `
     WITH _params AS (
-      SELECT $1::text[] AS include_schemas, $2::text[] AS exclude_schemas
+      SELECT $1::text[] AS include_schemas, $2::text[] AS exclude_schemas,
+             $3::text[] AS ignore_extensions
     ),
     procs AS (
       SELECT
@@ -93,7 +128,7 @@ export async function introspectFunctions(
       JOIN pg_language l  ON l.oid = p.prolang
       LEFT JOIN pg_roles o ON o.oid = p.proowner
       WHERE p.prokind IN ('f', 'p')
-        ${schemaFilter}
+        ${schemaFilter}${extFilter}
     ),
     grants AS (
       SELECT
@@ -144,7 +179,7 @@ export async function introspectFunctions(
     definition: string | null;
     grants: Array<{ role: string; grantable: boolean }>;
     default_acl: boolean;
-  }>(sql, [options.schemas ?? [], excludes]);
+  }>(sql, [options.schemas ?? [], excludes, options.extensions?.ignore ?? []]);
 
   return rows.map((r) => ({
     oid: r.oid,

--- a/packages/safegres/src/report/markdown.ts
+++ b/packages/safegres/src/report/markdown.ts
@@ -10,7 +10,7 @@
  */
 
 import type { RoleAccessEntry } from '../checks/lattice';
-import type { Score } from '../score/score';
+import type { Score, ScoreDeduction } from '../score/score';
 import type { Finding, PlaneReport, Report, Severity } from '../types';
 import { formatDelta, type ReportComparison, type RuleDelta, type ScoreDelta } from './compare';
 import { type ReportView, selectView, type ViewConfig } from './view';
@@ -177,11 +177,7 @@ function planeSection(view: ReportView): string[] {
       '',
       '| Rule | Findings | Points | Grade | Payoff |',
       '| --- | ---: | ---: | --- | ---: |',
-      ...plane.score.deductions.map((d) =>
-        d.unscored
-          ? `| \`${d.code}\` | ${d.count} | — | — | *unscored* |`
-          : `| \`${d.code}\` | ${d.count} | −${d.points} | **${d.grade}** | +${d.potential.toFixed(1)} |`
-      )
+      ...plane.score.deductions.map(deductionRow)
     );
   }
   return out;
@@ -337,16 +333,24 @@ function comparisonSection(cmp: ReportComparison): string[] {
  * rule alone goes to zero — the number worth ranking work by, and not
  * proportional to the finding count, because the curve is exponential.
  */
+/**
+ * One rule's row. Findings and fixes are different numbers when a rule fans
+ * out over a single repair, and points are charged on the second.
+ */
+function deductionRow(d: ScoreDeduction): string {
+  const found = d.units === undefined ? `${d.count}` : `${d.count} (${d.units} fixes)`;
+  const points = d.capped ? `−${d.points} (capped)` : `−${d.points}`;
+  return d.unscored
+    ? `| \`${d.code}\` | ${found} | — | — | *unscored* |`
+    : `| \`${d.code}\` | ${found} | ${points} | **${d.grade}** | +${d.potential.toFixed(1)} |`;
+}
+
 function ruleTable(label: string, score: Score | undefined, options: RenderMarkdownOptions): string[] {
   if (!score || score.deductions.length === 0) return [];
   const table = [
     '| Rule | Findings | Points | Grade | Payoff |',
     '| --- | ---: | ---: | --- | ---: |',
-    ...score.deductions.map((d) =>
-      d.unscored
-        ? `| \`${d.code}\` | ${d.count} | — | — | *unscored* |`
-        : `| \`${d.code}\` | ${d.count} | −${d.points} | **${d.grade}** | +${d.potential.toFixed(1)} |`
-    )
+    ...score.deductions.map(deductionRow)
   ];
   return options.verbose
     ? [`### ${label} by rule`, '', ...table, '']

--- a/packages/safegres/src/report/markdown.ts
+++ b/packages/safegres/src/report/markdown.ts
@@ -74,6 +74,8 @@ export function renderMarkdown(report: Report, options: RenderMarkdownOptions = 
     );
   }
 
+  if (view.has('scorecards')) out.push(...scorecardSection(view), '');
+
   if (view.has('planes')) out.push(...planeSection(view), '');
 
   out.push(countsTable(report), '');
@@ -158,6 +160,31 @@ export function renderMarkdown(report: Report, options: RenderMarkdownOptions = 
  * working as designed — so they read as context under the headline rather
  * than as a second verdict competing with it.
  */
+/**
+ * The other named scores. Same findings, different questions — which is the
+ * point: a team that gates on `anon-surface` is not being asked to care
+ * about the headline, and `raw` is there so nobody has to trust that the
+ * config was written in good faith.
+ */
+function scorecardSection(view: ReportView): string[] {
+  const out: string[] = [
+    '### Scorecards',
+    '',
+    '_The same findings, scored by question. Nothing here filters the report — '
+      + 'a scorecard decides what a number is *about*, never what is reported._',
+    '',
+    '| Scorecard | Score | Grade | Findings | Question |',
+    '| --- | ---: | --- | ---: | --- |'
+  ];
+  for (const card of view.scorecards) {
+    out.push(
+      `| \`${card.name}\` | ${card.score.value} | **${card.score.grade}** | ${card.findings} `
+        + `| ${card.description ?? card.title ?? ''} |`
+    );
+  }
+  return out;
+}
+
 function planeSection(view: ReportView): string[] {
   const out: string[] = [
     '### Other access planes',

--- a/packages/safegres/src/report/pretty.ts
+++ b/packages/safegres/src/report/pretty.ts
@@ -1,6 +1,6 @@
 import yanse from 'yanse';
 
-import type { Score } from '../score/score';
+import type { Score, ScoreDeduction } from '../score/score';
 import type { Finding, PlaneReport, Report, Severity } from '../types';
 import { renderCallGraph, renderCallGraphDiff } from './callgraph';
 import { formatDelta, type ScoreDelta } from './compare';
@@ -320,13 +320,20 @@ function scoreLines(label: string, score: Score, colorEnabled: boolean): string[
   const top = scored.slice(0, 3);
   if (top.length > 0) {
     lines.push(
-      `  top deductions: ${top.map((d) => `${d.code} −${d.points} (×${d.count})`).join('  ')}`
+      `  top deductions: ${top.map(deductionLabel).join('  ')}`
     );
     // Payoff, not points: what the score becomes if the rule goes to zero.
     lines.push(
       `  by rule: ${scored
         .map((d) => `${d.code} ${d.grade} (+${d.potential.toFixed(1)})`)
         .join('  ')}`
+    );
+  }
+  const capped = scored.filter((d) => d.capped);
+  if (capped.length > 0) {
+    lines.push(
+      `  capped: ${capped.map((d) => d.code).join(', ')}`
+        + '  — one rule cannot decide the grade; the finding count is unchanged'
     );
   }
   const unscored = score.deductions.filter((d) => d.unscored);
@@ -337,6 +344,17 @@ function scoreLines(label: string, score: Score, colorEnabled: boolean): string[
     );
   }
   return lines;
+}
+
+/**
+ * `L19 −664 (×568 → 166 fixes)` — the finding count and what it costs to
+ * clear are different numbers, and only the second one is charged.
+ */
+function deductionLabel(d: ScoreDeduction): string {
+  const count = d.units === undefined
+    ? `×${d.count}`
+    : `×${d.count} → ${d.units} fix${d.units === 1 ? '' : 'es'}`;
+  return `${d.code} −${d.points} (${count})`;
 }
 
 function deltaLine(d: ScoreDelta, ref: string | undefined, colorEnabled: boolean): string {

--- a/packages/safegres/src/report/pretty.ts
+++ b/packages/safegres/src/report/pretty.ts
@@ -104,6 +104,10 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
     lines.push('');
   }
 
+  if (view.has('scorecards')) {
+    lines.push(...scorecardLines(view, colorEnabled), '');
+  }
+
   if (view.has('planes')) {
     lines.push(...planeLines(view, colorEnabled), '');
   }
@@ -269,6 +273,26 @@ export function renderPretty(report: Report, options: RenderPrettyOptions = {}):
   }
 
   return lines.join('\n');
+}
+
+/**
+ * The other named scores. One line each: the headline answers the question
+ * the preset was written for, and these answer the ones a particular team
+ * actually gates on. `raw` sits among them deliberately — a number no
+ * configuration softened, next to the one that was.
+ */
+function scorecardLines(view: ReportView, colorEnabled: boolean): string[] {
+  const lines = ['scorecards — the same findings, scored by question:'];
+  for (const card of view.scorecards) {
+    const grade = colorEnabled
+      ? gradePaintFor(card.score)(`${card.score.value} (${card.score.grade})`)
+      : `${card.score.value} (${card.score.grade})`;
+    lines.push(
+      `  ${card.name}: ${grade}  — ${card.findings} finding(s)`
+        + (card.description ? `  ${card.description}` : '')
+    );
+  }
+  return lines;
 }
 
 /**

--- a/packages/safegres/src/report/view.ts
+++ b/packages/safegres/src/report/view.ts
@@ -10,6 +10,7 @@
  */
 
 import type { ReportConfig } from '../config/types';
+import type { ScorecardReport } from '../score/scorecards';
 import type { Finding, PlaneReport, Report } from '../types';
 import type { ScoreDelta } from './compare';
 
@@ -18,6 +19,7 @@ export type ViewSection =
   | 'delta'
   | 'findings'
   | 'planes'
+  | 'scorecards'
   | 'role-access'
   | 'call-graph';
 
@@ -26,6 +28,7 @@ export const ALL_SECTIONS: ViewSection[] = [
   'delta',
   'findings',
   'planes',
+  'scorecards',
   'role-access',
   'call-graph'
 ];
@@ -78,6 +81,12 @@ export interface ReportView {
   planes: PlaneReport[];
   /** Planes the view config asked to see in full. */
   expandedPlanes: PlaneReport[];
+  /**
+   * Named scores other than `default`, which is the headline and is already
+   * rendered as the score. Kept in config order so the file decides what a
+   * reader sees first.
+   */
+  scorecards: ScorecardReport[];
   security: ViewFindings;
   perf?: ViewFindings;
   has(section: ViewSection): boolean;
@@ -144,6 +153,8 @@ export function selectView(report: Report, config: ViewConfig = {}): ReportView 
     });
   }
 
+  const scorecards = (report.scorecards ?? []).filter((c) => c.name !== 'default');
+
   const securityAll = report.perf
     ? report.findings.filter((f) => f.dimension !== 'perf')
     : report.findings;
@@ -154,6 +165,7 @@ export function selectView(report: Report, config: ViewConfig = {}): ReportView 
     scores,
     planes: secondary,
     expandedPlanes,
+    scorecards,
     security: partition(securityAll, config),
     ...(report.perf && dimensions.has('perf')
       ? { perf: partition(report.perf.findings, config) }
@@ -165,6 +177,8 @@ export function selectView(report: Report, config: ViewConfig = {}): ReportView 
         return report.comparison != null;
       case 'planes':
         return secondary.length > 0;
+      case 'scorecards':
+        return scorecards.length > 0;
       case 'role-access':
         return (report.roleAccess?.roles.length ?? 0) > 0;
       case 'call-graph':

--- a/packages/safegres/src/rules/registry.ts
+++ b/packages/safegres/src/rules/registry.ts
@@ -441,7 +441,8 @@ export const RULES: RuleMeta[] = [
     defaultSeverity: 'info',
     direction: 'fail-closed',
     title: 'Revocable grant — a role holds EXECUTE no reachable path exercises (options: { roles: [...] })',
-    scope: 'table'
+    scope: 'table',
+    subject: 'routine'
   },
   {
     code: 'W1',

--- a/packages/safegres/src/rules/registry.ts
+++ b/packages/safegres/src/rules/registry.ts
@@ -30,11 +30,41 @@ export interface RuleMeta {
    * read function definitions rather than the catalog, and run their own pass.
    */
   scope: 'table' | 'policy-ast' | 'index' | 'stats' | 'function-src';
+  /**
+   * What the finding is *about*, which decides how its exposure is judged.
+   *
+   * A `relation` finding is exposed when its table is on the API surface. A
+   * `routine` finding is exposed when an untrusted role can *call the
+   * function* — schema USAGE plus EXECUTE — which is a different question and
+   * frequently a different answer: a definer function in a private schema is
+   * off the API surface and still one grant away from anonymous.
+   *
+   * Judging routine findings by relation reach is why a real audit reported
+   * every `C*` and `L19` finding as `exposed: false`, and therefore scored
+   * them at zero. Defaults to `relation`.
+   */
+  subject?: 'relation' | 'routine';
+  /**
+   * The finding's unit of repair, as a dotted path into the finding
+   * (`context.function`). The score counts *distinct* units, not findings,
+   * so a rule that emits one finding per (relation × function) pair moves the
+   * score by how much work it represents rather than by its own fan-out.
+   *
+   * L19 is the case that forced this: 568 findings over 166 functions, where
+   * promoting the rule one notch took the audit from A+ to F on multiplicity
+   * alone. Omitted means one finding is one unit.
+   */
+  dedupBy?: string;
 }
 
 /** The scoring axis a rule belongs to (`security` unless declared otherwise). */
 export function dimensionOf(meta: RuleMeta): Dimension {
   return meta.dimension ?? 'security';
+}
+
+/** What a rule's findings are about (`relation` unless declared otherwise). */
+export function subjectOf(meta: RuleMeta): 'relation' | 'routine' {
+  return meta.subject ?? 'relation';
 }
 
 export const RULES: RuleMeta[] = [
@@ -369,7 +399,12 @@ export const RULES: RuleMeta[] = [
     defaultSeverity: 'info',
     direction: 'fail-open',
     title: 'Definer-function reach — an untrusted role touches a relation by executing a SECURITY DEFINER function (options: { roles: [...] })',
-    scope: 'table'
+    scope: 'table',
+    // The reach is the function's, not the relation's: a definer function in
+    // an unexposed schema still runs as its owner for whoever holds EXECUTE.
+    subject: 'routine',
+    // One finding per (relation × function) pair, but one revoke per function.
+    dedupBy: 'context.function'
   },
   {
     code: 'L20',
@@ -381,7 +416,9 @@ export const RULES: RuleMeta[] = [
     defaultSeverity: 'info',
     direction: 'fail-open',
     title: 'INSTEAD OF trigger write — an untrusted role writes a relation through a trigger function that runs as its owner (options: { roles: [...] })',
-    scope: 'table'
+    scope: 'table',
+    subject: 'routine',
+    dedupBy: 'context.function'
   },
   {
     code: 'L21',
@@ -537,7 +574,8 @@ export const RULES: RuleMeta[] = [
     defaultSeverity: 'high',
     direction: 'fail-open',
     title: 'Function sets search_path (house rule: never set it — fully-qualify instead)',
-    scope: 'function-src'
+    scope: 'function-src',
+    subject: 'routine'
   },
   {
     code: 'C2',
@@ -545,7 +583,8 @@ export const RULES: RuleMeta[] = [
     defaultSeverity: 'medium',
     direction: 'neutral',
     title: 'Function uses a #variable_conflict directive',
-    scope: 'function-src'
+    scope: 'function-src',
+    subject: 'routine'
   },
   {
     code: 'C3',
@@ -553,7 +592,10 @@ export const RULES: RuleMeta[] = [
     defaultSeverity: 'low',
     direction: 'neutral',
     title: 'Function has an unqualified relation reference (relies on search_path)',
-    scope: 'function-src'
+    scope: 'function-src',
+    subject: 'routine',
+    // Every unqualified reference in one body is one edit to that body.
+    dedupBy: 'context.function'
   },
   {
     code: 'C4',
@@ -561,7 +603,9 @@ export const RULES: RuleMeta[] = [
     defaultSeverity: 'high',
     direction: 'fail-open',
     title: 'Function uses dynamic SQL (waivable with a categorized reason)',
-    scope: 'function-src'
+    scope: 'function-src',
+    subject: 'routine',
+    dedupBy: 'context.function'
   }
 ];
 

--- a/packages/safegres/src/score/score.ts
+++ b/packages/safegres/src/score/score.ts
@@ -1,4 +1,5 @@
 import type { Grade, ScoringConfig } from '../config/types';
+import { RULES_BY_CODE } from '../rules/registry';
 import type { Finding, Severity } from '../types';
 import { meetsThreshold } from '../types';
 
@@ -26,6 +27,18 @@ export interface ScoreDeduction {
    * fixing them would move the score; it cannot.
    */
   unscored?: boolean;
+  /**
+   * The rule's raw points exceeded `maxRuleDensity` and were cut to it. The
+   * finding count is unchanged: what is capped is the rule's influence on the
+   * score, not the size of the problem it reports.
+   */
+  capped?: boolean;
+  /**
+   * Distinct units of repair behind `count`, when a rule declares one
+   * (`RuleMeta.dedupBy`). Points are charged per unit, so a rule that emits
+   * one finding per (relation × function) pair costs what fixing it costs.
+   */
+  units?: number;
 }
 
 export interface Score {
@@ -75,6 +88,7 @@ export const DEFAULT_GRADE_BANDS: Record<Exclude<Grade, 'F'>, number> = {
 };
 
 const DEFAULT_MAX_DEDUCTION_PER_RULE = 40;
+const DEFAULT_MAX_RULE_DENSITY = 0.5;
 const DEFAULT_DENSITY_K = 0.17;
 const DEFAULT_UNKNOWN_EXPOSURE_CAP = 80;
 const DEFAULT_FAIL_CLOSED_WEIGHT = 0;
@@ -106,6 +120,12 @@ export function computeScore(
  * `failClosedWeight`, default 0 — denied-at-runtime hygiene doesn't reduce
  * the score). With the default k, one critical per ~10 exposed tables lands
  * around a C; one critical per table is an F.
+ *
+ * Two things keep a rule's *shape* out of the arithmetic. Points are charged
+ * per unit of repair, not per finding, for rules that declare one — a rule
+ * emitting a row per (relation × function) pair costs what fixing it costs.
+ * And each rule's total is capped at a fraction of the points that would fail
+ * an audit alone (`maxRuleDensity`), so no single rule can decide the grade.
  */
 function computeDensityScore(
   findings: Finding[],
@@ -123,38 +143,66 @@ function computeDensityScore(
   // unknown-exposure cap is their penalty, not weighted points.
   const scorable = findings.filter((f) => f.exposed !== false && !f.acknowledged && f.category !== 'meta');
 
-  const byRule = new Map<string, { count: number; points: number }>();
+  const exposedTables = Math.max(1, context.exposedTables ?? 1);
+
+  const byRule = new Map<string, RuleTally>();
   for (const f of scorable) {
     let weight = perRule[f.code] ?? weights[f.severity] ?? 0;
     if (f.direction === 'fail-closed') weight *= failClosedWeight;
-    const entry = byRule.get(f.code) ?? { count: 0, points: 0 };
+    const entry = byRule.get(f.code) ?? { count: 0, points: 0, units: new Set<string>() };
     entry.count += 1;
-    entry.points += Math.max(0, weight);
+    // A rule with a declared unit of repair is charged once per unit: the
+    // second finding against the same function is the same fix, and letting
+    // it charge again grades fan-out rather than risk.
+    const unit = repairUnit(f);
+    if (unit === undefined || !entry.units.has(unit)) {
+      entry.points += Math.max(0, weight);
+      if (unit !== undefined) entry.units.add(unit);
+    }
     byRule.set(f.code, entry);
   }
 
-  const riskPoints = [...byRule.values()].reduce((sum, r) => sum + r.points, 0);
-  const exposedTables = Math.max(1, context.exposedTables ?? 1);
+  // No single rule may contribute more than `maxRuleDensity` of the points
+  // that would take the score to F alone — at the default half, one rule can
+  // cost two grade bands but an F still takes breadth. Solved from the curve
+  // rather than fixed, so retuning `k` or the bands moves the cap with them.
+  const maxRuleDensity = config.maxRuleDensity ?? DEFAULT_MAX_RULE_DENSITY;
+  const pointsToF = (Math.log(100 / (bands.D || 50)) / k) * exposedTables;
+  const ruleCap = maxRuleDensity === false ? Infinity : maxRuleDensity * pointsToF;
+
+  const capped = new Map<string, { count: number; points: number; raw: number; units?: number }>();
+  for (const [code, tally] of byRule) {
+    capped.set(code, {
+      count: tally.count,
+      points: Math.min(tally.points, ruleCap),
+      raw: tally.points,
+      ...(tally.units.size > 0 ? { units: tally.units.size } : {})
+    });
+  }
+
+  const riskPoints = [...capped.values()].reduce((sum, r) => sum + r.points, 0);
   const density = riskPoints / exposedTables;
   const curve = (points: number) => round1(100 * Math.exp((-k * points) / exposedTables));
 
   let value = round1(100 * Math.exp(-k * density));
 
-  const deductions: ScoreDeduction[] = [...byRule.entries()]
-    .map(([code, { count, points }]) => ({
+  const deductions: ScoreDeduction[] = [...capped.entries()]
+    .map(([code, { count, points, raw, units }]) => ({
       code,
       count,
       points,
       score: curve(points),
       grade: gradeFor(curve(points), bands),
       potential: round1(curve(riskPoints - points) - value),
+      ...(units !== undefined && units !== count ? { units } : {}),
+      ...(raw > points ? { capped: true } : {}),
       ...(points === 0 ? { unscored: true } : {})
     }))
     .sort(byPayoff);
 
-  const cap = config.unknownExposureCap ?? DEFAULT_UNKNOWN_EXPOSURE_CAP;
-  const capped = context.exposureKnown === false && cap !== false && value > cap;
-  if (capped) value = cap;
+  const unknownCap = config.unknownExposureCap ?? DEFAULT_UNKNOWN_EXPOSURE_CAP;
+  const cappedByUnknown = context.exposureKnown === false && unknownCap !== false && value > unknownCap;
+  if (cappedByUnknown) value = unknownCap;
 
   let grade = gradeFor(value, bands);
   if (
@@ -173,8 +221,30 @@ function computeDensityScore(
     deductions,
     density: Math.round(density * 1000) / 1000,
     exposedTables,
-    ...(capped ? { cappedByUnknownExposure: true } : {})
+    ...(cappedByUnknown ? { cappedByUnknownExposure: true } : {})
   };
+}
+
+interface RuleTally {
+  count: number;
+  points: number;
+  /** Distinct repair units seen, for rules that declare one. */
+  units: Set<string>;
+}
+
+/**
+ * The finding's unit of repair, from the rule's declared `dedupBy` path.
+ * `undefined` when the rule declares none — one finding, one unit.
+ */
+function repairUnit(finding: Finding): string | undefined {
+  const path = RULES_BY_CODE.get(finding.code)?.dedupBy;
+  if (!path) return undefined;
+  let value: unknown = finding;
+  for (const key of path.split('.')) {
+    if (value === null || typeof value !== 'object') return undefined;
+    value = (value as Record<string, unknown>)[key];
+  }
+  return typeof value === 'string' ? value : undefined;
 }
 
 /**

--- a/packages/safegres/src/score/score.ts
+++ b/packages/safegres/src/score/score.ts
@@ -69,6 +69,13 @@ export interface ScoreContext {
   exposedTables?: number;
   /** Whether an exposure surface was configured/resolved. */
   exposureKnown?: boolean;
+  /**
+   * The caller has already decided which findings count (a scorecard's
+   * selector). Skips the built-in exposure/acknowledgement/meta filtering,
+   * which would otherwise silently overrule a selector that asked for
+   * unexposed findings.
+   */
+  prefiltered?: boolean;
 }
 
 export const DEFAULT_WEIGHTS: Record<Severity, number> = {
@@ -141,7 +148,9 @@ function computeDensityScore(
 
   // Meta findings (e.g. W1) are advisories about the audit itself — the
   // unknown-exposure cap is their penalty, not weighted points.
-  const scorable = findings.filter((f) => f.exposed !== false && !f.acknowledged && f.category !== 'meta');
+  const scorable = context.prefiltered
+    ? findings
+    : findings.filter((f) => f.exposed !== false && !f.acknowledged && f.category !== 'meta');
 
   const exposedTables = Math.max(1, context.exposedTables ?? 1);
 
@@ -264,7 +273,9 @@ function computeWeightedScore(
   const bands = { ...DEFAULT_GRADE_BANDS, ...(config.gradeBands ?? {}) };
   const floor = config.floorOnCritical === undefined ? 'C' : config.floorOnCritical;
 
-  const scorable = findings.filter((f) => f.exposed !== false && !f.acknowledged && f.category !== 'meta');
+  const scorable = context.prefiltered
+    ? findings
+    : findings.filter((f) => f.exposed !== false && !f.acknowledged && f.category !== 'meta');
 
   const byRule = new Map<string, { count: number; points: number }>();
   for (const f of scorable) {

--- a/packages/safegres/src/score/scorecards.ts
+++ b/packages/safegres/src/score/scorecards.ts
@@ -1,0 +1,205 @@
+import type { ScorecardConfig, ScorecardSelector } from '../config/types';
+import { RULES_BY_CODE } from '../rules/registry';
+import { type Finding, type Severity, summarize,type Summary } from '../types';
+import { computeScore, type Score, type ScoreContext } from './score';
+
+/**
+ * One named score over a selected slice of the findings.
+ *
+ * The headline score answers one question well and every other question
+ * badly: a platform team gating on what `anonymous` reaches and an
+ * application team gating on house style are not arguing about the same
+ * number, and forcing them to is how a single number becomes something
+ * nobody trusts. A scorecard is that question, written down — a selector
+ * over the findings plus the weighting to grade them with.
+ */
+export interface ScorecardReport {
+  /** Config key, e.g. `anon-surface`. */
+  name: string;
+  /** Human-readable heading for reports. */
+  title?: string;
+  /**
+   * Why this scorecard exists — what decision it informs. Rendered with the
+   * score, because a number whose question is unstated invites the reader to
+   * supply their own.
+   */
+  description?: string;
+  /** The findings it selected, graded by its own weighting. */
+  score: Score;
+  /** How many findings the selector matched. */
+  findings: number;
+  /** Severity counts over the selected findings. */
+  summary: Summary;
+  /** The resolved selector, so a report explains its own arithmetic. */
+  select: ScorecardSelector;
+  /**
+   * Reserved scorecards safegres computes itself: `default` is the headline
+   * (`report.score`, verbatim) and `raw` is every finding at its declared
+   * severity with no exposure filter. Neither can be redefined into
+   * something flattering.
+   */
+  reserved?: boolean;
+}
+
+export interface ScorecardContext extends ScoreContext {
+  /** Relations on the exposed surface — the default density denominator. */
+  exposedTables?: number;
+  /** Every relation in the audited schemas — the `all` denominator. */
+  totalTables?: number;
+}
+
+/**
+ * The two scorecards every run carries, whatever the config says.
+ *
+ * `raw` is the honest one: no exposure filter, no acknowledgements, no
+ * preset severity retuning, fail-closed findings weighted like anything
+ * else. It is not flattering and it is not meant to be — it is the number
+ * that is comparable between two databases, and the one a preset cannot
+ * talk down.
+ */
+export const RESERVED_SCORECARDS: Record<string, ScorecardConfig> = {
+  default: {
+    title: 'Safegres score',
+    description: 'The headline: exposed, fail-open findings at their configured severities.'
+  },
+  raw: {
+    title: 'Raw score',
+    description:
+      'Every finding at its declared severity, exposure ignored — comparable across databases.',
+    select: {
+      severities: 'declared',
+      exposure: 'all',
+      acknowledged: 'include',
+      denominator: 'all'
+    },
+    failClosedWeight: 1,
+    maxRuleDensity: false
+  }
+};
+
+/**
+ * Grade each configured scorecard. `default` is not recomputed — it is the
+ * headline score passed in, so a scorecard block can never move the number
+ * on the badge by redefining what `default` means.
+ */
+export function computeScorecards(
+  findings: Finding[],
+  headline: Score,
+  cards: Record<string, ScorecardConfig>,
+  context: ScorecardContext
+): ScorecardReport[] {
+  const out: ScorecardReport[] = [];
+  for (const [name, card] of Object.entries(cards)) {
+    const reserved = name in RESERVED_SCORECARDS;
+    const select = { ...(RESERVED_SCORECARDS[name]?.select ?? {}), ...(card.select ?? {}) };
+    if (name === 'default') {
+      out.push({
+        name,
+        ...titleOf(name, card),
+        score: headline,
+        findings: findings.filter((f) => f.exposed !== false && !f.acknowledged).length,
+        summary: summarize(findings.filter((f) => f.exposed !== false && !f.acknowledged)),
+        select,
+        reserved: true
+      });
+      continue;
+    }
+    const selected = selectFindings(findings, select);
+    const denominator = select.denominator === 'all'
+      ? (context.totalTables ?? context.exposedTables)
+      : context.exposedTables;
+    out.push({
+      name,
+      ...titleOf(name, card),
+      score: computeScore(selected, card, {
+        ...context,
+        exposedTables: denominator,
+        // The selector has already decided what counts; scoring must not
+        // filter again, or `exposure: 'all'` would be silently overruled.
+        prefiltered: true
+      }),
+      findings: selected.length,
+      summary: summarize(selected),
+      select,
+      ...(reserved ? { reserved: true } : {})
+    });
+  }
+  return out;
+}
+
+function titleOf(name: string, card: ScorecardConfig): { title?: string; description?: string } {
+  const base = RESERVED_SCORECARDS[name] ?? {};
+  const title = card.title ?? base.title;
+  const description = card.description ?? base.description;
+  return { ...(title ? { title } : {}), ...(description ? { description } : {}) };
+}
+
+/**
+ * The findings a scorecard grades. Every clause is a narrowing filter, so an
+ * empty selector selects what the headline does: exposed, non-acknowledged,
+ * security findings.
+ */
+export function selectFindings(findings: Finding[], select: ScorecardSelector): Finding[] {
+  const dimension = select.dimension ?? 'security';
+  const rules = select.rules?.map(matcher);
+  const exclude = select.exclude?.map(matcher);
+  const roles = select.roles ? new Set(select.roles) : undefined;
+  const planes = select.planes ? new Set(select.planes) : undefined;
+  const schemas = select.schemas ? new Set(select.schemas) : undefined;
+  const severity = select.minSeverity ? SEVERITY_RANK[select.minSeverity] : undefined;
+
+  const selected = findings.filter((f) => {
+    if (f.category === 'meta') return false;
+    if (dimension !== 'all' && (f.dimension ?? 'security') !== dimension) return false;
+    if (select.exposure !== 'all' && f.exposed === false) return false;
+    if (select.acknowledged !== 'include' && f.acknowledged) return false;
+    if (select.direction && select.direction !== 'any' && f.direction !== select.direction) {
+      return false;
+    }
+    if (rules && !rules.some((m) => m(f.code))) return false;
+    if (exclude?.some((m) => m(f.code))) return false;
+    if (schemas && (f.schema === undefined || !schemas.has(f.schema))) return false;
+    if (roles && !touchesRole(f, roles)) return false;
+    if (planes && !f.planes?.some((p) => planes.has(p))) return false;
+    if (severity !== undefined && SEVERITY_RANK[f.severity] < severity) return false;
+    return true;
+  });
+
+  // Declared severities answer "how bad is this really", independent of what
+  // a preset chose to quiet down. Copies, never mutation: the findings in
+  // the report keep the severity the config resolved.
+  return select.severities === 'declared'
+    ? selected.map((f) => {
+      const declared = RULES_BY_CODE.get(f.code)?.defaultSeverity;
+      return declared === undefined || declared === f.severity ? f : { ...f, severity: declared };
+    })
+    : selected;
+}
+
+const SEVERITY_RANK: Record<Severity, number> = {
+  info: 0,
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 4
+};
+
+/**
+ * A role clause asks "is this finding about one of these roles" — which the
+ * finding answers in one of three places: the graded `role` column, a
+ * grantee list, or the reachability context a lattice rule attached.
+ */
+function touchesRole(finding: Finding, roles: Set<string>): boolean {
+  if (finding.role && roles.has(finding.role)) return true;
+  const context = finding.context as { role?: string; roles?: unknown } | undefined;
+  if (context?.role && roles.has(context.role)) return true;
+  return Array.isArray(context?.roles)
+    && context.roles.some((r) => typeof r === 'string' && roles.has(r));
+}
+
+/** Rule code matcher: exact, or a `C*` prefix wildcard. */
+function matcher(pattern: string): (code: string) => boolean {
+  if (!pattern.endsWith('*')) return (code) => code === pattern;
+  const prefix = pattern.slice(0, -1);
+  return (code) => code.startsWith(prefix);
+}

--- a/packages/safegres/src/types.ts
+++ b/packages/safegres/src/types.ts
@@ -265,6 +265,13 @@ export interface Report {
    * into gating.
    */
   planes?: PlaneReport[];
+  /**
+   * Named scores over slices of the same findings (`scorecards` config), the
+   * reserved `default` and `raw` cards first. Different teams gate on
+   * different questions; this is where each one's answer lives, computed
+   * from the one set of findings so they can never disagree about the facts.
+   */
+  scorecards?: import('./score/scorecards').ScorecardReport[];
   /** Effective per-role access, for the configured untrusted roles. */
   roleAccess?: RoleAccessReport;
   /**


### PR DESCRIPTION
## Summary

Rebase of #1627 + #1628 onto current `main` (post-L21), collapsed into one PR against `main` so it gets full CI. Nothing conceptually superseded — `main` gained L21 (`granted − reachable`) and a parser-ecosystem bump; neither touches scoring, routine exposure or the report shape. Rebase was conflict-free.

Two changes, in order.

**1. The score was arithmetic-blind to functions.** `Finding.exposed` was computed from a relation, so every function-scoped finding was `exposed: false` by construction and could never move the score — `C1: high` / `C4: high` in the `constructive` preset were decorative. And the density model had no per-rule cap, so a rule's fan-out and its severity were the same number.

- rules declare `subject: 'relation' | 'routine'`; routine findings are graded by whether an untrusted role can *call* the function (`exposure/routines.ts`: schema USAGE + EXECUTE/PUBLIC/inheritance/ownership).
- deductions are charged per **unit of repair** (`dedupBy`), not per finding: `C4 −320 (×80 → 32 fixes)`.
- a single rule's density contribution is capped (`maxRuleDensity`, default 0.5).
- `extensions.ignore` now reaches routines, not just relations.

Measured on constructive-db: `100 (A+)` → **`88.9 (B)`**, and `high` *drops* 366 → 113 because a third were pg_partman function bodies the ignore list never filtered. With partman excluded, C1 and C2 are clean — free to promote to hard errors.

**2. Scorecards: one report, several graded questions.** Findings are the data; a scorecard is a named query + weighting over them. `report.findings` is never narrowed by one.

```jsonc
"scorecards": {
  "anon-surface": { "select": { "roles": ["anonymous"], "direction": "fail-open", "exposure": "all" },
                    "weights": { "info": 1 }, "floorOnCritical": "C" },
  "sql-conventions": { "select": { "rules": ["C*"], "exposure": "all", "denominator": "all" } }
},
"failOn": { "scorecards": { "anon-surface": { "grade": "A" } } }
```

`computeScorecards(findings, headline, cards, ctx)` → `selectFindings` → the existing `computeScore`. Two names are reserved: `default` (the headline, passed through verbatim so config can't move the badge) and `raw` (every finding at its *registry* severity, exposure ignored, fail-closed weighted, no density cap). Selector clauses: `rules`/`exclude` (prefix `*`), `dimension`, `roles`, `planes`, `schemas`, `direction`, `minSeverity`, `exposure`, `acknowledged`, `severities`, `denominator`. Rendered in pretty + markdown, gated per-card, schema-validated.

```
score (headline): 88.9 (B)
raw:              62.3 (D)   2110 findings
anon-surface:     94.4 (A)    857 findings
sql-conventions:  83.2 (B)    159 findings
```

**3. New here, on top of the two:** L21 is a routine-subject rule (one finding per role × function) but shipped with the default relation subject, so its exposure was graded against a table. One line in the registry: `subject: 'routine'`. Score-neutral — L21 is `info`/fail-closed — but it makes the finding's `exposed` flag mean what it says, and matters to any scorecard selecting on it.

Known limitation, called out rather than hidden: `anon-surface` at `A` is flattering — that surface is 853 L19 findings over 166 *functions*, but the density denominator is relations. A subject-aware denominator is the follow-up.

## Verification

- 50 suites / 585 tests green (includes L21's suites), `tsc --noEmit` clean, `pnpm build`, schema regenerated via `scripts/write-schema.js`.
- Lint: 0 errors (2 pre-existing warnings in `config/loader.ts`, untouched).
- Live audit against constructive-db for every number above.

Supersedes #1627 and #1628, both now closed. Independent of #1634 (dep bump) — no shared files.


Link to Devin session: https://app.devin.ai/sessions/ec06ef6eabae4872ae5ec3926f037c85
Requested by: @pyramation