### PR TITLE
feat(pgpm): resolve cross-package tag dependencies (pkg:@tag) at the workspace ingestion seam

### DIFF
--- a/pgpm/core/__tests__/diff/cross-package-tags.test.ts
+++ b/pgpm/core/__tests__/diff/cross-package-tags.test.ts
@@ -1,0 +1,77 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { loadWorkspaceModuleSources } from '../../src/diff/sides';
+
+/**
+ * A workspace with two modules where the downstream module depends on an
+ * upstream module's *tag* (`base:@v1`). The workspace loader has every plan in
+ * context, so the cross-package tag must resolve to the canonical
+ * `base:<change>` qualified name — the same form the deploy-time resolver
+ * emits — instead of being passed through verbatim.
+ */
+describe('loadWorkspaceModuleSources cross-package tag resolution', () => {
+  let ws: string;
+
+  beforeEach(() => {
+    ws = mkdtempSync(join(tmpdir(), 'pgpm-xpkg-'));
+  });
+
+  afterEach(() => {
+    rmSync(ws, { recursive: true, force: true });
+  });
+
+  const writeModule = (
+    name: string,
+    plan: string[],
+    scripts: Record<string, string>
+  ) => {
+    const dir = join(ws, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'pgpm.plan'),
+      ['%syntax-version=1.0.0', `%project=${name}`, `%uri=${name}`, '', ...plan, ''].join('\n')
+    );
+    writeFileSync(
+      join(dir, `${name}.control`),
+      `default_version = '0.0.1'\ncomment = '${name}'\n`
+    );
+    for (const [change, sql] of Object.entries(scripts)) {
+      const file = join(dir, 'deploy', `${change}.sql`);
+      mkdirSync(join(file, '..'), { recursive: true });
+      writeFileSync(file, sql);
+    }
+  };
+
+  it('resolves a `base:@tag` dependency to `base:<change>`', async () => {
+    writeFileSync(join(ws, 'pgpm.json'), JSON.stringify({ packages: ['*'] }, null, 2));
+
+    writeModule(
+      'base',
+      [
+        'schemas/base/schema 2017-08-11T08:11:51Z t <t@x> # schema',
+        '@v1 schemas/base/schema 2017-08-11T08:11:51Z t <t@x> # release v1'
+      ],
+      { 'schemas/base/schema': '-- Deploy base schema\nCREATE SCHEMA base;\n' }
+    );
+
+    writeModule(
+      'app',
+      ['schemas/app/schema [base:@v1] 2017-08-11T08:11:51Z t <t@x> # schema'],
+      { 'schemas/app/schema': '-- Deploy app schema\nCREATE SCHEMA app;\n' }
+    );
+    // app requires base
+    writeFileSync(
+      join(ws, 'app', 'app.control'),
+      "default_version = '0.0.1'\ncomment = 'app'\nrequires = 'base'\n"
+    );
+
+    const { modules, warnings } = await loadWorkspaceModuleSources(ws);
+    const app = modules.find(m => m.name === 'app')!;
+    const change = app.changes.find(c => c.name === 'schemas/app/schema')!;
+
+    expect(change.dependencies).toEqual(['base:schemas/base/schema']);
+    expect(warnings.filter(w => w.includes('cross-package'))).toEqual([]);
+  });
+});

--- a/pgpm/core/src/diff/sides.ts
+++ b/pgpm/core/src/diff/sides.ts
@@ -7,6 +7,8 @@
  * SQL wrapping); this module supplies the I/O they need and that only core
  * has: workspace module-map resolution (`PgpmPackage`) and `pg_dump`.
  */
