### PR TITLE
fix(pgpm): byte-correct statement slicing in transform drivers (multibyte SQL)

### DIFF
--- a/pgpm/transform/__tests__/byte-slice.test.ts
+++ b/pgpm/transform/__tests__/byte-slice.test.ts
@@ -1,0 +1,58 @@
+import { classifyStatements } from '@pgsql/semantics';
+import { loadModule } from 'plpgsql-parser';
+
+import { sliceStatementBytes, sqlSourceBytes } from '../src/byte-slice';
+import { diffSchemas } from '../src/semantic-diff-driver';
+
+beforeAll(async () => {
+  await loadModule();
+});
+
+// A COMMENT whose literal contains a multibyte em dash, followed by more
+// statements. libpg-query reports statement spans as UTF-8 byte offsets, so
+// slicing the JS (UTF-16) string directly mis-cuts every statement after the
+// em dash — `COMMENT ON` reappears as `MMENT ON` and fails to reparse.
+const MULTIBYTE = [
+  'CREATE SCHEMA app;',
+  'CREATE TABLE app.users (id uuid PRIMARY KEY, scope text);',
+  "COMMENT ON COLUMN app.users.scope IS 'Origin scope: platform, org, app — where created';",
+  'CREATE TABLE app.posts (id uuid PRIMARY KEY);',
+  "COMMENT ON TABLE app.posts IS 'Posts — authored content';"
+].join('\n');
+
+describe('sliceStatementBytes', () => {
+  it('recovers every statement text exactly, past a multibyte character', () => {
+    const bytes = sqlSourceBytes(MULTIBYTE);
+    const facts = classifyStatements(MULTIBYTE);
+    const texts = facts.map(f => sliceStatementBytes(bytes, f.span.start, f.span.len).trim());
+
+    // The statement after the em dash must start at COMMENT, not a mid-word cut.
+    // (libpg-query spans exclude the trailing semicolon.)
+    expect(texts[3]).toBe('CREATE TABLE app.posts (id uuid PRIMARY KEY)');
+    expect(texts[4]).toBe("COMMENT ON TABLE app.posts IS 'Posts — authored content'");
+    for (const t of texts) expect(t.startsWith('MMENT') || t.startsWith('REATE')).toBe(false);
+  });
+
+  it('naive JS-string slicing is what would mis-cut (guards the regression)', () => {
+    const facts = classifyStatements(MULTIBYTE);
+    const naive = MULTIBYTE.slice(facts[4].span.start, facts[4].span.start + facts[4].span.len);
+    // The em dash (3 bytes / 1 JS char) shifts the byte-offset span two code
+    // units past the real start, so the naive slice loses the leading "CO".
+    expect(naive.startsWith('COMMENT')).toBe(false);
+  });
+});
+
+describe('diffSchemas with multibyte source', () => {
+  it('diffs a script containing a multibyte comment without a parse error', () => {
+    const to = `${MULTIBYTE}\nCREATE TABLE app.tags (id uuid PRIMARY KEY);`;
+    const result = diffSchemas(MULTIBYTE, to);
+    expect(result.objects).toContainEqual(
+      expect.objectContaining({ delta: 'added', path: 'schemas/app/tables/tags/table' })
+    );
+  });
+
+  it('is identical to itself when a multibyte comment is present', () => {
+    const result = diffSchemas(MULTIBYTE, MULTIBYTE);
+    expect(result.identical).toBe(true);
+  });
+});

--- a/pgpm/transform/__tests__/program.test.ts
+++ b/pgpm/transform/__tests__/program.test.ts
@@ -69,3 +69,43 @@ describe('emitSqlProgram', () => {
     expect(reparsed.statements).toHaveLength(3);
   });
 });
+
+// Statement spans are UTF-8 byte offsets; a multibyte character shifts every
+// later offset past its JS-string index, so raw slicing and gap reassembly
+// must both go through the bytes.
+const multibyte = `-- Header — with an em dash
+CREATE SCHEMA app;
+
+COMMENT ON SCHEMA app IS 'Application schema — core';
+
+CREATE TABLE app.users (
+  id uuid PRIMARY KEY
+);
+`;
+
+describe('multibyte sources', () => {
+  it('extracts verbatim raw text correctly past a multibyte character', () => {
+    const program = parseSqlProgram(multibyte);
+    const comment = program.statements[1];
+    expect(comment.facts.kind).toBe('comment');
+    expect(comment.raw.trim()).toBe("COMMENT ON SCHEMA app IS 'Application schema — core'");
+    expect(program.statements[2].raw).toContain('CREATE TABLE app.users');
+  });
+
+  it('emits byte-identical source with a multibyte character and nothing dirty', () => {
+    const program = parseSqlProgram(multibyte);
+    expect(emitSqlProgram(program)).toBe(multibyte);
+  });
+
+  it('preserves multibyte gaps when a statement is dirty', () => {
+    const program = parseSqlProgram(multibyte);
+    const table = program.statements[2];
+    table.stmt.CreateStmt.relation.schemaname = 'tenant';
+    table.dirty = true;
+
+    const out = emitSqlProgram(program);
+    expect(out).toContain('-- Header — with an em dash');
+    expect(out).toContain("COMMENT ON SCHEMA app IS 'Application schema — core';");
+    expect(out).toContain('tenant.users');
+  });
+});

