### PR TITLE
fix(pgpm): decode git-quoted paths in `package --check` change detection

### DIFF
--- a/pgpm/core/__tests__/packaging/check.test.ts
+++ b/pgpm/core/__tests__/packaging/check.test.ts
@@ -177,6 +177,68 @@ describe('package check (git change detection)', () => {
     expect(mapFilesToModules(changedFiles(dir, 'main'), modules)).toEqual(['second']);
   });
 
+  it('sees a path with a space and a non-ASCII character', () => {
+    // git quotes and C-escapes such a path by default ("caf\303\251 dir/x.sql");
+    // a consumer that only strips the quotes silently loses the whole module.
+    write('packages/second/deploy/café dir/x.sql');
+    expect(mapFilesToModules(changedFiles(dir, 'main'), modules)).toEqual(['second']);
+  });
+
+  it('sees a committed path with a space and a non-ASCII character', () => {
+    git('checkout', '-q', '-b', 'feature');
+    write('packages/second/deploy/café dir/x.sql');
+    git('add', '.');
+    git('commit', '-qm', 'accented');
+
+    const changed = changedFiles(dir, 'main');
+    expect(changed).toContain(join(dir, 'packages/second/deploy/café dir/x.sql'));
+    expect(mapFilesToModules(changed, modules)).toEqual(['second']);
+  });
+
+  it('sees a deleted non-ASCII path, which no longer exists in either form', () => {
+    write('packages/second/deploy/café dir/x.sql');
+    git('add', '.');
+    git('commit', '-qm', 'accented');
+    git('checkout', '-q', '-b', 'feature');
+    git('rm', '-q', '-r', 'packages/second/deploy/café dir');
+    git('commit', '-qm', 'drop accented');
+
+    const changed = changedFiles(dir, 'main');
+    expect(changed).toContain(join(dir, 'packages/second/deploy/café dir/x.sql'));
+  });
+
+  it('reports the destination of a rename', () => {
+    git('checkout', '-q', '-b', 'feature');
+    git('mv', 'packages/first/deploy/schema.sql', 'packages/first/deploy/renamed.sql');
+    git('commit', '-qm', 'rename');
+
+    expect(changedFiles(dir, 'main')).toContain(
+      join(dir, 'packages/first/deploy/renamed.sql')
+    );
+  });
+
+  it('resolves paths against the git root when the workspace is a subdirectory', () => {
+    // `cwd` is the pgpm workspace root, nested below the git root: git reports
+    // repo-root-relative paths, so resolving them against `cwd` would be wrong.
+    const workspace = join(dir, 'workspace');
+    const nested = ['first', 'second'].map((name) => ({
+      name,
+      dir: join(workspace, 'packages', name),
+    }));
+    write('workspace/packages/first/deploy/schema.sql');
+    git('add', '.');
+    git('commit', '-qm', 'workspace');
+
+    git('checkout', '-q', '-b', 'feature');
+    write('workspace/packages/second/deploy/schema.sql');
+    git('add', '.');
+    git('commit', '-qm', 'second');
+
+    const changed = changedFiles(workspace, 'main');
+    expect(changed).toContain(join(workspace, 'packages/second/deploy/schema.sql'));
+    expect(mapFilesToModules(changed, nested)).toEqual(['second']);
+  });
+
   it('rejects an explicit --since that does not resolve', async () => {
     await expect(checkPackages({ cwd: dir, since: 'origin/nope' })).rejects.toThrow(
       /Could not diff against 'origin\/nope'/

--- a/pgpm/core/src/packaging/check.ts
+++ b/pgpm/core/src/packaging/check.ts
@@ -1,5 +1,6 @@
 import { verifyBundle } from '@pgpmjs/bundle';
 import { execFileSync } from 'child_process';
+import { existsSync } from 'fs';
 import { changedFiles as gitChangedFiles, resolveBase as resolveChangedBase } from 'git-changed';
 import { isAbsolute, relative, resolve as resolvePath } from 'path';
 
@@ -146,7 +147,68 @@ export function resolveBase(since?: string, cwd: string = process.cwd()): string
 export function changedFiles(cwd: string, base?: string): string[] {
   // `base: false` when there is no base: the ref is resolved by the caller, and
   // git-changed would otherwise resolve one of its own.
-  return gitChangedFiles({ cwd, base: base ?? false, existingOnly: false }).paths;
+  return gitChangedFiles({ cwd, base: base ?? false, existingOnly: false }).paths.map(
+    decodeGitPath
+  );
+}
+
+/**
+ * Undo git's C-escaping of a path it decided to quote.
+ *
+ * With `core.quotepath` on (the default) git renders a path holding a non-ASCII
+ * byte as `"caf\303\251 dir/x.sql"`: octal escapes, one per UTF-8 byte. A caller
+ * that only strips the surrounding quotes is left with a filename that exists
+ * nowhere on disk, so the module owning it silently drops out of the check —
+ * `pgpm package --check` passes while the module's bundle is stale.
+ *
+ * Only applied when it actually resolves something: if the escaped form exists on
+ * disk and the decoded one does not, the backslashes were part of the filename.
+ */
+function decodeGitPath(path: string): string {
+  if (!path.includes('\\')) return path;
+  const decoded = cUnescape(path);
+  if (decoded === path) return path;
+  if (existsSync(decoded)) return decoded;
+  // Neither form exists for a deleted file; the decoded name is the real one.
+  return existsSync(path) ? path : decoded;
+}
+
+const C_ESCAPES: Record<string, number> = {
+  a: 0x07,
+  b: 0x08,
+  f: 0x0c,
+  n: 0x0a,
+  r: 0x0d,
+  t: 0x09,
+  v: 0x0b,
+  '\\': 0x5c,
+  '"': 0x22,
+};
+
+/** Decode `\NNN` octal byte escapes and the single-character C escapes git emits. */
+function cUnescape(input: string): string {
+  const bytes: number[] = [];
+  for (let i = 0; i < input.length; i += 1) {
+    const ch = input[i];
+    if (ch !== '\\' || i + 1 >= input.length) {
+      bytes.push(...Buffer.from(ch, 'utf8'));
+      continue;
+    }
+    const next = input[i + 1];
+    const octal = input.slice(i + 1, i + 4);
+    if (/^[0-7]{3}$/.test(octal)) {
+      bytes.push(parseInt(octal, 8));
+      i += 3;
+      continue;
+    }
+    if (next in C_ESCAPES) {
+      bytes.push(C_ESCAPES[next]);
+      i += 1;
+      continue;
+    }
+    bytes.push(...Buffer.from(ch, 'utf8'));
+  }
+  return Buffer.from(bytes).toString('utf8');
 }
 
 function refExists(ref: string, cwd: string): boolean {


### PR DESCRIPTION
## Summary

`pgpm package --check` could silently pass on a drifted module: any changed file whose path contains a space or a non-ASCII byte was never attributed to its module, so the module's committed `.bundle.tar.gz` was never compared against `deploy/`.

Cause: with `core.quotepath` on (git's default), both `git diff --name-status` and `git status --porcelain` render such a path quoted and C-escaped — `"packages/second/deploy/caf\303\251 dir/x.sql"`. `git-changed` unquotes with `JSON.parse`, which does not understand octal byte escapes, so the path comes back as the literal `caf\303\251 dir/x.sql`. `mapFilesToModules` then resolves a filename that exists nowhere and the owning module drops out of the check. For `constructive-db`'s `pgpm bundle sync` job that means a deploy of unreviewed SQL behind a green check.

Fix is confined to `changedFiles()`, which now decodes what git escaped:

```ts
gitChangedFiles({ cwd, base: base ?? false, existingOnly: false }).paths.map(decodeGitPath);

// decodeGitPath: \NNN -> byte, \t/\n/\\/\" -> char, bytes -> utf8
// keeps the raw form only when it, and not the decoded form, exists on disk
// (a real backslash in a filename); for a deleted path neither exists, so the
// decoded name wins and the deletion still reaches mapFilesToModules.
```

No API or CLI change: signature, options, result shape and output strings are untouched, and the rest of change detection stays on `git-changed` (merge-base three-dot diff ∪ working tree ∪ untracked, repo-root-relative paths resolved against the git root).

## Tests

`pgpm/core/__tests__/packaging/check.test.ts` gains cases over a throwaway git repo (no git mocking): a `café dir/x.sql` change detected both untracked and committed, the same path deleted (neither form on disk), a rename reporting its destination, and a workspace root nested below the git root resolving correctly.


Link to Devin session: https://app.devin.ai/sessions/63f123cbefd94effab05a5131507b83c
Requested by: @pyramation