### PR TITLE
ci: run the 34 packages whose tests no job was running, and fail when one is unclaimed

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -72,6 +72,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      # A package with tests that no batch below claims runs nowhere, and until
+      # this check existed nothing said so.
+      - name: Check test coverage of the CI matrix
+        run: node scripts/check-test-coverage.cjs
+
       - name: Build
         run: pnpm run build
 
@@ -97,13 +102,19 @@ jobs:
       matrix:
         include:
           - batch: uploads
-            packages: 'uploads/mime-bytes uploads/uuid-hash uploads/uuid-stream uploads/etag-hash uploads/etag-stream uploads/stream-to-etag uploads/content-type-stream uploads/upload-names'
+            packages: 'uploads/mime-bytes uploads/uuid-hash uploads/uuid-stream uploads/etag-hash uploads/etag-stream uploads/stream-to-etag uploads/content-type-stream uploads/upload-names uploads/s3-utils'
           - batch: packages-core
-            packages: 'packages/url-domains postgres/query-builder packages/csrf packages/oauth packages/12factor-env packages/orm packages/express-context'
+            packages: 'packages/url-domains postgres/query-builder packages/csrf packages/oauth packages/12factor-env packages/orm packages/express-context packages/errors packages/llm-env packages/node-type-registry packages/query-spec packages/server-utils postgres/pg-cache postgres/pg-env'
           - batch: packages-services
             packages: 'packages/postmaster packages/smtppostmaster packages/csv-to-pg packages/cli postgres/pgsql-client postgres/pg-ast'
           - batch: graphql
             packages: 'graphql/query graphql/codegen'
+          - batch: graphile-unit
+            packages: 'graphile/graphile-plugin-utils graphile/graphile-realtime-subscriptions graphile/graphile-sql-expression-validator graphile/graphile-upload-plugin'
+          - batch: agentic
+            packages: 'agentic/protocol agentic/agentic-kit agentic/agent agentic/harness agentic/chat agentic/cli agentic/pi agentic/react agentic/agentic-server agentic/anthropic agentic/openai agentic/ollama'
+          - batch: pgpm-unit
+            packages: 'pgpm/types pgpm/naming-spec pgpm/diff pgpm/import pgpm/slice pgpm/transform'
           - batch: pglite
             packages: 'postgres/pglite-adapter postgres/pglite-test examples/pglite-socket examples/pgpm-projections'
 
@@ -235,6 +246,8 @@ jobs:
             packages: 'postgres/pgsql-test postgres/drizzle-orm-test postgres/introspectron graphile/graphile-test graphile/graphile-connection-filter graphile/graphile-postgis'
           - batch: pg-graphql
             packages: 'graphile/graphile-search graphile/graphile-ltree graphile/graphile-bulk-mutations graphile/graphile-function-bindings graphile/graphile-history graphile/graphile-meta graphile/graphile-schema graphql/orm-test graphql/test graphql/playwright-test'
+          - batch: pg-graphile-extras
+            packages: 'graphile/graphile-i18n graphile/graphile-pg-aggregates graphile/graphile-query'
 
     env:
       PGHOST: localhost

