### PR TITLE
refactor(pgpm): use git-changed for bundle-drift change detection

### DIFF
--- a/.agents/skills/pgpm/references/package-check.md
+++ b/.agents/skills/pgpm/references/package-check.md
@@ -39,11 +39,14 @@ Change detection layers cheapest-source-first, then maps files to modules
 through the workspace graph:
 
 1. **Base ref** — explicit `--since <ref>` wins; otherwise the PR base in CI
-   (`origin/$GITHUB_BASE_REF`); otherwise working-tree only.
-2. **Changed files** — union of `git diff --name-only <base>...HEAD`
-   (three-dot, so branches/refs/tags all work) and `git status --porcelain`
-   (uncommitted + untracked). It shells out to the `git` binary — no
-   `simple-git`/Octokit dependency.
+   (`origin/$GITHUB_BASE_REF`); otherwise the repository's default branch;
+   otherwise working-tree only (a shallow or detached checkout).
+2. **Changed files** — union of the committed diff since the **merge base** with
+   that ref and `git status --porcelain -uall` (uncommitted + untracked). Both
+   come from the [`git-changed`](https://npmjs.com/package/git-changed) package,
+   shared with the `@pgsql/lint --changed` gate, so the two agree on what
+   "changed" means. Deleted paths are kept here: removing a `deploy/` file makes
+   the bundle stale exactly as much as editing one.
 3. **Files → modules** — each changed path is attributed to its owning module
    (longest-matching module directory). Only those modules are checked.
    `--all` skips detection; `--dependents` walks the reverse `requires` graph.

--- a/pgpm/core/__tests__/packaging/check.test.ts
+++ b/pgpm/core/__tests__/packaging/check.test.ts
@@ -1,14 +1,25 @@
-import { readFileSync, rmSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { execFileSync } from 'child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
 
 import { resolveBundleArtifactPath, writeBundleArtifact } from '../../src/bundle/artifact';
 import { PgpmPackage } from '../../src/core/class/pgpm';
 import {
   addDependents,
+  changedFiles,
   checkModuleArtifact,
   checkPackages,
   enumerateModules,
   mapFilesToModules,
+  ModuleRef,
 } from '../../src/packaging/check';
 import { TestFixture } from '../../test-utils';
 
@@ -92,6 +103,83 @@ describe('package check (artifact drift verification)', () => {
     const result = await checkPackages({ cwd: root, all: true, failFast: false });
     expect(new Set(result.drifted.map((d) => d.name))).toEqual(
       new Set(['my-first', 'my-second'])
+    );
+  });
+});
+
+/**
+ * Change detection, over a throwaway git repo shaped like a workspace. The two
+ * cases that used to be wrong before this moved to `git-changed`: a module whose
+ * files are all untracked (git reports the *directory* without `-uall`), and a
+ * deleted `deploy/` file (dropped as "no longer on disk", though a deletion
+ * makes the bundle just as stale as an edit).
+ */
+describe('package check (git change detection)', () => {
+  const repos: string[] = [];
+  let dir: string;
+  let modules: ModuleRef[];
+
+  const git = (...args: string[]): void => {
+    execFileSync('git', args, { cwd: dir, stdio: 'ignore' });
+  };
+
+  const write = (rel: string): void => {
+    const full = join(dir, rel);
+    mkdirSync(dirname(full), { recursive: true });
+    writeFileSync(full, '-- sql\n');
+  };
+
+  beforeEach(() => {
+    dir = realpathSync(mkdtempSync(join(tmpdir(), 'pgpm-check-git-')));
+    repos.push(dir);
+    modules = ['first', 'second'].map((name) => ({
+      name,
+      dir: join(dir, 'packages', name),
+    }));
+
+    git('init', '-q', '-b', 'main');
+    git('config', 'user.email', 'test@example.com');
+    git('config', 'user.name', 'Test');
+    write('packages/first/deploy/schema.sql');
+    git('add', '.');
+    git('commit', '-qm', 'base');
+  });
+
+  afterAll(() => {
+    for (const repo of repos) rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('sees every file of an entirely untracked module', () => {
+    write('packages/second/deploy/schema.sql');
+    expect(mapFilesToModules(changedFiles(dir, 'main'), modules)).toEqual(['second']);
+  });
+
+  it('sees a deleted deploy file, which makes the bundle stale too', () => {
+    git('checkout', '-q', '-b', 'feature');
+    git('rm', '-q', 'packages/first/deploy/schema.sql');
+    git('commit', '-qm', 'drop schema');
+
+    expect(mapFilesToModules(changedFiles(dir, 'main'), modules)).toEqual(['first']);
+  });
+
+  it('does not attribute base-branch commits to the branch', () => {
+    git('checkout', '-q', '-b', 'feature');
+    write('packages/second/deploy/schema.sql');
+    git('add', '.');
+    git('commit', '-qm', 'second');
+
+    git('checkout', '-q', 'main');
+    write('packages/first/deploy/other.sql');
+    git('add', '.');
+    git('commit', '-qm', 'unrelated work on main');
+    git('checkout', '-q', 'feature');
+
+    expect(mapFilesToModules(changedFiles(dir, 'main'), modules)).toEqual(['second']);
+  });
+
+  it('rejects an explicit --since that does not resolve', async () => {
+    await expect(checkPackages({ cwd: dir, since: 'origin/nope' })).rejects.toThrow(
+      /Could not diff against 'origin\/nope'/
     );
   });
 });

--- a/pgpm/core/package.json
+++ b/pgpm/core/package.json
@@ -59,6 +59,7 @@
     "@pgpmjs/types": "workspace:^",
     "csv-to-pg": "workspace:^",
     "genomic": "^5.6.2",
+    "git-changed": "^0.3.0",
     "glob": "^13.0.6",
     "parse-package-name": "^1.0.0",
     "pg": "^8.21.0",

--- a/pgpm/core/src/packaging/check.ts
+++ b/pgpm/core/src/packaging/check.ts
@@ -1,5 +1,6 @@
 import { verifyBundle } from '@pgpmjs/bundle';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
+import { changedFiles as gitChangedFiles, resolveBase as resolveChangedBase } from 'git-changed';
 import { isAbsolute, relative, resolve as resolvePath } from 'path';
 
 import {
@@ -40,8 +41,9 @@ export interface PackageCheckOptions {
   cwd?: string;
   /**
    * Git ref/branch/tag to diff `HEAD` against for change detection. When
-   * omitted, the check auto-detects the base (`origin/$GITHUB_BASE_REF` in a
-   * PR, otherwise it only inspects uncommitted/untracked working-tree changes).
+   * omitted, the base is auto-detected: `origin/$GITHUB_BASE_REF` in a PR,
+   * otherwise the repository's default branch, falling back to working-tree
+   * changes only when neither is available.
    */
   since?: string;
   /** Check every module in the workspace, skipping git change detection. */
@@ -123,65 +125,40 @@ export function checkModuleArtifact(moduleDir: string, name: string): ModuleDrif
   return null;
 }
 
-function git(args: string, cwd: string): string {
-  return execSync(`git ${args}`, {
-    cwd,
-    encoding: 'utf-8',
-    stdio: ['ignore', 'pipe', 'ignore'],
-    maxBuffer: 64 * 1024 * 1024,
-  });
-}
-
 /**
- * Resolve the git ref to diff against. Explicit `--since` wins; otherwise use
- * the PR base branch when running in GitHub Actions; otherwise `undefined`
- * (working-tree changes only).
+ * Resolve the git ref to diff against. Explicit `--since` wins; otherwise the
+ * PR base branch when running in GitHub Actions; otherwise the repository's
+ * default branch. `undefined` means there is nothing to diff against — a
+ * shallow or detached checkout — and only the working tree is inspected.
  */
-export function resolveBase(since?: string): string | undefined {
-  if (since) return since;
-  const prBase = process.env.GITHUB_BASE_REF;
-  if (prBase && prBase.trim()) return `origin/${prBase.trim()}`;
-  return undefined;
+export function resolveBase(since?: string, cwd: string = process.cwd()): string | undefined {
+  return resolveChangedBase(since, cwd);
 }
 
 /**
- * Collect the set of changed files, combining committed changes since `base`
- * (three-dot diff, so it works with branches, refs, and tags) with any
- * uncommitted/untracked changes in the working tree. Returns absolute paths.
+ * Collect the set of changed files: committed changes since the **merge base**
+ * with `base`, unioned with uncommitted and untracked working-tree changes.
+ *
+ * Returns absolute paths, including paths that no longer exist — deleting a
+ * `deploy/` file makes a module's bundle stale exactly as much as editing one,
+ * so the deletion has to reach {@link mapFilesToModules}.
  */
 export function changedFiles(cwd: string, base?: string): string[] {
-  const files = new Set<string>();
+  // `base: false` when there is no base: the ref is resolved by the caller, and
+  // git-changed would otherwise resolve one of its own.
+  return gitChangedFiles({ cwd, base: base ?? false, existingOnly: false }).paths;
+}
 
-  const status = git('status --porcelain', cwd);
-  for (const rawLine of status.split('\n')) {
-    const line = rawLine.trimEnd();
-    if (!line) continue;
-    let p = line.slice(3);
-    const arrow = p.indexOf(' -> ');
-    if (arrow !== -1) p = p.slice(arrow + 4);
-    p = p.replace(/^"|"$/g, '');
-    if (p) files.add(resolvePath(cwd, p));
+function refExists(ref: string, cwd: string): boolean {
+  try {
+    execFileSync('git', ['rev-parse', '--verify', '--quiet', ref], {
+      cwd,
+      stdio: 'ignore',
+    });
+    return true;
+  } catch {
+    return false;
   }
-
-  if (base) {
-    let diff: string;
-    try {
-      diff = git(`diff --name-only ${base}...HEAD`, cwd);
-    } catch (err) {
-      throw new Error(
-        `Could not diff against '${base}'. Ensure the ref exists locally ` +
-          `(e.g. \`git fetch origin\`). Original error: ${
-            err instanceof Error ? err.message : String(err)
-          }`
-      );
-    }
-    for (const rawLine of diff.split('\n')) {
-      const p = rawLine.trim();
-      if (p) files.add(resolvePath(cwd, p));
-    }
-  }
-
-  return [...files];
 }
 
 /** Enumerate the modules to consider — the whole workspace, or the single module. */
@@ -261,9 +238,14 @@ export async function checkPackages(
   if (options.all) {
     targetNames = modules.map((m) => m.name);
   } else {
-    base = resolveBase(options.since);
-    const files = changedFiles(cwd, base);
-    changedModules = mapFilesToModules(files, modules);
+    base = resolveBase(options.since, cwd);
+    if (options.since && !refExists(options.since, cwd)) {
+      throw new Error(
+        `Could not diff against '${options.since}'. Ensure the ref exists locally ` +
+          '(e.g. `git fetch origin`).'
+      );
+    }
+    changedModules = mapFilesToModules(changedFiles(cwd, base), modules);
     const set = new Set(changedModules);
     if (options.dependents && pkg.getWorkspacePath()) addDependents(set, pkg);
     targetNames = [...set];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2949,6 +2949,9 @@ importers:
       genomic:
         specifier: ^5.6.2
         version: 5.6.2
+      git-changed:
+        specifier: ^0.3.0
+        version: 0.3.0
       glob:
         specifier: ^13.0.6
         version: 13.0.6
@@ -10566,6 +10569,13 @@ packages:
         integrity: sha512-mKZj9JLQrwMBtj5wxi6MH8Z5eSKaERpAwjg43dPtlGI1ZVEgH/qC7T8/6R2OBSUA+zzHBZgICsVJaEIV2tKTDA==,
       }
     engines: { node: '>=6.0' }
+
+  git-changed@0.3.0:
+    resolution:
+      {
+        integrity: sha512-tNAKg96UMf8YBlyr7nZFulqS/yEhSQ+Q/1QVFnQ4mUe4f5eIwhK+Oie11x4IixWD+SB4AmSaLR84S3qj2DTkKA==,
+      }
+    hasBin: true
 
   git-raw-commits@3.0.0:
     resolution:
@@ -20299,6 +20309,8 @@ snapshots:
   get-value@3.0.1:
     dependencies:
       isobject: 3.0.1
+
+  git-changed@0.3.0: {}
 
   git-raw-commits@3.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

`pgpm package --check`'s change detection was one of three hand-rolled copies of the same algorithm (the other two being `@pgsql/lint --changed` and a shell version in constructive-db's review skill). It is now the published [`git-changed`](https://npmjs.com/package/git-changed), so `check.ts` loses ~55 lines of `execSync` git plumbing and picks up two fixes it was missing.

**`-uall`.** `git status --porcelain` collapses a brand-new directory to one entry, `packages/foo/`, instead of the files inside it. A module whose `deploy/` tree is entirely new therefore mapped to *nothing* locally, and the drift check silently checked zero modules — the exact case a `pgpm init` + `pgpm package`-forgotten workflow hits. `git-changed` uses `-uall`.

**Deletions.** `git-changed` drops paths that no longer exist by default, which is right for a linter and wrong here — deleting a `deploy/` file makes the bundle stale exactly as much as editing one — so this passes `existingOnly: false` and keeps them.

Also a behaviour change worth knowing: with no `--since` and no `$GITHUB_BASE_REF`, the base is now the repository's default branch rather than nothing, so a local `pgpm package --check` sees committed-but-unpushed work instead of only the dirty working tree. CI is unaffected (`$GITHUB_BASE_REF` is set). And the diff is taken from the merge base rather than `base...HEAD` — same result, explicit.

```diff
-const status = git('status --porcelain', cwd);        // …manual parse, rename arrow, quotes
-const diff = git(`diff --name-only ${base}...HEAD`, cwd);
+return gitChangedFiles({ cwd, base: base ?? false, existingOnly: false }).paths;
```

`resolveBase` and `changedFiles` keep their signatures (`resolveBase` gains an optional `cwd`), so `pgpm/cli` and the exported API are unchanged.

The one thing not delegated is validating an explicit `--since`: `git-changed` can't distinguish "ref doesn't exist" from "no merge base", and the actionable *"Ensure the ref exists locally (e.g. `git fetch origin`)"* error is worth keeping, so a two-line `refExists` does that check up front.

## Tests

Change detection had no test coverage at all, which is why both bugs above survived. Adds four: an entirely-untracked module (fails without `-uall`), a deleted `deploy/` file (fails without `existingOnly: false`), base-branch commits after the fork not being attributed to the branch, and the `--since` error. 14 passing in `check.test.ts`.

Note the lockfile diff is one entry — `pnpm install` reflows the whole file, so it's been run back through prettier.


Link to Devin session: https://app.devin.ai/sessions/e84444b40007481e9de0285d8b5340b6
Requested by: @pyramation