--- a/pgpm/transform/src/byte-slice.ts
+++ b/pgpm/transform/src/byte-slice.ts
@@ -1,0 +1,27 @@
+/**
+ * Byte-correct statement slicing.
+ *
+ * libpg-query reports statement offsets (`stmt_location` / `stmt_len`, and the
+ * `span` that `@pgsql/semantics` derives from them) as UTF-8 **byte** offsets,
+ * but JavaScript string indexing is UTF-16. The two agree only while a script
+ * is pure ASCII; a single non-ASCII byte (an em dash in a comment, an accented
+ * word in a seed row, an emoji) shifts every later byte offset past its JS
+ * index, so slicing the source string directly with `String.prototype.slice`
+ * mis-cuts every statement that follows it — e.g. `COMMENT ON ...` reappears as
+ * `MMENT ON ...` and fails to reparse.
+ *
+ * Slice on the UTF-8 bytes instead and decode back to text. Statement offsets
+ * always fall on character boundaries, so decoding a byte range never splits a
+ * multibyte character.
+ */
+export const sqlSourceBytes = (source: string): Buffer => Buffer.from(source, 'utf8');
+
+/**
+ * Slice a statement's verbatim text out of the source bytes by its byte-offset
+ * span. `len === undefined` slices to the end of the source (libpg-query omits
+ * `stmt_len` for the final statement).
+ */
+export const sliceStatementBytes = (sourceBytes: Buffer, start: number, len?: number): string => {
+  const end = len === undefined ? sourceBytes.length : start + len;
+  return sourceBytes.subarray(start, end).toString('utf8');
+};

--- a/pgpm/transform/src/granularity-driver.ts
+++ b/pgpm/transform/src/granularity-driver.ts
@@ -29,6 +29,7 @@ import {
   restructureSql
 } from '@pgsql/transform';
 
+import { sliceStatementBytes, sqlSourceBytes } from './byte-slice';
 import { nameUnnamedConstraints, subObjectIdentityOf } from './sub-object';
 
 export type { Granularity } from '@pgsql/transform';
