### PR TITLE
test(export): drop the dead constructive_*_public schemas, and run pgpm/export in CI

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -241,7 +241,7 @@ jobs:
       matrix:
         include:
           - batch: pg-core
-            packages: 'pgpm/ast pgpm/traverse pgpm/bundle pgpm/core pgpm/cli pgpm/portability packages/client packages/safegres postgres/pg-codegen'
+            packages: 'pgpm/ast pgpm/traverse pgpm/bundle pgpm/core pgpm/cli pgpm/portability pgpm/export packages/client packages/safegres postgres/pg-codegen'
           - batch: pg-postgres
             packages: 'postgres/pgsql-test postgres/drizzle-orm-test postgres/introspectron graphile/graphile-test graphile/graphile-connection-filter graphile/graphile-postgis'
           - batch: pg-graphql

--- a/pgpm/export/__tests__/cross-flow-parity.test.ts
+++ b/pgpm/export/__tests__/cross-flow-parity.test.ts
@@ -312,7 +312,7 @@ describe('Cross-flow parity: exportMeta vs exportGraphQLMeta', () => {
         // Create schemas and tables
         await pg.query(`
           CREATE SCHEMA IF NOT EXISTS metaschema_public;
-          CREATE SCHEMA IF NOT EXISTS constructive_routing_public;
+          CREATE SCHEMA IF NOT EXISTS routing_public;
           CREATE SCHEMA IF NOT EXISTS metaschema_modules_public;
 
           -- metaschema_public tables
@@ -346,8 +346,8 @@ describe('Cross-flow parity: exportMeta vs exportGraphQLMeta', () => {
             description text
           );
 
-          -- constructive_routing_public tables
-          CREATE TABLE constructive_routing_public.domains (
+          -- routing_public tables
+          CREATE TABLE routing_public.domains (
             id uuid PRIMARY KEY,
             database_id uuid,
             hostname text,
@@ -358,7 +358,7 @@ describe('Cross-flow parity: exportMeta vs exportGraphQLMeta', () => {
             tls_status text,
             is_published boolean
           );
-          CREATE TABLE constructive_routing_public.sites (
+          CREATE TABLE routing_public.sites (
             id uuid PRIMARY KEY,
             database_id uuid,
             name text,
@@ -367,7 +367,7 @@ describe('Cross-flow parity: exportMeta vs exportGraphQLMeta', () => {
             config jsonb,
             is_published boolean
           );
-          CREATE TABLE constructive_routing_public.apis (
+          CREATE TABLE routing_public.apis (
             id uuid PRIMARY KEY,
             database_id uuid,
             name text,
@@ -376,7 +376,7 @@ describe('Cross-flow parity: exportMeta vs exportGraphQLMeta', () => {
             anon_role text,
             config jsonb
           );
-          CREATE TABLE constructive_routing_public.api_schemas (
+          CREATE TABLE routing_public.api_schemas (
             id uuid PRIMARY KEY,
             database_id uuid,
             schema_id uuid,
@@ -408,7 +408,7 @@ describe('Cross-flow parity: exportMeta vs exportGraphQLMeta', () => {
             force_enabled boolean,
             priority int4
           );
-          CREATE TABLE constructive_routing_public.cors_settings (
+          CREATE TABLE routing_public.cors_settings (
             id uuid PRIMARY KEY,
             database_id uuid,
             api_id uuid,
@@ -479,22 +479,22 @@ describe('Cross-flow parity: exportMeta vs exportGraphQLMeta', () => {
         `, [FIELD_ID_1, DATABASE_ID, TABLE_ID_USERS, FIELD_ID_2, FIELD_ID_3, TABLE_ID_POSTS]);
 
         await pg.query(`
-          INSERT INTO constructive_routing_public.apis (id, database_id, name, is_published, role_name, anon_role)
+          INSERT INTO routing_public.apis (id, database_id, name, is_published, role_name, anon_role)
           VALUES ($1, $2, 'public-api', true, 'authenticated', 'anonymous')
         `, [API_ID, DATABASE_ID]);
 
         await pg.query(`
-          INSERT INTO constructive_routing_public.sites (id, database_id, name, title, description)
+          INSERT INTO routing_public.sites (id, database_id, name, title, description)
           VALUES ($1, $2, 'test-app', 'Test App', 'A test application')
         `, [SITE_ID, DATABASE_ID]);
 
         await pg.query(`
-          INSERT INTO constructive_routing_public.domains (id, database_id, hostname, managed, is_wildcard, is_published)
+          INSERT INTO routing_public.domains (id, database_id, hostname, managed, is_wildcard, is_published)
           VALUES ($1, $2, 'app.example.com', false, false, true)
         `, [DOMAIN_ID, DATABASE_ID]);
 
         await pg.query(`
-          INSERT INTO constructive_routing_public.api_schemas (id, database_id, schema_id, api_id)
+          INSERT INTO routing_public.api_schemas (id, database_id, schema_id, api_id)
           VALUES ($1, $2, $3, $4)
         `, [API_SCHEMA_ID, DATABASE_ID, SCHEMA_ID_PUB, API_ID]);
 
@@ -513,14 +513,14 @@ describe('Cross-flow parity: exportMeta vs exportGraphQLMeta', () => {
 
         // cors_settings table — tests text[] columns
         await pg.query(`
-          INSERT INTO constructive_routing_public.cors_settings (id, database_id, api_id, allowed_origins)
+          INSERT INTO routing_public.cors_settings (id, database_id, api_id, allowed_origins)
           VALUES ($1, $2, $3, ARRAY['http://localhost:3000', 'https://example.com']::text[])
         `, [CORS_SETTINGS_ID, DATABASE_ID, API_ID]);
 
         // surface module config tables (catalog / routing planes)
         await pg.query(`
           INSERT INTO metaschema_modules_public.catalog_module (id, database_id, schema_id, public_schema_name, domains_table_name, apis_table_name, sites_table_name, apps_table_name, scope, policies)
-          VALUES ($1, $2, $3, 'constructive_catalog_public', 'domains', 'apis', 'sites', 'apps', 'platform', '{"select": "public"}'::jsonb)
+          VALUES ($1, $2, $3, 'catalog_public', 'domains', 'apis', 'sites', 'apps', 'platform', '{"select": "public"}'::jsonb)
         `, [CATALOG_MODULE_ID, DATABASE_ID, SCHEMA_ID_PUB]);
 
         await pg.query(`

--- a/pgpm/export/__tests__/export-flow.test.ts
+++ b/pgpm/export/__tests__/export-flow.test.ts
@@ -62,8 +62,8 @@ function getDirectoryStructure(dir: string, baseDir?: string): string[] {
 const SCHEMA_SHIMS_SQL = `
   CREATE SCHEMA IF NOT EXISTS metaschema_public;
   CREATE SCHEMA IF NOT EXISTS metaschema_modules_public;
-  CREATE SCHEMA IF NOT EXISTS constructive_routing_public;
-  CREATE SCHEMA IF NOT EXISTS constructive_apps_public;
+  CREATE SCHEMA IF NOT EXISTS routing_public;
+  CREATE SCHEMA IF NOT EXISTS apps_public;
   CREATE SCHEMA IF NOT EXISTS db_migrate;
 
   -- metaschema_public tables
@@ -99,8 +99,8 @@ const SCHEMA_SHIMS_SQL = `
     description text
   );
 
-  -- constructive_routing_public tables
-  CREATE TABLE IF NOT EXISTS constructive_routing_public.domains (
+  -- routing_public tables
+  CREATE TABLE IF NOT EXISTS routing_public.domains (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     database_id uuid,
     hostname text,
@@ -115,7 +115,7 @@ const SCHEMA_SHIMS_SQL = `
     updated_at timestamptz DEFAULT now()
   );
 
-  CREATE TABLE IF NOT EXISTS constructive_routing_public.apis (
+  CREATE TABLE IF NOT EXISTS routing_public.apis (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     database_id uuid,
     name text,
@@ -128,7 +128,7 @@ const SCHEMA_SHIMS_SQL = `
     updated_at timestamptz DEFAULT now()
   );
 
-  CREATE TABLE IF NOT EXISTS constructive_routing_public.sites (
+  CREATE TABLE IF NOT EXISTS routing_public.sites (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     database_id uuid,
     name text,
@@ -140,7 +140,7 @@ const SCHEMA_SHIMS_SQL = `
     updated_at timestamptz DEFAULT now()
   );
 
-  CREATE TABLE IF NOT EXISTS constructive_routing_public.api_schemas (
+  CREATE TABLE IF NOT EXISTS routing_public.api_schemas (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     database_id uuid,
     schema_id uuid,
@@ -150,7 +150,7 @@ const SCHEMA_SHIMS_SQL = `
   );
 
   -- Additional scoped tables required by exportMeta
-  CREATE TABLE IF NOT EXISTS constructive_apps_public.apps (
+  CREATE TABLE IF NOT EXISTS apps_public.apps (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     database_id uuid,
     name text,
@@ -163,7 +163,7 @@ const SCHEMA_SHIMS_SQL = `
     updated_at timestamptz DEFAULT now()
   );
 
-  CREATE TABLE IF NOT EXISTS constructive_routing_public.site_modules (
+  CREATE TABLE IF NOT EXISTS routing_public.site_modules (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     database_id uuid,
     site_id uuid,
@@ -173,7 +173,7 @@ const SCHEMA_SHIMS_SQL = `
     updated_at timestamptz DEFAULT now()
   );
 
-  CREATE TABLE IF NOT EXISTS constructive_routing_public.site_themes (
+  CREATE TABLE IF NOT EXISTS routing_public.site_themes (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     database_id uuid,
     site_id uuid,
@@ -182,7 +182,7 @@ const SCHEMA_SHIMS_SQL = `
     updated_at timestamptz DEFAULT now()
   );
 
-  CREATE TABLE IF NOT EXISTS constructive_routing_public.site_metadata (
+  CREATE TABLE IF NOT EXISTS routing_public.site_metadata (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     database_id uuid,
     site_id uuid,
@@ -193,7 +193,7 @@ const SCHEMA_SHIMS_SQL = `
     updated_at timestamptz DEFAULT now()
   );
 
-  CREATE TABLE IF NOT EXISTS constructive_routing_public.api_modules (
+  CREATE TABLE IF NOT EXISTS routing_public.api_modules (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     database_id uuid,
     api_id uuid,
@@ -581,21 +581,21 @@ INSERT INTO metaschema_public.field (id, database_id, table_id, name, type, desc
   ('cccc0021-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'bbbb0003-0000-0000-0000-000000000001', 'name', 'citext', 'Species name');
 
 -- Scoped plane data
-INSERT INTO constructive_routing_public.apis (id, database_id, name, dbname, is_published, role_name, anon_role) VALUES
+INSERT INTO routing_public.apis (id, database_id, name, dbname, is_published, role_name, anon_role) VALUES
   ('eeee0001-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'public', 'pets-db', true, 'authenticated', 'anonymous');
 
-INSERT INTO constructive_routing_public.sites (id, database_id, name, title, description, is_published) VALUES
+INSERT INTO routing_public.sites (id, database_id, name, title, description, is_published) VALUES
   ('ffff0001-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'pet-clinic', 'Pet Clinic', 'A pet management application', true);
 
-INSERT INTO constructive_routing_public.domains (id, database_id, hostname, managed, is_wildcard, is_published) VALUES
+INSERT INTO routing_public.domains (id, database_id, hostname, managed, is_wildcard, is_published) VALUES
   ('dddd0001-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'pets.localhost', false, false, true);
 
-INSERT INTO constructive_routing_public.api_schemas (id, database_id, schema_id, api_id) VALUES
+INSERT INTO routing_public.api_schemas (id, database_id, schema_id, api_id) VALUES
   ('1111aaaa-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'aaaa0001-0000-0000-0000-000000000001', 'eeee0001-0000-0000-0000-000000000001');
 
 -- Surface module configuration
 INSERT INTO metaschema_modules_public.catalog_module (id, database_id, schema_id, public_schema_name, domains_table_name, apis_table_name, sites_table_name, apps_table_name, api_name, scope) VALUES
-  ('2222aaaa-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'aaaa0001-0000-0000-0000-000000000001', 'constructive_catalog_public', 'domains', 'apis', 'sites', 'apps', 'public', 'platform');
+  ('2222aaaa-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'aaaa0001-0000-0000-0000-000000000001', 'catalog_public', 'domains', 'apis', 'sites', 'apps', 'public', 'platform');
 
 INSERT INTO metaschema_modules_public.domain_module (id, database_id, schema_id, catalog_module_id, domains_table_name, managed_domains_table_name, scope, prefix) VALUES
   ('2222bbbb-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'aaaa0001-0000-0000-0000-000000000001', '2222aaaa-0000-0000-0000-000000000001', 'domains', 'managed_domains', 'platform', '');
@@ -638,14 +638,14 @@ INSERT INTO metaschema_modules_public.database_settings_module (id, database_id,
     expect(parseInt(fieldResult.rows[0].count)).toBeGreaterThan(0);
   });
 
-  it('should have seeded the database with constructive_routing_public data', async () => {
-    const apiResult = await pg.query('SELECT COUNT(*) as count FROM constructive_routing_public.apis');
+  it('should have seeded the database with routing_public data', async () => {
+    const apiResult = await pg.query('SELECT COUNT(*) as count FROM routing_public.apis');
     expect(parseInt(apiResult.rows[0].count)).toBeGreaterThan(0);
 
-    const siteResult = await pg.query('SELECT COUNT(*) as count FROM constructive_routing_public.sites');
+    const siteResult = await pg.query('SELECT COUNT(*) as count FROM routing_public.sites');
     expect(parseInt(siteResult.rows[0].count)).toBeGreaterThan(0);
 
-    const domainResult = await pg.query('SELECT COUNT(*) as count FROM constructive_routing_public.domains');
+    const domainResult = await pg.query('SELECT COUNT(*) as count FROM routing_public.domains');
     expect(parseInt(domainResult.rows[0].count)).toBeGreaterThan(0);
   });
 

--- a/pgpm/export/__tests__/export-meta.test.ts
+++ b/pgpm/export/__tests__/export-meta.test.ts
@@ -3,7 +3,7 @@
  * 
  * These tests validate that META_TABLE_CONFIG uses correct table names,
  * schema groupings, and field definitions for exporting metaschema_public,
- * constructive_routing_public, constructive_apps_public, and
+ * routing_public, apps_public, and
  * metaschema_modules_public data.
  * 
  * Uses actual imports instead of string-matching source files.
@@ -29,25 +29,25 @@ describe('Export Meta Config Validation', () => {
     });
   });
 
-  describe('constructive_routing_public tables', () => {
+  describe('routing_public tables', () => {
     const required = [
       'domains', 'sites', 'apis',
       'site_modules', 'site_themes', 'site_metadata',
-      'api_modules', 'api_schemas'
+      'api_schemas'
     ];
 
-    it('should include all required constructive_routing_public tables in config', () => {
+    it('should include all required routing_public tables in config', () => {
       for (const table of required) {
         expect(META_TABLE_CONFIG).toHaveProperty(table);
-        expect(META_TABLE_CONFIG[table].schema).toBe('constructive_routing_public');
+        expect(META_TABLE_CONFIG[table].schema).toBe('routing_public');
       }
     });
   });
 
-  describe('constructive_apps_public tables', () => {
+  describe('apps_public tables', () => {
     it('should include apps in config', () => {
       expect(META_TABLE_CONFIG).toHaveProperty('apps');
-      expect(META_TABLE_CONFIG.apps.schema).toBe('constructive_apps_public');
+      expect(META_TABLE_CONFIG.apps.schema).toBe('apps_public');
     });
   });
 

--- a/pgpm/export/__tests__/export-parity.test.ts
+++ b/pgpm/export/__tests__/export-parity.test.ts
@@ -97,8 +97,8 @@ const pgRowToCamel = (row: Record<string, unknown>): Record<string, unknown> => 
 const SCHEMA_SHIMS_SQL = `
   CREATE SCHEMA IF NOT EXISTS metaschema_public;
   CREATE SCHEMA IF NOT EXISTS metaschema_modules_public;
-  CREATE SCHEMA IF NOT EXISTS constructive_routing_public;
-  CREATE SCHEMA IF NOT EXISTS constructive_apps_public;
+  CREATE SCHEMA IF NOT EXISTS routing_public;
+  CREATE SCHEMA IF NOT EXISTS apps_public;
   CREATE SCHEMA IF NOT EXISTS db_migrate;
 
   CREATE TABLE IF NOT EXISTS metaschema_public.database (
@@ -117,46 +117,46 @@ const SCHEMA_SHIMS_SQL = `
     table_id uuid REFERENCES metaschema_public.table(id), name text, type text, description text
   );
 
-  CREATE TABLE IF NOT EXISTS constructive_routing_public.domains (
+  CREATE TABLE IF NOT EXISTS routing_public.domains (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, hostname text, managed boolean,
     is_wildcard boolean, parent_hostname text, verification_status text, tls_status text,
     tls_secret_name text, is_published boolean,
     created_at timestamptz DEFAULT now(), updated_at timestamptz DEFAULT now()
   );
-  CREATE TABLE IF NOT EXISTS constructive_routing_public.apis (
+  CREATE TABLE IF NOT EXISTS routing_public.apis (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, name text,
     dbname text DEFAULT current_database(), role_name text, anon_role text,
     is_published boolean, config jsonb,
     created_at timestamptz DEFAULT now(), updated_at timestamptz DEFAULT now()
   );
-  CREATE TABLE IF NOT EXISTS constructive_routing_public.sites (
+  CREATE TABLE IF NOT EXISTS routing_public.sites (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, name text, title text,
     description text, config jsonb, is_published boolean,
     created_at timestamptz DEFAULT now(), updated_at timestamptz DEFAULT now()
   );
-  CREATE TABLE IF NOT EXISTS constructive_routing_public.api_schemas (
+  CREATE TABLE IF NOT EXISTS routing_public.api_schemas (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, schema_id uuid, api_id uuid,
     created_at timestamptz DEFAULT now(), updated_at timestamptz DEFAULT now()
   );
-  CREATE TABLE IF NOT EXISTS constructive_apps_public.apps (
+  CREATE TABLE IF NOT EXISTS apps_public.apps (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, name text, title text,
     description text, status text, config jsonb, is_published boolean,
     created_at timestamptz DEFAULT now(), updated_at timestamptz DEFAULT now()
   );
-  CREATE TABLE IF NOT EXISTS constructive_routing_public.site_modules (
+  CREATE TABLE IF NOT EXISTS routing_public.site_modules (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, site_id uuid, name text, data jsonb,
     created_at timestamptz DEFAULT now(), updated_at timestamptz DEFAULT now()
   );
-  CREATE TABLE IF NOT EXISTS constructive_routing_public.site_themes (
+  CREATE TABLE IF NOT EXISTS routing_public.site_themes (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, site_id uuid, theme jsonb,
     created_at timestamptz DEFAULT now(), updated_at timestamptz DEFAULT now()
   );
-  CREATE TABLE IF NOT EXISTS constructive_routing_public.site_metadata (
+  CREATE TABLE IF NOT EXISTS routing_public.site_metadata (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, site_id uuid, title text,
     description text, og_image text,
     created_at timestamptz DEFAULT now(), updated_at timestamptz DEFAULT now()
   );
-  CREATE TABLE IF NOT EXISTS constructive_routing_public.api_modules (
+  CREATE TABLE IF NOT EXISTS routing_public.api_modules (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(), database_id uuid, api_id uuid, name text, data jsonb,
     created_at timestamptz DEFAULT now(), updated_at timestamptz DEFAULT now()
   );
@@ -186,16 +186,16 @@ const SEED_SQL = `
     ('cccc0002-0000-0000-0000-000000000001', '${DATABASE_ID}', 'bbbb0001-0000-0000-0000-000000000001', 'name', 'text', 'Owner name'),
     ('cccc0003-0000-0000-0000-000000000001', '${DATABASE_ID}', 'bbbb0001-0000-0000-0000-000000000001', 'email', 'text', 'Contact email');
 
-  INSERT INTO constructive_routing_public.apis (id, database_id, name, dbname, is_published, role_name, anon_role) VALUES
+  INSERT INTO routing_public.apis (id, database_id, name, dbname, is_published, role_name, anon_role) VALUES
     ('eeee0001-0000-0000-0000-000000000001', '${DATABASE_ID}', 'public', 'pets-db', true, 'authenticated', 'anonymous');
 
-  INSERT INTO constructive_routing_public.sites (id, database_id, name, title, description, is_published) VALUES
+  INSERT INTO routing_public.sites (id, database_id, name, title, description, is_published) VALUES
     ('ffff0001-0000-0000-0000-000000000001', '${DATABASE_ID}', 'pet-clinic', 'Pet Clinic', 'A pet management application', true);
 
-  INSERT INTO constructive_routing_public.domains (id, database_id, hostname, managed, is_wildcard, is_published) VALUES
+  INSERT INTO routing_public.domains (id, database_id, hostname, managed, is_wildcard, is_published) VALUES
     ('dddd0001-0000-0000-0000-000000000001', '${DATABASE_ID}', 'pets.localhost', false, false, true);
 
-  INSERT INTO constructive_routing_public.api_schemas (id, database_id, schema_id, api_id) VALUES
+  INSERT INTO routing_public.api_schemas (id, database_id, schema_id, api_id) VALUES
     ('1111aaaa-0000-0000-0000-000000000001', '${DATABASE_ID}', 'aaaa0001-0000-0000-0000-000000000001', 'eeee0001-0000-0000-0000-000000000001');
 
   INSERT INTO db_migrate.sql_actions (name, database_id, deploy, deps, content, revert, verify) VALUES

--- a/pgpm/export/__tests__/export-utils.test.ts
+++ b/pgpm/export/__tests__/export-utils.test.ts
@@ -71,9 +71,9 @@ describe('META_TABLE_CONFIG and META_TABLE_ORDER consistency', () => {
     const validSchemas = [
       'metaschema_public',
       'metaschema_modules_public',
-      'constructive_catalog_public',
-      'constructive_routing_public',
-      'constructive_apps_public'
+      'catalog_public',
+      'routing_public',
+      'apps_public'
     ];
 
     for (const [key, config] of Object.entries(META_TABLE_CONFIG)) {

--- a/pgpm/export/src/export-graphql-meta.ts
+++ b/pgpm/export/src/export-graphql-meta.ts
@@ -1,8 +1,8 @@
 /**
  * GraphQL equivalent of export-meta.ts.
  * 
- * Fetches metadata from metaschema_public, constructive_routing_public,
- * constructive_apps_public, and metaschema_modules_public
+ * Fetches metadata from metaschema_public, routing_public,
+ * apps_public, and metaschema_modules_public
  * via GraphQL queries instead of direct SQL, then uses the same csv-to-pg Parser to
  * generate SQL INSERT statements.
  */
@@ -149,7 +149,7 @@ export const exportGraphQLMeta = async ({
     const tableConfig = META_TABLE_CONFIG[key];
     if (!tableConfig) return;
 
-    // Schema-qualified manifest keys (e.g. constructive_catalog_public.apis)
+    // Schema-qualified manifest keys (e.g. catalog_public.apis)
     // mark tables whose name collides with a table in another plane. GraphQL
     // type/query names are derived from the bare table name, so these cannot
     // be addressed unambiguously through the meta API — only the SQL flow

--- a/pgpm/export/src/export-migrations.ts
+++ b/pgpm/export/src/export-migrations.ts
@@ -40,7 +40,7 @@ interface ExportMigrationsToDiskOptions {
   serviceOutdir?: string;
   /**
    * Skip schema name replacement for infrastructure schemas.
-   * When true, schema names like metaschema_public, constructive_routing_public will not be renamed.
+   * When true, schema names like metaschema_public, routing_public will not be renamed.
    * Useful for self-referential introspection where you want to apply policies to real schemas.
    */
   skipSchemaRenaming?: boolean;
@@ -91,7 +91,7 @@ interface ExportOptions {
   serviceOutdir?: string;
   /**
    * Skip schema name replacement for infrastructure schemas.
-   * When true, schema names like metaschema_public, constructive_routing_public will not be renamed.
+   * When true, schema names like metaschema_public, routing_public will not be renamed.
    * Useful for self-referential introspection where you want to apply policies to real schemas.
    */
   skipSchemaRenaming?: boolean;
@@ -173,7 +173,7 @@ const exportMigrationsToDisk = async ({
 
   // When skipSchemaRenaming is true, pass empty schemas array to avoid renaming
   // This is useful for self-referential introspection where you want to apply
-  // policies to real infrastructure schemas (metaschema_public, constructive_routing_public, etc.)
+  // policies to real infrastructure schemas (metaschema_public, routing_public, etc.)
   const schemasForReplacement = skipSchemaRenaming
     ? []
     : schemas.rows.filter((schema: any) => schema_names.includes(schema.schema_name));

--- a/pgpm/export/src/graphql-naming.ts
+++ b/pgpm/export/src/graphql-naming.ts
@@ -9,8 +9,8 @@
  * Examples:
  *   metaschema_public.database -> databases (query), Database (type)
  *   metaschema_public.foreign_key_constraint -> foreignKeyConstraints
- *   constructive_routing_public.api_schemas -> apiSchemas
- *   constructive_apps_public.apps -> apps
+ *   routing_public.api_schemas -> apiSchemas
+ *   apps_public.apps -> apps
  *   metaschema_modules_public.api_surface_module -> apiSurfaceModules
  *   db_migrate.sql_actions -> sqlActions
  *   column database_id -> databaseId

--- a/scripts/check-test-coverage.cjs
+++ b/scripts/check-test-coverage.cjs
@@ -31,10 +31,7 @@ const EXCLUSIONS = {
     'the filtered one — a real plugin bug, not test drift. constructive-planning#1426.',
   'graphql/react':
     'Requires an external GraphQL endpoint via $TESTING_URL and throws at ' +
-    'import time without one — a manual suite, not a CI one.',
-  'pgpm/export':
-    'Meta export emits nothing for the routing/apps tables since the schemas ' +
-    'were repointed off services_public; 7 tests fail. constructive-planning#1426.'
+    'import time without one — a manual suite, not a CI one.'
 };
 
 function claimedPackages() {


### PR DESCRIPTION
## Summary

`pgpm/export` was excluded from CI in #1646 because 7 tests failed and four of them looked like a shipped export regression — `apis`, `sites`, `domains` and `api_schemas` producing no files. **That read was wrong, and this corrects it.** The suite's fixtures build `constructive_routing_public` / `constructive_apps_public` / `constructive_catalog_public`, schemas that died with the repoint off `services_public` (7759b2b40). The generated manifest has said `routing_public` / `apps_public` / `catalog_public` ever since, so the exporter was correctly finding nothing in a database that no longer exists. Nothing was broken in the export path.

So this is the cleanup Dan asked for: the dead names are gone from the whole suite (and from three stale `src` comments), plus one dead table dropped from the required set —

```diff
  const required = [
    'domains', 'sites', 'apis',
    'site_modules', 'site_themes', 'site_metadata',
-   'api_modules', 'api_schemas'
+   'api_schemas'
  ];
```

`api_modules` exists in neither the manifest nor `application/constructive/deploy/schemas/routing_public/tables/`.

176/176 pass, so the package comes out of `EXCLUSIONS` in `scripts/check-test-coverage.cjs` and into the `pg-core` batch — the guard added in #1646 now reports `2 excluded` rather than 3, and would fail if that exclusion had been left behind stale.

Correction posted on constructive-planning#1426; the realtime sparse-set bug there is unaffected and still open.


Link to Devin session: https://app.devin.ai/sessions/087553534c774929918ec4d378845881
Requested by: @pyramation