+import type { ExtendedPlanFile } from '@pgpmjs/ast';
+import { parsePlanFile } from '@pgpmjs/ast';
 import type { DiffSide } from '@pgpmjs/diff';
 import {
   loadDiffSideFromDisk,
@@ -52,7 +54,12 @@ export const loadWorkspaceModuleSources = async (
   const { resolved, external } = await pkg.resolveWorkspaceExtensionDependencies();
 
   const warnings: string[] = [];
-  const modules: ModuleSource[] = [];
+
+  // First pass: collect the plan-bearing local modules and their parsed plans,
+  // keyed by package name (`%project`), so the second pass can resolve
+  // cross-package tag dependencies (`pkg:@tag`) against the plan that owns them.
+  const eligible: { name: string; moduleDir: string }[] = [];
+  const crossPackagePlans = new Map<string, ExtendedPlanFile>();
   for (const name of resolved) {
     if (external.includes(name)) continue;
     const entry = moduleMap[name];
@@ -65,7 +72,14 @@ export const loadWorkspaceModuleSources = async (
       warnings.push(`${name}: no pgpm.plan (proxy or apply-spec module); skipped`);
       continue;
     }
-    const source = loadModuleSource(moduleDir);
+    eligible.push({ name, moduleDir });
+    const parsed = parsePlanFile(path.join(moduleDir, 'pgpm.plan'));
+    if (parsed.data) crossPackagePlans.set(parsed.data.package, parsed.data);
+  }
+
+  const modules: ModuleSource[] = [];
+  for (const { name, moduleDir } of eligible) {
+    const source = loadModuleSource(moduleDir, { crossPackagePlans });
     warnings.push(...source.warnings.map(w => `${name}: ${w}`));
     modules.push(source);
   }

--- a/pgpm/transform/__tests__/module-source.test.ts
+++ b/pgpm/transform/__tests__/module-source.test.ts
@@ -1,3 +1,5 @@
+import type { ExtendedPlanFile } from '@pgpmjs/ast';
+import { parsePlanFile } from '@pgpmjs/ast';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -136,13 +138,45 @@ describe('loadModuleSource', () => {
     expect(source.warnings.some(w => w.includes('@nope'))).toBe(true);
   });
 
-  it('leaves a cross-package tag dependency unresolved with a warning', () => {
+  it('leaves a cross-package tag dependency unresolved with a warning when no plan is in context', () => {
     writeTaggedModule('other:@v1');
     const source = loadModuleSource(dir);
     const table = source.changes.find(c => c.name === 'schemas/app/tables/users/table')!;
     expect(table.dependencies).toEqual(['other:@v1']);
     expect(source.warnings.some(w => w.includes('cross-package'))).toBe(true);
   });
+
+  it('resolves a cross-package tag to pkg:change when the owning plan is in context', () => {
+    writeTaggedModule('other:@v1');
+    // The "other" package's plan: a tag @v1 pointing at a concrete change.
+    const otherPlan = parsePlanFile(writeOtherPlan());
+    expect(otherPlan.data).toBeTruthy();
+    const crossPackagePlans = new Map<string, ExtendedPlanFile>([
+      ['other', otherPlan.data!]
+    ]);
+
+    const source = loadModuleSource(dir, { crossPackagePlans });
+    const table = source.changes.find(c => c.name === 'schemas/app/tables/users/table')!;
+    expect(table.dependencies).toEqual(['other:schemas/other/schema']);
+    expect(source.warnings).toEqual([]);
+  });
+
+  const writeOtherPlan = (): string => {
+    const otherPlanPath = join(dir, 'other.plan');
+    writeFileSync(
+      otherPlanPath,
+      [
+        '%syntax-version=1.0.0',
+        '%project=other',
+        '%uri=other',
+        '',
+        'schemas/other/schema 2017-08-11T08:11:51Z tester <tester@x> # add schema',
+        '@v1 schemas/other/schema 2017-08-11T08:11:51Z tester <tester@x> # release v1',
+        ''
+      ].join('\n')
+    );
+    return otherPlanPath;
+  };
 });
 
 describe('parsePartitionConfig', () => {

--- a/pgpm/transform/src/module-source.ts
+++ b/pgpm/transform/src/module-source.ts
@@ -44,36 +44,70 @@ export const stripTransactionWrapper = (sql: string): string =>
     .join('\n')
     .trim();
 
+/** Options controlling how {@link loadModuleSource} ingests a module. */
+export interface LoadModuleSourceOptions {
+  /**
+   * Parsed plans of the other packages in the same workspace, keyed by
+   * package name (`%project`). Lets a cross-package tag dependency
+   * (`pkg:@tag`) resolve against the plan that defines the tag. Without it,
+   * cross-package tags cannot be resolved from a single module's plan and are
+   * left verbatim with a warning.
+   */
+  crossPackagePlans?: Map<string, ExtendedPlanFile>;
+}
+
+const CROSS_PACKAGE_TAG = /^([^:]+):@(.+)$/;
+
 /**
- * Resolve a plan dependency token to a concrete change name.
+ * Resolve a plan dependency token to a concrete change identity.
  *
  * Non-tag tokens (a bare change name, or a `pkg:change` cross-package name)
  * pass through unchanged — they are already the identity the ledger and
- * generated plans record. A tag token (`@tag`) is resolved to its change via
- * the plan that defines it, so a dependency written against a tag is not
- * re-emitted verbatim into a generated plan or a ledger row. Cross-package
- * tags (`pkg:@tag`) cannot be resolved from a single module's plan and are
- * left as-is with a warning; the resolver returns them unchanged. Anything
- * that fails to resolve is kept verbatim (never dropped) with a warning.
+ * generated plans record. A tag token is resolved so a dependency written
+ * against a tag is never re-emitted verbatim into a generated plan or a
+ * ledger row:
+ * - a local tag (`@tag`) resolves to its change name via this plan;
+ * - a cross-package tag (`pkg:@tag`) resolves to the canonical `pkg:change`
+ *   qualified name via `crossPackagePlans[pkg]` when available.
+ *
+ * Anything that cannot be resolved (unknown tag, or a cross-package tag with
+ * no plan in context) is kept verbatim — never dropped — with a warning.
  */
 const resolveDependencyToken = (
   token: string,
   plan: ExtendedPlanFile,
   warnings: string[],
-  changeName: string
+  changeName: string,
+  crossPackagePlans?: Map<string, ExtendedPlanFile>
 ): string => {
   if (!token.includes('@')) return token;
+
+  const cross = token.match(CROSS_PACKAGE_TAG);
+  if (cross && cross[1] !== plan.package) {
+    const pkg = cross[1];
+    const otherPlan = crossPackagePlans?.get(pkg);
+    if (!otherPlan) {
+      warnings.push(
+        `${changeName}: dependency tag "${token}" is cross-package; left unresolved (no plan for "${pkg}" in context)`
+      );
+      return token;
+    }
+    const resolved = resolveReference(token, otherPlan, pkg);
+    if (resolved.error || !resolved.change) {
+      warnings.push(
+        `${changeName}: could not resolve cross-package dependency tag "${token}" (${resolved.error ?? 'no matching change'}); left as-is`
+      );
+      return token;
+    }
+    return `${pkg}:${resolved.change}`;
+  }
+
   const resolved = resolveReference(token, plan, plan.package);
   if (resolved.error || !resolved.change) {
     warnings.push(
       `${changeName}: could not resolve dependency tag "${token}" (${resolved.error ?? 'no matching change'}); left as-is`
     );
     return token;
-  }
-  if (resolved.change === token) {
-    warnings.push(
-      `${changeName}: dependency tag "${token}" is cross-package; left unresolved (resolve it in workspace context)`
-    );
   }
   return resolved.change;
 };
@@ -84,7 +118,10 @@ const resolveDependencyToken = (
  * result can be flattened straight into the dials pipeline
  * (`restructureChanges` / `partitionUnits`).
  */
-export const loadModuleSource = (moduleDir: string): ModuleSource => {
+export const loadModuleSource = (
+  moduleDir: string,
+  options: LoadModuleSourceOptions = {}
+): ModuleSource => {
   const modulePath = path.resolve(moduleDir);
   const planResult = parsePlanFile(path.join(modulePath, 'pgpm.plan'));
   if (!planResult.data) {
@@ -106,7 +143,7 @@ export const loadModuleSource = (moduleDir: string): ModuleSource => {
     changes.push({
       name: change.name,
       dependencies: (change.dependencies ?? []).map(dep =>
-        resolveDependencyToken(dep, plan, warnings, change.name)
+        resolveDependencyToken(dep, plan, warnings, change.name, options.crossPackagePlans)
       ),
       deploy: stripTransactionWrapper(body)
     });


### PR DESCRIPTION
## Summary

Finishes the tag-resolution sweep started in #1633. That PR resolved local `@tag` deps at `loadModuleSource`, but a **cross-package** tag (`base:@v1`) can't be resolved from a single module's plan — the tag lives in *another* module — so it was passed through verbatim with a warning. A verbatim `base:@v1` re-emitted into a generated plan or a `pgpm_migrate` `requires` array is a dangling reference (the ledger records concrete change identities, not tags).

The workspace loader *does* have every plan in context, so it now resolves them there. `loadModuleSource` gains an opt-in context map; the core workspace loader builds it in a first pass and feeds it in:

```ts
// pgpm/transform — resolveDependencyToken, now cross-package aware
'base:@v1' + crossPackagePlans.get('base')  ->  'base:schemas/base/schema'   // canonical pkg:change
'base:@v1' (no plan in context)             ->  'base:@v1'  + warning         // single-module load: unchanged
'@v1' / 'schemas/...'                        ->  (unchanged from #1633)

// pgpm/core — loadWorkspaceModuleSources: two passes
pass 1: parse every local plan -> Map<packageName, ExtendedPlanFile>
pass 2: loadModuleSource(dir, { crossPackagePlans })   // each module resolves foreign tags against the owning plan
```

The resolved form (`${pkg}:${change}`) is exactly what the deploy-time resolver already emits (`resolveDependencies`, deps.ts:503), so ingestion and deploy now agree. `resolveReference` from `@pgpmjs/ast` does the lookup — no new resolver, no transform→core cycle.

## Notes
- Opt-in and backward compatible: `loadModuleSource(dir)` with no options behaves exactly as before (single-module callers — `import`/`transform` — still warn on a cross-package tag rather than guessing). Only the workspace loader, which legitimately has the other plans, resolves them.
- Only tokens containing `@` are touched; bare and already-qualified `pkg:change` deps are byte-for-byte unchanged.

## Test plan
- `pgpm/transform` — `resolveDependencyToken`: cross-package tag resolves to `pkg:change` when the owning plan is supplied; still left verbatim + warning when it isn't; local/unknown/plain cases unchanged.
- `pgpm/core` — `loadWorkspaceModuleSources`: a two-module workspace where `app` depends on `base:@v1` resolves to `base:schemas/base/schema` with no cross-package warning.
- Regression: transform (117), core (480), and the #1630/#1633 ledger + diff e2e suites all green.


Link to Devin session: https://app.devin.ai/sessions/34f64615befa49d7b807f3467a07e726
Requested by: @pyramation