--- a/graphile/graphile-realtime-subscriptions/__tests__/plugin.test.ts
+++ b/graphile/graphile-realtime-subscriptions/__tests__/plugin.test.ts
@@ -379,7 +379,7 @@ describe('createRealtimeSubscriptionsPlugin', () => {
       expect(result.plans['Subscription']).toBeDefined();
       expect(result.plans['Subscription']['onProjectsChanged']).toBeDefined();
 
-      const mockArgs = { get: jest.fn(() => 'test-id') };
+      const mockArgs = { getRaw: jest.fn(() => 'test-id') };
       result.plans['Subscription']['onProjectsChanged'].subscribePlan(null, mockArgs);
 
       expect(mockConstant).toHaveBeenCalledWith('realtime:app_public.projects');
@@ -398,7 +398,7 @@ describe('createRealtimeSubscriptionsPlugin', () => {
 
       const result = capturedFactory!(build);
 
-      const mockArgs = { get: jest.fn(() => 'test-id') };
+      const mockArgs = { getRaw: jest.fn(() => 'test-id') };
       result.plans['Subscription']['onItemsChanged'].subscribePlan(null, mockArgs);
 
       expect(mockConstant).toHaveBeenCalledWith('realtime:inventory_public.items');
@@ -430,7 +430,7 @@ describe('createRealtimeSubscriptionsPlugin', () => {
       });
 
       const result = capturedFactory!(build);
-      const mockArgs = { get: jest.fn(() => 'some-id') };
+      const mockArgs = { getRaw: jest.fn(() => 'some-id') };
 
       result.plans['Subscription']['onTasksChanged'].subscribePlan(null, mockArgs);
 
@@ -573,14 +573,14 @@ describe('createRealtimeSubscriptionsPlugin', () => {
       });
 
       const result = capturedFactory!(build);
-      const mockArgs = { get: jest.fn((key: string) => {
+      const mockArgs = { getRaw: jest.fn((key: string) => {
         if (key === 'ids') return ['id-a', 'id-b'];
         return null;
       }) };
 
       result.plans['Subscription']['onTasksChanged'].subscribePlan(null, mockArgs);
 
-      expect(mockArgs.get).toHaveBeenCalledWith('ids');
+      expect(mockArgs.getRaw).toHaveBeenCalledWith('ids');
 
       // The listen callback is captured but not invoked by the mock.
       // Invoke it manually to verify ids are threaded through.

--- a/graphile/graphile-realtime-test/jest.config.js
+++ b/graphile/graphile-realtime-test/jest.config.js
@@ -14,5 +14,9 @@ module.exports = {
   transformIgnorePatterns: [`/node_modules/*`],
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  modulePathIgnorePatterns: ['dist/*']
+  modulePathIgnorePatterns: ['dist/*'],
+  // src/ uses ESM-style './foo.js' specifiers; resolve them to the .ts source.
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
+  }
 };

--- a/graphile/graphile-upload-plugin/src/plugin.ts
+++ b/graphile/graphile-upload-plugin/src/plugin.ts
@@ -25,6 +25,7 @@ import 'graphile-build';
 import 'graphile-build-pg';
 
 import type { GraphileConfig } from 'graphile-config';
+import { isInputType } from 'graphql';
 import { Readable, Transform } from 'stream';
 
 import type { UploadFieldDefinition, UploadPluginOptions } from './types';
@@ -196,8 +197,12 @@ export function createUploadPlugin(
             return fields;
           }
 
+          // getTypeByName is untyped beyond GraphQLNamedType, and the field
+          // below needs an input type — narrow rather than assert, so a
+          // non-input 'Upload' registered by another plugin skips instead of
+          // building an invalid schema.
           const UploadType = build.getTypeByName('Upload');
-          if (!UploadType) {
+          if (!UploadType || !isInputType(UploadType)) {
             return fields;
           }
 

--- a/scripts/check-test-coverage.cjs
+++ b/scripts/check-test-coverage.cjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * Fails when a workspace package has tests that no CI job runs.
+ *
+ * The test matrices in .github/workflows/run-tests.yaml are hand-maintained
+ * lists of package paths. Adding a package to the workspace does not add it to
+ * a batch, and nothing complained: 35 packages / 89 test files had accumulated
+ * in no job at all, so genuinely broken code (a type error in
+ * graphile-upload-plugin, stale mocks in graphile-realtime-subscriptions) sat
+ * green for as long as nobody ran them locally.
+ *
+ * Omission is now countable. A package with tests must either be claimed by a
+ * batch or listed in EXCLUSIONS with a reason — silence is not an option.
+ */
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const WORKFLOW = path.join(ROOT, '.github/workflows/run-tests.yaml');
+
+/**
+ * Packages deliberately not in any batch. Every entry needs a reason; a stale
+ * exclusion (the package no longer exists, or has no tests) is also an error,
+ * so this list cannot rot quietly.
+ */
+const EXCLUSIONS = {
+  'graphile/graphile-realtime-test':
+    'Sparse-set filtering delivers a bogus UNKNOWN event instead of dropping ' +
+    'the filtered one — a real plugin bug, not test drift. constructive-planning#1426.',
+  'graphql/react':
+    'Requires an external GraphQL endpoint via $TESTING_URL and throws at ' +
+    'import time without one — a manual suite, not a CI one.',
+  'pgpm/export':
+    'Meta export emits nothing for the routing/apps tables since the schemas ' +
+    'were repointed off services_public; 7 tests fail. constructive-planning#1426.'
+};
+
+function claimedPackages() {
+  const workflow = fs.readFileSync(WORKFLOW, 'utf8');
+  const claimed = new Set();
+  for (const [, list] of workflow.matchAll(/^\s*packages:\s*'([^']+)'/gm)) {
+    for (const pkg of list.split(/\s+/).filter(Boolean)) claimed.add(pkg);
+  }
+  for (const [, pkg] of workflow.matchAll(/^\s*- package:\s*(\S+)/gm)) {
+    claimed.add(pkg);
+  }
+  return claimed;
+}
+
+function hasTests(dir) {
+  const stack = [path.join(dir, '__tests__'), path.join(dir, 'src')];
+  while (stack.length) {
+    const current = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue; // directory simply doesn't exist
+    }
+    for (const entry of entries) {
+      if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) stack.push(full);
+      else if (/\.(test|spec)\.(t|j)sx?$/.test(entry.name)) return true;
+    }
+  }
+  return false;
+}
+
+function workspacePackages() {
+  const raw = execFileSync('pnpm', ['-r', 'list', '--json', '--depth', '-1'], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024
+  });
+  return JSON.parse(raw)
+    .map(pkg => pkg.path)
+    .filter(Boolean)
+    .map(abs => path.relative(ROOT, abs))
+    .filter(rel => rel && !rel.startsWith('..'));
+}
+
+function main() {
+  const claimed = claimedPackages();
+  if (claimed.size === 0) {
+    throw new Error(
+      `parsed no packages out of ${path.relative(ROOT, WORKFLOW)} — the matrix ` +
+        'format changed and this check is now vacuous'
+    );
+  }
+
+  const tested = workspacePackages().filter(rel => hasTests(path.join(ROOT, rel)));
+  const unclaimed = tested.filter(rel => !claimed.has(rel) && !(rel in EXCLUSIONS));
+  const staleExclusions = Object.keys(EXCLUSIONS).filter(rel => !tested.includes(rel));
+
+  for (const rel of unclaimed) {
+    console.error(`✗ ${rel} has tests but no CI job runs them`);
+  }
+  for (const rel of staleExclusions) {
+    console.error(`✗ ${rel} is excluded but has no tests (or no longer exists)`);
+  }
+
+  if (unclaimed.length || staleExclusions.length) {
+    console.error(
+      '\nAdd the package to a batch in .github/workflows/run-tests.yaml, or to ' +
+        'EXCLUSIONS in this script with a reason.'
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `✓ ${tested.length} packages with tests, all claimed ` +
+      `(${Object.keys(EXCLUSIONS).length} excluded with reasons)`
+  );
+}
+
+main();


### PR DESCRIPTION
## Summary

The test matrices in `run-tests.yaml` are hand-maintained package lists, so adding a package to the workspace never added it to CI, and nothing complained. Enumerating the workspace against the matrices found **35 packages / 89 test files that no job ran** — about a third of the packages that have tests. This wires 34 of them in and makes the omission countable.

Four were red. Two of those were defects that had already shipped, and only looked green because nobody ran them:

- **`graphile-upload-plugin` did not compile.** `build.getTypeByName('Upload')` is typed `GraphQLNamedType`, assigned to a field wanting `GraphQLInputType` (`TS2322`). Two of three suites never loaded, so 42 of its 51 tests were dark. Narrowed rather than asserted, so a non-input `Upload` registered by another plugin skips instead of building an invalid schema:
  ```diff
  - if (!UploadType) return fields;
  + if (!UploadType || !isInputType(UploadType)) return fields;
  ```
- **`graphile-realtime-subscriptions`** mocks pass `args.get`; the plugin has called `args.getRaw('ids')` since it moved to the real grafast `FieldArgs` API. Mocks updated to the actual interface.
- **`graphile-realtime-test`** could not *load* either suite — `src/` uses ESM-style `./foo.js` specifiers and the jest config had no `moduleNameMapper` (every other package that does this has one).
- `pgpm/export` — see below.

Tier placement was verified empirically rather than guessed: each candidate was re-run with `PGHOST` pointed at a dead port, so the 30 in `unit-tests` provably need no services and only `graphile-i18n`, `graphile-pg-aggregates` and `graphile-query` went to `pg-tests`.

### The part that stops this recurring

`scripts/check-test-coverage.cjs`, run in the `build` job. It parses the batch lists out of the workflow, enumerates every workspace package that has tests, and fails on any package no batch claims — and equally on an exclusion that has gone stale (package deleted, or tests removed), so the escape hatch can't rot either. Exclusions must carry a reason:

```
✓ 99 packages with tests, all claimed (3 excluded with reasons)
```

### What is deliberately still excluded

Two packages fail on **product bugs, not CI plumbing**, so they are excluded with reasons and written up in constructive-planning#1426 rather than papered over or force-passed here:

- **`graphile-realtime-test`** — sparse-set filtering doesn't drop anything. Returning `null` from the lambda inside `listen(...)` still produces an event; the payload resolver coalesces it to `event: 'UNKNOWN'`. So a subscriber on `ids: [watched]` gets a junk event every time some *other* row changes, and throttled events leak the same way. Grafast's `listen` has no way to suppress an event from the stream, so the fix is a design call (filter in a wrapping `pgSubscriber`, or narrow the NOTIFY channel) — the test asserting `UPDATE` is right and the plugin is wrong.
- **`pgpm/export`** — three failures are stale schema names, but the other four say meta export has been **silently omitting `apis`, `sites`, `domains` and `api_schemas`** since the repoint off `services_public`: those files vanished from the E2E snapshot and both export flows return `undefined` for them. No error, just missing files. Needs someone who knows the intended post-repoint surface to say whether the generated manifest, the exporter or the seed is wrong.

`graphql/react` is excluded too, but benignly — it throws at import without an external `$TESTING_URL` endpoint.


Link to Devin session: https://app.devin.ai/sessions/087553534c774929918ec4d378845881
Requested by: @pyramation