@@ -172,6 +173,7 @@ export function restructureChanges(
   // target (creates[0]), so a table's CREATE and its remaining ALTERs land
   // in the same change regardless of statement kind.
   const facts = classifyStatements(sql);
+  const sqlBytes = sqlSourceBytes(sql);
 
   if (options.changeGranularity === 'single') {
     const name = options.singleChangeName ?? 'module/init';
@@ -180,7 +182,7 @@ export function restructureChanges(
       changes.flatMap(c => c.dependencies).filter(d => !inputNames.has(d))
     )].sort();
     const statements = facts
-      .map(f => sql.slice(f.span.start, f.span.start + f.span.len).trim())
+      .map(f => sliceStatementBytes(sqlBytes, f.span.start, f.span.len).trim())
       .filter(Boolean)
       .map(text => (text.endsWith(';') ? text : `${text};`));
     const revert = revertFor(facts);
@@ -264,7 +266,7 @@ export function restructureChanges(
   const groupStatements: StatementFacts[][] = groupNames.map((): StatementFacts[] => []);
 
   facts.forEach((f, i) => {
-    const text = sql.slice(f.span.start, f.span.start + f.span.len).trim();
+    const text = sliceStatementBytes(sqlBytes, f.span.start, f.span.len).trim();
     const g = groupOf[i];
     if (g !== -1 && text) {
       groupSql[g].push(text.endsWith(';') ? text : `${text};`);

--- a/pgpm/transform/src/partition-driver.ts
+++ b/pgpm/transform/src/partition-driver.ts
@@ -29,6 +29,8 @@ import {
   ObjectIdentityKind
 } from '@pgsql/transform';
 
+import { sliceStatementBytes, sqlSourceBytes } from './byte-slice';
+
 /** One deployable unit: an object (by identity) and the statements that build it. */
 export interface PartitionUnit {
   /** The object's identity, or `null` for split riders and the residual unit. */
@@ -201,6 +203,7 @@ interface UnitGraph {
  */
 function buildUnitGraph(sql: string, style: PathStyle, splitRiders: Set<StatementKind>): UnitGraph {
   const facts = classifyStatements(sql);
+  const sqlBytes = sqlSourceBytes(sql);
   const graph = buildStatementGraph(facts);
 
   const unitOf: number[] = new Array(facts.length).fill(-1);
@@ -287,7 +290,7 @@ function buildUnitGraph(sql: string, style: PathStyle, splitRiders: Set<Statemen
   });
 
   facts.forEach((f, i) => {
-    const text = sql.slice(f.span.start, f.span.start + f.span.len).trim();
+    const text = sliceStatementBytes(sqlBytes, f.span.start, f.span.len).trim();
     if (!text) return;
     const unit = units[unitOf[i]];
     unit.statements.push(i);

--- a/pgpm/transform/src/program.ts
+++ b/pgpm/transform/src/program.ts
@@ -13,6 +13,8 @@ import type { StatementFacts } from '@pgsql/semantics';
 import { classifyStatements } from '@pgsql/semantics';
 import { Deparser, parseSql } from 'plpgsql-parser';
 
+import { sliceStatementBytes, sqlSourceBytes } from './byte-slice';
+
 /** A statement's location in the source script (byte offsets). */
 export type SqlStatementSpan = StatementFacts['span'];
 
@@ -44,6 +46,7 @@ export function parseSqlProgram(source: string): SqlProgram {
   const parseResult = parseSql(source);
   const stmts: any[] = parseResult?.stmts ?? [];
   const facts = classifyStatements(source);
+  const sourceBytes = sqlSourceBytes(source);
   const statements: SqlStatementAst[] = [];
   for (let i = 0; i < stmts.length; i++) {
     const rawStmt = stmts[i];
@@ -53,7 +56,7 @@ export function parseSqlProgram(source: string): SqlProgram {
       stmt: rawStmt.stmt,
       facts: facts[i],
       span: { start, len },
-      raw: source.slice(start, start + len),
+      raw: sliceStatementBytes(sourceBytes, start, len),
       dirty: false
     });
   }
@@ -69,14 +72,22 @@ export function parseSqlProgram(source: string): SqlProgram {
 export function emitSqlProgram(program: SqlProgram): string {
   const { source, statements } = program;
   if (!statements.some(s => s.dirty)) return source;
+  // Spans are UTF-8 byte offsets; slice statements and the verbatim gaps
+  // between them on the bytes so a multibyte character never mis-cuts the
+  // reassembly. Statement boundaries fall on character boundaries.
+  const sourceBytes = sqlSourceBytes(source);
   const pieces: string[] = [];
   let cursor = 0;
   for (const statement of statements) {
     const { start, len } = statement.span;
-    if (start > cursor) pieces.push(source.slice(cursor, start));
-    pieces.push(statement.dirty ? Deparser.deparse(statement.stmt) : source.slice(start, start + len));
+    if (start > cursor) pieces.push(sliceStatementBytes(sourceBytes, cursor, start - cursor));
+    pieces.push(
+      statement.dirty
+        ? Deparser.deparse(statement.stmt)
+        : sliceStatementBytes(sourceBytes, start, len)
+    );
     cursor = start + len;
   }
-  if (cursor < source.length) pieces.push(source.slice(cursor));
+  if (cursor < sourceBytes.length) pieces.push(sliceStatementBytes(sourceBytes, cursor));
   return pieces.join('');
 }

--- a/pgpm/transform/src/semantic-diff-driver.ts
+++ b/pgpm/transform/src/semantic-diff-driver.ts
@@ -39,6 +39,7 @@ import {
 } from '@pgsql/transform';
 import { Deparser, parseSync } from 'plpgsql-parser';
 
+import { sliceStatementBytes, sqlSourceBytes } from './byte-slice';
 import { ConstraintNode, defaultConstraintName } from './constraint-names';
 import { ChangeGranularity, GranularityChange, restructureChanges } from './granularity-driver';
 
@@ -118,8 +119,10 @@ function readSide(sql: string, warnings: string[], label: string): SideProgram {
   const unitOf: (string | null)[] = new Array(facts.length).fill(null);
   const byObject = new Map<string, string>();
 
+  const sqlBytes = sqlSourceBytes(sql);
+
   facts.forEach((f, i) => {
-    const text = sql.slice(f.span.start, f.span.start + f.span.len).trim();
+    const text = sliceStatementBytes(sqlBytes, f.span.start, f.span.len).trim();
     if (!text) return;
 
     let identity = groupingIdentity(f);

--- a/pgpm/transform/src/sub-object.ts
+++ b/pgpm/transform/src/sub-object.ts
@@ -13,6 +13,7 @@ import type { ObjectIdentity } from '@pgpmjs/naming-spec';
 import type { StatementFacts } from '@pgsql/semantics';
 import { Deparser, parseSync } from 'plpgsql-parser';
 
+import { sliceStatementBytes, sqlSourceBytes } from './byte-slice';
 import { ConstraintNode, defaultConstraintName } from './constraint-names';
 
 interface AlterTableCmdNode {
@@ -74,6 +75,7 @@ export function subObjectIdentityOf(facts: StatementFacts): ObjectIdentity | nul
  */
 export function nameUnnamedConstraints(sql: string): string {
   const parsed = parseSync(sql);
+  const sqlBytes = sqlSourceBytes(sql);
   const pieces: string[] = [];
   for (const raw of parsed.sql.stmts) {
     const node = raw.stmt as Record<string, unknown>;
@@ -98,7 +100,7 @@ export function nameUnnamedConstraints(sql: string): string {
     } else {
       const start = (raw as { stmt_location?: number }).stmt_location ?? 0;
       const len = (raw as { stmt_len?: number }).stmt_len;
-      const text = len === undefined ? sql.slice(start) : sql.slice(start, start + len);
+      const text = sliceStatementBytes(sqlBytes, start, len);
       const trimmed = text.trim();
       pieces.push(trimmed.endsWith(';') ? trimmed : `${trimmed};`);
     }


### PR DESCRIPTION
## Summary

The `@pgpmjs/transform` drivers slice each statement's verbatim text out of the source with `source.slice(span.start, span.start + span.len)`, but `span.start`/`len` (from libpg-query via `@pgsql/semantics`, and raw `stmt_location`/`stmt_len`) are **UTF-8 byte offsets** while JS `String.prototype.slice` indexes **UTF-16 code units**. The two agree only for pure-ASCII scripts. A single non-ASCII byte earlier in the source — an em dash in a `COMMENT`, an accented word in a seed row, an emoji — shifts every later byte offset past its JS index, so each subsequent statement gets mis-cut:

```
COMMENT ON COLUMN ... IS 'scope: platform, org, app — created';
COMMENT ON TABLE  ...            ->  sliced as  "MMENT ON TABLE ..."   -> SqlError: syntax error at or near "MMENT"
```

This surfaced while diffing real generated `constructive-db` workspaces: `pgpm diff <old> <new>` crashed with `syntax error at or near "EMA"` / `"MMENT"`. On the flagship `application/constructive` module, **8035 of 8371** statements mis-parse under the old slicing (the concatenated side has 300 more bytes than JS chars); with the fix, **0**.

Fix: one shared helper slices on the UTF-8 bytes and decodes back. Statement offsets always land on character boundaries, so decoding a byte range never splits a multibyte character.

```ts
// pgpm/transform/src/byte-slice.ts
export const sqlSourceBytes = (source: string): Buffer => Buffer.from(source, 'utf8');
export const sliceStatementBytes = (sourceBytes: Buffer, start: number, len?: number): string =>
  sourceBytes.subarray(start, len === undefined ? sourceBytes.length : start + len).toString('utf8');
```

Applied at every span-slice site:
- `semantic-diff-driver.ts` `readSide` — the per-statement text feeding the diff.
- `granularity-driver.ts` (2 sites) — `single` and per-group restructuring (`restructureChanges`, the forward/delta path).
- `partition-driver.ts` `buildUnitGraph`.
- `sub-object.ts` `nameUnnamedConstraints` (raw `stmt_location`/`stmt_len`).
- `program.ts` `parseSqlProgram.raw` and `emitSqlProgram` — statement pieces **and** the verbatim gaps between them now slice on bytes, so reassembly stays byte-identical on multibyte input too. The "nothing dirty → return source unchanged" fast path is unchanged.

No behavior change for ASCII scripts (byte offset == char index), and no public API change — the helper is transform-internal.

## Tests

- New `__tests__/byte-slice.test.ts`: exact-text recovery past an em dash, a guard asserting the naive JS slice *would* mis-cut, and `diffSchemas` over a multibyte source (added-object diff + self-identity).
- `__tests__/program.test.ts`: multibyte `raw` extraction, byte-identical emit with a multibyte char, and gap preservation when a statement is dirty.
- Full transform suite green (124 tests); `diff`/`core`/`cli` build clean.


Link to Devin session: https://app.devin.ai/sessions/34f64615befa49d7b807f3467a07e726
Requested by: @pyramation