### PR TITLE
Isolate Graphile plugin and storage data paths

### DIFF
--- a/graphile/graphile-bucket-provisioner-plugin/__tests__/plugin.test.ts
+++ b/graphile/graphile-bucket-provisioner-plugin/__tests__/plugin.test.ts
@@ -75,9 +75,31 @@ jest.mock('graphile-utils', () => ({
 }));
 
 import { createBucketProvisionerPlugin } from '../src/plugin';
-import type { BucketProvisionerPluginOptions } from '../src/types';
+import type {
+  BucketProvisionerPluginOptions,
+  BucketProvisionerStorageModule,
+} from '../src/types';
 
 // --- Test helpers ---
+
+function storageModule(
+  overrides: Partial<BucketProvisionerStorageModule> = {},
+): BucketProvisionerStorageModule {
+  return {
+    id: 'sm-uuid-456',
+    bucketsQualifiedName: 'app_public.buckets',
+    schemaName: 'app_public',
+    bucketsTableName: 'buckets',
+    scope: 'app',
+    entityTableId: null,
+    entityQualifiedName: null,
+    endpoint: null,
+    publicUrlPrefix: null,
+    provider: null,
+    allowedOrigins: null,
+    ...overrides,
+  };
+}
 
 function createDefaultOptions(
   overrides: Partial<BucketProvisionerPluginOptions> = {},
@@ -91,6 +113,7 @@ function createDefaultOptions(
       secretAccessKey: 'minioadmin',
     },
     allowedOrigins: ['https://app.example.com'],
+    preloadedStorageModules: [storageModule()],
     ...overrides,
   };
 }
@@ -99,17 +122,6 @@ function createMockPgClient(overrides: Record<string, any> = {}) {
   const defaultQueries: Record<string, any> = {
     'jwt_private.current_database_id': {
       rows: [{ id: 'db-uuid-123' }],
-    },
-    'metaschema_modules_public.storage_module': {
-      rows: [{
-        id: 'sm-uuid-456',
-        buckets_schema: 'app_public',
-        buckets_table: 'buckets',
-        endpoint: null,
-        public_url_prefix: null,
-        provider: null,
-        allowed_origins: null,
-      }],
     },
     app_public: {
       rows: [{
@@ -127,6 +139,9 @@ function createMockPgClient(overrides: Record<string, any> = {}) {
   return {
     query: jest.fn((arg: any) => {
       const sql: string = typeof arg === 'string' ? arg : arg.text;
+      if (sql.includes('UPDATE') && sql.includes('SET physical_name')) {
+        return Promise.resolve({ rows: [{ physical_name: arg.values[0] }] });
+      }
       for (const [key, value] of Object.entries({ ...defaultQueries, ...overrides })) {
         if (sql.includes(key)) {
           return Promise.resolve(value);
@@ -369,11 +384,11 @@ describe('createBucketProvisionerPlugin', () => {
     });
 
     it('throws STORAGE_MODULE_NOT_PROVISIONED when no storage module exists', async () => {
-      createBucketProvisionerPlugin(createDefaultOptions());
+      createBucketProvisionerPlugin(createDefaultOptions({
+        preloadedStorageModules: [],
+      }));
 
-      const pgClient = createMockPgClient({
-        'metaschema_modules_public.storage_module': { rows: [] },
-      });
+      const pgClient = createMockPgClient();
       const mockWithPgClient = jest.fn((_settings: any, callback: any) =>
         callback(pgClient),
       );
@@ -423,7 +438,7 @@ describe('createBucketProvisionerPlugin', () => {
       });
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('S3 connection refused');
+      expect(result.error).toBe('BUCKET_PROVISIONING_FAILED');
       expect(result.bucketName).toBe('public');
     });
 
@@ -451,6 +466,8 @@ describe('createBucketProvisionerPlugin', () => {
       expect(update![0].text).toContain('physical_name IS NULL');
       // Records the exact name returned by the provisioner against the row id.
       expect(update![0].values).toEqual(['public', 'bucket-uuid-789']);
+      expect(mockWithPgClient).toHaveBeenCalledTimes(1);
+      expect(mockWithPgClient.mock.calls[0][0]).toEqual({ role: 'admin' });
     });
 
     it('provisions the stored physical_name verbatim when already recorded', async () => {
@@ -521,20 +538,15 @@ describe('createBucketProvisionerPlugin', () => {
     });
 
     it('applies per-database endpoint override from storage module', async () => {
-      createBucketProvisionerPlugin(createDefaultOptions());
+      createBucketProvisionerPlugin(createDefaultOptions({
+        preloadedStorageModules: [storageModule({
+          endpoint: 'http://custom-minio:9000',
+          publicUrlPrefix: 'https://cdn.example.com',
+          provider: 'minio',
+        })],
+      }));
 
-      const pgClient = createMockPgClient({
-        'metaschema_modules_public.storage_module': {
-          rows: [{
-            id: 'sm-uuid-456',
-            buckets_schema: 'app_public',
-            buckets_table: 'buckets',
-            endpoint: 'http://custom-minio:9000',
-            public_url_prefix: 'https://cdn.example.com',
-            provider: 'minio',
-          }],
-        },
-      });
+      const pgClient = createMockPgClient();
       const mockWithPgClient = jest.fn((_settings: any, callback: any) =>
         callback(pgClient),
       );
@@ -578,20 +590,13 @@ describe('createBucketProvisionerPlugin', () => {
     });
 
     it('passes publicUrlPrefix from storage module to provision call', async () => {
-      createBucketProvisionerPlugin(createDefaultOptions());
+      createBucketProvisionerPlugin(createDefaultOptions({
+        preloadedStorageModules: [storageModule({
+          publicUrlPrefix: 'https://cdn.example.com',
+        })],
+      }));
 
-      const pgClient = createMockPgClient({
-        'metaschema_modules_public.storage_module': {
-          rows: [{
-            id: 'sm-uuid-456',
-            buckets_schema: 'app_public',
-            buckets_table: 'buckets',
-            endpoint: null,
-            public_url_prefix: 'https://cdn.example.com',
-            provider: null,
-          }],
-        },
-      });
+      const pgClient = createMockPgClient();
       const mockWithPgClient = jest.fn((_settings: any, callback: any) =>
         callback(pgClient),
       );
@@ -607,6 +612,108 @@ describe('createBucketProvisionerPlugin', () => {
           publicUrlPrefix: 'https://cdn.example.com',
         }),
       );
+    });
+  });
+
+  describe('storage snapshot isolation', () => {
+    it('rejects missing request settings before acquiring a PostgreSQL client', async () => {
+      createBucketProvisionerPlugin(createDefaultOptions());
+      const withPgClient = jest.fn();
+
+      await expect(capturedLambdaCallback!({
+        input: { bucketKey: 'public' },
+        withPgClient,
+        pgSettings: null,
+      })).rejects.toThrow('STORAGE_REQUEST_SETTINGS_UNAVAILABLE');
+      expect(withPgClient).not.toHaveBeenCalled();
+      expect(mockProvision).not.toHaveBeenCalled();
+    });
+
+    it('fails closed without a snapshot and never queries metaschema or calls S3', async () => {
+      createBucketProvisionerPlugin(createDefaultOptions({
+        preloadedStorageModules: undefined,
+      }));
+      const pgClient = createMockPgClient();
+      const withPgClient = jest.fn((_settings: any, callback: any) => callback(pgClient));
+
+      await expect(capturedLambdaCallback!({
+        input: { bucketKey: 'public' },
+        withPgClient,
+        pgSettings: { role: 'tenant_member' },
+      })).rejects.toThrow('STORAGE_MODULE_SNAPSHOT_REQUIRED');
+
+      expect(pgClient.query.mock.calls.map((call: any[]) => call[0].text).join('\n'))
+        .not.toContain('metaschema_');
+      expect(mockProvision).not.toHaveBeenCalled();
+    });
+
+    it('rejects duplicate app modules before reading a bucket or calling S3', async () => {
+      createBucketProvisionerPlugin(createDefaultOptions({
+        preloadedStorageModules: [
+          storageModule({ id: 'app-a' }),
+          storageModule({ id: 'app-b', bucketsTableName: 'other_buckets' }),
+        ],
+      }));
+      const pgClient = createMockPgClient();
+      const withPgClient = jest.fn((_settings: any, callback: any) => callback(pgClient));
+
+      await expect(capturedLambdaCallback!({
+        input: { bucketKey: 'public' },
+        withPgClient,
+        pgSettings: { role: 'tenant_member' },
+      })).rejects.toThrow('STORAGE_MODULE_AMBIGUOUS:app');
+      expect(mockProvision).not.toHaveBeenCalled();
+    });
+
+    it('probes only safely quoted preloaded entity tables and rejects ambiguous owners', async () => {
+      createBucketProvisionerPlugin(createDefaultOptions({
+        preloadedStorageModules: [
+          storageModule({
+            id: 'team-a',
+            scope: 'team-a',
+            schemaName: 'team_a_public',
+            bucketsTableName: 'buckets',
+            entityTableId: 'entity-a',
+            entityQualifiedName: '"tenant-a"."teams"',
+          }),
+          storageModule({
+            id: 'team-b',
+            scope: 'team-b',
+            schemaName: 'team_b_public',
+            bucketsTableName: 'buckets',
+            entityTableId: 'entity-b',
+            entityQualifiedName: '"tenant-b"."teams"',
+          }),
+        ],
+      }));
+      const pgClient = createMockPgClient({
+        '"tenant-a".teams': { rows: [{ '?column?': 1 }] },
+        '"tenant-b".teams': { rows: [{ '?column?': 1 }] },
+      });
+      const withPgClient = jest.fn((_settings: any, callback: any) => callback(pgClient));
+
+      await expect(capturedLambdaCallback!({
+        input: { bucketKey: 'private', ownerId: 'owner-a' },
+        withPgClient,
+        pgSettings: { role: 'tenant_member' },
+      })).rejects.toThrow('STORAGE_MODULE_AMBIGUOUS:owner');
+
+      const sql = pgClient.query.mock.calls.map((call: any[]) => call[0].text).join('\n');
+      expect(sql).toContain('FROM "tenant-a".teams');
+      expect(sql).toContain('FROM "tenant-b".teams');
+      expect(sql).not.toContain('metaschema_');
+      expect(mockProvision).not.toHaveBeenCalled();
+    });
+
+    it('rejects an expression masquerading as an entity table at build time', () => {
+      expect(() => createBucketProvisionerPlugin(createDefaultOptions({
+        preloadedStorageModules: [storageModule({
+          id: 'malicious',
+          scope: 'team',
+          entityTableId: 'entity-a',
+          entityQualifiedName: 'safe.teams; SELECT pg_sleep(10)',
+        })],
+      }))).toThrow('STORAGE_MODULE_METADATA_INVALID:entity:malicious');
     });
   });
 
@@ -1110,7 +1217,11 @@ describe('CORS resolution hierarchy', () => {
       lifecycleRules: [],
     });
 
-    createBucketProvisionerPlugin(createDefaultOptions());
+    createBucketProvisionerPlugin(createDefaultOptions({
+      preloadedStorageModules: [storageModule({
+        allowedOrigins: ['https://db-default.example.com'],
+      })],
+    }));
 
     const pgClient = createMockPgClient({
       app_public: {
@@ -1120,17 +1231,6 @@ describe('CORS resolution hierarchy', () => {
           type: 'public',
           is_public: true,
           allowed_origins: ['*'],
-        }],
-      },
-      'metaschema_modules_public.storage_module': {
-        rows: [{
-          id: 'sm-uuid-456',
-          buckets_schema: 'app_public',
-          buckets_table: 'buckets',
-          endpoint: null,
-          public_url_prefix: null,
-          provider: null,
-          allowed_origins: ['https://db-default.example.com'],
         }],
       },
     });
@@ -1167,7 +1267,11 @@ describe('CORS resolution hierarchy', () => {
       lifecycleRules: [],
     });
 
-    createBucketProvisionerPlugin(createDefaultOptions());
+    createBucketProvisionerPlugin(createDefaultOptions({
+      preloadedStorageModules: [storageModule({
+        allowedOrigins: ['https://db-default.example.com'],
+      })],
+    }));
 
     const pgClient = createMockPgClient({
       app_public: {
@@ -1177,17 +1281,6 @@ describe('CORS resolution hierarchy', () => {
           type: 'public',
           is_public: true,
           allowed_origins: null, // No bucket-level override
-        }],
-      },
-      'metaschema_modules_public.storage_module': {
-        rows: [{
-          id: 'sm-uuid-456',
-          buckets_schema: 'app_public',
-          buckets_table: 'buckets',
-          endpoint: null,
-          public_url_prefix: null,
-          provider: null,
-          allowed_origins: ['https://db-default.example.com'],
         }],
       },
     });
@@ -1235,17 +1328,6 @@ describe('CORS resolution hierarchy', () => {
           key: 'docs',
           type: 'private',
           is_public: false,
-          allowed_origins: null,
-        }],
-      },
-      'metaschema_modules_public.storage_module': {
-        rows: [{
-          id: 'sm-uuid-456',
-          buckets_schema: 'app_public',
-          buckets_table: 'buckets',
-          endpoint: null,
-          public_url_prefix: null,
-          provider: null,
           allowed_origins: null,
         }],
       },
@@ -1346,6 +1428,7 @@ describe('bucket name resolution', () => {
         secretAccessKey: 'test',
       },
       allowedOrigins: ['https://app.example.com'],
+      preloadedStorageModules: [storageModule()],
     });
 
     const pgClient = createMockPgClient({
@@ -1400,6 +1483,7 @@ describe('bucket name resolution', () => {
         secretAccessKey: 'test',
       },
       allowedOrigins: ['https://app.example.com'],
+      preloadedStorageModules: [storageModule()],
       bucketNamePrefix: 'should-be-ignored',
       resolveBucketName: customResolver,
     });

--- a/graphile/graphile-bucket-provisioner-plugin/src/index.ts
+++ b/graphile/graphile-bucket-provisioner-plugin/src/index.ts
@@ -44,6 +44,7 @@ export type {
   BucketAccessType,
   BucketNameResolver,
   BucketProvisionerPluginOptions,
+  BucketProvisionerStorageModule,
   ConnectionConfigOrGetter,
   ProvisionBucketInput,
   ProvisionBucketPayload,

--- a/graphile/graphile-bucket-provisioner-plugin/src/plugin.ts
+++ b/graphile/graphile-bucket-provisioner-plugin/src/plugin.ts
@@ -43,70 +43,95 @@ import { extendSchema, gql } from 'graphile-utils';
 
 import type {
   BucketProvisionerPluginOptions,
+  BucketProvisionerStorageModule,
 } from './types';
 
 const log = new Logger('graphile-bucket-provisioner:plugin');
 
-// --- Storage module queries ---
+const QUALIFIED_IDENTIFIER = /^("(?:[^"]|"")+"|[a-z_][a-z0-9_$]*)\.("(?:[^"]|"")+"|[a-z_][a-z0-9_$]*)$/;
+
+function decodeIdentifier(identifier: string): string {
+  return identifier.startsWith('"')
+    ? identifier.slice(1, -1).replace(/""/g, '"')
+    : identifier;
+}
 
 /**
- * Resolve the app-level storage module (scope = 'app').
+ * Parse exactly two SQL identifiers, then quote both components again. This
+ * accepts the canonical quoted names emitted by the control-plane loader but
+ * rejects expressions, search paths, comments, and extra qualification.
  */
-const APP_STORAGE_MODULE_QUERY = `
-  SELECT
-    sm.id,
-    sm.scope,
-    sm.entity_table_id,
-    bs.schema_name AS buckets_schema,
-    bt.name AS buckets_table,
-    sm.endpoint,
-    sm.public_url_prefix,
-    sm.provider,
-    sm.allowed_origins
-  FROM metaschema_modules_public.storage_module sm
-  JOIN metaschema_public.table bt ON bt.id = sm.buckets_table_id
-  JOIN metaschema_public.schema bs ON bs.id = bt.schema_id
-  WHERE sm.database_id = $1
-    AND sm.scope = 'app'
-  LIMIT 1
-`;
+function quotePreloadedQualifiedIdentifier(value: string, label: string): string {
+  const match = QUALIFIED_IDENTIFIER.exec(value);
+  if (!match) {
+    throw new Error(`STORAGE_MODULE_METADATA_INVALID:${label}`);
+  }
+  const schema = decodeIdentifier(match[1]);
+  const objectName = decodeIdentifier(match[2]);
+  if (
+    schema.length === 0 ||
+    objectName.length === 0 ||
+    schema.includes('\0') ||
+    objectName.includes('\0') ||
+    Buffer.byteLength(schema, 'utf8') > 63 ||
+    Buffer.byteLength(objectName, 'utf8') > 63
+  ) {
+    throw new Error(`STORAGE_MODULE_METADATA_INVALID:${label}`);
+  }
+  return QuoteUtils.quoteQualifiedIdentifier(schema, objectName);
+}
 
-/**
- * Resolve ALL storage modules for a database (for ownerId-based resolution).
- */
-const ALL_STORAGE_MODULES_QUERY = `
-  SELECT
-    sm.id,
-    sm.scope,
-    sm.entity_table_id,
-    bs.schema_name AS buckets_schema,
-    bt.name AS buckets_table,
-    sm.endpoint,
-    sm.public_url_prefix,
-    sm.provider,
-    sm.allowed_origins,
-    es.schema_name AS entity_schema,
-    et.name AS entity_table
-  FROM metaschema_modules_public.storage_module sm
-  JOIN metaschema_public.table bt ON bt.id = sm.buckets_table_id
-  JOIN metaschema_public.schema bs ON bs.id = bt.schema_id
-  LEFT JOIN metaschema_public.table et ON et.id = sm.entity_table_id
-  LEFT JOIN metaschema_public.schema es ON es.id = et.schema_id
-  WHERE sm.database_id = $1
-`;
+function snapshotStorageModules(
+  modules: readonly BucketProvisionerStorageModule[] | undefined,
+): readonly BucketProvisionerStorageModule[] | undefined {
+  if (modules === undefined) return undefined;
 
-interface StorageModuleRow {
-  id: string;
-  scope: string;
-  entity_table_id: string | null;
-  buckets_schema: string;
-  buckets_table: string;
-  endpoint: string | null;
-  public_url_prefix: string | null;
-  provider: string | null;
-  allowed_origins: string[] | null;
-  entity_schema?: string | null;
-  entity_table?: string | null;
+  for (const module of modules) {
+    if (
+      !module ||
+      typeof module.id !== 'string' ||
+      module.id.length === 0 ||
+      typeof module.scope !== 'string' ||
+      module.scope.length === 0 ||
+      typeof module.schemaName !== 'string' ||
+      module.schemaName.length === 0 ||
+      module.schemaName.includes('\0') ||
+      Buffer.byteLength(module.schemaName, 'utf8') > 63 ||
+      typeof module.bucketsTableName !== 'string' ||
+      module.bucketsTableName.length === 0 ||
+      module.bucketsTableName.includes('\0') ||
+      Buffer.byteLength(module.bucketsTableName, 'utf8') > 63
+    ) {
+      throw new Error('STORAGE_MODULE_METADATA_INVALID');
+    }
+    QuoteUtils.quoteQualifiedIdentifier(module.schemaName, module.bucketsTableName);
+    if (module.scope === 'app') {
+      if (module.entityTableId !== null || module.entityQualifiedName !== null) {
+        throw new Error(`STORAGE_MODULE_METADATA_INVALID:${module.id}`);
+      }
+    } else if (!module.entityTableId || !module.entityQualifiedName) {
+      throw new Error(`STORAGE_MODULE_METADATA_INVALID:${module.id}`);
+    } else {
+      quotePreloadedQualifiedIdentifier(module.entityQualifiedName, `entity:${module.id}`);
+    }
+  }
+
+  if (
+    Object.isFrozen(modules) &&
+    modules.every((module) =>
+      Object.isFrozen(module) &&
+      (module.allowedOrigins === null || Object.isFrozen(module.allowedOrigins)),
+    )
+  ) {
+    return modules;
+  }
+
+  return Object.freeze(modules.map((module) => Object.freeze({
+    ...module,
+    allowedOrigins: module.allowedOrigins === null
+      ? null
+      : Object.freeze([...module.allowedOrigins]),
+  })));
 }
 
 /**
@@ -125,6 +150,18 @@ function runQuery(
   return pgClient.query(values === undefined ? { text } : { text, values });
 }
 
+function assertStorageRequestContext(withPgClient: unknown, pgSettings: unknown): asserts withPgClient is (
+  settings: Record<string, string>,
+  callback: (pgClient: any) => Promise<unknown>,
+) => Promise<unknown> {
+  if (typeof withPgClient !== 'function') {
+    throw new Error('STORAGE_CONTEXT_UNAVAILABLE');
+  }
+  if (typeof pgSettings !== 'object' || pgSettings === null || Array.isArray(pgSettings)) {
+    throw new Error('STORAGE_REQUEST_SETTINGS_UNAVAILABLE');
+  }
+}
+
 /**
  * Resolve the storage module for a given scope.
  * If ownerId is provided, probes entity tables to find the matching module.
@@ -132,33 +169,43 @@ function runQuery(
  */
 async function resolveStorageModule(
   pgClient: any,
-  databaseId: string,
+  modules: readonly BucketProvisionerStorageModule[] | undefined,
   ownerId?: string,
-): Promise<StorageModuleRow | null> {
-  if (!ownerId) {
-    // App-level resolution
-    const result = await runQuery(pgClient, APP_STORAGE_MODULE_QUERY, [databaseId]);
-    return (result.rows[0] as StorageModuleRow) ?? null;
+): Promise<BucketProvisionerStorageModule | null> {
+  if (modules === undefined) {
+    throw new Error('STORAGE_MODULE_SNAPSHOT_REQUIRED');
   }
 
-  // Entity-scoped: load all modules and probe entity tables
-  const result = await runQuery(pgClient, ALL_STORAGE_MODULES_QUERY, [databaseId]);
-  const modules = result.rows as StorageModuleRow[];
-  const entityModules = modules.filter((m) => m.entity_schema && m.entity_table);
+  if (!ownerId) {
+    const appModules = modules.filter((module) => module.scope === 'app');
+    if (appModules.length > 1) {
+      throw new Error('STORAGE_MODULE_AMBIGUOUS:app');
+    }
+    return appModules[0] ?? null;
+  }
+
+  const entityModules = modules.filter((module) => module.scope !== 'app');
+  const matches: BucketProvisionerStorageModule[] = [];
 
   for (const mod of entityModules) {
-    const entityTable = QuoteUtils.quoteQualifiedIdentifier(mod.entity_schema!, mod.entity_table!);
+    const entityTable = quotePreloadedQualifiedIdentifier(
+      mod.entityQualifiedName!,
+      `entity:${mod.id}`,
+    );
     const probe = await runQuery(
       pgClient,
       `SELECT 1 FROM ${entityTable} WHERE id = $1 LIMIT 1`,
       [ownerId],
     );
     if (probe.rows.length > 0) {
-      return mod;
+      matches.push(mod);
     }
   }
 
-  return null;
+  if (matches.length > 1) {
+    throw new Error('STORAGE_MODULE_AMBIGUOUS:owner');
+  }
+  return matches[0] ?? null;
 }
 
 interface BucketRow {
@@ -185,24 +232,47 @@ function storedPhysicalName(row: Pick<BucketRow, 'physical_name'>): string | nul
 /**
  * Record the physical S3 bucket name on the source bucket row.
  *
- * Runs in the system lane (`withPgClient(null, ...)`) — server bookkeeping,
- * RLS-independent. Idempotent via the `physical_name IS NULL` guard so a
- * re-provision never clobbers an already-recorded coordinate.
+ * Runs on the request's already-scoped client. The write must satisfy the same
+ * role, claims, and RLS policies as the bucket read that authorized
+ * provisioning; a policy denial fails closed. It is idempotent via the
+ * `physical_name IS NULL` guard so a re-provision never clobbers an
+ * already-recorded coordinate.
  */
 async function recordPhysicalName(
-  withPgClient: (pgSettings: null, cb: (client: any) => Promise<unknown>) => Promise<unknown>,
+  pgClient: any,
   bucketsTable: string,
   bucketId: string,
   physicalName: string,
-): Promise<void> {
-  await withPgClient(null, (client: any) =>
-    runQuery(
-      client,
-      `UPDATE ${bucketsTable} SET physical_name = $1 WHERE id = $2 AND physical_name IS NULL`,
-      [physicalName, bucketId],
-    ),
+): Promise<string> {
+  const updated = await runQuery(
+    pgClient,
+    `UPDATE ${bucketsTable}
+     SET physical_name = $1
+     WHERE id = $2 AND physical_name IS NULL
+     RETURNING physical_name`,
+    [physicalName, bucketId],
   );
-  log.info(`Recorded physical_name="${physicalName}" on bucket ${bucketId}`);
+  const written = updated.rows[0]?.physical_name;
+  if (updated.rows.length === 1 && typeof written === 'string') {
+    log.info(`Recorded physical_name="${written}" on bucket ${bucketId}`);
+    return written;
+  }
+  if (updated.rows.length > 1) {
+    throw new Error('BUCKET_COORDINATE_AMBIGUOUS');
+  }
+
+  // Another process may have won the first-provision race. Route to the
+  // durable value it recorded; never return a losing candidate.
+  const existing = await runQuery(
+    pgClient,
+    `SELECT physical_name FROM ${bucketsTable} WHERE id = $1 LIMIT 2`,
+    [bucketId],
+  );
+  const authoritative = existing.rows[0]?.physical_name;
+  if (existing.rows.length !== 1 || typeof authoritative !== 'string') {
+    throw new Error('BUCKET_COORDINATE_WRITE_FAILED');
+  }
+  return authoritative;
 }
 
 // --- Helpers ---
@@ -259,16 +329,16 @@ async function resolveDatabaseId(pgClient: any): Promise<string | null> {
  */
 function resolveAllowedOrigins(
   bucketOrigins: string[] | null | undefined,
-  storageModuleOrigins: string[] | null | undefined,
+  storageModuleOrigins: readonly string[] | null | undefined,
   pluginOrigins: string[],
 ): string[] {
   if (bucketOrigins && bucketOrigins.length > 0) {
-    return bucketOrigins;
+    return [...bucketOrigins];
   }
   if (storageModuleOrigins && storageModuleOrigins.length > 0) {
-    return storageModuleOrigins;
+    return [...storageModuleOrigins];
   }
-  return pluginOrigins;
+  return [...pluginOrigins];
 }
 
 /**
@@ -276,14 +346,14 @@ function resolveAllowedOrigins(
  */
 function buildProvisioner(
   options: BucketProvisionerPluginOptions,
-  storageModule: StorageModuleRow | null,
+  storageModule: BucketProvisionerStorageModule,
   effectiveOrigins: string[],
 ): BucketProvisioner {
   const connection = resolveConnection(options);
   const effectiveConnection: StorageConnectionConfig = {
     ...connection,
-    ...(storageModule?.endpoint ? { endpoint: storageModule.endpoint } : {}),
-    ...(storageModule?.provider
+    ...(storageModule.endpoint ? { endpoint: storageModule.endpoint } : {}),
+    ...(storageModule.provider
       ? { provider: storageModule.provider as StorageConnectionConfig['provider'] }
       : {}),
   };
@@ -299,23 +369,20 @@ function buildProvisioner(
  * auto-provisioning hook.
  */
 async function provisionBucketForRow(
-  pgClient: any,
   databaseId: string,
   bucketKey: string,
   bucketType: string,
   bucketAllowedOrigins: string[] | null | undefined,
   options: BucketProvisionerPluginOptions,
   s3BucketName: string,
+  storageModule: BucketProvisionerStorageModule,
 ): Promise<ProvisionResult> {
   const accessType = bucketType as 'public' | 'private' | 'temp';
-
-  // Read storage module config to check for endpoint/provider/CORS overrides
-  const storageModule = await resolveStorageModule(pgClient, databaseId);
 
   // Resolve CORS origins using the 3-tier hierarchy
   const effectiveOrigins = resolveAllowedOrigins(
     bucketAllowedOrigins,
-    storageModule?.allowed_origins,
+    storageModule.allowedOrigins,
     options.allowedOrigins,
   );
 
@@ -330,7 +397,7 @@ async function provisionBucketForRow(
     bucketName: s3BucketName,
     accessType,
     versioning: options.versioning ?? false,
-    publicUrlPrefix: storageModule?.public_url_prefix ?? undefined,
+    publicUrlPrefix: storageModule.publicUrlPrefix ?? undefined,
     allowedOrigins: effectiveOrigins,
   });
 
@@ -346,21 +413,19 @@ async function provisionBucketForRow(
  * Update CORS on an existing S3 bucket when allowed_origins changes.
  */
 async function updateBucketCors(
-  pgClient: any,
   databaseId: string,
   bucketKey: string,
   bucketType: string,
   bucketAllowedOrigins: string[] | null | undefined,
   options: BucketProvisionerPluginOptions,
   s3BucketName: string,
+  storageModule: BucketProvisionerStorageModule,
 ): Promise<void> {
   const accessType = bucketType as 'public' | 'private' | 'temp';
 
-  const storageModule = await resolveStorageModule(pgClient, databaseId);
-
   const effectiveOrigins = resolveAllowedOrigins(
     bucketAllowedOrigins,
-    storageModule?.allowed_origins,
+    storageModule.allowedOrigins,
     options.allowedOrigins,
   );
 
@@ -401,6 +466,9 @@ export function createBucketProvisionerPlugin(
   options: BucketProvisionerPluginOptions,
 ): GraphileConfig.Plugin {
   const autoProvision = options.autoProvision ?? true;
+  const preloadedStorageModules = snapshotStorageModules(
+    options.preloadedStorageModules,
+  );
 
   // The extendSchema plugin adds the explicit provisionBucket mutation
   const mutationPlugin = extendSchema(() => ({
@@ -461,6 +529,8 @@ export function createBucketProvisionerPlugin(
               throw new Error('INVALID_BUCKET_KEY');
             }
 
+            assertStorageRequestContext(withPgClient, pgSettings);
+
             return withPgClient(pgSettings, async (pgClient: any) => {
               // Resolve database ID from JWT context
               const databaseId = await resolveDatabaseId(pgClient);
@@ -469,7 +539,11 @@ export function createBucketProvisionerPlugin(
               }
 
               // Resolve storage module (app-level or entity-scoped via ownerId)
-              const storageModule = await resolveStorageModule(pgClient, databaseId, ownerId);
+              const storageModule = await resolveStorageModule(
+                pgClient,
+                preloadedStorageModules,
+                ownerId,
+              );
               if (!storageModule) {
                 throw new Error(
                   ownerId
@@ -480,23 +554,29 @@ export function createBucketProvisionerPlugin(
 
               // Look up the bucket row (RLS enforced via pgSettings)
               const hasOwner = ownerId && storageModule.scope !== 'app';
-              const bucketsTable = QuoteUtils.quoteQualifiedIdentifier(storageModule.buckets_schema, storageModule.buckets_table);
+              const bucketsTable = QuoteUtils.quoteQualifiedIdentifier(
+                storageModule.schemaName,
+                storageModule.bucketsTableName,
+              );
               const bucketResult = await runQuery(
                 pgClient,
                 hasOwner
                   ? `SELECT id, key, type, is_public, allowed_origins, physical_name
                      FROM ${bucketsTable}
                      WHERE key = $1 AND owner_id = $2
-                     LIMIT 1`
+                     LIMIT 2`
                   : `SELECT id, key, type, is_public, allowed_origins, physical_name
                      FROM ${bucketsTable}
                      WHERE key = $1
-                     LIMIT 1`,
+                     LIMIT 2`,
                 hasOwner ? [bucketKey, ownerId] : [bucketKey],
               );
 
               if (bucketResult.rows.length === 0) {
                 throw new Error('BUCKET_NOT_FOUND');
+              }
+              if (bucketResult.rows.length > 1) {
+                throw new Error('BUCKET_AMBIGUOUS');
               }
 
               const bucket = bucketResult.rows[0] as BucketRow;
@@ -510,21 +590,26 @@ export function createBucketProvisionerPlugin(
 
               try {
                 const result = await provisionBucketForRow(
-                  pgClient,
                   databaseId,
                   bucket.key,
                   bucket.type,
                   bucket.allowed_origins,
                   options,
                   s3BucketName,
+                  storageModule,
                 );
 
                 // Record the exact provisioned name on the source row.
-                await recordPhysicalName(withPgClient, bucketsTable, bucket.id, result.bucketName);
+                const authoritativeBucketName = await recordPhysicalName(
+                  pgClient,
+                  bucketsTable,
+                  bucket.id,
+                  result.bucketName,
+                );
 
                 return {
                   success: true,
-                  bucketName: result.bucketName,
+                  bucketName: authoritativeBucketName,
                   accessType: result.accessType,
                   provider: result.provider,
                   endpoint: result.endpoint,
@@ -538,7 +623,7 @@ export function createBucketProvisionerPlugin(
                   accessType: bucket.type,
                   provider: resolveConnection(options).provider,
                   endpoint: resolveConnection(options).endpoint ?? null,
-                  error: err.message,
+                  error: 'BUCKET_PROVISIONING_FAILED',
                 };
               }
             });
@@ -622,10 +707,7 @@ export function createBucketProvisionerPlugin(
                 const withPgClient = graphqlContext.withPgClient;
                 const pgSettings = graphqlContext.pgSettings;
 
-                if (!withPgClient) {
-                  log.warn(`${isCreate ? 'Auto-provision' : 'CORS update'} skipped: withPgClient not available in context`);
-                  return result;
-                }
+                assertStorageRequestContext(withPgClient, pgSettings);
 
                 if (isCreate) {
                   // --- CREATE: full provisioning ---
@@ -645,27 +727,49 @@ export function createBucketProvisionerPlugin(
                     }
 
                     // Newly-created row has no stored coordinate yet — mint on first provision.
-                    const result = await provisionBucketForRow(
+                    const storageModule = await resolveStorageModule(
                       pgClient,
+                      preloadedStorageModules,
+                    );
+                    if (!storageModule) {
+                      throw new Error('STORAGE_MODULE_NOT_PROVISIONED');
+                    }
+
+                    const result = await provisionBucketForRow(
                       databaseId,
                       bucketInput.key,
                       bucketInput.type,
                       bucketInput.allowedOrigins ?? bucketInput.allowed_origins ?? null,
                       options,
                       resolveBucketName(bucketInput.key, databaseId, options),
+                      storageModule,
                     );
 
                     // Record the provisioned name on the just-created row.
-                    const storageModule = await resolveStorageModule(pgClient, databaseId);
-                    if (storageModule) {
-                      const bucketsTable = QuoteUtils.quoteQualifiedIdentifier(storageModule.buckets_schema, storageModule.buckets_table);
-                      const idResult = await runQuery(
-                        pgClient,
-                        `SELECT id FROM ${bucketsTable} WHERE key = $1 LIMIT 1`,
-                        [bucketInput.key],
+                    const bucketsTable = QuoteUtils.quoteQualifiedIdentifier(
+                      storageModule.schemaName,
+                      storageModule.bucketsTableName,
+                    );
+                    const idResult = await runQuery(
+                      pgClient,
+                      `SELECT id FROM ${bucketsTable} WHERE key = $1 LIMIT 2`,
+                      [bucketInput.key],
+                    );
+                    if (idResult.rows.length !== 1) {
+                      throw new Error(
+                        idResult.rows.length === 0
+                          ? 'BUCKET_NOT_FOUND'
+                          : 'BUCKET_AMBIGUOUS',
                       );
-                      const bucketId = idResult.rows[0]?.id;
-                      if (bucketId) await recordPhysicalName(withPgClient, bucketsTable, bucketId, result.bucketName);
+                    }
+                    const bucketId = idResult.rows[0]?.id;
+                    if (bucketId) {
+                      await recordPhysicalName(
+                        pgClient,
+                        bucketsTable,
+                        bucketId,
+                        result.bucketName,
+                      );
                     }
                   });
                 } else {
@@ -686,7 +790,10 @@ export function createBucketProvisionerPlugin(
                     }
 
                     // Read the storage module config (app-level; auto-hook doesn't have ownerId context)
-                    const storageModule = await resolveStorageModule(pgClient, databaseId);
+                    const storageModule = await resolveStorageModule(
+                      pgClient,
+                      preloadedStorageModules,
+                    );
                     if (!storageModule) {
                       log.warn('CORS update skipped: storage module not provisioned');
                       return;
@@ -705,19 +812,25 @@ export function createBucketProvisionerPlugin(
                     }
 
                     // Read the full bucket row (post-update) to get type + origins
-                    const bucketsTable = QuoteUtils.quoteQualifiedIdentifier(storageModule.buckets_schema, storageModule.buckets_table);
+                    const bucketsTable = QuoteUtils.quoteQualifiedIdentifier(
+                      storageModule.schemaName,
+                      storageModule.bucketsTableName,
+                    );
                     const bucketResult = await runQuery(
                       pgClient,
                       `SELECT id, key, type, is_public, allowed_origins, physical_name
                        FROM ${bucketsTable}
                        WHERE key = $1
-                       LIMIT 1`,
+                       LIMIT 2`,
                       [patchKey],
                     );
 
                     if (bucketResult.rows.length === 0) {
                       log.warn(`CORS update skipped: bucket "${patchKey}" not found`);
                       return;
+                    }
+                    if (bucketResult.rows.length > 1) {
+                      throw new Error('BUCKET_AMBIGUOUS');
                     }
 
                     const bucket = bucketResult.rows[0] as BucketRow;
@@ -728,7 +841,6 @@ export function createBucketProvisionerPlugin(
                     const recorded = storedPhysicalName(bucket);
 
                     await updateBucketCors(
-                      pgClient,
                       databaseId,
                       bucket.key,
                       bucket.type,
@@ -737,6 +849,7 @@ export function createBucketProvisionerPlugin(
                       recorded === null
                         ? resolveBucketName(bucket.key, databaseId, options)
                         : recorded,
+                      storageModule,
                     );
                   });
                 }

--- a/graphile/graphile-bucket-provisioner-plugin/src/types.ts
+++ b/graphile/graphile-bucket-provisioner-plugin/src/types.ts
@@ -37,6 +37,25 @@ export type ConnectionConfigOrGetter =
 export type BucketNameResolver = (bucketKey: string, databaseId: string) => string;
 
 /**
+ * Immutable storage routing metadata resolved by the control plane for one
+ * exact Graphile build. This intentionally mirrors the subset consumed by the
+ * provisioner without making the provisioner depend on the presigned plugin.
+ */
+export interface BucketProvisionerStorageModule {
+  id: string;
+  bucketsQualifiedName: string;
+  schemaName: string;
+  bucketsTableName: string;
+  scope: string;
+  entityTableId: string | null;
+  entityQualifiedName: string | null;
+  endpoint: string | null;
+  publicUrlPrefix: string | null;
+  provider: string | null;
+  allowedOrigins: readonly string[] | null;
+}
+
+/**
  * Plugin options for the bucket provisioner plugin.
  */
 export interface BucketProvisionerPluginOptions {
@@ -52,6 +71,14 @@ export interface BucketProvisionerPluginOptions {
    * Required for browser-based presigned URL uploads.
    */
   allowedOrigins: string[];
+
+  /**
+   * Exact-build storage metadata supplied by the control plane. An empty list
+   * is authoritative. If this is omitted, provisioning fails closed; the
+   * plugin never discovers tenant routing metadata from a request-time SQL
+   * query.
+   */
+  preloadedStorageModules?: readonly BucketProvisionerStorageModule[];
 
   /**
    * Optional prefix for S3 bucket names.

--- a/graphile/graphile-bulk-mutations/__tests__/bulk-where-type.test.ts
+++ b/graphile/graphile-bulk-mutations/__tests__/bulk-where-type.test.ts
@@ -1,0 +1,38 @@
+import { GraphQLInputObjectType } from 'graphql';
+
+import { resolveBulkWhereType } from '../src/plugins/BulkTypesPlugin';
+
+describe('bulk mutation where type resolution', () => {
+  it('uses connection-filter without touching a disabled condition inflector', () => {
+    const filter = new GraphQLInputObjectType({ name: 'ItemFilter', fields: {} });
+    const getTypeByName = jest.fn((name: string) => name === 'ItemFilter' ? filter : undefined);
+    const conditionType = jest.fn(() => {
+      throw new Error('disabled condition inflector must not be called');
+    });
+
+    expect(resolveBulkWhereType({ getTypeByName } as any, { conditionType }, 'Item')).toBe(filter);
+    expect(conditionType).not.toHaveBeenCalled();
+    expect(getTypeByName).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the built-in condition type when no filter exists', () => {
+    const condition = new GraphQLInputObjectType({ name: 'ItemCondition', fields: {} });
+    const getTypeByName = jest.fn((name: string) =>
+      name === 'ItemCondition' ? condition : undefined
+    );
+
+    expect(resolveBulkWhereType(
+      { getTypeByName } as any,
+      { conditionType: () => 'ItemCondition' },
+      'Item'
+    )).toBe(condition);
+  });
+
+  it('returns undefined when neither predicate plugin is enabled', () => {
+    expect(resolveBulkWhereType(
+      { getTypeByName: (): undefined => undefined } as any,
+      {},
+      'Item'
+    )).toBeUndefined();
+  });
+});

--- a/graphile/graphile-bulk-mutations/__tests__/identifier-quoting.test.ts
+++ b/graphile/graphile-bulk-mutations/__tests__/identifier-quoting.test.ts
@@ -1,0 +1,42 @@
+import {
+  buildBulkDeleteSQL,
+  buildBulkInsertSQL,
+  buildBulkUpdateSQL,
+} from '../src/utils/sql-builder';
+
+describe('bulk mutation catalog identifier quoting', () => {
+  const hostile = 'value" RETURNING secret --';
+  const quoted = '"value"" RETURNING secret --"';
+
+  it('escapes insert, conflict, update, and returning identifiers', () => {
+    const [query] = buildBulkInsertSQL(
+      'tenant_a.items',
+      [{ name: hostile, sqlType: 'text' }],
+      [{ [hostile]: 'safe-value' }],
+      [hostile],
+      { conflictColumns: [hostile], action: 'UPDATE', updateColumns: [hostile] }
+    );
+
+    expect(query.text).toContain(`(${quoted})`);
+    expect(query.text).toContain(`ON CONFLICT (${quoted})`);
+    expect(query.text).toContain(`${quoted} = EXCLUDED.${quoted}`);
+    expect(query.text).toContain(`RETURNING ${quoted}`);
+    expect(query.values).toEqual(['safe-value']);
+  });
+
+  it('escapes update and delete identifiers', () => {
+    const update = buildBulkUpdateSQL(
+      'tenant_a.items',
+      { [hostile]: 'safe-value' },
+      [{ name: hostile, sqlType: 'text' }],
+      [hostile],
+      'TRUE',
+      []
+    );
+    const deletion = buildBulkDeleteSQL('tenant_a.items', [hostile], 'TRUE', []);
+
+    expect(update.text).toContain(`${quoted} = $1::text`);
+    expect(update.text).toContain(`RETURNING ${quoted}`);
+    expect(deletion.text).toContain(`RETURNING ${quoted}`);
+  });
+});

--- a/graphile/graphile-bulk-mutations/__tests__/pg-client-query-contract.test.ts
+++ b/graphile/graphile-bulk-mutations/__tests__/pg-client-query-contract.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const plugins = [
+  'BulkInsertPlugin',
+  'BulkUpsertPlugin',
+  'BulkUpdatePlugin',
+  'BulkDeletePlugin'
+] as const;
+
+describe.each(plugins)('%s PgClient query contract', (plugin) => {
+  const source = readFileSync(
+    join(__dirname, '..', 'src', 'plugins', `${plugin}.ts`),
+    'utf8'
+  );
+
+  it('types the callback as the @dataplan/pg PgClient', () => {
+    expect(source).toContain('pgClient: PgClient');
+  });
+
+  it('uses object-form query arguments instead of node-postgres positional arguments', () => {
+    const queryCall = String.raw`pgClient\.query(?:<[^)]+>)?\(`;
+    expect(source).toMatch(new RegExp(`${queryCall}\\s*\\{`));
+    expect(source).not.toMatch(new RegExp(`${queryCall}\\s*(?:\`|'|")`));
+    expect(source).not.toMatch(
+      new RegExp(`${queryCall}\\s*[A-Za-z_$][\\w$]*\\s*,`)
+    );
+  });
+});

--- a/graphile/graphile-bulk-mutations/package.json
+++ b/graphile/graphile-bulk-mutations/package.json
@@ -41,6 +41,9 @@
   "bugs": {
     "url": "https://github.com/constructive-io/constructive/issues"
   },
+  "dependencies": {
+    "@pgsql/quotes": "^18.1.0"
+  },
   "devDependencies": {
     "@types/node": "^22.19.11",
     "graphile-test": "workspace:^",

--- a/graphile/graphile-bulk-mutations/src/plugins/BulkDeletePlugin.ts
+++ b/graphile/graphile-bulk-mutations/src/plugins/BulkDeletePlugin.ts
@@ -1,10 +1,12 @@
 import '../augmentations';
 
-import { sideEffectWithPgClient } from '@dataplan/pg';
+import { type PgClient,sideEffectWithPgClient } from '@dataplan/pg';
+import { QuoteUtils } from '@pgsql/quotes';
 import type { GraphileConfig } from 'graphile-config';
 import type { GraphQLInputType,GraphQLOutputType } from 'graphql';
 
 const version = '0.1.0';
+const qi = (name: string): string => QuoteUtils.quoteIdentifier(name);
 
 /**
  * BulkDeletePlugin
@@ -79,7 +81,7 @@ export const BulkDeletePlugin: GraphileConfig.Plugin = {
           // Extract primary key columns for RETURNING clause
           const primaryUnique = resource.uniques.find((u: any) => u.isPrimary) ?? resource.uniques[0];
           const pkColumns: string[] = primaryUnique.attributes;
-          const pkReturning = pkColumns.map((c) => `"${c}"`).join(', ');
+          const pkReturning = pkColumns.map(qi).join(', ');
 
           const compiledFrom = sql.compile(resource.from).text;
 
@@ -105,7 +107,7 @@ export const BulkDeletePlugin: GraphileConfig.Plugin = {
                     const $result = sideEffectWithPgClient(
                       executor,
                       $input,
-                      async (pgClient: any, input: any) => {
+                      async (pgClient: PgClient, input: any) => {
                         if (requireWhere && (!input.where || Object.keys(input.where).length === 0)) {
                           throw new Error(
                             'Bulk delete requires a non-empty where condition. Set bulkRequireWhere: false to allow unrestricted deletes.'
@@ -125,11 +127,11 @@ export const BulkDeletePlugin: GraphileConfig.Plugin = {
                             const sqlType = attrToSqlType[attrName];
 
                             if (spec === null) {
-                              whereClauses.push(`"${attrName}" IS NULL`);
+                              whereClauses.push(`${qi(attrName)} IS NULL`);
                             } else if (spec !== undefined && typeof spec !== 'object') {
                               // Simple equality (Condition type)
                               values.push(spec);
-                              whereClauses.push(`"${attrName}" = $${values.length}::${sqlType}`);
+                              whereClauses.push(`${qi(attrName)} = $${values.length}::${sqlType}`);
                             } else if (spec && typeof spec === 'object') {
                               // Operator-based (Filter type)
                               for (const [op, val] of Object.entries(spec) as [string, any][]) {
@@ -137,22 +139,22 @@ export const BulkDeletePlugin: GraphileConfig.Plugin = {
                                 const paramRef = `$${values.length}::${sqlType}`;
                                 switch (op) {
                                 case 'equalTo':
-                                  whereClauses.push(`"${attrName}" = ${paramRef}`);
+                                  whereClauses.push(`${qi(attrName)} = ${paramRef}`);
                                   break;
                                 case 'notEqualTo':
-                                  whereClauses.push(`"${attrName}" != ${paramRef}`);
+                                  whereClauses.push(`${qi(attrName)} != ${paramRef}`);
                                   break;
                                 case 'greaterThan':
-                                  whereClauses.push(`"${attrName}" > ${paramRef}`);
+                                  whereClauses.push(`${qi(attrName)} > ${paramRef}`);
                                   break;
                                 case 'greaterThanOrEqualTo':
-                                  whereClauses.push(`"${attrName}" >= ${paramRef}`);
+                                  whereClauses.push(`${qi(attrName)} >= ${paramRef}`);
                                   break;
                                 case 'lessThan':
-                                  whereClauses.push(`"${attrName}" < ${paramRef}`);
+                                  whereClauses.push(`${qi(attrName)} < ${paramRef}`);
                                   break;
                                 case 'lessThanOrEqualTo':
-                                  whereClauses.push(`"${attrName}" <= ${paramRef}`);
+                                  whereClauses.push(`${qi(attrName)} <= ${paramRef}`);
                                   break;
                                 case 'in':
                                   if (Array.isArray(val)) {
@@ -161,15 +163,15 @@ export const BulkDeletePlugin: GraphileConfig.Plugin = {
                                       return `$${values.length}::${sqlType}`;
                                     });
                                     values.pop();
-                                    whereClauses.push(`"${attrName}" IN (${placeholders.join(', ')})`);
+                                    whereClauses.push(`${qi(attrName)} IN (${placeholders.join(', ')})`);
                                   }
                                   break;
                                 case 'isNull':
                                   values.pop();
                                   if (val) {
-                                    whereClauses.push(`"${attrName}" IS NULL`);
+                                    whereClauses.push(`${qi(attrName)} IS NULL`);
                                   } else {
-                                    whereClauses.push(`"${attrName}" IS NOT NULL`);
+                                    whereClauses.push(`${qi(attrName)} IS NOT NULL`);
                                   }
                                   break;
                                 default:
@@ -194,7 +196,7 @@ export const BulkDeletePlugin: GraphileConfig.Plugin = {
                         // Use RETURNING <pk_columns> instead of RETURNING *
                         // For delete, we capture PKs before rows are gone
                         const text = `DELETE FROM ${compiledFrom}\nWHERE ${whereStr}\nRETURNING ${pkReturning}`;
-                        const mutationResult = await pgClient.query(text, values);
+                        const mutationResult = await pgClient.query({ text, values });
                         const affectedCount = mutationResult.rowCount ?? 0;
 
                         // For delete, rows no longer exist so we can't do a

--- a/graphile/graphile-bulk-mutations/src/plugins/BulkInsertPlugin.ts
+++ b/graphile/graphile-bulk-mutations/src/plugins/BulkInsertPlugin.ts
@@ -1,6 +1,7 @@
 import '../augmentations';
 
-import { sideEffectWithPgClient } from '@dataplan/pg';
+import { type PgClient,sideEffectWithPgClient } from '@dataplan/pg';
+import { QuoteUtils } from '@pgsql/quotes';
 import type { GraphileConfig } from 'graphile-config';
 import type { GraphQLInputType, GraphQLOutputType } from 'graphql';
 
@@ -10,6 +11,7 @@ import type { ColumnSpec } from '../utils/sql-builder';
 import { buildBulkInsertSQL } from '../utils/sql-builder';
 
 const version = '0.1.0';
+const qi = (name: string): string => QuoteUtils.quoteIdentifier(name);
 
 /**
  * BulkInsertPlugin
@@ -131,7 +133,7 @@ export const BulkInsertPlugin: GraphileConfig.Plugin = {
                     const $result = sideEffectWithPgClient(
                       executor,
                       $input,
-                      async (pgClient: any, input: any) => {
+                      async (pgClient: PgClient, input: any) => {
                         const values = input.values;
                         if (!values || !Array.isArray(values) || values.length === 0) {
                           return { affectedCount: 0, returning: [] };
@@ -200,10 +202,10 @@ export const BulkInsertPlugin: GraphileConfig.Plugin = {
                         const allPkRows: Record<string, unknown>[] = [];
 
                         for (const batch of batches) {
-                          const result = await pgClient.query(
-                            batch.text,
-                            batch.values
-                          );
+                          const result = await pgClient.query<Record<string, unknown>>({
+                            text: batch.text,
+                            values: batch.values
+                          });
                           totalAffected += result.rowCount ?? 0;
                           if (result.rows) {
                             allPkRows.push(...result.rows);
@@ -259,10 +261,10 @@ export const BulkInsertPlugin: GraphileConfig.Plugin = {
                               );
 
                               for (const batch of childBatches) {
-                                const result = await pgClient.query(
-                                  batch.text,
-                                  batch.values
-                                );
+                                const result = await pgClient.query({
+                                  text: batch.text,
+                                  values: batch.values
+                                });
                                 totalAffected += result.rowCount ?? 0;
                               }
                             }
@@ -275,18 +277,18 @@ export const BulkInsertPlugin: GraphileConfig.Plugin = {
                           const pkConditions = allPkRows.map((pkRow, rowIdx) => {
                             return pkColumns.map((col, colIdx) => {
                               const paramIdx = rowIdx * pkColumns.length + colIdx + 1;
-                              return `"${col}" = $${paramIdx}`;
+                              return `${qi(col)} = $${paramIdx}`;
                             }).join(' AND ');
                           });
                           const whereClause = pkConditions.map((c) => `(${c})`).join(' OR ');
                           const selectParams = allPkRows.flatMap((pkRow) =>
                             pkColumns.map((col) => pkRow[col])
                           );
-                          const selectResult = await pgClient.query(
-                            `SELECT * FROM ${compiledFrom} WHERE ${whereClause}`,
-                            selectParams
-                          );
-                          returning = selectResult.rows || [];
+                          const selectResult = await pgClient.query<Record<string, unknown>>({
+                            text: `SELECT * FROM ${compiledFrom} WHERE ${whereClause}`,
+                            values: selectParams
+                          });
+                          returning = [...selectResult.rows];
                         }
 
                         return {

--- a/graphile/graphile-bulk-mutations/src/plugins/BulkTypesPlugin.ts
+++ b/graphile/graphile-bulk-mutations/src/plugins/BulkTypesPlugin.ts
@@ -26,6 +26,27 @@ function isBulkMutationCandidate(resource: any): boolean {
 }
 
 /**
+ * Resolve the strongest available predicate input without assuming that the
+ * built-in condition plugin is enabled. Constructive disables that plugin when
+ * graphile-connection-filter supplies the richer `${typeName}Filter` type.
+ */
+export function resolveBulkWhereType(
+  build: Pick<GraphileBuild.Build, 'getTypeByName'>,
+  inflection: { conditionType?: (typeName: string) => string },
+  typeName: string
+): GraphQLInputType | undefined {
+  const filterType = build.getTypeByName(`${typeName}Filter`) as
+    | GraphQLInputType
+    | undefined;
+  if (filterType) return filterType;
+
+  const conditionTypeName = inflection.conditionType?.(typeName);
+  return conditionTypeName
+    ? build.getTypeByName(conditionTypeName) as GraphQLInputType | undefined
+    : undefined;
+}
+
+/**
  * BulkTypesPlugin
  *
  * Registers all shared types for bulk mutations:
@@ -465,16 +486,7 @@ export const BulkTypesPlugin: GraphileConfig.Plugin = {
                   where: fieldWithHooks(
                     { fieldName: 'where' },
                     () => {
-                      // Try to use connection-filter type if available
-                      const filterTypeName = `${typeName}Filter`;
-                      const filterType = build.getTypeByName(filterTypeName) as GraphQLInputType | undefined;
-                      // Fall back to PostGraphile's built-in condition type
-                      const conditionTypeName = inflection.conditionType(
-                        typeName
-                      );
-                      const conditionType =
-                        build.getTypeByName(conditionTypeName) as GraphQLInputType | undefined;
-                      const whereType = filterType || conditionType;
+                      const whereType = resolveBulkWhereType(build, inflection, typeName);
                       return {
                         description:
                           'Condition to select which rows to update.',
@@ -511,14 +523,7 @@ export const BulkTypesPlugin: GraphileConfig.Plugin = {
                   where: fieldWithHooks(
                     { fieldName: 'where' },
                     () => {
-                      const filterTypeName = `${typeName}Filter`;
-                      const filterType = build.getTypeByName(filterTypeName) as GraphQLInputType | undefined;
-                      const conditionTypeName = inflection.conditionType(
-                        typeName
-                      );
-                      const conditionType =
-                        build.getTypeByName(conditionTypeName) as GraphQLInputType | undefined;
-                      const whereType = filterType || conditionType;
+                      const whereType = resolveBulkWhereType(build, inflection, typeName);
                       return {
                         description:
                           'Condition to select which rows to delete.',

--- a/graphile/graphile-bulk-mutations/src/plugins/BulkUpdatePlugin.ts
+++ b/graphile/graphile-bulk-mutations/src/plugins/BulkUpdatePlugin.ts
@@ -1,10 +1,12 @@
 import '../augmentations';
 
-import { sideEffectWithPgClient } from '@dataplan/pg';
+import { type PgClient,sideEffectWithPgClient } from '@dataplan/pg';
+import { QuoteUtils } from '@pgsql/quotes';
 import type { GraphileConfig } from 'graphile-config';
 import type { GraphQLInputType, GraphQLOutputType } from 'graphql';
 
 const version = '0.1.0';
+const qi = (name: string): string => QuoteUtils.quoteIdentifier(name);
 
 /**
  * BulkUpdatePlugin
@@ -80,7 +82,7 @@ export const BulkUpdatePlugin: GraphileConfig.Plugin = {
           // Extract primary key columns for RETURNING clause
           const primaryUnique = resource.uniques.find((u: any) => u.isPrimary) ?? resource.uniques[0];
           const pkColumns: string[] = primaryUnique.attributes;
-          const pkReturning = pkColumns.map((c) => `"${c}"`).join(', ');
+          const pkReturning = pkColumns.map(qi).join(', ');
 
           const compiledFrom = sql.compile(resource.from).text;
 
@@ -106,7 +108,7 @@ export const BulkUpdatePlugin: GraphileConfig.Plugin = {
                     const $result = sideEffectWithPgClient(
                       executor,
                       $input,
-                      async (pgClient: any, input: any) => {
+                      async (pgClient: PgClient, input: any) => {
                         if (requireWhere && (!input.where || Object.keys(input.where).length === 0)) {
                           throw new Error(
                             'Bulk update requires a non-empty where condition. Set bulkRequireWhere: false to allow unrestricted updates.'
@@ -126,7 +128,7 @@ export const BulkUpdatePlugin: GraphileConfig.Plugin = {
                           if (!attrName) continue;
                           const sqlType = attrToSqlType[attrName];
                           values.push(val);
-                          setClauses.push(`"${attrName}" = $${values.length}::${sqlType}`);
+                          setClauses.push(`${qi(attrName)} = $${values.length}::${sqlType}`);
                         }
 
                         if (setClauses.length === 0) {
@@ -144,11 +146,11 @@ export const BulkUpdatePlugin: GraphileConfig.Plugin = {
                             const sqlType = attrToSqlType[attrName];
 
                             if (spec === null) {
-                              whereClauses.push(`"${attrName}" IS NULL`);
+                              whereClauses.push(`${qi(attrName)} IS NULL`);
                             } else if (spec !== undefined && typeof spec !== 'object') {
                               // Simple equality (Condition type)
                               values.push(spec);
-                              whereClauses.push(`"${attrName}" = $${values.length}::${sqlType}`);
+                              whereClauses.push(`${qi(attrName)} = $${values.length}::${sqlType}`);
                             } else if (spec && typeof spec === 'object') {
                               // Operator-based (Filter type)
                               for (const [op, val] of Object.entries(spec) as [string, any][]) {
@@ -156,22 +158,22 @@ export const BulkUpdatePlugin: GraphileConfig.Plugin = {
                                 const paramRef = `$${values.length}::${sqlType}`;
                                 switch (op) {
                                 case 'equalTo':
-                                  whereClauses.push(`"${attrName}" = ${paramRef}`);
+                                  whereClauses.push(`${qi(attrName)} = ${paramRef}`);
                                   break;
                                 case 'notEqualTo':
-                                  whereClauses.push(`"${attrName}" != ${paramRef}`);
+                                  whereClauses.push(`${qi(attrName)} != ${paramRef}`);
                                   break;
                                 case 'greaterThan':
-                                  whereClauses.push(`"${attrName}" > ${paramRef}`);
+                                  whereClauses.push(`${qi(attrName)} > ${paramRef}`);
                                   break;
                                 case 'greaterThanOrEqualTo':
-                                  whereClauses.push(`"${attrName}" >= ${paramRef}`);
+                                  whereClauses.push(`${qi(attrName)} >= ${paramRef}`);
                                   break;
                                 case 'lessThan':
-                                  whereClauses.push(`"${attrName}" < ${paramRef}`);
+                                  whereClauses.push(`${qi(attrName)} < ${paramRef}`);
                                   break;
                                 case 'lessThanOrEqualTo':
-                                  whereClauses.push(`"${attrName}" <= ${paramRef}`);
+                                  whereClauses.push(`${qi(attrName)} <= ${paramRef}`);
                                   break;
                                 case 'in':
                                   if (Array.isArray(val)) {
@@ -180,15 +182,15 @@ export const BulkUpdatePlugin: GraphileConfig.Plugin = {
                                       return `$${values.length}::${sqlType}`;
                                     });
                                     values.pop();
-                                    whereClauses.push(`"${attrName}" IN (${placeholders.join(', ')})`);
+                                    whereClauses.push(`${qi(attrName)} IN (${placeholders.join(', ')})`);
                                   }
                                   break;
                                 case 'isNull':
                                   values.pop();
                                   if (val) {
-                                    whereClauses.push(`"${attrName}" IS NULL`);
+                                    whereClauses.push(`${qi(attrName)} IS NULL`);
                                   } else {
-                                    whereClauses.push(`"${attrName}" IS NOT NULL`);
+                                    whereClauses.push(`${qi(attrName)} IS NOT NULL`);
                                   }
                                   break;
                                 default:
@@ -212,28 +214,31 @@ export const BulkUpdatePlugin: GraphileConfig.Plugin = {
 
                         // Use RETURNING <pk_columns> instead of RETURNING *
                         const text = `UPDATE ${compiledFrom}\nSET ${setClauses.join(', ')}\nWHERE ${whereStr}\nRETURNING ${pkReturning}`;
-                        const mutationResult = await pgClient.query(text, values);
+                        const mutationResult = await pgClient.query<Record<string, unknown>>({
+                          text,
+                          values
+                        });
                         const affectedCount = mutationResult.rowCount ?? 0;
 
                         // Follow-up SELECT using PKs to respect column-level grants
                         let returning: unknown[] = [];
                         if (mutationResult.rows && mutationResult.rows.length > 0) {
-                          const pkRows: Record<string, unknown>[] = mutationResult.rows;
+                          const pkRows = mutationResult.rows;
                           const pkConditions = pkRows.map((pkRow, rowIdx) => {
                             return pkColumns.map((col, colIdx) => {
                               const paramIdx = rowIdx * pkColumns.length + colIdx + 1;
-                              return `"${col}" = $${paramIdx}`;
+                              return `${qi(col)} = $${paramIdx}`;
                             }).join(' AND ');
                           });
                           const selectWhere = pkConditions.map((c) => `(${c})`).join(' OR ');
                           const selectParams = pkRows.flatMap((pkRow) =>
                             pkColumns.map((col) => pkRow[col])
                           );
-                          const selectResult = await pgClient.query(
-                            `SELECT * FROM ${compiledFrom} WHERE ${selectWhere}`,
-                            selectParams
-                          );
-                          returning = selectResult.rows || [];
+                          const selectResult = await pgClient.query<Record<string, unknown>>({
+                            text: `SELECT * FROM ${compiledFrom} WHERE ${selectWhere}`,
+                            values: selectParams
+                          });
+                          returning = [...selectResult.rows];
                         }
 
                         return {

--- a/graphile/graphile-bulk-mutations/src/plugins/BulkUpsertPlugin.ts
+++ b/graphile/graphile-bulk-mutations/src/plugins/BulkUpsertPlugin.ts
@@ -1,6 +1,7 @@
 import '../augmentations';
 
-import { sideEffectWithPgClient } from '@dataplan/pg';
+import { type PgClient,sideEffectWithPgClient } from '@dataplan/pg';
+import { QuoteUtils } from '@pgsql/quotes';
 import type { GraphileConfig } from 'graphile-config';
 import type { GraphQLInputType, GraphQLOutputType } from 'graphql';
 
@@ -8,6 +9,7 @@ import type { ColumnSpec } from '../utils/sql-builder';
 import { buildBulkInsertSQL } from '../utils/sql-builder';
 
 const version = '0.1.0';
+const qi = (name: string): string => QuoteUtils.quoteIdentifier(name);
 
 /**
  * BulkUpsertPlugin
@@ -118,7 +120,7 @@ export const BulkUpsertPlugin: GraphileConfig.Plugin = {
                     const $result = sideEffectWithPgClient(
                       executor,
                       $input,
-                      async (pgClient: any, input: any) => {
+                      async (pgClient: PgClient, input: any) => {
                         const values = input.values;
                         if (!values || !Array.isArray(values) || values.length === 0) {
                           return { affectedCount: 0, returning: [] };
@@ -177,10 +179,10 @@ export const BulkUpsertPlugin: GraphileConfig.Plugin = {
                         const allPkRows: Record<string, unknown>[] = [];
 
                         for (const batch of batches) {
-                          const result = await pgClient.query(
-                            batch.text,
-                            batch.values
-                          );
+                          const result = await pgClient.query<Record<string, unknown>>({
+                            text: batch.text,
+                            values: batch.values
+                          });
                           totalAffected += result.rowCount ?? 0;
                           if (result.rows) {
                             allPkRows.push(...result.rows);
@@ -193,18 +195,18 @@ export const BulkUpsertPlugin: GraphileConfig.Plugin = {
                           const pkConditions = allPkRows.map((pkRow, rowIdx) => {
                             return pkColumns.map((col, colIdx) => {
                               const paramIdx = rowIdx * pkColumns.length + colIdx + 1;
-                              return `"${col}" = $${paramIdx}`;
+                              return `${qi(col)} = $${paramIdx}`;
                             }).join(' AND ');
                           });
                           const whereClause = pkConditions.map((c) => `(${c})`).join(' OR ');
                           const selectParams = allPkRows.flatMap((pkRow) =>
                             pkColumns.map((col) => pkRow[col])
                           );
-                          const selectResult = await pgClient.query(
-                            `SELECT * FROM ${compiledFrom} WHERE ${whereClause}`,
-                            selectParams
-                          );
-                          returning = selectResult.rows || [];
+                          const selectResult = await pgClient.query<Record<string, unknown>>({
+                            text: `SELECT * FROM ${compiledFrom} WHERE ${whereClause}`,
+                            values: selectParams
+                          });
+                          returning = [...selectResult.rows];
                         }
 
                         return {

--- a/graphile/graphile-bulk-mutations/src/utils/sql-builder.ts
+++ b/graphile/graphile-bulk-mutations/src/utils/sql-builder.ts
@@ -12,7 +12,11 @@
  * See: https://github.com/pyramation/graphile-column-privileges-mutations
  */
 
+import { QuoteUtils } from '@pgsql/quotes';
+
 import { PG_MAX_PARAMS } from '../types';
+
+const qi = (name: string): string => QuoteUtils.quoteIdentifier(name);
 
 export interface ColumnSpec {
   name: string;
@@ -45,12 +49,12 @@ export function buildBulkInsertSQL(
     updateColumns?: string[];
   }
 ): InsertBatch[] {
-  const colNames = columns.map((c) => `"${c.name}"`);
+  const colNames = columns.map((c) => qi(c.name));
   const colsPerRow = columns.length;
   const maxRowsPerBatch = Math.floor(PG_MAX_PARAMS / colsPerRow);
 
   const returningClause = returningColumns.length > 0
-    ? returningColumns.map((c) => `"${c}"`).join(', ')
+    ? returningColumns.map(qi).join(', ')
     : '*';
 
   const batches: InsertBatch[] = [];
@@ -79,7 +83,7 @@ export function buildBulkInsertSQL(
 
     if (onConflict) {
       if (onConflict.conflictColumns && onConflict.conflictColumns.length > 0) {
-        const colList = onConflict.conflictColumns.map((c) => `"${c}"`).join(', ');
+        const colList = onConflict.conflictColumns.map(qi).join(', ');
         text += `\nON CONFLICT (${colList})`;
       } else {
         text += '\nON CONFLICT';
@@ -93,7 +97,7 @@ export function buildBulkInsertSQL(
             ? onConflict.updateColumns
             : columns.map((c) => c.name);
         const setClause = setCols
-          .map((c) => `"${c}" = EXCLUDED."${c}"`)
+          .map((c) => `${qi(c)} = EXCLUDED.${qi(c)}`)
           .join(', ');
         text += ` DO UPDATE SET ${setClause}`;
       }
@@ -130,7 +134,7 @@ export function buildBulkUpdateSQL(
     if (value === undefined) continue;
 
     values.push(value);
-    setClauses.push(`"${col.name}" = $${values.length}::${col.sqlType}`);
+    setClauses.push(`${qi(col.name)} = $${values.length}::${col.sqlType}`);
   }
 
   if (setClauses.length === 0) {
@@ -146,7 +150,7 @@ export function buildBulkUpdateSQL(
   values.push(...whereParams);
 
   const returningClause = returningColumns.length > 0
-    ? returningColumns.map((c) => `"${c}"`).join(', ')
+    ? returningColumns.map(qi).join(', ')
     : '*';
 
   const text = `UPDATE ${tableName}\nSET ${setClauses.join(', ')}\nWHERE ${renumberedWhere}\nRETURNING ${returningClause}`;
@@ -167,7 +171,7 @@ export function buildBulkDeleteSQL(
   whereParams: unknown[]
 ): { text: string; values: unknown[] } {
   const returningClause = returningColumns.length > 0
-    ? returningColumns.map((c) => `"${c}"`).join(', ')
+    ? returningColumns.map(qi).join(', ')
     : '*';
 
   const text = `DELETE FROM ${tableName}\nWHERE ${whereClause}\nRETURNING ${returningClause}`;

--- a/graphile/graphile-function-bindings/src/__tests__/preloaded-bindings.test.ts
+++ b/graphile/graphile-function-bindings/src/__tests__/preloaded-bindings.test.ts
@@ -1,0 +1,122 @@
+import { withPgClientFromPgService } from '@dataplan/pg';
+import type { GraphileConfig } from 'graphile-config';
+
+import { createFunctionBindingsPlugin } from '../plugin';
+import type {
+  ComputeModuleNames,
+  PreloadedFunctionBinding
+} from '../types';
+
+jest.mock('@dataplan/pg', () => ({
+  ...jest.requireActual('@dataplan/pg'),
+  withPgClientFromPgService: jest.fn()
+}));
+
+const withPgClientMock = withPgClientFromPgService as unknown as jest.Mock;
+
+const moduleNames: ComputeModuleNames = {
+  computeSchema: 'compute_public',
+  bindingsTable: 'function_api_bindings',
+  definitionsTable: 'function_definitions',
+  invocationsSchema: 'compute_public',
+  invocationsTable: 'function_invocations',
+  invocationsEntityField: null
+};
+
+const binding = (): PreloadedFunctionBinding => ({
+  bindingId: 'binding-1',
+  alias: 'send_email',
+  config: {
+    graphql: { enabled: true },
+    schema: {
+      type: 'object',
+      properties: { to: { type: 'string' } }
+    }
+  },
+  functionDefinitionId: 'definition-1',
+  taskIdentifier: 'app:send_email',
+  description: 'Send an email',
+  payloadArgs: [{ name: 'to', type: 'text' }],
+  module: { ...moduleNames }
+});
+
+async function runGather(plugin: GraphileConfig.Plugin, includePgService = false) {
+  const output: Record<string, unknown> = {};
+  const main = (plugin.gather as any).main as (
+    output: Record<string, unknown>,
+    info: Record<string, unknown>
+  ) => Promise<void>;
+  await main(output, {
+    resolvedPreset: {
+      pgServices: includePgService ? [{ name: 'main' }] : []
+    }
+  });
+  return (output.functionApiBindings as {
+    bindings: readonly PreloadedFunctionBinding[];
+  }).bindings;
+}
+
+describe('FunctionBindingsPlugin preloaded bindings', () => {
+  beforeEach(() => {
+    withPgClientMock.mockReset();
+  });
+
+  it('treats an empty preloaded array as authoritative and performs zero SQL', async () => {
+    const plugin = createFunctionBindingsPlugin({
+      apiId: 'api-1',
+      modules: [],
+      preloadedBindings: []
+    });
+
+    await expect(runGather(plugin)).resolves.toEqual([]);
+    expect(withPgClientMock).not.toHaveBeenCalled();
+  });
+
+  it('snapshots nonempty preloaded rows immutably and performs zero SQL', async () => {
+    const original = binding();
+    const plugin = createFunctionBindingsPlugin({
+      apiId: 'api-1',
+      modules: [moduleNames],
+      preloadedBindings: [original]
+    });
+
+    original.alias = 'mutated_after_plugin_creation';
+    (original.config!.graphql as { enabled: boolean }).enabled = false;
+    original.payloadArgs![0].name = 'mutated';
+    original.module.invocationsTable = 'mutated_invocations';
+
+    const loaded = await runGather(plugin);
+
+    expect(withPgClientMock).not.toHaveBeenCalled();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]).toMatchObject({
+      alias: 'send_email',
+      payloadArgs: [{ name: 'to', type: 'text' }],
+      module: { invocationsTable: 'function_invocations' }
+    });
+    expect((loaded[0].config!.graphql as { enabled: boolean }).enabled).toBe(true);
+    expect(Object.isFrozen(loaded)).toBe(true);
+    expect(Object.isFrozen(loaded[0])).toBe(true);
+    expect(Object.isFrozen(loaded[0].config)).toBe(true);
+    expect(Object.isFrozen(loaded[0].payloadArgs)).toBe(true);
+    expect(Object.isFrozen(loaded[0].module)).toBe(true);
+  });
+
+  it('uses the generic SQL loader only when preloadedBindings is undefined', async () => {
+    const query = jest.fn().mockResolvedValue({ rows: [] });
+    withPgClientMock.mockImplementation(
+      async (_pgService: unknown, settings: unknown, callback: (client: unknown) => unknown) => {
+        expect(settings).toBeNull();
+        return callback({ query });
+      }
+    );
+    const plugin = createFunctionBindingsPlugin({
+      apiId: 'api-1',
+      modules: [moduleNames]
+    });
+
+    await expect(runGather(plugin, true)).resolves.toEqual([]);
+    expect(withPgClientMock).toHaveBeenCalledTimes(1);
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+});

--- a/graphile/graphile-function-bindings/src/index.ts
+++ b/graphile/graphile-function-bindings/src/index.ts
@@ -14,5 +14,6 @@ export type {
   FunctionBindingRow,
   FunctionBindingsPluginOptions,
   JsonSchemaNode,
-  PayloadArg
+  PayloadArg,
+  PreloadedFunctionBinding
 } from './types';

--- a/graphile/graphile-function-bindings/src/plugin.ts
+++ b/graphile/graphile-function-bindings/src/plugin.ts
@@ -1,12 +1,12 @@
 /**
  * PostGraphile v5 Function Bindings Plugin
  *
- * Exposes API-bound compute functions as GraphQL mutations. At gather time
- * the plugin queries the bindings table joined to the definitions table
- * (schema/table names resolved from the constructive metaschema via the
- * express-context compute module loader — never guessed or hard-coded)
- * for the configured api_id and emits one mutation per graphql-enabled
- * binding:
+ * Exposes API-bound compute functions as GraphQL mutations. A Constructive
+ * server can preload an authoritative control-plane snapshot, avoiding tenant
+ * runtime-pool metadata queries during gather. Generic callers may omit that
+ * snapshot and retain the bindings/definitions table query (schema/table names
+ * resolved from the constructive metaschema — never guessed or hard-coded).
+ * The plugin emits one mutation per graphql-enabled binding:
  *
  *   <alias>(input: <Alias>Input!): <Alias>Payload
  *
@@ -40,7 +40,12 @@ import { toCamelCase, toConstantCase, toPascalCase } from 'inflekt';
 
 import type { DerivedField, DerivedInput } from './derive';
 import { buildInvocationPayload, deriveInputFields, isGraphqlEnabled } from './derive';
-import type { ComputeModuleNames, FunctionBindingRow, FunctionBindingsPluginOptions } from './types';
+import type {
+  ComputeModuleNames,
+  FunctionBindingRow,
+  FunctionBindingsPluginOptions,
+  PreloadedFunctionBinding
+} from './types';
 
 const log = new Logger('graphile-function-bindings');
 
@@ -56,21 +61,63 @@ declare global {
   }
 }
 
-/** A binding together with the module (scope) it was loaded from. */
-interface LoadedBinding extends FunctionBindingRow {
-  module: ComputeModuleNames;
+interface FunctionBindingsBuildInput {
+  bindings: readonly PreloadedFunctionBinding[];
 }
 
-interface FunctionBindingsBuildInput {
-  bindings: LoadedBinding[];
+interface FunctionBindingsPluginOptionsSnapshot {
+  apiId: string;
+  modules: readonly ComputeModuleNames[];
+  preloadedBindings: readonly PreloadedFunctionBinding[] | undefined;
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== 'object' || Object.isFrozen(value)) {
+    return value;
+  }
+  Object.freeze(value);
+  for (const child of Object.values(value as Record<string, unknown>)) {
+    deepFreeze(child);
+  }
+  return value;
+}
+
+function snapshotBinding(binding: PreloadedFunctionBinding): PreloadedFunctionBinding {
+  return deepFreeze({
+    bindingId: binding.bindingId,
+    alias: binding.alias,
+    config: binding.config === null ? null : structuredClone(binding.config),
+    functionDefinitionId: binding.functionDefinitionId,
+    taskIdentifier: binding.taskIdentifier,
+    description: binding.description,
+    payloadArgs: binding.payloadArgs === null
+      ? null
+      : binding.payloadArgs.map((argument) => ({ ...argument })),
+    module: { ...binding.module }
+  });
+}
+
+function snapshotOptions(
+  options: FunctionBindingsPluginOptions
+): FunctionBindingsPluginOptionsSnapshot {
+  const preloadedBindings = options.preloadedBindings === undefined
+    ? undefined
+    : options.preloadedBindings
+      .map(snapshotBinding)
+      .filter((binding) => isGraphqlEnabled(binding.config));
+  return deepFreeze({
+    apiId: options.apiId,
+    modules: options.modules.map((module) => ({ ...module })),
+    preloadedBindings
+  });
 }
 
 async function loadBindings(
   pgService: GraphileConfig.PgServiceConfiguration,
-  options: FunctionBindingsPluginOptions
+  options: FunctionBindingsPluginOptionsSnapshot
 ): Promise<FunctionBindingsBuildInput> {
   return withPgClientFromPgService(pgService, null, async (client) => {
-    const bindings: LoadedBinding[] = [];
+    const bindings: PreloadedFunctionBinding[] = [];
     for (const module of options.modules) {
       const { computeSchema, bindingsTable, definitionsTable } = module;
       const { text, values } = new QueryBuilder()
@@ -124,6 +171,7 @@ async function loadBindings(
 export function createFunctionBindingsPlugin(
   options: FunctionBindingsPluginOptions
 ): GraphileConfig.Plugin {
+  const optionsSnapshot = snapshotOptions(options);
   return {
     name: 'FunctionBindingsPlugin',
     version: '0.1.0',
@@ -136,20 +184,25 @@ export function createFunctionBindingsPlugin(
       namespace: 'functionBindings',
       helpers: {},
       async main(output, info) {
-        const pgService = info.resolvedPreset.pgServices?.[0];
-        if (!pgService) {
-          throw new Error('FunctionBindingsPlugin: no pgService configured');
-        }
-        if (!options.apiId) {
+        if (!optionsSnapshot.apiId) {
           throw new Error('FunctionBindingsPlugin: apiId is required');
         }
-        if (!options.modules?.length) {
-          throw new Error('FunctionBindingsPlugin: at least one compute module is required');
+        let result: FunctionBindingsBuildInput;
+        if (optionsSnapshot.preloadedBindings !== undefined) {
+          result = { bindings: optionsSnapshot.preloadedBindings };
+        } else {
+          const pgService = info.resolvedPreset.pgServices?.[0];
+          if (!pgService) {
+            throw new Error('FunctionBindingsPlugin: no pgService configured');
+          }
+          if (optionsSnapshot.modules.length === 0) {
+            throw new Error('FunctionBindingsPlugin: at least one compute module is required');
+          }
+          result = await loadBindings(pgService, optionsSnapshot);
         }
-        const result = await loadBindings(pgService, options);
         (output as Record<string, unknown>).functionApiBindings = result;
         log.debug(
-          `Loaded ${result.bindings.length} graphql-enabled function binding(s) for api ${options.apiId}`
+          `Loaded ${result.bindings.length} graphql-enabled function binding(s) for api ${optionsSnapshot.apiId}`
         );
       }
     },

--- a/graphile/graphile-function-bindings/src/types.ts
+++ b/graphile/graphile-function-bindings/src/types.ts
@@ -23,7 +23,7 @@ export interface JsonSchemaNode {
 
 /**
  * A graphql-enabled function_api_bindings row joined to its
- * function_definitions row, loaded at gather time.
+ * function_definitions row, either preloaded or loaded at gather time.
  */
 export interface FunctionBindingRow {
   bindingId: string;
@@ -60,6 +60,15 @@ export interface ComputeModuleNames {
   invocationsEntityField: string | null;
 }
 
+/**
+ * A control-plane-resolved binding paired with the exact physical compute
+ * module used for invocation writes. Supplying these rows lets schema builds
+ * avoid querying tenant runtime pools for binding metadata.
+ */
+export interface PreloadedFunctionBinding extends FunctionBindingRow {
+  module: ComputeModuleNames;
+}
+
 export interface FunctionBindingsPluginOptions {
   /** Only bindings for this api are exposed as mutations. */
   apiId: string;
@@ -67,5 +76,12 @@ export interface FunctionBindingsPluginOptions {
    * One entry per provisioned function-module scope. Bindings from every
    * module are exposed; RLS on the underlying tables governs access.
    */
-  modules: ComputeModuleNames[];
+  modules: readonly ComputeModuleNames[];
+  /**
+   * Authoritative control-plane-resolved bindings for this build. When this
+   * option is defined, including as an empty array, the plugin performs no
+   * gather-time binding metadata query. Omit it to retain the generic SQL
+   * loader for callers that do not have a control-plane snapshot.
+   */
+  preloadedBindings?: readonly PreloadedFunctionBinding[];
 }

--- a/graphile/graphile-i18n/package.json
+++ b/graphile/graphile-i18n/package.json
@@ -29,6 +29,7 @@
     "url": "https://github.com/constructive-io/constructive/issues"
   },
   "dependencies": {
+    "@pgsql/quotes": "^18.1.0",
     "accept-language-parser": "^1.5.0"
   },
   "peerDependencies": {

--- a/graphile/graphile-i18n/src/__tests__/pg-query.test.ts
+++ b/graphile/graphile-i18n/src/__tests__/pg-query.test.ts
@@ -1,0 +1,33 @@
+import type { PgClient } from '@dataplan/pg';
+
+import { queryI18nRow } from '../pg-query';
+
+describe('queryI18nRow', () => {
+  it('passes one query configuration object to the @dataplan/pg client', async () => {
+    const query = jest.fn().mockResolvedValue({
+      rows: [{ lang_code: 'es', title: 'Hola' }],
+      rowCount: 1,
+      notices: [],
+    });
+    const client = { query } as unknown as Pick<PgClient, 'query'>;
+    const values = [1, ['es', 'en']];
+
+    await expect(queryI18nRow(client, 'SELECT $1, $2', values)).resolves.toEqual({
+      lang_code: 'es',
+      title: 'Hola',
+    });
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls[0]).toHaveLength(1);
+    expect(query).toHaveBeenCalledWith({
+      text: 'SELECT $1, $2',
+      values,
+    });
+  });
+
+  it('returns null when the translation query has no rows', async () => {
+    const query = jest.fn().mockResolvedValue({ rows: [], rowCount: 0, notices: [] });
+    const client = { query } as unknown as Pick<PgClient, 'query'>;
+
+    await expect(queryI18nRow(client, 'SELECT 1', [])).resolves.toBeNull();
+  });
+});

--- a/graphile/graphile-i18n/src/__tests__/plugin-isolation.test.ts
+++ b/graphile/graphile-i18n/src/__tests__/plugin-isolation.test.ts
@@ -1,0 +1,81 @@
+import {
+  assertI18nRequestContext,
+  resolveI18nTableInfo,
+} from '../plugin';
+
+function fixture(duplicateSameSchema = false) {
+  const idCodec = { name: 'tenant_id', sqlType: { kind: 'tenant_id' } };
+  const textCodec = { name: 'text', sqlType: { kind: 'text' } };
+  const baseCodec = {
+    name: 'posts',
+    attributes: {
+      id: { codec: idCodec },
+      title: { codec: textCodec },
+    },
+    extensions: {
+      pg: { serviceName: 'main', schemaName: 'tenant_a', name: 'posts' },
+      tags: { i18n: 'posts_translations' },
+    },
+  };
+  const translationCodec = (schemaName: string) => ({
+    name: `${schemaName}PostsTranslations`,
+    attributes: {
+      posts_id: { codec: idCodec },
+      lang_code: { codec: textCodec },
+      title: { codec: textCodec, notNull: true },
+    },
+    extensions: {
+      pg: { serviceName: 'main', schemaName, name: 'posts_translations' },
+    },
+  });
+  const tenantATranslation = translationCodec('tenant_a');
+  const resources: Record<string, any> = {
+    base: {
+      codec: baseCodec,
+      uniques: [{ isPrimary: true, attributes: ['id'] }],
+    },
+    tenantATranslation: { codec: tenantATranslation },
+    tenantBTranslation: { codec: translationCodec('tenant_b') },
+  };
+  if (duplicateSameSchema) {
+    resources.duplicateTenantATranslation = { codec: tenantATranslation };
+  }
+  const build = {
+    input: { pgRegistry: { pgResources: resources } },
+    inflection: { camelCase: (value: string) => value },
+    sql: {
+      compile: (value: unknown) => ({
+        text: value === idCodec.sqlType ? 'tenant_types.tenant_id' : 'text',
+        values: [] as unknown[],
+      }),
+    },
+  };
+  return { build, baseCodec };
+}
+
+describe('i18n exact-build isolation', () => {
+  it('resolves only the same-service, same-schema translation resource', () => {
+    const { build, baseCodec } = fixture();
+    expect(resolveI18nTableInfo(build, baseCodec as any, 'lang_code', ['text']))
+      .toMatchObject({
+        schemaName: 'tenant_a',
+        baseTable: 'posts',
+        translationTable: 'posts_translations',
+        pkType: 'tenant_types.tenant_id',
+      });
+  });
+
+  it('fails when the exact translation coordinate is ambiguous', () => {
+    const { build, baseCodec } = fixture(true);
+    expect(() => resolveI18nTableInfo(build, baseCodec as any, 'lang_code', ['text']))
+      .toThrow(/matches=2/);
+  });
+
+  it.each([
+    [undefined, {}, 1, 'I18N_PG_CLIENT_CONTEXT_UNAVAILABLE'],
+    [jest.fn(), null, 1, 'I18N_PG_SETTINGS_UNAVAILABLE'],
+    [jest.fn(), {}, undefined, 'I18N_PARENT_ID_UNAVAILABLE'],
+  ])('fails closed when request context is incomplete', (withPgClient, pgSettings, id, error) => {
+    expect(() => assertI18nRequestContext(withPgClient, pgSettings, id)).toThrow(error);
+  });
+});

--- a/graphile/graphile-i18n/src/pg-query.ts
+++ b/graphile/graphile-i18n/src/pg-query.ts
@@ -1,0 +1,10 @@
+import type { PgClient } from '@dataplan/pg';
+
+export async function queryI18nRow(
+  client: Pick<PgClient, 'query'>,
+  text: string,
+  values: any[]
+): Promise<Record<string, any> | null> {
+  const { rows } = await client.query<Record<string, any>>({ text, values });
+  return rows[0] ?? null;
+}

--- a/graphile/graphile-i18n/src/plugin.ts
+++ b/graphile/graphile-i18n/src/plugin.ts
@@ -20,11 +20,13 @@
 import 'graphile-build';
 import 'graphile-build-pg';
 
-import type { PgCodecWithAttributes } from '@dataplan/pg';
+import type { PgClient, PgCodecWithAttributes } from '@dataplan/pg';
 import { TYPES } from '@dataplan/pg';
+import { QuoteUtils } from '@pgsql/quotes';
 import { context as grafastContext, lambda, object } from 'grafast';
 import type { GraphileConfig } from 'graphile-config';
 
+import { queryI18nRow } from './pg-query';
 import type { I18nPluginOptions, I18nTableInfo, TranslatableField } from './types';
 
 // ─── Namespace Augmentations ─────────────────────────────────────────────────
@@ -47,20 +49,177 @@ function hasI18nTag(codec: PgCodecWithAttributes): string | false {
   return false;
 }
 
-function resolvePgTypeName(codec: any): string {
-  if (codec === TYPES.uuid) return 'uuid';
-  if (codec === TYPES.int) return 'int4';
-  if (codec === TYPES.bigint) return 'int8';
-  if (codec === TYPES.text) return 'text';
-  if (codec === TYPES.varchar) return 'text';
-  return codec?.name ?? 'text';
-}
-
 function resolveAttrPgType(codec: any): string {
   if (codec === TYPES.text) return 'text';
   if (codec === TYPES.varchar) return 'text';
   if (codec?.name === 'citext') return 'citext';
   return codec?.name ?? 'text';
+}
+
+function resourceIdentity(resource: any, label: string): {
+  serviceName: string;
+  schemaName: string;
+  name: string;
+} {
+  const pg = resource?.codec?.extensions?.pg ?? resource?.extensions?.pg;
+  if (!pg?.serviceName || !pg?.schemaName || !pg?.name) {
+    throw new Error(`[graphile-i18n] ${label} is missing exact service/schema/table metadata`);
+  }
+  return pg;
+}
+
+function compilePgType(build: any, codec: any, label: string): string {
+  if (!codec?.sqlType || typeof build?.sql?.compile !== 'function') {
+    throw new Error(`[graphile-i18n] ${label} has no compilable PostgreSQL type`);
+  }
+  const compiled = build.sql.compile(codec.sqlType);
+  if (!compiled?.text || (compiled.values?.length ?? 0) !== 0) {
+    throw new Error(`[graphile-i18n] ${label} PostgreSQL type did not compile to a static identifier`);
+  }
+  return compiled.text;
+}
+
+/** Resolve one @i18n tag exclusively against this exact build registry. */
+export function resolveI18nTableInfo(
+  build: any,
+  codec: PgCodecWithAttributes,
+  langCodeColumn: string,
+  allowedTypes: readonly string[]
+): I18nTableInfo | null {
+  const translationTableName = hasI18nTag(codec);
+  if (!translationTableName) return null;
+
+  const resources = Object.values(build.input?.pgRegistry?.pgResources ?? {}) as any[];
+  const baseMatches = resources.filter(
+    (resource) => !resource?.parameters && resource?.codec === codec
+  );
+  if (baseMatches.length !== 1) {
+    throw new Error(
+      `[graphile-i18n] @i18n codec '${codec.name}' must resolve exactly one base resource ` +
+      `(matches=${baseMatches.length})`
+    );
+  }
+  const baseResource = baseMatches[0];
+  const base = resourceIdentity(baseResource, 'base resource');
+
+  const primaryKeys = (baseResource.uniques as Array<{
+    attributes: string[];
+    isPrimary?: boolean;
+  }> | undefined)?.filter((unique) => unique.isPrimary) ?? [];
+  if (primaryKeys.length !== 1 || primaryKeys[0].attributes.length !== 1) {
+    throw new Error(
+      `[graphile-i18n] @i18n base '${base.schemaName}.${base.name}' requires one ` +
+      'single-column primary key'
+    );
+  }
+  const pkColumn = primaryKeys[0].attributes[0];
+  const pkAttr = codec.attributes?.[pkColumn] as any;
+  if (!pkAttr) {
+    throw new Error(
+      `[graphile-i18n] Primary key '${pkColumn}' is missing from ` +
+      `'${base.schemaName}.${base.name}'`
+    );
+  }
+  const pkType = compilePgType(build, pkAttr.codec, `${base.schemaName}.${base.name}.${pkColumn}`);
+
+  const translationMatches = resources.filter((resource) => {
+    if (resource?.parameters || !resource?.codec?.attributes) return false;
+    const pg = resource.codec.extensions?.pg ?? resource.extensions?.pg;
+    return pg?.serviceName === base.serviceName &&
+      pg?.schemaName === base.schemaName &&
+      pg?.name === translationTableName;
+  });
+  if (translationMatches.length !== 1) {
+    throw new Error(
+      `[graphile-i18n] @i18n on '${base.schemaName}.${base.name}' must resolve exactly ` +
+      `one same-service, same-schema '${translationTableName}' resource ` +
+      `(matches=${translationMatches.length})`
+    );
+  }
+
+  const translationResource = translationMatches[0];
+  const translation = resourceIdentity(translationResource, 'translation resource');
+  const translationCodec = translationResource.codec as PgCodecWithAttributes;
+  if (!translationCodec.attributes?.[langCodeColumn]) {
+    throw new Error(
+      `[graphile-i18n] Translation table '${translation.schemaName}.${translation.name}' ` +
+      `is missing language column '${langCodeColumn}'`
+    );
+  }
+
+  const conventionalFk = `${base.name}_id`;
+  const matchingFkColumns = Object.entries(translationCodec.attributes)
+    .filter(([attrName, attr]) =>
+      attrName !== 'id' &&
+      attrName !== langCodeColumn &&
+      (attr as any).codec === pkAttr.codec
+    )
+    .map(([attrName]) => attrName);
+  const fkColumn = matchingFkColumns.includes(conventionalFk)
+    ? conventionalFk
+    : matchingFkColumns.length === 1
+      ? matchingFkColumns[0]
+      : null;
+  if (!fkColumn) {
+    throw new Error(
+      `[graphile-i18n] Translation table '${translation.schemaName}.${translation.name}' ` +
+      `has ambiguous or missing FK metadata for '${base.schemaName}.${base.name}'`
+    );
+  }
+
+  const fields: Record<string, TranslatableField> = {};
+  for (const [attrName, attr] of Object.entries(translationCodec.attributes)) {
+    if (attrName === langCodeColumn || attrName === fkColumn) continue;
+    if (attrName === 'id' || attrName === 'created_at' || attrName === 'updated_at') continue;
+
+    const pgType = resolveAttrPgType((attr as any).codec);
+    if (!allowedTypes.includes(pgType)) continue;
+    if (!codec.attributes?.[attrName]) {
+      throw new Error(
+        `[graphile-i18n] Translation field '${translation.schemaName}.${translation.name}.` +
+        `${attrName}' has no matching base field on '${base.schemaName}.${base.name}'`
+      );
+    }
+
+    const gqlName = build.inflection.camelCase(attrName);
+    fields[gqlName] = {
+      column: attrName,
+      type: pgType,
+      isNotNull: !!(attr as any).notNull,
+    };
+  }
+  if (Object.keys(fields).length === 0) {
+    throw new Error(
+      `[graphile-i18n] Translation table '${translation.schemaName}.${translation.name}' ` +
+      'has no eligible translatable fields'
+    );
+  }
+
+  return {
+    baseTable: base.name,
+    translationTable: translation.name,
+    schemaName: base.schemaName,
+    fkColumn,
+    pkColumn,
+    pkType,
+    fields,
+  };
+}
+
+export function assertI18nRequestContext(
+  withPgClient: unknown,
+  pgSettings: unknown,
+  id: unknown
+): void {
+  if (typeof withPgClient !== 'function') {
+    throw new Error('I18N_PG_CLIENT_CONTEXT_UNAVAILABLE');
+  }
+  if (typeof pgSettings !== 'object' || pgSettings === null || Array.isArray(pgSettings)) {
+    throw new Error('I18N_PG_SETTINGS_UNAVAILABLE');
+  }
+  if (id === null || id === undefined) {
+    throw new Error('I18N_PARENT_ID_UNAVAILABLE');
+  }
 }
 
 // ─── Plugin Factory ──────────────────────────────────────────────────────────
@@ -74,8 +233,8 @@ export function createI18nPlugin(options: I18nPluginOptions = {}): GraphileConfi
   } = options;
 
   // Closure-scoped state shared between init and field hooks
-  let i18nRegistry: Record<string, I18nTableInfo> = {};
-  const localeTypeCache: Record<string, any> = {};
+  let i18nRegistry = new WeakMap<object, I18nTableInfo>();
+  let localeTypeCache: Record<string, any> = {};
 
   return {
     name: 'I18nPlugin',
@@ -85,119 +244,16 @@ export function createI18nPlugin(options: I18nPluginOptions = {}): GraphileConfi
       hooks: {
         init: {
           callback(_, build) {
-            i18nRegistry = {};
+            i18nRegistry = new WeakMap<object, I18nTableInfo>();
+            localeTypeCache = {};
 
             for (const [, codec] of Object.entries(build.input.pgRegistry.pgCodecs)) {
               const c = codec as PgCodecWithAttributes;
               if (!c.attributes) continue;
 
-              const translationTableName = hasI18nTag(c);
-              if (!translationTableName) continue;
-
-              // Get schema name from the codec's pg extensions
-              let schemaName = (c.extensions as any)?.pg?.schemaName ?? 'public';
-              let pkColumn: string | null = null;
-              let pkType = 'text';
-              for (const [, resource] of Object.entries(build.input.pgRegistry.pgResources)) {
-                const r = resource as any;
-                if (r.codec === c) {
-                  // Try multiple sources for schema name
-                  const rSchema = r.extensions?.pg?.schemaName ?? r.schemaName;
-                  if (rSchema) schemaName = rSchema;
-                  // Extract PK from the resource's uniques array
-                  const uniques = r.uniques as Array<{ attributes: string[]; isPrimary?: boolean }> | undefined;
-                  if (uniques) {
-                    const pk = uniques.find((u: any) => u.isPrimary);
-                    if (pk && pk.attributes.length === 1) {
-                      pkColumn = pk.attributes[0];
-                      const pkAttr = c.attributes[pkColumn];
-                      if (pkAttr) {
-                        pkType = resolvePgTypeName((pkAttr as any).codec);
-                      }
-                    }
-                  }
-                  break;
-                }
-              }
-              if (!pkColumn) continue;
-
-              // Find the translation codec. The @i18n tag value is the SQL table name
-              // (e.g. 'posts_translations'), but PostGraphile inflects codec names
-              // to camelCase (e.g. 'postsTranslations'). Match via resource name.
-              let translationCodec: PgCodecWithAttributes | null = null;
-              for (const [, resource] of Object.entries(build.input.pgRegistry.pgResources)) {
-                const r = resource as any;
-                if (!r.codec?.attributes) continue;
-                // Match by the resource's SQL name (which preserves snake_case)
-                const sqlName = r.codec?.extensions?.pg?.name ?? r.name;
-                if (sqlName === translationTableName) {
-                  translationCodec = r.codec as PgCodecWithAttributes;
-                  break;
-                }
-              }
-              // Fallback: try matching the inflected codec name directly
-              if (!translationCodec) {
-                const inflectedName = build.inflection.camelCase(translationTableName);
-                for (const [, tCodec] of Object.entries(build.input.pgRegistry.pgCodecs)) {
-                  const tc = tCodec as any;
-                  if (!tc.attributes) continue;
-                  if (tc.name === translationTableName || tc.name === inflectedName) {
-                    translationCodec = tc;
-                    break;
-                  }
-                }
-              }
-
-              if (!translationCodec) continue;
-
-              // Find FK column on translation table — convention first, then type match
-              let fkColumn: string | null = null;
-              const conventionalFk = `${c.name}_id`;
-              if (translationCodec.attributes[conventionalFk]) {
-                fkColumn = conventionalFk;
-              }
-              if (!fkColumn) {
-                // Fallback: find a column with the same type as the PK, excluding
-                // common non-FK columns (id, lang_code)
-                for (const [attrName, attr] of Object.entries(translationCodec.attributes)) {
-                  if (attrName === 'id' || attrName === langCodeColumn) continue;
-                  const a = attr as any;
-                  if (a.codec === (c.attributes[pkColumn] as any).codec) {
-                    fkColumn = attrName;
-                    break;
-                  }
-                }
-              }
-              if (!fkColumn) continue;
-
-              // Discover translatable fields
-              const fields: Record<string, TranslatableField> = {};
-              for (const [attrName, attr] of Object.entries(translationCodec.attributes)) {
-                if (attrName === langCodeColumn || attrName === fkColumn) continue;
-                if (attrName === 'id' || attrName === 'created_at' || attrName === 'updated_at') continue;
-
-                const pgType = resolveAttrPgType((attr as any).codec);
-                if (!allowedTypes.includes(pgType)) continue;
-
-                const gqlName = build.inflection.camelCase(attrName);
-                fields[gqlName] = {
-                  column: attrName,
-                  type: pgType,
-                  isNotNull: !!(attr as any).notNull,
-                };
-              }
-
-              if (Object.keys(fields).length === 0) continue;
-
-              i18nRegistry[c.name] = {
-                baseTable: c.name,
-                translationTable: translationTableName,
-                schemaName,
-                fkColumn,
-                pkColumn,
-                pkType,
-                fields,
-              };
+              if (!hasI18nTag(c)) continue;
+              const info = resolveI18nTableInfo(build, c, langCodeColumn, allowedTypes);
+              if (info) i18nRegistry.set(c, info);
             }
 
             return _;
@@ -211,7 +267,7 @@ export function createI18nPlugin(options: I18nPluginOptions = {}): GraphileConfi
           if (!scope.pgCodec || !scope.isPgClassType) return fields;
 
           const codec = scope.pgCodec as PgCodecWithAttributes;
-          const info = i18nRegistry[codec.name];
+          const info = i18nRegistry.get(codec);
           if (!info) return fields;
 
           const localeFieldsConfig: Record<string, any> = {
@@ -235,18 +291,22 @@ export function createI18nPlugin(options: I18nPluginOptions = {}): GraphileConfi
 
           const { schemaName, baseTable, translationTable, fkColumn, pkColumn, pkType, fields: i18nFields } = info;
 
+          const qi = (name: string): string => QuoteUtils.quoteIdentifier(name);
           const coalescedCols = Object.values(i18nFields)
-            .map(f => `coalesce(v."${f.column}", b."${f.column}") as "${f.column}"`)
+            .map(f => `coalesce(v.${qi(f.column)}, b.${qi(f.column)}) as ${qi(f.column)}`)
             .join(', ');
 
+          const baseTableRef = QuoteUtils.quoteQualifiedIdentifier(schemaName, baseTable);
+          const translationTableRef = QuoteUtils.quoteQualifiedIdentifier(schemaName, translationTable);
+
           // Build the SQL query template
-          const sqlQuery = `SELECT v."${langCodeColumn}" AS "lang_code", ${coalescedCols}
-             FROM "${schemaName}"."${baseTable}" b
-             LEFT JOIN "${schemaName}"."${translationTable}" v
-               ON v."${fkColumn}" = b."${pkColumn}"
-               AND array_position($2::text[], v."${langCodeColumn}") IS NOT NULL
-             WHERE b."${pkColumn}" = $1::${pkType}
-             ORDER BY array_position($2::text[], v."${langCodeColumn}") ASC NULLS LAST
+          const sqlQuery = `SELECT v.${qi(langCodeColumn)} AS "lang_code", ${coalescedCols}
+             FROM ${baseTableRef} b
+             LEFT JOIN ${translationTableRef} v
+               ON v.${qi(fkColumn)} = b.${qi(pkColumn)}
+               AND array_position($2::text[], v.${qi(langCodeColumn)}) IS NOT NULL
+             WHERE b.${qi(pkColumn)} = $1::${pkType}
+             ORDER BY array_position($2::text[], v.${qi(langCodeColumn)}) ASC NULLS LAST
              LIMIT 1`;
 
           // Build column names list for mapping base values
@@ -266,31 +326,26 @@ export function createI18nPlugin(options: I18nPluginOptions = {}): GraphileConfi
                   $baseCols[column] = $parent.get(column);
                 }
                 const $withPgClient = (grafastContext() as any).get('withPgClient');
+                const $pgSettings = (grafastContext() as any).get('pgSettings');
                 const $langCodes = (grafastContext() as any).get('langCodes');
 
                 // Combine all inputs into a single step
                 const $input = object({
                   id: $id,
                   withPgClient: $withPgClient,
+                  pgSettings: $pgSettings,
                   langCodes: $langCodes,
                   ...$baseCols,
                 });
 
                 return lambda($input, async (input: any) => {
-                  const { id, withPgClient, langCodes: ctxLangCodes, ...baseCols } = input;
+                  const { id, withPgClient, pgSettings, langCodes: ctxLangCodes, ...baseCols } = input;
                   const langs: string[] = ctxLangCodes ?? defaultLanguages;
 
-                  if (!withPgClient || !id) {
-                    const result: Record<string, any> = { [langCodeGqlField]: null };
-                    for (const { gqlName, column } of baseColNames) {
-                      result[gqlName] = baseCols[column] ?? null;
-                    }
-                    return result;
-                  }
+                  assertI18nRequestContext(withPgClient, pgSettings, id);
 
-                  const row = await withPgClient(null, async (client: any) => {
-                    const { rows } = await client.query(sqlQuery, [id, langs]);
-                    return rows[0] ?? null;
+                  const row = await withPgClient(pgSettings, async (client: PgClient) => {
+                    return queryI18nRow(client, sqlQuery, [id, langs]);
                   });
 
                   if (!row) {

--- a/graphile/graphile-llm/package.json
+++ b/graphile/graphile-llm/package.json
@@ -32,6 +32,7 @@
     "@agentic-kit/ollama": "workspace:*",
     "@constructive-io/express-context": "workspace:^",
     "@constructive-io/llm-env": "workspace:^",
+    "@pgsql/quotes": "^18.1.0",
     "graphile-cache": "workspace:^"
   },
   "peerDependencies": {

--- a/graphile/graphile-llm/src/__tests__/agent-discovery.test.ts
+++ b/graphile/graphile-llm/src/__tests__/agent-discovery.test.ts
@@ -1,0 +1,67 @@
+import { clearAgentDiscoveryCache, getAgentDiscovery } from '../plugins/agent-discovery-plugin';
+
+const TENANT_A = '11111111-1111-1111-1111-111111111111';
+const TENANT_B = '22222222-2222-2222-2222-222222222222';
+
+function makePool(schemaPrefix = 'tenant') {
+  const calls: Array<{ text: string; values?: unknown[] }> = [];
+  const rows: Record<string, any> = {
+    [TENANT_A]: {
+      schema_name: `${schemaPrefix}_a_agent`,
+      thread_table_name: 'agent_thread',
+      message_table_name: 'agent_message',
+      task_table_name: 'agent_task'
+    },
+    [TENANT_B]: {
+      schema_name: `${schemaPrefix}_b_agent`,
+      thread_table_name: 'agent_thread',
+      message_table_name: 'agent_message',
+      task_table_name: 'agent_task'
+    }
+  };
+  return {
+    calls,
+    query: async (text: string, values?: unknown[]) => {
+      calls.push({ text, values });
+      const row = rows[String(values?.[0])];
+      return { rows: row ? [row] : [] };
+    }
+  };
+}
+
+describe('agent discovery tenant isolation', () => {
+  beforeEach(() => clearAgentDiscoveryCache());
+
+  it('filters and caches discovery by database id', async () => {
+    const pool = makePool();
+    const a = await getAgentDiscovery(pool as any, TENANT_A);
+    const cachedA = await getAgentDiscovery(pool as any, TENANT_A);
+    const b = await getAgentDiscovery(pool as any, TENANT_B);
+
+    expect(pool.calls).toHaveLength(2);
+    expect(pool.calls[0].text).toContain('WHERE acm.database_id = $1');
+    expect(pool.calls.map((call) => call.values)).toEqual([[TENANT_A], [TENANT_B]]);
+    expect(a).toEqual(cachedA);
+    expect(a?.thread?.schemaName).toBe('tenant_a_agent');
+    expect(b?.thread?.schemaName).toBe('tenant_b_agent');
+  });
+
+  it('fails closed when database id is absent', async () => {
+    const pool = makePool();
+    await expect(getAgentDiscovery(pool as any, '')).rejects.toThrow(/databaseId is required/);
+    expect(pool.calls).toHaveLength(0);
+  });
+
+  it('does not share discovery across different physical pool identities', async () => {
+    const poolA = makePool('physical_a');
+    const poolB = makePool('physical_b');
+
+    const a = await getAgentDiscovery(poolA as any, TENANT_A);
+    const b = await getAgentDiscovery(poolB as any, TENANT_A);
+
+    expect(a?.thread?.schemaName).toBe('physical_a_a_agent');
+    expect(b?.thread?.schemaName).toBe('physical_b_a_agent');
+    expect(poolA.calls).toHaveLength(1);
+    expect(poolB.calls).toHaveLength(1);
+  });
+});

--- a/graphile/graphile-llm/src/__tests__/config-cache-isolation.test.ts
+++ b/graphile/graphile-llm/src/__tests__/config-cache-isolation.test.ts
@@ -1,0 +1,66 @@
+import {
+  getLlmBillingConfig,
+  invalidateLlmBillingConfig,
+} from '../config-cache';
+
+function makeClient(privateSchema: string) {
+  const query = jest.fn(async (text: string) => {
+    if (text.includes('information_schema.schemata')) return { rows: [{ exists: 1 }] };
+    if (text.includes('billing_module')) {
+      return {
+        rows: [{
+          public_schema: `${privateSchema}_public`,
+          private_schema: privateSchema,
+          record_usage_function: 'record_usage',
+        }],
+      };
+    }
+    if (text.includes('inference_log_module')) {
+      return { rows: [{ schema: privateSchema, table_name: 'usage_log_inference' }] };
+    }
+    throw new Error('unexpected SQL');
+  });
+  return { query };
+}
+
+describe('LLM config cache isolation', () => {
+  beforeEach(() => invalidateLlmBillingConfig());
+
+  it('keys the same database UUID by opaque exact-build identity', async () => {
+    const databaseId = '11111111-1111-1111-1111-111111111111';
+    const buildA = {};
+    const buildB = {};
+    const clientA = makeClient('tenant_a_private');
+    const clientB = makeClient('tenant_b_private');
+
+    const firstA = await getLlmBillingConfig(clientA, databaseId, buildA);
+    const cachedA = await getLlmBillingConfig(clientA, databaseId, buildA);
+    const firstB = await getLlmBillingConfig(clientB, databaseId, buildB);
+
+    expect(firstA).toBe(cachedA);
+    expect(firstA.billing?.privateSchema).toBe('tenant_a_private');
+    expect(firstB.billing?.privateSchema).toBe('tenant_b_private');
+    expect(clientA.query).toHaveBeenCalledTimes(4);
+    expect(clientB.query).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not cache or downgrade incomplete configuration', async () => {
+    const client = {
+      query: jest.fn(async (text: string) => {
+        if (text.includes('information_schema.schemata')) return { rows: [{ exists: 1 }] };
+        if (text.includes('billing_module')) {
+          return { rows: [{ private_schema: 'tenant_private' }] };
+        }
+        return { rows: [] };
+      }),
+    };
+
+    await expect(getLlmBillingConfig(client, 'database-a', {}))
+      .rejects.toThrow('LLM_BILLING_CONFIG_INCOMPLETE');
+  });
+
+  it('requires an explicit exact-build cache scope', async () => {
+    await expect(getLlmBillingConfig(makeClient('tenant_private'), 'database-a', null as any))
+      .rejects.toThrow('LLM_CONFIG_CACHE_SCOPE_UNAVAILABLE');
+  });
+});

--- a/graphile/graphile-llm/src/__tests__/rag-sql.test.ts
+++ b/graphile/graphile-llm/src/__tests__/rag-sql.test.ts
@@ -1,0 +1,103 @@
+import { buildChunkSearchSql, discoverChunkTables } from '../plugins/rag-plugin';
+import type { ChunkTableInfo } from '../types';
+
+const chunkTable = (overrides: Partial<ChunkTableInfo> = {}): ChunkTableInfo => ({
+  parentCodecName: 'articles',
+  chunksSchema: 'tenant-a-app-public',
+  vectorSchema: 'tenant-a-extensions',
+  chunksTableName: 'article_chunks',
+  parentFkField: 'article_id',
+  parentPkField: 'id',
+  embeddingField: 'embedding',
+  contentField: 'content',
+  ...overrides
+});
+
+describe('RAG SQL qualification', () => {
+  it('quotes tenant schemas and keeps parameter values separate', () => {
+    const query = buildChunkSearchSql(chunkTable(), '[1,0]', 7, 0.4);
+    expect(query.text).toContain('FROM "tenant-a-app-public".article_chunks');
+    expect(query.text).toContain('$1::"tenant-a-extensions".vector');
+    expect(query.text).toContain('OPERATOR("tenant-a-extensions".<=>)');
+    expect(query.values).toEqual(['[1,0]', 0.4, 7]);
+  });
+
+  it('discovers the exact physical chunks resource and vector type schema', () => {
+    const vectorCodec = {
+      name: 'vector',
+      extensions: {
+        pg: { serviceName: 'main', schemaName: 'tenant-a-extensions', name: 'vector' }
+      }
+    };
+    const chunkCodec = {
+      name: 'articleChunks',
+      attributes: {
+        article_id: {},
+        content: {},
+        embedding: { codec: vectorCodec }
+      },
+      extensions: {
+        pg: {
+          serviceName: 'main',
+          schemaName: 'tenant-a-app-public',
+          name: 'article_chunks'
+        }
+      }
+    };
+    const tables = discoverChunkTables({
+      input: {
+        pgRegistry: {
+          pgCodecs: {
+            articles: {
+              name: 'articles',
+              attributes: { id: {} },
+              extensions: {
+                pg: {
+                  serviceName: 'main',
+                  schemaName: 'tenant-a-app-public',
+                  name: 'articles'
+                },
+                tags: {
+                  hasChunks: {
+                    chunksTable: 'article_chunks',
+                    parentFk: 'article_id'
+                  }
+                }
+              }
+            }
+          },
+          pgResources: { articleChunks: { codec: chunkCodec } }
+        }
+      },
+      resolvedPreset: {
+        pgServices: [{ name: 'main', schemas: ['tenant-a-app-public'] }]
+      }
+    });
+    expect(tables).toHaveLength(1);
+    expect(tables[0].chunksSchema).toBe('tenant-a-app-public');
+    expect(tables[0].vectorSchema).toBe('tenant-a-extensions');
+  });
+
+  it('rejects a chunks schema outside the exact service allowlist', () => {
+    expect(() => discoverChunkTables({
+      input: {
+        pgRegistry: {
+          pgCodecs: {
+            articles: {
+              name: 'articles',
+              attributes: { id: {} },
+              extensions: {
+                pg: { serviceName: 'main', schemaName: 'tenant_a', name: 'articles' },
+                tags: {
+                  hasChunks: { chunksSchema: 'tenant_b', chunksTable: 'article_chunks' }
+                }
+              }
+            }
+          },
+          pgResources: {}
+        }
+      },
+      resolvedPreset: { pgServices: [{ name: 'main', schemas: ['tenant_a'] }] }
+    })).toThrow(/outside service 'main'/);
+  });
+});

--- a/graphile/graphile-llm/src/config-cache.ts
+++ b/graphile/graphile-llm/src/config-cache.ts
@@ -1,7 +1,7 @@
 /**
  * config-cache — Per-database LLM billing configuration cache
  *
- * Caches resolved billing function names per database_id.
+ * Caches resolved billing function names per exact Graphile build and database_id.
  * Uses an LRU cache with TTL so config changes propagate within a bounded window
  * without requiring a server restart.
  *
@@ -103,6 +103,21 @@ const billingCache = new ModuleConfigCache<LlmBillingCacheEntry>({
   max: 50
 });
 
+const billingScopeIds = new WeakMap<object, number>();
+let nextBillingScopeId = 1;
+
+function scopedCacheKey(cacheScope: object, databaseId: string): string {
+  if ((typeof cacheScope !== 'object' && typeof cacheScope !== 'function') || cacheScope === null) {
+    throw new Error('LLM_CONFIG_CACHE_SCOPE_UNAVAILABLE');
+  }
+  let scopeId = billingScopeIds.get(cacheScope);
+  if (scopeId === undefined) {
+    scopeId = nextBillingScopeId++;
+    billingScopeIds.set(cacheScope, scopeId);
+  }
+  return `${scopeId}\0${databaseId}`;
+}
+
 // ─── Resolution Functions ───────────────────────────────────────────────────
 
 /**
@@ -117,49 +132,46 @@ async function resolveInferenceLogConfig(
   pgClient: PgClient,
   databaseId: string
 ): Promise<InferenceLogConfig | null> {
-  try {
-    const schemaCheck = await pgClient.query(SCHEMA_EXISTS_SQL, ['metaschema_modules_public']);
-    if (schemaCheck.rows.length === 0) return null;
+  const schemaCheck = await pgClient.query(SCHEMA_EXISTS_SQL, ['metaschema_modules_public']);
+  if (schemaCheck.rows.length === 0) return null;
 
-    const result = await pgClient.query(INFERENCE_LOG_MODULE_SQL, [databaseId]);
-    const row = result.rows[0];
-    if (!row?.schema || !row?.table_name) return null;
-
-    return {
-      schema: row.schema as string,
-      tableName: row.table_name as string
-    };
-  } catch {
-    return null;
+  const result = await pgClient.query(INFERENCE_LOG_MODULE_SQL, [databaseId]);
+  const row = result.rows[0];
+  if (!row) return null;
+  if (!row.schema || !row.table_name) {
+    throw new Error('LLM_INFERENCE_LOG_CONFIG_INCOMPLETE');
   }
+
+  return {
+    schema: row.schema as string,
+    tableName: row.table_name as string
+  };
 }
 
 async function resolveBillingConfig(
   pgClient: PgClient,
   databaseId: string
 ): Promise<BillingConfig | null> {
-  try {
-    // Guard: check if the metaschema_modules_public schema exists.
-    // If the database doesn't have the billing module provisioned,
-    // this schema (or the billing_module table) won't exist.
-    const schemaCheck = await pgClient.query(SCHEMA_EXISTS_SQL, ['metaschema_modules_public']);
-    if (schemaCheck.rows.length === 0) return null;
+  // Guard: check if the metaschema_modules_public schema exists.
+  // If the database doesn't have the billing module provisioned,
+  // this schema (or the billing_module table) won't exist.
+  const schemaCheck = await pgClient.query(SCHEMA_EXISTS_SQL, ['metaschema_modules_public']);
+  if (schemaCheck.rows.length === 0) return null;
 
-    const result = await pgClient.query(BILLING_MODULE_SQL, [databaseId]);
-    const row = result.rows[0];
-    if (!row?.record_usage_function) return null;
-
-    return {
-      publicSchema: row.public_schema as string,
-      privateSchema: row.private_schema as string,
-      recordUsageFunction: row.record_usage_function as string,
-      // The check_billing_quota function name follows the inflection pattern
-      checkBillingQuotaFunction: 'check_billing_quota'
-    };
-  } catch {
-    // Schema/table doesn't exist or query failed — billing not available
-    return null;
+  const result = await pgClient.query(BILLING_MODULE_SQL, [databaseId]);
+  const row = result.rows[0];
+  if (!row) return null;
+  if (!row.public_schema || !row.private_schema || !row.record_usage_function) {
+    throw new Error('LLM_BILLING_CONFIG_INCOMPLETE');
   }
+
+  return {
+    publicSchema: row.public_schema as string,
+    privateSchema: row.private_schema as string,
+    recordUsageFunction: row.record_usage_function as string,
+    // The check_billing_quota function name follows the inflection pattern
+    checkBillingQuotaFunction: 'check_billing_quota'
+  };
 }
 
 // ─── Public API ─────────────────────────────────────────────────────────────
@@ -170,12 +182,16 @@ async function resolveBillingConfig(
  *
  * @param pgClient - A client connected to the tenant database (from withPgClient)
  * @param databaseId - The database UUID
+ * @param cacheScope - Opaque identity of the exact Graphile build/pool contract
  */
 export async function getLlmBillingConfig(
   pgClient: PgClient,
-  databaseId: string
+  databaseId: string,
+  cacheScope: object
 ): Promise<LlmBillingCacheEntry> {
-  const cached = billingCache.get(databaseId);
+  if (!databaseId) throw new Error('LLM_DATABASE_ID_UNAVAILABLE');
+  const cacheKey = scopedCacheKey(cacheScope, databaseId);
+  const cached = billingCache.get(cacheKey);
   if (cached) return cached;
 
   const [billing, inferenceLog] = await Promise.all([
@@ -184,19 +200,21 @@ export async function getLlmBillingConfig(
   ]);
 
   const entry: LlmBillingCacheEntry = { billing, inferenceLog };
-  billingCache.set(databaseId, entry);
+  billingCache.set(cacheKey, entry);
   return entry;
 }
 
 /**
  * Invalidate the cached config for a specific database (or all).
  */
-export function invalidateLlmBillingConfig(databaseId?: string): void {
-  if (databaseId) {
-    billingCache.delete(databaseId);
-  } else {
-    billingCache.clear();
+export function invalidateLlmBillingConfig(databaseId?: string, cacheScope?: object): void {
+  if (databaseId && cacheScope) {
+    billingCache.delete(scopedCacheKey(cacheScope, databaseId));
+    return;
   }
+  // A database UUID alone is not a safe cache identity. Conservatively clear
+  // every exact-build entry when the caller cannot provide the matching scope.
+  billingCache.clear();
 }
 
 /**

--- a/graphile/graphile-llm/src/plugins/agent-discovery-plugin.ts
+++ b/graphile/graphile-llm/src/plugins/agent-discovery-plugin.ts
@@ -34,14 +34,23 @@ export interface AgentDiscovery {
 
 // ─── Cache ──────────────────────────────────────────────────────────────────
 
-const agentDiscoveryCache = new ModuleConfigCache<AgentDiscovery | null>({
-  name: 'agent-discovery',
-  ttlMs: 60_000
-});
+let agentDiscoveryCaches = new WeakMap<object, ModuleConfigCache<AgentDiscovery | null>>();
+
+function cacheForPool(pool: object): ModuleConfigCache<AgentDiscovery | null> {
+  let cache = agentDiscoveryCaches.get(pool);
+  if (!cache) {
+    cache = new ModuleConfigCache<AgentDiscovery | null>({
+      name: 'agent-discovery',
+      ttlMs: 60_000
+    });
+    agentDiscoveryCaches.set(pool, cache);
+  }
+  return cache;
+}
 
 /** Clear all cached discovery results (for testing) */
 export function clearAgentDiscoveryCache(): void {
-  agentDiscoveryCache.clear();
+  agentDiscoveryCaches = new WeakMap<object, ModuleConfigCache<AgentDiscovery | null>>();
 }
 
 // ─── Discovery Query ────────────────────────────────────────────────────────
@@ -53,7 +62,9 @@ const DISCOVERY_SQL = `
     acm.message_table_name,
     acm.task_table_name
   FROM metaschema_modules_public.agent_chat_module acm
-  JOIN metaschema_public.schema s ON s.id = acm.schema_id
+  JOIN metaschema_public.schema s
+    ON s.id = acm.schema_id
+   AND s.database_id = acm.database_id
   WHERE acm.database_id = $1
   LIMIT 1
 `;
@@ -83,6 +94,7 @@ export async function getAgentDiscovery(
     throw new Error('getAgentDiscovery: databaseId is required');
   }
 
+  const agentDiscoveryCache = cacheForPool(pool);
   const cached = agentDiscoveryCache.get(databaseId);
   if (cached !== undefined) {
     return cached;

--- a/graphile/graphile-llm/src/plugins/metering-plugin.ts
+++ b/graphile/graphile-llm/src/plugins/metering-plugin.ts
@@ -26,7 +26,7 @@
  * **Graceful behavior:**
  * - billing_module not provisioned → embedder passes through unmetered
  * - entity_id not available → embedder passes through unmetered
- * - check_billing_quota throws → call is allowed (billing is opt-in)
+ * - check_billing_quota fails after billing is configured → call is denied
  * - record_usage throws → call succeeds, recording silently skipped
  * - quota exceeded → embedder returns null
  */
@@ -63,7 +63,8 @@ function defaultResolveEntityId(pgSettings: Record<string, string>): string | nu
 
 async function buildMeteringContext(
   graphqlContext: any,
-  resolveEntityId: (pgSettings: Record<string, string>) => string | null
+  resolveEntityId: (pgSettings: Record<string, string>) => string | null,
+  cacheScope: object
 ): Promise<MeteringContext | null> {
   const pgSettings: Record<string, string> = graphqlContext?.pgSettings ?? {};
   const entityId = resolveEntityId(pgSettings);
@@ -73,19 +74,15 @@ async function buildMeteringContext(
   if (!entityId || !databaseId) return null;
 
   const withPgClient: WithPgClient | undefined = graphqlContext?.withPgClient;
-  if (!withPgClient) return null;
+  if (!withPgClient) throw new Error('LLM_METERING_PG_CONTEXT_UNAVAILABLE');
 
   let billingConfig = null;
   let inferenceLogConfig = null;
-  try {
-    await withPgClient(pgSettings, async (pgClient: PgClient) => {
-      const entry = await getLlmBillingConfig(pgClient, databaseId);
-      billingConfig = entry.billing;
-      inferenceLogConfig = entry.inferenceLog;
-    });
-  } catch {
-    return null;
-  }
+  await withPgClient(pgSettings, async (pgClient: PgClient) => {
+    const entry = await getLlmBillingConfig(pgClient, databaseId, cacheScope);
+    billingConfig = entry.billing;
+    inferenceLogConfig = entry.inferenceLog;
+  });
 
   if (!billingConfig) return null;
 
@@ -210,12 +207,17 @@ export function createLlmMeteringPlugin(
 
           const defaultResolver = (obj: any) => obj[(context as any).scope.fieldName];
           const { resolve: oldResolve = defaultResolver, ...rest } = field;
+          const exactBuildCacheScope = build as object;
 
           return {
             ...rest,
             async resolve(source: any, args: any, graphqlContext: any, info: any) {
               // Build the metering context for this request
-              const ctx = await buildMeteringContext(graphqlContext, resolveEntityId);
+              const ctx = await buildMeteringContext(
+                graphqlContext,
+                resolveEntityId,
+                exactBuildCacheScope
+              );
 
               // Run the original resolver within the AsyncLocalStorage scope
               // so any embedder calls made by downstream plugins pick up the ctx

--- a/graphile/graphile-llm/src/plugins/rag-plugin.ts
+++ b/graphile/graphile-llm/src/plugins/rag-plugin.ts
@@ -20,6 +20,7 @@
  *   2. Falls back to error if not configured
  */
 
+import { QuoteUtils } from '@pgsql/quotes';
 import { context as grafastContext, lambda, object } from 'grafast';
 import type { GraphileConfig } from 'graphile-config';
 import { extendSchema, gql } from 'graphile-utils';
@@ -76,6 +77,7 @@ function parseHasChunksTag(raw: any, codec: any): ChunkTableInfo | null {
   return {
     parentCodecName: codec.name || 'unknown',
     chunksSchema,
+    vectorSchema: '',
     chunksTableName: parsed.chunksTable,
     parentFkField: parsed.parentFk || 'parent_id',
     parentPkField: parsed.parentPk || 'id',
@@ -84,10 +86,60 @@ function parseHasChunksTag(raw: any, codec: any): ChunkTableInfo | null {
   };
 }
 
+function requirePgIdentity(value: any, label: string): {
+  serviceName: string;
+  schemaName: string;
+  name: string;
+} {
+  const pg = value?.extensions?.pg;
+  if (!pg?.serviceName || !pg?.schemaName || !pg?.name) {
+    throw new Error(`[graphile-llm] ${label} is missing exact service/schema/table metadata`);
+  }
+  return pg;
+}
+
+function configuredSchemas(build: any, serviceName: string): ReadonlySet<string> | null {
+  const services = build?.resolvedPreset?.pgServices;
+  if (!Array.isArray(services)) return null;
+  const matches = services.filter(
+    (service: any) => (service?.name ?? 'main') === serviceName
+  );
+  if (matches.length !== 1) {
+    throw new Error(
+      `[graphile-llm] @hasChunks cannot resolve exact service '${serviceName}' ` +
+      `(matches=${matches.length})`
+    );
+  }
+  const service = matches[0];
+  const schemas = service?.schemas;
+  if (!Array.isArray(schemas) || schemas.length === 0) {
+    throw new Error(
+      `[graphile-llm] @hasChunks service '${serviceName}' has no configured schema allowlist`
+    );
+  }
+  const dependencySchemas = service?.introspectionAllowedDependencySchemas;
+  if (dependencySchemas !== undefined && !Array.isArray(dependencySchemas)) {
+    throw new Error(
+      `[graphile-llm] @hasChunks service '${serviceName}' has an invalid dependency schema allowlist`
+    );
+  }
+  return new Set([...schemas, ...(dependencySchemas ?? [])]);
+}
+
+function requireField(codec: any, fieldName: string, label: string, table: string): any {
+  const field = codec?.attributes?.[fieldName];
+  if (!field) {
+    throw new Error(
+      `[graphile-llm] @hasChunks ${label} '${fieldName}' does not exist on '${table}'`
+    );
+  }
+  return field;
+}
+
 /**
  * Discover all chunk-aware tables from the pgRegistry.
  */
-function discoverChunkTables(build: any): ChunkTableInfo[] {
+export function discoverChunkTables(build: any): ChunkTableInfo[] {
   const chunkTables: ChunkTableInfo[] = [];
   const pgRegistry = build.input?.pgRegistry ?? build.pgRegistry;
   if (!pgRegistry) return chunkTables;
@@ -101,9 +153,67 @@ function discoverChunkTables(build: any): ChunkTableInfo[] {
     if (!tags?.hasChunks) continue;
 
     const info = parseHasChunksTag(tags.hasChunks, c);
-    if (info) {
-      chunkTables.push(info);
+    if (!info) {
+      throw new Error(`[graphile-llm] @hasChunks on '${c.name}' must be a valid JSON object`);
     }
+
+    const parent = requirePgIdentity(c, 'parent codec');
+    if (!info.chunksSchema) {
+      throw new Error(`[graphile-llm] @hasChunks on '${parent.name}' has no chunks schema`);
+    }
+    const allowedSchemas = configuredSchemas(build, parent.serviceName);
+    if (allowedSchemas && !allowedSchemas.has(info.chunksSchema)) {
+      throw new Error(
+        `[graphile-llm] @hasChunks on '${parent.schemaName}.${parent.name}' references ` +
+        `schema '${info.chunksSchema}' outside service '${parent.serviceName}'`
+      );
+    }
+
+    const matches = Object.values(pgRegistry.pgResources ?? {}).filter((resource: any) => {
+      if (resource?.parameters || !resource?.codec?.attributes) return false;
+      const pg = resource.codec.extensions?.pg;
+      return pg?.serviceName === parent.serviceName &&
+        pg?.schemaName === info.chunksSchema &&
+        pg?.name === info.chunksTableName;
+    }) as any[];
+    if (matches.length !== 1) {
+      throw new Error(
+        `[graphile-llm] @hasChunks on '${parent.schemaName}.${parent.name}' must resolve ` +
+        `exactly one '${info.chunksSchema}.${info.chunksTableName}' resource ` +
+        `(matches=${matches.length})`
+      );
+    }
+
+    const chunksCodec = matches[0].codec;
+    const chunks = requirePgIdentity(chunksCodec, 'chunks codec');
+    requireField(c, info.parentPkField, 'parentPk', `${parent.schemaName}.${parent.name}`);
+    requireField(chunksCodec, info.parentFkField, 'parentFk', `${chunks.schemaName}.${chunks.name}`);
+    requireField(chunksCodec, info.contentField, 'contentField', `${chunks.schemaName}.${chunks.name}`);
+    const embedding = requireField(
+      chunksCodec,
+      info.embeddingField,
+      'embeddingField',
+      `${chunks.schemaName}.${chunks.name}`
+    );
+    const vectorPg = embedding.codec?.extensions?.pg;
+    if (
+      vectorPg?.name !== 'vector' ||
+      vectorPg?.serviceName !== parent.serviceName ||
+      !vectorPg?.schemaName
+    ) {
+      throw new Error(
+        `[graphile-llm] @hasChunks embedding '${chunks.schemaName}.${chunks.name}.` +
+        `${info.embeddingField}' is not bound to an exact vector type for service ` +
+        `'${parent.serviceName}'`
+      );
+    }
+
+    chunkTables.push({
+      ...info,
+      chunksSchema: chunks.schemaName,
+      chunksTableName: chunks.name,
+      vectorSchema: vectorPg.schemaName,
+    });
   }
 
   return chunkTables;
@@ -112,37 +222,43 @@ function discoverChunkTables(build: any): ChunkTableInfo[] {
 /**
  * Build a SQL query string to search a chunks table for similar embeddings.
  */
-function buildChunkSearchSql(
+export function buildChunkSearchSql(
   table: ChunkTableInfo,
   vectorString: string,
   limit: number,
   maxDistance: number | null
 ): { text: string; values: any[] } {
-  const schema = table.chunksSchema;
-  const qualifiedTable = schema
-    ? `"${schema}"."${table.chunksTableName}"`
-    : `"${table.chunksTableName}"`;
+  const qualifiedTable = QuoteUtils.quoteQualifiedIdentifier(
+    table.chunksSchema || null,
+    table.chunksTableName
+  );
 
-  const embeddingCol = `"${table.embeddingField}"`;
-  const contentCol = `"${table.contentField}"`;
-  const parentFkCol = `"${table.parentFkField}"`;
+  const embeddingCol = QuoteUtils.quoteIdentifier(table.embeddingField);
+  const contentCol = QuoteUtils.quoteIdentifier(table.contentField);
+  const parentFkCol = QuoteUtils.quoteIdentifier(table.parentFkField);
+  if (!table.vectorSchema) {
+    throw new Error('[graphile-llm] RAG chunk table is missing an exact vector schema');
+  }
+  const vectorType = QuoteUtils.quoteQualifiedIdentifier(table.vectorSchema, 'vector');
+  const vectorDistanceOperator = `OPERATOR(${QuoteUtils.quoteIdentifier(table.vectorSchema)}.<=>)`;
 
   let text = `
     SELECT
       ${contentCol} AS content,
       ${parentFkCol}::text AS parent_id,
-      (${embeddingCol} <=> $1::vector) AS distance
+      (${embeddingCol} ${vectorDistanceOperator} $1::${vectorType}) AS distance
     FROM ${qualifiedTable}
   `;
 
   const values: any[] = [vectorString];
 
   if (maxDistance !== null) {
-    text += ` WHERE (${embeddingCol} <=> $1::vector) <= $2`;
+    text += ` WHERE (${embeddingCol} ${vectorDistanceOperator} $1::${vectorType}) <= $2`;
     values.push(maxDistance);
   }
 
-  text += ` ORDER BY ${embeddingCol} <=> $1::vector LIMIT $${values.length + 1}`;
+  text += ` ORDER BY ${embeddingCol} ${vectorDistanceOperator} $1::${vectorType} ` +
+    `LIMIT $${values.length + 1}`;
   values.push(limit);
 
   return { text, values };
@@ -174,7 +290,7 @@ export function createLlmRagPlugin(
   let embedder: EmbedderFunction | null = null;
   let chatCompleter: ChatFunction | null = null;
 
-  const schemaExtension = extendSchema((build) => {
+  const schemaExtension = extendSchema((_build) => {
     return {
       typeDefs: gql`
         """A source chunk retrieved during RAG context assembly."""
@@ -307,6 +423,12 @@ export function createLlmRagPlugin(
               }> = [];
 
               if (chunkTables.length > 0) {
+                if (typeof withPgClient !== 'function') {
+                  throw new Error('RAG_PG_CLIENT_CONTEXT_UNAVAILABLE');
+                }
+                if (typeof pgSettings !== 'object' || pgSettings === null) {
+                  throw new Error('RAG_PG_SETTINGS_UNAVAILABLE');
+                }
                 await withPgClient(pgSettings, async (pgClient: any) => {
                   for (const table of chunkTables) {
                     const query = buildChunkSearchSql(table, vectorString, limit, maxDistance);

--- a/graphile/graphile-llm/src/types.ts
+++ b/graphile/graphile-llm/src/types.ts
@@ -174,6 +174,8 @@ export interface ChunkTableInfo {
   parentCodecName: string;
   /** Schema of the chunks table (or null for public/default) */
   chunksSchema: string | null;
+  /** Exact schema containing the pgvector `vector` type for this service */
+  vectorSchema: string;
   /** Name of the chunks table */
   chunksTableName: string;
   /** FK column on chunks table pointing to parent */

--- a/graphile/graphile-ltree/src/__tests__/schema-qualified-sql.test.ts
+++ b/graphile/graphile-ltree/src/__tests__/schema-qualified-sql.test.ts
@@ -1,0 +1,176 @@
+import sql from 'pg-sql2';
+
+import { createLtreeOperatorFactory } from '../plugins/connection-filter-operators';
+import {
+  resolveLtreeExtensionInfo,
+  type LtreeExtensionInfo,
+} from '../plugins/detect-ltree';
+import { createFolderOperatorFactory } from '../plugins/folder-filter-operators';
+import { LtreeCodecPlugin } from '../plugins/ltree-codec';
+
+const codec = (name: string, schemaName = 'extension_tools') => ({
+  name,
+  extensions: {
+    pg: {
+      serviceName: 'tenant_service',
+      schemaName,
+      name,
+    },
+  },
+});
+
+const helperResource = (
+  name: 'to_path' | 'to_query',
+  returnCodec: any,
+  schemaName = 'tenant_helpers'
+) => ({
+  name: `resource_${name}`,
+  parameters: [{ codec: codec('text', 'pg_catalog') }],
+  codec: returnCodec,
+  extensions: {
+    pg: {
+      serviceName: 'tenant_service',
+      schemaName,
+      name,
+    },
+  },
+});
+
+const registryBuild = (options: {
+  includeHelpers?: boolean;
+  ltreeCodec?: any;
+  lqueryCodec?: any;
+  resources?: Record<string, any>;
+} = {}) => {
+  const ltreeCodec = options.ltreeCodec ?? codec('ltree');
+  const lqueryCodec = options.lqueryCodec ?? codec('lquery');
+  const includeHelpers = options.includeHelpers ?? false;
+  return {
+    input: {
+      pgRegistry: {
+        pgCodecs: { ltree: ltreeCodec, lquery: lqueryCodec },
+        pgResources: options.resources ?? (includeHelpers ? {
+          toPath: helperResource('to_path', ltreeCodec),
+          toQuery: helperResource('to_query', lqueryCodec),
+        } : {}),
+      },
+    },
+  };
+};
+
+const resolveSql = (
+  info: LtreeExtensionInfo,
+  factory: ReturnType<typeof createFolderOperatorFactory>,
+  operatorName: string,
+  input: string
+) => {
+  const registration = factory({ pgLtreeExtensionInfo: info } as any)
+    .find((entry) => entry.operatorName === operatorName)!;
+  const fragment = registration.spec.resolve!(
+    sql.identifier('path'),
+    sql.null,
+    input,
+    null,
+    { fieldName: 'path', operatorName }
+  );
+  return sql.compile(fragment!);
+};
+
+describe('ltree extension identity', () => {
+  it('qualifies and annotates a native codec from gather introspection', async () => {
+    const gatherHook = (LtreeCodecPlugin as any).gather.hooks.pgCodecs_findPgCodec;
+    const event: any = {
+      pgCodec: {
+        name: 'ltree',
+        sqlType: sql.fragment`ltree`,
+        extensions: undefined,
+      },
+      pgType: { typname: 'ltree', typnamespace: '910', _id: '911' },
+      serviceName: 'tenant_service',
+    };
+    const originalCodec = event.pgCodec;
+    await gatherHook({
+      helpers: {
+        pgIntrospection: {
+          getNamespace: jest.fn().mockResolvedValue({ nspname: 'extension_tools' }),
+        },
+      },
+    }, event);
+
+    expect(event.pgCodec).toBe(originalCodec);
+    expect(event.pgCodec.extensions).toMatchObject({
+      oid: '911',
+      pg: {
+        serviceName: 'tenant_service',
+        schemaName: 'extension_tools',
+        name: 'ltree',
+      },
+    });
+    expect(sql.compile(event.pgCodec.sqlType).text).toBe('"extension_tools"."ltree"');
+  });
+
+  it('derives codec and actual helper schemas from one service/build', () => {
+    const info = resolveLtreeExtensionInfo(registryBuild({ includeHelpers: true }));
+    expect(info).toMatchObject({
+      serviceName: 'tenant_service',
+      schemaName: 'extension_tools',
+      helperSchemaName: 'tenant_helpers',
+    });
+  });
+
+  it('fails closed on missing codec identity and incomplete helpers', () => {
+    expect(() => resolveLtreeExtensionInfo(registryBuild({
+      ltreeCodec: { name: 'ltree', extensions: { pg: { name: 'ltree' } } },
+    }))).toThrow(/missing exact service\/schema metadata/);
+
+    const ltreeCodec = codec('ltree');
+    expect(() => resolveLtreeExtensionInfo(registryBuild({
+      ltreeCodec,
+      resources: {
+        onlyPath: helperResource('to_path', ltreeCodec),
+      },
+    }))).toThrow(/incomplete or ambiguous/);
+  });
+
+  it('fails closed when ltree and lquery identities disagree', () => {
+    expect(() => resolveLtreeExtensionInfo(registryBuild({
+      lqueryCodec: codec('lquery', 'other_extension_schema'),
+    }))).toThrow(/does not match/);
+  });
+});
+
+describe('ltree SQL qualification', () => {
+  it('qualifies helper functions and operators in the folder factory', () => {
+    const info = resolveLtreeExtensionInfo(registryBuild({ includeHelpers: true }))!;
+    const within = resolveSql(info, createFolderOperatorFactory(), 'within', '/a/b');
+    const glob = resolveSql(info, createFolderOperatorFactory(), 'glob', '/a/*');
+
+    expect(within.text).toContain('OPERATOR("extension_tools".<@)');
+    expect(within.text).toContain('"tenant_helpers"."to_path"($1)');
+    expect(glob.text).toContain('OPERATOR("extension_tools".~)');
+    expect(glob.text).toContain('"tenant_helpers"."to_query"($1)');
+  });
+
+  it('qualifies inline casts when helper functions are absent', () => {
+    const info = resolveLtreeExtensionInfo(registryBuild())!;
+    const within = resolveSql(info, createFolderOperatorFactory(), 'within', '/a/b');
+    const glob = resolveSql(info, createFolderOperatorFactory(), 'glob', '/a/*');
+
+    expect(within.text).toContain('::"extension_tools"."ltree"');
+    expect(within.text).toContain('OPERATOR("extension_tools".<@)');
+    expect(glob.text).toContain('::"extension_tools"."lquery"');
+    expect(glob.text).toContain('OPERATOR("extension_tools".~)');
+  });
+
+  it('qualifies the deprecated duplicate operator factory too', () => {
+    const info = resolveLtreeExtensionInfo(registryBuild())!;
+    const result = resolveSql(
+      info,
+      createLtreeOperatorFactory() as ReturnType<typeof createFolderOperatorFactory>,
+      'isDescendantOf',
+      '/a/b'
+    );
+    expect(result.text).toContain('OPERATOR("extension_tools".@>)');
+    expect(result.text).toContain('::"extension_tools"."ltree"');
+  });
+});

--- a/graphile/graphile-ltree/src/plugins/connection-filter-operators.ts
+++ b/graphile/graphile-ltree/src/plugins/connection-filter-operators.ts
@@ -10,35 +10,13 @@ import type {
 import type { SQL } from 'pg-sql2';
 import sql from 'pg-sql2';
 
+import type { LtreeExtensionInfo } from './detect-ltree';
 import { LTREE_SCALAR_NAME } from './ltree-codec';
-
-function hasLtreeHelpers(build: any): boolean {
-  const pgRegistry = build.input?.pgRegistry;
-  if (!pgRegistry) return false;
-  for (const resource of Object.values(pgRegistry.pgResources)) {
-    const r = resource as any;
-    if (r?.extensions?.pg?.schemaName === 'ltree_helpers') return true;
-  }
-  return false;
-}
-
-function toPathExpr(value: SQL, useHelpers: boolean): SQL {
-  if (useHelpers) {
-    return sql.fragment`ltree_helpers.to_path(${value})`;
-  }
-  return sql.fragment`replace(ltrim(${value}, '/'), '/', '.')::ltree`;
-}
-
-function toQueryExpr(value: SQL, useHelpers: boolean): SQL {
-  if (useHelpers) {
-    return sql.fragment`ltree_helpers.to_query(${value})`;
-  }
-  // Glob → lquery conversion:
-  //   ** → * (0+ labels in lquery)
-  //   *  → *{1} (exactly 1 label)
-  // We use a placeholder to avoid ** being affected by the * → *{1} step.
-  return sql.fragment`replace(replace(replace(replace(ltrim(${value}, '/'), '**', '__DSTAR__'), '*', '*{1}'), '__DSTAR__', '*'), '/', '.')::lquery`;
-}
+import {
+  ltreeOperatorExpression,
+  ltreePathExpression,
+  ltreeQueryExpression,
+} from './qualified-sql';
 
 /**
  * Creates the ltree connection filter operator factory.
@@ -55,10 +33,10 @@ function toQueryExpr(value: SQL, useHelpers: boolean): SQL {
  */
 export function createLtreeOperatorFactory(): ConnectionFilterOperatorFactory {
   return (build) => {
-    const ltreeInfo = (build as any).pgLtreeExtensionInfo;
+    const ltreeInfo: LtreeExtensionInfo | undefined =
+      (build as any).pgLtreeExtensionInfo;
     if (!ltreeInfo) return [];
 
-    const useHelpers = hasLtreeHelpers(build);
     const registrations: ConnectionFilterOperatorRegistration[] = [];
 
     registrations.push({
@@ -78,7 +56,12 @@ export function createLtreeOperatorFactory(): ConnectionFilterOperatorFactory {
           _details: { fieldName: string | null; operatorName: string }
         ) {
           const pathVal = sql.value(String(input));
-          return sql.fragment`${sqlIdentifier} <@ ${toPathExpr(pathVal, useHelpers)}`;
+          return ltreeOperatorExpression(
+            '<@',
+            sqlIdentifier,
+            ltreePathExpression(pathVal, ltreeInfo),
+            ltreeInfo
+          );
         }
       } satisfies ConnectionFilterOperatorSpec
     });
@@ -100,7 +83,12 @@ export function createLtreeOperatorFactory(): ConnectionFilterOperatorFactory {
           _details: { fieldName: string | null; operatorName: string }
         ) {
           const pathVal = sql.value(String(input));
-          return sql.fragment`${sqlIdentifier} @> ${toPathExpr(pathVal, useHelpers)}`;
+          return ltreeOperatorExpression(
+            '@>',
+            sqlIdentifier,
+            ltreePathExpression(pathVal, ltreeInfo),
+            ltreeInfo
+          );
         }
       } satisfies ConnectionFilterOperatorSpec
     });
@@ -122,7 +110,12 @@ export function createLtreeOperatorFactory(): ConnectionFilterOperatorFactory {
           _details: { fieldName: string | null; operatorName: string }
         ) {
           const globVal = sql.value(String(input));
-          return sql.fragment`${sqlIdentifier} ~ ${toQueryExpr(globVal, useHelpers)}`;
+          return ltreeOperatorExpression(
+            '~',
+            sqlIdentifier,
+            ltreeQueryExpression(globVal, ltreeInfo),
+            ltreeInfo
+          );
         }
       } satisfies ConnectionFilterOperatorSpec
     });

--- a/graphile/graphile-ltree/src/plugins/detect-ltree.ts
+++ b/graphile/graphile-ltree/src/plugins/detect-ltree.ts
@@ -5,8 +5,12 @@ import type { PgCodec } from '@dataplan/pg';
 import type { GraphileConfig } from 'graphile-config';
 
 export interface LtreeExtensionInfo {
+  serviceName: string;
+  schemaName: string;
   ltreeCodec: PgCodec;
   lqueryCodec: PgCodec | null;
+  /** Exact schema containing both validated helper functions, when present. */
+  helperSchemaName: string | null;
 }
 
 function isLtreeCodec(codec: any): boolean {
@@ -21,6 +25,117 @@ function isLqueryCodec(codec: any): boolean {
     codec?.name === 'lquery' ||
     codec?.extensions?.pg?.name === 'lquery'
   );
+}
+
+function codecIdentity(codec: any, typeName: string): {
+  serviceName: string;
+  schemaName: string;
+} {
+  const pg = codec?.extensions?.pg;
+  if (!pg?.serviceName || !pg?.schemaName) {
+    throw new Error(
+      `[graphile-ltree] ${typeName} codec is missing exact service/schema metadata`
+    );
+  }
+  return { serviceName: pg.serviceName, schemaName: pg.schemaName };
+}
+
+function helperSchemaName(
+  pgRegistry: any,
+  serviceName: string
+): string | null {
+  const matches: Record<'to_path' | 'to_query', any[]> = {
+    to_path: [],
+    to_query: [],
+  };
+
+  for (const resource of Object.values(pgRegistry.pgResources ?? {}) as any[]) {
+    if (!Array.isArray(resource?.parameters)) continue;
+    const pg = resource?.extensions?.pg;
+    const rawFunctionName = pg?.name ?? resource?.name;
+    if (rawFunctionName !== 'to_path' && rawFunctionName !== 'to_query') continue;
+    const functionName: 'to_path' | 'to_query' = rawFunctionName;
+
+    const returnMatches = functionName === 'to_path'
+      ? isLtreeCodec(resource.codec)
+      : isLqueryCodec(resource.codec);
+    const parameter = resource.parameters[0];
+    const parameterName = parameter?.codec?.extensions?.pg?.name ?? parameter?.codec?.name;
+    const signatureMatches =
+      returnMatches &&
+      resource.parameters.length === 1 &&
+      (parameterName === 'text' || parameterName === 'varchar' || parameterName === 'bpchar');
+    if (!signatureMatches) continue;
+
+    if (!pg?.serviceName || !pg?.schemaName) {
+      throw new Error(
+        `[graphile-ltree] ${functionName} helper is missing exact service/schema metadata`
+      );
+    }
+    if (pg.serviceName !== serviceName) continue;
+    matches[functionName].push(resource);
+  }
+
+  const pathMatches = matches.to_path;
+  const queryMatches = matches.to_query;
+  if (pathMatches.length === 0 && queryMatches.length === 0) return null;
+  if (pathMatches.length !== 1 || queryMatches.length !== 1) {
+    throw new Error(
+      `[graphile-ltree] Helper functions for service '${serviceName}' are incomplete ` +
+      `or ambiguous (to_path=${pathMatches.length}, to_query=${queryMatches.length})`
+    );
+  }
+
+  const pathSchema = pathMatches[0].extensions.pg.schemaName;
+  const querySchema = queryMatches[0].extensions.pg.schemaName;
+  if (pathSchema !== querySchema) {
+    throw new Error(
+      `[graphile-ltree] Helper functions for service '${serviceName}' resolve to ` +
+      `different schemas ('${pathSchema}', '${querySchema}')`
+    );
+  }
+  return pathSchema;
+}
+
+/** Resolve one unambiguous ltree identity from this exact build registry. */
+export function resolveLtreeExtensionInfo(build: any): LtreeExtensionInfo | undefined {
+  const pgRegistry = build.input?.pgRegistry;
+  if (!pgRegistry) return undefined;
+
+  const ltreeCodecs = Object.values(pgRegistry.pgCodecs).filter(isLtreeCodec) as PgCodec[];
+  const lqueryCodecs = Object.values(pgRegistry.pgCodecs).filter(isLqueryCodec) as PgCodec[];
+  if (ltreeCodecs.length === 0) return undefined;
+  if (ltreeCodecs.length !== 1) {
+    throw new Error(
+      `[graphile-ltree] Expected one ltree codec per build, found ${ltreeCodecs.length}`
+    );
+  }
+
+  const ltreeCodec = ltreeCodecs[0];
+  const identity = codecIdentity(ltreeCodec, 'ltree');
+  const matchingLquery = lqueryCodecs.filter((codec) => {
+    const candidate = codecIdentity(codec, 'lquery');
+    return candidate.serviceName === identity.serviceName &&
+      candidate.schemaName === identity.schemaName;
+  });
+  if (lqueryCodecs.length > 0 && matchingLquery.length !== lqueryCodecs.length) {
+    throw new Error(
+      '[graphile-ltree] lquery codec service/schema does not match the ltree codec'
+    );
+  }
+  if (matchingLquery.length > 1) {
+    throw new Error(
+      `[graphile-ltree] Expected at most one matching lquery codec, found ` +
+      `${matchingLquery.length}`
+    );
+  }
+
+  return {
+    ...identity,
+    ltreeCodec,
+    lqueryCodec: matchingLquery[0] ?? null,
+    helperSchemaName: helperSchemaName(pgRegistry, identity.serviceName),
+  };
 }
 
 /**
@@ -40,30 +155,8 @@ export const LtreeExtensionDetectionPlugin: GraphileConfig.Plugin = {
   schema: {
     hooks: {
       build(build) {
-        const pgRegistry = build.input?.pgRegistry;
-        if (!pgRegistry) {
-          return build;
-        }
-
-        let ltreeCodec: PgCodec | null = null;
-        let lqueryCodec: PgCodec | null = null;
-
-        for (const codec of Object.values(pgRegistry.pgCodecs)) {
-          if (isLtreeCodec(codec)) {
-            ltreeCodec = codec;
-          } else if (isLqueryCodec(codec)) {
-            lqueryCodec = codec;
-          }
-        }
-
-        if (!ltreeCodec) {
-          return build;
-        }
-
-        const ltreeInfo: LtreeExtensionInfo = {
-          ltreeCodec,
-          lqueryCodec
-        };
+        const ltreeInfo = resolveLtreeExtensionInfo(build);
+        if (!ltreeInfo) return build;
 
         return build.extend(
           build,

--- a/graphile/graphile-ltree/src/plugins/folder-filter-operators.ts
+++ b/graphile/graphile-ltree/src/plugins/folder-filter-operators.ts
@@ -10,31 +10,13 @@ import type {
 import type { SQL } from 'pg-sql2';
 import sql from 'pg-sql2';
 
+import type { LtreeExtensionInfo } from './detect-ltree';
 import { LTREE_SCALAR_NAME } from './ltree-codec';
-
-function hasLtreeHelpers(build: any): boolean {
-  const pgRegistry = build.input?.pgRegistry;
-  if (!pgRegistry) return false;
-  for (const resource of Object.values(pgRegistry.pgResources)) {
-    const r = resource as any;
-    if (r?.extensions?.pg?.schemaName === 'ltree_helpers') return true;
-  }
-  return false;
-}
-
-function slashToLtree(value: SQL, useHelpers: boolean): SQL {
-  if (useHelpers) {
-    return sql.fragment`ltree_helpers.to_path(${value})`;
-  }
-  return sql.fragment`replace(ltrim(${value}, '/'), '/', '.')::ltree`;
-}
-
-function slashGlobToLquery(value: SQL, useHelpers: boolean): SQL {
-  if (useHelpers) {
-    return sql.fragment`ltree_helpers.to_query(${value})`;
-  }
-  return sql.fragment`replace(replace(replace(replace(ltrim(${value}, '/'), '**', '__DSTAR__'), '*', '*{1}'), '__DSTAR__', '*'), '/', '.')::lquery`;
-}
+import {
+  ltreeOperatorExpression,
+  ltreePathExpression,
+  ltreeQueryExpression,
+} from './qualified-sql';
 
 /**
  * Creates folder-oriented connection filter operators for the LTree scalar.
@@ -56,10 +38,10 @@ function slashGlobToLquery(value: SQL, useHelpers: boolean): SQL {
  */
 export function createFolderOperatorFactory(): ConnectionFilterOperatorFactory {
   return (build) => {
-    const ltreeInfo = (build as any).pgLtreeExtensionInfo;
+    const ltreeInfo: LtreeExtensionInfo | undefined =
+      (build as any).pgLtreeExtensionInfo;
     if (!ltreeInfo) return [];
 
-    const useHelpers = hasLtreeHelpers(build);
     const registrations: ConnectionFilterOperatorRegistration[] = [];
 
     registrations.push({
@@ -79,7 +61,12 @@ export function createFolderOperatorFactory(): ConnectionFilterOperatorFactory {
           _details: { fieldName: string | null; operatorName: string }
         ) {
           const pathVal = sql.value(String(input));
-          return sql.fragment`${sqlIdentifier} <@ ${slashToLtree(pathVal, useHelpers)}`;
+          return ltreeOperatorExpression(
+            '<@',
+            sqlIdentifier,
+            ltreePathExpression(pathVal, ltreeInfo),
+            ltreeInfo
+          );
         }
       } satisfies ConnectionFilterOperatorSpec
     });
@@ -101,7 +88,12 @@ export function createFolderOperatorFactory(): ConnectionFilterOperatorFactory {
           _details: { fieldName: string | null; operatorName: string }
         ) {
           const pathVal = sql.value(String(input));
-          return sql.fragment`${sqlIdentifier} @> ${slashToLtree(pathVal, useHelpers)}`;
+          return ltreeOperatorExpression(
+            '@>',
+            sqlIdentifier,
+            ltreePathExpression(pathVal, ltreeInfo),
+            ltreeInfo
+          );
         }
       } satisfies ConnectionFilterOperatorSpec
     });
@@ -124,7 +116,12 @@ export function createFolderOperatorFactory(): ConnectionFilterOperatorFactory {
           _details: { fieldName: string | null; operatorName: string }
         ) {
           const globVal = sql.value(String(input));
-          return sql.fragment`${sqlIdentifier} ~ ${slashGlobToLquery(globVal, useHelpers)}`;
+          return ltreeOperatorExpression(
+            '~',
+            sqlIdentifier,
+            ltreeQueryExpression(globVal, ltreeInfo),
+            ltreeInfo
+          );
         }
       } satisfies ConnectionFilterOperatorSpec
     });

--- a/graphile/graphile-ltree/src/plugins/ltree-codec.ts
+++ b/graphile/graphile-ltree/src/plugins/ltree-codec.ts
@@ -56,8 +56,6 @@ export const LtreeCodecPlugin: GraphileConfig.Plugin = {
   gather: {
     hooks: {
       async pgCodecs_findPgCodec(info, event) {
-        if (event.pgCodec) return;
-
         const { pgType: type, serviceName } = event;
 
         const isLtree = type.typname === 'ltree';
@@ -70,7 +68,39 @@ export const LtreeCodecPlugin: GraphileConfig.Plugin = {
           serviceName,
           type.typnamespace
         );
-        const schemaName = ns?.nspname || 'pg_catalog';
+        if (!ns?.nspname) {
+          throw new Error(
+            `[graphile-ltree] Cannot resolve namespace for ${type.typname} ` +
+            `codec in service '${serviceName}'`
+          );
+        }
+        const schemaName = ns.nspname;
+
+        if (event.pgCodec) {
+          const existingPg = event.pgCodec.extensions?.pg;
+          if (
+            (existingPg?.serviceName && existingPg.serviceName !== serviceName) ||
+            (existingPg?.schemaName && existingPg.schemaName !== schemaName)
+          ) {
+            throw new Error(
+              `[graphile-ltree] Existing ${type.typname} codec identity conflicts with ` +
+              `introspection for service '${serviceName}'`
+            );
+          }
+          const existingCodec = event.pgCodec as any;
+          existingCodec.sqlType = sql.identifier(schemaName, type.typname);
+          existingCodec.extensions = {
+            ...existingCodec.extensions,
+            oid: type._id,
+            pg: {
+              ...existingPg,
+              serviceName,
+              schemaName,
+              name: type.typname,
+            },
+          };
+          return;
+        }
 
         event.pgCodec = {
           name: type.typname,

--- a/graphile/graphile-ltree/src/plugins/qualified-sql.ts
+++ b/graphile/graphile-ltree/src/plugins/qualified-sql.ts
@@ -1,0 +1,39 @@
+import type { SQL } from 'pg-sql2';
+import sql from 'pg-sql2';
+
+import type { LtreeExtensionInfo } from './detect-ltree';
+
+export function ltreePathExpression(value: SQL, info: LtreeExtensionInfo): SQL {
+  if (info.helperSchemaName) {
+    const toPath = sql.identifier(info.helperSchemaName, 'to_path');
+    return sql.fragment`${toPath}(${value})`;
+  }
+  const ltreeType = sql.identifier(info.schemaName, 'ltree');
+  return sql.fragment`replace(ltrim(${value}, '/'), '/', '.')::${ltreeType}`;
+}
+
+export function ltreeQueryExpression(value: SQL, info: LtreeExtensionInfo): SQL {
+  if (info.helperSchemaName) {
+    const toQuery = sql.identifier(info.helperSchemaName, 'to_query');
+    return sql.fragment`${toQuery}(${value})`;
+  }
+  const lqueryType = sql.identifier(info.schemaName, 'lquery');
+  return sql.fragment`replace(replace(replace(replace(ltrim(${value}, '/'), '**', '__DSTAR__'), '*', '*{1}'), '__DSTAR__', '*'), '/', '.')::${lqueryType}`;
+}
+
+export function ltreeOperatorExpression(
+  operator: '<@' | '@>' | '~',
+  left: SQL,
+  right: SQL,
+  info: LtreeExtensionInfo
+): SQL {
+  const schema = sql.identifier(info.schemaName);
+  switch (operator) {
+  case '<@':
+    return sql.fragment`${left} OPERATOR(${schema}.<@) ${right}`;
+  case '@>':
+    return sql.fragment`${left} OPERATOR(${schema}.@>) ${right}`;
+  case '~':
+    return sql.fragment`${left} OPERATOR(${schema}.~) ${right}`;
+  }
+}

--- a/graphile/graphile-postgis/__tests__/codec.test.ts
+++ b/graphile/graphile-postgis/__tests__/codec.test.ts
@@ -1,4 +1,5 @@
 import type { PgCodec } from '@dataplan/pg';
+import sql from 'pg-sql2';
 
 import { GisSubtype } from '../src/constants';
 import { PostgisCodecPlugin } from '../src/plugins/codec';
@@ -27,16 +28,33 @@ describe('PostgisCodecPlugin', () => {
     const gatherHook = (PostgisCodecPlugin as { gather: { hooks: { pgCodecs_findPgCodec: Function } } })
       .gather.hooks.pgCodecs_findPgCodec;
 
-    it('should skip if pgCodec is already set', async () => {
-      const info = { helpers: { pgIntrospection: { getNamespace: jest.fn() } } };
-      const event = { pgCodec: { name: 'existing' }, pgType: { typname: 'geometry' }, serviceName: 'main' };
+    it('should bind exact identity when a native pgCodec is already set', async () => {
+      const info = {
+        helpers: {
+          pgIntrospection: {
+            getNamespace: jest.fn().mockResolvedValue({ _id: '123', nspname: 'postgis_ext' })
+          }
+        }
+      };
+      const event = {
+        pgCodec: { name: 'geometry' } as PgCodec,
+        pgType: { typname: 'geometry', typnamespace: '123', _id: '456' },
+        serviceName: 'main'
+      };
+      const originalCodec = event.pgCodec;
 
       await gatherHook(info, event);
-      // Should not have called getNamespace since pgCodec was already set
-      expect(info.helpers.pgIntrospection.getNamespace).not.toHaveBeenCalled();
+      expect(event.pgCodec).toBe(originalCodec);
+      expect(info.helpers.pgIntrospection.getNamespace).toHaveBeenCalledWith('main', '123');
+      expect(event.pgCodec.extensions?.pg).toEqual({
+        serviceName: 'main',
+        schemaName: 'postgis_ext',
+        name: 'geometry'
+      });
+      expect(sql.compile(event.pgCodec.sqlType!).text).toBe('"postgis_ext"."geometry"');
     });
 
-    it('should skip if namespace is not found', async () => {
+    it('should fail closed if namespace is not found', async () => {
       const info = {
         helpers: { pgIntrospection: { getNamespace: jest.fn().mockResolvedValue(null) } }
       };
@@ -46,8 +64,9 @@ describe('PostgisCodecPlugin', () => {
         serviceName: 'main'
       };
 
-      await gatherHook(info, event);
-      expect(event.pgCodec).toBeNull();
+      await expect(gatherHook(info, event)).rejects.toThrow(
+        /Cannot resolve namespace for geometry codec/
+      );
     });
 
     it('should create geometry codec when type is geometry', async () => {

--- a/graphile/graphile-postgis/__tests__/connection-filter-operators.test.ts
+++ b/graphile/graphile-postgis/__tests__/connection-filter-operators.test.ts
@@ -343,31 +343,31 @@ describe('PostGIS operator factory (createPostgisOperatorFactory)', () => {
 
       it('generates correct SQL for = operator', () => {
         expect(runOp('exactlyEquals').text).toBe(
-          '"col" = "public"."st_geomfromgeojson"($1::text)'
+          '"col" OPERATOR("public".=) "public"."st_geomfromgeojson"($1::text)'
         );
       });
 
       it('generates correct SQL for && operator', () => {
         expect(runOp('bboxIntersects2D').text).toBe(
-          '"col" && "public"."st_geomfromgeojson"($1::text)'
+          '"col" OPERATOR("public".&&) "public"."st_geomfromgeojson"($1::text)'
         );
       });
 
       it('generates correct SQL for ~ operator', () => {
         expect(runOp('bboxContains').text).toBe(
-          '"col" ~ "public"."st_geomfromgeojson"($1::text)'
+          '"col" OPERATOR("public".~) "public"."st_geomfromgeojson"($1::text)'
         );
       });
 
       it('generates correct SQL for ~= operator', () => {
         expect(runOp('bboxEquals').text).toBe(
-          '"col" ~= "public"."st_geomfromgeojson"($1::text)'
+          '"col" OPERATOR("public".~=) "public"."st_geomfromgeojson"($1::text)'
         );
       });
 
       it('generates correct SQL for &&& operator', () => {
         expect(runOp('bboxIntersectsND').text).toBe(
-          '"col" &&& "public"."st_geomfromgeojson"($1::text)'
+          '"col" OPERATOR("public".&&&) "public"."st_geomfromgeojson"($1::text)'
         );
       });
     });

--- a/graphile/graphile-postgis/__tests__/detect-extension.test.ts
+++ b/graphile/graphile-postgis/__tests__/detect-extension.test.ts
@@ -40,7 +40,7 @@ describe('PostgisExtensionDetectionPlugin', () => {
     it('should detect PostGIS with only geometry codec (no geography)', () => {
       const geometryCodec = {
         name: 'geometry',
-        extensions: { pg: { name: 'geometry', schemaName: 'public' } }
+        extensions: { pg: { name: 'geometry', schemaName: 'public', serviceName: 'main' } }
       };
       const build = {
         input: {
@@ -57,17 +57,18 @@ describe('PostgisExtensionDetectionPlugin', () => {
       expect(result.pgGISExtensionInfo).toBeDefined();
       expect(result.pgGISExtensionInfo.geometryCodec).toBe(geometryCodec);
       expect(result.pgGISExtensionInfo.geographyCodec).toBeNull();
+      expect(result.pgGISExtensionInfo.serviceName).toBe('main');
       expect(result.pgGISExtensionInfo.schemaName).toBe('public');
     });
 
     it('should detect PostGIS when both geometry and geography codecs exist', () => {
       const geometryCodec = {
         name: 'geometry',
-        extensions: { pg: { name: 'geometry', schemaName: 'public' } }
+        extensions: { pg: { name: 'geometry', schemaName: 'public', serviceName: 'main' } }
       };
       const geographyCodec = {
         name: 'geography',
-        extensions: { pg: { name: 'geography', schemaName: 'public' } }
+        extensions: { pg: { name: 'geography', schemaName: 'public', serviceName: 'main' } }
       };
 
       const build = {
@@ -90,11 +91,11 @@ describe('PostgisExtensionDetectionPlugin', () => {
     it('should detect custom schema for PostGIS installation', () => {
       const geometryCodec = {
         name: 'geometry',
-        extensions: { pg: { name: 'geometry', schemaName: 'postgis' } }
+        extensions: { pg: { name: 'geometry', schemaName: 'postgis', serviceName: 'main' } }
       };
       const geographyCodec = {
         name: 'geography',
-        extensions: { pg: { name: 'geography', schemaName: 'postgis' } }
+        extensions: { pg: { name: 'geography', schemaName: 'postgis', serviceName: 'main' } }
       };
 
       const build = {
@@ -113,11 +114,11 @@ describe('PostgisExtensionDetectionPlugin', () => {
     it('should skip codecs without pg extensions', () => {
       const geometryCodec = {
         name: 'geometry',
-        extensions: { pg: { name: 'geometry', schemaName: 'public' } }
+        extensions: { pg: { name: 'geometry', schemaName: 'public', serviceName: 'main' } }
       };
       const geographyCodec = {
         name: 'geography',
-        extensions: { pg: { name: 'geography', schemaName: 'public' } }
+        extensions: { pg: { name: 'geography', schemaName: 'public', serviceName: 'main' } }
       };
       const otherCodec = {
         name: 'custom',
@@ -139,6 +140,45 @@ describe('PostgisExtensionDetectionPlugin', () => {
 
       const result = buildHook(build);
       expect(result.pgGISExtensionInfo).toBeDefined();
+    });
+
+    it('fails closed when codec identity is missing or inconsistent', () => {
+      const extend = (base: any, ext: any) => ({ ...base, ...ext });
+      expect(() => buildHook({
+        input: {
+          pgRegistry: {
+            pgCodecs: {
+              geometry: {
+                name: 'geometry',
+                extensions: { pg: { name: 'geometry', schemaName: 'postgis' } }
+              }
+            }
+          }
+        },
+        extend
+      })).toThrow(/missing exact service\/schema metadata/);
+
+      expect(() => buildHook({
+        input: {
+          pgRegistry: {
+            pgCodecs: {
+              geometry: {
+                name: 'geometry',
+                extensions: {
+                  pg: { name: 'geometry', schemaName: 'postgis_a', serviceName: 'main' }
+                }
+              },
+              geography: {
+                name: 'geography',
+                extensions: {
+                  pg: { name: 'geography', schemaName: 'postgis_b', serviceName: 'main' }
+                }
+              }
+            }
+          }
+        },
+        extend
+      })).toThrow(/different service\/schema identities/);
     });
   });
 });

--- a/graphile/graphile-postgis/__tests__/spatial-relations.test.ts
+++ b/graphile/graphile-postgis/__tests__/spatial-relations.test.ts
@@ -1,6 +1,7 @@
 import sql from 'pg-sql2';
 
 import {
+  buildSpatialJoinFragment,
   collectSpatialRelations,
   OPERATOR_REGISTRY,
   parseSpatialRelationTag,
@@ -129,6 +130,23 @@ describe('OPERATOR_REGISTRY', () => {
         expect(op.pgToken).toBe(op.name);
       }
     }
+  });
+
+  it('schema-qualifies the PostGIS infix operator in relation SQL', () => {
+    const fragment = buildSpatialJoinFragment(
+      {
+        ownerAttributeName: 'location',
+        targetAttributeName: 'geom',
+        operator: OPERATOR_REGISTRY.st_bbox_intersects,
+      } as any,
+      'postgis_ext',
+      sql.identifier('owner'),
+      sql.identifier('target'),
+      null
+    );
+    expect(sql.compile(fragment).text).toBe(
+      '"owner"."location" OPERATOR("postgis_ext".&&) "target"."geom"'
+    );
   });
 });
 

--- a/graphile/graphile-postgis/src/plugins/codec.ts
+++ b/graphile/graphile-postgis/src/plugins/codec.ts
@@ -199,11 +199,11 @@ export const PostgisCodecPlugin: GraphileConfig.Plugin = {
   gather: {
     hooks: {
       async pgCodecs_findPgCodec(info, event) {
-        if (event.pgCodec) {
+        const { pgType: type, serviceName } = event;
+
+        if (type.typname !== 'geometry' && type.typname !== 'geography') {
           return;
         }
-
-        const { pgType: type, serviceName } = event;
 
         // Find the namespace for this type by its OID
         const typeNamespace = await info.helpers.pgIntrospection.getNamespace(
@@ -212,6 +212,35 @@ export const PostgisCodecPlugin: GraphileConfig.Plugin = {
         );
 
         if (!typeNamespace) {
+          throw new Error(
+            `[graphile-postgis] Cannot resolve namespace for ${type.typname} ` +
+            `codec in service '${serviceName}'`
+          );
+        }
+
+        if (event.pgCodec) {
+          const existingPg = event.pgCodec.extensions?.pg;
+          if (
+            (existingPg?.serviceName && existingPg.serviceName !== serviceName) ||
+            (existingPg?.schemaName && existingPg.schemaName !== typeNamespace.nspname)
+          ) {
+            throw new Error(
+              `[graphile-postgis] Existing ${type.typname} codec identity conflicts ` +
+              `with introspection for service '${serviceName}'`
+            );
+          }
+          const existingCodec = event.pgCodec as any;
+          existingCodec.sqlType = sql.identifier(typeNamespace.nspname, type.typname);
+          existingCodec.extensions = {
+            ...existingCodec.extensions,
+            oid: type._id,
+            pg: {
+              ...existingPg,
+              serviceName,
+              schemaName: typeNamespace.nspname,
+              name: type.typname,
+            },
+          };
           return;
         }
 

--- a/graphile/graphile-postgis/src/plugins/connection-filter-operators.ts
+++ b/graphile/graphile-postgis/src/plugins/connection-filter-operators.ts
@@ -18,21 +18,22 @@ import type { PostgisExtensionInfo } from './detect-extension';
  * Builds an infix operator SQL fragment from a validated operator string.
  * Uses explicit template literals for each operator to avoid sql.raw.
  */
-function buildOperatorExpr(op: string, i: SQL, v: SQL): SQL {
+function buildOperatorExpr(schemaName: string, op: string, i: SQL, v: SQL): SQL {
+  const schema = sql.identifier(schemaName);
   switch (op) {
-  case '=':   return sql.fragment`${i} = ${v}`;
-  case '&&':  return sql.fragment`${i} && ${v}`;
-  case '&&&': return sql.fragment`${i} &&& ${v}`;
-  case '&<':  return sql.fragment`${i} &< ${v}`;
-  case '&<|': return sql.fragment`${i} &<| ${v}`;
-  case '&>':  return sql.fragment`${i} &> ${v}`;
-  case '|&>': return sql.fragment`${i} |&> ${v}`;
-  case '<<':  return sql.fragment`${i} << ${v}`;
-  case '<<|': return sql.fragment`${i} <<| ${v}`;
-  case '>>':  return sql.fragment`${i} >> ${v}`;
-  case '|>>': return sql.fragment`${i} |>> ${v}`;
-  case '~':   return sql.fragment`${i} ~ ${v}`;
-  case '~=':  return sql.fragment`${i} ~= ${v}`;
+  case '=':   return sql.fragment`${i} OPERATOR(${schema}.=) ${v}`;
+  case '&&':  return sql.fragment`${i} OPERATOR(${schema}.&&) ${v}`;
+  case '&&&': return sql.fragment`${i} OPERATOR(${schema}.&&&) ${v}`;
+  case '&<':  return sql.fragment`${i} OPERATOR(${schema}.&<) ${v}`;
+  case '&<|': return sql.fragment`${i} OPERATOR(${schema}.&<|) ${v}`;
+  case '&>':  return sql.fragment`${i} OPERATOR(${schema}.&>) ${v}`;
+  case '|&>': return sql.fragment`${i} OPERATOR(${schema}.|&>) ${v}`;
+  case '<<':  return sql.fragment`${i} OPERATOR(${schema}.<<) ${v}`;
+  case '<<|': return sql.fragment`${i} OPERATOR(${schema}.<<|) ${v}`;
+  case '>>':  return sql.fragment`${i} OPERATOR(${schema}.>>) ${v}`;
+  case '|>>': return sql.fragment`${i} OPERATOR(${schema}.|>>) ${v}`;
+  case '~':   return sql.fragment`${i} OPERATOR(${schema}.~) ${v}`;
+  case '~=':  return sql.fragment`${i} OPERATOR(${schema}.~=) ${v}`;
   default:
     throw new Error(`Unexpected PostGIS SQL operator: ${op}`);
   }
@@ -289,7 +290,8 @@ export function createPostgisOperatorFactory(): ConnectionFilterOperatorFactory 
           operatorName,
           description,
           baseType: baseType as 'geometry' | 'geography',
-          resolve: (i: SQL, v: SQL) => buildOperatorExpr(capturedOp, i, v)
+          resolve: (i: SQL, v: SQL) =>
+            buildOperatorExpr(schemaName, capturedOp, i, v)
         });
       }
     }

--- a/graphile/graphile-postgis/src/plugins/detect-extension.ts
+++ b/graphile/graphile-postgis/src/plugins/detect-extension.ts
@@ -8,6 +8,62 @@ import type { PostgisExtensionInfo } from '../types';
 
 export type { PostgisExtensionInfo } from '../types';
 
+function codecIdentity(codec: any, typeName: string): {
+  serviceName: string;
+  schemaName: string;
+} {
+  const pg = codec?.extensions?.pg;
+  if (!pg?.serviceName || !pg?.schemaName) {
+    throw new Error(
+      `[graphile-postgis] ${typeName} codec is missing exact service/schema metadata`
+    );
+  }
+  return { serviceName: pg.serviceName, schemaName: pg.schemaName };
+}
+
+/** Resolve one unambiguous PostGIS installation identity for this build. */
+export function resolvePostgisExtensionInfo(build: any): PostgisExtensionInfo | undefined {
+  const pgRegistry = build.input?.pgRegistry;
+  if (!pgRegistry) return undefined;
+
+  const geometryCodecs: PgCodec[] = [];
+  const geographyCodecs: PgCodec[] = [];
+  for (const codec of Object.values(pgRegistry.pgCodecs) as PgCodec[]) {
+    const name = codec?.extensions?.pg?.name;
+    if (name === 'geometry') geometryCodecs.push(codec);
+    if (name === 'geography') geographyCodecs.push(codec);
+  }
+  if (geometryCodecs.length === 0 && geographyCodecs.length === 0) return undefined;
+  if (geometryCodecs.length > 1 || geographyCodecs.length > 1) {
+    throw new Error(
+      `[graphile-postgis] Ambiguous codecs in one build ` +
+      `(geometry=${geometryCodecs.length}, geography=${geographyCodecs.length})`
+    );
+  }
+
+  const geometryCodec = geometryCodecs[0] ?? null;
+  const geographyCodec = geographyCodecs[0] ?? null;
+  const primary = geometryCodec ?? geographyCodec!;
+  const identity = codecIdentity(primary, geometryCodec ? 'geometry' : 'geography');
+  if (geometryCodec && geographyCodec) {
+    const geographyIdentity = codecIdentity(geographyCodec, 'geography');
+    if (
+      geographyIdentity.serviceName !== identity.serviceName ||
+      geographyIdentity.schemaName !== identity.schemaName
+    ) {
+      throw new Error(
+        '[graphile-postgis] geometry/geography codecs resolve to different service/schema identities'
+      );
+    }
+  }
+
+  return {
+    ...identity,
+    geometryCodec,
+    geographyCodec,
+  };
+}
+
 /**
  * PostgisExtensionDetectionPlugin
  *
@@ -25,44 +81,8 @@ export const PostgisExtensionDetectionPlugin: GraphileConfig.Plugin = {
   schema: {
     hooks: {
       build(build) {
-        const pgRegistry = build.input?.pgRegistry;
-        if (!pgRegistry) {
-          return build;
-        }
-
-        let geometryCodec: PgCodec | null = null;
-        let geographyCodec: PgCodec | null = null;
-        let schemaName: string = 'public';
-
-        // Search through codecs for geometry and geography types
-        for (const codec of Object.values(pgRegistry.pgCodecs)) {
-          const pg = codec?.extensions?.pg;
-          if (!pg) continue;
-
-          if (pg.name === 'geometry') {
-            geometryCodec = codec;
-            schemaName = pg.schemaName || 'public';
-          } else if (pg.name === 'geography') {
-            geographyCodec = codec;
-            if (!geometryCodec) {
-              schemaName = pg.schemaName || 'public';
-            }
-          }
-        }
-
-        // PostGIS is detected when at least one of geometry or geography
-        // codecs is present. Some databases use only geography columns
-        // (e.g. use_geography: true in SearchSpatial), so PostGraphile may
-        // introspect geography but not geometry.
-        if (!geometryCodec && !geographyCodec) {
-          return build;
-        }
-
-        const postgisInfo: PostgisExtensionInfo = {
-          schemaName,
-          geometryCodec,
-          geographyCodec
-        };
+        const postgisInfo = resolvePostgisExtensionInfo(build);
+        if (!postgisInfo) return build;
 
         return build.extend(build, {
           pgGISExtensionInfo: postgisInfo,

--- a/graphile/graphile-postgis/src/plugins/spatial-relations.ts
+++ b/graphile/graphile-postgis/src/plugins/spatial-relations.ts
@@ -451,7 +451,7 @@ function spatialFilterTypeName(build: any, rel: SpatialRelationInfo): string {
  * Build the SQL fragment that joins the inner (target) row to the outer
  * (owner) row using the resolved PostGIS predicate.
  */
-function buildSpatialJoinFragment(
+export function buildSpatialJoinFragment(
   rel: SpatialRelationInfo,
   schemaName: string,
   outerAlias: SQL,
@@ -467,8 +467,8 @@ function buildSpatialJoinFragment(
   const ownerExpr = sql`${outerAlias}.${sql.identifier(rel.ownerAttributeName)}`;
   const targetExpr = sql`${innerAlias}.${sql.identifier(rel.targetAttributeName)}`;
   if (rel.operator.kind === 'infix') {
-    // Only `&&` today — simple inline (symmetric).
-    return sql`${ownerExpr} && ${targetExpr}`;
+    // Only `&&` today. Bind it to this build's exact PostGIS namespace.
+    return sql`${ownerExpr} OPERATOR(${sql.identifier(schemaName)}.&&) ${targetExpr}`;
   }
   const fn = sql.identifier(schemaName, rel.operator.pgToken);
   if (rel.operator.parametric) {

--- a/graphile/graphile-postgis/src/types.ts
+++ b/graphile/graphile-postgis/src/types.ts
@@ -22,6 +22,8 @@ export interface GisFieldValue {
  * PostGIS extension detection result stored on the build object.
  */
 export interface PostgisExtensionInfo {
+  /** Exact Graphile PostgreSQL service that owns these codecs. */
+  serviceName: string;
   /** The schema name where PostGIS is installed (e.g. 'public') */
   schemaName: string;
   /** The geometry codec from the registry (null if only geography columns are used) */

--- a/graphile/graphile-presigned-url-plugin/__tests__/cache-isolation.test.ts
+++ b/graphile/graphile-presigned-url-plugin/__tests__/cache-isolation.test.ts
@@ -1,0 +1,761 @@
+import {
+  getBucketConfig,
+  getStorageModuleCacheScope,
+  getStorageModuleConfig,
+  getStorageModuleConfigForOwner,
+  isS3BucketProvisioned,
+  loadAllStorageModules,
+  markS3BucketProvisioned,
+  resolveStorageConfigFromCodec,
+} from '../src/storage-module-cache';
+import { resolveDownloadStorageTarget } from '../src/download-url-field';
+import { mintPhysicalBucketName, resolveS3Config } from '../src/s3-config';
+import {
+  loadStorageModulesForBuild,
+  snapshotPreloadedStorageModules,
+  type StorageWithPgClient,
+} from '../src/storage-module-source';
+import type { WithPgClient } from '../src/request-pg-client';
+import type {
+  PresignedUrlPluginOptions,
+  StorageModuleConfig,
+} from '../src/types';
+
+const DATABASE_ID = '00000000-0000-0000-0000-000000000001';
+const MODULE_ID = '00000000-0000-0000-0000-000000000002';
+const BUCKET_ID = '00000000-0000-0000-0000-000000000003';
+type QueryOptions = { text: string; values?: unknown[] };
+
+/**
+ * Model Graphile's real request-client contract: acquire without settings,
+ * open one explicit transaction, then apply every request GUC with set_config
+ * before tenant-bound SQL is allowed to run.
+ */
+function requestPgHarness(
+  pgSettings: Record<string, string>,
+  requestQuery: (query: QueryOptions) => Promise<{ rows: any[] }>,
+) {
+  let transactionActive = false;
+  let appliedSettings: Record<string, string> | null = null;
+  const pgClient: any = {};
+
+  const query = jest.fn(async (queryOptions: QueryOptions) => {
+    if (queryOptions.text.includes('SELECT set_config')) {
+      expect(transactionActive).toBe(true);
+      const entries = JSON.parse(String(queryOptions.values?.[0])) as Array<[string, string]>;
+      appliedSettings = Object.fromEntries(entries);
+      expect(appliedSettings).toEqual(pgSettings);
+      return { rows: [] };
+    }
+
+    expect(transactionActive).toBe(true);
+    expect(appliedSettings).toEqual(pgSettings);
+    return requestQuery(queryOptions);
+  });
+  const withTransaction = jest.fn(async (callback: (tx: any) => Promise<unknown>) => {
+    expect(transactionActive).toBe(false);
+    transactionActive = true;
+    try {
+      return await callback(pgClient);
+    } finally {
+      appliedSettings = null;
+      transactionActive = false;
+    }
+  });
+  pgClient.query = query;
+  pgClient.withTransaction = withTransaction;
+
+  const withPgClientMock = jest.fn(async (
+    settings: Record<string, string> | null,
+    callback: (client: any) => Promise<unknown>,
+  ) => {
+    expect(settings).toBeNull();
+    return callback(pgClient);
+  });
+
+  return {
+    withPgClient: withPgClientMock as unknown as WithPgClient & StorageWithPgClient,
+    withPgClientMock,
+    withTransaction,
+    query,
+  };
+}
+
+function storageRow(publicUrlPrefix: string, maxFileSize = 1024): Record<string, unknown> {
+  return {
+    id: MODULE_ID,
+    database_id: DATABASE_ID,
+    scope: 'app',
+    entity_table_id: null,
+    buckets_database_id: DATABASE_ID,
+    buckets_schema: 'storage_public',
+    buckets_schema_database_id: DATABASE_ID,
+    buckets_table: 'app_buckets',
+    files_database_id: DATABASE_ID,
+    files_schema: 'storage_public',
+    files_schema_database_id: DATABASE_ID,
+    files_table: 'app_files',
+    endpoint: null,
+    public_url_prefix: publicUrlPrefix,
+    provider: 's3',
+    allowed_origins: null,
+    upload_url_expiry_seconds: 900,
+    download_url_expiry_seconds: 3600,
+    default_max_file_size: maxFileSize,
+    max_filename_length: 1024,
+    cache_ttl_seconds: 3600,
+    max_bulk_files: 100,
+    max_bulk_total_size: 1073741824,
+    has_path_shares: false,
+    entity_database_id: null,
+    entity_schema_database_id: null,
+    entity_schema: null,
+    entity_table: null,
+  };
+}
+
+function bucketRow(maxFileSize: number): Record<string, unknown> {
+  return {
+    id: BUCKET_ID,
+    key: 'private',
+    type: 'private',
+    is_public: false,
+    owner_id: null,
+    allowed_mime_types: ['application/pdf'],
+    max_file_size: maxFileSize,
+    allow_custom_keys: false,
+    physical_name: 'persisted-test-bucket',
+  };
+}
+
+function options(bucket: string): PresignedUrlPluginOptions {
+  return {
+    s3: {
+      client: {} as any,
+      bucket,
+      publicUrlPrefix: `https://${bucket}.example`,
+    },
+  };
+}
+
+function preloadedConfig(publicUrlPrefix: string): StorageModuleConfig {
+  return {
+    id: MODULE_ID,
+    bucketsQualifiedName: 'storage_public.app_buckets',
+    filesQualifiedName: 'storage_public.app_files',
+    schemaName: 'storage_public',
+    bucketsTableName: 'app_buckets',
+    filesTableName: 'app_files',
+    scope: 'app',
+    entityTableId: null,
+    entityQualifiedName: null,
+    endpoint: null,
+    publicUrlPrefix,
+    provider: 's3',
+    allowedOrigins: ['https://app.example'],
+    uploadUrlExpirySeconds: 900,
+    downloadUrlExpirySeconds: 1234,
+    defaultMaxFileSize: 1024,
+    maxFilenameLength: 1024,
+    cacheTtlSeconds: 3600,
+    hasPathShares: false,
+    maxBulkFiles: 100,
+    maxBulkTotalSize: 1073741824,
+  };
+}
+
+describe('build-local storage metadata caches', () => {
+  it('uses fixed-expiry caches rather than extending metadata lifetime on reads', () => {
+    const scope = getStorageModuleCacheScope({});
+    expect(scope.storageModuleCache.updateAgeOnGet).toBe(false);
+    expect(scope.bucketCache.updateAgeOnGet).toBe(false);
+  });
+
+  it('binds every legacy metadata join to the requested physical database', async () => {
+    const scope = getStorageModuleCacheScope({});
+    const client = {
+      query: jest.fn(async (_query: QueryOptions) => ({
+        rows: [storageRow('https://tenant.example')],
+      })),
+    };
+
+    await getStorageModuleConfig(client, DATABASE_ID, scope);
+
+    const query = client.query.mock.calls[0][0] as QueryOptions;
+    expect(query.values).toEqual([DATABASE_ID]);
+    expect(query.text).toContain('bt.database_id = sm.database_id');
+    expect(query.text).toContain('bs.database_id = sm.database_id');
+    expect(query.text).toContain('ft.database_id = sm.database_id');
+    expect(query.text).toContain('fs.database_id = sm.database_id');
+    expect(query.text).not.toContain('LIMIT 1');
+  });
+
+  it('rejects wrong-database metadata rows and never caches them', async () => {
+    const scope = getStorageModuleCacheScope({});
+    const client = {
+      query: jest.fn(async () => ({
+        rows: [{
+          ...storageRow('https://tenant.example'),
+          buckets_schema_database_id: '00000000-0000-0000-0000-000000000099',
+        }],
+      })),
+    };
+
+    await expect(getStorageModuleConfig(client, DATABASE_ID, scope))
+      .rejects.toThrow(`STORAGE_MODULE_CROSS_DATABASE_METADATA:${MODULE_ID}`);
+    await expect(getStorageModuleConfig(client, DATABASE_ID, scope))
+      .rejects.toThrow(`STORAGE_MODULE_CROSS_DATABASE_METADATA:${MODULE_ID}`);
+    expect(client.query).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects duplicate app metadata instead of selecting the first row', async () => {
+    const scope = getStorageModuleCacheScope({});
+    const client = {
+      query: jest.fn(async () => ({
+        rows: [
+          storageRow('https://tenant-a.example'),
+          { ...storageRow('https://tenant-b.example'), id: 'module-b' },
+        ],
+      })),
+    };
+
+    await expect(getStorageModuleConfig(client, DATABASE_ID, scope))
+      .rejects.toThrow('STORAGE_MODULE_METADATA_AMBIGUOUS:app');
+  });
+
+  it('rejects a codec mapped by more than one preloaded module', () => {
+    const first = preloadedConfig('https://tenant-a.example');
+    const second = { ...preloadedConfig('https://tenant-b.example'), id: 'module-b' };
+
+    expect(() => resolveStorageConfigFromCodec({
+      name: 'app_files',
+      extensions: { pg: { schemaName: 'storage_public', name: 'app_files' } },
+    }, [first, second])).toThrow('STORAGE_MODULE_AMBIGUOUS:codec');
+  });
+
+  it('isolates identical logical IDs and object names by exact Graphile build', async () => {
+    const firstBuild = {};
+    const secondBuild = {};
+    const firstScope = getStorageModuleCacheScope(firstBuild);
+    const secondScope = getStorageModuleCacheScope(secondBuild);
+
+    expect(getStorageModuleCacheScope(firstBuild)).toBe(firstScope);
+    expect(secondScope).not.toBe(firstScope);
+
+    const firstClient = {
+      query: jest.fn(async ({ text }: { text: string }) => ({
+        rows: text.includes('metaschema_modules_public.storage_module')
+          ? [storageRow('https://tenant-a.example', 111)]
+          : /SELECT id\s+FROM/.test(text)
+            ? [{ id: BUCKET_ID }]
+            : [bucketRow(111)],
+      })),
+    };
+    const secondClient = {
+      query: jest.fn(async ({ text }: { text: string }) => ({
+        rows: text.includes('metaschema_modules_public.storage_module')
+          ? [storageRow('https://tenant-b.example', 222)]
+          : /SELECT id\s+FROM/.test(text)
+            ? [{ id: BUCKET_ID }]
+            : [bucketRow(222)],
+      })),
+    };
+
+    const [firstModules, secondModules] = await Promise.all([
+      loadAllStorageModules(firstClient, DATABASE_ID, firstScope),
+      loadAllStorageModules(secondClient, DATABASE_ID, secondScope),
+    ]);
+
+    expect(firstModules[0]).toMatchObject({
+      id: MODULE_ID,
+      bucketsQualifiedName: 'storage_public.app_buckets',
+      publicUrlPrefix: 'https://tenant-a.example',
+      defaultMaxFileSize: 111,
+    });
+    expect(secondModules[0]).toMatchObject({
+      id: MODULE_ID,
+      bucketsQualifiedName: 'storage_public.app_buckets',
+      publicUrlPrefix: 'https://tenant-b.example',
+      defaultMaxFileSize: 222,
+    });
+
+    const firstBucket = await getBucketConfig(
+      firstClient,
+      firstModules[0],
+      DATABASE_ID,
+      'private',
+      undefined,
+      firstScope,
+    );
+    const secondBucket = await getBucketConfig(
+      secondClient,
+      secondModules[0],
+      DATABASE_ID,
+      'private',
+      undefined,
+      secondScope,
+    );
+
+    expect(firstBucket).toMatchObject({ id: BUCKET_ID, key: 'private', max_file_size: 111 });
+    expect(secondBucket).toMatchObject({ id: BUCKET_ID, key: 'private', max_file_size: 222 });
+
+    markS3BucketProvisioned('same-physical-bucket-name', firstScope);
+    expect(isS3BucketProvisioned('same-physical-bucket-name', firstScope)).toBe(true);
+    expect(isS3BucketProvisioned('same-physical-bucket-name', secondScope)).toBe(false);
+  });
+
+  it('negative-caches metadata inside one build without poisoning another build', async () => {
+    const missingScope = getStorageModuleCacheScope({});
+    const presentScope = getStorageModuleCacheScope({});
+    const missingClient = {
+      query: jest.fn(async (_opts: QueryOptions): Promise<{ rows: unknown[] }> => ({ rows: [] })),
+    };
+    const presentClient = {
+      query: jest.fn(async () => ({ rows: [storageRow('https://present.example')] })),
+    };
+
+    await expect(getStorageModuleConfig(missingClient, DATABASE_ID, missingScope)).resolves.toBeNull();
+    await expect(getStorageModuleConfig(missingClient, DATABASE_ID, missingScope)).resolves.toBeNull();
+    expect(missingClient.query).toHaveBeenCalledTimes(1);
+
+    await expect(getStorageModuleConfig(presentClient, DATABASE_ID, presentScope)).resolves.toMatchObject({
+      id: MODULE_ID,
+      publicUrlPrefix: 'https://present.example',
+    });
+    expect(presentClient.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('negative-caches bucket metadata but rechecks RLS on every cache hit', async () => {
+    const scope = getStorageModuleCacheScope({});
+    const moduleClient = {
+      query: jest.fn(async () => ({ rows: [storageRow('https://tenant.example')] })),
+    };
+    const [storageConfig] = await loadAllStorageModules(moduleClient, DATABASE_ID, scope);
+    const bucketClient = {
+      query: jest.fn(async (_opts: QueryOptions): Promise<{ rows: unknown[] }> => ({ rows: [] })),
+    };
+
+    await expect(
+      getBucketConfig(bucketClient, storageConfig, DATABASE_ID, 'private', undefined, scope),
+    ).resolves.toBeNull();
+    await expect(
+      getBucketConfig(bucketClient, storageConfig, DATABASE_ID, 'private', undefined, scope),
+    ).resolves.toBeNull();
+
+    expect(bucketClient.query).toHaveBeenCalledTimes(2);
+    const calls = bucketClient.query.mock.calls as unknown as Array<[QueryOptions]>;
+    expect(calls[0][0].text).toContain('allowed_mime_types');
+    expect(calls[1][0].text).toMatch(/SELECT id\s+FROM/);
+  });
+
+  it('does not return a positive bucket cache hit when the current RLS context cannot see it', async () => {
+    const scope = getStorageModuleCacheScope({});
+    const moduleClient = {
+      query: jest.fn(async () => ({ rows: [storageRow('https://tenant.example')] })),
+    };
+    const [storageConfig] = await loadAllStorageModules(moduleClient, DATABASE_ID, scope);
+    const authorizedClient = {
+      query: jest.fn(async () => ({ rows: [bucketRow(512)] })),
+    };
+    const unauthorizedClient = {
+      query: jest.fn(async (_opts: QueryOptions): Promise<{ rows: unknown[] }> => ({ rows: [] })),
+    };
+
+    await expect(
+      getBucketConfig(authorizedClient, storageConfig, DATABASE_ID, 'private', undefined, scope),
+    ).resolves.toMatchObject({ id: BUCKET_ID, max_file_size: 512 });
+    await expect(
+      getBucketConfig(unauthorizedClient, storageConfig, DATABASE_ID, 'private', undefined, scope),
+    ).resolves.toBeNull();
+
+    const calls = unauthorizedClient.query.mock.calls as unknown as Array<[QueryOptions]>;
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0].text).toMatch(/SELECT id\s+FROM/);
+  });
+
+  it('memoizes lazy S3 configuration per build instead of on shared preset options', () => {
+    const firstScope = getStorageModuleCacheScope({});
+    const secondScope = getStorageModuleCacheScope({});
+    let activeBucket = 'tenant-a-bucket';
+    const getter = jest.fn(() => ({
+      client: {} as any,
+      bucket: activeBucket,
+    }));
+    const sharedOptions: PresignedUrlPluginOptions = { s3: getter };
+
+    const first = resolveS3Config(sharedOptions, firstScope);
+    activeBucket = 'tenant-b-bucket';
+    const second = resolveS3Config(sharedOptions, secondScope);
+    activeBucket = 'unrelated-later-value';
+
+    expect(resolveS3Config(sharedOptions, firstScope)).toBe(first);
+    expect(resolveS3Config(sharedOptions, secondScope)).toBe(second);
+    expect(first.bucket).toBe('tenant-a-bucket');
+    expect(second.bucket).toBe('tenant-b-bucket');
+    expect(getter).toHaveBeenCalledTimes(2);
+    expect(typeof sharedOptions.s3).toBe('function');
+  });
+
+  it('matches the bucket provisioner resolver argument order on first provision', () => {
+    const cacheScope = getStorageModuleCacheScope({});
+    const resolver = jest.fn((bucketKey: string, databaseId: string) =>
+      `physical-${bucketKey}-${databaseId}`,
+    );
+
+    expect(mintPhysicalBucketName(
+      { ...options('fallback'), resolveBucketName: resolver },
+      'private',
+      DATABASE_ID,
+      cacheScope,
+    )).toBe(`physical-private-${DATABASE_ID}`);
+    expect(resolver).toHaveBeenCalledWith('private', DATABASE_ID);
+  });
+
+  it('does not cache an owner lookup across RLS principals', async () => {
+    const scope = getStorageModuleCacheScope({});
+    const entityRow = {
+      ...storageRow('https://tenant.example'),
+      scope: 'team',
+      entity_table_id: '00000000-0000-0000-0000-000000000004',
+      entity_database_id: DATABASE_ID,
+      entity_schema_database_id: DATABASE_ID,
+      entity_schema: 'app_public',
+      entity_table: 'teams',
+    };
+    const authorizedClient = {
+      query: jest.fn(async ({ text }: QueryOptions) => ({
+        rows: text.includes('metaschema_modules_public.storage_module')
+          ? [entityRow]
+          : [{ '?column?': 1 }],
+      })),
+    };
+    const unauthorizedClient = {
+      query: jest.fn(async (_opts: QueryOptions): Promise<{ rows: unknown[] }> => ({ rows: [] })),
+    };
+
+    await expect(
+      getStorageModuleConfigForOwner(authorizedClient, DATABASE_ID, 'owner-id', scope),
+    ).resolves.toMatchObject({ id: MODULE_ID, scope: 'team' });
+    await expect(
+      getStorageModuleConfigForOwner(unauthorizedClient, DATABASE_ID, 'owner-id', scope),
+    ).resolves.toBeNull();
+
+    expect(unauthorizedClient.query).toHaveBeenCalledTimes(1);
+    const calls = unauthorizedClient.query.mock.calls as unknown as Array<[QueryOptions]>;
+    expect(calls[0][0].text).toContain('WHERE id = $1');
+  });
+});
+
+describe('download target fail-closed resolution', () => {
+  const codec = {
+    name: 'app_files',
+    extensions: { pg: { schemaName: 'storage_public', name: 'app_files' } },
+  };
+
+  it('keeps identical logical tenants on their own build configuration', async () => {
+    async function resolveForBuild(
+      build: object,
+      publicUrlPrefix: string,
+      s3Bucket: string,
+    ) {
+      const pgSettings = {
+        role: 'member',
+        'jwt.claims.api_id': 'api-a',
+        'jwt.claims.database_id': DATABASE_ID,
+        'jwt.claims.user_id': '',
+      };
+      const requestQuery = jest.fn(async ({ text }: QueryOptions) => {
+        if (text.includes('current_database_id')) return { rows: [{ id: DATABASE_ID }] };
+        if (text.includes('metaschema_modules_public.storage_module')) {
+          return { rows: [storageRow(publicUrlPrefix)] };
+        }
+        if (text.includes('SELECT key, physical_name FROM')) {
+          return { rows: [{ key: 'private', physical_name: s3Bucket }] };
+        }
+        throw new Error(`Unexpected query: ${text}`);
+      });
+      const { withPgClient } = requestPgHarness(pgSettings, requestQuery);
+
+      return resolveDownloadStorageTarget({
+        options: options(s3Bucket),
+        preloadedStorageModules: undefined,
+        cacheScope: getStorageModuleCacheScope(build),
+        codec,
+        withPgClient,
+        pgSettings,
+        bucketId: BUCKET_ID,
+      });
+    }
+
+    const [first, second] = await Promise.all([
+      resolveForBuild({}, 'https://tenant-a.example', 'tenant-a-bucket'),
+      resolveForBuild({}, 'https://tenant-b.example', 'tenant-b-bucket'),
+    ]);
+
+    expect(first.s3).toMatchObject({
+      bucket: 'tenant-a-bucket',
+      publicUrlPrefix: 'https://tenant-a.example',
+    });
+    expect(second.s3).toMatchObject({
+      bucket: 'tenant-b-bucket',
+      publicUrlPrefix: 'https://tenant-b.example',
+    });
+  });
+
+  it('propagates lookup failures and never resolves fallback signing config', async () => {
+    const pgSettings = {
+      role: 'member',
+      'jwt.claims.api_id': 'api-a',
+      'jwt.claims.database_id': DATABASE_ID,
+      'jwt.claims.user_id': '',
+    };
+    const s3Getter = jest.fn(() => ({
+      client: {} as any,
+      bucket: 'unsafe-global-fallback',
+    }));
+    const requestQuery = jest.fn(async ({ text }: QueryOptions) => {
+      if (text.includes('current_database_id')) return { rows: [{ id: DATABASE_ID }] };
+      throw new Error('tenant metadata lookup failed');
+    });
+    const { withPgClient } = requestPgHarness(pgSettings, requestQuery);
+
+    await expect(resolveDownloadStorageTarget({
+      options: { s3: s3Getter },
+      preloadedStorageModules: undefined,
+      cacheScope: getStorageModuleCacheScope({}),
+      codec,
+      withPgClient,
+      pgSettings,
+      bucketId: BUCKET_ID,
+    })).rejects.toThrow('tenant metadata lookup failed');
+    expect(s3Getter).not.toHaveBeenCalled();
+  });
+
+  it('does not consult global signing config when tenant metadata is absent', async () => {
+    const pgSettings = {
+      role: 'member',
+      'jwt.claims.api_id': 'api-a',
+      'jwt.claims.database_id': DATABASE_ID,
+      'jwt.claims.user_id': '',
+    };
+    const s3Getter = jest.fn(() => ({
+      client: {} as any,
+      bucket: 'unsafe-global-fallback',
+    }));
+    const requestQuery = jest.fn(async ({ text }: QueryOptions) => {
+      if (text.includes('current_database_id')) return { rows: [{ id: DATABASE_ID }] };
+      if (text.includes('metaschema_modules_public.storage_module')) return { rows: [] };
+      throw new Error(`Unexpected query: ${text}`);
+    });
+    const { withPgClient } = requestPgHarness(pgSettings, requestQuery);
+
+    await expect(resolveDownloadStorageTarget({
+      options: { s3: s3Getter },
+      preloadedStorageModules: undefined,
+      cacheScope: getStorageModuleCacheScope({}),
+      codec,
+      withPgClient,
+      pgSettings,
+      bucketId: BUCKET_ID,
+    })).rejects.toThrow('STORAGE_MODULE_NOT_FOUND');
+    expect(s3Getter).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing request settings before acquiring a metadata client or signing', async () => {
+    const s3Getter = jest.fn(() => ({
+      client: {} as any,
+      bucket: 'unsafe-global-fallback',
+    }));
+    const withPgClient = jest.fn();
+
+    await expect(resolveDownloadStorageTarget({
+      options: { s3: s3Getter },
+      preloadedStorageModules: undefined,
+      cacheScope: getStorageModuleCacheScope({}),
+      codec,
+      withPgClient,
+      pgSettings: null,
+      bucketId: BUCKET_ID,
+    })).rejects.toThrow('STORAGE_REQUEST_SETTINGS_UNAVAILABLE');
+    expect(withPgClient).not.toHaveBeenCalled();
+    expect(s3Getter).not.toHaveBeenCalled();
+  });
+
+  it('uses persisted physical_name verbatim without consulting the naming resolver', async () => {
+    const resolver = jest.fn(() => 'recomputed-and-wrong');
+    const pgSettings = { role: 'member' };
+    const requestQuery = jest.fn(async ({ text }: QueryOptions) => {
+      if (text.includes('current_database_id')) return { rows: [{ id: DATABASE_ID }] };
+      if (text.includes('SELECT key, physical_name FROM')) {
+        return { rows: [{ key: 'private', physical_name: 'persisted-physical-bucket' }] };
+      }
+      throw new Error(`Unexpected query: ${text}`);
+    });
+    const { withPgClient } = requestPgHarness(pgSettings, requestQuery);
+
+    await expect(resolveDownloadStorageTarget({
+      options: {
+        ...options('global-fallback'),
+        resolveBucketName: resolver,
+      },
+      preloadedStorageModules: snapshotPreloadedStorageModules([
+        preloadedConfig('https://tenant.example'),
+      ]),
+      cacheScope: getStorageModuleCacheScope({}),
+      codec,
+      withPgClient,
+      pgSettings,
+      bucketId: BUCKET_ID,
+    })).resolves.toMatchObject({
+      s3: { bucket: 'persisted-physical-bucket' },
+    });
+    expect(resolver).not.toHaveBeenCalled();
+  });
+});
+
+describe('preloaded storage-module configuration', () => {
+  const codec = {
+    name: 'app_files',
+    extensions: { pg: { schemaName: 'storage_public', name: 'app_files' } },
+  };
+
+  it('takes an immutable snapshot and performs zero metadata SQL', async () => {
+    const source = [preloadedConfig('https://tenant.example')];
+    const snapshot = snapshotPreloadedStorageModules(source)!;
+    source[0].publicUrlPrefix = 'https://mutated.example';
+    source[0].allowedOrigins!.push('https://mutated.example');
+    const withPgClient = jest.fn(async () => {
+      throw new Error('preloaded configuration must not acquire a metadata client');
+    });
+
+    await expect(loadStorageModulesForBuild(
+      snapshot,
+      withPgClient,
+      { role: 'tenant_member' },
+      DATABASE_ID,
+      getStorageModuleCacheScope({}),
+    )).resolves.toBe(snapshot);
+
+    expect(withPgClient).not.toHaveBeenCalled();
+    expect(Object.isFrozen(snapshot)).toBe(true);
+    expect(Object.isFrozen(snapshot[0])).toBe(true);
+    expect(Object.isFrozen(snapshot[0].allowedOrigins)).toBe(true);
+    expect(snapshotPreloadedStorageModules(snapshot)).toBe(snapshot);
+    expect(snapshot[0].publicUrlPrefix).toBe('https://tenant.example');
+    expect(snapshot[0].allowedOrigins).toEqual(['https://app.example']);
+  });
+
+  it('rejects executable SQL and inconsistent object names in a preload', () => {
+    expect(() => snapshotPreloadedStorageModules([{
+      ...preloadedConfig('https://tenant.example'),
+      bucketsQualifiedName: 'storage_public.app_buckets; SELECT pg_sleep(10)',
+    }])).toThrow(`STORAGE_MODULE_METADATA_INVALID:buckets:${MODULE_ID}`);
+
+    expect(() => snapshotPreloadedStorageModules([{
+      ...preloadedConfig('https://tenant.example'),
+      bucketsQualifiedName: 'other_schema.app_buckets',
+    }])).toThrow(`STORAGE_MODULE_METADATA_INCONSISTENT:${MODULE_ID}`);
+  });
+
+  it('rejects duplicate scope metadata in a preload', () => {
+    expect(() => snapshotPreloadedStorageModules([
+      preloadedConfig('https://tenant-a.example'),
+      { ...preloadedConfig('https://tenant-b.example'), id: 'module-b' },
+    ])).toThrow('STORAGE_MODULE_METADATA_AMBIGUOUS');
+  });
+
+  it('treats an empty preloaded list as authoritative instead of falling back', async () => {
+    const snapshot = snapshotPreloadedStorageModules([])!;
+    const withPgClient = jest.fn(async () => {
+      throw new Error('empty preload must not fall back');
+    });
+
+    await expect(loadStorageModulesForBuild(
+      snapshot,
+      withPgClient,
+      { role: 'tenant_member' },
+      DATABASE_ID,
+      getStorageModuleCacheScope({}),
+    )).resolves.toEqual([]);
+    expect(withPgClient).not.toHaveBeenCalled();
+  });
+
+  it('keeps request identity and bucket authorization under pgSettings', async () => {
+    const pgSettings = { role: 'tenant_member' };
+    const requestQuery = jest.fn(async ({ text }: QueryOptions) => {
+      if (text.includes('current_database_id')) {
+        return { rows: [{ id: DATABASE_ID }] };
+      }
+      if (text.includes('SELECT key, physical_name FROM storage_public.app_buckets')) {
+        return { rows: [{ key: 'private', physical_name: 'tenant-bucket' }] };
+      }
+      if (text.includes('metaschema_')) {
+        throw new Error('metadata SQL must not run');
+      }
+      throw new Error(`Unexpected query: ${text}`);
+    });
+    const {
+      withPgClient,
+      withPgClientMock,
+      withTransaction,
+      query,
+    } = requestPgHarness(pgSettings, requestQuery);
+    const preloaded = snapshotPreloadedStorageModules([
+      preloadedConfig('https://tenant.example'),
+    ]);
+
+    await expect(resolveDownloadStorageTarget({
+      options: options('tenant-bucket'),
+      preloadedStorageModules: preloaded,
+      cacheScope: getStorageModuleCacheScope({}),
+      codec,
+      withPgClient,
+      pgSettings,
+      bucketId: BUCKET_ID,
+    })).resolves.toMatchObject({
+      s3: {
+        bucket: 'tenant-bucket',
+        publicUrlPrefix: 'https://tenant.example',
+      },
+      downloadUrlExpirySeconds: 1234,
+    });
+
+    expect(withPgClientMock).toHaveBeenCalledTimes(1);
+    expect(withTransaction).toHaveBeenCalledTimes(1);
+    expect(query).toHaveBeenCalledTimes(3);
+    expect(requestQuery).toHaveBeenCalledTimes(2);
+    expect(requestQuery.mock.calls.map(([arg]) => arg.text).join('\n')).not.toContain('metaschema_');
+  });
+
+  it('retains the metadata SQL fallback only when preloaded modules are undefined and applies request settings', async () => {
+    const pgSettings = {
+      role: 'tenant_member',
+      'jwt.claims.api_id': 'api-a',
+      'jwt.claims.database_id': DATABASE_ID,
+      'jwt.claims.user_id': '',
+      'transaction_read_only': 'off',
+      'row_security': 'on',
+    };
+    const pgClient = {
+      query: jest.fn(async () => ({ rows: [storageRow('https://generic.example')] })),
+    };
+    const withPgClient = jest.fn(async (
+      settings: unknown,
+      callback: (client: typeof pgClient) => Promise<unknown> | unknown,
+    ) => {
+      expect(settings).toBe(pgSettings);
+      return callback(pgClient);
+    }) as unknown as StorageWithPgClient;
+
+    await expect(loadStorageModulesForBuild(
+      undefined,
+      withPgClient,
+      pgSettings,
+      DATABASE_ID,
+      getStorageModuleCacheScope({}),
+    )).resolves.toHaveLength(1);
+
+    expect(withPgClient).toHaveBeenCalledTimes(1);
+    expect(pgClient.query).toHaveBeenCalledTimes(1);
+  });
+});

--- a/graphile/graphile-presigned-url-plugin/__tests__/upload-owner-scope.test.ts
+++ b/graphile/graphile-presigned-url-plugin/__tests__/upload-owner-scope.test.ts
@@ -1,0 +1,82 @@
+import { resolveUploadOwnerScope } from '../src/plugin';
+import type { StorageModuleConfig } from '../src/types';
+
+const moduleConfig = (scope: string): StorageModuleConfig => ({
+  id: '00000000-0000-4000-8000-000000000001',
+  bucketsQualifiedName: 'storage_public.app_buckets',
+  filesQualifiedName: 'storage_public.app_files',
+  schemaName: 'storage_public',
+  bucketsTableName: 'app_buckets',
+  filesTableName: 'app_files',
+  scope,
+  entityTableId: scope === 'app' ? null : '00000000-0000-4000-8000-000000000002',
+  entityQualifiedName: scope === 'app' ? null : 'app_public.organizations',
+  endpoint: null,
+  publicUrlPrefix: null,
+  provider: 's3',
+  allowedOrigins: null,
+  uploadUrlExpirySeconds: 900,
+  downloadUrlExpirySeconds: 3600,
+  defaultMaxFileSize: 1024,
+  maxFilenameLength: 1024,
+  cacheTtlSeconds: 300,
+  hasPathShares: false,
+  maxBulkFiles: 100,
+  maxBulkTotalSize: 1024,
+});
+
+const filesCodec = {
+  name: 'app_files',
+  extensions: {
+    pg: { schemaName: 'storage_public', name: 'app_files' },
+  },
+};
+
+const bucketCodec = (withOwnerColumn = true) => ({
+  name: 'app_buckets',
+  attributes: withOwnerColumn ? { owner_id: { codec: 'uuid-codec' } } : {},
+  extensions: {
+    pg: { schemaName: 'storage_public', name: 'app_buckets' },
+  },
+});
+
+describe('upload owner scope', () => {
+  it('keeps ownerId optional for an authoritative app-scoped module', () => {
+    expect(resolveUploadOwnerScope(
+      filesCodec,
+      bucketCodec(),
+      [moduleConfig('app')],
+    )).toEqual({ hasOwnerId: false, ownerIdCodec: 'uuid-codec' });
+  });
+
+  it('requires ownerId for an authoritative entity-scoped module', () => {
+    expect(resolveUploadOwnerScope(
+      filesCodec,
+      bucketCodec(),
+      [moduleConfig('organization')],
+    )).toEqual({ hasOwnerId: true, ownerIdCodec: 'uuid-codec' });
+  });
+
+  it('fails closed when entity scope has no owner_id column', () => {
+    expect(() => resolveUploadOwnerScope(
+      filesCodec,
+      bucketCodec(false),
+      [moduleConfig('organization')],
+    )).toThrow('STORAGE_OWNER_COLUMN_REQUIRED:storage_public.app_buckets');
+  });
+
+  it('omits upload fields when an authoritative snapshot has no matching module', () => {
+    expect(resolveUploadOwnerScope(filesCodec, bucketCodec(), [])).toBeNull();
+  });
+
+  it('retains column inference only for generic consumers without a snapshot', () => {
+    expect(resolveUploadOwnerScope(filesCodec, bucketCodec(), undefined)).toEqual({
+      hasOwnerId: true,
+      ownerIdCodec: 'uuid-codec',
+    });
+    expect(resolveUploadOwnerScope(filesCodec, bucketCodec(false), undefined)).toEqual({
+      hasOwnerId: false,
+      ownerIdCodec: null,
+    });
+  });
+});

--- a/graphile/graphile-presigned-url-plugin/src/download-url-field.ts
+++ b/graphile/graphile-presigned-url-plugin/src/download-url-field.ts
@@ -25,10 +25,27 @@ import { Logger } from '@pgpmjs/logger';
 import { context as grafastContext, lambda, object } from 'grafast';
 import type { GraphileConfig } from 'graphile-config';
 
-import { withRequestPgClient } from './request-pg-client';
+import {
+  type RequestPgClient,
+  type WithPgClient,
+  withRequestPgClient,
+} from './request-pg-client';
 import { generatePresignedGetUrl } from './s3-signer';
-import { loadAllStorageModules, resolveStorageConfigFromCodec, storedPhysicalName } from './storage-module-cache';
-import type { PresignedUrlPluginOptions, S3Config, StorageModuleConfig } from './types';
+import { resolveS3ConfigForPhysicalBucket } from './s3-config';
+import {
+  getStorageModuleCacheScope,
+  resolveStorageConfigFromCodec,
+  storedPhysicalName,
+  type StorageModuleCacheScope,
+} from './storage-module-cache';
+import {
+  assertStorageRequestContext,
+  loadStorageModulesForBuild,
+  snapshotPreloadedStorageModules,
+  type PreloadedStorageModules,
+  type StorageWithPgClient,
+} from './storage-module-source';
+import type { PresignedUrlPluginOptions, S3Config } from './types';
 
 const log = new Logger('graphile-presigned-url:download-url');
 
@@ -41,48 +58,101 @@ const log = new Logger('graphile-presigned-url:download-url');
  * the storage module's files table, which we discover at schema-build time
  * via the `@storageFiles` smart tag.
  */
-/**
- * Resolve the S3 config from the options. If the option is a lazy getter
- * function, call it (and cache the result).
- */
-function resolveS3(options: PresignedUrlPluginOptions): S3Config {
-  if (typeof options.s3 === 'function') {
-    const resolved = options.s3();
-    options.s3 = resolved;
-    return resolved;
-  }
-  return options.s3;
+interface DownloadStorageTargetOptions {
+  options: PresignedUrlPluginOptions;
+  preloadedStorageModules: PreloadedStorageModules;
+  cacheScope: StorageModuleCacheScope;
+  codec: {
+    name: string;
+    extensions?: { pg?: { schemaName?: string; name?: string } };
+    sqlType?: string;
+  };
+  withPgClient: (WithPgClient & StorageWithPgClient) | null | undefined;
+  pgSettings: unknown;
+  bucketId: string | null | undefined;
+}
+
+function withCurrentRequestPgClient(
+  pgClient: RequestPgClient,
+): StorageWithPgClient {
+  return async (_pgSettings, callback) => callback(pgClient);
 }
 
 /**
- * Build a per-database S3Config for a *known* physical bucket. `physicalName`
- * is required — the stored coordinate on the bucket row is the only source;
- * no name is ever recomputed here. Same logic as plugin.ts resolveS3ForDatabase.
+ * Resolve every tenant-bound input before choosing credentials or signing.
+ * Any missing metadata or database error rejects the field instead of signing
+ * the same key with process-global fallback configuration.
  */
-function resolveS3ForDatabase(
-  options: PresignedUrlPluginOptions,
-  storageConfig: StorageModuleConfig,
-  physicalName: string,
-): S3Config {
-  const globalS3 = resolveS3(options);
-  const publicUrlPrefix = storageConfig.publicUrlPrefix != null
-    ? storageConfig.publicUrlPrefix
-    : globalS3.publicUrlPrefix;
+export async function resolveDownloadStorageTarget({
+  options,
+  preloadedStorageModules,
+  cacheScope,
+  codec,
+  withPgClient,
+  pgSettings,
+  bucketId,
+}: DownloadStorageTargetOptions): Promise<{
+  s3: S3Config;
+  downloadUrlExpirySeconds: number;
+}> {
+  assertStorageRequestContext(withPgClient, pgSettings);
+  const requestSettings = pgSettings as Record<string, string>;
 
-  if (physicalName === globalS3.bucket && publicUrlPrefix === globalS3.publicUrlPrefix) {
-    return globalS3;
-  }
+  return withRequestPgClient(withPgClient, requestSettings, async (pgClient) => {
+    const result = await pgClient.query({
+      text: `SELECT jwt_private.current_database_id() AS id`,
+    });
+    const databaseId = result.rows[0]?.id as string | null | undefined;
+    if (!databaseId) {
+      throw new Error('DATABASE_NOT_FOUND');
+    }
 
-  return {
-    ...globalS3,
-    bucket: physicalName,
-    ...(publicUrlPrefix != null ? { publicUrlPrefix } : {}),
-  };
+    const allConfigs = await loadStorageModulesForBuild(
+      preloadedStorageModules,
+      withCurrentRequestPgClient(pgClient),
+      requestSettings,
+      databaseId,
+      cacheScope,
+    );
+    const storageConfig = resolveStorageConfigFromCodec(codec, allConfigs);
+    if (!storageConfig) {
+      throw new Error('STORAGE_MODULE_NOT_FOUND');
+    }
+    if (!bucketId) {
+      throw new Error('BUCKET_NOT_FOUND');
+    }
+
+    const bucketResult = await pgClient.query({
+      text: `SELECT key, physical_name FROM ${storageConfig.bucketsQualifiedName} WHERE id = $1 LIMIT 1`,
+      values: [bucketId],
+    });
+    const bucketRow = bucketResult.rows[0] as { key: string; physical_name?: string | null } | undefined;
+    if (!bucketRow) {
+      throw new Error('BUCKET_NOT_FOUND');
+    }
+    const physicalName = storedPhysicalName(bucketRow);
+    if (physicalName === null) {
+      throw new Error('BUCKET_NOT_PROVISIONED');
+    }
+
+    return {
+      s3: resolveS3ConfigForPhysicalBucket(
+        options,
+        storageConfig,
+        physicalName,
+        cacheScope,
+      ),
+      downloadUrlExpirySeconds: storageConfig.downloadUrlExpirySeconds,
+    };
+  });
 }
 
 export function createDownloadUrlPlugin(
   options: PresignedUrlPluginOptions,
 ): GraphileConfig.Plugin {
+  const preloadedStorageModules = snapshotPreloadedStorageModules(
+    options.preloadedStorageModules,
+  );
 
   return {
     name: 'PresignedUrlDownloadPlugin',
@@ -108,6 +178,7 @@ export function createDownloadUrlPlugin(
           }
 
           log.debug(`Adding downloadUrl field to type: ${pgCodec.name} (has @storageFiles tag)`);
+          const cacheScope = getStorageModuleCacheScope(build);
 
           const {
             graphql: { GraphQLString },
@@ -146,56 +217,32 @@ export function createDownloadUrlPlugin(
                     return lambda($combined, async ({ key, isPublic, filename, bucketId, withPgClient, pgSettings }: any) => {
                       if (!key) return null;
 
-                      let s3ForDb = resolveS3(options);
-                      let downloadUrlExpirySeconds = 3600;
+                      let target: Awaited<ReturnType<typeof resolveDownloadStorageTarget>>;
                       try {
-                        if (withPgClient && pgSettings) {
-                          const databaseId = await withRequestPgClient(withPgClient, pgSettings, async (pgClient) => {
-                            const dbResult = await pgClient.query({
-                              text: `SELECT jwt_private.current_database_id() AS id`,
-                            });
-                            return (dbResult.rows[0]?.id as string | undefined) ?? null;
-                          });
-                          // Module registration is server config, not user data:
-                          // resolve it without the request role's pgSettings.
-                          const config = databaseId
-                            ? resolveStorageConfigFromCodec(
-                              capturedCodec,
-                              await withPgClient(null, (pgClient: any) => loadAllStorageModules(pgClient, databaseId)),
-                            )
-                            : null;
-                          const resolved = config && bucketId
-                            ? await withRequestPgClient(withPgClient, pgSettings, async (pgClient) => {
-                              // Look up the stored physical coordinate for scoped S3 resolution
-                              const bucketResult = await pgClient.query({
-                                text: `SELECT key, physical_name FROM ${config.bucketsQualifiedName} WHERE id = $1 LIMIT 1`,
-                                values: [bucketId],
-                              });
-                              const row = bucketResult.rows[0] as { key: string; physical_name?: string | null } | undefined;
-                              return row ? { config, physicalName: storedPhysicalName(row) } : null;
-                            })
-                            : null;
-                          if (resolved) {
-                            if (resolved.physicalName === null) {
-                              // No physical bucket was ever provisioned — no object can exist.
-                              return null;
-                            }
-                            downloadUrlExpirySeconds = resolved.config.downloadUrlExpirySeconds;
-                            s3ForDb = resolveS3ForDatabase(options, resolved.config, resolved.physicalName);
-                          }
+                        target = await resolveDownloadStorageTarget({
+                          options,
+                          preloadedStorageModules,
+                          cacheScope,
+                          codec: capturedCodec,
+                          withPgClient,
+                          pgSettings,
+                          bucketId,
+                        });
+                      } catch (error) {
+                        if (error instanceof Error && error.message === 'BUCKET_NOT_PROVISIONED') {
+                          return null;
                         }
-                      } catch {
-                        // Fall back to global config if lookup fails
+                        throw error;
                       }
 
-                      if (isPublic && s3ForDb.publicUrlPrefix) {
-                        return `${s3ForDb.publicUrlPrefix}/${s3ForDb.bucket}/${key}`;
+                      if (isPublic && target.s3.publicUrlPrefix) {
+                        return `${target.s3.publicUrlPrefix}/${target.s3.bucket}/${key}`;
                       }
 
                       return generatePresignedGetUrl(
-                        s3ForDb,
+                        target.s3,
                         key,
-                        downloadUrlExpirySeconds,
+                        target.downloadUrlExpirySeconds,
                         filename || undefined,
                       );
                     });

--- a/graphile/graphile-presigned-url-plugin/src/index.ts
+++ b/graphile/graphile-presigned-url-plugin/src/index.ts
@@ -28,10 +28,25 @@
  */
 
 export { createDownloadUrlPlugin } from './download-url-field';
-export { createPresignedUrlPlugin,PresignedUrlPlugin } from './plugin';
+export { createPresignedUrlPlugin, PresignedUrlPlugin } from './plugin';
 export { PresignedUrlPreset } from './preset';
+export { snapshotPreloadedStorageModules } from './storage-module-source';
 export { deleteS3Object, generatePresignedGetUrl, generatePresignedPutUrl, headObject } from './s3-signer';
-export { clearBucketCache, clearStorageModuleCache, getBucketConfig, getStorageModuleConfig, getStorageModuleConfigForOwner, isS3BucketProvisioned, loadAllStorageModules, markS3BucketProvisioned,resolveStorageConfigFromCodec, resolveStorageModuleByFileId } from './storage-module-cache';
+export {
+  getStorageModuleConfig,
+  getStorageModuleConfigForOwner,
+  getBucketConfig,
+  resolveStorageModuleByFileId,
+  loadAllStorageModules,
+  resolveStorageConfigFromCodec,
+  clearStorageModuleCache,
+  clearBucketCache,
+  isS3BucketProvisioned,
+  markS3BucketProvisioned,
+  StorageModuleCacheScope,
+  getStorageModuleCacheScope,
+  storedPhysicalName,
+} from './storage-module-cache';
 export type {
   BucketConfig,
   BucketNameResolver,

--- a/graphile/graphile-presigned-url-plugin/src/plugin.ts
+++ b/graphile/graphile-presigned-url-plugin/src/plugin.ts
@@ -23,10 +23,32 @@ import { Logger } from '@pgpmjs/logger';
 import { access, context as grafastContext, lambda, object } from 'grafast';
 import type { GraphileConfig } from 'graphile-config';
 
-import { type WithPgClient,withRequestPgClient } from './request-pg-client';
-import { deleteS3Object,generatePresignedPutUrl } from './s3-signer';
-import { getBucketConfig, isS3BucketProvisioned, loadAllStorageModules, markS3BucketProvisioned,resolveStorageConfigFromCodec, storedPhysicalName } from './storage-module-cache';
-import type { BucketConfig,PresignedUrlPluginOptions, S3Config, StorageModuleConfig } from './types';
+import {
+  type RequestPgClient,
+  type WithPgClient,
+  withRequestPgClient,
+} from './request-pg-client';
+import {
+  mintPhysicalBucketName,
+  resolveS3ConfigForPhysicalBucket,
+} from './s3-config';
+import { deleteS3Object, generatePresignedPutUrl } from './s3-signer';
+import {
+  getBucketConfig,
+  getStorageModuleCacheScope,
+  isS3BucketProvisioned,
+  markS3BucketProvisioned,
+  resolveStorageConfigFromCodec,
+  type StorageModuleCacheScope,
+  storedPhysicalName,
+} from './storage-module-cache';
+import {
+  assertStorageRequestContext,
+  loadStorageModulesForBuild,
+  snapshotPreloadedStorageModules,
+  type StorageWithPgClient,
+} from './storage-module-source';
+import type { BucketConfig, PresignedUrlPluginOptions, S3Config, StorageModuleConfig } from './types';
 
 const log = new Logger('graphile-presigned-url:plugin');
 
@@ -37,6 +59,49 @@ const MAX_CONTENT_TYPE_LENGTH = 255;
 const MAX_CUSTOM_KEY_LENGTH = 1024;
 const SHA256_HEX_REGEX = /^[a-f0-9]{64}$/;
 const CUSTOM_KEY_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9_.\-/]*$/;
+
+type TaggedStorageCodec = {
+  name: string;
+  attributes?: Record<string, { codec?: unknown }>;
+  extensions?: { pg?: { schemaName?: string; name?: string } };
+};
+
+/**
+ * Resolve the upload input's owner scope at schema-build time.
+ *
+ * Exact-build preloaded metadata is authoritative: app-scoped modules must
+ * not expose a required ownerId merely because their canonical bucket table
+ * retains a nullable owner_id column. Generic consumers without a preloaded
+ * snapshot retain the legacy column-based inference because their module
+ * scope is available only at request time.
+ */
+export function resolveUploadOwnerScope(
+  filesCodec: TaggedStorageCodec,
+  bucketCodec: TaggedStorageCodec,
+  preloadedStorageModules: readonly StorageModuleConfig[] | undefined,
+): { hasOwnerId: boolean; ownerIdCodec: unknown | null } | null {
+  const ownerIdCodec = bucketCodec.attributes?.owner_id?.codec ?? null;
+  if (preloadedStorageModules === undefined) {
+    return {
+      hasOwnerId: ownerIdCodec !== null,
+      ownerIdCodec,
+    };
+  }
+
+  const storageConfig = resolveStorageConfigFromCodec(
+    filesCodec,
+    preloadedStorageModules,
+  );
+  if (!storageConfig) return null;
+
+  const hasOwnerId = storageConfig.scope !== 'app';
+  if (hasOwnerId && ownerIdCodec === null) {
+    throw new Error(
+      `STORAGE_OWNER_COLUMN_REQUIRED:${storageConfig.schemaName}.${storageConfig.bucketsTableName}`,
+    );
+  }
+  return { hasOwnerId, ownerIdCodec };
+}
 
 // --- Helpers ---
 
@@ -81,58 +146,39 @@ async function resolveDatabaseId(pgClient: any): Promise<string | null> {
   return result.rows[0]?.id ?? null;
 }
 
-function resolveS3(options: PresignedUrlPluginOptions): S3Config {
-  if (typeof options.s3 === 'function') {
-    const resolved = options.s3();
-    options.s3 = resolved;
-    return resolved;
-  }
-  return options.s3;
+type RequestStorageWithPgClient = WithPgClient & StorageWithPgClient;
+
+function withCurrentRequestPgClient(
+  pgClient: RequestPgClient,
+): StorageWithPgClient {
+  return async (_pgSettings, callback) => callback(pgClient);
 }
 
-/**
- * Mint the physical S3 bucket name for a logical bucket's first provision.
- *
- * This is a naming *policy*, consulted exactly once per bucket — before the
- * physical bucket exists. Once provisioned, the recorded `physical_name` on
- * the row is authoritative and this function must not be consulted again.
- */
-function mintPhysicalBucketName(
-  options: PresignedUrlPluginOptions,
-  databaseId: string,
-  bucketKey: string,
-): string {
-  if (options.resolveBucketName) {
-    return options.resolveBucketName(databaseId, bucketKey);
-  }
-  // Single-bucket deployment: the globally configured bucket is the physical bucket.
-  return resolveS3(options).bucket;
-}
+async function resolveRequestStorageModules(
+  preloadedStorageModules: readonly StorageModuleConfig[] | undefined,
+  cacheScope: StorageModuleCacheScope,
+  withPgClient: RequestStorageWithPgClient | null | undefined,
+  pgSettings: unknown,
+): Promise<{
+  databaseId: string;
+  allConfigs: readonly StorageModuleConfig[];
+}> {
+  assertStorageRequestContext(withPgClient, pgSettings);
+  const requestSettings = pgSettings as Record<string, string>;
 
-/**
- * Build the S3 config for a *known* physical bucket. `physicalName` is
- * required — callers must resolve the coordinate (stored row value, or a
- * freshly provisioned name) before getting here. No name is ever recomputed.
- */
-function resolveS3ForDatabase(
-  options: PresignedUrlPluginOptions,
-  storageConfig: StorageModuleConfig,
-  physicalName: string,
-): S3Config {
-  const globalS3 = resolveS3(options);
-  const publicUrlPrefix = storageConfig.publicUrlPrefix != null
-    ? storageConfig.publicUrlPrefix
-    : globalS3.publicUrlPrefix;
+  return withRequestPgClient(withPgClient, requestSettings, async (pgClient) => {
+    const databaseId = await resolveDatabaseId(pgClient);
+    if (!databaseId) throw new Error('DATABASE_NOT_FOUND');
 
-  if (physicalName === globalS3.bucket && publicUrlPrefix === globalS3.publicUrlPrefix) {
-    return globalS3;
-  }
-
-  return {
-    ...globalS3,
-    bucket: physicalName,
-    ...(publicUrlPrefix != null ? { publicUrlPrefix } : {}),
-  };
+    const allConfigs = await loadStorageModulesForBuild(
+      preloadedStorageModules,
+      withCurrentRequestPgClient(pgClient),
+      requestSettings,
+      databaseId,
+      cacheScope,
+    );
+    return { databaseId, allConfigs };
+  });
 }
 
 /**
@@ -144,48 +190,71 @@ function resolveS3ForDatabase(
  * value is the durable coordinate: route resolution and every later read use
  * it verbatim; nothing is recomputed.
  *
- * The record write runs in the system lane (privileged role, so it bypasses the
- * RLS that stops request roles from UPDATE-ing bucket rows) — it is server
- * bookkeeping, not request data. It still carries the tenant `database_id`
- * claim, because the buckets table's catalog-sync trigger calls
- * `jwt_private.current_database_id()` and would otherwise raise
- * DATABASE_CLAIM_REQUIRED; `withRequestPgClient` applies that claim inside the
- * write's transaction without switching off the privileged role.
- * `bucket` (the cached config) is mutated in place so subsequent reads observe
- * the recorded name without a DB round-trip.
+ * The record write reuses the complete request settings. It must satisfy the
+ * same role, claims, and RLS policies as the bucket read that authorized the
+ * upload; a policy denial fails closed. `bucket` (the cached config) is mutated
+ * in place so subsequent reads observe the recorded name without a DB round-trip.
  */
 async function provisionAndRecordPhysicalBucket(
   options: PresignedUrlPluginOptions,
   withPgClient: WithPgClient,
+  pgSettings: Record<string, string>,
   storageConfig: StorageModuleConfig,
   databaseId: string,
   bucket: BucketConfig,
   allowedOrigins: string[] | null,
+  cacheScope: StorageModuleCacheScope,
 ): Promise<string> {
-  const s3BucketName = mintPhysicalBucketName(options, databaseId, bucket.key);
+  const s3BucketName = mintPhysicalBucketName(
+    options,
+    bucket.key,
+    databaseId,
+    cacheScope,
+  );
 
-  if (options.ensureBucketProvisioned && !isS3BucketProvisioned(s3BucketName)) {
+  if (options.ensureBucketProvisioned && !isS3BucketProvisioned(s3BucketName, cacheScope)) {
     log.info(`Lazy-provisioning S3 bucket "${s3BucketName}" for database ${databaseId}`);
     await options.ensureBucketProvisioned(s3BucketName, bucket.type, databaseId, allowedOrigins);
-    markS3BucketProvisioned(s3BucketName);
+    markS3BucketProvisioned(s3BucketName, cacheScope);
     log.info(`Lazy-provisioned S3 bucket "${s3BucketName}" successfully`);
   }
 
-  // Record the physical coordinate on the source row. The `physical_name IS NULL`
-  // guard keeps this idempotent and race-safe across concurrent first uploads.
-  // The catalog-sync trigger on this UPDATE needs `jwt.claims.database_id`, so the
-  // write runs under the resolved database claim (privileged role preserved).
-  await withRequestPgClient(withPgClient, { 'jwt.claims.database_id': databaseId }, (client) =>
-    client.query({
-      text: `UPDATE ${storageConfig.bucketsQualifiedName}
+  // Record the physical coordinate on the source row. If another process won
+  // the race, read its value and route to that authoritative coordinate rather
+  // than signing against this process's losing candidate.
+  // Keep the complete request role and claims active for both race-resolution
+  // statements; a policy denial must fail closed rather than use a system lane.
+  const recordedPhysicalName = await withRequestPgClient(
+    withPgClient,
+    pgSettings,
+    async (client) => {
+      const updated = await client.query({
+        text: `UPDATE ${storageConfig.bucketsQualifiedName}
              SET physical_name = $1
-             WHERE id = $2 AND physical_name IS NULL`,
-      values: [s3BucketName, bucket.id],
-    }),
+             WHERE id = $2 AND physical_name IS NULL
+             RETURNING physical_name`,
+        values: [s3BucketName, bucket.id],
+      });
+      const updatedName = storedPhysicalName(updated.rows[0] ?? {});
+      if (updatedName !== null) return updatedName;
+
+      const existing = await client.query({
+        text: `SELECT physical_name
+             FROM ${storageConfig.bucketsQualifiedName}
+             WHERE id = $1
+             LIMIT 1`,
+        values: [bucket.id],
+      });
+      return storedPhysicalName(existing.rows[0] ?? {});
+    },
   );
-  bucket.physical_name = s3BucketName;
-  log.info(`Recorded physical_name="${s3BucketName}" on bucket ${bucket.id}`);
-  return s3BucketName;
+  if (recordedPhysicalName === null) {
+    throw new Error('BUCKET_PHYSICAL_NAME_NOT_RECORDED');
+  }
+
+  bucket.physical_name = recordedPhysicalName;
+  log.info(`Using physical_name="${recordedPhysicalName}" for bucket ${bucket.id}`);
+  return recordedPhysicalName;
 }
 
 // --- Plugin factory ---
@@ -193,6 +262,9 @@ async function provisionAndRecordPhysicalBucket(
 export function createPresignedUrlPlugin(
   options: PresignedUrlPluginOptions,
 ): GraphileConfig.Plugin {
+  const preloadedStorageModules = snapshotPreloadedStorageModules(
+    options.preloadedStorageModules,
+  );
 
   return {
     name: 'PresignedUrlPlugin',
@@ -259,11 +331,22 @@ export function createPresignedUrlPlugin(
               continue;
             }
 
-            const hasOwnerId = !!matchingBucketCodec.attributes.owner_id;
+            const ownerScope = resolveUploadOwnerScope(
+              filesCodec,
+              matchingBucketCodec,
+              preloadedStorageModules,
+            );
+            if (!ownerScope) {
+              log.debug(
+                `Skipping upload mutation for ${filesCodec.name}: no authoritative preloaded storage module`,
+              );
+              continue;
+            }
+            const { hasOwnerId, ownerIdCodec } = ownerScope;
             const mutationName = `upload${filesTypeName}`;
 
             const ownerIdGqlType = hasOwnerId
-              ? (build as any).getGraphQLTypeByPgCodec(matchingBucketCodec.attributes.owner_id.codec, 'input')
+              ? (build as any).getGraphQLTypeByPgCodec(ownerIdCodec, 'input')
               : null;
 
             const InputType = new GraphQLInputObjectType({
@@ -294,6 +377,7 @@ export function createPresignedUrlPlugin(
             });
 
             const capturedFilesCodec = filesCodec;
+            const cacheScope = getStorageModuleCacheScope(build);
 
             log.debug(`Adding file upload mutation "${mutationName}" for ${filesTypeName} (entity-scoped=${hasOwnerId})`);
 
@@ -330,34 +414,50 @@ export function createPresignedUrlPlugin(
                     });
 
                     return lambda($combined, async (vals: any) => {
-                      // Request-lane reads/writes run under the request role's pgSettings
-                      // inside an explicit transaction so the jwt claims stay applied
-                      // across every statement (see withRequestPgClient).
-                      const databaseId = await withRequestPgClient(vals.withPgClient, vals.pgSettings, (pgClient) =>
-                        resolveDatabaseId(pgClient),
-                      );
-                      if (!databaseId) throw new Error('DATABASE_NOT_FOUND');
-
-                      // Module registration is server config, not user data:
-                      // resolve it without the request role's pgSettings.
-                      const allConfigs = await vals.withPgClient(null, (pgClient: any) =>
-                        loadAllStorageModules(pgClient, databaseId),
+                      // Resolve the request tenant and exact build-scoped module
+                      // metadata inside one transaction carrying every request GUC.
+                      const { databaseId, allConfigs } = await resolveRequestStorageModules(
+                        preloadedStorageModules,
+                        cacheScope,
+                        vals.withPgClient,
+                        vals.pgSettings,
                       );
                       const storageConfig = resolveStorageConfigFromCodec(capturedFilesCodec, allConfigs);
                       if (!storageConfig) throw new Error('STORAGE_MODULE_NOT_FOUND');
 
                       // Bucket config read under the request role (RLS-gated visibility).
                       const bucket = await withRequestPgClient(vals.withPgClient, vals.pgSettings, (pgClient) =>
-                        getBucketConfig(pgClient, storageConfig, databaseId, vals.bucketKey, vals.ownerId || undefined),
+                        getBucketConfig(
+                          pgClient,
+                          storageConfig,
+                          databaseId,
+                          vals.bucketKey,
+                          vals.ownerId || undefined,
+                          cacheScope,
+                        ),
                       );
                       if (!bucket) throw new Error('BUCKET_NOT_FOUND');
 
                       // First provision mints + records the coordinate; afterwards the
                       // stored physical_name is authoritative and nothing is recomputed.
                       const physicalName = bucket.physical_name === null
-                        ? await provisionAndRecordPhysicalBucket(options, vals.withPgClient, storageConfig, databaseId, bucket, storageConfig.allowedOrigins)
+                        ? await provisionAndRecordPhysicalBucket(
+                          options,
+                          vals.withPgClient,
+                          vals.pgSettings,
+                          storageConfig,
+                          databaseId,
+                          bucket,
+                          storageConfig.allowedOrigins,
+                          cacheScope,
+                        )
                         : bucket.physical_name;
-                      const s3ForDb = resolveS3ForDatabase(options, storageConfig, physicalName);
+                      const s3ForDb = resolveS3ConfigForPhysicalBucket(
+                        options,
+                        storageConfig,
+                        physicalName,
+                        cacheScope,
+                      );
 
                       // File row INSERT under the request role (RLS enforced).
                       return withRequestPgClient(vals.withPgClient, vals.pgSettings, (txClient) =>
@@ -444,25 +544,27 @@ export function createPresignedUrlPlugin(
                     });
 
                     return lambda($combined, async (vals: any) => {
-                      // Request-lane reads/writes run under the request role's pgSettings
-                      // inside an explicit transaction so the jwt claims stay applied
-                      // across every statement (see withRequestPgClient).
-                      const databaseId = await withRequestPgClient(vals.withPgClient, vals.pgSettings, (pgClient) =>
-                        resolveDatabaseId(pgClient),
-                      );
-                      if (!databaseId) throw new Error('DATABASE_NOT_FOUND');
-
-                      // Module registration is server config, not user data:
-                      // resolve it without the request role's pgSettings.
-                      const allConfigs = await vals.withPgClient(null, (pgClient: any) =>
-                        loadAllStorageModules(pgClient, databaseId),
+                      // Resolve the request tenant and exact build-scoped module
+                      // metadata inside one transaction carrying every request GUC.
+                      const { databaseId, allConfigs } = await resolveRequestStorageModules(
+                        preloadedStorageModules,
+                        cacheScope,
+                        vals.withPgClient,
+                        vals.pgSettings,
                       );
                       const storageConfig = resolveStorageConfigFromCodec(capturedFilesCodec, allConfigs);
                       if (!storageConfig) throw new Error('STORAGE_MODULE_NOT_FOUND');
 
                       // Bucket config read under the request role (RLS-gated visibility).
                       const bucket = await withRequestPgClient(vals.withPgClient, vals.pgSettings, (pgClient) =>
-                        getBucketConfig(pgClient, storageConfig, databaseId, vals.bucketKey, vals.ownerId || undefined),
+                        getBucketConfig(
+                          pgClient,
+                          storageConfig,
+                          databaseId,
+                          vals.bucketKey,
+                          vals.ownerId || undefined,
+                          cacheScope,
+                        ),
                       );
                       if (!bucket) throw new Error('BUCKET_NOT_FOUND');
 
@@ -483,9 +585,23 @@ export function createPresignedUrlPlugin(
                       // First provision mints + records the coordinate; afterwards the
                       // stored physical_name is authoritative and nothing is recomputed.
                       const physicalName = bucket.physical_name === null
-                        ? await provisionAndRecordPhysicalBucket(options, vals.withPgClient, storageConfig, databaseId, bucket, storageConfig.allowedOrigins)
+                        ? await provisionAndRecordPhysicalBucket(
+                          options,
+                          vals.withPgClient,
+                          vals.pgSettings,
+                          storageConfig,
+                          databaseId,
+                          bucket,
+                          storageConfig.allowedOrigins,
+                          cacheScope,
+                        )
                         : bucket.physical_name;
-                      const s3ForDb = resolveS3ForDatabase(options, storageConfig, physicalName);
+                      const s3ForDb = resolveS3ConfigForPhysicalBucket(
+                        options,
+                        storageConfig,
+                        physicalName,
+                        cacheScope,
+                      );
 
                       // File row INSERTs under the request role (RLS enforced).
                       return withRequestPgClient(vals.withPgClient, vals.pgSettings, async (txClient) => {
@@ -548,6 +664,7 @@ export function createPresignedUrlPlugin(
           const defaultResolver = (obj: any) => obj[fieldName];
           const { resolve: oldResolve = defaultResolver, ...rest } = field;
           const capturedCodec = pgCodec;
+          const cacheScope = getStorageModuleCacheScope(build);
 
           return {
             ...rest,
@@ -567,12 +684,14 @@ export function createPresignedUrlPlugin(
 
                 if (withPgClient) {
                   try {
-                    const databaseId = await withRequestPgClient(withPgClient, pgSettings, (pgClient) => resolveDatabaseId(pgClient));
-                    // Module registration is server config, not user data:
-                    // resolve it without the request role's pgSettings.
-                    const allConfigs = databaseId
-                      ? await withPgClient(null, (pgClient: any) => loadAllStorageModules(pgClient, databaseId))
-                      : [];
+                    // Prefer the exact-build control-plane snapshot; the SQL
+                    // fallback exists only for generic package consumers.
+                    const { allConfigs } = await resolveRequestStorageModules(
+                      preloadedStorageModules,
+                      cacheScope,
+                      withPgClient,
+                      pgSettings,
+                    );
                     const storageConfig = resolveStorageConfigFromCodec(capturedCodec, allConfigs);
 
                     if (storageConfig) {
@@ -603,12 +722,14 @@ export function createPresignedUrlPlugin(
 
                 if (withPgClient) {
                   try {
-                    const databaseId = await withRequestPgClient(withPgClient, pgSettings, (pgClient) => resolveDatabaseId(pgClient));
-                    // Module registration is server config, not user data:
-                    // resolve it without the request role's pgSettings.
-                    const allConfigs = databaseId
-                      ? await withPgClient(null, (pgClient: any) => loadAllStorageModules(pgClient, databaseId))
-                      : [];
+                    // Prefer the exact-build control-plane snapshot; the SQL
+                    // fallback exists only for generic package consumers.
+                    const { allConfigs } = await resolveRequestStorageModules(
+                      preloadedStorageModules,
+                      cacheScope,
+                      withPgClient,
+                      pgSettings,
+                    );
                     const storageConfig = resolveStorageConfigFromCodec(capturedCodec, allConfigs);
 
                     if (storageConfig) await withRequestPgClient(withPgClient, pgSettings, async (pgClient) => {
@@ -642,7 +763,12 @@ export function createPresignedUrlPlugin(
                         log.warn(`Bucket ${fileRow!.bucket_id} has no physical_name; skipping S3 delete`);
                         return;
                       }
-                      const s3ForDb = resolveS3ForDatabase(options, storageConfig, physicalName);
+                      const s3ForDb = resolveS3ConfigForPhysicalBucket(
+                        options,
+                        storageConfig,
+                        physicalName,
+                        cacheScope,
+                      );
                       await deleteS3Object(s3ForDb, fileRow!.key);
                       log.info(`Sync S3 delete succeeded for key=${fileRow!.key}`);
                     });

--- a/graphile/graphile-presigned-url-plugin/src/preset.ts
+++ b/graphile/graphile-presigned-url-plugin/src/preset.ts
@@ -10,6 +10,7 @@ import type { GraphileConfig } from 'graphile-config';
 
 import { createDownloadUrlPlugin } from './download-url-field';
 import { createPresignedUrlPlugin } from './plugin';
+import { snapshotPreloadedStorageModules } from './storage-module-source';
 import type { PresignedUrlPluginOptions } from './types';
 
 /**
@@ -38,10 +39,17 @@ import type { PresignedUrlPluginOptions } from './types';
 export function PresignedUrlPreset(
   options: PresignedUrlPluginOptions,
 ): GraphileConfig.Preset {
+  const preloadedStorageModules = snapshotPreloadedStorageModules(
+    options.preloadedStorageModules,
+  );
+  const buildOptions = preloadedStorageModules === undefined
+    ? options
+    : { ...options, preloadedStorageModules };
+
   return {
     plugins: [
-      createPresignedUrlPlugin(options),
-      createDownloadUrlPlugin(options),
+      createPresignedUrlPlugin(buildOptions),
+      createDownloadUrlPlugin(buildOptions),
     ],
   };
 }

--- a/graphile/graphile-presigned-url-plugin/src/s3-config.ts
+++ b/graphile/graphile-presigned-url-plugin/src/s3-config.ts
@@ -1,0 +1,85 @@
+import type {
+  PresignedUrlPluginOptions,
+  S3Config,
+  StorageModuleConfig,
+} from './types';
+import type { StorageModuleCacheScope } from './storage-module-cache';
+
+const s3ConfigsByBuild = new WeakMap<
+  StorageModuleCacheScope,
+  WeakMap<PresignedUrlPluginOptions, S3Config>
+>();
+
+/**
+ * Resolve the current runtime's S3 configuration without mutating the shared
+ * preset options. A preset may be reused by several Graphile builds, so
+ * memoizing the first getter result here would bind later builds to it.
+ */
+export function resolveS3Config(
+  options: PresignedUrlPluginOptions,
+  cacheScope: StorageModuleCacheScope,
+): S3Config {
+  if (typeof options.s3 !== 'function') {
+    return options.s3;
+  }
+
+  let configsForBuild = s3ConfigsByBuild.get(cacheScope);
+  if (!configsForBuild) {
+    configsForBuild = new WeakMap<PresignedUrlPluginOptions, S3Config>();
+    s3ConfigsByBuild.set(cacheScope, configsForBuild);
+  }
+
+  const cached = configsForBuild.get(options);
+  if (cached) {
+    return cached;
+  }
+
+  const resolved = options.s3();
+  configsForBuild.set(options, resolved);
+  return resolved;
+}
+
+/**
+ * Mint a physical bucket name for a bucket that has never been provisioned.
+ *
+ * This deliberately matches graphile-bucket-provisioner-plugin's resolver
+ * contract: logical bucket key first, database ID second. Callers must persist
+ * the result and use the stored physical_name for every later operation.
+ */
+export function mintPhysicalBucketName(
+  options: PresignedUrlPluginOptions,
+  bucketKey: string,
+  databaseId: string,
+  cacheScope: StorageModuleCacheScope,
+): string {
+  const base = resolveS3Config(options, cacheScope);
+  return options.resolveBucketName
+    ? options.resolveBucketName(bucketKey, databaseId)
+    : base.bucket;
+}
+
+/**
+ * Build an S3 config for a persisted physical coordinate.
+ *
+ * No naming resolver is consulted here: physical_name is authoritative once
+ * recorded, even if naming policy or environment configuration later changes.
+ */
+export function resolveS3ConfigForPhysicalBucket(
+  options: PresignedUrlPluginOptions,
+  storageConfig: StorageModuleConfig,
+  physicalBucketName: string,
+  cacheScope: StorageModuleCacheScope,
+): S3Config {
+  const base = resolveS3Config(options, cacheScope);
+  const publicUrlPrefix = storageConfig.publicUrlPrefix ?? base.publicUrlPrefix;
+
+  if (physicalBucketName === base.bucket && publicUrlPrefix === base.publicUrlPrefix) {
+    return base;
+  }
+
+  return {
+    ...base,
+    bucket: physicalBucketName,
+    ...(publicUrlPrefix != null ? { publicUrlPrefix } : {}),
+  };
+}

--- a/graphile/graphile-presigned-url-plugin/src/storage-module-cache.ts
+++ b/graphile/graphile-presigned-url-plugin/src/storage-module-cache.ts
@@ -18,21 +18,62 @@ const DEFAULT_MAX_BULK_TOTAL_SIZE = 1073741824; // 1GB
 const FIVE_MINUTES_MS = 1000 * 60 * 5;
 const ONE_HOUR_MS = 1000 * 60 * 60;
 
+type StorageCacheEntry =
+  | { kind: 'config'; value: StorageModuleConfig | null }
+  | { kind: 'list'; value: StorageModuleConfig[] };
+
+const CACHE_TTL_MS = process.env.NODE_ENV === 'development'
+  ? FIVE_MINUTES_MS
+  : ONE_HOUR_MS;
+
 /**
- * LRU cache for per-database StorageModuleConfig.
+ * Metadata owned by one exact Graphile build.
  *
- * Each PostGraphile instance serves a single database, but the presigned URL
- * plugin needs to know the generated table names (buckets, files)
- * and their schemas. This cache avoids re-querying metaschema
- * on every request.
- *
- * Pattern: same as graphile-cache's LRU with TTL-based eviction.
+ * Logical database/module identifiers are deliberately only keys inside this
+ * scope. They never select the scope itself, because separate physical pools
+ * may legitimately expose identical identifiers.
  */
-const storageModuleCache = new LRUCache<string, StorageModuleConfig>({
-  max: 50,
-  ttl: process.env.NODE_ENV === 'development' ? FIVE_MINUTES_MS : ONE_HOUR_MS,
-  updateAgeOnGet: true,
-});
+export class StorageModuleCacheScope {
+  readonly storageModuleCache = new LRUCache<string, StorageCacheEntry>({
+    max: 100,
+    ttl: CACHE_TTL_MS,
+    updateAgeOnGet: false,
+  });
+
+  readonly bucketCache = new LRUCache<string, BucketConfig | null>({
+    max: 500,
+    ttl: CACHE_TTL_MS,
+    updateAgeOnGet: false,
+  });
+
+  readonly provisionedBuckets = new Set<string>();
+
+  clear(): void {
+    this.storageModuleCache.clear();
+    this.bucketCache.clear();
+    this.provisionedBuckets.clear();
+  }
+}
+
+/**
+ * Weak ownership ties cached metadata to the exact Graphile build object.
+ * Reusing a preset/plugin object for another build therefore cannot reuse the
+ * first build's tenant metadata, and releasing the build releases its cache.
+ */
+const cacheScopesByBuild = new WeakMap<object, StorageModuleCacheScope>();
+
+export function getStorageModuleCacheScope(build: object): StorageModuleCacheScope {
+  if ((typeof build !== 'object' || build === null) && typeof build !== 'function') {
+    throw new TypeError('A Graphile build object is required for storage cache isolation');
+  }
+
+  let scope = cacheScopesByBuild.get(build);
+  if (!scope) {
+    scope = new StorageModuleCacheScope();
+    cacheScopesByBuild.set(build, scope);
+  }
+  return scope;
+}
 
 /**
  * SQL query to resolve the app-level storage module config for a database.
@@ -45,11 +86,16 @@ const storageModuleCache = new LRUCache<string, StorageModuleConfig>({
 const APP_STORAGE_MODULE_QUERY = `
   SELECT
     sm.id,
+    sm.database_id,
     sm.scope,
     sm.entity_table_id,
+    bt.database_id AS buckets_database_id,
     bs.schema_name AS buckets_schema,
+    bs.database_id AS buckets_schema_database_id,
     bt.name AS buckets_table,
+    ft.database_id AS files_database_id,
     fs.schema_name AS files_schema,
+    fs.database_id AS files_schema_database_id,
     ft.name AS files_table,
     sm.endpoint,
     sm.public_url_prefix,
@@ -63,16 +109,26 @@ const APP_STORAGE_MODULE_QUERY = `
     sm.max_bulk_files,
     sm.max_bulk_total_size,
     sm.has_path_shares,
+    NULL AS entity_database_id,
+    NULL AS entity_schema_database_id,
     NULL AS entity_schema,
     NULL AS entity_table
   FROM metaschema_modules_public.storage_module sm
-  JOIN metaschema_public.table bt ON bt.id = sm.buckets_table_id
-  JOIN metaschema_public.schema bs ON bs.id = bt.schema_id
-  JOIN metaschema_public.table ft ON ft.id = sm.files_table_id
-  JOIN metaschema_public.schema fs ON fs.id = ft.schema_id
+  JOIN metaschema_public.table bt
+    ON bt.id = sm.buckets_table_id
+   AND bt.database_id = sm.database_id
+  JOIN metaschema_public.schema bs
+    ON bs.id = bt.schema_id
+   AND bs.database_id = sm.database_id
+  JOIN metaschema_public.table ft
+    ON ft.id = sm.files_table_id
+   AND ft.database_id = sm.database_id
+  JOIN metaschema_public.schema fs
+    ON fs.id = ft.schema_id
+   AND fs.database_id = sm.database_id
   WHERE sm.database_id = $1
     AND sm.scope = 'app'
-  LIMIT 1
+  ORDER BY sm.id
 `;
 
 /**
@@ -84,11 +140,16 @@ const APP_STORAGE_MODULE_QUERY = `
 const ALL_STORAGE_MODULES_QUERY = `
   SELECT
     sm.id,
+    sm.database_id,
     sm.scope,
     sm.entity_table_id,
+    bt.database_id AS buckets_database_id,
     bs.schema_name AS buckets_schema,
+    bs.database_id AS buckets_schema_database_id,
     bt.name AS buckets_table,
+    ft.database_id AS files_database_id,
     fs.schema_name AS files_schema,
+    fs.database_id AS files_schema_database_id,
     ft.name AS files_table,
     sm.endpoint,
     sm.public_url_prefix,
@@ -102,25 +163,45 @@ const ALL_STORAGE_MODULES_QUERY = `
     sm.max_bulk_files,
     sm.max_bulk_total_size,
     sm.has_path_shares,
+    et.database_id AS entity_database_id,
+    es.database_id AS entity_schema_database_id,
     es.schema_name AS entity_schema,
     et.name AS entity_table
   FROM metaschema_modules_public.storage_module sm
-  JOIN metaschema_public.table bt ON bt.id = sm.buckets_table_id
-  JOIN metaschema_public.schema bs ON bs.id = bt.schema_id
-  JOIN metaschema_public.table ft ON ft.id = sm.files_table_id
-  JOIN metaschema_public.schema fs ON fs.id = ft.schema_id
-  LEFT JOIN metaschema_public.table et ON et.id = sm.entity_table_id
-  LEFT JOIN metaschema_public.schema es ON es.id = et.schema_id
+  JOIN metaschema_public.table bt
+    ON bt.id = sm.buckets_table_id
+   AND bt.database_id = sm.database_id
+  JOIN metaschema_public.schema bs
+    ON bs.id = bt.schema_id
+   AND bs.database_id = sm.database_id
+  JOIN metaschema_public.table ft
+    ON ft.id = sm.files_table_id
+   AND ft.database_id = sm.database_id
+  JOIN metaschema_public.schema fs
+    ON fs.id = ft.schema_id
+   AND fs.database_id = sm.database_id
+  LEFT JOIN metaschema_public.table et
+    ON et.id = sm.entity_table_id
+   AND et.database_id = sm.database_id
+  LEFT JOIN metaschema_public.schema es
+    ON es.id = et.schema_id
+   AND es.database_id = sm.database_id
   WHERE sm.database_id = $1
+  ORDER BY sm.scope, sm.id
 `;
 
 interface StorageModuleRow {
   id: string;
+  database_id: string;
   scope: string;
   entity_table_id: string | null;
+  buckets_database_id: string;
   buckets_schema: string;
+  buckets_schema_database_id: string;
   buckets_table: string;
+  files_database_id: string;
   files_schema: string;
+  files_schema_database_id: string;
   files_table: string;
   endpoint: string | null;
   public_url_prefix: string | null;
@@ -134,6 +215,8 @@ interface StorageModuleRow {
   max_bulk_files: number | null;
   max_bulk_total_size: number | null;
   has_path_shares: boolean;
+  entity_database_id: string | null;
+  entity_schema_database_id: string | null;
   entity_schema: string | null;
   entity_table: string | null;
 }
@@ -141,19 +224,82 @@ interface StorageModuleRow {
 /**
  * Build a StorageModuleConfig from a raw DB row.
  */
-function buildConfig(row: StorageModuleRow): StorageModuleConfig {
+function quoteMetadataIdentifier(schema: string, objectName: string, label: string): string {
+  if (
+    typeof schema !== 'string' ||
+    schema.length === 0 ||
+    schema.includes('\0') ||
+    Buffer.byteLength(schema, 'utf8') > 63 ||
+    typeof objectName !== 'string' ||
+    objectName.length === 0 ||
+    objectName.includes('\0') ||
+    Buffer.byteLength(objectName, 'utf8') > 63
+  ) {
+    throw new Error(`STORAGE_MODULE_METADATA_INVALID:${label}`);
+  }
+  return QuoteUtils.quoteQualifiedIdentifier(schema, objectName);
+}
+
+function buildConfig(row: StorageModuleRow, databaseId: string): StorageModuleConfig {
+  const objectDatabaseIds = [
+    row.database_id,
+    row.buckets_database_id,
+    row.buckets_schema_database_id,
+    row.files_database_id,
+    row.files_schema_database_id,
+  ];
+  if (objectDatabaseIds.some((id) => id !== databaseId)) {
+    throw new Error(`STORAGE_MODULE_CROSS_DATABASE_METADATA:${row.id}`);
+  }
+  if (
+    typeof row.id !== 'string' ||
+    row.id.length === 0 ||
+    typeof row.scope !== 'string' ||
+    row.scope.length === 0
+  ) {
+    throw new Error('STORAGE_MODULE_METADATA_INVALID');
+  }
+
+  if (row.entity_table_id === null) {
+    if (
+      row.scope !== 'app' ||
+      row.entity_database_id !== null ||
+      row.entity_schema_database_id !== null ||
+      row.entity_schema !== null ||
+      row.entity_table !== null
+    ) {
+      throw new Error(`STORAGE_MODULE_METADATA_INVALID:${row.id}`);
+    }
+  } else if (
+    row.scope === 'app' ||
+    row.entity_database_id !== databaseId ||
+    row.entity_schema_database_id !== databaseId ||
+    !row.entity_schema ||
+    !row.entity_table
+  ) {
+    throw new Error(`STORAGE_MODULE_CROSS_DATABASE_METADATA:${row.id}`);
+  }
+
   const cacheTtlSeconds = row.cache_ttl_seconds ?? DEFAULT_CACHE_TTL_SECONDS;
   return {
     id: row.id,
-    bucketsQualifiedName: QuoteUtils.quoteQualifiedIdentifier(row.buckets_schema, row.buckets_table),
-    filesQualifiedName: QuoteUtils.quoteQualifiedIdentifier(row.files_schema, row.files_table),
+    bucketsQualifiedName: quoteMetadataIdentifier(
+      row.buckets_schema,
+      row.buckets_table,
+      `buckets:${row.id}`,
+    ),
+    filesQualifiedName: quoteMetadataIdentifier(
+      row.files_schema,
+      row.files_table,
+      `files:${row.id}`,
+    ),
     schemaName: row.buckets_schema,
     bucketsTableName: row.buckets_table,
     filesTableName: row.files_table,
     scope: row.scope,
     entityTableId: row.entity_table_id,
     entityQualifiedName: row.entity_schema && row.entity_table
-      ? QuoteUtils.quoteQualifiedIdentifier(row.entity_schema, row.entity_table)
+      ? quoteMetadataIdentifier(row.entity_schema, row.entity_table, `entity:${row.id}`)
       : null,
     endpoint: row.endpoint,
     publicUrlPrefix: row.public_url_prefix,
@@ -170,6 +316,28 @@ function buildConfig(row: StorageModuleRow): StorageModuleConfig {
   };
 }
 
+function assertUnambiguousModules(configs: readonly StorageModuleConfig[]): void {
+  const ids = new Set<string>();
+  const scopes = new Set<string>();
+  const buckets = new Set<string>();
+  const files = new Set<string>();
+
+  for (const config of configs) {
+    if (
+      ids.has(config.id) ||
+      scopes.has(config.scope) ||
+      buckets.has(config.bucketsQualifiedName) ||
+      files.has(config.filesQualifiedName)
+    ) {
+      throw new Error('STORAGE_MODULE_METADATA_AMBIGUOUS');
+    }
+    ids.add(config.id);
+    scopes.add(config.scope);
+    buckets.add(config.bucketsQualifiedName);
+    files.add(config.filesQualifiedName);
+  }
+}
+
 /**
  * Resolve the app-level storage module config for a database, using the LRU cache.
  *
@@ -183,11 +351,16 @@ function buildConfig(row: StorageModuleRow): StorageModuleConfig {
 export async function getStorageModuleConfig(
   pgClient: { query: (opts: { text: string; values?: unknown[] }) => Promise<{ rows: unknown[] }> },
   databaseId: string,
+  cacheScope: StorageModuleCacheScope,
 ): Promise<StorageModuleConfig | null> {
+  const { storageModuleCache } = cacheScope;
   const cacheKey = `storage:${databaseId}:app`;
-  const cached = storageModuleCache.get(cacheKey);
-  if (cached) {
-    return cached;
+  if (storageModuleCache.has(cacheKey)) {
+    const cached = storageModuleCache.get(cacheKey);
+    if (cached?.kind !== 'config') {
+      throw new Error('STORAGE_CACHE_INTEGRITY_ERROR');
+    }
+    return cached.value;
   }
 
   log.debug(`Cache miss for app-level storage in database ${databaseId}, querying metaschema...`);
@@ -196,11 +369,15 @@ export async function getStorageModuleConfig(
 
   if (result.rows.length === 0) {
     log.warn(`No app-level storage module found for database ${databaseId}`);
+    storageModuleCache.set(cacheKey, { kind: 'config', value: null });
     return null;
   }
+  if (result.rows.length !== 1) {
+    throw new Error('STORAGE_MODULE_METADATA_AMBIGUOUS:app');
+  }
 
-  const config = buildConfig(result.rows[0] as StorageModuleRow);
-  storageModuleCache.set(cacheKey, config);
+  const config = buildConfig(result.rows[0] as StorageModuleRow, databaseId);
+  storageModuleCache.set(cacheKey, { kind: 'config', value: config });
   log.debug(`Cached app-level storage config for database ${databaseId}: ${config.bucketsQualifiedName}`);
 
   return config;
@@ -225,56 +402,34 @@ export async function getStorageModuleConfigForOwner(
   pgClient: { query: (opts: { text: string; values?: unknown[] }) => Promise<{ rows: unknown[] }> },
   databaseId: string,
   ownerId: string,
+  cacheScope: StorageModuleCacheScope,
 ): Promise<StorageModuleConfig | null> {
-  // Check if we already have a cached mapping for this ownerId
-  const ownerCacheKey = `storage:${databaseId}:owner:${ownerId}`;
-  const cachedOwner = storageModuleCache.get(ownerCacheKey);
-  if (cachedOwner) {
-    return cachedOwner;
-  }
+  const allConfigs = await loadAllStorageModules(pgClient, databaseId, cacheScope);
 
-  // Load all storage modules for this database
-  const allModulesCacheKey = `storage:${databaseId}:all`;
-  let allConfigs: StorageModuleConfig[];
-  const cachedAll = storageModuleCache.get(allModulesCacheKey);
-  if (cachedAll) {
-    // We stored a sentinel; re-derive from individual caches
-    // Actually, let's just query fresh — this is the cache-miss path
-    allConfigs = [];
-  } else {
-    allConfigs = [];
-  }
-
-  if (allConfigs.length === 0) {
-    log.debug(`Loading all storage modules for database ${databaseId} to resolve ownerId ${ownerId}`);
-    const result = await pgClient.query({ text: ALL_STORAGE_MODULES_QUERY, values: [databaseId] });
-    allConfigs = (result.rows as StorageModuleRow[]).map(buildConfig);
-
-    // Cache each individual config by its scope
-    for (const config of allConfigs) {
-      const key = `storage:${databaseId}:scope:${config.scope}`;
-      storageModuleCache.set(key, config);
-    }
-  }
-
-  // Find entity-scoped modules and probe their entity tables for the ownerId
+  // The module list is build-local configuration, but owner visibility is
+  // request/RLS-specific. Always probe it under the current pgClient instead
+  // of caching one principal's authorization decision for another principal.
   const entityModules = allConfigs.filter((c) => c.entityQualifiedName !== null);
 
+  const matches: StorageModuleConfig[] = [];
   for (const mod of entityModules) {
     const probeResult = await pgClient.query({
       text: `SELECT 1 FROM ${mod.entityQualifiedName} WHERE id = $1 LIMIT 1`,
       values: [ownerId],
     });
     if (probeResult.rows.length > 0) {
-      // Found the matching module — cache the ownerId→module mapping
-      storageModuleCache.set(ownerCacheKey, mod);
       log.debug(
         `Resolved ownerId ${ownerId} to storage module ${mod.id} ` +
         `(scope=${mod.scope}, table=${mod.bucketsQualifiedName})`,
       );
-      return mod;
+      matches.push(mod);
     }
   }
+
+  if (matches.length > 1) {
+    throw new Error('STORAGE_MODULE_AMBIGUOUS:owner');
+  }
+  if (matches.length === 1) return matches[0];
 
   log.warn(`No entity-scoped storage module found for ownerId ${ownerId} in database ${databaseId}`);
   return null;
@@ -299,10 +454,15 @@ export async function resolveStorageModuleByFileId(
   log.debug(`Resolving file ${fileId} across all storage modules for database ${databaseId}`);
 
   const allConfigs = (await pgClient.query({ text: ALL_STORAGE_MODULES_QUERY, values: [databaseId] })).rows.map(
-    (row: unknown) => buildConfig(row as StorageModuleRow),
+    (row: unknown) => buildConfig(row as StorageModuleRow, databaseId),
   );
+  assertUnambiguousModules(allConfigs);
 
   // Probe each module's files table for the fileId
+  const matches: Array<{
+    storageConfig: StorageModuleConfig;
+    file: { id: string; key: string; mime_type: string; bucket_id: string };
+  }> = [];
   for (const config of allConfigs) {
     const fileResult = await pgClient.query({
       text: `SELECT id, key, mime_type, bucket_id
@@ -313,9 +473,14 @@ export async function resolveStorageModuleByFileId(
     });
     if (fileResult.rows.length > 0) {
       const file = fileResult.rows[0] as { id: string; key: string; mime_type: string; bucket_id: string };
-      return { storageConfig: config, file };
+      matches.push({ storageConfig: config, file });
     }
   }
+
+  if (matches.length > 1) {
+    throw new Error('STORAGE_MODULE_AMBIGUOUS:file');
+  }
+  if (matches.length === 1) return matches[0];
 
   return null;
 }
@@ -329,28 +494,27 @@ export async function resolveStorageModuleByFileId(
 export async function loadAllStorageModules(
   pgClient: { query: (opts: { text: string; values?: unknown[] }) => Promise<{ rows: unknown[] }> },
   databaseId: string,
+  cacheScope: StorageModuleCacheScope,
 ): Promise<StorageModuleConfig[]> {
+  const { storageModuleCache } = cacheScope;
   const cacheKey = `storage:${databaseId}:all-list`;
-  const cached = storageModuleCache.get(cacheKey);
-  if (cached) {
-    return (cached as any)._allConfigs as StorageModuleConfig[];
+  if (storageModuleCache.has(cacheKey)) {
+    const cached = storageModuleCache.get(cacheKey);
+    if (cached?.kind !== 'list') {
+      throw new Error('STORAGE_CACHE_INTEGRITY_ERROR');
+    }
+    return cached.value;
   }
 
   log.debug(`Loading all storage modules for database ${databaseId}`);
   const result = await pgClient.query({ text: ALL_STORAGE_MODULES_QUERY, values: [databaseId] });
-  const configs = (result.rows as StorageModuleRow[]).map(buildConfig);
-
-  // Cache each individual config by its scope
-  for (const config of configs) {
-    const key = `storage:${databaseId}:scope:${config.scope}`;
-    storageModuleCache.set(key, config);
-  }
-
-  // Store the full list under a sentinel key (only if non-empty to avoid caching failed lookups)
-  if (configs.length > 0) {
-    const sentinel = { ...configs[0], _allConfigs: configs } as any;
-    storageModuleCache.set(cacheKey, sentinel);
-  }
+  const configs = (result.rows as StorageModuleRow[]).map((row) =>
+    buildConfig(row, databaseId),
+  );
+  assertUnambiguousModules(configs);
+  // Empty results are intentional negative cache entries. Query failures are
+  // never cached, so a transient control-plane error cannot become a miss.
+  storageModuleCache.set(cacheKey, { kind: 'list', value: configs });
 
   return configs;
 }
@@ -367,17 +531,21 @@ export async function loadAllStorageModules(
  */
 export function resolveStorageConfigFromCodec(
   pgCodec: { name: string; extensions?: { pg?: { schemaName?: string; name?: string } }; sqlType?: string },
-  allConfigs: StorageModuleConfig[],
+  allConfigs: readonly StorageModuleConfig[],
 ): StorageModuleConfig | null {
   const schemaName = pgCodec.extensions?.pg?.schemaName;
   const tableName = pgCodec.extensions?.pg?.name ?? pgCodec.name;
 
   if (!schemaName || !tableName) return null;
 
-  return allConfigs.find((c) =>
+  const matches = allConfigs.filter((c) =>
     (c.filesTableName === tableName && c.schemaName === schemaName) ||
     (c.bucketsTableName === tableName && c.schemaName === schemaName),
-  ) || null;
+  );
+  if (matches.length > 1) {
+    throw new Error('STORAGE_MODULE_AMBIGUOUS:codec');
+  }
+  return matches[0] ?? null;
 }
 
 // --- Bucket metadata cache ---
@@ -386,21 +554,13 @@ export function resolveStorageConfigFromCodec(
  * LRU cache for per-database bucket metadata.
  *
  * Buckets are essentially static config — created once and rarely changed.
- * Caching avoids a DB query on every requestUploadUrl call. The bucket
- * lookup in the plugin runs under RLS, but since AuthzEntityMembership
- * grants all org members access to all org buckets, and the cached data
- * is just config (mime types, size limits), bypassing RLS on cache hits
- * is safe. The important RLS is on the files table (INSERT/UPDATE),
- * which is never cached.
+ * Cache hits still execute an exact ID lookup through the request's RLS
+ * context. The cached metadata is returned only when that authorized ID
+ * matches, so cached data never substitutes for row authorization.
  *
- * Keys: `bucket:${databaseId}:${storageModuleId}:${bucketKey}`
- * TTL: same as storage module cache (5min dev / 1hr prod)
+ * Keys are local to the exact build scope; database/module identifiers never
+ * select cache entries belonging to another physical Graphile build.
  */
-const bucketCache = new LRUCache<string, BucketConfig>({
-  max: 500, // many buckets across many databases
-  ttl: process.env.NODE_ENV === 'development' ? FIVE_MINUTES_MS : ONE_HOUR_MS,
-  updateAgeOnGet: true,
-});
 
 /**
  * Normalize the recorded physical coordinate at the DB boundary.
@@ -432,35 +592,70 @@ export async function getBucketConfig(
   storageConfig: StorageModuleConfig,
   databaseId: string,
   bucketKey: string,
-  ownerId?: string,
+  ownerId: string | undefined,
+  cacheScope: StorageModuleCacheScope,
 ): Promise<BucketConfig | null> {
+  const { bucketCache } = cacheScope;
   const cacheKey = `bucket:${databaseId}:${storageConfig.id}:${bucketKey}${ownerId ? `:${ownerId}` : ''}`;
-  const cached = bucketCache.get(cacheKey);
-  if (cached) {
-    return cached;
+  // Entity-scoped buckets use (owner_id, key) composite lookup;
+  // app-level buckets just use key.
+  const isEntityScoped = storageConfig.scope !== 'app';
+  if (isEntityScoped && !ownerId) {
+    throw new Error('STORAGE_OWNER_REQUIRED');
+  }
+  const hasOwner = Boolean(ownerId && isEntityScoped);
+  const whereSql = hasOwner
+    ? 'key = $1 AND owner_id = $2'
+    : 'key = $1';
+  const values = hasOwner ? [bucketKey, ownerId] : [bucketKey];
+
+  if (bucketCache.has(cacheKey)) {
+    // This query runs with the current request's pgSettings/RLS context. Do
+    // not return even immutable cached metadata without reauthorizing it.
+    const authorized = await pgClient.query({
+      text: `SELECT id
+         FROM ${storageConfig.bucketsQualifiedName}
+         WHERE ${whereSql}
+         LIMIT 2`,
+      values,
+    });
+    const authorizedId = (authorized.rows[0] as { id?: string } | undefined)?.id;
+    if (authorized.rows.length > 1) {
+      throw new Error('STORAGE_BUCKET_AMBIGUOUS');
+    }
+    if (!authorizedId) {
+      return null;
+    }
+
+    const cached = bucketCache.get(cacheKey);
+    if (cached?.id === authorizedId) {
+      return cached;
+    }
+    // A formerly missing bucket may now exist, or a bucket may have been
+    // replaced under the same key. Reload its immutable metadata below.
   }
 
   log.debug(`Bucket cache miss for ${databaseId}:${bucketKey}${ownerId ? ` (owner=${ownerId})` : ''}, querying DB...`);
 
-  // Entity-scoped buckets use (owner_id, key) composite lookup;
-  // app-level buckets just use key.
-  const isEntityScoped = storageConfig.scope !== 'app';
-  const hasOwner = ownerId && isEntityScoped;
   const result = await pgClient.query({
     text: hasOwner
       ? `SELECT id, key, type, is_public, owner_id, allowed_mime_types, max_file_size, allow_custom_keys, physical_name
          FROM ${storageConfig.bucketsQualifiedName}
-         WHERE key = $1 AND owner_id = $2
-         LIMIT 1`
+         WHERE ${whereSql}
+         LIMIT 2`
       : `SELECT id, key, type, is_public, ${isEntityScoped ? 'owner_id,' : ''} allowed_mime_types, max_file_size, allow_custom_keys, physical_name
          FROM ${storageConfig.bucketsQualifiedName}
-         WHERE key = $1
-         LIMIT 1`,
-    values: hasOwner ? [bucketKey, ownerId] : [bucketKey],
+         WHERE ${whereSql}
+         LIMIT 2`,
+    values,
   });
 
   if (result.rows.length === 0) {
+    bucketCache.set(cacheKey, null);
     return null;
+  }
+  if (result.rows.length > 1) {
+    throw new Error('STORAGE_BUCKET_AMBIGUOUS');
   }
 
   const row = result.rows[0] as {
@@ -508,20 +703,24 @@ export async function getBucketConfig(
  * The set resets on server restart, which is fine because the
  * provisioner's createBucket is idempotent (handles "already exists").
  */
-const provisionedBuckets = new Set<string>();
-
 /**
  * Check whether an S3 bucket has already been provisioned (cached).
  */
-export function isS3BucketProvisioned(s3BucketName: string): boolean {
-  return provisionedBuckets.has(s3BucketName);
+export function isS3BucketProvisioned(
+  s3BucketName: string,
+  cacheScope: StorageModuleCacheScope,
+): boolean {
+  return cacheScope.provisionedBuckets.has(s3BucketName);
 }
 
 /**
  * Mark an S3 bucket as provisioned in the in-memory cache.
  */
-export function markS3BucketProvisioned(s3BucketName: string): void {
-  provisionedBuckets.add(s3BucketName);
+export function markS3BucketProvisioned(
+  s3BucketName: string,
+  cacheScope: StorageModuleCacheScope,
+): void {
+  cacheScope.provisionedBuckets.add(s3BucketName);
   log.debug(`Marked S3 bucket "${s3BucketName}" as provisioned`);
 }
 
@@ -529,17 +728,19 @@ export function markS3BucketProvisioned(s3BucketName: string): void {
  * Clear the storage module cache AND bucket cache.
  * Useful for testing or schema changes.
  */
-export function clearStorageModuleCache(): void {
-  storageModuleCache.clear();
-  bucketCache.clear();
-  provisionedBuckets.clear();
+export function clearStorageModuleCache(cacheScope: StorageModuleCacheScope): void {
+  cacheScope.clear();
 }
 
 /**
  * Clear cached bucket entries for a specific database.
  * Useful when bucket config changes are detected.
  */
-export function clearBucketCache(databaseId?: string): void {
+export function clearBucketCache(
+  databaseId: string | undefined,
+  cacheScope: StorageModuleCacheScope,
+): void {
+  const { bucketCache } = cacheScope;
   if (!databaseId) {
     bucketCache.clear();
     return;

--- a/graphile/graphile-presigned-url-plugin/src/storage-module-source.ts
+++ b/graphile/graphile-presigned-url-plugin/src/storage-module-source.ts
@@ -1,0 +1,185 @@
+import { QuoteUtils } from '@pgsql/quotes';
+
+import type { StorageModuleConfig } from './types';
+import {
+  loadAllStorageModules,
+  type StorageModuleCacheScope,
+} from './storage-module-cache';
+
+export type StoragePgClient = {
+  query: (opts: {
+    text: string;
+    values?: unknown[];
+  }) => Promise<{ rows: any[] }>;
+};
+
+export type StorageWithPgClient = <T>(
+  pgSettings: unknown,
+  callback: (pgClient: StoragePgClient) => Promise<T> | T,
+) => Promise<T>;
+
+export function assertStorageRequestContext(
+  withPgClient: StorageWithPgClient | null | undefined,
+  pgSettings: unknown,
+): asserts withPgClient is StorageWithPgClient {
+  if (typeof withPgClient !== 'function') {
+    throw new Error('STORAGE_CONTEXT_UNAVAILABLE');
+  }
+  if (typeof pgSettings !== 'object' || pgSettings === null || Array.isArray(pgSettings)) {
+    throw new Error('STORAGE_REQUEST_SETTINGS_UNAVAILABLE');
+  }
+}
+
+export type PreloadedStorageModules = readonly StorageModuleConfig[] | undefined;
+
+const QUALIFIED_IDENTIFIER = /^("(?:[^"]|"")+"|[a-z_][a-z0-9_$]*)\.("(?:[^"]|"")+"|[a-z_][a-z0-9_$]*)$/;
+
+function decodeIdentifier(identifier: string): string {
+  return identifier.startsWith('"')
+    ? identifier.slice(1, -1).replace(/""/g, '"')
+    : identifier;
+}
+
+function normalizeQualifiedIdentifier(
+  value: string,
+  label: string,
+): { schema: string; objectName: string; sql: string } {
+  const match = QUALIFIED_IDENTIFIER.exec(value);
+  if (!match) throw new Error(`STORAGE_MODULE_METADATA_INVALID:${label}`);
+
+  const schema = decodeIdentifier(match[1]);
+  const objectName = decodeIdentifier(match[2]);
+  if (
+    schema.length === 0 ||
+    objectName.length === 0 ||
+    schema.includes('\0') ||
+    objectName.includes('\0') ||
+    Buffer.byteLength(schema, 'utf8') > 63 ||
+    Buffer.byteLength(objectName, 'utf8') > 63
+  ) {
+    throw new Error(`STORAGE_MODULE_METADATA_INVALID:${label}`);
+  }
+  return {
+    schema,
+    objectName,
+    sql: QuoteUtils.quoteQualifiedIdentifier(schema, objectName),
+  };
+}
+
+/**
+ * Capture an immutable per-build snapshot. `undefined` deliberately remains
+ * distinct from an empty list: only the former enables the generic SQL path.
+ */
+export function snapshotPreloadedStorageModules(
+  modules: readonly StorageModuleConfig[] | undefined,
+): PreloadedStorageModules {
+  if (modules === undefined) {
+    return undefined;
+  }
+
+  const ids = new Set<string>();
+  const scopes = new Set<string>();
+  const buckets = new Set<string>();
+  const files = new Set<string>();
+  const normalized = modules.map((module) => {
+    if (
+      !module ||
+      typeof module.id !== 'string' ||
+      module.id.length === 0 ||
+      typeof module.scope !== 'string' ||
+      module.scope.length === 0 ||
+      typeof module.schemaName !== 'string' ||
+      typeof module.bucketsTableName !== 'string' ||
+      typeof module.filesTableName !== 'string'
+    ) {
+      throw new Error('STORAGE_MODULE_METADATA_INVALID');
+    }
+
+    const bucketName = normalizeQualifiedIdentifier(
+      module.bucketsQualifiedName,
+      `buckets:${module.id}`,
+    );
+    const fileName = normalizeQualifiedIdentifier(
+      module.filesQualifiedName,
+      `files:${module.id}`,
+    );
+    if (
+      bucketName.schema !== module.schemaName ||
+      bucketName.objectName !== module.bucketsTableName ||
+      fileName.schema !== module.schemaName ||
+      fileName.objectName !== module.filesTableName
+    ) {
+      throw new Error(`STORAGE_MODULE_METADATA_INCONSISTENT:${module.id}`);
+    }
+
+    let entityQualifiedName: string | null = null;
+    if (module.scope === 'app') {
+      if (module.entityTableId !== null || module.entityQualifiedName !== null) {
+        throw new Error(`STORAGE_MODULE_METADATA_INVALID:${module.id}`);
+      }
+    } else {
+      if (!module.entityTableId || !module.entityQualifiedName) {
+        throw new Error(`STORAGE_MODULE_METADATA_INVALID:${module.id}`);
+      }
+      entityQualifiedName = normalizeQualifiedIdentifier(
+        module.entityQualifiedName,
+        `entity:${module.id}`,
+      ).sql;
+    }
+
+    if (
+      ids.has(module.id) ||
+      scopes.has(module.scope) ||
+      buckets.has(bucketName.sql) ||
+      files.has(fileName.sql)
+    ) {
+      throw new Error('STORAGE_MODULE_METADATA_AMBIGUOUS');
+    }
+    ids.add(module.id);
+    scopes.add(module.scope);
+    buckets.add(bucketName.sql);
+    files.add(fileName.sql);
+
+    return Object.freeze({
+      ...module,
+      bucketsQualifiedName: bucketName.sql,
+      filesQualifiedName: fileName.sql,
+      entityQualifiedName,
+      allowedOrigins: module.allowedOrigins
+        ? Object.freeze([...module.allowedOrigins])
+        : null,
+    }) as StorageModuleConfig;
+  });
+
+  const unchanged = Object.isFrozen(modules) && modules.every((module, index) =>
+    Object.isFrozen(module) &&
+    (module.allowedOrigins === null || Object.isFrozen(module.allowedOrigins)) &&
+    module.bucketsQualifiedName === normalized[index].bucketsQualifiedName &&
+    module.filesQualifiedName === normalized[index].filesQualifiedName &&
+    module.entityQualifiedName === normalized[index].entityQualifiedName,
+  );
+  return unchanged ? modules : Object.freeze(normalized);
+}
+
+/**
+ * Preloaded configuration is authoritative and never acquires a metadata
+ * client. The database branch exists only for generic package consumers that
+ * did not supply a control-plane snapshot; because callers reach this helper
+ * from request execution, that fallback must carry the exact request settings.
+ */
+export async function loadStorageModulesForBuild(
+  preloaded: PreloadedStorageModules,
+  withPgClient: StorageWithPgClient,
+  pgSettings: unknown,
+  databaseId: string,
+  cacheScope: StorageModuleCacheScope,
+): Promise<readonly StorageModuleConfig[]> {
+  if (preloaded !== undefined) {
+    return preloaded;
+  }
+
+  assertStorageRequestContext(withPgClient, pgSettings);
+  return withPgClient(pgSettings, (pgClient) =>
+    loadAllStorageModules(pgClient, databaseId, cacheScope),
+  );
+}

--- a/graphile/graphile-presigned-url-plugin/src/types.ts
+++ b/graphile/graphile-presigned-url-plugin/src/types.ts
@@ -149,24 +149,25 @@ export interface S3Config {
 
 /**
  * S3 configuration or a lazy getter that returns it on first use.
- * When a function is provided, it will only be called when the first
- * mutation or resolver actually needs the S3 client — avoiding eager
- * env-var reads and S3Client creation at module import time.
+ * When a function is provided, it is called lazily once per exact Graphile
+ * build — avoiding eager env-var reads while keeping credentials isolated
+ * when a shared preset is used for multiple physical pools.
  */
 export type S3ConfigOrGetter = S3Config | (() => S3Config);
 
 /**
- * Function to derive the actual S3 bucket name for a given database and bucket key.
+ * Function to derive the actual S3 bucket name for a logical bucket on its
+ * first provision. The returned name is persisted as physical_name and is not
+ * recomputed for later operations.
  *
- * When provided, the presigned URL plugin calls this on every request
- * to determine which S3 bucket to use — enabling per-(database, bucketKey)
- * isolation. If not provided, falls back to `s3Config.bucket` (global).
+ * When provided, the presigned URL plugin calls this only when physical_name
+ * is absent. If not provided, first provision uses `s3Config.bucket`.
  *
- * @param databaseId - The metaschema database UUID
  * @param bucketKey - The logical bucket key (e.g., "public", "private")
+ * @param databaseId - The metaschema database UUID
  * @returns The S3 bucket name for this database + bucket key
  */
-export type BucketNameResolver = (databaseId: string, bucketKey: string) => string;
+export type BucketNameResolver = (bucketKey: string, databaseId: string) => string;
 
 /**
  * Callback to lazily provision an S3 bucket on first use.
@@ -195,6 +196,16 @@ export type EnsureBucketProvisioned = (
 export interface PresignedUrlPluginOptions {
   /** S3 configuration (concrete or lazy getter) */
   s3: S3ConfigOrGetter;
+
+  /**
+   * Storage-module configuration resolved by the control plane for this exact
+   * Graphile build. Supplying this option, including an empty array, disables
+   * runtime metaschema SQL; the plugin treats an immutable snapshot of this
+   * list as authoritative for the build.
+   *
+   * Omit only for generic integrations that need the legacy database lookup.
+   */
+  preloadedStorageModules?: readonly StorageModuleConfig[];
 
   /**
    * Optional function to resolve S3 bucket name per-database.

--- a/graphile/graphile-search/package.json
+++ b/graphile/graphile-search/package.json
@@ -29,6 +29,7 @@
     "url": "https://github.com/constructive-io/constructive/issues"
   },
   "dependencies": {
+    "@pgsql/quotes": "^18.1.0",
     "graphile-plugin-utils": "workspace:^"
   },
   "devDependencies": {

--- a/graphile/graphile-search/src/__tests__/bm25-codec.test.ts
+++ b/graphile/graphile-search/src/__tests__/bm25-codec.test.ts
@@ -1,0 +1,353 @@
+import { createBm25Adapter } from '../adapters/bm25';
+import { collectBm25Indexes } from '../codecs/bm25-codec';
+
+interface MockIndexOptions {
+  schema: string;
+  classId: string;
+  table?: string;
+  column?: string;
+  attributeNumber?: number;
+  index: string;
+  accessMethod?: string;
+  valid?: boolean | null;
+  ready?: boolean | null;
+  live?: boolean | null;
+}
+
+const mockIndex = ({
+  schema,
+  classId,
+  table = 'documents',
+  column = 'body',
+  attributeNumber = 2,
+  index,
+  accessMethod = 'bm25',
+  valid = true,
+  ready = true,
+  live = true
+}: MockIndexOptions) => {
+  const namespace = { nspname: schema };
+  const tableClass = {
+    _id: classId,
+    relname: table,
+    relnamespace: schema,
+    getNamespace: () => namespace
+  };
+  const indexClass = {
+    relname: index,
+    getAccessMethod: () => ({ amname: accessMethod })
+  };
+  const attribute = { attnum: attributeNumber, attname: column };
+  return {
+    indisvalid: valid,
+    indisready: ready,
+    indislive: live,
+    indnkeyatts: 1,
+    indkey: [attributeNumber],
+    getIndexClass: () => indexClass,
+    getClass: () => tableClass,
+    getKeys: () => [attribute]
+  };
+};
+
+const introspectionWith = (...indexes: ReturnType<typeof mockIndex>[]) => ({
+  indexes,
+  extensions: [{ extname: 'pg_textsearch', extnamespace: '900' }],
+  getNamespace: ({ id }: { id: string }) => id === '900'
+    ? { _id: '900', nspname: 'extension_tools' }
+    : { _id: id, nspname: id }
+} as any);
+
+describe('BM25 introspection binding', () => {
+  it('keeps identical tenant table names isolated by the configured schema', () => {
+    const introspection = introspectionWith(
+      mockIndex({
+        schema: 'tenant_a',
+        classId: '100',
+        index: 'tenant_a_documents_body_bm25_idx'
+      }),
+      mockIndex({
+        schema: 'tenant_b',
+        classId: '200',
+        index: 'tenant_b_documents_body_bm25_idx'
+      })
+    );
+
+    const tenantA = collectBm25Indexes(introspection, ['tenant_a'], 'service_a');
+    const tenantB = collectBm25Indexes(introspection, ['tenant_b'], 'service_b');
+
+    expect([...tenantA.values()]).toEqual([
+      {
+        serviceName: 'service_a',
+        extensionSchema: 'extension_tools',
+        schemaName: 'tenant_a',
+        tableName: 'documents',
+        columnName: 'body',
+        indexName: 'tenant_a_documents_body_bm25_idx'
+      }
+    ]);
+    expect([...tenantB.values()]).toEqual([
+      {
+        serviceName: 'service_b',
+        extensionSchema: 'extension_tools',
+        schemaName: 'tenant_b',
+        tableName: 'documents',
+        columnName: 'body',
+        indexName: 'tenant_b_documents_body_bm25_idx'
+      }
+    ]);
+  });
+
+  it('does not retain indexes across rebuilds', () => {
+    const first = collectBm25Indexes(
+      introspectionWith(
+        mockIndex({ schema: 'tenant_a', classId: '100', index: 'first_idx' })
+      ),
+      ['tenant_a'],
+      'main'
+    );
+    const rebuilt = collectBm25Indexes(introspectionWith(), ['tenant_a'], 'main');
+
+    expect(first.size).toBe(1);
+    expect(rebuilt.size).toBe(0);
+  });
+
+  it('skips invalid and non-BM25 indexes', () => {
+    const result = collectBm25Indexes(
+      introspectionWith(
+        mockIndex({
+          schema: 'tenant_a',
+          classId: '100',
+          index: 'invalid_idx',
+          valid: false
+        }),
+        mockIndex({
+          schema: 'tenant_a',
+          classId: '100',
+          index: 'unknown_state_idx',
+          live: null
+        }),
+        mockIndex({
+          schema: 'tenant_a',
+          classId: '100',
+          index: 'btree_idx',
+          accessMethod: 'btree'
+        })
+      ),
+      ['tenant_a'],
+      'main'
+    );
+
+    expect(result.size).toBe(0);
+  });
+
+  it('fails deterministically when two BM25 indexes target one attribute', () => {
+    const introspection = introspectionWith(
+      mockIndex({ schema: 'tenant_a', classId: '100', index: 'z_idx' }),
+      mockIndex({ schema: 'tenant_a', classId: '100', index: 'a_idx' })
+    );
+
+    expect(() => collectBm25Indexes(introspection, ['tenant_a'], 'main')).toThrow(
+      'Multiple BM25 indexes target tenant_a.documents.body: a_idx, z_idx'
+    );
+  });
+
+  it('lets the adapter consume metadata bound to the exact codec attribute', () => {
+    const adapter = createBm25Adapter();
+    const codec = {
+      attributes: {
+        body: {
+          codec: { name: 'text' },
+          extensions: {
+            bm25Index: {
+              serviceName: 'main',
+              extensionSchema: 'extension_tools',
+              schemaName: 'tenant_a',
+              tableName: 'documents',
+              columnName: 'body',
+              indexName: 'tenant_a_documents_body_bm25_idx'
+            }
+          }
+        }
+      }
+    };
+
+    expect(adapter.detectColumns(codec, {})).toEqual([
+      {
+        attributeName: 'body',
+        adapterData: {
+          bm25Index: codec.attributes.body.extensions.bm25Index,
+          chunksInfo: undefined
+        }
+      }
+    ]);
+  });
+
+  it('binds chunk search to its introspected physical index name', () => {
+    const adapter = createBm25Adapter();
+    const parentIndex = {
+      serviceName: 'service_a',
+      extensionSchema: 'extension_tools',
+      schemaName: 'tenant_a',
+      tableName: 'documents',
+      columnName: 'body',
+      indexName: 'parent_idx'
+    };
+    const chunkIndex = {
+      serviceName: 'service_a',
+      extensionSchema: 'extension_tools',
+      schemaName: 'tenant_a',
+      tableName: 'document_chunks',
+      columnName: 'content',
+      indexName: 'nonconventional_exact_chunk_idx'
+    };
+    const parentCodec = {
+      attributes: {
+        id: { codec: { name: 'uuid' } },
+        body: {
+          codec: { name: 'text' },
+          extensions: { bm25Index: parentIndex }
+        }
+      },
+      extensions: {
+        pg: { serviceName: 'service_a', schemaName: 'tenant_a', name: 'documents' },
+        tags: {
+          hasChunks: {
+            chunksTable: 'document_chunks',
+            contentField: 'content',
+            searchIndexes: ['bm25']
+          }
+        }
+      }
+    };
+    const chunksCodec = {
+      attributes: {
+        parent_id: {},
+        embedding: {},
+        content: { extensions: { bm25Index: chunkIndex } }
+      },
+      extensions: {
+        pg: {
+          serviceName: 'service_a',
+          schemaName: 'tenant_a',
+          name: 'document_chunks'
+        }
+      }
+    };
+    const build = {
+      input: {
+        pgRegistry: {
+          pgCodecs: {
+            wrongServiceChunks: {
+              attributes: {
+                content: {
+                  extensions: {
+                    bm25Index: {
+                      ...chunkIndex,
+                      serviceName: 'service_b',
+                      indexName: 'wrong_service_idx'
+                    }
+                  }
+                }
+              }
+            },
+            chunks: chunksCodec
+          },
+          pgResources: { chunks: { codec: chunksCodec } }
+        }
+      },
+      resolvedPreset: {
+        pgServices: [{ name: 'service_a', schemas: ['tenant_a'] }]
+      }
+    };
+
+    const [column] = adapter.detectColumns(parentCodec, build);
+    expect(column.adapterData).toEqual({
+      bm25Index: parentIndex,
+      chunksInfo: {
+        chunksSchema: 'tenant_a',
+        chunksTableName: 'document_chunks',
+        parentFkField: 'parent_id',
+        parentPkField: 'id',
+        embeddingField: 'embedding',
+        contentField: 'content',
+        searchField: null,
+        searchIndexes: ['bm25']
+      },
+      chunkBm25Index: chunkIndex
+    });
+
+    const sql = Object.assign(
+      (strings: TemplateStringsArray, ...values: any[]) =>
+        strings.reduce((text, part, index) => text + part + (values[index] ?? ''), ''),
+      {
+        identifier: (...names: string[]) => names.map((name) => `"${name}"`).join('.'),
+        value: (value: any) => `'${value}'`
+      }
+    );
+    const result = adapter.buildFilterApply(
+      sql,
+      'docs' as any,
+      column,
+      { query: 'tenant memory' },
+      build
+    );
+    expect(String(result?.scoreExpression)).toContain(
+      'tenant_a.nonconventional_exact_chunk_idx'
+    );
+    expect(String(result?.scoreExpression)).toContain(
+      'OPERATOR("extension_tools".<@>)'
+    );
+    expect(String(result?.scoreExpression)).not.toContain('wrong_service_idx');
+  });
+
+  it('fails closed when chunk BM25 metadata cannot be bound', () => {
+    const adapter = createBm25Adapter();
+    const codec = {
+      attributes: {
+        id: { codec: { name: 'uuid' } },
+        body: {
+          codec: { name: 'text' },
+          extensions: {
+            bm25Index: {
+              serviceName: 'main',
+              extensionSchema: 'extension_tools',
+              schemaName: 'tenant_a',
+              tableName: 'documents',
+              columnName: 'body',
+              indexName: 'parent_idx'
+            }
+          }
+        }
+      },
+      extensions: {
+        pg: { serviceName: 'main', schemaName: 'tenant_a', name: 'documents' },
+        tags: {
+          hasChunks: {
+            chunksTable: 'document_chunks',
+            searchIndexes: ['bm25']
+          }
+        }
+      }
+    };
+    const chunksCodec = {
+      attributes: { parent_id: {}, embedding: {}, content: {} },
+      extensions: {
+        pg: { serviceName: 'main', schemaName: 'tenant_a', name: 'document_chunks' }
+      }
+    };
+
+    expect(() => adapter.detectColumns(codec, {
+      input: {
+        pgRegistry: {
+          pgCodecs: { chunks: chunksCodec },
+          pgResources: { chunks: { codec: chunksCodec } }
+        }
+      },
+      resolvedPreset: { pgServices: [{ name: 'main', schemas: ['tenant_a'] }] }
+    })).toThrow(
+      'BM25 chunk search could not bind an introspected index for '
+      + 'tenant_a.document_chunks.content'
+    );
+  });
+});

--- a/graphile/graphile-search/src/__tests__/chunks-isolation.test.ts
+++ b/graphile/graphile-search/src/__tests__/chunks-isolation.test.ts
@@ -1,0 +1,92 @@
+import { getChunksInfo } from '../adapters/chunks';
+
+function fixture(overrides: {
+  chunksSchema?: string;
+  duplicate?: boolean;
+  dependencySchemas?: string[];
+} = {}) {
+  const parentCodec = {
+    name: 'documents',
+    attributes: { id: {} },
+    extensions: {
+      pg: { serviceName: 'main', schemaName: 'tenant_a', name: 'documents' },
+      tags: {
+        hasChunks: {
+          chunksSchema: overrides.chunksSchema ?? 'tenant_a',
+          chunksTable: 'documents_chunks',
+          parentFk: 'document_id',
+        },
+      },
+    },
+  };
+  const chunkCodec = {
+    name: 'documentsChunks',
+    attributes: {
+      document_id: {},
+      embedding: {},
+      content: {},
+    },
+    extensions: {
+      pg: {
+        serviceName: 'main',
+        schemaName: overrides.chunksSchema ?? 'tenant_a',
+        name: 'documents_chunks',
+      },
+    },
+  };
+  const resource = { codec: chunkCodec };
+  return {
+    parentCodec,
+    build: {
+      input: {
+        pgRegistry: {
+          pgResources: overrides.duplicate
+            ? { first: resource, second: { codec: chunkCodec } }
+            : { chunks: resource },
+        },
+      },
+      resolvedPreset: {
+        pgServices: [{
+          name: 'main',
+          schemas: ['tenant_a'],
+          introspectionAllowedDependencySchemas: overrides.dependencySchemas ?? [],
+        }],
+      },
+    },
+  };
+}
+
+describe('@hasChunks exact-build isolation', () => {
+  it('resolves one exact resource inside the service schema allowlist', () => {
+    const { parentCodec, build } = fixture();
+    expect(getChunksInfo(parentCodec, build)).toMatchObject({
+      chunksSchema: 'tenant_a',
+      chunksTableName: 'documents_chunks',
+      parentFkField: 'document_id',
+    });
+  });
+
+  it('rejects a cross-schema resource even when it exists in the registry', () => {
+    const { parentCodec, build } = fixture({ chunksSchema: 'tenant_b' });
+    expect(() => getChunksInfo(parentCodec, build)).toThrow(/outside service 'main'/);
+  });
+
+  it('accepts a resource only when its dependency schema is explicitly allowlisted', () => {
+    const { parentCodec, build } = fixture({
+      chunksSchema: 'tenant_chunks',
+      dependencySchemas: ['tenant_chunks'],
+    });
+    expect(getChunksInfo(parentCodec, build)?.chunksSchema).toBe('tenant_chunks');
+  });
+
+  it('rejects ambiguous exact resource matches', () => {
+    const { parentCodec, build } = fixture({ duplicate: true });
+    expect(() => getChunksInfo(parentCodec, build)).toThrow(/matches=2/);
+  });
+
+  it('rejects malformed tags instead of silently disabling chunk routing', () => {
+    const { parentCodec, build } = fixture();
+    parentCodec.extensions.tags.hasChunks = 'not-json' as any;
+    expect(() => getChunksInfo(parentCodec, build)).toThrow(/valid JSON/);
+  });
+});

--- a/graphile/graphile-search/src/__tests__/extension-schema-qualification.test.ts
+++ b/graphile/graphile-search/src/__tests__/extension-schema-qualification.test.ts
@@ -1,0 +1,322 @@
+import sql from 'pg-sql2';
+
+import { createPgvectorAdapter } from '../adapters/pgvector';
+import { createTrgmAdapter } from '../adapters/trgm';
+import { createTrgmOperatorFactories } from '../codecs/operator-factories';
+import { VectorCodecPlugin } from '../codecs/vector-codec';
+import {
+  collectSearchExtensionSchemas,
+  extensionSchemasByService,
+  requireBuildExtensionSchema,
+  resolveBuildExtensionSchema,
+  type SearchExtensionSchemas,
+} from '../extension-metadata';
+
+const extensionBinding = (
+  overrides: Partial<SearchExtensionSchemas> = {}
+): SearchExtensionSchemas => ({
+  serviceName: 'tenant_service',
+  pgTrgmSchema: 'extension_tools',
+  pgvectorSchema: 'extension_tools',
+  ...overrides,
+});
+
+const introspection = (extensions: any[]) => ({
+  extensions,
+  getNamespace: ({ id }: { id: string }) =>
+    id === '910' ? { nspname: 'extension_tools' } : undefined,
+} as any);
+
+describe('search extension schema binding', () => {
+  it('collects exact pg_trgm and pgvector schemas from one service introspection', () => {
+    expect(collectSearchExtensionSchemas(
+      introspection([
+        { extname: 'pg_trgm', extnamespace: '910' },
+        { extname: 'vector', extnamespace: '910' },
+      ]),
+      'tenant_service'
+    )).toEqual(extensionBinding());
+  });
+
+  it('fails closed on ambiguous or unresolved extension metadata', () => {
+    expect(() => collectSearchExtensionSchemas(
+      introspection([
+        { extname: 'pg_trgm', extnamespace: '910' },
+        { extname: 'pg_trgm', extnamespace: '910' },
+      ]),
+      'tenant_service'
+    )).toThrow(/ambiguous pg_trgm/);
+
+    expect(() => collectSearchExtensionSchemas(
+      introspection([{ extname: 'pg_trgm', extnamespace: '999' }]),
+      'tenant_service'
+    )).toThrow(/cannot resolve the namespace/);
+  });
+
+  it('requires one complete build-wide schema for shared operator factories', () => {
+    expect(requireBuildExtensionSchema({
+      pgSearchExtensionSchemasByService: new Map([
+        ['tenant_service', extensionBinding()],
+      ]),
+    }, 'pg_trgm')).toBe('extension_tools');
+
+    expect(() => requireBuildExtensionSchema({
+      pgSearchExtensionSchemasByService: new Map([
+        ['a', extensionBinding({ serviceName: 'a', pgTrgmSchema: 'ext_a' })],
+        ['b', extensionBinding({ serviceName: 'b', pgTrgmSchema: 'ext_b' })],
+      ]),
+    }, 'pg_trgm')).toThrow(/ambiguous schemas/);
+
+    const absentBuild = {
+      pgSearchExtensionSchemasByService: new Map([
+        ['tenant_service', extensionBinding({ pgTrgmSchema: null })],
+      ]),
+    };
+    expect(resolveBuildExtensionSchema(absentBuild, 'pg_trgm')).toBeNull();
+    expect(() => requireBuildExtensionSchema(absentBuild, 'pg_trgm')).toThrow(
+      /required by this feature but is not installed/
+    );
+  });
+
+  it('disables optional operators for an empty service and still fails on missing record metadata', () => {
+    const emptyBuild = {
+      input: { pgRegistry: { pgCodecs: { text: { name: 'text' } } } },
+    };
+    expect(resolveBuildExtensionSchema(emptyBuild, 'pg_trgm')).toBeNull();
+    expect(createTrgmOperatorFactories()(emptyBuild as any)).toEqual([]);
+
+    const recordWithoutBinding = {
+      input: {
+        pgRegistry: {
+          pgCodecs: {
+            animals: { name: 'animals', attributes: {} },
+          },
+        },
+      },
+    };
+    expect(() => resolveBuildExtensionSchema(
+      recordWithoutBinding,
+      'pg_trgm'
+    )).toThrow(/requires service-bound extension metadata/);
+  });
+
+  it('retains service identity on a record codec even without attributes', () => {
+    const binding = extensionBinding();
+    const build = {
+      input: {
+        pgRegistry: {
+          pgCodecs: {
+            emptyRecord: {
+              name: 'empty_record',
+              extensions: { searchExtensionSchemas: binding },
+            },
+          },
+        },
+      },
+    };
+    expect(extensionSchemasByService(build).get('tenant_service')).toBe(binding);
+  });
+});
+
+describe('pg_trgm SQL qualification', () => {
+  const adapter = createTrgmAdapter({ requireIntentionalSearch: false });
+
+  it('binds metadata to the eligible attribute and qualifies similarity', () => {
+    const codec = {
+      name: 'documents',
+      attributes: {
+        title: {
+          codec: { name: 'text' },
+          extensions: { searchExtensionSchemas: extensionBinding() },
+        },
+      },
+    };
+    const [column] = adapter.detectColumns(codec, {});
+    const result = adapter.buildFilterApply(
+      sql,
+      sql.identifier('documents'),
+      column,
+      { value: 'memory density', threshold: 0.2 },
+      {}
+    );
+    const compiled = sql.compile(result!.whereClause!);
+    expect(compiled.text).toContain(
+      '"extension_tools"."similarity"("documents"."title", $1)'
+    );
+    expect(compiled.text).not.toMatch(/(^|[^."])similarity\(/);
+  });
+
+  it('qualifies similarity and word_similarity in operator factories', () => {
+    const registrations = createTrgmOperatorFactories()({
+      sql,
+      pgSearchExtensionSchemasByService: new Map([
+        ['tenant_service', extensionBinding()],
+      ]),
+      getTypeByName: () => ({ name: 'TrgmSearchInput' }),
+    } as any);
+    const similar = registrations.find((entry) => entry.operatorName === 'similarTo')!;
+    const word = registrations.find((entry) => entry.operatorName === 'wordSimilarTo')!;
+
+    const similarSql = similar.spec.resolve!(
+      sql.identifier('title'),
+      sql.null,
+      { value: 'memory', threshold: 0.3 },
+      null,
+      { fieldName: 'title', operatorName: 'similarTo' }
+    );
+    const wordSql = word.spec.resolve!(
+      sql.identifier('title'),
+      sql.null,
+      { value: 'memory', threshold: 0.3 },
+      null,
+      { fieldName: 'title', operatorName: 'wordSimilarTo' }
+    );
+    expect(sql.compile(similarSql!).text).toContain(
+      '"extension_tools"."similarity"'
+    );
+    expect(sql.compile(wordSql!).text).toContain(
+      '"extension_tools"."word_similarity"'
+    );
+  });
+
+  it('fails closed when an eligible attribute has no bound schema', () => {
+    expect(() => adapter.detectColumns({
+      name: 'documents',
+      attributes: { title: { codec: { name: 'text' } } },
+    }, {})).toThrow(/missing service-bound extension schema/);
+  });
+
+  it('disables the adapter and operator factory when pg_trgm is absent', () => {
+    const absent = extensionBinding({ pgTrgmSchema: null });
+    const defaultAdapter = createTrgmAdapter();
+    expect(defaultAdapter.detectColumns({
+      name: 'documents',
+      attributes: {
+        title: {
+          codec: { name: 'text' },
+          extensions: { searchExtensionSchemas: absent },
+        },
+      },
+    }, {})).toEqual([]);
+
+    expect(createTrgmOperatorFactories()({
+      sql,
+      pgSearchExtensionSchemasByService: new Map([
+        ['tenant_service', absent],
+      ]),
+    } as any)).toEqual([]);
+  });
+
+  it('fails closed when an explicit trgm feature requires an absent extension', () => {
+    expect(() => adapter.detectColumns({
+      name: 'documents',
+      attributes: {
+        title: {
+          codec: { name: 'text' },
+          extensions: {
+            searchExtensionSchemas: extensionBinding({ pgTrgmSchema: null }),
+          },
+        },
+      },
+    }, {})).toThrow(/required .* but is not installed/);
+  });
+});
+
+describe('pgvector SQL qualification', () => {
+  const vectorCodec = {
+    name: 'vector',
+    extensions: {
+      pg: {
+        serviceName: 'tenant_service',
+        schemaName: 'extension_tools',
+        name: 'vector',
+      },
+    },
+  };
+
+  it('qualifies and annotates a native vector codec during gather', async () => {
+    const gatherHook = (VectorCodecPlugin as any).gather.hooks.pgCodecs_findPgCodec;
+    const event: any = {
+      pgCodec: {
+        name: 'vector',
+        sqlType: sql.fragment`vector`,
+        extensions: undefined,
+      },
+      pgType: { typname: 'vector', typnamespace: '910', _id: '912' },
+      serviceName: 'tenant_service',
+    };
+    const originalCodec = event.pgCodec;
+    await gatherHook({
+      helpers: {
+        pgIntrospection: {
+          getNamespace: jest.fn().mockResolvedValue({ nspname: 'extension_tools' }),
+        },
+      },
+    }, event);
+
+    expect(event.pgCodec).toBe(originalCodec);
+    expect(event.pgCodec.extensions).toMatchObject({
+      oid: '912',
+      pg: {
+        serviceName: 'tenant_service',
+        schemaName: 'extension_tools',
+        name: 'vector',
+      },
+    });
+    expect(sql.compile(event.pgCodec.sqlType).text).toBe('"extension_tools"."vector"');
+  });
+
+  it('fails closed when the vector type namespace cannot be resolved', async () => {
+    const gatherHook = (VectorCodecPlugin as any).gather.hooks.pgCodecs_findPgCodec;
+    await expect(gatherHook({
+      helpers: {
+        pgIntrospection: {
+          getNamespace: jest.fn().mockResolvedValue(undefined),
+        },
+      },
+    }, {
+      pgType: { typname: 'vector', typnamespace: '999', _id: '912' },
+      serviceName: 'tenant_service',
+    })).rejects.toThrow(/cannot resolve the vector type namespace/i);
+  });
+
+  it('qualifies the vector cast and distance operator', () => {
+    const adapter = createPgvectorAdapter();
+    const [column] = adapter.detectColumns({
+      name: 'documents',
+      attributes: {
+        embedding: {
+          codec: vectorCodec,
+          extensions: { searchExtensionSchemas: extensionBinding() },
+        },
+      },
+    }, {});
+    const result = adapter.buildFilterApply(
+      sql,
+      sql.identifier('documents'),
+      column,
+      { vector: [1, 0, 0], metric: 'COSINE' },
+      {}
+    );
+    const compiled = sql.compile(result!.scoreExpression);
+    expect(compiled.text).toContain('::"extension_tools"."vector"');
+    expect(compiled.text).toContain('OPERATOR("extension_tools".<=>)');
+  });
+
+  it('fails closed when codec and extension identities disagree', () => {
+    const adapter = createPgvectorAdapter();
+    expect(() => adapter.detectColumns({
+      name: 'documents',
+      attributes: {
+        embedding: {
+          codec: vectorCodec,
+          extensions: {
+            searchExtensionSchemas: extensionBinding({
+              pgvectorSchema: 'other_extension_schema',
+            }),
+          },
+        },
+      },
+    }, {})).toThrow(/does not match extension/);
+  });
+});

--- a/graphile/graphile-search/src/__tests__/plugin-cache-isolation.test.ts
+++ b/graphile/graphile-search/src/__tests__/plugin-cache-isolation.test.ts
@@ -1,0 +1,66 @@
+import type { SearchAdapter } from '../types';
+import { createUnifiedSearchPlugin } from '../plugin';
+
+describe('UnifiedSearchPlugin build isolation', () => {
+  it('does not reuse discovery results across same-named codecs from different builds', () => {
+    const detectColumns = jest.fn((codec: any, build: any) => [
+      { attributeName: build.tenantColumn ?? codec.extensions.tenantColumn },
+    ]);
+    const adapter: SearchAdapter = {
+      name: 'tenant-test',
+      filterPrefix: 'tenantTest',
+      scoreSemantics: { metric: 'score', lowerIsBetter: false, range: null },
+      detectColumns,
+      registerTypes: jest.fn(),
+      getFilterTypeName: jest.fn(() => 'TenantTestInput'),
+      buildFilterApply: jest.fn(),
+    };
+    const plugin = createUnifiedSearchPlugin({
+      adapters: [adapter],
+      enableSearchScore: false,
+      enableUnifiedSearch: false,
+    });
+    const callback = (plugin.schema!.entityBehavior!.pgCodecAttribute as any)
+      .inferred.callback;
+    const buildA = { tenantColumn: 'tenant_a_search' };
+    const buildB = { tenantColumn: 'tenant_b_search' };
+    const codecA = {
+      name: 'documents',
+      attributes: { tenant_a_search: {} },
+      extensions: { tenantColumn: 'tenant_a_search' },
+    };
+    const codecB = {
+      name: 'documents',
+      attributes: { tenant_b_search: {} },
+      extensions: { tenantColumn: 'tenant_b_search' },
+    };
+
+    expect(callback('default', [codecA, 'tenant_a_search'], buildA)).toContain(
+      'unifiedSearch:select'
+    );
+    expect(callback('default', [codecB, 'tenant_b_search'], buildB)).toContain(
+      'unifiedSearch:select'
+    );
+    expect(callback('default', [codecB, 'tenant_a_search'], buildB)).toBe('default');
+    expect(detectColumns).toHaveBeenCalledTimes(2);
+
+    // Reusing the same codec object within one build should still hit the cache.
+    callback('default', [codecB, 'tenant_b_search'], buildB);
+    expect(detectColumns).toHaveBeenCalledTimes(2);
+
+    // Discovery is build-dependent, so even a reused codec object must not
+    // carry adapter metadata across builds.
+    const sharedCodec = {
+      name: 'shared_documents',
+      attributes: { tenant_a_search: {}, tenant_b_search: {} },
+      extensions: { tenantColumn: 'unused' },
+    };
+    expect(callback('default', [sharedCodec, 'tenant_a_search'], buildA)).toContain(
+      'unifiedSearch:select'
+    );
+    expect(callback('default', [sharedCodec, 'tenant_b_search'], buildB)).toContain(
+      'unifiedSearch:select'
+    );
+    expect(detectColumns).toHaveBeenCalledTimes(4);
+  });
+});

--- a/graphile/graphile-search/src/__tests__/search-config.test.ts
+++ b/graphile/graphile-search/src/__tests__/search-config.test.ts
@@ -13,6 +13,31 @@ import { createPgvectorAdapter } from '../adapters/pgvector';
 import { createTsvectorAdapter } from '../adapters/tsvector';
 import { createUnifiedSearchPlugin } from '../plugin';
 
+const VECTOR_ADAPTER_IDENTITY = {
+  serviceName: 'main',
+  extensionSchema: 'extension_tools',
+};
+
+const vectorAttribute = () => ({
+  codec: {
+    name: 'vector',
+    extensions: {
+      pg: {
+        serviceName: 'main',
+        schemaName: 'extension_tools',
+        name: 'vector',
+      },
+    },
+  },
+  extensions: {
+    searchExtensionSchemas: {
+      serviceName: 'main',
+      pgTrgmSchema: 'extension_tools',
+      pgvectorSchema: 'extension_tools',
+    },
+  },
+});
+
 // ─── pgvector adapter: chunk detection ────────────────────────────────────────
 
 describe('pgvector adapter — chunk querying (Phase E)', () => {
@@ -24,7 +49,7 @@ describe('pgvector adapter — chunk querying (Phase E)', () => {
         name: 'documents',
         attributes: {
           id: { codec: { name: 'uuid' } },
-          embedding: { codec: { name: 'vector' } },
+          embedding: vectorAttribute(),
         },
         extensions: { tags: {} },
       };
@@ -32,7 +57,7 @@ describe('pgvector adapter — chunk querying (Phase E)', () => {
       const columns = adapter.detectColumns(codec, {});
       expect(columns).toHaveLength(1);
       expect(columns[0].attributeName).toBe('embedding');
-      expect(columns[0].adapterData).toBeUndefined();
+      expect(columns[0].adapterData).toEqual(VECTOR_ADAPTER_IDENTITY);
     });
 
     it('includes chunksInfo when @hasChunks smart tag has metadata', () => {
@@ -40,7 +65,7 @@ describe('pgvector adapter — chunk querying (Phase E)', () => {
         name: 'documents',
         attributes: {
           id: { codec: { name: 'uuid' } },
-          embedding: { codec: { name: 'vector' } },
+          embedding: vectorAttribute(),
         },
         extensions: {
           tags: {
@@ -58,6 +83,7 @@ describe('pgvector adapter — chunk querying (Phase E)', () => {
       expect(columns).toHaveLength(1);
       expect(columns[0].attributeName).toBe('embedding');
       expect(columns[0].adapterData).toEqual({
+        ...VECTOR_ADAPTER_IDENTITY,
         chunksInfo: {
           chunksSchema: 'app_public',
           chunksTableName: 'documents_chunks',
@@ -75,7 +101,7 @@ describe('pgvector adapter — chunk querying (Phase E)', () => {
       const codec = {
         name: 'documents',
         attributes: {
-          embedding: { codec: { name: 'vector' } },
+          embedding: vectorAttribute(),
         },
         extensions: {
           tags: {
@@ -93,6 +119,7 @@ describe('pgvector adapter — chunk querying (Phase E)', () => {
       const columns = adapter.detectColumns(codec, {});
       expect(columns).toHaveLength(1);
       expect(columns[0].adapterData).toEqual({
+        ...VECTOR_ADAPTER_IDENTITY,
         chunksInfo: {
           chunksSchema: 'private_schema',
           chunksTableName: 'doc_chunks',
@@ -106,11 +133,11 @@ describe('pgvector adapter — chunk querying (Phase E)', () => {
       });
     });
 
-    it('uses default parentFk, parentPk, and embeddingField when not specified', () => {
+    it('fails closed when neither the tag nor parent codec identifies a schema', () => {
       const codec = {
         name: 'documents',
         attributes: {
-          embedding: { codec: { name: 'vector' } },
+          embedding: vectorAttribute(),
         },
         extensions: {
           tags: {
@@ -119,26 +146,14 @@ describe('pgvector adapter — chunk querying (Phase E)', () => {
         },
       };
 
-      const columns = adapter.detectColumns(codec, {});
-      expect(columns[0].adapterData).toEqual({
-        chunksInfo: {
-          chunksSchema: null,
-          chunksTableName: 'my_chunks',
-          parentFkField: 'parent_id',
-          parentPkField: 'id',
-          embeddingField: 'embedding',
-          contentField: 'content',
-          searchField: null,
-          searchIndexes: [],
-        },
-      });
+      expect(() => adapter.detectColumns(codec, {})).toThrow(/chunksSchema/);
     });
 
     it('inherits schema from parent codec when not explicitly set', () => {
       const codec = {
         name: 'documents',
         attributes: {
-          embedding: { codec: { name: 'vector' } },
+          embedding: vectorAttribute(),
         },
         extensions: {
           tags: {
@@ -150,6 +165,7 @@ describe('pgvector adapter — chunk querying (Phase E)', () => {
 
       const columns = adapter.detectColumns(codec, {});
       expect(columns[0].adapterData).toEqual({
+        ...VECTOR_ADAPTER_IDENTITY,
         chunksInfo: {
           chunksSchema: 'my_schema',
           chunksTableName: 'my_chunks',
@@ -163,36 +179,32 @@ describe('pgvector adapter — chunk querying (Phase E)', () => {
       });
     });
 
-    it('ignores boolean true @hasChunks (no metadata to resolve)', () => {
+    it('rejects boolean true @hasChunks (no metadata to resolve)', () => {
       const codec = {
         name: 'documents',
         attributes: {
-          embedding: { codec: { name: 'vector' } },
+          embedding: vectorAttribute(),
         },
         extensions: {
           tags: { hasChunks: true },
         },
       };
 
-      const columns = adapter.detectColumns(codec, {});
-      expect(columns).toHaveLength(1);
-      expect(columns[0].adapterData).toBeUndefined();
+      expect(() => adapter.detectColumns(codec, {})).toThrow(/JSON object/);
     });
 
-    it('ignores invalid JSON in @hasChunks string', () => {
+    it('rejects invalid JSON in @hasChunks string', () => {
       const codec = {
         name: 'documents',
         attributes: {
-          embedding: { codec: { name: 'vector' } },
+          embedding: vectorAttribute(),
         },
         extensions: {
           tags: { hasChunks: 'not-valid-json' },
         },
       };
 
-      const columns = adapter.detectColumns(codec, {});
-      expect(columns).toHaveLength(1);
-      expect(columns[0].adapterData).toBeUndefined();
+      expect(() => adapter.detectColumns(codec, {})).toThrow(/valid JSON/);
     });
 
     it('does not detect chunks when enableChunkQuerying is false', () => {
@@ -200,7 +212,7 @@ describe('pgvector adapter — chunk querying (Phase E)', () => {
       const codec = {
         name: 'documents',
         attributes: {
-          embedding: { codec: { name: 'vector' } },
+          embedding: vectorAttribute(),
         },
         extensions: {
           tags: {
@@ -211,7 +223,7 @@ describe('pgvector adapter — chunk querying (Phase E)', () => {
 
       const columns = noChunksAdapter.detectColumns(codec, {});
       expect(columns).toHaveLength(1);
-      expect(columns[0].adapterData).toBeUndefined();
+      expect(columns[0].adapterData).toEqual(VECTOR_ADAPTER_IDENTITY);
     });
   });
 
@@ -220,7 +232,7 @@ describe('pgvector adapter — chunk querying (Phase E)', () => {
 
     // Mock sql object that mimics pg-sql2 behavior
     const mockSql = {
-      identifier: (name: string) => `"${name}"`,
+      identifier: (...names: string[]) => names.map((name) => `"${name}"`).join('.'),
       value: (val: any) => `'${val}'`,
       raw: (s: string) => s,
       fragment: (strings: TemplateStringsArray, ...values: any[]) => {
@@ -251,7 +263,10 @@ describe('pgvector adapter — chunk querying (Phase E)', () => {
       const result = adapter.buildFilterApply(
         sql,
         'tbl' as any,
-        { attributeName: 'embedding' },
+        {
+          attributeName: 'embedding',
+          adapterData: VECTOR_ADAPTER_IDENTITY,
+        },
         { vector: [1, 0, 0], metric: 'COSINE' },
         {},
       );
@@ -269,6 +284,7 @@ describe('pgvector adapter — chunk querying (Phase E)', () => {
         {
           attributeName: 'embedding',
           adapterData: {
+            ...VECTOR_ADAPTER_IDENTITY,
             chunksInfo: {
               chunksSchema: null,
               chunksTableName: 'documents_chunks',
@@ -296,6 +312,7 @@ describe('pgvector adapter — chunk querying (Phase E)', () => {
         {
           attributeName: 'embedding',
           adapterData: {
+            ...VECTOR_ADAPTER_IDENTITY,
             chunksInfo: {
               chunksSchema: null,
               chunksTableName: 'documents_chunks',
@@ -323,6 +340,7 @@ describe('pgvector adapter — chunk querying (Phase E)', () => {
         {
           attributeName: 'embedding',
           adapterData: {
+            ...VECTOR_ADAPTER_IDENTITY,
             chunksInfo: {
               chunksSchema: 'app_private',
               chunksTableName: 'doc_chunks',
@@ -421,5 +439,46 @@ describe('VectorNearbyInput includeChunks field (Phase E)', () => {
     expect(fields.includeChunks).toBeDefined();
     expect(fields.includeChunks.type).toBe('Boolean');
     expect(fields.includeChunks.description).toContain('chunks');
+  });
+});
+
+describe('BM25 index qualification', () => {
+  const sql = Object.assign(
+    (strings: TemplateStringsArray, ...values: any[]) =>
+      strings.reduce((text, part, index) => text + part + (values[index] ?? ''), ''),
+    {
+      identifier: (name: string) => `"${name}"`,
+      value: (value: any) => `'${value}'`
+    }
+  );
+
+  it('passes the physical schema-qualified index name as the regclass-like value', () => {
+    const adapter = createBm25Adapter();
+    const result = adapter.buildFilterApply(
+      sql,
+      'docs' as any,
+      {
+        attributeName: 'body',
+        adapterData: {
+          bm25Index: {
+            serviceName: 'main',
+            extensionSchema: 'extension_tools',
+            schemaName: 'tenant-a-app-public',
+            tableName: 'documents',
+            columnName: 'body',
+            indexName: 'documents_body_bm25_idx'
+          }
+        }
+      },
+      { query: 'memory density' },
+      {}
+    );
+
+    expect(String(result?.scoreExpression)).toContain(
+      '"tenant-a-app-public".documents_body_bm25_idx'
+    );
+    expect(String(result?.scoreExpression)).toContain(
+      'OPERATOR("extension_tools".<@>)'
+    );
   });
 });

--- a/graphile/graphile-search/src/adapters/bm25.ts
+++ b/graphile/graphile-search/src/adapters/bm25.ts
@@ -4,8 +4,8 @@
  * Detects text columns with BM25 indexes (via pg_textsearch) and generates
  * BM25 relevance scoring. Wraps the same SQL logic as graphile-bm25.
  *
- * Requires the Bm25CodecPlugin to be loaded first (for index discovery).
- * The adapter reads from the bm25IndexStore populated during the gather phase.
+ * Requires the Bm25CodecPlugin to be loaded first. The adapter reads index
+ * metadata attached to the exact codec attribute during the same gather.
  *
  * Supports chunk-aware querying via @hasChunks smart tag: when the parent
  * table has chunks with a BM25 index, the adapter includes a lateral
@@ -13,26 +13,20 @@
  * LEAST(parent_score, chunk_score) (lower = better for BM25).
  */
 
+import { QuoteUtils } from '@pgsql/quotes';
 import type { SQL } from 'pg-sql2';
 
-import { bm25IndexStore as moduleBm25IndexStore } from '../codecs/bm25-codec';
-import type { FilterApplyResult,SearchableColumn, SearchAdapter } from '../types';
+import type { Bm25IndexInfo } from '../codecs/bm25-codec';
+import type { FilterApplyResult, SearchableColumn, SearchAdapter } from '../types';
 import { type ChunksInfo,getChunksInfo } from './chunks';
 
-/**
- * BM25 index info discovered during gather phase.
- */
-export interface Bm25IndexInfo {
-  schemaName: string;
-  tableName: string;
-  columnName: string;
-  indexName: string;
-}
+export type { Bm25IndexInfo } from '../codecs/bm25-codec';
 
 /** Combined adapter data for a BM25-searchable column */
 interface Bm25ColumnData {
   bm25Index: Bm25IndexInfo;
   chunksInfo?: ChunksInfo;
+  chunkBm25Index?: Bm25IndexInfo;
 }
 
 function isTextCodec(codec: any): boolean {
@@ -46,42 +40,44 @@ export interface Bm25AdapterOptions {
    * @default 'bm25'
    */
   filterPrefix?: string;
-
-  /**
-   * External BM25 index store. If not provided, the adapter will attempt
-   * to read from the build object's `pgBm25IndexStore`.
-   */
-  bm25IndexStore?: Map<string, Bm25IndexInfo>;
 }
 
 export function createBm25Adapter(
   options: Bm25AdapterOptions = {}
 ): SearchAdapter {
-  const { filterPrefix = 'bm25', bm25IndexStore } = options;
-
-  function getIndexStore(build: any): Map<string, Bm25IndexInfo> | undefined {
-    if (bm25IndexStore) return bm25IndexStore;
-    // Try build.pgBm25IndexStore (set by standalone Bm25SearchPlugin's build hook)
-    const buildStore = build.pgBm25IndexStore as Map<string, Bm25IndexInfo> | undefined;
-    if (buildStore && buildStore.size > 0) return buildStore;
-    // Fall back to module-level store populated by Bm25CodecPlugin's gather phase
-    if (moduleBm25IndexStore && moduleBm25IndexStore.size > 0) return moduleBm25IndexStore;
-    return undefined;
-  }
+  const { filterPrefix = 'bm25' } = options;
 
   function getBm25IndexForAttribute(
     codec: any,
-    attributeName: string,
-    build: any,
+    attributeName: string
   ): Bm25IndexInfo | undefined {
-    const store = getIndexStore(build);
-    if (!store) return undefined;
+    const bound = codec.attributes?.[attributeName]?.extensions?.bm25Index;
+    return bound as Bm25IndexInfo | undefined;
+  }
 
-    const pg = codec?.extensions?.pg;
-    if (!pg) return undefined;
-
-    const key = `${pg.schemaName}.${pg.name}.${attributeName}`;
-    return store.get(key);
+  function findBoundBm25Index(
+    build: any,
+    serviceName: string,
+    schemaName: string,
+    tableName: string,
+    columnName: string
+  ): Bm25IndexInfo | undefined {
+    for (const codec of Object.values(
+      build?.input?.pgRegistry?.pgCodecs ?? {}
+    ) as any[]) {
+      for (const attribute of Object.values(codec?.attributes ?? {}) as any[]) {
+        const index = attribute?.extensions?.bm25Index as Bm25IndexInfo | undefined;
+        if (
+          index?.serviceName === serviceName
+          && index.schemaName === schemaName
+          && index.tableName === tableName
+          && index.columnName === columnName
+        ) {
+          return index;
+        }
+      }
+    }
+    return undefined;
   }
 
   return {
@@ -110,17 +106,45 @@ export function createBm25Adapter(
         codec.attributes as Record<string, any>
       )) {
         if (!isTextCodec(attribute.codec)) continue;
-        const bm25Index = getBm25IndexForAttribute(codec, attributeName, build);
+        const bm25Index = getBm25IndexForAttribute(codec, attributeName);
         if (!bm25Index) continue;
 
         // Check for chunk-aware BM25
-        const chunksInfo = getChunksInfo(codec);
-        const hasChunkBm25 = chunksInfo?.searchIndexes.includes('bm25');
+        const chunksInfo = getChunksInfo(codec, build);
+        const hasChunkBm25 = chunksInfo?.searchIndexes.includes('bm25') === true;
+        let chunkBm25Index: Bm25IndexInfo | undefined;
+        if (hasChunkBm25) {
+          if (!bm25Index.serviceName) {
+            throw new Error('BM25 chunk search requires a bound PostgreSQL service identity');
+          }
+          if (!chunksInfo?.chunksSchema) {
+            throw new Error(
+              `BM25 chunk search for '${chunksInfo?.chunksTableName}' requires a physical schema`
+            );
+          }
+          chunkBm25Index = findBoundBm25Index(
+            build,
+            bm25Index.serviceName,
+            chunksInfo.chunksSchema,
+            chunksInfo.chunksTableName,
+            chunksInfo.contentField
+          );
+          if (!chunkBm25Index) {
+            throw new Error(
+              'BM25 chunk search could not bind an introspected index for '
+              + `${chunksInfo.chunksSchema}.${chunksInfo.chunksTableName}.`
+              + chunksInfo.contentField
+            );
+          }
+        }
 
         const columnData: Bm25ColumnData = {
-          bm25Index,
-          chunksInfo: hasChunkBm25 ? chunksInfo : undefined,
+          bm25Index
         };
+        if (hasChunkBm25) {
+          columnData.chunksInfo = chunksInfo;
+          columnData.chunkBm25Index = chunkBm25Index;
+        }
         columns.push({ attributeName, adapterData: columnData });
       }
       return columns;
@@ -181,14 +205,25 @@ export function createBm25Adapter(
       const bm25Index = columnData.bm25Index;
       const columnExpr = sql`${alias}.${sql.identifier(column.attributeName)}`;
 
-      // Use quoteQualifiedIdentifier to produce the qualified index name
-      const qualifiedIndexName = `"${bm25Index.schemaName}"."${bm25Index.indexName}"`;
-      const bm25queryExpr = sql`to_bm25query(${sql.value(query)}, ${sql.value(qualifiedIndexName)})`;
-      const scoreExpr = sql`(${columnExpr} <@> ${bm25queryExpr})`;
+      const qualifiedIndexName = QuoteUtils.quoteQualifiedIdentifier(
+        bm25Index.schemaName,
+        bm25Index.indexName
+      );
+      const bm25queryExpr = sql`${sql.identifier(
+        bm25Index.extensionSchema,
+        'to_bm25query'
+      )}(${sql.value(query)}, ${sql.value(qualifiedIndexName)})`;
+      const scoreExpr = sql`(${columnExpr} OPERATOR(${sql.identifier(
+        bm25Index.extensionSchema
+      )}.<@>) ${bm25queryExpr})`;
 
       // Check for chunk-aware querying
       const chunksInfo = columnData.chunksInfo;
       if (chunksInfo && chunksInfo.searchIndexes.includes('bm25') && (includeChunks !== false)) {
+        const chunkBm25Index = columnData.chunkBm25Index;
+        if (!chunkBm25Index) {
+          throw new Error('BM25 chunk search is missing its bound introspected index');
+        }
         const chunksTableRef = chunksInfo.chunksSchema
           ? sql`${sql.identifier(chunksInfo.chunksSchema)}.${sql.identifier(chunksInfo.chunksTableName)}`
           : sql`${sql.identifier(chunksInfo.chunksTableName)}`;
@@ -197,12 +232,17 @@ export function createBm25Adapter(
         const parentId = sql`${alias}.${sql.identifier(chunksInfo.parentPkField)}`;
         const chunksAlias = sql.identifier('__bm25_chunks');
 
-        // BM25 on chunks requires an index name on the chunks table.
-        // We construct it from the chunks table schema + a conventional index name.
-        // The BM25 index on chunks is named: {chunks_table}_{content_field}_bm25_idx
-        const chunksIndexName = `"${chunksInfo.chunksSchema || bm25Index.schemaName}"."${chunksInfo.chunksTableName}_${chunksInfo.contentField}_bm25_idx"`;
-        const chunkBm25queryExpr = sql`to_bm25query(${sql.value(query)}, ${sql.value(chunksIndexName)})`;
-        const chunkScoreExpr = sql`(${chunksAlias}.${chunkContentField} <@> ${chunkBm25queryExpr})`;
+        const chunksIndexName = QuoteUtils.quoteQualifiedIdentifier(
+          chunkBm25Index.schemaName,
+          chunkBm25Index.indexName
+        );
+        const chunkBm25queryExpr = sql`${sql.identifier(
+          chunkBm25Index.extensionSchema,
+          'to_bm25query'
+        )}(${sql.value(query)}, ${sql.value(chunksIndexName)})`;
+        const chunkScoreExpr = sql`(${chunksAlias}.${chunkContentField} OPERATOR(${sql.identifier(
+          chunkBm25Index.extensionSchema
+        )}.<@>) ${chunkBm25queryExpr})`;
 
         // Subquery: MIN(bm25_score) across chunks (lower = better for BM25)
         const chunkScoreSubquery = sql`(

--- a/graphile/graphile-search/src/adapters/chunks.ts
+++ b/graphile/graphile-search/src/adapters/chunks.ts
@@ -23,6 +23,77 @@ export interface ChunksInfo {
   searchIndexes: string[];
 }
 
+interface PgIdentity {
+  serviceName: string;
+  schemaName: string;
+  name: string;
+}
+
+function requireNonEmptyString(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length === 0 || value.includes('\0')) {
+    throw new Error(`[graphile-search] @hasChunks ${label} must be a non-empty PostgreSQL identifier`);
+  }
+  return value;
+}
+
+function pgIdentity(value: any, label: string): PgIdentity {
+  const pg = value?.extensions?.pg;
+  if (!pg?.serviceName || !pg?.schemaName || !pg?.name) {
+    throw new Error(
+      `[graphile-search] ${label} is missing exact service/schema/table metadata`
+    );
+  }
+  return {
+    serviceName: pg.serviceName,
+    schemaName: pg.schemaName,
+    name: pg.name,
+  };
+}
+
+function configuredSchemas(build: any, serviceName: string): ReadonlySet<string> | null {
+  const services = build?.resolvedPreset?.pgServices;
+  if (!Array.isArray(services)) return null;
+  const matches = services.filter(
+    (service: any) => (service?.name ?? 'main') === serviceName
+  );
+  if (matches.length !== 1) {
+    throw new Error(
+      `[graphile-search] @hasChunks cannot resolve exact service '${serviceName}' ` +
+      `(matches=${matches.length})`
+    );
+  }
+  const service = matches[0];
+  const schemas = service?.schemas;
+  if (!Array.isArray(schemas) || schemas.length === 0) {
+    throw new Error(
+      `[graphile-search] @hasChunks service '${serviceName}' has no configured schema allowlist`
+    );
+  }
+  const dependencySchemas = service?.introspectionAllowedDependencySchemas;
+  if (dependencySchemas !== undefined && !Array.isArray(dependencySchemas)) {
+    throw new Error(
+      `[graphile-search] @hasChunks service '${serviceName}' has an invalid dependency schema allowlist`
+    );
+  }
+  return new Set([...schemas, ...(dependencySchemas ?? [])]);
+}
+
+function parseSearchIndexes(value: unknown): string[] {
+  let parsed = value;
+  if (typeof parsed === 'string') {
+    try {
+      parsed = JSON.parse(parsed);
+    } catch {
+      throw new Error('[graphile-search] @hasChunks searchIndexes must be a JSON string array');
+    }
+  }
+  if (parsed == null) return [];
+  if (!Array.isArray(parsed)) {
+    throw new Error('[graphile-search] @hasChunks searchIndexes must be an array');
+  }
+  return parsed.map((entry) => requireNonEmptyString(entry, 'searchIndexes entry'));
+}
+
 /**
  * Read @hasChunks smart tag from codec extensions.
  *
@@ -38,7 +109,7 @@ export interface ChunksInfo {
  *   "searchIndexes": ["fulltext","bm25"] // optional, defaults to []
  * }
  */
-export function getChunksInfo(codec: any): ChunksInfo | undefined {
+export function getChunksInfo(codec: any, build?: any): ChunksInfo | undefined {
   const tags = codec?.extensions?.tags;
   if (!tags) return undefined;
   const raw = tags.hasChunks;
@@ -49,43 +120,89 @@ export function getChunksInfo(codec: any): ChunksInfo | undefined {
     try {
       parsed = JSON.parse(raw);
     } catch {
-      return undefined;
+      throw new Error('[graphile-search] @hasChunks must contain valid JSON');
     }
-  } else if (typeof raw === 'object') {
+  } else if (typeof raw === 'object' && raw !== null && !Array.isArray(raw)) {
     parsed = raw;
-  } else if (raw === true) {
-    return undefined;
   } else {
-    return undefined;
+    throw new Error('[graphile-search] @hasChunks must be a JSON object');
   }
 
-  if (!parsed.chunksTable) return undefined;
+  const chunksTableName = requireNonEmptyString(parsed.chunksTable, 'chunksTable');
+  const parentPg = codec?.extensions?.pg;
+  const chunksSchema = requireNonEmptyString(
+    parsed.chunksSchema || parentPg?.schemaName,
+    'chunksSchema'
+  );
+  const parentFkField = requireNonEmptyString(parsed.parentFk || 'parent_id', 'parentFk');
+  const parentPkField = requireNonEmptyString(parsed.parentPk || 'id', 'parentPk');
+  const embeddingField = requireNonEmptyString(
+    parsed.embeddingField || 'embedding',
+    'embeddingField'
+  );
+  const contentField = requireNonEmptyString(parsed.contentField || 'content', 'contentField');
+  const searchField = parsed.searchField == null
+    ? null
+    : requireNonEmptyString(parsed.searchField, 'searchField');
+  const searchIndexes = parseSearchIndexes(parsed.searchIndexes);
 
-  const chunksSchema = parsed.chunksSchema
-    || codec?.extensions?.pg?.schemaName
-    || null;
+  const pgRegistry = build?.input?.pgRegistry ?? build?.pgRegistry;
+  if (pgRegistry) {
+    const parentIdentity = pgIdentity(codec, 'parent codec');
+    const allowedSchemas = configuredSchemas(build, parentIdentity.serviceName);
+    if (allowedSchemas && !allowedSchemas.has(chunksSchema)) {
+      throw new Error(
+        `[graphile-search] @hasChunks on '${parentIdentity.schemaName}.${parentIdentity.name}' ` +
+        `references schema '${chunksSchema}' outside service '${parentIdentity.serviceName}'`
+      );
+    }
 
-  // Parse searchIndexes from tag (may be array or JSON string)
-  let searchIndexes: string[] = [];
-  if (Array.isArray(parsed.searchIndexes)) {
-    searchIndexes = parsed.searchIndexes;
-  } else if (typeof parsed.searchIndexes === 'string') {
-    try {
-      const arr = JSON.parse(parsed.searchIndexes);
-      if (Array.isArray(arr)) searchIndexes = arr;
-    } catch {
-      // ignore
+    const matches = Object.values(pgRegistry.pgResources ?? {}).filter((resource: any) => {
+      if (resource?.parameters || !resource?.codec?.attributes) return false;
+      const pg = resource.codec.extensions?.pg;
+      return pg?.serviceName === parentIdentity.serviceName &&
+        pg?.schemaName === chunksSchema &&
+        pg?.name === chunksTableName;
+    }) as any[];
+    if (matches.length !== 1) {
+      throw new Error(
+        `[graphile-search] @hasChunks on '${parentIdentity.schemaName}.${parentIdentity.name}' ` +
+        `must resolve exactly one '${chunksSchema}.${chunksTableName}' resource ` +
+        `(matches=${matches.length})`
+      );
+    }
+
+    const chunkIdentity = pgIdentity(matches[0].codec, 'chunks codec');
+    const chunkAttributes = matches[0].codec.attributes;
+    for (const [field, label] of [
+      [parentFkField, 'parentFk'],
+      [embeddingField, 'embeddingField'],
+      [contentField, 'contentField'],
+      ...(searchField ? [[searchField, 'searchField']] : []),
+    ] as Array<[string, string]>) {
+      if (!chunkAttributes[field]) {
+        throw new Error(
+          `[graphile-search] @hasChunks ${label} '${field}' does not exist on ` +
+          `'${chunkIdentity.schemaName}.${chunkIdentity.name}'`
+        );
+      }
+    }
+    if (!codec?.attributes?.[parentPkField]) {
+      throw new Error(
+        `[graphile-search] @hasChunks parentPk '${parentPkField}' does not exist on ` +
+        `'${parentIdentity.schemaName}.${parentIdentity.name}'`
+      );
     }
   }
 
   return {
     chunksSchema,
-    chunksTableName: parsed.chunksTable,
-    parentFkField: parsed.parentFk || 'parent_id',
-    parentPkField: parsed.parentPk || 'id',
-    embeddingField: parsed.embeddingField || 'embedding',
-    contentField: parsed.contentField || 'content',
-    searchField: parsed.searchField || null,
+    chunksTableName,
+    parentFkField,
+    parentPkField,
+    embeddingField,
+    contentField,
+    searchField,
     searchIndexes,
   };
 }

--- a/graphile/graphile-search/src/adapters/pgvector.ts
+++ b/graphile/graphile-search/src/adapters/pgvector.ts
@@ -8,8 +8,15 @@
 
 import type { SQL } from 'pg-sql2';
 
+import type { SearchExtensionSchemas } from '../extension-metadata';
 import type { FilterApplyResult,SearchableColumn, SearchAdapter } from '../types';
 import { type ChunksInfo,getChunksInfo } from './chunks';
+
+interface PgvectorColumnData {
+  serviceName: string;
+  extensionSchema: string;
+  chunksInfo?: ChunksInfo;
+}
 
 /**
  * Build a distance expression for the given metric.
@@ -20,15 +27,16 @@ function buildDistanceExpr(
   columnExpr: SQL,
   vectorExpr: SQL,
   metric: string,
+  extensionSchema: string,
 ): SQL {
   switch (metric) {
   case 'L2':
-    return sql`(${columnExpr} <-> ${vectorExpr})`;
+    return sql`(${columnExpr} OPERATOR(${sql.identifier(extensionSchema)}.<->) ${vectorExpr})`;
   case 'IP':
-    return sql`(${columnExpr} <#> ${vectorExpr})`;
+    return sql`(${columnExpr} OPERATOR(${sql.identifier(extensionSchema)}.<#>) ${vectorExpr})`;
   case 'COSINE':
   default:
-    return sql`(${columnExpr} <=> ${vectorExpr})`;
+    return sql`(${columnExpr} OPERATOR(${sql.identifier(extensionSchema)}.<=>) ${vectorExpr})`;
   }
 }
 
@@ -82,19 +90,43 @@ export function createPgvectorAdapter(
     supportsTextSearch: false,
     // pgvector requires a vector array, not plain text — no buildTextSearchInput
 
-    detectColumns(codec: any, _build: any): SearchableColumn[] {
+    detectColumns(codec: any, build: any): SearchableColumn[] {
       if (!codec?.attributes) return [];
 
       const columns: SearchableColumn[] = [];
-      const chunksInfo = enableChunkQuerying ? getChunksInfo(codec) : undefined;
+      const chunksInfo = enableChunkQuerying ? getChunksInfo(codec, build) : undefined;
 
       for (const [attributeName, attribute] of Object.entries(
         codec.attributes as Record<string, any>
       )) {
         if (isVectorCodec(attribute.codec)) {
+          const binding: SearchExtensionSchemas | undefined =
+            attribute?.extensions?.searchExtensionSchemas;
+          const codecPg = attribute.codec?.extensions?.pg;
+          if (!binding?.pgvectorSchema || !codecPg?.schemaName || !codecPg?.serviceName) {
+            const tableName = codec?.extensions?.pg?.name ?? codec?.name ?? '<unknown>';
+            throw new Error(
+              `[graphile-search] pgvector column '${tableName}.${attributeName}' is ` +
+              'missing exact codec/service extension metadata'
+            );
+          }
+          if (
+            codecPg.schemaName !== binding.pgvectorSchema ||
+            codecPg.serviceName !== binding.serviceName
+          ) {
+            throw new Error(
+              `[graphile-search] pgvector column '${attributeName}' codec identity ` +
+              `'${codecPg.serviceName}/${codecPg.schemaName}' does not match extension ` +
+              `'${binding.serviceName}/${binding.pgvectorSchema}'`
+            );
+          }
           columns.push({
             attributeName,
-            adapterData: chunksInfo ? { chunksInfo } : undefined,
+            adapterData: {
+              serviceName: binding.serviceName,
+              extensionSchema: binding.pgvectorSchema,
+              ...(chunksInfo ? { chunksInfo } : {}),
+            } satisfies PgvectorColumnData,
           });
         }
       }
@@ -195,12 +227,21 @@ export function createPgvectorAdapter(
       const { vector, metric, distance, includeChunks } = filterValue;
       if (!vector || !Array.isArray(vector) || vector.length === 0) return null;
 
+      const adapterData = column.adapterData as PgvectorColumnData | undefined;
+      if (!adapterData?.extensionSchema || !adapterData.serviceName) {
+        throw new Error(
+          `[graphile-search] pgvector column '${column.attributeName}' has no bound ` +
+          'extension schema'
+        );
+      }
       const resolvedMetric = metric || defaultMetric;
       const vectorString = `[${vector.join(',')}]`;
-      const vectorExpr = sql`${sql.value(vectorString)}::vector`;
+      const vectorExpr = sql`${sql.value(vectorString)}::${sql.identifier(
+        adapterData.extensionSchema,
+        'vector'
+      )}`;
 
       // Check if this column has chunks info and chunk querying is requested
-      const adapterData = column.adapterData as { chunksInfo?: ChunksInfo } | undefined;
       const chunksInfo = adapterData?.chunksInfo;
 
       if (chunksInfo && (includeChunks !== false)) {
@@ -217,7 +258,13 @@ export function createPgvectorAdapter(
         const chunksAlias = sql.identifier('__chunks');
 
         // Subquery: SELECT MIN(distance) FROM chunks WHERE chunks.parent_fk = parent.pk
-        const chunkDistanceExpr = buildDistanceExpr(sql, sql`${chunksAlias}.${chunkEmbedding}`, vectorExpr, resolvedMetric);
+        const chunkDistanceExpr = buildDistanceExpr(
+          sql,
+          sql`${chunksAlias}.${chunkEmbedding}`,
+          vectorExpr,
+          resolvedMetric,
+          adapterData.extensionSchema
+        );
         const chunkDistanceSubquery = sql`(
           SELECT MIN(${chunkDistanceExpr})
           FROM ${chunksTableRef} AS ${chunksAlias}
@@ -226,7 +273,13 @@ export function createPgvectorAdapter(
 
         // Also compute direct parent distance if the parent has an embedding
         const parentColumnExpr = sql`${alias}.${sql.identifier(column.attributeName)}`;
-        const parentDistanceExpr = buildDistanceExpr(sql, parentColumnExpr, vectorExpr, resolvedMetric);
+        const parentDistanceExpr = buildDistanceExpr(
+          sql,
+          parentColumnExpr,
+          vectorExpr,
+          resolvedMetric,
+          adapterData.extensionSchema
+        );
 
         // Use LEAST of parent distance and closest chunk distance
         // COALESCE handles cases where parent or chunks may not have embeddings
@@ -248,7 +301,13 @@ export function createPgvectorAdapter(
 
       // Standard (non-chunk) query
       const columnExpr = sql`${alias}.${sql.identifier(column.attributeName)}`;
-      const distanceExpr = buildDistanceExpr(sql, columnExpr, vectorExpr, resolvedMetric);
+      const distanceExpr = buildDistanceExpr(
+        sql,
+        columnExpr,
+        vectorExpr,
+        resolvedMetric,
+        adapterData.extensionSchema
+      );
 
       let whereClause: SQL | null = null;
       if (distance !== undefined && distance !== null) {

--- a/graphile/graphile-search/src/adapters/trgm.ts
+++ b/graphile/graphile-search/src/adapters/trgm.ts
@@ -12,6 +12,7 @@
 
 import type { SQL } from 'pg-sql2';
 
+import type { SearchExtensionSchemas } from '../extension-metadata';
 import type { FilterApplyResult,SearchableColumn, SearchAdapter } from '../types';
 import { type ChunksInfo,getChunksInfo } from './chunks';
 
@@ -48,6 +49,12 @@ export interface TrgmAdapterOptions {
   requireIntentionalSearch?: boolean;
 }
 
+interface TrgmColumnData {
+  serviceName: string;
+  extensionSchema: string;
+  chunksInfo?: ChunksInfo;
+}
+
 export function createTrgmAdapter(
   options: TrgmAdapterOptions = {}
 ): SearchAdapter {
@@ -81,7 +88,7 @@ export function createTrgmAdapter(
       return { value: text };
     },
 
-    detectColumns(codec: any, _build: any): SearchableColumn[] {
+    detectColumns(codec: any, build: any): SearchableColumn[] {
       if (!codec?.attributes) return [];
 
       const columns: SearchableColumn[] = [];
@@ -89,12 +96,41 @@ export function createTrgmAdapter(
         codec.attributes as Record<string, any>
       )) {
         if (isTextCodec(attribute.codec)) {
+          const binding: SearchExtensionSchemas | undefined =
+            attribute?.extensions?.searchExtensionSchemas;
+          if (!binding) {
+            const tableName = codec?.extensions?.pg?.name ?? codec?.name ?? '<unknown>';
+            throw new Error(
+              `[graphile-search] pg_trgm column '${tableName}.${attributeName}' is ` +
+              'missing service-bound extension schema metadata'
+            );
+          }
+          if (!binding.pgTrgmSchema) {
+            const explicitlyRequired =
+              requireIntentionalSearch === false ||
+              codec?.extensions?.tags?.trgmSearch === true ||
+              attribute?.extensions?.tags?.trgmSearch === true;
+            if (explicitlyRequired) {
+              const tableName = codec?.extensions?.pg?.name ?? codec?.name ?? '<unknown>';
+              throw new Error(
+                `[graphile-search] pg_trgm is required for '${tableName}.${attributeName}' ` +
+                `but is not installed for service '${binding.serviceName}'`
+              );
+            }
+            // The adapter is enabled in the preset, but this service does not
+            // install pg_trgm. Leave the attribute untouched.
+            continue;
+          }
           // Store chunks info if available and chunks have trigram search
-          const chunksInfo = getChunksInfo(codec);
+          const chunksInfo = getChunksInfo(codec, build);
           const hasChunkTrgm = chunksInfo?.searchIndexes.includes('trigram');
           columns.push({
             attributeName,
-            adapterData: hasChunkTrgm ? chunksInfo : undefined,
+            adapterData: {
+              serviceName: binding.serviceName,
+              extensionSchema: binding.pgTrgmSchema,
+              ...(hasChunkTrgm ? { chunksInfo } : {}),
+            } satisfies TrgmColumnData,
           });
         }
       }
@@ -152,12 +188,20 @@ export function createTrgmAdapter(
       const { value, threshold, includeChunks } = filterValue;
       if (!value || typeof value !== 'string' || value.trim().length === 0) return null;
 
+      const columnData = column.adapterData as TrgmColumnData | undefined;
+      if (!columnData?.extensionSchema || !columnData.serviceName) {
+        throw new Error(
+          `[graphile-search] pg_trgm column '${column.attributeName}' has no bound ` +
+          'extension schema'
+        );
+      }
       const th = threshold != null ? threshold : defaultThreshold;
       const columnExpr = sql`${alias}.${sql.identifier(column.attributeName)}`;
-      const similarityExpr = sql`similarity(${columnExpr}, ${sql.value(value)})`;
+      const similarity = sql.identifier(columnData.extensionSchema, 'similarity');
+      const similarityExpr = sql`${similarity}(${columnExpr}, ${sql.value(value)})`;
 
       // Check for chunk-aware querying
-      const chunksInfo = column.adapterData as ChunksInfo | undefined;
+      const chunksInfo = columnData.chunksInfo;
       if (chunksInfo && chunksInfo.searchIndexes.includes('trigram') && (includeChunks !== false)) {
         const chunksTableRef = chunksInfo.chunksSchema
           ? sql`${sql.identifier(chunksInfo.chunksSchema)}.${sql.identifier(chunksInfo.chunksTableName)}`
@@ -169,10 +213,10 @@ export function createTrgmAdapter(
 
         // Subquery: MAX(similarity) across chunks (higher = better for trgm)
         const chunkSimilaritySubquery = sql`(
-          SELECT MAX(similarity(${chunksAlias}.${chunkContentField}, ${sql.value(value)}))
+          SELECT MAX(${similarity}(${chunksAlias}.${chunkContentField}, ${sql.value(value)}))
           FROM ${chunksTableRef} AS ${chunksAlias}
           WHERE ${chunksAlias}.${parentFk} = ${parentId}
-            AND similarity(${chunksAlias}.${chunkContentField}, ${sql.value(value)}) > ${sql.value(th)}
+            AND ${similarity}(${chunksAlias}.${chunkContentField}, ${sql.value(value)}) > ${sql.value(th)}
         )`;
 
         // Combined: GREATEST of parent similarity and best chunk similarity

--- a/graphile/graphile-search/src/adapters/tsvector.ts
+++ b/graphile/graphile-search/src/adapters/tsvector.ts
@@ -63,7 +63,7 @@ export function createTsvectorAdapter(
       return text;
     },
 
-    detectColumns(codec: any, _build: any): SearchableColumn[] {
+    detectColumns(codec: any, build: any): SearchableColumn[] {
       if (!codec?.attributes) return [];
 
       const columns: SearchableColumn[] = [];
@@ -72,7 +72,7 @@ export function createTsvectorAdapter(
       )) {
         if (isTsvectorCodec(attribute.codec)) {
           // Store chunks info if available and chunks have fulltext search
-          const chunksInfo = getChunksInfo(codec);
+          const chunksInfo = getChunksInfo(codec, build);
           const hasChunkFulltext = chunksInfo?.searchField &&
             chunksInfo.searchIndexes.includes('fulltext');
           columns.push({

--- a/graphile/graphile-search/src/codecs/bm25-codec.ts
+++ b/graphile/graphile-search/src/codecs/bm25-codec.ts
@@ -2,25 +2,37 @@
  * Bm25CodecPlugin
  *
  * Teaches PostGraphile v5 how to handle the pg_textsearch `bm25query` type
- * and discovers all BM25 indexes in the database.
+ * and discovers BM25 indexes from Graphile's scoped introspection payload.
  *
  * This plugin:
  * 1. Creates a codec for bm25query via gather.hooks.pgCodecs_findPgCodec
- * 2. Discovers all BM25 indexes via gather.hooks.pgIntrospection_introspection
- *    by querying pg_index + pg_am + pg_class + pg_attribute
- * 3. Stores discovered BM25 index info in a module-level Map for use by
- *    the BM25 adapter during the schema build phase
+ * 2. Discovers requested-schema BM25 indexes without issuing side-channel SQL
+ * 3. Attaches index metadata to the exact codec attribute for this build
  */
 
 import 'graphile-build-pg';
 
 import type { GraphileConfig } from 'graphile-config';
+import { gatherConfig } from 'graphile-build';
 import sql from 'pg-sql2';
+
+type Introspection = Parameters<
+  GraphileConfig.GatherHooks['pgIntrospection_introspection']
+>[0]['introspection'];
+
+interface ScopedPgService {
+  name?: string;
+  schemas?: readonly string[];
+}
 
 /**
  * Represents a discovered BM25 index in the database.
  */
 export interface Bm25IndexInfo {
+  /** Graphile PostgreSQL service that owns this index. */
+  serviceName: string;
+  /** Schema containing pg_textsearch's functions and operators. */
+  extensionSchema: string;
   /** Schema name (e.g. 'public') */
   schemaName: string;
   /** Table name (e.g. 'documents') */
@@ -31,46 +43,105 @@ export interface Bm25IndexInfo {
   indexName: string;
 }
 
-/**
- * Module-level store for discovered BM25 indexes.
- * Populated during the gather phase, read during the schema build phase.
- *
- * Key: "schemaName.tableName.columnName"
- * Value: Bm25IndexInfo
- */
-export const bm25IndexStore = new Map<string, Bm25IndexInfo>();
+declare global {
+  namespace GraphileConfig {
+    interface GatherHelpers {
+      bm25Codec: Record<string, never>;
+    }
+  }
 
-/**
- * Whether pg_textsearch extension was detected in the database.
- */
-export let bm25ExtensionDetected = false;
+  namespace DataplanPg {
+    interface PgCodecAttributeExtensions {
+      /** Exact physical BM25 index bound during this gather generation. */
+      bm25Index?: Bm25IndexInfo;
+    }
+  }
+}
 
-/**
- * The SQL query that discovers BM25 indexes in the database.
- * Joins pg_index -> pg_class -> pg_am to find all indexes using the 'bm25'
- * access method, then resolves the schema, table, column, and index names.
- */
-const BM25_DISCOVERY_SQL = `
-  SELECT
-    n.nspname  AS schema_name,
-    c.relname  AS table_name,
-    a.attname  AS column_name,
-    i.relname  AS index_name
-  FROM pg_index ix
-  JOIN pg_class i ON i.oid = ix.indexrelid
-  JOIN pg_am am ON am.oid = i.relam
-  JOIN pg_class c ON c.oid = ix.indrelid
-  JOIN pg_namespace n ON n.oid = c.relnamespace
-  JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = ANY(ix.indkey)
-  WHERE am.amname = 'bm25'
-`;
+const attributeKey = (classId: string, attributeNumber: number): string =>
+  `${classId}:${attributeNumber}`;
+
+/** Collect exact requested-schema indexes from this build's own introspection. */
+export const collectBm25Indexes = (
+  introspection: Introspection,
+  schemas: readonly string[],
+  serviceName: string
+): Map<string, Bm25IndexInfo> => {
+  const allowedSchemas = new Set(schemas);
+  const discovered = new Map<string, Bm25IndexInfo>();
+  const extension = introspection.extensions.find(
+    (candidate) => candidate.extname === 'pg_textsearch'
+  );
+  const extensionNamespace = extension?.extnamespace
+    ? introspection.getNamespace({ id: extension.extnamespace })
+    : undefined;
+  const indexes = [...introspection.indexes].sort((left, right) => {
+    const leftName = left.getIndexClass()?.relname ?? '';
+    const rightName = right.getIndexClass()?.relname ?? '';
+    return leftName.localeCompare(rightName);
+  });
+
+  for (const index of indexes) {
+    if (index.indisvalid !== true || index.indisready !== true || index.indislive !== true) {
+      continue;
+    }
+    const indexClass = index.getIndexClass();
+    const tableClass = index.getClass();
+    const namespace = tableClass
+      ? introspection.getNamespace({ id: tableClass.relnamespace })
+      : undefined;
+    if (
+      !indexClass
+      || indexClass.getAccessMethod()?.amname !== 'bm25'
+      || !tableClass
+      || !namespace
+      || !allowedSchemas.has(namespace.nspname)
+    ) {
+      continue;
+    }
+
+    const keyCount = index.indnkeyatts ?? index.indkey.length;
+    for (const attribute of index.getKeys().slice(0, keyCount)) {
+      if (!attribute) continue;
+      const key = attributeKey(tableClass._id, attribute.attnum);
+      if (!extensionNamespace) {
+        throw new Error(
+          `BM25 index ${namespace.nspname}.${indexClass.relname} has no `
+          + 'introspected pg_textsearch extension schema'
+        );
+      }
+      const indexInfo: Bm25IndexInfo = {
+        serviceName,
+        extensionSchema: extensionNamespace.nspname,
+        schemaName: namespace.nspname,
+        tableName: tableClass.relname,
+        columnName: attribute.attname,
+        indexName: indexClass.relname
+      };
+      const existing = discovered.get(key);
+      if (existing && existing.indexName !== indexInfo.indexName) {
+        throw new Error(
+          `Multiple BM25 indexes target ${indexInfo.schemaName}.${indexInfo.tableName}.` +
+          `${indexInfo.columnName}: ${existing.indexName}, ${indexInfo.indexName}`
+        );
+      }
+      discovered.set(key, indexInfo);
+    }
+  }
+  return discovered;
+};
 
 export const Bm25CodecPlugin: GraphileConfig.Plugin = {
   name: 'Bm25CodecPlugin',
   version: '1.0.0',
   description: 'Registers a codec for the pg_textsearch bm25query type and discovers BM25 indexes',
 
-  gather: {
+  gather: gatherConfig({
+    namespace: 'bm25Codec',
+    initialState: () => ({
+      indexesByService: new Map<string, Map<string, Bm25IndexInfo>>()
+    }),
+    helpers: {},
     hooks: {
       /**
        * Register the bm25query codec when detected during type introspection.
@@ -112,65 +183,34 @@ export const Bm25CodecPlugin: GraphileConfig.Plugin = {
         };
       },
 
-      /**
-       * After introspection completes, query for all BM25 indexes.
-       * Uses the pgService's adaptorSettings to create a direct pg.Pool
-       * connection and runs the BM25 discovery query.
-       */
-      async pgIntrospection_introspection(info, event) {
-        const { serviceName } = event;
-
-        // Get the pgService from the resolved preset
-        const pgService = info.resolvedPreset?.pgServices?.find(
-          (s: { name?: string }) => (s.name ?? 'main') === serviceName
+      pgIntrospection_introspection(info, event) {
+        const { introspection, serviceName } = event;
+        const pgServices = info.resolvedPreset.pgServices as
+          | readonly ScopedPgService[]
+          | undefined;
+        const pgService = pgServices?.find(
+          (service) => (service.name ?? 'main') === serviceName
         );
-        if (!pgService) return;
-
-        // Clear previous entries for this introspection run
-        bm25IndexStore.clear();
-
-        try {
-          const adaptorSettings = (pgService as any).adaptorSettings;
-          if (!adaptorSettings?.connectionString && !adaptorSettings?.pool) {
-            return;
-          }
-
-          // Import pg dynamically for the discovery query
-          const { Pool } = await import('pg');
-          const existingPool = adaptorSettings.pool;
-          const pool = existingPool ?? new Pool({
-            connectionString: adaptorSettings.connectionString,
-            max: 1,
-          });
-          const isOwnPool = !existingPool;
-
-          try {
-            const result = await pool.query(BM25_DISCOVERY_SQL);
-
-            if (result.rows && result.rows.length > 0) {
-              bm25ExtensionDetected = true;
-              for (const row of result.rows) {
-                const key = `${row.schema_name}.${row.table_name}.${row.column_name}`;
-                bm25IndexStore.set(key, {
-                  schemaName: row.schema_name,
-                  tableName: row.table_name,
-                  columnName: row.column_name,
-                  indexName: row.index_name,
-                });
-              }
-            }
-          } finally {
-            if (isOwnPool) {
-              await pool.end();
-            }
-          }
-        } catch {
-          // pg_textsearch not installed or query failed — gracefully skip
-          bm25ExtensionDetected = false;
+        if (!pgService) throw new Error(`BM25 gather could not find service '${serviceName}'`);
+        if (!pgService.schemas?.length) {
+          throw new Error(`BM25 gather requires configured schemas for service '${serviceName}'`);
         }
+        info.state.indexesByService.set(
+          serviceName,
+          collectBm25Indexes(introspection, pgService.schemas, serviceName)
+        );
+      },
+
+      pgCodecs_attribute(info, event) {
+        const indexInfo = info.state.indexesByService
+          .get(event.serviceName)
+          ?.get(attributeKey(event.pgClass._id, event.pgAttribute.attnum));
+        if (!indexInfo) return;
+        event.attribute.extensions ??= Object.create(null);
+        event.attribute.extensions.bm25Index = indexInfo;
       },
     },
-  },
+  }),
 
   schema: {
     hooks: {

--- a/graphile/graphile-search/src/codecs/index.ts
+++ b/graphile/graphile-search/src/codecs/index.ts
@@ -10,8 +10,6 @@ export type { Bm25IndexInfo } from './bm25-codec';
 export {
   Bm25CodecPlugin,
   Bm25CodecPreset,
-  bm25ExtensionDetected,
-  bm25IndexStore,
 } from './bm25-codec';
 export type { TsvectorCodecPluginOptions } from './tsvector-codec';
 export {

--- a/graphile/graphile-search/src/codecs/operator-factories.ts
+++ b/graphile/graphile-search/src/codecs/operator-factories.ts
@@ -11,6 +11,8 @@
 import type { ConnectionFilterOperatorFactory } from 'graphile-connection-filter';
 import type { SQL } from 'pg-sql2';
 
+import { resolveBuildExtensionSchema } from '../extension-metadata';
+
 /**
  * Creates the `matches` filter operator factory for full-text search.
  * Declared here so it's registered via the declarative
@@ -59,6 +61,10 @@ export function createMatchesOperatorFactory(
 export function createTrgmOperatorFactories(): ConnectionFilterOperatorFactory {
   return (build) => {
     const { sql } = build;
+    const extensionSchema = resolveBuildExtensionSchema(build, 'pg_trgm');
+    if (!extensionSchema) return [];
+    const similarity = sql.identifier(extensionSchema, 'similarity');
+    const wordSimilarity = sql.identifier(extensionSchema, 'word_similarity');
 
     return [
       {
@@ -82,7 +88,7 @@ export function createTrgmOperatorFactories(): ConnectionFilterOperatorFactory {
               return null;
             }
             const th = threshold != null ? threshold : 0.3;
-            return sql`similarity(${sqlIdentifier}, ${sql.value(value)}) > ${sql.value(th)}`;
+            return sql`${similarity}(${sqlIdentifier}, ${sql.value(value)}) > ${sql.value(th)}`;
           },
         },
       },
@@ -107,7 +113,7 @@ export function createTrgmOperatorFactories(): ConnectionFilterOperatorFactory {
               return null;
             }
             const th = threshold != null ? threshold : 0.3;
-            return sql`word_similarity(${sql.value(value)}, ${sqlIdentifier}) > ${sql.value(th)}`;
+            return sql`${wordSimilarity}(${sql.value(value)}, ${sqlIdentifier}) > ${sql.value(th)}`;
           },
         },
       },

--- a/graphile/graphile-search/src/codecs/vector-codec.ts
+++ b/graphile/graphile-search/src/codecs/vector-codec.ts
@@ -26,8 +26,6 @@ export const VectorCodecPlugin: GraphileConfig.Plugin = {
   gather: {
     hooks: {
       async pgCodecs_findPgCodec(info, event) {
-        if (event.pgCodec) return;
-
         const { pgType: type, serviceName } = event;
         if (type.typname !== 'vector') return;
 
@@ -35,9 +33,40 @@ export const VectorCodecPlugin: GraphileConfig.Plugin = {
           serviceName,
           type.typnamespace
         );
-        if (!typeNamespace) return;
+        if (!typeNamespace?.nspname) {
+          throw new Error(
+            `[graphile-search] Cannot resolve the vector type namespace for ` +
+            `service '${serviceName}'`
+          );
+        }
 
         const schemaName = typeNamespace.nspname;
+
+        if (event.pgCodec) {
+          const existingPg = event.pgCodec.extensions?.pg;
+          if (
+            (existingPg?.serviceName && existingPg.serviceName !== serviceName) ||
+            (existingPg?.schemaName && existingPg.schemaName !== schemaName)
+          ) {
+            throw new Error(
+              `[graphile-search] Existing vector codec identity conflicts with ` +
+              `introspection for service '${serviceName}'`
+            );
+          }
+          const existingCodec = event.pgCodec as any;
+          existingCodec.sqlType = sql.identifier(schemaName, 'vector');
+          existingCodec.extensions = {
+            ...existingCodec.extensions,
+            oid: type._id,
+            pg: {
+              ...existingPg,
+              serviceName,
+              schemaName,
+              name: 'vector',
+            },
+          };
+          return;
+        }
 
         event.pgCodec = {
           name: 'vector',

--- a/graphile/graphile-search/src/extension-metadata.ts
+++ b/graphile/graphile-search/src/extension-metadata.ts
@@ -1,0 +1,245 @@
+import 'graphile-build';
+import 'graphile-build-pg';
+
+import type { GraphileConfig } from 'graphile-config';
+import { gatherConfig } from 'graphile-build';
+
+type Introspection = Parameters<
+  GraphileConfig.GatherHooks['pgIntrospection_introspection']
+>[0]['introspection'];
+
+/** Extension namespaces discovered for one exact Graphile PostgreSQL service. */
+export interface SearchExtensionSchemas {
+  serviceName: string;
+  pgTrgmSchema: string | null;
+  pgvectorSchema: string | null;
+}
+
+declare global {
+  namespace GraphileConfig {
+    interface GatherHelpers {
+      unifiedSearchExtensionMetadata: Record<string, never>;
+    }
+  }
+
+  namespace DataplanPg {
+    interface PgCodecExtensions {
+      /** Exact extension schemas for the service that owns this record codec. */
+      searchExtensionSchemas?: SearchExtensionSchemas;
+    }
+
+    interface PgCodecAttributeExtensions {
+      /** Exact extension schemas bound from this service's introspection generation. */
+      searchExtensionSchemas?: SearchExtensionSchemas;
+    }
+  }
+
+  namespace GraphileBuild {
+    interface Build {
+      /** Per-service extension schemas for this build only. */
+      pgSearchExtensionSchemasByService?: ReadonlyMap<string, SearchExtensionSchemas>;
+    }
+  }
+}
+
+function extensionSchema(
+  introspection: Introspection,
+  extensionName: string,
+  serviceName: string
+): string | null {
+  const matches = introspection.extensions.filter(
+    (extension) => extension.extname === extensionName
+  );
+  if (matches.length > 1) {
+    throw new Error(
+      `[graphile-search] Service '${serviceName}' has ambiguous ${extensionName} ` +
+      `extension metadata (${matches.length} entries)`
+    );
+  }
+  if (matches.length === 0) return null;
+
+  const extension = matches[0];
+  if (extension.extnamespace == null) {
+    throw new Error(
+      `[graphile-search] Service '${serviceName}' has ${extensionName} without an ` +
+      'introspected extension namespace'
+    );
+  }
+  const namespace = introspection.getNamespace({ id: extension.extnamespace });
+  if (!namespace?.nspname) {
+    throw new Error(
+      `[graphile-search] Service '${serviceName}' cannot resolve the namespace for ` +
+      `${extensionName}`
+    );
+  }
+  return namespace.nspname;
+}
+
+/** Resolve extension schemas exclusively from the current service introspection. */
+export function collectSearchExtensionSchemas(
+  introspection: Introspection,
+  serviceName: string
+): SearchExtensionSchemas {
+  return Object.freeze({
+    serviceName,
+    pgTrgmSchema: extensionSchema(introspection, 'pg_trgm', serviceName),
+    pgvectorSchema: extensionSchema(introspection, 'vector', serviceName),
+  });
+}
+
+/**
+ * Gather configuration used by UnifiedSearchPlugin.
+ *
+ * Metadata is attached to every attribute while its service identity is still
+ * explicit. Adapters later retain only the exact binding for eligible columns.
+ */
+export const SearchExtensionMetadataGather = gatherConfig({
+  namespace: 'unifiedSearchExtensionMetadata',
+  initialState: () => ({
+    schemasByService: new Map<string, SearchExtensionSchemas>(),
+  }),
+  helpers: {},
+  hooks: {
+    pgIntrospection_introspection(info, event) {
+      const { introspection, serviceName } = event;
+      info.state.schemasByService.set(
+        serviceName,
+        collectSearchExtensionSchemas(introspection, serviceName)
+      );
+    },
+
+    pgCodecs_PgCodec(info, event) {
+      // Record codecs are service-local, unlike built-in scalar codecs that may
+      // be shared. Keeping one carrier per exposed class also covers builds
+      // whose attributes are later reduced from the registry.
+      if (!event.pgClass) return;
+      const binding = info.state.schemasByService.get(event.serviceName);
+      if (!binding) {
+        throw new Error(
+          `[graphile-search] No extension metadata was gathered for service ` +
+          `'${event.serviceName}'`
+        );
+      }
+      event.pgCodec.extensions ??= Object.create(null);
+      event.pgCodec.extensions.searchExtensionSchemas = binding;
+    },
+
+    pgCodecs_attribute(info, event) {
+      const binding = info.state.schemasByService.get(event.serviceName);
+      if (!binding) {
+        throw new Error(
+          `[graphile-search] No extension metadata was gathered for service ` +
+          `'${event.serviceName}'`
+        );
+      }
+      event.attribute.extensions ??= Object.create(null);
+      event.attribute.extensions.searchExtensionSchemas = binding;
+    },
+  },
+});
+
+/** Build an immutable, consistency-checked service map from bound attributes. */
+export function extensionSchemasByService(build: any): ReadonlyMap<string, SearchExtensionSchemas> {
+  const schemasByService = new Map<string, SearchExtensionSchemas>();
+  const codecs = build.input?.pgRegistry?.pgCodecs;
+  if (!codecs) return schemasByService;
+
+  const addBinding = (binding: SearchExtensionSchemas): void => {
+    const existing = schemasByService.get(binding.serviceName);
+    if (
+      existing &&
+      (existing.pgTrgmSchema !== binding.pgTrgmSchema ||
+        existing.pgvectorSchema !== binding.pgvectorSchema)
+    ) {
+      throw new Error(
+        `[graphile-search] Conflicting extension metadata for service ` +
+        `'${binding.serviceName}' in one build`
+      );
+    }
+    schemasByService.set(binding.serviceName, binding);
+  };
+
+  for (const codec of Object.values(codecs) as any[]) {
+    const codecBinding: SearchExtensionSchemas | undefined =
+      codec?.extensions?.searchExtensionSchemas;
+    if (codecBinding) {
+      addBinding(codecBinding);
+    }
+    if (!codec?.attributes) continue;
+    for (const attribute of Object.values(codec.attributes) as any[]) {
+      const binding: SearchExtensionSchemas | undefined =
+        attribute?.extensions?.searchExtensionSchemas;
+      if (!binding) continue;
+      addBinding(binding);
+    }
+  }
+  return schemasByService;
+}
+
+/**
+ * Resolve one extension namespace for a build-wide operator factory.
+ * Shared GraphQL filter types cannot safely route to different schemas, so a
+ * multi-service build with partial or differing namespaces is rejected. A
+ * build where every service lacks the optional extension resolves to null.
+ */
+export function resolveBuildExtensionSchema(
+  build: any,
+  extension: 'pg_trgm' | 'vector'
+): string | null {
+  const schemasByService: ReadonlyMap<string, SearchExtensionSchemas> =
+    build.pgSearchExtensionSchemasByService ?? extensionSchemasByService(build);
+  if (schemasByService.size === 0) {
+    const codecs = build.input?.pgRegistry?.pgCodecs;
+    const hasServiceBoundCodec = codecs && Object.values(codecs).some(
+      (codec: any) =>
+        codec?.attributes != null || codec?.extensions?.pg?.serviceName != null
+    );
+    if (!hasServiceBoundCodec) {
+      // An empty exposed schema has no service-local codec on which gather can
+      // carry optional extension metadata. No operator is registered, so no
+      // unqualified SQL path is created.
+      return null;
+    }
+    throw new Error(
+      `[graphile-search] ${extension} requires service-bound extension metadata`
+    );
+  }
+
+  const field = extension === 'pg_trgm' ? 'pgTrgmSchema' : 'pgvectorSchema';
+  const schemas = new Set<string>();
+  let missingCount = 0;
+  for (const binding of schemasByService.values()) {
+    const schemaName = binding[field];
+    if (!schemaName) {
+      missingCount++;
+      continue;
+    }
+    schemas.add(schemaName);
+  }
+  if (schemas.size === 0) return null;
+  if (missingCount > 0) {
+    throw new Error(
+      `[graphile-search] ${extension} is present for only part of this multi-service build`
+    );
+  }
+  if (schemas.size !== 1) {
+    throw new Error(
+      `[graphile-search] ${extension} has ambiguous schemas across this build: ` +
+      [...schemas].sort().join(', ')
+    );
+  }
+  return schemas.values().next().value!;
+}
+
+export function requireBuildExtensionSchema(
+  build: any,
+  extension: 'pg_trgm' | 'vector'
+): string {
+  const schemaName = resolveBuildExtensionSchema(build, extension);
+  if (!schemaName) {
+    throw new Error(
+      `[graphile-search] ${extension} is required by this feature but is not installed`
+    );
+  }
+  return schemaName;
+}

--- a/graphile/graphile-search/src/index.ts
+++ b/graphile/graphile-search/src/index.ts
@@ -33,6 +33,14 @@
 // Core plugin
 export { createUnifiedSearchPlugin } from './plugin';
 
+// Exact per-service extension namespace binding
+export type { SearchExtensionSchemas } from './extension-metadata';
+export {
+  collectSearchExtensionSchemas,
+  requireBuildExtensionSchema,
+  resolveBuildExtensionSchema,
+} from './extension-metadata';
+
 // Preset
 export type { UnifiedSearchPresetOptions } from './preset';
 export { UnifiedSearchPreset } from './preset';
@@ -68,7 +76,6 @@ export type {
 export {
   Bm25CodecPlugin,
   Bm25CodecPreset,
-  bm25IndexStore,
   createTsvectorCodecPlugin,
   TsvectorCodecPlugin,
   TsvectorCodecPreset,

--- a/graphile/graphile-search/src/plugin.ts
+++ b/graphile/graphile-search/src/plugin.ts
@@ -26,6 +26,10 @@ import { TYPES } from '@dataplan/pg';
 import type { GraphileConfig } from 'graphile-config';
 import { getQueryBuilder } from 'graphile-plugin-utils';
 
+import {
+  extensionSchemasByService,
+  SearchExtensionMetadataGather,
+} from './extension-metadata';
 import type { SearchableColumn, SearchAdapter, UnifiedSearchOptions } from './types';
 
 // ─── TypeScript Namespace Augmentations ──────────────────────────────────────
@@ -171,8 +175,14 @@ export function createUnifiedSearchPlugin(
 ): GraphileConfig.Plugin {
   const { adapters, enableSearchScore = true, enableUnifiedSearch = true, rrfK = 60 } = options;
 
-  // Per-codec cache of discovered columns, keyed by codec name
-  const codecCache = new Map<string, AdapterColumnCache[]>();
+  // Adapter discovery may depend on both the codec and the surrounding build
+  // registry. Object-identity keys prevent a long-lived preset from reusing
+  // tenant A's result for tenant B, even if a caller reuses a codec object.
+  // Weak keys also allow disposed builds and codecs to be collected.
+  const buildCodecCache = new WeakMap<
+    object,
+    WeakMap<PgCodecWithAttributes, AdapterColumnCache[]>
+  >();
 
   // Bridge between orderBy enum apply and filter apply.
   // The orderBy enum runs on the PgSelectStep while the filter runs on
@@ -195,9 +205,14 @@ export function createUnifiedSearchPlugin(
    * count as intentional search.
    */
   function getAdapterColumns(codec: PgCodecWithAttributes, build: any): AdapterColumnCache[] {
-    const cacheKey = codec.name;
-    if (codecCache.has(cacheKey)) {
-      return codecCache.get(cacheKey)!;
+    let codecCache = buildCodecCache.get(build);
+    if (!codecCache) {
+      codecCache = new WeakMap<PgCodecWithAttributes, AdapterColumnCache[]>();
+      buildCodecCache.set(build, codecCache);
+    }
+    const cached = codecCache.get(codec);
+    if (cached) {
+      return cached;
     }
 
     const primaryAdapters = adapters.filter((a) => !a.isSupplementary);
@@ -238,7 +253,7 @@ export function createUnifiedSearchPlugin(
       }
     }
 
-    codecCache.set(cacheKey, results);
+    codecCache.set(codec, results);
     return results;
   }
 
@@ -259,6 +274,8 @@ export function createUnifiedSearchPlugin(
       'Bm25CodecPlugin',
       'VectorCodecPlugin',
     ],
+
+    gather: SearchExtensionMetadataGather,
 
     // ─── Custom Inflection Methods ─────────────────────────────────────
     inflection: {
@@ -328,6 +345,17 @@ export function createUnifiedSearchPlugin(
       },
 
       hooks: {
+        /** Publish only this build's consistency-checked extension bindings. */
+        build(build) {
+          return build.extend(
+            build,
+            {
+              pgSearchExtensionSchemasByService: extensionSchemasByService(build),
+            },
+            'UnifiedSearchPlugin adding per-service extension schemas'
+          );
+        },
+
         /**
          * Register all adapter-specific GraphQL types during init.
          */
@@ -375,7 +403,7 @@ export function createUnifiedSearchPlugin(
             inflection,
             sql,
             graphql: { GraphQLFloat },
-            grafast: { lambda },
+            grafast: { constant, lambda },
           } = build;
           const {
             scope: { isPgClassType, pgCodec: rawPgCodec },
@@ -424,7 +452,7 @@ export function createUnifiedSearchPlugin(
                         const $select = typeof $row.getClassStep === 'function'
                           ? $row.getClassStep()
                           : null;
-                        if (!$select) return build.grafast.constant(null);
+                        if (!$select) return constant(null);
 
                         if (typeof $select.setInliningForbidden === 'function') {
                           $select.setInliningForbidden();
@@ -522,7 +550,7 @@ export function createUnifiedSearchPlugin(
                       const $select = typeof $row.getClassStep === 'function'
                         ? $row.getClassStep()
                         : null;
-                      if (!$select) return build.grafast.constant(null);
+                      if (!$select) return constant(null);
 
                       if (typeof $select.setInliningForbidden === 'function') {
                         $select.setInliningForbidden();

--- a/graphql/env/README.md
+++ b/graphql/env/README.md
@@ -43,6 +43,13 @@ In addition to all environment variables supported by `@pgpmjs/env`, this packag
 
 ### GraphQL Schema
 - `GRAPHILE_SCHEMA` - Comma-separated list of PostgreSQL schemas to expose
+- `GRAPHILE_INTROSPECTION_CLIENT_RELEASE_MODE` - `reuse` preserves the introspection backend; `destroy` retires that exact client after gather and reconnects lazily for runtime traffic; defaults to `reuse`
+- `GRAPHILE_REALTIME_SCHEMA` - Exact physical schema containing realtime cursor functions; omission preserves `realtime_public`
+- `GRAPHILE_REALTIME_NOTIFICATION_MODE` - `dedicated` keeps one PostGraphile subscriber per instance; `shared-exact` opts into the per-database exact-topic broker and requires an application `notificationPgResolver`; defaults to `dedicated`
+- `GRAPHILE_REALTIME_NOTIFICATION_ROLE_REVALIDATION_MS` - Maximum age of a successful shared-listener role audit; defaults to `60000`
+- `GRAPHILE_REALTIME_CURSOR_POLL_INTERVAL_MS` - Realtime cursor recovery poll interval; defaults to `5000`
+- `GRAPHILE_REALTIME_CURSOR_HEARTBEAT_INTERVAL_MS` - Realtime cursor heartbeat interval; defaults to `30000`
+- `GRAPHILE_RELEASE_BUILD_STATE_AFTER_VALIDATION` - Opt in to releasing schema-construction-only Graphile state after successful validation; defaults to `false`
 
 ### Feature Flags
 - `FEATURES_SIMPLE_INFLECTION` - Enable simple inflection plugin
@@ -54,8 +61,18 @@ In addition to all environment variables supported by `@pgpmjs/env`, this packag
 - `API_IS_PUBLIC` - Whether API is public
 - `API_EXPOSED_SCHEMAS` - Comma-separated list of exposed schemas
 - `API_META_SCHEMAS` - Comma-separated list of meta schemas
+- `API_ALLOW_META_SCHEMA_HEADER` - Explicitly enable the privileged `X-Meta-Schema` control-plane surface. Defaults to false and must only be used on a separate private admin ingress.
 - `API_ANON_ROLE` - Anonymous role name
 - `API_ROLE_NAME` - Default role name
+- `GRAPHQL_INTERNAL_REQUEST_SECRET` - Minimum-32-byte token required before private routing/actor headers or the HTTP cache flush endpoint are trusted. `X-Schemata` remains prohibited; use an authoritative API name.
+
+### Routing Metadata Cache
+- `GRAPHQL_ROUTING_CACHE_MAX_ENTRIES` - Capacity reserved for routing metadata diagnostics. Security-sensitive request routing is resolved authoritatively and never served from this cache.
+
+### Runtime PostgreSQL credentials
+
+- `GRAPHQL_RUNTIME_PGUSER` and `GRAPHQL_RUNTIME_PGPASSWORD` populate the legacy static `runtimePg` login.
+- Production and `GRAPHILE_INTROSPECTION_MODE=scoped-required` do not accept those two values as a dynamic multi-tenant credential source. Use a programmatic `runtimePgResolver`; for a dedicated one-route server, pair an explicit static database with `runtimePgStaticIdentity` in trusted configuration.
 
 ## Defaults
 
@@ -75,8 +92,10 @@ GraphQL defaults are provided by `@constructive-io/graphql-types`:
     roleName: 'administrator',
     isPublic: true,
     metaSchemas: ['routing_public', 'metaschema_public', 'metaschema_modules_public'],
+    allowMetaSchemaHeader: false,
     routingSchema: 'routing_public'
-  }
+  },
+  routingCache: {}
 }
 ```
 

--- a/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
+++ b/graphql/env/__tests__/__snapshots__/merge.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`getEnvOptions merges pgpm defaults, graphql defaults, config, env, and overrides 1`] = `
 {
   "api": {
+    "allowMetaSchemaHeader": false,
     "anonRole": "env_anon",
     "exposedSchemas": [
       "public",
@@ -70,10 +71,19 @@ exports[`getEnvOptions merges pgpm defaults, graphql defaults, config, env, and 
   },
   "graphile": {
     "extends": [],
+    "introspectionClientReleaseMode": "reuse",
+    "introspectionDependencySchemas": [],
+    "introspectionMode": "stock",
     "preset": {},
+    "realtimeCursorHeartbeatIntervalMs": 30000,
+    "realtimeCursorPollIntervalMs": 5000,
+    "realtimeNotificationMode": "dedicated",
+    "realtimeNotificationRoleRevalidationMs": 60000,
+    "releaseBuildStateAfterValidation": false,
     "schema": [
       "override_schema",
     ],
+    "trustCallerPresetsInProduction": false,
   },
   "migrations": {
     "codegen": {
@@ -87,6 +97,7 @@ exports[`getEnvOptions merges pgpm defaults, graphql defaults, config, env, and 
     "port": 5432,
     "user": "env-user",
   },
+  "routingCache": {},
   "server": {
     "host": "localhost",
     "port": 5000,

--- a/graphql/env/__tests__/merge.test.ts
+++ b/graphql/env/__tests__/merge.test.ts
@@ -138,6 +138,46 @@ describe('getEnvOptions', () => {
     expect(result.api?.metaSchemas).toEqual(['env_meta', 'override_meta']);
   });
 
+  it('parses the internal request secret without exposing a default', () => {
+    const secret = '0123456789abcdef0123456789abcdef';
+
+    expect(getGraphQLEnvVars({ GRAPHQL_INTERNAL_REQUEST_SECRET: secret }).api)
+      .toMatchObject({ internalRequestSecret: secret });
+    expect(getGraphQLEnvVars({}).api?.internalRequestSecret).toBeUndefined();
+  });
+
+  it('keeps the privileged metadata header disabled unless explicitly configured', () => {
+    expect(getGraphQLEnvVars({ API_ALLOW_META_SCHEMA_HEADER: 'true' }).api)
+      .toMatchObject({ allowMetaSchemaHeader: true });
+    expect(getGraphQLEnvVars({ API_ALLOW_META_SCHEMA_HEADER: 'false' }).api)
+      .toMatchObject({ allowMetaSchemaHeader: false });
+    expect(getGraphQLEnvVars({}).api?.allowMetaSchemaHeader).toBeUndefined();
+  });
+
+  it('preserves the exact static runtime route contract from trusted config', () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'graphql-env-runtime-pg-'));
+    const identity = {
+      databaseId: 'database-a',
+      databaseName: 'tenant_a',
+      apiId: 'api-a',
+      schemas: ['tenant_a_public', 'tenant_a_auth'],
+      roles: ['tenant_a_anon', 'tenant_a_user']
+    };
+    writeConfig(tempDir, {
+      runtimePg: {
+        database: 'tenant_a',
+        user: 'tenant_a_runtime',
+        password: 'runtime-secret'
+      },
+      runtimePgStaticIdentity: identity
+    });
+
+    const result = getEnvOptions({}, tempDir, {});
+
+    expect(result.runtimePgStaticIdentity).toEqual(identity);
+    expect(result.runtimePg?.database).toBe('tenant_a');
+  });
+
   it('parses SMS environment variables into typed options', () => {
     const result = getGraphQLEnvVars({
       SMS_PROVIDER: 'devsms',

--- a/graphql/env/src/__tests__/runtime-pg.test.ts
+++ b/graphql/env/src/__tests__/runtime-pg.test.ts
@@ -1,0 +1,172 @@
+import { getGraphQLEnvVars } from '../env';
+
+describe('GraphQL runtime PostgreSQL environment', () => {
+  it('maps the dedicated runtime credentials without changing control-plane pg', () => {
+    const result = getGraphQLEnvVars({
+      GRAPHQL_RUNTIME_PGUSER: 'graphql_runtime',
+      GRAPHQL_RUNTIME_PGPASSWORD: 'runtime-secret'
+    });
+
+    expect(result.runtimePg).toEqual({
+      user: 'graphql_runtime',
+      password: 'runtime-secret'
+    });
+    expect(result.pg).toBeUndefined();
+  });
+
+  it('does not create a runtime override when both variables are absent', () => {
+    expect(getGraphQLEnvVars({}).runtimePg).toBeUndefined();
+  });
+});
+
+describe('Graphile introspection environment', () => {
+  it.each(['stock', 'scoped-required'] as const)(
+    'accepts the explicit %s mode',
+    (introspectionMode) => {
+      expect(
+        getGraphQLEnvVars({ GRAPHILE_INTROSPECTION_MODE: introspectionMode }).graphile
+      ).toEqual({ introspectionMode });
+    }
+  );
+
+  it('rejects unknown modes instead of falling back to stock', () => {
+    expect(() =>
+      getGraphQLEnvVars({ GRAPHILE_INTROSPECTION_MODE: 'scoped-if-possible' })
+    ).toThrow("GRAPHILE_INTROSPECTION_MODE must be 'stock' or 'scoped-required'");
+  });
+
+  it.each(['reuse', 'destroy'] as const)(
+    'accepts the explicit %s introspection-client release mode',
+    (introspectionClientReleaseMode) => {
+      expect(getGraphQLEnvVars({
+        GRAPHILE_INTROSPECTION_CLIENT_RELEASE_MODE: introspectionClientReleaseMode
+      }).graphile).toEqual({ introspectionClientReleaseMode });
+    }
+  );
+
+  it('rejects an unknown introspection-client release mode', () => {
+    expect(() => getGraphQLEnvVars({
+      GRAPHILE_INTROSPECTION_CLIENT_RELEASE_MODE: 'best-effort'
+    })).toThrow(
+      "GRAPHILE_INTROSPECTION_CLIENT_RELEASE_MODE must be 'reuse' or 'destroy'"
+    );
+  });
+
+  it('parses the ordered dependency-schema allowlist without duplicates', () => {
+    expect(getGraphQLEnvVars({
+      GRAPHILE_INTROSPECTION_DEPENDENCY_SCHEMAS: 'extensions, shared_api,extensions'
+    }).graphile).toEqual({
+      introspectionDependencySchemas: ['extensions', 'shared_api']
+    });
+  });
+
+  it('rejects an empty dependency-schema entry', () => {
+    expect(() => getGraphQLEnvVars({
+      GRAPHILE_INTROSPECTION_DEPENDENCY_SCHEMAS: 'extensions, ,shared_api'
+    })).toThrow('must be a comma-separated list of non-empty schema names');
+  });
+});
+
+describe('Graphile realtime environment', () => {
+  it.each(['dedicated', 'shared-exact'] as const)(
+    'maps the explicit %s notification mode',
+    (realtimeNotificationMode) => {
+      expect(getGraphQLEnvVars({
+        GRAPHILE_REALTIME_NOTIFICATION_MODE: realtimeNotificationMode
+      }).graphile).toEqual({ realtimeNotificationMode });
+    }
+  );
+
+  it('rejects unknown notification modes', () => {
+    expect(() => getGraphQLEnvVars({
+      GRAPHILE_REALTIME_NOTIFICATION_MODE: 'shared-prefix'
+    })).toThrow("must be 'dedicated' or 'shared-exact'");
+  });
+
+  it('maps role revalidation and cursor timing intervals', () => {
+    expect(getGraphQLEnvVars({
+      GRAPHILE_REALTIME_NOTIFICATION_ROLE_REVALIDATION_MS: '60000',
+      GRAPHILE_REALTIME_CURSOR_POLL_INTERVAL_MS: '30000',
+      GRAPHILE_REALTIME_CURSOR_HEARTBEAT_INTERVAL_MS: '90000'
+    }).graphile).toEqual({
+      realtimeNotificationRoleRevalidationMs: 60_000,
+      realtimeCursorPollIntervalMs: 30_000,
+      realtimeCursorHeartbeatIntervalMs: 90_000
+    });
+  });
+
+  it('maps one exact cursor-function schema', () => {
+    expect(getGraphQLEnvVars({
+      GRAPHILE_REALTIME_SCHEMA: ' tenant_a_realtime '
+    }).graphile).toEqual({
+      realtimeSchema: 'tenant_a_realtime'
+    });
+  });
+
+  it('rejects a whitespace-only cursor schema', () => {
+    expect(() => getGraphQLEnvVars({
+      GRAPHILE_REALTIME_SCHEMA: '   '
+    })).toThrow('GRAPHILE_REALTIME_SCHEMA must be one non-empty exact schema name');
+  });
+
+  it('preserves the compatibility default by omitting absent configuration', () => {
+    expect(getGraphQLEnvVars({}).graphile?.realtimeSchema).toBeUndefined();
+  });
+});
+
+describe('Grafast cache-limit environment', () => {
+  it('maps all three schema-local cache bounds', () => {
+    expect(getGraphQLEnvVars({
+      GRAPHILE_QUERY_CACHE_MAX_LENGTH: '64',
+      GRAPHILE_OPERATIONS_CACHE_MAX_LENGTH: '32',
+      GRAPHILE_OPERATION_PLANS_CACHE_MAX_LENGTH: '8'
+    }).graphile?.grafastCache).toEqual({
+      queryCacheMaxLength: 64,
+      operationsCacheMaxLength: 32,
+      operationOperationPlansCacheMaxLength: 8
+    });
+  });
+
+  it.each(['0', '-1', '1.5', '12entries'])(
+    'rejects an invalid cache bound %s',
+    (value) => {
+      expect(() => getGraphQLEnvVars({
+        GRAPHILE_OPERATIONS_CACHE_MAX_LENGTH: value
+      })).toThrow('must be a positive safe integer');
+    }
+  );
+});
+
+describe('Graphile build-state retirement environment', () => {
+  it.each([
+    ['true', true],
+    ['false', false]
+  ])('maps the explicit %s value', (value, expected) => {
+    expect(getGraphQLEnvVars({
+      GRAPHILE_RELEASE_BUILD_STATE_AFTER_VALIDATION: value
+    }).graphile?.releaseBuildStateAfterValidation).toBe(expected);
+  });
+
+  it('keeps retirement absent unless explicitly configured', () => {
+    expect(
+      getGraphQLEnvVars({}).graphile?.releaseBuildStateAfterValidation
+    ).toBeUndefined();
+  });
+});
+
+describe('Routing metadata cache environment', () => {
+  it('maps the explicit process capacity', () => {
+    expect(getGraphQLEnvVars({
+      GRAPHQL_ROUTING_CACHE_MAX_ENTRIES: '4096'
+    }).routingCache).toEqual({ maxEntries: 4096 });
+  });
+
+  it.each(['0', '-1', '1.5', '12entries'])(
+    'rejects an invalid routing cache capacity %s',
+    (value) => {
+      expect(() => getGraphQLEnvVars({
+        GRAPHQL_ROUTING_CACHE_MAX_ENTRIES: value
+      })).toThrow('must be a positive safe integer');
+    }
+  );
+});

--- a/graphql/env/src/env.ts
+++ b/graphql/env/src/env.ts
@@ -7,6 +7,20 @@ import { parseEnvBoolean, parseEnvNumber } from '12factor-env';
 export const getGraphQLEnvVars = (env: NodeJS.ProcessEnv = process.env): Partial<ConstructiveOptions> => {
   const {
     GRAPHILE_SCHEMA,
+    GRAPHILE_INTROSPECTION_MODE,
+    GRAPHILE_INTROSPECTION_CLIENT_RELEASE_MODE,
+    GRAPHILE_INTROSPECTION_DEPENDENCY_SCHEMAS,
+    GRAPHILE_QUERY_CACHE_MAX_LENGTH,
+    GRAPHILE_OPERATIONS_CACHE_MAX_LENGTH,
+    GRAPHILE_OPERATION_PLANS_CACHE_MAX_LENGTH,
+    GRAPHILE_REALTIME_SCHEMA,
+    GRAPHILE_REALTIME_NOTIFICATION_MODE,
+    GRAPHILE_REALTIME_NOTIFICATION_ROLE_REVALIDATION_MS,
+    GRAPHILE_REALTIME_CURSOR_POLL_INTERVAL_MS,
+    GRAPHILE_REALTIME_CURSOR_HEARTBEAT_INTERVAL_MS,
+    GRAPHILE_RELEASE_BUILD_STATE_AFTER_VALIDATION,
+
+    GRAPHQL_ROUTING_CACHE_MAX_ENTRIES,
 
     FEATURES_SIMPLE_INFLECTION,
     FEATURES_OPPOSITE_BASE_NAMES,
@@ -16,8 +30,14 @@ export const getGraphQLEnvVars = (env: NodeJS.ProcessEnv = process.env): Partial
     API_IS_PUBLIC,
     API_EXPOSED_SCHEMAS,
     API_META_SCHEMAS,
+    API_ALLOW_META_SCHEMA_HEADER,
     API_ANON_ROLE,
     API_ROLE_NAME,
+
+    GRAPHQL_INTERNAL_REQUEST_SECRET,
+
+    GRAPHQL_RUNTIME_PGUSER,
+    GRAPHQL_RUNTIME_PGPASSWORD,
 
     EMBEDDER_PROVIDER,
     EMBEDDER_MODEL,
@@ -47,7 +67,93 @@ export const getGraphQLEnvVars = (env: NodeJS.ProcessEnv = process.env): Partial
   );
 
   return {
+    ...((GRAPHQL_RUNTIME_PGUSER || GRAPHQL_RUNTIME_PGPASSWORD) && {
+      runtimePg: {
+        ...(GRAPHQL_RUNTIME_PGUSER && { user: GRAPHQL_RUNTIME_PGUSER }),
+        ...(GRAPHQL_RUNTIME_PGPASSWORD && { password: GRAPHQL_RUNTIME_PGPASSWORD })
+      }
+    }),
+    ...(GRAPHQL_ROUTING_CACHE_MAX_ENTRIES && {
+      routingCache: {
+        maxEntries: parsePositiveSafeInteger(
+          GRAPHQL_ROUTING_CACHE_MAX_ENTRIES,
+          'GRAPHQL_ROUTING_CACHE_MAX_ENTRIES'
+        )
+      }
+    }),
     graphile: {
+      ...(GRAPHILE_INTROSPECTION_MODE && {
+        introspectionMode: parseGraphileIntrospectionMode(GRAPHILE_INTROSPECTION_MODE)
+      }),
+      ...(GRAPHILE_INTROSPECTION_CLIENT_RELEASE_MODE && {
+        introspectionClientReleaseMode: parseGraphileIntrospectionClientReleaseMode(
+          GRAPHILE_INTROSPECTION_CLIENT_RELEASE_MODE
+        )
+      }),
+      ...(GRAPHILE_INTROSPECTION_DEPENDENCY_SCHEMAS && {
+        introspectionDependencySchemas: parseSchemaList(
+          GRAPHILE_INTROSPECTION_DEPENDENCY_SCHEMAS,
+          'GRAPHILE_INTROSPECTION_DEPENDENCY_SCHEMAS'
+        )
+      }),
+      ...((GRAPHILE_QUERY_CACHE_MAX_LENGTH
+        || GRAPHILE_OPERATIONS_CACHE_MAX_LENGTH
+        || GRAPHILE_OPERATION_PLANS_CACHE_MAX_LENGTH) && {
+        grafastCache: {
+          ...(GRAPHILE_QUERY_CACHE_MAX_LENGTH && {
+            queryCacheMaxLength: parsePositiveSafeInteger(
+              GRAPHILE_QUERY_CACHE_MAX_LENGTH,
+              'GRAPHILE_QUERY_CACHE_MAX_LENGTH'
+            )
+          }),
+          ...(GRAPHILE_OPERATIONS_CACHE_MAX_LENGTH && {
+            operationsCacheMaxLength: parsePositiveSafeInteger(
+              GRAPHILE_OPERATIONS_CACHE_MAX_LENGTH,
+              'GRAPHILE_OPERATIONS_CACHE_MAX_LENGTH'
+            )
+          }),
+          ...(GRAPHILE_OPERATION_PLANS_CACHE_MAX_LENGTH && {
+            operationOperationPlansCacheMaxLength: parsePositiveSafeInteger(
+              GRAPHILE_OPERATION_PLANS_CACHE_MAX_LENGTH,
+              'GRAPHILE_OPERATION_PLANS_CACHE_MAX_LENGTH'
+            )
+          })
+        }
+      }),
+      ...(GRAPHILE_REALTIME_SCHEMA && {
+        realtimeSchema: parseExactSchemaName(
+          GRAPHILE_REALTIME_SCHEMA,
+          'GRAPHILE_REALTIME_SCHEMA'
+        )
+      }),
+      ...(GRAPHILE_REALTIME_NOTIFICATION_MODE && {
+        realtimeNotificationMode: parseGraphileRealtimeNotificationMode(
+          GRAPHILE_REALTIME_NOTIFICATION_MODE
+        )
+      }),
+      ...(GRAPHILE_REALTIME_NOTIFICATION_ROLE_REVALIDATION_MS && {
+        realtimeNotificationRoleRevalidationMs: parsePositiveSafeInteger(
+          GRAPHILE_REALTIME_NOTIFICATION_ROLE_REVALIDATION_MS,
+          'GRAPHILE_REALTIME_NOTIFICATION_ROLE_REVALIDATION_MS'
+        )
+      }),
+      ...(GRAPHILE_REALTIME_CURSOR_POLL_INTERVAL_MS && {
+        realtimeCursorPollIntervalMs: parsePositiveSafeInteger(
+          GRAPHILE_REALTIME_CURSOR_POLL_INTERVAL_MS,
+          'GRAPHILE_REALTIME_CURSOR_POLL_INTERVAL_MS'
+        )
+      }),
+      ...(GRAPHILE_REALTIME_CURSOR_HEARTBEAT_INTERVAL_MS && {
+        realtimeCursorHeartbeatIntervalMs: parsePositiveSafeInteger(
+          GRAPHILE_REALTIME_CURSOR_HEARTBEAT_INTERVAL_MS,
+          'GRAPHILE_REALTIME_CURSOR_HEARTBEAT_INTERVAL_MS'
+        )
+      }),
+      ...(GRAPHILE_RELEASE_BUILD_STATE_AFTER_VALIDATION && {
+        releaseBuildStateAfterValidation: parseEnvBoolean(
+          GRAPHILE_RELEASE_BUILD_STATE_AFTER_VALIDATION
+        )
+      }),
       ...(GRAPHILE_SCHEMA && {
         schema: GRAPHILE_SCHEMA.includes(',')
           ? GRAPHILE_SCHEMA.split(',').map(s => s.trim())
@@ -64,8 +170,14 @@ export const getGraphQLEnvVars = (env: NodeJS.ProcessEnv = process.env): Partial
       ...(API_IS_PUBLIC && { isPublic: parseEnvBoolean(API_IS_PUBLIC) }),
       ...(API_EXPOSED_SCHEMAS && { exposedSchemas: API_EXPOSED_SCHEMAS.split(',').map(s => s.trim()) }),
       ...(API_META_SCHEMAS && { metaSchemas: API_META_SCHEMAS.split(',').map(s => s.trim()) }),
+      ...(API_ALLOW_META_SCHEMA_HEADER && {
+        allowMetaSchemaHeader: parseEnvBoolean(API_ALLOW_META_SCHEMA_HEADER)
+      }),
       ...(API_ANON_ROLE && { anonRole: API_ANON_ROLE }),
-      ...(API_ROLE_NAME && { roleName: API_ROLE_NAME })
+      ...(API_ROLE_NAME && { roleName: API_ROLE_NAME }),
+      ...(GRAPHQL_INTERNAL_REQUEST_SECRET && {
+        internalRequestSecret: GRAPHQL_INTERNAL_REQUEST_SECRET
+      })
     },
     ...((EMBEDDER_PROVIDER || CHAT_PROVIDER) && {
       llm: {
@@ -101,4 +213,57 @@ export const getGraphQLEnvVars = (env: NodeJS.ProcessEnv = process.env): Partial
       }
     })
   };
+};
+
+const parseGraphileIntrospectionMode = (
+  value: string
+): 'stock' | 'scoped-required' => {
+  if (value === 'stock' || value === 'scoped-required') return value;
+  throw new Error(
+    `GRAPHILE_INTROSPECTION_MODE must be 'stock' or 'scoped-required'; received '${value}'`
+  );
+};
+
+const parseGraphileIntrospectionClientReleaseMode = (
+  value: string
+): 'reuse' | 'destroy' => {
+  if (value === 'reuse' || value === 'destroy') return value;
+  throw new Error(
+    "GRAPHILE_INTROSPECTION_CLIENT_RELEASE_MODE must be 'reuse' or 'destroy'; "
+    + `received '${value}'`
+  );
+};
+
+const parseGraphileRealtimeNotificationMode = (
+  value: string
+): 'dedicated' | 'shared-exact' => {
+  if (value === 'dedicated' || value === 'shared-exact') return value;
+  throw new Error(
+    "GRAPHILE_REALTIME_NOTIFICATION_MODE must be 'dedicated' or 'shared-exact'; "
+    + `received '${value}'`
+  );
+};
+
+const parseSchemaList = (value: string, variable: string): string[] => {
+  const schemas = value.split(',').map((schema) => schema.trim());
+  if (schemas.some((schema) => schema.length === 0)) {
+    throw new Error(`${variable} must be a comma-separated list of non-empty schema names`);
+  }
+  return [...new Set(schemas)];
+};
+
+const parseExactSchemaName = (value: string, variable: string): string => {
+  const schema = value.trim();
+  if (schema.length === 0) {
+    throw new Error(`${variable} must be one non-empty exact schema name`);
+  }
+  return schema;
+};
+
+const parsePositiveSafeInteger = (value: string, variable: string): number => {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${variable} must be a positive safe integer; received '${value}'`);
+  }
+  return parsed;
 };

--- a/graphql/env/src/merge.ts
+++ b/graphql/env/src/merge.ts
@@ -44,6 +44,11 @@ export const getEnvOptions = (
       ...(configOptions.graphile && { graphile: configOptions.graphile }),
       ...(configOptions.features && { features: configOptions.features }),
       ...(configOptions.api && { api: configOptions.api }),
+      ...(configOptions.routingCache && { routingCache: configOptions.routingCache }),
+      ...(configOptions.runtimePg && { runtimePg: configOptions.runtimePg }),
+      ...(configOptions.runtimePgStaticIdentity && {
+        runtimePgStaticIdentity: configOptions.runtimePgStaticIdentity
+      }),
       ...(configOptions.sms && { sms: configOptions.sms }),
     },
     graphqlEnvOptions,

--- a/graphql/types/README.md
+++ b/graphql/types/README.md
@@ -43,6 +43,14 @@ const config: ConstructiveOptions = {
     routingSchema: 'routing_public',
     exposedSchemas: ['public'],
   },
+  routingCache: {
+    maxEntries: 4096,
+  },
+  runtimePgResolver: async (route) => ({
+    database: route.databaseName,
+    user: await runtimeUsers.forRoute(route),
+    password: await runtimePasswords.forRoute(route),
+  }),
   features: {
     simpleInflection: true,
     postgis: true,
@@ -63,6 +71,27 @@ PostGraphile/Graphile configuration including schema, plugins, and build options
 ### ApiOptions
 
 Configuration for the Constructive API including meta API settings, exposed schemas, and role configuration.
+
+### RoutingCacheOptions
+
+Configuration for the process-wide routing/service-label metadata cache. This
+cache is independent from Graphile build identity and its `maxEntries` value
+must be at least the effective resident Graphile capacity.
+
+### RuntimePgResolver
+
+Production multi-tenant servers resolve a least-privilege login from the exact
+credential-free `RuntimePgResolverInput`: database id/name, API id, ordered
+schemas, and `[anonymous, authenticated]` roles. The resolver must return an
+explicit user, password, and matching database. A static `runtimePg` is accepted
+in production or scoped introspection only with `runtimePgStaticIdentity`, which
+binds it to one byte-exact route contract.
+
+`runtimePgResolver` is trusted infrastructure and should look up the login by
+immutable `databaseId`. Its normalized host, port, database, and TLS policy must
+match the control-plane tenant connection. Multi-cluster routing requires a
+future per-route resolver shared by both lanes; runtime-only endpoint divergence
+fails closed.
 
 ### GraphileFeatureOptions
 

--- a/graphql/types/src/constructive.ts
+++ b/graphql/types/src/constructive.ts
@@ -7,7 +7,7 @@ import {
   PgTestConnectionOptions,
   ServerOptions} from '@pgpmjs/types';
 import deepmerge from 'deepmerge';
-import { PgConfig } from 'pg-env';
+import type { PgConfig, PgPoolConfig } from 'pg-env';
 
 import {
   apiDefaults,
@@ -19,6 +19,53 @@ import {
 import { LlmOptions } from './llm';
 import { SmsOptions } from './sms';
 
+/** Process-wide routing-label metadata cache configuration. */
+export interface RoutingCacheOptions {
+  /** Maximum resolved service labels retained by one GraphQL server process. */
+  maxEntries?: number;
+}
+
+/** Credential-free routing input for resolving one physical listener login. */
+export interface NotificationPgResolverInput {
+  databaseId: string;
+  databaseName: string;
+  apiId: string;
+  schemas: readonly string[];
+}
+
+export type NotificationPgConfig = Partial<PgConfig> & { pool?: PgPoolConfig };
+
+/**
+ * Resolve a dedicated notification login for one physical database. The
+ * result must explicitly contain its user and password; server code never
+ * falls back to runtime or control-plane credentials.
+ */
+export type NotificationPgResolver = (
+  input: Readonly<NotificationPgResolverInput>
+) => NotificationPgConfig | Promise<NotificationPgConfig>;
+
+/** Credential-free exact route contract for one tenant execution identity. */
+export interface RuntimePgResolverInput {
+  databaseId: string;
+  databaseName: string;
+  apiId: string;
+  /** Physical schemas in Graphile exposure order. */
+  schemas: readonly string[];
+  /** Request roles in `[anonymous, authenticated]` order. */
+  roles: readonly [anonymous: string, authenticated: string];
+}
+
+export type RuntimePgConfig = Partial<PgConfig> & { pool?: PgPoolConfig };
+
+/**
+ * Resolve one least-privilege tenant execution login from the exact routed
+ * contract. Results must contain explicit user, password, and database fields;
+ * control-plane credentials are never inherited.
+ */
+export type RuntimePgResolver = (
+  input: Readonly<RuntimePgResolverInput>
+) => RuntimePgConfig | Promise<RuntimePgConfig>;
+
 /**
  * GraphQL-specific options for Constructive
  */
@@ -29,6 +76,8 @@ export interface ConstructiveGraphQLOptions {
   features?: GraphileFeatureOptions;
   /** API configuration options */
   api?: ApiOptions;
+  /** Routing-label metadata cache configuration */
+  routingCache?: RoutingCacheOptions;
 }
 
 /**
@@ -40,6 +89,19 @@ export interface ConstructiveOptions extends PgpmOptions, ConstructiveGraphQLOpt
   db?: Partial<PgTestConnectionOptions>;
   /** PostgreSQL connection configuration */
   pg?: Partial<PgConfig>;
+  /**
+   * Static least-privilege PostgreSQL login used for tenant GraphQL execution.
+   * Production and scoped introspection require `runtimePgStaticIdentity` and
+   * accept this login for that one exact route only. Multi-tenant servers must
+   * use `runtimePgResolver` instead.
+   */
+  runtimePg?: RuntimePgConfig;
+  /** Exact credential-free route authorized to use the static `runtimePg`. */
+  runtimePgStaticIdentity?: RuntimePgResolverInput;
+  /** Per-route least-privilege tenant execution login resolver. */
+  runtimePgResolver?: RuntimePgResolver;
+  /** Per-physical-database login resolver used only by shared realtime LISTEN. */
+  notificationPgResolver?: NotificationPgResolver;
   /** PostGraphile/Graphile configuration */
   graphile?: GraphileOptions;
   /** HTTP server configuration */
@@ -48,6 +110,8 @@ export interface ConstructiveOptions extends PgpmOptions, ConstructiveGraphQLOpt
   features?: GraphileFeatureOptions;
   /** API configuration options */
   api?: ApiOptions;
+  /** Routing-label metadata cache configuration */
+  routingCache?: RoutingCacheOptions;
   /** CDN and file storage configuration */
   cdn?: CDNOptions;
   /** Module deployment configuration */
@@ -66,7 +130,8 @@ export interface ConstructiveOptions extends PgpmOptions, ConstructiveGraphQLOpt
 export const constructiveGraphqlDefaults: ConstructiveGraphQLOptions = {
   graphile: graphileDefaults,
   features: graphileFeatureDefaults,
-  api: apiDefaults
+  api: apiDefaults,
+  routingCache: {}
 };
 
 /**

--- a/graphql/types/src/graphile.ts
+++ b/graphql/types/src/graphile.ts
@@ -1,15 +1,88 @@
 import type { GraphileConfig } from 'graphile-config';
 
+export type GraphileIntrospectionMode = 'stock' | 'scoped-required';
+export type GraphileIntrospectionClientReleaseMode = 'reuse' | 'destroy';
+export type GraphileRealtimeNotificationMode = 'dedicated' | 'shared-exact';
+
+/** Per-schema Grafast parse, operation, and plan cache bounds. */
+export interface GrafastCacheLimits {
+  /** Maximum parsed and validated GraphQL documents retained by one schema. */
+  queryCacheMaxLength?: number;
+  /** Maximum GraphQL operations with retained plan lookup state per schema. */
+  operationsCacheMaxLength?: number;
+  /** Maximum context/variable-specific plans retained for one operation. */
+  operationOperationPlansCacheMaxLength?: number;
+}
+
 /**
  * PostGraphile/Graphile v5 configuration
  */
 export interface GraphileOptions {
   /** Database schema(s) to expose through GraphQL */
   schema?: string | string[];
-  /** Additional presets to extend */
+  /**
+   * Additional trusted startup presets, applied after Constructive's feature
+   * preset. The server rejects nested attempts to replace its pgServices,
+   * tenant request context, transport/error policy, or fixed runtime plugins.
+   */
   extends?: GraphileConfig.Preset[];
-  /** Preset overrides */
+  /**
+   * Trusted startup preset overrides. Safe schema and runtime settings plus
+   * caller plugins are applied; Constructive-owned tenant boundaries remain
+   * authoritative and fail closed on explicit override attempts.
+   */
   preset?: Partial<GraphileConfig.Preset>;
+  /**
+   * Admit `extends` and `preset` as fully trusted in-process code in production.
+   *
+   * Graphile plugins are not sandboxed: an admitted plugin can execute raw SQL
+   * through the configured PostgreSQL service and can access the Node.js
+   * process. Production therefore rejects every non-empty caller preset unless
+   * the deployment explicitly opts it into the server trust boundary.
+   */
+  trustCallerPresetsInProduction?: boolean;
+  /** PostgreSQL catalog introspection strategy; scoped mode fails if any requested schema is absent */
+  introspectionMode?: GraphileIntrospectionMode;
+  /**
+   * Whether the exact PostgreSQL client used for catalog introspection is
+   * returned to the runtime pool or destroyed after the gather query. Destroy
+   * avoids carrying catalog-query backend memory into request traffic and
+   * costs one lazy reconnect after each schema build.
+   */
+  introspectionClientReleaseMode?: GraphileIntrospectionClientReleaseMode;
+  /**
+   * Ordered, non-writable schemas that exposed objects may depend on (for
+   * example the schema containing PostGIS or pgvector). Scoped mode fails if
+   * catalog closure reaches any other non-system schema.
+   */
+  introspectionDependencySchemas?: string[];
+  /** Explicit per-schema Grafast cache bounds used for tenant-density control. */
+  grafastCache?: GrafastCacheLimits;
+  /**
+   * Release schema-construction-only Graphile state after successful schema
+   * validation. This is an opt-in density optimization; materialized schemas
+   * and runtime execution state remain tenant-dedicated.
+   */
+  releaseBuildStateAfterValidation?: boolean;
+  /**
+   * Exact physical schema containing realtime cursor functions. Omit for the
+   * compatibility default `realtime_public`.
+   */
+  realtimeSchema?: string;
+  /**
+   * PostgreSQL notification transport. `dedicated` preserves the current
+   * per-Graphile PgSubscriber; `shared-exact` is an experimental, default-off,
+   * role-attested broker whose leases are restricted to compiled physical
+   * topics. The GraphQL server routes WebSocket upgrades independently through
+   * the exact tenant build contract and admission boundary.
+   */
+  realtimeNotificationMode?: GraphileRealtimeNotificationMode;
+  /** Maximum age of a successful shared-listener role attestation. */
+  realtimeNotificationRoleRevalidationMs?: number;
+  /** Cursor recovery poll interval; lower values trade database QPS for latency. */
+  realtimeCursorPollIntervalMs?: number;
+  /** Cursor listener heartbeat interval. */
+  realtimeCursorHeartbeatIntervalMs?: number;
 }
 
 /**
@@ -39,11 +112,23 @@ export interface ApiOptions {
   /** Schemas containing metadata tables */
   metaSchemas?: string[];
   /**
+   * Allow the authenticated X-Meta-Schema private-header surface. This is a
+   * privileged, potentially cross-tenant control-plane API and is disabled by
+   * default; it must never share a tenant-facing ingress.
+   */
+  allowMetaSchemaHeader?: boolean;
+  /**
    * Schema containing the compiled resolve_route() resolver. Requests are
    * always resolved through the scoped-routing plane via
    * <schema>.resolve_route() (host → tenant/api/db/role).
    */
   routingSchema?: string;
+  /**
+   * Process secret that authenticates reserved internal routing, identity, and
+   * cache-administration headers. It must contain at least 32 bytes. When it
+   * is absent, those headers are rejected rather than trusted from the network.
+   */
+  internalRequestSecret?: string;
 }
 
 /**
@@ -52,7 +137,16 @@ export interface ApiOptions {
 export const graphileDefaults: GraphileOptions = {
   schema: [],
   extends: [],
-  preset: {}
+  preset: {},
+  trustCallerPresetsInProduction: false,
+  introspectionMode: 'stock',
+  introspectionClientReleaseMode: 'reuse',
+  introspectionDependencySchemas: [],
+  releaseBuildStateAfterValidation: false,
+  realtimeNotificationMode: 'dedicated',
+  realtimeNotificationRoleRevalidationMs: 60_000,
+  realtimeCursorPollIntervalMs: 5_000,
+  realtimeCursorHeartbeatIntervalMs: 30_000
 };
 
 /**
@@ -77,5 +171,6 @@ export const apiDefaults: ApiOptions = {
     'metaschema_public',
     'metaschema_modules_public'
   ],
+  allowMetaSchemaHeader: false,
   routingSchema: 'routing_public'
 };

--- a/graphql/types/src/index.ts
+++ b/graphql/types/src/index.ts
@@ -2,17 +2,30 @@
 export {
   apiDefaults,
   ApiOptions,
+  GrafastCacheLimits,
   graphileDefaults,
   graphileFeatureDefaults,
   GraphileFeatureOptions,
-  GraphileOptions} from './graphile';
+  GraphileIntrospectionClientReleaseMode,
+  GraphileIntrospectionMode,
+  GraphileOptions,
+  GraphileRealtimeNotificationMode,
+} from './graphile';
 
 // Export Constructive combined types
 export {
   constructiveDefaults,
   constructiveGraphqlDefaults,
   ConstructiveGraphQLOptions,
-  ConstructiveOptions} from './constructive';
+  ConstructiveOptions,
+  NotificationPgConfig,
+  NotificationPgResolver,
+  NotificationPgResolverInput,
+  RoutingCacheOptions,
+  RuntimePgConfig,
+  RuntimePgResolver,
+  RuntimePgResolverInput
+} from './constructive';
 
 // Export GraphQL adapter types
 export {

--- a/packages/express-context/__tests__/context-pool-leases.test.ts
+++ b/packages/express-context/__tests__/context-pool-leases.test.ts
@@ -1,0 +1,279 @@
+import { EventEmitter } from 'node:events';
+
+import type { NextFunction, Request, Response } from 'express';
+import type { Pool } from 'pg';
+import { acquirePgPool, getPgPool, getPgPoolIdentity } from 'pg-cache';
+
+import { buildContext, createContextMiddleware } from '../src/context';
+import type { ApiStructure } from '../src/types';
+
+jest.mock('pg-cache', () => ({
+  acquirePgPool: jest.fn(),
+  getPgPool: jest.fn(),
+  getPgPoolIdentity: jest.fn(() => 'pg:v1:test')
+}));
+
+const mockedAcquire = acquirePgPool as jest.MockedFunction<typeof acquirePgPool>;
+const mockedGet = getPgPool as jest.MockedFunction<typeof getPgPool>;
+const mockedIdentity = getPgPoolIdentity as jest.MockedFunction<typeof getPgPoolIdentity>;
+
+const api: ApiStructure = {
+  apiId: 'api-a',
+  databaseId: 'database-a',
+  dbname: 'tenant_a',
+  anonRole: 'anonymous',
+  roleName: 'authenticated',
+  schema: ['tenant_a_public'],
+  domains: [],
+  isPublic: false
+};
+
+const makeRequest = (): Request => Object.assign(new EventEmitter(), {
+  api,
+  requestId: 'request-a',
+  get: jest.fn((): undefined => undefined),
+  aborted: false,
+  destroyed: false,
+  socket: { destroyed: false }
+}) as unknown as Request;
+
+const makePool = (): Pool => ({ query: jest.fn() } as unknown as Pool);
+
+const makeResponse = (): Response => {
+  const response = new EventEmitter() as EventEmitter & {
+    destroyed: boolean;
+    writableEnded: boolean;
+  };
+  response.destroyed = false;
+  response.writableEnded = false;
+  return response as unknown as Response;
+};
+
+const leaseFor = (pool: Pool) => ({
+  pool,
+  identity: `pool-${Math.random()}`,
+  release: jest.fn()
+});
+
+describe('context PostgreSQL pool lifetimes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('pins runtime and loader pools until the response finishes', () => {
+    const leases = [leaseFor(makePool()), leaseFor(makePool()), leaseFor(makePool())];
+    mockedAcquire
+      .mockReturnValueOnce(leases[0])
+      .mockReturnValueOnce(leases[1])
+      .mockReturnValueOnce(leases[2]);
+    const response = makeResponse();
+    const next = jest.fn() as unknown as NextFunction;
+    const middleware = createContextMiddleware({
+      pg: { database: 'routing' },
+      runtimePg: { user: 'runtime', password: 'secret' },
+      loaders: { resolve: jest.fn() } as any
+    });
+
+    middleware(makeRequest(), response, next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(mockedAcquire).toHaveBeenCalledTimes(3);
+    for (const lease of leases) expect(lease.release).not.toHaveBeenCalled();
+
+    response.emit('finish');
+    response.emit('close');
+    for (const lease of leases) expect(lease.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the exact server-owned runtime resolution and exposes only its opaque identity', () => {
+    const runtime = leaseFor(makePool());
+    runtime.identity = 'pg:v1:exact-runtime';
+    const otherLeases = [leaseFor(makePool()), leaseFor(makePool())];
+    mockedAcquire
+      .mockReturnValueOnce(runtime)
+      .mockReturnValueOnce(otherLeases[0])
+      .mockReturnValueOnce(otherLeases[1]);
+    const request = makeRequest();
+    const getRuntimePgResolution = jest.fn(() => ({
+      pgConfig: {
+        host: 'db.internal',
+        port: 5432,
+        database: 'tenant_a',
+        user: 'tenant_a_runtime',
+        password: 'runtime-secret'
+      },
+      poolIdentity: runtime.identity
+    }));
+
+    const context = buildContext(request, {
+      pg: { database: 'routing' },
+      getRuntimePgResolution,
+      loaders: { resolve: jest.fn() } as any
+    }, []);
+
+    expect(getRuntimePgResolution).toHaveBeenCalledWith(request, api);
+    expect(mockedAcquire.mock.calls[0][0]).toEqual({
+      host: 'db.internal',
+      port: 5432,
+      database: 'tenant_a',
+      user: 'tenant_a_runtime',
+      password: 'runtime-secret'
+    });
+    expect(context?.runtimePoolIdentity).toBe('pg:v1:exact-runtime');
+  });
+
+  it('fails closed when the supplied runtime identity changes before acquisition', () => {
+    const runtime = leaseFor(makePool());
+    runtime.identity = 'pg:v1:different-runtime';
+    mockedAcquire.mockReturnValueOnce(runtime);
+
+    expect(() => buildContext(makeRequest(), {
+      getRuntimePgResolution: () => ({
+        pgConfig: {
+          database: 'tenant_a',
+          user: 'tenant_a_runtime',
+          password: 'runtime-secret'
+        },
+        poolIdentity: 'pg:v1:expected-runtime'
+      })
+    }, [])).toThrow('pool identity changed before context acquisition');
+  });
+
+  it('does not acquire leases for a request that already ended', () => {
+    const request = makeRequest();
+    Object.assign(request, { aborted: true });
+    const next = jest.fn() as unknown as NextFunction;
+    const middleware = createContextMiddleware({
+      pg: { database: 'routing' },
+      loaders: { resolve: jest.fn() } as any
+    });
+
+    middleware(request, makeResponse(), next);
+
+    expect(mockedAcquire).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('does not acquire leases after the request transport socket is destroyed', () => {
+    const request = makeRequest();
+    Object.assign(request.socket, { destroyed: true });
+    const next = jest.fn() as unknown as NextFunction;
+    const middleware = createContextMiddleware({
+      pg: { database: 'routing' },
+      loaders: { resolve: jest.fn() } as any
+    });
+
+    middleware(request, makeResponse(), next);
+
+    expect(mockedAcquire).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('continues after a parser consumed and auto-destroyed the request stream', () => {
+    const request = makeRequest();
+    Object.assign(request, {
+      destroyed: true,
+      readableEnded: true,
+      complete: true
+    });
+    const leases = [leaseFor(makePool()), leaseFor(makePool()), leaseFor(makePool())];
+    mockedAcquire
+      .mockReturnValueOnce(leases[0])
+      .mockReturnValueOnce(leases[1])
+      .mockReturnValueOnce(leases[2]);
+    const response = makeResponse();
+    const next = jest.fn() as unknown as NextFunction;
+    const middleware = createContextMiddleware({
+      pg: { database: 'routing' },
+      runtimePg: { user: 'runtime', password: 'secret' },
+      loaders: { resolve: jest.fn() } as any
+    });
+
+    middleware(request, response, next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(mockedAcquire).toHaveBeenCalledTimes(3);
+    response.emit('finish');
+    for (const lease of leases) expect(lease.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases leases when the response ends during context construction', () => {
+    const response = makeResponse();
+    const leases = [leaseFor(makePool()), leaseFor(makePool()), leaseFor(makePool())];
+    mockedAcquire
+      .mockReturnValueOnce(leases[0])
+      .mockImplementationOnce(() => {
+        Object.assign(response, { destroyed: true });
+        return leases[1];
+      })
+      .mockReturnValueOnce(leases[2]);
+    const next = jest.fn() as unknown as NextFunction;
+    const middleware = createContextMiddleware({
+      pg: { database: 'routing' },
+      runtimePg: { user: 'runtime', password: 'secret' },
+      loaders: { resolve: jest.fn() } as any
+    });
+
+    middleware(makeRequest(), response, next);
+
+    expect(mockedAcquire).toHaveBeenCalledTimes(3);
+    for (const lease of leases) expect(lease.release).toHaveBeenCalledTimes(1);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('releases leases when the request aborts', () => {
+    const request = makeRequest();
+    const response = makeResponse();
+    const leases = [leaseFor(makePool()), leaseFor(makePool()), leaseFor(makePool())];
+    mockedAcquire
+      .mockReturnValueOnce(leases[0])
+      .mockReturnValueOnce(leases[1])
+      .mockReturnValueOnce(leases[2]);
+    const middleware = createContextMiddleware({
+      pg: { database: 'routing' },
+      runtimePg: { user: 'runtime', password: 'secret' },
+      loaders: { resolve: jest.fn() } as any
+    });
+
+    middleware(request, response, jest.fn());
+    request.emit('aborted');
+
+    for (const lease of leases) expect(lease.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases earlier leases when a later acquisition fails', () => {
+    const first = leaseFor(makePool());
+    const error = new Error('capacity');
+    mockedAcquire.mockReturnValueOnce(first).mockImplementationOnce(() => {
+      throw error;
+    });
+    const next = jest.fn() as unknown as NextFunction;
+    const middleware = createContextMiddleware({
+      pg: { database: 'routing' },
+      loaders: { resolve: jest.fn() } as any
+    });
+
+    middleware(
+      makeRequest(),
+      new EventEmitter() as unknown as Response,
+      next
+    );
+
+    expect(first.release).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(error);
+  });
+
+  it('preserves unleased getPgPool behavior for direct buildContext callers', () => {
+    mockedGet.mockReturnValue(makePool());
+
+    const context = buildContext(makeRequest(), {
+      pg: { database: 'routing' },
+      loaders: { resolve: jest.fn() } as any
+    });
+
+    expect(context).not.toBeNull();
+    expect(mockedGet).toHaveBeenCalledTimes(3);
+    expect(mockedIdentity).toHaveBeenCalledTimes(3);
+    expect(mockedAcquire).not.toHaveBeenCalled();
+  });
+});

--- a/packages/express-context/__tests__/pg-settings.test.ts
+++ b/packages/express-context/__tests__/pg-settings.test.ts
@@ -29,14 +29,14 @@ describe('buildPgSettings — jwt.claims.api_id provenance', () => {
     expect(settings['jwt.claims.user_id']).toBe('u1');
   });
 
-  it('omits jwt.claims.api_id when the api has no apiId (non-API surface)', () => {
+  it('clears jwt.claims.api_id when the api has no apiId (non-API surface)', () => {
     const settings = buildPgSettings({
       api: { ...api, apiId: undefined },
       token: null,
       requestId: 'r1'
     });
 
-    expect(settings['jwt.claims.api_id']).toBeUndefined();
+    expect(settings['jwt.claims.api_id']).toBe('');
   });
 
   it('is derived only from the resolved api, never from the token', () => {

--- a/packages/express-context/package.json
+++ b/packages/express-context/package.json
@@ -34,6 +34,7 @@
     "@pgpmjs/logger": "workspace:^",
     "@pgpmjs/server-utils": "workspace:^",
     "@pgpmjs/types": "workspace:^",
+    "@pgsql/quotes": "^18.2.0",
     "lru-cache": "^11.2.7",
     "pg": "^8.21.0",
     "pg-cache": "workspace:^",

--- a/packages/express-context/src/__tests__/compute-loader.test.ts
+++ b/packages/express-context/src/__tests__/compute-loader.test.ts
@@ -1,0 +1,55 @@
+import type { Pool } from 'pg';
+
+import { computeLoader } from '../loaders/compute';
+
+describe('compute control-plane loader', () => {
+  afterEach(() => computeLoader.invalidate());
+
+  it('loads API bindings through the control-plane tenant pool', async () => {
+    const query = jest.fn()
+      .mockResolvedValueOnce({
+        rows: [{
+          functions_schema_name: 'compute"schema',
+          definitions_table_name: 'definitions',
+          bindings_table_name: 'bindings',
+          invocations_schema_name: 'invocations',
+          invocations_table_name: 'jobs',
+          invocations_entity_field: 'database_id'
+        }]
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'binding-a',
+          alias: 'summarize',
+          config: { graphql: true },
+          function_definition_id: 'definition-a',
+          task_identifier: 'summarize-task',
+          description: 'Summarize content',
+          payload_args: [{ name: 'body', type: 'string' }]
+        }]
+      });
+    const ctx = {
+      routingPool: {} as Pool,
+      tenantPool: { query } as unknown as Pool,
+      databaseId: 'database-compute-loader-test',
+      apiId: 'api-a',
+      dbname: 'tenant_db'
+    };
+
+    const result = await computeLoader.resolve(ctx);
+
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(query.mock.calls[1][0]).toContain('FROM "compute""schema"."bindings" b');
+    expect(query.mock.calls[1][1]).toEqual(['api-a']);
+    expect(result?.bindings).toEqual([{
+      bindingId: 'binding-a',
+      alias: 'summarize',
+      config: { graphql: true },
+      functionDefinitionId: 'definition-a',
+      taskIdentifier: 'summarize-task',
+      description: 'Summarize content',
+      payloadArgs: [{ name: 'body', type: 'string' }],
+      module: result?.modules[0]
+    }]);
+  });
+});

--- a/packages/express-context/src/__tests__/loader-cache-isolation.test.ts
+++ b/packages/express-context/src/__tests__/loader-cache-isolation.test.ts
@@ -1,0 +1,175 @@
+import type { Pool } from 'pg';
+
+import { createModuleLoader } from '../loaders/create-loader';
+import type { LoaderContext } from '../loaders/types';
+
+const context = (
+  routingPool: Pool,
+  tenantPool: Pool,
+  suffix: string
+): LoaderContext => ({
+  routingPool,
+  routingPoolIdentity: `routing:${suffix}`,
+  tenantPool,
+  tenantPoolIdentity: `tenant:${suffix}`,
+  databaseId: 'cloned-database-id',
+  apiId: 'cloned-api-id',
+  dbname: 'cloned_database'
+});
+
+describe('module loader physical cache isolation', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does not share one logical database/API entry across physical pool contracts', async () => {
+    const routingA = {} as Pool;
+    const routingB = {} as Pool;
+    const tenantA = {} as Pool;
+    const tenantB = {} as Pool;
+    const ctxA = context(routingA, tenantA, 'a');
+    const ctxB = context(routingB, tenantB, 'b');
+    const resolve = jest.fn(async (ctx: LoaderContext) =>
+      ctx.tenantPoolIdentity === 'tenant:a' ? 'config-a' : 'config-b'
+    );
+    const loader = createModuleLoader({ name: 'physical-isolation', resolve });
+
+    await expect(loader.resolve(ctxA)).resolves.toBe('config-a');
+    await expect(loader.resolve(ctxB)).resolves.toBe('config-b');
+    await expect(loader.resolve(ctxA)).resolves.toBe('config-a');
+    await expect(loader.resolve(ctxB)).resolves.toBe('config-b');
+
+    expect(resolve).toHaveBeenCalledTimes(2);
+  });
+
+  it('can invalidate one physical contract without evicting its logical twin', async () => {
+    const ctxA = context({} as Pool, {} as Pool, 'a');
+    const ctxB = context({} as Pool, {} as Pool, 'b');
+    let generation = 0;
+    const resolve = jest.fn(async (ctx: LoaderContext) =>
+      `${ctx.tenantPoolIdentity}:${++generation}`
+    );
+    const loader = createModuleLoader({ name: 'physical-invalidation', resolve });
+
+    const firstA = await loader.resolve(ctxA);
+    const firstB = await loader.resolve(ctxB);
+    loader.invalidate(ctxA.databaseId, ctxA);
+
+    await expect(loader.resolve(ctxB)).resolves.toBe(firstB);
+    await expect(loader.resolve(ctxA)).resolves.not.toBe(firstA);
+    expect(resolve).toHaveBeenCalledTimes(3);
+  });
+
+  it('falls back to pool object identity for generic callers without opaque identities', async () => {
+    const routingPool = {} as Pool;
+    const tenantA = {} as Pool;
+    const tenantB = {} as Pool;
+    const base = {
+      routingPool,
+      databaseId: 'cloned-database-id',
+      apiId: 'cloned-api-id',
+      dbname: 'cloned_database'
+    };
+    const resolve = jest.fn(async (ctx: LoaderContext) =>
+      ctx.tenantPool === tenantA ? 'config-a' : 'config-b'
+    );
+    const loader = createModuleLoader({ name: 'object-isolation', resolve });
+
+    await expect(loader.resolve({ ...base, tenantPool: tenantA })).resolves.toBe('config-a');
+    await expect(loader.resolve({ ...base, tenantPool: tenantB })).resolves.toBe('config-b');
+    await expect(loader.resolve({ ...base, tenantPool: tenantA })).resolves.toBe('config-a');
+
+    expect(resolve).toHaveBeenCalledTimes(2);
+  });
+
+  it('isolates routing schemas even when the physical pools and logical IDs match', async () => {
+    const base = context({} as Pool, {} as Pool, 'shared');
+    const resolve = jest.fn(async (ctx: LoaderContext) => ctx.routingSchema);
+    const loader = createModuleLoader({ name: 'routing-schema-isolation', resolve });
+
+    await expect(loader.resolve({ ...base, routingSchema: 'routing_a' }))
+      .resolves.toBe('routing_a');
+    await expect(loader.resolve({ ...base, routingSchema: 'routing_b' }))
+      .resolves.toBe('routing_b');
+    await expect(loader.resolve({ ...base, routingSchema: 'routing_a' }))
+      .resolves.toBe('routing_a');
+
+    expect(resolve).toHaveBeenCalledTimes(2);
+  });
+
+  it('coalesces concurrent misses for one exact build contract', async () => {
+    const ctx = context({} as Pool, {} as Pool, 'shared');
+    const resolve = jest.fn(async () => 'shared-config');
+    const loader = createModuleLoader({ name: 'concurrent-coalescing', resolve });
+
+    await expect(Promise.all([
+      loader.resolve(ctx),
+      loader.resolve(ctx),
+      loader.resolve(ctx)
+    ])).resolves.toEqual(['shared-config', 'shared-config', 'shared-config']);
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not publish a resolution invalidated while its query is in flight', async () => {
+    const ctx = context({} as Pool, {} as Pool, 'shared');
+    let complete!: (value: string) => void;
+    const first = new Promise<string>((resolve) => {
+      complete = resolve;
+    });
+    const resolve = jest.fn()
+      .mockImplementationOnce(() => first)
+      .mockResolvedValueOnce('fresh-config');
+    const loader = createModuleLoader<string>({
+      name: 'inflight-invalidation',
+      resolve
+    });
+
+    const stale = loader.resolve(ctx);
+    loader.invalidate(ctx.databaseId, ctx);
+    const fresh = loader.resolve(ctx);
+    await expect(fresh).resolves.toBe('fresh-config');
+    complete('stale-config');
+    await expect(stale).resolves.toBe('stale-config');
+    await expect(loader.resolve(ctx)).resolves.toBe('fresh-config');
+    expect(resolve).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses a hard TTL that cache hits cannot extend indefinitely', async () => {
+    let now = 1;
+    jest.spyOn(performance, 'now').mockImplementation(() => now);
+    const ctx = context({} as Pool, {} as Pool, 'shared');
+    let generation = 0;
+    const resolve = jest.fn(async () => `config-${++generation}`);
+    const loader = createModuleLoader({
+      name: 'hard-expiry',
+      ttlMs: 100,
+      resolve
+    });
+
+    await expect(loader.resolve(ctx)).resolves.toBe('config-1');
+    now = 76;
+    await expect(loader.resolve(ctx)).resolves.toBe('config-1');
+    now = 106;
+    await expect(loader.resolve(ctx)).resolves.toBe('config-2');
+    expect(resolve).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache or coalesce authoritative loader reads', async () => {
+    const ctx = context({} as Pool, {} as Pool, 'shared');
+    let generation = 0;
+    const resolve = jest.fn(async () => `config-${++generation}`);
+    const loader = createModuleLoader({
+      name: 'authoritative',
+      cache: false,
+      resolve
+    });
+
+    await expect(Promise.all([
+      loader.resolve(ctx),
+      loader.resolve(ctx)
+    ])).resolves.toEqual(['config-1', 'config-2']);
+    await expect(loader.resolve(ctx)).resolves.toBe('config-3');
+    expect(resolve).toHaveBeenCalledTimes(3);
+    expect(loader.cacheSize).toBe(0);
+  });
+});

--- a/packages/express-context/src/__tests__/pg-settings.test.ts
+++ b/packages/express-context/src/__tests__/pg-settings.test.ts
@@ -1,0 +1,104 @@
+import { buildPgSettings, SECURITY_GUC_KEYS } from '../pg-settings';
+import type { ApiStructure } from '../types';
+
+const api: ApiStructure = {
+  apiId: 'api-a',
+  databaseId: 'database-a',
+  dbname: 'tenant_a',
+  schema: ['tenant_a_public'],
+  roleName: 'tenant_user',
+  anonRole: 'tenant_anon'
+};
+
+describe('buildPgSettings', () => {
+  it('initializes every security GUC and explicit transaction state for anonymous requests', () => {
+    const settings = buildPgSettings({ api, token: null, requestId: 'request-a' });
+
+    expect(settings.role).toBe('tenant_anon');
+    expect(settings['request.id']).toBe('request-a');
+    expect(settings['transaction_read_only']).toBe('off');
+    expect(settings['search_path']).toBe('pg_catalog, "tenant_a_public"');
+    expect(settings['row_security']).toBe('on');
+    for (const key of SECURITY_GUC_KEYS) {
+      expect(Object.prototype.hasOwnProperty.call(settings, key)).toBe(true);
+    }
+    expect(settings['jwt.claims.user_id']).toBe('');
+  });
+
+  it('quotes every physical schema in the pinned search path', () => {
+    const settings = buildPgSettings({
+      api: { ...api, schema: ['tenant-a', 'quoted"schema'] },
+      token: null,
+      requestId: 'request-search-path',
+      dependencySchemas: ['postgis-ext', 'shared"api']
+    });
+
+    expect(settings['search_path']).toBe(
+      'pg_catalog, "postgis-ext", "shared""api", "tenant-a", "quoted""schema"'
+    );
+  });
+
+  it('sets known claims while keeping every absent claim empty', () => {
+    const settings = buildPgSettings({
+      api,
+      token: {
+        id: 'token-a',
+        user_id: 'user-a',
+        access_level: 'read_only',
+        kind: 'api_key'
+      },
+      requestId: 'request-b',
+      clientIp: '127.0.0.1',
+      origin: 'https://example.test',
+      userAgent: 'test-agent',
+      deviceToken: 'device-a'
+    });
+
+    expect(settings).toMatchObject({
+      role: 'tenant_user',
+      'jwt.claims.token_id': 'token-a',
+      'jwt.claims.user_id': 'user-a',
+      'jwt.claims.principal_id': 'user-a',
+      'jwt.claims.session_id': '',
+      'jwt.claims.access_level': 'read_only',
+      'jwt.claims.device_token': 'device-a',
+      'transaction_read_only': 'on'
+    });
+  });
+
+  it('does not retain claims or read-only state across requests', () => {
+    buildPgSettings({
+      api,
+      token: { user_id: 'user-a', access_level: 'read_only' },
+      requestId: 'request-a'
+    });
+    const next = buildPgSettings({ api, token: null, requestId: 'request-b' });
+
+    expect(next['jwt.claims.user_id']).toBe('');
+    expect(next['jwt.claims.access_level']).toBe('');
+    expect(next['transaction_read_only']).toBe('off');
+  });
+
+  it('rejects runtime-shaped trusted claims that could override session state', () => {
+    expect(() => buildPgSettings({
+      api,
+      token: null,
+      requestId: 'request-extra-claim',
+      trustedClaims: {
+        role: 'cross_tenant_owner'
+      } as unknown as Record<'jwt.claims.user_id', string>
+    })).toThrow("trustedClaims contains unsupported security GUC 'role'");
+
+    const claims = Object.create(null) as Record<string, unknown>;
+    Object.defineProperty(claims, 'jwt.claims.user_id', {
+      enumerable: true,
+      get: () => 'getter-value'
+    });
+    expect(() => buildPgSettings({
+      api,
+      token: null,
+      requestId: 'request-accessor-claim',
+      trustedClaims: claims as Record<'jwt.claims.user_id', string>
+    })).toThrow('trustedClaims.jwt.claims.user_id must be a string data property');
+  });
+});

--- a/packages/express-context/src/__tests__/security-loader-freshness.test.ts
+++ b/packages/express-context/src/__tests__/security-loader-freshness.test.ts
@@ -1,0 +1,269 @@
+import type { Pool } from 'pg';
+
+import { authSettingsLoader } from '../loaders/auth-settings';
+import { corsLoader } from '../loaders/cors';
+import { databaseSettingsLoader } from '../loaders/database-settings';
+import { pubkeyLoader } from '../loaders/pubkey';
+import { rlsLoader } from '../loaders/rls';
+import type { LoaderContext } from '../loaders/types';
+import { webauthnLoader } from '../loaders/webauthn';
+
+const loaderContext = (
+  routingPool: Pool,
+  tenantPool: Pool
+): LoaderContext => ({
+  routingPool,
+  routingPoolIdentity: 'routing:security-test',
+  routingSchema: 'routing_public',
+  tenantPool,
+  tenantPoolIdentity: 'tenant:security-test',
+  databaseId: 'database-123',
+  apiId: 'api-123',
+  dbname: 'tenant_database'
+});
+
+describe('security-sensitive module freshness', () => {
+  afterEach(() => {
+    rlsLoader.invalidate();
+    authSettingsLoader.invalidate();
+    corsLoader.invalidate();
+    databaseSettingsLoader.invalidate();
+    pubkeyLoader.invalidate();
+    webauthnLoader.invalidate();
+  });
+
+  it('reads RLS authentication routing authoritatively on every request', async () => {
+    const query = jest.fn()
+      .mockResolvedValueOnce({ rows: [{
+        authenticate: 'authenticate_v1',
+        authenticate_strict: 'authenticate_strict_v1',
+        authenticate_schema: 'auth_private',
+        role_schema: 'auth_public',
+        current_role: 'current_role',
+        current_role_id: 'current_role_id',
+        current_ip_address: 'current_ip_address',
+        current_user_agent: 'current_user_agent'
+      }] })
+      .mockResolvedValueOnce({ rows: [{
+        authenticate: 'authenticate_v2',
+        authenticate_strict: 'authenticate_strict_v2',
+        authenticate_schema: 'auth_private',
+        role_schema: 'auth_public',
+        current_role: 'current_role',
+        current_role_id: 'current_role_id',
+        current_ip_address: 'current_ip_address',
+        current_user_agent: 'current_user_agent'
+      }] });
+    const routingPool = { query } as unknown as Pool;
+    const ctx = loaderContext(routingPool, {} as Pool);
+
+    await expect(rlsLoader.resolve(ctx)).resolves.toMatchObject({
+      authenticate: 'authenticate_v1'
+    });
+    await expect(rlsLoader.resolve(ctx)).resolves.toMatchObject({
+      authenticate: 'authenticate_v2'
+    });
+
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(rlsLoader.cacheSize).toBe(0);
+  });
+
+  it('reads cookie and CAPTCHA policy authoritatively on every request', async () => {
+    const query = jest.fn()
+      .mockResolvedValueOnce({
+        rows: [{ schema_name: 'sessions_private', table_name: 'auth_settings' }]
+      })
+      .mockResolvedValueOnce({ rows: [{
+        cookie_secure: true,
+        cookie_samesite: 'lax',
+        cookie_domain: null,
+        cookie_httponly: true,
+        cookie_max_age: '3600',
+        cookie_path: '/',
+        remember_me_duration: '86400',
+        enable_captcha: false,
+        captcha_site_key: null
+      }] })
+      .mockResolvedValueOnce({
+        rows: [{ schema_name: 'sessions_private', table_name: 'auth_settings' }]
+      })
+      .mockResolvedValueOnce({ rows: [{
+        cookie_secure: true,
+        cookie_samesite: 'strict',
+        cookie_domain: null,
+        cookie_httponly: true,
+        cookie_max_age: '1800',
+        cookie_path: '/',
+        remember_me_duration: '43200',
+        enable_captcha: true,
+        captcha_site_key: 'site-key-v2'
+      }] });
+    const tenantPool = { query } as unknown as Pool;
+    const ctx = loaderContext({} as Pool, tenantPool);
+
+    await expect(authSettingsLoader.resolve(ctx)).resolves.toMatchObject({
+      cookieSamesite: 'lax',
+      enableCaptcha: false
+    });
+    await expect(authSettingsLoader.resolve(ctx)).resolves.toMatchObject({
+      cookieSamesite: 'strict',
+      enableCaptcha: true
+    });
+
+    expect(query).toHaveBeenCalledTimes(4);
+    expect(authSettingsLoader.cacheSize).toBe(0);
+  });
+
+  it('does not retain revoked CORS policy', async () => {
+    const query = jest.fn()
+      .mockResolvedValueOnce({ rows: [{ allowed_origins: ['https://old.example'] }] })
+      .mockResolvedValueOnce({ rows: [{ allowed_origins: [] }] });
+    const ctx = loaderContext({ query } as unknown as Pool, {} as Pool);
+
+    await expect(corsLoader.resolve(ctx)).resolves.toEqual(['https://old.example']);
+    await expect(corsLoader.resolve(ctx)).resolves.toEqual([]);
+
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(corsLoader.cacheSize).toBe(0);
+  });
+
+  it('does not retain a revoked Graphile/realtime feature surface', async () => {
+    const settings = (enabled: boolean) => ({
+      resolved_enable_aggregates: enabled,
+      resolved_enable_postgis: enabled,
+      resolved_enable_search: enabled,
+      resolved_enable_direct_uploads: enabled,
+      resolved_enable_presigned_uploads: enabled,
+      resolved_enable_many_to_many: enabled,
+      resolved_enable_connection_filter: enabled,
+      resolved_enable_ltree: enabled,
+      resolved_enable_llm: enabled,
+      resolved_enable_realtime: enabled,
+      resolved_enable_bulk: enabled,
+      resolved_enable_i18n: enabled
+    });
+    const query = jest.fn()
+      .mockResolvedValueOnce({ rows: [settings(true)] })
+      .mockResolvedValueOnce({ rows: [settings(false)] });
+    const ctx = loaderContext({ query } as unknown as Pool, {} as Pool);
+
+    await expect(databaseSettingsLoader.resolve(ctx)).resolves.toMatchObject({
+      enableRealtime: true,
+      enableSearch: true
+    });
+    await expect(databaseSettingsLoader.resolve(ctx)).resolves.toMatchObject({
+      enableRealtime: false,
+      enableSearch: false
+    });
+
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(databaseSettingsLoader.cacheSize).toBe(0);
+  });
+
+  it('rejects ambiguous or incomplete Graphile feature contracts', async () => {
+    const settings = {
+      resolved_enable_aggregates: false,
+      resolved_enable_postgis: false,
+      resolved_enable_search: false,
+      resolved_enable_direct_uploads: false,
+      resolved_enable_presigned_uploads: false,
+      resolved_enable_many_to_many: false,
+      resolved_enable_connection_filter: false,
+      resolved_enable_ltree: false,
+      resolved_enable_llm: false,
+      resolved_enable_realtime: false,
+      resolved_enable_bulk: false,
+      resolved_enable_i18n: false
+    };
+    const ambiguous = loaderContext({
+      query: jest.fn().mockResolvedValue({ rows: [settings, settings] })
+    } as unknown as Pool, {} as Pool);
+    const incomplete = loaderContext({
+      query: jest.fn().mockResolvedValue({
+        rows: [{ ...settings, resolved_enable_search: null }]
+      })
+    } as unknown as Pool, {} as Pool);
+
+    await expect(databaseSettingsLoader.resolve(ambiguous))
+      .rejects.toThrow('Ambiguous database feature configuration');
+    await expect(databaseSettingsLoader.resolve(incomplete))
+      .rejects.toThrow('Incomplete database feature configuration');
+  });
+
+  it('does not retain changed public-key or WebAuthn policy', async () => {
+    const pubkeyQuery = jest.fn()
+      .mockResolvedValueOnce({ rows: [{
+        schema: 'auth_public',
+        crypto_network: 'mainnet',
+        sign_up_with_key: 'sign_up_v1',
+        sign_in_request_challenge: 'request_v1',
+        sign_in_record_failure: 'failure_v1',
+        sign_in_with_challenge: 'sign_in_v1'
+      }] })
+      .mockResolvedValueOnce({ rows: [{
+        schema: 'auth_public',
+        crypto_network: 'mainnet',
+        sign_up_with_key: 'sign_up_v2',
+        sign_in_request_challenge: 'request_v2',
+        sign_in_record_failure: 'failure_v2',
+        sign_in_with_challenge: 'sign_in_v2'
+      }] });
+    const pubkeyContext = loaderContext(
+      { query: pubkeyQuery } as unknown as Pool,
+      {} as Pool
+    );
+
+    await expect(pubkeyLoader.resolve(pubkeyContext)).resolves.toMatchObject({
+      signUpWithKey: 'sign_up_v1'
+    });
+    await expect(pubkeyLoader.resolve(pubkeyContext)).resolves.toMatchObject({
+      signUpWithKey: 'sign_up_v2'
+    });
+
+    const webauthnQuery = jest.fn()
+      .mockResolvedValueOnce({ rows: [{
+        schema: 'auth_public',
+        credentials_schema: 'auth_private',
+        sessions_schema: 'sessions_private',
+        session_secrets_schema: 'sessions_private',
+        rp_id: 'old.example',
+        rp_name: 'Old',
+        origin_allowlist: ['https://old.example'],
+        attestation_type: 'none',
+        require_user_verification: false,
+        resident_key: 'preferred',
+        challenge_expiry_seconds: 300
+      }] })
+      .mockResolvedValueOnce({ rows: [{
+        schema: 'auth_public',
+        credentials_schema: 'auth_private',
+        sessions_schema: 'sessions_private',
+        session_secrets_schema: 'sessions_private',
+        rp_id: 'new.example',
+        rp_name: 'New',
+        origin_allowlist: ['https://new.example'],
+        attestation_type: 'direct',
+        require_user_verification: true,
+        resident_key: 'required',
+        challenge_expiry_seconds: 60
+      }] });
+    const webauthnContext = loaderContext(
+      { query: webauthnQuery } as unknown as Pool,
+      {} as Pool
+    );
+
+    await expect(webauthnLoader.resolve(webauthnContext)).resolves.toMatchObject({
+      rpId: 'old.example',
+      requireUserVerification: false
+    });
+    await expect(webauthnLoader.resolve(webauthnContext)).resolves.toMatchObject({
+      rpId: 'new.example',
+      requireUserVerification: true
+    });
+
+    expect(pubkeyQuery).toHaveBeenCalledTimes(2);
+    expect(webauthnQuery).toHaveBeenCalledTimes(2);
+    expect(pubkeyLoader.cacheSize).toBe(0);
+    expect(webauthnLoader.cacheSize).toBe(0);
+  });
+});

--- a/packages/express-context/src/__tests__/security-metadata.test.ts
+++ b/packages/express-context/src/__tests__/security-metadata.test.ts
@@ -1,0 +1,134 @@
+import type { Pool } from 'pg';
+
+import { createBillingClient } from '../billing-client';
+import { quoteQualifiedSqlIdentifier, quoteSqlIdentifier } from '../sql-identifiers';
+import { agentChatLoader } from '../loaders/agent-chat';
+import { authSettingsLoader } from '../loaders/auth-settings';
+import { rlsLoader } from '../loaders/rls';
+import type { LoaderContext } from '../loaders/types';
+
+const context = (
+  routingQuery: jest.Mock,
+  tenantQuery: jest.Mock
+): LoaderContext => ({
+  routingPool: { query: routingQuery } as unknown as Pool,
+  routingPoolIdentity: 'routing-a',
+  tenantPool: { query: tenantQuery } as unknown as Pool,
+  tenantPoolIdentity: 'tenant-a',
+  databaseId: '11111111-1111-4111-8111-111111111111',
+  apiId: '22222222-2222-4222-8222-222222222222',
+  dbname: 'tenant_a'
+});
+
+describe('security-sensitive metadata SQL', () => {
+  afterEach(() => {
+    agentChatLoader.invalidate();
+    authSettingsLoader.invalidate();
+    rlsLoader.invalidate();
+  });
+
+  it('quotes arbitrary PostgreSQL identifiers and rejects truncation/NUL cases', () => {
+    expect(quoteQualifiedSqlIdentifier('tenant-a', 'table"name'))
+      .toBe('"tenant-a"."table""name"');
+    expect(() => quoteSqlIdentifier('')).toThrow('Invalid SQL identifier');
+    expect(() => quoteSqlIdentifier('bad\0name')).toThrow('Invalid SQL identifier');
+    expect(() => quoteSqlIdentifier('a'.repeat(64))).toThrow('Invalid SQL identifier');
+  });
+
+  it('constrains RLS schemas and functions to the requested database and schema', async () => {
+    const routingQuery = jest.fn().mockResolvedValue({ rows: [{
+      authenticate_schema: 'auth_private',
+      role_schema: 'auth_public',
+      authenticate: 'authenticate',
+      authenticate_strict: 'authenticate_strict',
+      current_role: 'current_role',
+      current_role_id: 'current_role_id',
+      current_user_agent: 'current_user_agent',
+      current_ip_address: 'current_ip_address'
+    }] });
+    await rlsLoader.resolve(context(routingQuery, jest.fn()));
+
+    const [sql, values] = routingQuery.mock.calls[0];
+    expect(values).toEqual(['11111111-1111-4111-8111-111111111111']);
+    expect(sql).toContain('auth_fn.database_id = rs.database_id');
+    expect(sql).toContain('auth_fn.schema_id = rs.authenticate_schema_id');
+    expect(sql).toContain('role_fn.schema_id = rs.role_schema_id');
+  });
+
+  it('rejects an RLS row whose referenced metadata did not resolve exactly', async () => {
+    const routingQuery = jest.fn().mockResolvedValue({ rows: [{
+      authenticate_schema: null,
+      role_schema: 'auth_public',
+      authenticate: null,
+      authenticate_strict: null,
+      current_role: 'current_role',
+      current_role_id: 'current_role_id',
+      current_user_agent: 'current_user_agent',
+      current_ip_address: 'current_ip_address'
+    }] });
+
+    await expect(rlsLoader.resolve(context(routingQuery, jest.fn())))
+      .rejects.toThrow('Incomplete or cross-database RLS module configuration');
+  });
+
+  it('scopes tenant module discovery and safely quotes discovered identifiers', async () => {
+    const tenantQuery = jest.fn()
+      .mockResolvedValueOnce({
+        rows: [{ schema_name: 'session-private', table_name: 'auth"settings' }]
+      })
+      .mockResolvedValueOnce({ rows: [{
+        cookie_secure: true,
+        cookie_samesite: 'lax',
+        cookie_domain: null,
+        cookie_httponly: true,
+        cookie_max_age: null,
+        cookie_path: '/',
+        remember_me_duration: null,
+        enable_captcha: false,
+        captcha_site_key: null
+      }] });
+    await authSettingsLoader.resolve(context(jest.fn(), tenantQuery));
+
+    expect(tenantQuery.mock.calls[0][0]).toContain('WHERE sm.database_id = $1');
+    expect(tenantQuery.mock.calls[0][1]).toEqual([
+      '11111111-1111-4111-8111-111111111111'
+    ]);
+    expect(tenantQuery.mock.calls[1][0])
+      .toContain('FROM "session-private"."auth""settings"');
+  });
+
+  it('scopes agent chat discovery to the exact logical database', async () => {
+    const tenantQuery = jest.fn().mockResolvedValue({ rows: [{
+      schema_name: 'agent_public',
+      thread_table_name: 'threads',
+      message_table_name: 'messages',
+      task_table_name: 'tasks'
+    }] });
+    await agentChatLoader.resolve(context(jest.fn(), tenantQuery));
+
+    expect(tenantQuery.mock.calls[0][0]).toContain('WHERE acm.database_id = $1');
+    expect(tenantQuery.mock.calls[0][1]).toEqual([
+      '11111111-1111-4111-8111-111111111111'
+    ]);
+  });
+
+  it('fails a configured billing quota check closed and quotes its function', async () => {
+    const query = jest.fn().mockRejectedValue(new Error('billing unavailable'));
+    const withPgClient = jest.fn(async (callback) => callback({ query }));
+    const billing = createBillingClient(
+      withPgClient as never,
+      '33333333-3333-4333-8333-333333333333',
+      {
+        publicSchema: 'billing-public',
+        privateSchema: 'billing"private',
+        recordUsageFunction: 'record_usage',
+        checkBillingQuotaFunction: 'check"quota'
+      },
+      null
+    );
+
+    await expect(billing.checkQuota('tokens')).resolves.toBe(false);
+    expect(query.mock.calls[0][0])
+      .toContain('SELECT "billing""private"."check""quota"(');
+  });
+});

--- a/packages/express-context/src/__tests__/storage-loader.test.ts
+++ b/packages/express-context/src/__tests__/storage-loader.test.ts
@@ -1,0 +1,55 @@
+import type { Pool } from 'pg';
+
+import { storageLoader, STORAGE_MODULE_SQL } from '../loaders/storage';
+
+describe('storage control-plane loader', () => {
+  afterEach(() => storageLoader.invalidate());
+
+  it('normalizes immutable module metadata and caches it by database contract', async () => {
+    const query = jest.fn().mockResolvedValue({
+      rows: [{
+        id: 'storage-a',
+        scope: 'app',
+        entity_table_id: null,
+        buckets_schema: 'tenant-a',
+        buckets_table: 'buckets"table',
+        files_schema: 'tenant-a',
+        files_table: 'files',
+        endpoint: null,
+        public_url_prefix: null,
+        provider: null,
+        allowed_origins: null,
+        upload_url_expiry_seconds: null,
+        download_url_expiry_seconds: null,
+        default_max_file_size: null,
+        max_filename_length: null,
+        cache_ttl_seconds: null,
+        max_bulk_files: null,
+        max_bulk_total_size: '1073741824',
+        has_path_shares: null,
+        entity_schema: null,
+        entity_table: null
+      }]
+    });
+    const ctx = {
+      routingPool: {} as Pool,
+      tenantPool: { query } as unknown as Pool,
+      databaseId: 'database-storage-loader-test',
+      dbname: 'tenant_db'
+    };
+
+    const first = await storageLoader.resolve(ctx);
+    const cached = await storageLoader.resolve(ctx);
+
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query).toHaveBeenCalledWith(STORAGE_MODULE_SQL, [ctx.databaseId]);
+    expect(cached).toBe(first);
+    expect(first?.modules[0]).toMatchObject({
+      bucketsQualifiedName: '"tenant-a"."buckets""table"',
+      filesQualifiedName: '"tenant-a"."files"',
+      uploadUrlExpirySeconds: 900,
+      maxBulkTotalSize: 1073741824,
+      hasPathShares: false
+    });
+  });
+});

--- a/packages/express-context/src/billing-client.ts
+++ b/packages/express-context/src/billing-client.ts
@@ -15,6 +15,7 @@
 
 import { Logger } from '@pgpmjs/logger';
 
+import { quoteQualifiedSqlIdentifier } from './sql-identifiers';
 import type { BillingConfig, InferenceLogConfig, WithPgClient } from './types';
 
 const log = new Logger('billing-client');
@@ -48,7 +49,8 @@ export interface BillingClient {
    * Check if the entity has sufficient quota for the requested amount.
    * Returns true if allowed, false if quota is exceeded.
    *
-   * Gracefully returns true if billing is not provisioned or errors.
+   * Returns true when billing is not provisioned. Once billing is configured,
+   * lookup failures deny the request so quota enforcement cannot fail open.
    */
   checkQuota(meterSlug: string, amount?: number): Promise<boolean>;
 
@@ -79,14 +81,19 @@ export function createBillingClient(
 
       try {
         return await withPgClient(async (client) => {
-          const sql = `SELECT "${billing.privateSchema}"."${billing.checkBillingQuotaFunction}"($1, $2::uuid, $3) AS allowed`;
+          const fn = quoteQualifiedSqlIdentifier(
+            billing.privateSchema,
+            billing.checkBillingQuotaFunction,
+            'billing quota function'
+          );
+          const sql = `SELECT ${fn}($1, $2::uuid, $3) AS allowed`;
           const result = await client.query(sql, [meterSlug, entityId, amount]);
           return result.rows[0]?.allowed !== false;
         });
       } catch (e: unknown) {
         const message = e instanceof Error ? e.message : String(e);
-        log.warn(`check_billing_quota failed (allowing): ${message}`);
-        return true;
+        log.warn(`check_billing_quota failed (denying): ${message}`);
+        return false;
       }
     },
 
@@ -95,7 +102,12 @@ export function createBillingClient(
 
       try {
         await withPgClient(async (client) => {
-          const sql = `SELECT "${billing.privateSchema}"."${billing.recordUsageFunction}"($1, $2::uuid, $3, $4::jsonb)`;
+          const fn = quoteQualifiedSqlIdentifier(
+            billing.privateSchema,
+            billing.recordUsageFunction,
+            'billing usage function'
+          );
+          const sql = `SELECT ${fn}($1, $2::uuid, $3, $4::jsonb)`;
           await client.query(sql, [meterSlug, entityId, amount, JSON.stringify(metadata ?? {})]);
         });
       } catch (e: unknown) {
@@ -109,8 +121,13 @@ export function createBillingClient(
 
       try {
         await withPgClient(async (client) => {
+          const table = quoteQualifiedSqlIdentifier(
+            inferenceLog.schema,
+            inferenceLog.tableName,
+            'inference log table'
+          );
           await client.query(
-            `INSERT INTO "${inferenceLog.schema}"."${inferenceLog.tableName}"
+            `INSERT INTO ${table}
              (entity_id, actor_id, model, provider, service, operation,
               input_tokens, output_tokens, total_tokens, latency_ms, status,
               cache_read_tokens, cache_write_tokens,

--- a/packages/express-context/src/context.ts
+++ b/packages/express-context/src/context.ts
@@ -17,7 +17,13 @@
 import type { PgpmOptions } from '@pgpmjs/types';
 import type { NextFunction, Request, RequestHandler, Response } from 'express';
 import type { Pool } from 'pg';
-import { getPgPool } from 'pg-cache';
+import {
+  acquirePgPool,
+  getPgPool,
+  getPgPoolIdentity,
+  type GetPgPoolOptions,
+  type PgPoolLease
+} from 'pg-cache';
 
 import type { BillingClient } from './billing-client';
 import { createBillingClient } from './billing-client';
@@ -25,23 +31,69 @@ import type { LoaderRegistry } from './loaders/registry';
 import type { LoaderContext } from './loaders/types';
 import { withPgClient as withPgClientFn } from './pg-client';
 import { buildPgSettings } from './pg-settings';
-import type { BillingConfig, BuiltinModuleMap, ConstructiveContext, InferenceLogConfig, LlmConfig } from './types';
+import type { ApiStructure, BillingConfig, BuiltinModuleMap, ConstructiveContext, InferenceLogConfig, LlmConfig } from './types';
+
+type PoolConfig = Parameters<typeof acquirePgPool>[0];
+
+/**
+ * Secret-bearing connection config resolved by the owning server, paired with
+ * the opaque identity that both request context and Graphile must consume.
+ */
+export interface RuntimePgPoolResolution {
+  pgConfig: PoolConfig;
+  poolIdentity: string;
+}
 
 export interface ContextMiddlewareOptions {
   /** Base PG options for pool creation (host, port, user, password) */
   pg?: PgpmOptions['pg'];
+  /** Least-privilege tenant execution login; inherits unspecified pg fields. */
+  runtimePg?: PgpmOptions['pg'];
+  /**
+   * Read the server-owned request resolution. Implementations should keep raw
+   * credentials outside the Express request object (for example in a WeakMap).
+   */
+  getRuntimePgResolution?: (
+    req: Request,
+    api: ApiStructure
+  ) => Readonly<RuntimePgPoolResolution>;
+  /** Optional fail-closed admission check for the tenant execution pool. */
+  validateRuntimePool?: (pool: Pool, api: ApiStructure) => Promise<void>;
+  /** Ordered, audited extension/shared schemas used by request SQL. */
+  dependencySchemas?: readonly string[];
   /** Module loader registry for per-database cached lookups */
   loaders?: LoaderRegistry;
   /** Routing-plane schema loaders query (defaults to routing_public) */
   routingSchema?: string;
 }
 
+interface ResolvedPool {
+  pool: Pool;
+  identity: string;
+}
+
+const resolvePool = (
+  config: PoolConfig,
+  options: GetPgPoolOptions,
+  leases?: PgPoolLease[]
+): ResolvedPool => {
+  if (!leases) {
+    return {
+      pool: getPgPool(config, options),
+      identity: getPgPoolIdentity(config, options)
+    };
+  }
+  const lease = acquirePgPool(config, options);
+  leases.push(lease);
+  return { pool: lease.pool, identity: lease.identity };
+};
+
 /**
  * Create a `useModule` function bound to the given loader context.
  *
- * Calling `useModule('rlsModule')` lazily resolves the RLS loader,
- * hitting the DB only on cache miss. The function is a no-op (returns
- * undefined) when no registry is configured.
+ * Calling `useModule('rlsModule')` lazily resolves the RLS loader according to
+ * that loader's freshness policy. The function is a no-op (returns undefined)
+ * when no registry is configured.
  */
 function createUseModule(
   registry: LoaderRegistry | undefined,
@@ -65,7 +117,9 @@ function createUseModule(
  */
 export function buildContext(
   req: Request,
-  opts: ContextMiddlewareOptions = {}
+  opts: ContextMiddlewareOptions = {},
+  /** Internal request lifetime. Omit for backwards-compatible direct use. */
+  poolLeases?: PgPoolLease[]
 ): ConstructiveContext | null {
   const api = req.api;
   if (!api) return null;
@@ -77,30 +131,75 @@ export function buildContext(
     api,
     token,
     requestId,
-    clientIp: req.clientIp
+    clientIp: req.clientIp,
+    origin: req.get('origin'),
+    userAgent: req.get('User-Agent'),
+    deviceToken: req.deviceToken,
+    dependencySchemas: opts.dependencySchemas
   });
 
-  const tenantPool: Pool = getPgPool({
+  const suppliedRuntimeResolution = opts.getRuntimePgResolution
+    ? opts.getRuntimePgResolution(req, api)
+    : undefined;
+  if (opts.getRuntimePgResolution && !suppliedRuntimeResolution) {
+    throw new Error(
+      'Runtime PostgreSQL resolution provider returned no exact identity'
+    );
+  }
+  const runtimeConfig = suppliedRuntimeResolution?.pgConfig ?? {
     ...opts.pg,
+    ...opts.runtimePg,
     database: api.dbname
-  });
+  };
+  const runtimePool = resolvePool(
+    runtimeConfig,
+    { purpose: 'runtime', sanitizeOnCheckout: true },
+    poolLeases
+  );
+  if (
+    suppliedRuntimeResolution
+    && runtimePool.identity !== suppliedRuntimeResolution.poolIdentity
+  ) {
+    throw new Error(
+      'Resolved runtime PostgreSQL pool identity changed before context acquisition'
+    );
+  }
+  const tenantPool = runtimePool.pool;
 
   // Build loader context (if registry provided and databaseId known)
   let loaderCtx: LoaderContext | null = null;
   if (opts.loaders && api.databaseId) {
-    const routingPool: Pool = getPgPool(opts.pg);
+    const routingPool = resolvePool(opts.pg ?? {}, {
+      purpose: 'routing-request-control',
+      sanitizeOnCheckout: true
+    }, poolLeases);
+    const controlTenantPool = resolvePool({
+      ...opts.pg,
+      database: api.dbname
+    }, {
+      purpose: 'tenant-request-control',
+      sanitizeOnCheckout: true
+    }, poolLeases);
     loaderCtx = {
-      routingPool,
+      routingPool: routingPool.pool,
+      routingPoolIdentity: routingPool.identity,
       routingSchema: opts.routingSchema,
-      tenantPool,
+      tenantPool: controlTenantPool.pool,
+      tenantPoolIdentity: controlTenantPool.identity,
       databaseId: api.databaseId,
       apiId: api.apiId,
       dbname: api.dbname
     };
   }
 
+  let runtimeSafetyPromise: Promise<void> | null = null;
+  const ensureRuntimePoolIsSafe = (): Promise<void> => {
+    if (!opts.validateRuntimePool) return Promise.resolve();
+    runtimeSafetyPromise ??= opts.validateRuntimePool(tenantPool, api);
+    return runtimeSafetyPromise;
+  };
   const withPgClient = <T>(fn: (client: any) => Promise<T>) =>
-    withPgClientFn(tenantPool, pgSettings, fn);
+    ensureRuntimePoolIsSafe().then(() => withPgClientFn(tenantPool, pgSettings, fn));
   const useModule = createUseModule(opts.loaders, loaderCtx);
 
   // Lazy-initialized billing client (cached per request)
@@ -116,6 +215,7 @@ export function buildContext(
     userId: token?.user_id ?? null,
     requestId,
     pool: tenantPool,
+    runtimePoolIdentity: runtimePool.identity,
     withPgClient,
     useModule,
     async useBilling() {
@@ -172,8 +272,8 @@ export function buildContext(
  * // Downstream middleware/routes call useModule on demand:
  * app.post('/v1/chat', async (req, res) => {
  *   const ctx = req.constructive;
- *   const rls = await ctx.useModule('rlsModule');       // only fires if not cached
- *   const auth = await ctx.useModule('authSettings');    // only fires if not cached
+ *   const rls = await ctx.useModule('rlsModule');        // authoritative read
+ *   const auth = await ctx.useModule('authSettings');    // authoritative read
  *   // webauthnSettings loader never fires if nobody asks for it
  * });
  * ```
@@ -181,11 +281,48 @@ export function buildContext(
 export function createContextMiddleware(
   opts: ContextMiddlewareOptions = {}
 ): RequestHandler {
-  return (req: Request, _res: Response, next: NextFunction): void => {
-    const ctx = buildContext(req, opts);
-    if (ctx) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const requestEnded = (): boolean =>
+      Boolean(
+        req.aborted
+        || req.socket?.destroyed
+        || res.destroyed
+        || res.writableEnded
+      );
+    if (requestEnded()) return;
+
+    const leases: PgPoolLease[] = [];
+    let released = false;
+    const releaseLeases = (): void => {
+      if (released) return;
+      released = true;
+      req.removeListener('aborted', releaseLeases);
+      res.removeListener('finish', releaseLeases);
+      res.removeListener('close', releaseLeases);
+      for (const lease of leases.reverse()) lease.release();
+    };
+
+    try {
+      const ctx = buildContext(req, opts, leases);
+      if (!ctx) {
+        releaseLeases();
+        next();
+        return;
+      }
       req.constructive = ctx;
+      req.once('aborted', releaseLeases);
+      res.once('finish', releaseLeases);
+      res.once('close', releaseLeases);
+      // The response may have ended while the synchronous context builder was
+      // acquiring its pool leases, before these listeners could be attached.
+      if (requestEnded()) {
+        releaseLeases();
+        return;
+      }
+      next();
+    } catch (error) {
+      releaseLeases();
+      next(error);
     }
-    next();
   };
 }

--- a/packages/express-context/src/index.ts
+++ b/packages/express-context/src/index.ts
@@ -9,7 +9,7 @@
  *   - withPgClient (tenant-scoped RLS transaction helper)
  *   - requestId middleware (UUID correlation ID)
  *   - Context middleware (composes all of the above into req.constructive)
- *   - Module loaders (pluggable per-database cached lookups)
+ *   - Module loaders (pluggable authoritative or hard-TTL lookups)
  *
  * @example
  * ```typescript
@@ -28,8 +28,8 @@
  *
  * app.post('/v1/chat', async (req, res) => {
  *   const ctx = req.constructive;
- *   const rls = await ctx.useModule('rlsModule');       // only fires if not cached
- *   const auth = await ctx.useModule('authSettings');    // only fires if not cached
+ *   const rls = await ctx.useModule('rlsModule');        // authoritative read
+ *   const auth = await ctx.useModule('authSettings');    // authoritative read
  *   // webauthnSettings loader never fires if nobody asks for it
  * });
  * ```
@@ -45,6 +45,7 @@ export type {
   AuthSurface,
   BillingConfig,
   BuiltinModuleMap,
+  ComputeBindingConfig,
   ComputeConfig,
   ComputeModuleConfig,
   ConstructiveAPIToken,
@@ -56,6 +57,8 @@ export type {
   LlmConfig,
   PubkeyChallengeSettings,
   RlsModule,
+  StorageConfig,
+  StorageModuleConfig,
   WebauthnSettings,
   WithPgClient,
 } from './types';
@@ -65,8 +68,15 @@ export type { BillingClient, InferenceLogEntry } from './billing-client';
 export { createBillingClient } from './billing-client';
 
 // pgSettings builder
-export type { PgSettingsInput } from './pg-settings';
-export { buildPgSettings } from './pg-settings';
+export type { PgSettingsInput, SecurityGucKey } from './pg-settings';
+export { buildPgSettings, SECURITY_GUC_KEYS } from './pg-settings';
+
+// Safe interpolation for trusted metadata identifiers. Request values still
+// belong in query parameters.
+export {
+  quoteQualifiedSqlIdentifier,
+  quoteSqlIdentifier
+} from './sql-identifiers';
 
 // withPgClient helper
 export { withPgClient } from './pg-client';
@@ -75,7 +85,10 @@ export { withPgClient } from './pg-client';
 export { requestIdMiddleware } from './request-id';
 
 // Context middleware
-export type { ContextMiddlewareOptions } from './context';
+export type {
+  ContextMiddlewareOptions,
+  RuntimePgPoolResolution
+} from './context';
 export { buildContext, createContextMiddleware } from './context';
 
 // Module loaders
@@ -103,6 +116,7 @@ export {
   requireDatabaseId,
   requireIdentityProvider,
   rlsLoader,
+  storageLoader,
   webauthnLoader,
 } from './loaders';
 

--- a/packages/express-context/src/loaders/agent-chat.ts
+++ b/packages/express-context/src/loaders/agent-chat.ts
@@ -23,9 +23,10 @@ const AGENT_CHAT_MODULE_SQL = `
     acm.message_table_name,
     acm.task_table_name
   FROM metaschema_modules_public.agent_chat_module acm
-  JOIN metaschema_public.schema s ON s.id = acm.schema_id
+  JOIN metaschema_public.schema s
+    ON s.id = acm.schema_id
+   AND s.database_id = acm.database_id
   WHERE acm.database_id = $1
-  LIMIT 1
 `;
 
 // ─── Row Types ──────────────────────────────────────────────────────────────
@@ -50,6 +51,9 @@ export const agentChatLoader: ModuleLoader<AgentChatConfig> = createModuleLoader
       AGENT_CHAT_MODULE_SQL,
       [databaseId],
     );
+    if (result.rows.length > 1) {
+      throw new Error('Ambiguous agent chat module configuration');
+    }
     const row = result.rows[0];
     if (!row) return undefined;
 

--- a/packages/express-context/src/loaders/auth-settings.ts
+++ b/packages/express-context/src/loaders/auth-settings.ts
@@ -16,6 +16,7 @@
  * makes that resolution sticky for its TTL.
  */
 
+import { quoteQualifiedSqlIdentifier } from '../sql-identifiers';
 import type { AuthSettings } from '../types';
 import { createModuleLoader } from './create-loader';
 import type { LoaderContext, ModuleLoader } from './types';
@@ -26,9 +27,10 @@ import { requireDatabaseId } from './types';
 const AUTH_SETTINGS_DISCOVERY_SQL = `
   SELECT s.schema_name, sm.auth_settings_table_name AS table_name
   FROM metaschema_modules_public.sessions_module sm
-  JOIN metaschema_public.schema s ON s.id = sm.schema_id
+  JOIN metaschema_public.schema s
+    ON s.id = sm.schema_id
+   AND s.database_id = sm.database_id
   WHERE sm.database_id = $1
-  LIMIT 1
 `;
 
 const buildAuthSettingsQuery = (schemaName: string, tableName: string) => `
@@ -42,7 +44,7 @@ const buildAuthSettingsQuery = (schemaName: string, tableName: string) => `
     remember_me_duration,
     enable_captcha,
     captcha_site_key
-  FROM "${schemaName}"."${tableName}"
+  FROM ${quoteQualifiedSqlIdentifier(schemaName, tableName, 'auth settings table')}
   LIMIT 1
 `;
 
@@ -64,7 +66,9 @@ interface AuthSettingsRow {
 
 export const authSettingsLoader: ModuleLoader<AuthSettings> = createModuleLoader<AuthSettings>({
   name: 'authSettings',
-  ttlMs: 5 * 60_000,
+  // Cookie and CAPTCHA policy changes must take effect on the next request,
+  // independently of lossy LISTEN delivery.
+  cache: false,
   async resolve(ctx: LoaderContext) {
     const { tenantPool, databaseId } = ctx;
     requireDatabaseId(databaseId, 'authSettings');
@@ -74,6 +78,9 @@ export const authSettingsLoader: ModuleLoader<AuthSettings> = createModuleLoader
       AUTH_SETTINGS_DISCOVERY_SQL,
       [databaseId]
     );
+    if (discovery.rows.length > 1) {
+      throw new Error('Ambiguous sessions module configuration');
+    }
     const resolved = discovery.rows[0];
     if (!resolved) return undefined;
 

--- a/packages/express-context/src/loaders/billing.ts
+++ b/packages/express-context/src/loaders/billing.ts
@@ -17,10 +17,13 @@ const BILLING_MODULE_SQL = `
     ps.schema_name AS private_schema,
     bm.record_usage_function
   FROM metaschema_modules_public.billing_module bm
-  JOIN metaschema_public.schema s ON bm.schema_id = s.id
-  JOIN metaschema_public.schema ps ON bm.private_schema_id = ps.id
+  JOIN metaschema_public.schema s
+    ON bm.schema_id = s.id
+   AND s.database_id = bm.database_id
+  JOIN metaschema_public.schema ps
+    ON bm.private_schema_id = ps.id
+   AND ps.database_id = bm.database_id
   WHERE bm.database_id = $1
-  LIMIT 1
 `;
 
 // ─── Row Types ──────────────────────────────────────────────────────────────
@@ -43,8 +46,14 @@ export const billingLoader: ModuleLoader<BillingConfig> = createModuleLoader<Bil
       BILLING_MODULE_SQL,
       [databaseId],
     );
+    if (result.rows.length > 1) {
+      throw new Error('Ambiguous billing module configuration');
+    }
     const row = result.rows[0];
-    if (!row?.record_usage_function) return undefined;
+    if (!row) return undefined;
+    if (!row.public_schema || !row.private_schema || !row.record_usage_function) {
+      throw new Error('Incomplete or cross-database billing module configuration');
+    }
 
     return {
       publicSchema: row.public_schema,

--- a/packages/express-context/src/loaders/compute.ts
+++ b/packages/express-context/src/loaders/compute.ts
@@ -12,9 +12,10 @@
  * the underlying tables governs access.
  */
 
-import type { ComputeConfig } from '../types';
-import { createModuleLoader } from './create-loader';
+import type { ComputeBindingConfig, ComputeConfig, ComputeModuleConfig } from '../types';
+import { quoteQualifiedSqlIdentifier } from '../sql-identifiers';
 import type { LoaderContext, ModuleLoader } from './types';
+import { createModuleLoader } from './create-loader';
 
 // ─── SQL ────────────────────────────────────────────────────────────────────
 
@@ -27,10 +28,14 @@ const COMPUTE_MODULE_SQL = `
     ivm.invocations_table_name,
     ivm.entity_field AS invocations_entity_field
   FROM metaschema_modules_public.function_module fm
-  JOIN metaschema_public.schema fs ON fs.id = fm.schema_id
+  JOIN metaschema_public.schema fs
+    ON fs.id = fm.schema_id
+   AND fs.database_id = fm.database_id
   JOIN metaschema_modules_public.function_invocation_module ivm
     ON ivm.database_id = fm.database_id AND ivm.scope = fm.scope
-  JOIN metaschema_public.schema ivs ON ivs.id = ivm.schema_id
+  JOIN metaschema_public.schema ivs
+    ON ivs.id = ivm.schema_id
+   AND ivs.database_id = ivm.database_id
   WHERE fm.database_id = $1
   ORDER BY fs.schema_name
 `;
@@ -46,6 +51,32 @@ interface ComputeModuleRow {
   invocations_entity_field: string | null;
 }
 
+interface ComputeBindingRow {
+  id: string;
+  alias: string;
+  config: Record<string, unknown> | null;
+  function_definition_id: string;
+  task_identifier: string;
+  description: string | null;
+  payload_args: ComputeBindingConfig['payloadArgs'];
+}
+
+const bindingSql = (module: ComputeModuleConfig): string => `
+  SELECT
+    b.id,
+    b.alias,
+    b.config,
+    b.function_definition_id,
+    d.task_identifier,
+    d.description,
+    d.payload_args
+  FROM ${quoteQualifiedSqlIdentifier(module.schemaName, module.bindingsTableName, 'compute bindings table')} b
+  JOIN ${quoteQualifiedSqlIdentifier(module.schemaName, module.definitionsTableName, 'compute definitions table')} d
+    ON d.id = b.function_definition_id
+  WHERE b.api_id = $1
+  ORDER BY b.alias
+`;
+
 // ─── Loader ─────────────────────────────────────────────────────────────────
 
 export const computeLoader: ModuleLoader<ComputeConfig> = createModuleLoader<ComputeConfig>({
@@ -60,8 +91,7 @@ export const computeLoader: ModuleLoader<ComputeConfig> = createModuleLoader<Com
     );
     if (result.rows.length === 0) return undefined;
 
-    return {
-      modules: result.rows.map((row) => ({
+    const modules: ComputeModuleConfig[] = result.rows.map((row) => ({
         schemaName: row.functions_schema_name,
         definitionsTableName: row.definitions_table_name,
         // Physical bindings table name, recorded by the metaschema generator
@@ -72,8 +102,27 @@ export const computeLoader: ModuleLoader<ComputeConfig> = createModuleLoader<Com
         invocationsTableName: row.invocations_table_name,
         // Scope-key column of the invocations table (entity_field), or NULL
         // for global scopes. Consumers set this column on inserts.
-        invocationsEntityField: row.invocations_entity_field,
-      })),
-    };
+        invocationsEntityField: row.invocations_entity_field
+      }));
+    const bindings = ctx.apiId
+      ? (await Promise.all(modules.map(async (module) => {
+          const bindingResult = await tenantPool.query<ComputeBindingRow>(
+            bindingSql(module),
+            [ctx.apiId]
+          );
+          return bindingResult.rows.map((row): ComputeBindingConfig => ({
+            bindingId: row.id,
+            alias: row.alias,
+            config: row.config,
+            functionDefinitionId: row.function_definition_id,
+            taskIdentifier: row.task_identifier,
+            description: row.description,
+            payloadArgs: row.payload_args,
+            module
+          }));
+        }))).flat()
+      : [];
+
+    return { modules, bindings };
   },
 });

--- a/packages/express-context/src/loaders/cors.ts
+++ b/packages/express-context/src/loaders/cors.ts
@@ -36,7 +36,8 @@ interface CorsSettingsRow {
 
 export const corsLoader: ModuleLoader<string[]> = createModuleLoader<string[]>({
   name: 'corsOrigins',
-  ttlMs: 5 * 60_000,
+  // Revoking an allowed browser/WebSocket origin is a security policy change.
+  cache: false,
   async resolve(ctx: LoaderContext) {
     const { routingPool, databaseId, apiId } = ctx;
     const schema = routingSchemaOf(ctx);

--- a/packages/express-context/src/loaders/create-loader.ts
+++ b/packages/express-context/src/loaders/create-loader.ts
@@ -1,85 +1,205 @@
 /**
- * create-loader — Factory for building cached ModuleLoader instances.
+ * create-loader — Factory for building ModuleLoader instances.
  *
- * Wraps a raw resolve function with an LRU cache keyed by databaseId:apiId.
- * Each loader gets its own independent cache with configurable TTL and
- * max entries.
+ * Optionally wraps a raw resolve function with an LRU cache keyed by the exact
+ * routing and tenant pool identities plus databaseId:apiId. Each cached loader
+ * gets its own independent hard TTL and max entries.
  */
 
 import { Logger } from '@pgpmjs/logger';
 import { LRUCache } from 'lru-cache';
 
-import type { LoaderContext, ModuleLoader } from './types';
+import {
+  type LoaderContext,
+  type ModuleLoader,
+  routingSchemaOf
+} from './types';
 
 export interface CreateLoaderOptions<T> {
   /** Unique loader name (used in log prefix and modules map key) */
   name: string;
+  /**
+   * Whether successful/absent results may be shared across requests.
+   * Security-boundary configuration should set this to false so every
+   * request observes an authoritative database read.
+   */
+  cache?: boolean;
   /** TTL in milliseconds (default: 60_000 — 1 minute) */
   ttlMs?: number;
-  /** Max cache entries before LRU eviction (default: 100) */
+  /** Max cache entries before LRU eviction (default: 1024) */
   max?: number;
   /** The actual resolution function. Called on cache miss. */
   resolve: (ctx: LoaderContext) => Promise<T | undefined>;
 }
 
 const DEFAULT_TTL_MS = 60_000;
-const DEFAULT_MAX = 100;
+// Match the Graphile instance governor's hard ceiling. A smaller hidden
+// metadata cache would thrash control-plane queries long before heap pressure
+// requires evicting the corresponding resident tenant handlers.
+const DEFAULT_MAX = 1024;
+
+let nextPoolObjectIdentity = 0;
+const poolObjectIdentities = new WeakMap<object, string>();
+
+const poolIdentity = (pool: object, explicitIdentity?: string): string => {
+  if (explicitIdentity?.trim()) return explicitIdentity;
+  let identity = poolObjectIdentities.get(pool);
+  if (!identity) {
+    identity = `pool-object:${++nextPoolObjectIdentity}`;
+    poolObjectIdentities.set(pool, identity);
+  }
+  return identity;
+};
+
+interface LoaderCacheContract {
+  databaseId: string;
+  routingSchema: string;
+  routingPoolIdentity: string;
+  tenantPoolIdentity: string;
+}
+
+const cacheContract = (ctx: LoaderContext): LoaderCacheContract => ({
+  databaseId: ctx.databaseId,
+  routingSchema: routingSchemaOf(ctx),
+  routingPoolIdentity: poolIdentity(ctx.routingPool, ctx.routingPoolIdentity),
+  tenantPoolIdentity: poolIdentity(ctx.tenantPool, ctx.tenantPoolIdentity)
+});
+
+const cacheKey = (ctx: LoaderContext, contract: LoaderCacheContract): string =>
+  JSON.stringify([
+    contract.routingPoolIdentity,
+    contract.tenantPoolIdentity,
+    contract.routingSchema,
+    contract.databaseId,
+    ctx.apiId ?? null
+  ]);
+
+interface LoaderCacheEntry<T> {
+  contract: LoaderCacheContract;
+  value: T | undefined;
+}
+
+interface PendingResolution<T> {
+  contract: LoaderCacheContract;
+  invalidated: boolean;
+  promise: Promise<T | undefined>;
+}
+
+const samePhysicalContract = (
+  left: LoaderCacheContract,
+  right: LoaderCacheContract
+): boolean =>
+  left.routingPoolIdentity === right.routingPoolIdentity
+  && left.tenantPoolIdentity === right.tenantPoolIdentity
+  && left.routingSchema === right.routingSchema;
 
 export function createModuleLoader<T>(opts: CreateLoaderOptions<T>): ModuleLoader<T> {
   const log = new Logger(`loader:${opts.name}`);
-  const cache = new LRUCache<string, T | undefined>({
+  const cacheEnabled = opts.cache !== false;
+  const cache = new LRUCache<string, LoaderCacheEntry<T>>({
     max: opts.max ?? DEFAULT_MAX,
     ttl: opts.ttlMs ?? DEFAULT_TTL_MS,
-    updateAgeOnGet: true,
-    allowStale: false,
+    ttlResolution: 0,
+    // A hit must never extend configuration lifetime indefinitely. This is a
+    // hard maximum staleness bound for non-security-sensitive module data.
+    updateAgeOnGet: false,
+    allowStale: false
   });
+  const pending = new Map<string, PendingResolution<T>>();
 
   return {
     name: opts.name,
 
     async resolve(ctx: LoaderContext): Promise<T | undefined> {
-      const key = ctx.apiId ? `${ctx.databaseId}:${ctx.apiId}` : ctx.databaseId;
+      const logicalKey = ctx.apiId
+        ? `${ctx.databaseId}:${ctx.apiId}`
+        : ctx.databaseId;
 
-      if (cache.has(key)) {
-        log.debug(`Cache HIT databaseId=${key}`);
-        return cache.get(key);
+      if (!cacheEnabled) {
+        log.debug(`Authoritative resolve databaseId=${logicalKey}`);
+        try {
+          return await opts.resolve(ctx);
+        } catch (e: any) {
+          if (e.code === '42P01') {
+            log.debug(`Module tables absent for databaseId=${logicalKey}: ${e.message}`);
+            return undefined;
+          }
+          log.warn(`Failed to resolve databaseId=${logicalKey}: ${e.message}`);
+          throw e;
+        }
       }
 
-      log.debug(`Cache MISS databaseId=${key}, resolving`);
+      const contract = cacheContract(ctx);
+      const key = cacheKey(ctx, contract);
+      const cached = cache.get(key);
+      if (cached !== undefined) {
+        log.debug(`Cache HIT databaseId=${logicalKey}`);
+        return cached.value;
+      }
+
+      const existing = pending.get(key);
+      if (existing && !existing.invalidated) {
+        log.debug(`Cache COALESCE databaseId=${logicalKey}`);
+        return existing.promise;
+      }
+
+      log.debug(`Cache MISS databaseId=${logicalKey}, resolving`);
       // "Not provisioned" is expressed by the loader returning undefined, or
       // by the module's tables not existing at all (42P01 undefined_table).
       // Any other resolution error (bad query, ambiguous config) propagates —
       // never silently coerced into "module absent".
-      try {
-        const value = await opts.resolve(ctx);
-        cache.set(key, value);
-        return value;
-      } catch (e: any) {
-        if (e.code === '42P01') {
-          log.debug(`Module tables absent for databaseId=${key}: ${e.message}`);
-          cache.set(key, undefined);
-          return undefined;
+      const resolution: PendingResolution<T> = {
+        contract,
+        invalidated: false,
+        promise: undefined as unknown as Promise<T | undefined>
+      };
+      resolution.promise = Promise.resolve().then(async () => {
+        try {
+          const value = await opts.resolve(ctx);
+          if (!resolution.invalidated) cache.set(key, { contract, value });
+          return value;
+        } catch (e: any) {
+          if (e.code === '42P01') {
+            log.debug(`Module tables absent for databaseId=${logicalKey}: ${e.message}`);
+            if (!resolution.invalidated) {
+              cache.set(key, { contract, value: undefined });
+            }
+            return undefined;
+          }
+          log.warn(`Failed to resolve databaseId=${logicalKey}: ${e.message}`);
+          throw e;
+        } finally {
+          if (pending.get(key) === resolution) pending.delete(key);
         }
-        log.warn(`Failed to resolve databaseId=${key}: ${e.message}`);
-        throw e;
-      }
+      });
+      pending.set(key, resolution);
+      return resolution.promise;
     },
 
-    invalidate(databaseId?: string): void {
-      if (databaseId) {
-        // Clear the plain databaseId key and any composite databaseId:apiId keys
-        let cleared = 0;
-        for (const k of cache.keys()) {
-          if (k === databaseId || k.startsWith(`${databaseId}:`)) {
-            cache.delete(k);
-            cleared++;
-          }
-        }
-        log.debug(`Invalidated ${cleared} entries for databaseId=${databaseId}`);
-      } else {
+    invalidate(databaseId?: string, context?: LoaderContext): void {
+      if (!databaseId && !context) {
+        const previousSize = cache.size;
         cache.clear();
-        log.debug(`Invalidated all entries (was size=${cache.size})`);
+        for (const resolution of pending.values()) resolution.invalidated = true;
+        log.debug(`Invalidated all entries (was size=${previousSize})`);
+        return;
       }
+
+      const exact = context ? cacheContract(context) : null;
+      const matches = (contract: LoaderCacheContract): boolean =>
+        (!databaseId || contract.databaseId === databaseId)
+        && (!exact || samePhysicalContract(contract, exact));
+      let cleared = 0;
+      for (const [key, entry] of cache.entries()) {
+        if (!matches(entry.contract)) continue;
+        if (cache.delete(key)) cleared++;
+      }
+      for (const resolution of pending.values()) {
+        if (matches(resolution.contract)) resolution.invalidated = true;
+      }
+      log.debug(
+        `Invalidated ${cleared} entries${databaseId ? ` for databaseId=${databaseId}` : ''}`
+      );
     },
 
     get cacheSize(): number {

--- a/packages/express-context/src/loaders/database-settings.ts
+++ b/packages/express-context/src/loaders/database-settings.ts
@@ -30,7 +30,6 @@ const databaseSettingsSql = (schema: string): string => `
   FROM "${schema}".database_settings ds
   LEFT JOIN "${schema}".api_settings aps ON ds.database_id = aps.database_id AND aps.api_id = $2
   WHERE ds.database_id = $1
-  LIMIT 1
 `;
 
 // ─── Row Types ──────────────────────────────────────────────────────────────
@@ -50,11 +49,28 @@ interface DatabaseSettingsRow {
   resolved_enable_i18n: boolean;
 }
 
+const BOOLEAN_COLUMNS: readonly (keyof DatabaseSettingsRow)[] = [
+  'resolved_enable_aggregates',
+  'resolved_enable_postgis',
+  'resolved_enable_search',
+  'resolved_enable_direct_uploads',
+  'resolved_enable_presigned_uploads',
+  'resolved_enable_many_to_many',
+  'resolved_enable_connection_filter',
+  'resolved_enable_ltree',
+  'resolved_enable_llm',
+  'resolved_enable_realtime',
+  'resolved_enable_bulk',
+  'resolved_enable_i18n'
+];
+
 // ─── Loader ─────────────────────────────────────────────────────────────────
 
 export const databaseSettingsLoader: ModuleLoader<DatabaseSettings> = createModuleLoader<DatabaseSettings>({
   name: 'databaseSettings',
-  ttlMs: 5 * 60_000,
+  // These flags select the executable Graphile/plugin surface and realtime
+  // admission, so a disable/revocation must alter the next build contract.
+  cache: false,
   async resolve(ctx: LoaderContext) {
     const { routingPool, databaseId, apiId } = ctx;
 
@@ -62,8 +78,18 @@ export const databaseSettingsLoader: ModuleLoader<DatabaseSettings> = createModu
       databaseSettingsSql(routingSchemaOf(ctx)),
       [databaseId, apiId ?? null]
     );
+    if (result.rows.length > 1) {
+      throw new Error(
+        `Ambiguous database feature configuration for database ${databaseId}`
+      );
+    }
     const row = result.rows[0];
     if (!row) return undefined;
+    if (BOOLEAN_COLUMNS.some((column) => typeof row[column] !== 'boolean')) {
+      throw new Error(
+        `Incomplete database feature configuration for database ${databaseId}`
+      );
+    }
 
     return {
       enableAggregates: row.resolved_enable_aggregates,

--- a/packages/express-context/src/loaders/index.ts
+++ b/packages/express-context/src/loaders/index.ts
@@ -55,6 +55,7 @@ export { inferenceLogLoader } from './inference-log';
 export { llmLoader } from './llm';
 export { pubkeyLoader } from './pubkey';
 export { rlsLoader } from './rls';
+export { storageLoader } from './storage';
 export { webauthnLoader } from './webauthn';
 
 /**
@@ -72,6 +73,7 @@ import { llmLoader } from './llm';
 import { pubkeyLoader } from './pubkey';
 import { createLoaderRegistry } from './registry';
 import { rlsLoader } from './rls';
+import { storageLoader } from './storage';
 import { webauthnLoader } from './webauthn';
 
 export function createDefaultRegistry() {
@@ -88,5 +90,6 @@ export function createDefaultRegistry() {
   registry.register(agentChatLoader);
   registry.register(llmLoader);
   registry.register(computeLoader);
+  registry.register(storageLoader);
   return registry;
 }

--- a/packages/express-context/src/loaders/inference-log.ts
+++ b/packages/express-context/src/loaders/inference-log.ts
@@ -16,9 +16,10 @@ const INFERENCE_LOG_MODULE_SQL = `
     s.schema_name AS schema,
     ilm.inference_log_table_name AS table_name
   FROM metaschema_modules_public.inference_log_module ilm
-  JOIN metaschema_public.schema s ON ilm.schema_id = s.id
+  JOIN metaschema_public.schema s
+    ON ilm.schema_id = s.id
+   AND s.database_id = ilm.database_id
   WHERE ilm.database_id = $1
-  LIMIT 1
 `;
 
 // ─── Row Types ──────────────────────────────────────────────────────────────
@@ -40,8 +41,14 @@ export const inferenceLogLoader: ModuleLoader<InferenceLogConfig> = createModule
       INFERENCE_LOG_MODULE_SQL,
       [databaseId],
     );
+    if (result.rows.length > 1) {
+      throw new Error('Ambiguous inference-log module configuration');
+    }
     const row = result.rows[0];
-    if (!row?.schema || !row?.table_name) return undefined;
+    if (!row) return undefined;
+    if (!row.schema || !row.table_name) {
+      throw new Error('Incomplete or cross-database inference-log configuration');
+    }
 
     return {
       schema: row.schema,

--- a/packages/express-context/src/loaders/llm.ts
+++ b/packages/express-context/src/loaders/llm.ts
@@ -28,7 +28,6 @@ const LLM_MODULE_SQL = `
     lm.rag_context_limit
   FROM metaschema_modules_public.llm_module lm
   WHERE lm.database_id = $1
-  LIMIT 1
 `;
 
 // ─── Row Types ──────────────────────────────────────────────────────────────
@@ -58,6 +57,9 @@ export const llmLoader: ModuleLoader<LlmConfig> = createModuleLoader<LlmConfig>(
       LLM_MODULE_SQL,
       [databaseId],
     );
+    if (result.rows.length > 1) {
+      throw new Error('Ambiguous LLM module configuration');
+    }
     const row = result.rows[0];
     if (!row) return undefined;
 

--- a/packages/express-context/src/loaders/pubkey.ts
+++ b/packages/express-context/src/loaders/pubkey.ts
@@ -22,13 +22,26 @@ const pubkeySettingsSql = (schema: string): string => `
     sign_in_fail_fn.name AS sign_in_record_failure,
     sign_in_fn.name AS sign_in_with_challenge
   FROM "${schema}".pubkey_settings ps
-  LEFT JOIN metaschema_public.schema s ON ps.schema_id = s.id
-  LEFT JOIN metaschema_public.function sign_up_fn ON ps.sign_up_with_key_function_id = sign_up_fn.id
-  LEFT JOIN metaschema_public.function sign_in_req_fn ON ps.sign_in_request_challenge_function_id = sign_in_req_fn.id
-  LEFT JOIN metaschema_public.function sign_in_fail_fn ON ps.sign_in_record_failure_function_id = sign_in_fail_fn.id
-  LEFT JOIN metaschema_public.function sign_in_fn ON ps.sign_in_with_challenge_function_id = sign_in_fn.id
+  LEFT JOIN metaschema_public.schema s
+    ON ps.schema_id = s.id
+   AND s.database_id = ps.database_id
+  LEFT JOIN metaschema_public.function sign_up_fn
+    ON ps.sign_up_with_key_function_id = sign_up_fn.id
+   AND sign_up_fn.database_id = ps.database_id
+   AND sign_up_fn.schema_id = ps.schema_id
+  LEFT JOIN metaschema_public.function sign_in_req_fn
+    ON ps.sign_in_request_challenge_function_id = sign_in_req_fn.id
+   AND sign_in_req_fn.database_id = ps.database_id
+   AND sign_in_req_fn.schema_id = ps.schema_id
+  LEFT JOIN metaschema_public.function sign_in_fail_fn
+    ON ps.sign_in_record_failure_function_id = sign_in_fail_fn.id
+   AND sign_in_fail_fn.database_id = ps.database_id
+   AND sign_in_fail_fn.schema_id = ps.schema_id
+  LEFT JOIN metaschema_public.function sign_in_fn
+    ON ps.sign_in_with_challenge_function_id = sign_in_fn.id
+   AND sign_in_fn.database_id = ps.database_id
+   AND sign_in_fn.schema_id = ps.schema_id
   WHERE ps.database_id = $1
-  LIMIT 1
 `;
 
 // ─── Row Types ──────────────────────────────────────────────────────────────
@@ -45,7 +58,18 @@ interface PubkeySettingsRow {
 // ─── Transforms ─────────────────────────────────────────────────────────────
 
 function fromRow(row: PubkeySettingsRow | null): PubkeyChallengeSettings | undefined {
-  if (!row?.schema || !row?.sign_up_with_key) return undefined;
+  if (!row) return undefined;
+  const required = [
+    row.schema,
+    row.crypto_network,
+    row.sign_up_with_key,
+    row.sign_in_request_challenge,
+    row.sign_in_record_failure,
+    row.sign_in_with_challenge
+  ];
+  if (required.some((value) => typeof value !== 'string' || value.length === 0)) {
+    throw new Error('Incomplete or cross-database public-key authentication configuration');
+  }
   return {
     schema: row.schema,
     cryptoNetwork: row.crypto_network,
@@ -60,10 +84,14 @@ function fromRow(row: PubkeySettingsRow | null): PubkeyChallengeSettings | undef
 
 export const pubkeyLoader: ModuleLoader<PubkeyChallengeSettings> = createModuleLoader<PubkeyChallengeSettings>({
   name: 'pubkeyChallengeSettings',
-  ttlMs: 5 * 60_000,
+  // Public-key authentication policy must be authoritative per request.
+  cache: false,
   async resolve(ctx: LoaderContext) {
     const { routingPool, databaseId } = ctx;
     const result = await routingPool.query<PubkeySettingsRow>(pubkeySettingsSql(routingSchemaOf(ctx)), [databaseId]);
+    if (result.rows.length > 1) {
+      throw new Error('Ambiguous public-key authentication configuration');
+    }
     return fromRow(result.rows[0] ?? null);
   }
 });

--- a/packages/express-context/src/loaders/registry.ts
+++ b/packages/express-context/src/loaders/registry.ts
@@ -40,8 +40,8 @@ export interface LoaderRegistry {
   /** Check whether a loader is registered. */
   has(name: string): boolean;
 
-  /** Invalidate caches for one database (or all databases if omitted). */
-  invalidate(databaseId?: string): void;
+  /** Invalidate caches for one database, optionally limited to an exact pool pair. */
+  invalidate(databaseId?: string, context?: LoaderContext): void;
 
   /** List all registered loader names. */
   readonly names: string[];
@@ -96,9 +96,9 @@ export function createLoaderRegistry(): LoaderRegistry {
       return loaders.has(name);
     },
 
-    invalidate(databaseId?: string): void {
+    invalidate(databaseId?: string, context?: LoaderContext): void {
       for (const loader of loaders.values()) {
-        loader.invalidate(databaseId);
+        loader.invalidate(databaseId, context);
       }
       log.debug(
         databaseId

--- a/packages/express-context/src/loaders/rls.ts
+++ b/packages/express-context/src/loaders/rls.ts
@@ -24,16 +24,37 @@ const rlsSettingsSql = (schema: string): string => `
     ua_fn.name AS current_user_agent,
     ip_fn.name AS current_ip_address
   FROM "${schema}".rls_settings rs
-  LEFT JOIN metaschema_public.schema auth_schema ON rs.authenticate_schema_id = auth_schema.id
-  LEFT JOIN metaschema_public.schema role_schema ON rs.role_schema_id = role_schema.id
-  LEFT JOIN metaschema_public.function auth_fn ON rs.authenticate_function_id = auth_fn.id
-  LEFT JOIN metaschema_public.function auth_strict_fn ON rs.authenticate_strict_function_id = auth_strict_fn.id
-  LEFT JOIN metaschema_public.function role_fn ON rs.current_role_function_id = role_fn.id
-  LEFT JOIN metaschema_public.function role_id_fn ON rs.current_role_id_function_id = role_id_fn.id
-  LEFT JOIN metaschema_public.function ua_fn ON rs.current_user_agent_function_id = ua_fn.id
-  LEFT JOIN metaschema_public.function ip_fn ON rs.current_ip_address_function_id = ip_fn.id
+  LEFT JOIN metaschema_public.schema auth_schema
+    ON rs.authenticate_schema_id = auth_schema.id
+   AND auth_schema.database_id = rs.database_id
+  LEFT JOIN metaschema_public.schema role_schema
+    ON rs.role_schema_id = role_schema.id
+   AND role_schema.database_id = rs.database_id
+  LEFT JOIN metaschema_public.function auth_fn
+    ON rs.authenticate_function_id = auth_fn.id
+   AND auth_fn.database_id = rs.database_id
+   AND auth_fn.schema_id = rs.authenticate_schema_id
+  LEFT JOIN metaschema_public.function auth_strict_fn
+    ON rs.authenticate_strict_function_id = auth_strict_fn.id
+   AND auth_strict_fn.database_id = rs.database_id
+   AND auth_strict_fn.schema_id = rs.authenticate_schema_id
+  LEFT JOIN metaschema_public.function role_fn
+    ON rs.current_role_function_id = role_fn.id
+   AND role_fn.database_id = rs.database_id
+   AND role_fn.schema_id = rs.role_schema_id
+  LEFT JOIN metaschema_public.function role_id_fn
+    ON rs.current_role_id_function_id = role_id_fn.id
+   AND role_id_fn.database_id = rs.database_id
+   AND role_id_fn.schema_id = rs.role_schema_id
+  LEFT JOIN metaschema_public.function ua_fn
+    ON rs.current_user_agent_function_id = ua_fn.id
+   AND ua_fn.database_id = rs.database_id
+   AND ua_fn.schema_id = rs.role_schema_id
+  LEFT JOIN metaschema_public.function ip_fn
+    ON rs.current_ip_address_function_id = ip_fn.id
+   AND ip_fn.database_id = rs.database_id
+   AND ip_fn.schema_id = rs.role_schema_id
   WHERE rs.database_id = $1
-  LIMIT 1
 `;
 
 // ─── Row Types ──────────────────────────────────────────────────────────────
@@ -53,7 +74,18 @@ interface RlsSettingsRow {
 
 function fromSettings(row: RlsSettingsRow | null): RlsModule | undefined {
   if (!row) return undefined;
-  if (!row.authenticate || !row.authenticate_schema) return undefined;
+  const required = [
+    row.authenticate,
+    row.authenticate_schema,
+    row.role_schema,
+    row.current_role,
+    row.current_role_id,
+    row.current_ip_address,
+    row.current_user_agent
+  ];
+  if (required.some((value) => typeof value !== 'string' || value.length === 0)) {
+    throw new Error('Incomplete or cross-database RLS module configuration');
+  }
   return {
     authenticate: row.authenticate,
     authenticateStrict: row.authenticate_strict,
@@ -70,10 +102,16 @@ function fromSettings(row: RlsSettingsRow | null): RlsModule | undefined {
 
 export const rlsLoader: ModuleLoader<RlsModule> = createModuleLoader<RlsModule>({
   name: 'rlsModule',
-  ttlMs: 5 * 60_000,
+  // Authentication routing is an authorization boundary. Resolve it from the
+  // routing plane on every request; LISTEN notifications and TTLs are not an
+  // acceptable revocation mechanism because notifications can be missed.
+  cache: false,
   async resolve(ctx: LoaderContext) {
     const { routingPool, databaseId } = ctx;
     const result = await routingPool.query<RlsSettingsRow>(rlsSettingsSql(routingSchemaOf(ctx)), [databaseId]);
+    if (result.rows.length > 1) {
+      throw new Error('Ambiguous RLS module configuration');
+    }
     return fromSettings(result.rows[0] ?? null);
   }
 });

--- a/packages/express-context/src/loaders/storage.ts
+++ b/packages/express-context/src/loaders/storage.ts
@@ -1,0 +1,157 @@
+/**
+ * Storage Module Loader
+ *
+ * Resolves immutable storage-module routing metadata through the privileged
+ * control-plane tenant pool. Graphile receives the normalized descriptors at
+ * build time, so its least-privilege runtime pool never reads metaschema
+ * configuration with `withPgClient(null)`.
+ */
+
+import { quoteQualifiedSqlIdentifier } from '../sql-identifiers';
+import type { StorageConfig, StorageModuleConfig } from '../types';
+import { createModuleLoader } from './create-loader';
+import type { LoaderContext, ModuleLoader } from './types';
+
+const DEFAULT_UPLOAD_URL_EXPIRY_SECONDS = 900;
+const DEFAULT_DOWNLOAD_URL_EXPIRY_SECONDS = 3600;
+const DEFAULT_MAX_FILE_SIZE = 200 * 1024 * 1024;
+const DEFAULT_MAX_FILENAME_LENGTH = 1024;
+const DEFAULT_CACHE_TTL_SECONDS = process.env.NODE_ENV === 'development' ? 300 : 3600;
+const DEFAULT_MAX_BULK_FILES = 100;
+const DEFAULT_MAX_BULK_TOTAL_SIZE = 1024 * 1024 * 1024;
+
+export const STORAGE_MODULE_SQL = `
+  SELECT
+    sm.id,
+    sm.scope,
+    sm.entity_table_id,
+    bs.schema_name AS buckets_schema,
+    bt.name AS buckets_table,
+    fs.schema_name AS files_schema,
+    ft.name AS files_table,
+    sm.endpoint,
+    sm.public_url_prefix,
+    sm.provider,
+    sm.allowed_origins,
+    sm.upload_url_expiry_seconds,
+    sm.download_url_expiry_seconds,
+    sm.default_max_file_size,
+    sm.max_filename_length,
+    sm.cache_ttl_seconds,
+    sm.max_bulk_files,
+    sm.max_bulk_total_size,
+    sm.has_path_shares,
+    es.schema_name AS entity_schema,
+    et.name AS entity_table
+  FROM metaschema_modules_public.storage_module sm
+  JOIN metaschema_public.table bt
+    ON bt.id = sm.buckets_table_id
+   AND bt.database_id = sm.database_id
+  JOIN metaschema_public.schema bs
+    ON bs.id = bt.schema_id
+   AND bs.database_id = sm.database_id
+  JOIN metaschema_public.table ft
+    ON ft.id = sm.files_table_id
+   AND ft.database_id = sm.database_id
+  JOIN metaschema_public.schema fs
+    ON fs.id = ft.schema_id
+   AND fs.database_id = sm.database_id
+  LEFT JOIN metaschema_public.table et
+    ON et.id = sm.entity_table_id
+   AND et.database_id = sm.database_id
+  LEFT JOIN metaschema_public.schema es
+    ON es.id = et.schema_id
+   AND es.database_id = sm.database_id
+  WHERE sm.database_id = $1
+  ORDER BY sm.scope, sm.id
+`;
+
+interface StorageModuleRow {
+  id: string;
+  scope: string;
+  entity_table_id: string | null;
+  buckets_schema: string;
+  buckets_table: string;
+  files_schema: string;
+  files_table: string;
+  endpoint: string | null;
+  public_url_prefix: string | null;
+  provider: string | null;
+  allowed_origins: string[] | null;
+  upload_url_expiry_seconds: number | string | null;
+  download_url_expiry_seconds: number | string | null;
+  default_max_file_size: number | string | null;
+  max_filename_length: number | string | null;
+  cache_ttl_seconds: number | string | null;
+  max_bulk_files: number | string | null;
+  max_bulk_total_size: number | string | null;
+  has_path_shares: boolean | null;
+  entity_schema: string | null;
+  entity_table: string | null;
+}
+
+const numberOr = (value: number | string | null, fallback: number): number => {
+  if (value == null) return fallback;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error(`Invalid storage module numeric setting '${value}'`);
+  }
+  return parsed;
+};
+
+export const normalizeStorageModule = (row: StorageModuleRow): StorageModuleConfig => ({
+  id: row.id,
+  bucketsQualifiedName: quoteQualifiedSqlIdentifier(
+    row.buckets_schema,
+    row.buckets_table,
+    'storage buckets table'
+  ),
+  filesQualifiedName: quoteQualifiedSqlIdentifier(
+    row.files_schema,
+    row.files_table,
+    'storage files table'
+  ),
+  schemaName: row.buckets_schema,
+  bucketsTableName: row.buckets_table,
+  filesTableName: row.files_table,
+  scope: row.scope,
+  entityTableId: row.entity_table_id,
+  entityQualifiedName: row.entity_schema && row.entity_table
+    ? quoteQualifiedSqlIdentifier(
+        row.entity_schema,
+        row.entity_table,
+        'storage entity table'
+      )
+    : null,
+  endpoint: row.endpoint,
+  publicUrlPrefix: row.public_url_prefix,
+  provider: row.provider,
+  allowedOrigins: row.allowed_origins,
+  uploadUrlExpirySeconds: numberOr(
+    row.upload_url_expiry_seconds,
+    DEFAULT_UPLOAD_URL_EXPIRY_SECONDS
+  ),
+  downloadUrlExpirySeconds: numberOr(
+    row.download_url_expiry_seconds,
+    DEFAULT_DOWNLOAD_URL_EXPIRY_SECONDS
+  ),
+  defaultMaxFileSize: numberOr(row.default_max_file_size, DEFAULT_MAX_FILE_SIZE),
+  maxFilenameLength: numberOr(row.max_filename_length, DEFAULT_MAX_FILENAME_LENGTH),
+  cacheTtlSeconds: numberOr(row.cache_ttl_seconds, DEFAULT_CACHE_TTL_SECONDS),
+  hasPathShares: row.has_path_shares ?? false,
+  maxBulkFiles: numberOr(row.max_bulk_files, DEFAULT_MAX_BULK_FILES),
+  maxBulkTotalSize: numberOr(row.max_bulk_total_size, DEFAULT_MAX_BULK_TOTAL_SIZE)
+});
+
+export const storageLoader: ModuleLoader<StorageConfig> = createModuleLoader<StorageConfig>({
+  name: 'storage',
+  ttlMs: 60_000,
+  async resolve(ctx: LoaderContext) {
+    const result = await ctx.tenantPool.query<StorageModuleRow>(
+      STORAGE_MODULE_SQL,
+      [ctx.databaseId]
+    );
+    if (result.rows.length === 0) return undefined;
+    return { modules: result.rows.map(normalizeStorageModule) };
+  }
+});

--- a/packages/express-context/src/loaders/types.ts
+++ b/packages/express-context/src/loaders/types.ts
@@ -1,9 +1,8 @@
 /**
  * Module Loader Types
  *
- * A ModuleLoader is a per-database cached lookup that resolves config
- * from the routing DB or tenant DB. Each loader owns its own LRU cache
- * keyed by databaseId, with independent TTL and eviction.
+ * A ModuleLoader resolves per-database config from the routing DB or tenant
+ * DB. Each loader chooses authoritative reads or an independent hard-TTL LRU.
  *
  * Loaders are registered in a LoaderRegistry and resolved in parallel
  * during context building. The result is a typed modules map on
@@ -56,10 +55,14 @@ export function requireDatabaseId(
 export interface LoaderContext {
   /** Routing/configuration database pool (for routing-plane lookups) */
   routingPool: Pool;
+  /** Opaque identity of the exact routing-pool connection contract. */
+  routingPoolIdentity?: string;
   /** Routing-plane schema to query (defaults to the published routing_public) */
   routingSchema?: string;
   /** Tenant database pool (for metaschema_modules_public.* lookups) */
   tenantPool: Pool;
+  /** Opaque identity of the exact tenant control-pool connection contract. */
+  tenantPoolIdentity?: string;
   /** UUID of the database being resolved */
   databaseId: string;
   /** UUID of the API (if resolved from domain/api-name lookup) */
@@ -69,16 +72,19 @@ export interface LoaderContext {
 }
 
 /**
- * A single module loader. Encapsulates the SQL query, type transform,
- * and per-databaseId LRU cache for one piece of per-database config.
+ * A single module loader. Encapsulates the SQL query, type transform, and
+ * freshness policy for one piece of per-database config.
  */
 export interface ModuleLoader<T = unknown> {
   /** Unique name (used in log prefix and as the key in the modules map) */
   readonly name: string;
   /** Resolve the module config for a given database. Returns undefined if not provisioned. */
   resolve(ctx: LoaderContext): Promise<T | undefined>;
-  /** Invalidate the cache for one database (or all databases if omitted) */
-  invalidate(databaseId?: string): void;
+  /**
+   * Invalidate one logical database across all physical pools, or only the
+   * exact pool pair represented by `context`. Omitting both clears everything.
+   */
+  invalidate(databaseId?: string, context?: LoaderContext): void;
   /** Current number of cached entries */
   readonly cacheSize: number;
 }

--- a/packages/express-context/src/loaders/webauthn.ts
+++ b/packages/express-context/src/loaders/webauthn.ts
@@ -26,12 +26,19 @@ const webauthnSettingsSql = (schema: string): string => `
     ws.resident_key,
     ws.challenge_expiry_seconds
   FROM "${schema}".webauthn_settings ws
-  LEFT JOIN metaschema_public.schema s ON ws.schema_id = s.id
-  LEFT JOIN metaschema_public.schema cred_s ON ws.credentials_schema_id = cred_s.id
-  LEFT JOIN metaschema_public.schema sess_s ON ws.sessions_schema_id = sess_s.id
-  LEFT JOIN metaschema_public.schema sec_s ON ws.session_secrets_schema_id = sec_s.id
+  LEFT JOIN metaschema_public.schema s
+    ON ws.schema_id = s.id
+   AND s.database_id = ws.database_id
+  LEFT JOIN metaschema_public.schema cred_s
+    ON ws.credentials_schema_id = cred_s.id
+   AND cred_s.database_id = ws.database_id
+  LEFT JOIN metaschema_public.schema sess_s
+    ON ws.sessions_schema_id = sess_s.id
+   AND sess_s.database_id = ws.database_id
+  LEFT JOIN metaschema_public.schema sec_s
+    ON ws.session_secrets_schema_id = sec_s.id
+   AND sec_s.database_id = ws.database_id
   WHERE ws.database_id = $1
-  LIMIT 1
 `;
 
 // ─── Row Types ──────────────────────────────────────────────────────────────
@@ -54,13 +61,36 @@ interface WebauthnSettingsRow {
 
 export const webauthnLoader: ModuleLoader<WebauthnSettings> = createModuleLoader<WebauthnSettings>({
   name: 'webauthnSettings',
-  ttlMs: 5 * 60_000,
+  // RP/origin/verification policy revocation must take effect immediately.
+  cache: false,
   async resolve(ctx: LoaderContext) {
     const { routingPool, databaseId } = ctx;
 
     const result = await routingPool.query<WebauthnSettingsRow>(webauthnSettingsSql(routingSchemaOf(ctx)), [databaseId]);
+    if (result.rows.length > 1) {
+      throw new Error('Ambiguous WebAuthn configuration');
+    }
     const row = result.rows[0];
-    if (!row?.schema) return undefined;
+    if (!row) return undefined;
+    const required = [
+      row.schema,
+      row.credentials_schema,
+      row.sessions_schema,
+      row.session_secrets_schema,
+      row.rp_id,
+      row.rp_name,
+      row.attestation_type,
+      row.resident_key
+    ];
+    if (
+      required.some((value) => typeof value !== 'string' || value.length === 0)
+      || !Array.isArray(row.origin_allowlist)
+      || typeof row.require_user_verification !== 'boolean'
+      || !Number.isSafeInteger(row.challenge_expiry_seconds)
+      || row.challenge_expiry_seconds <= 0
+    ) {
+      throw new Error('Incomplete or cross-database WebAuthn configuration');
+    }
 
     return {
       schema: row.schema,

--- a/packages/express-context/src/pg-settings.ts
+++ b/packages/express-context/src/pg-settings.ts
@@ -12,6 +12,56 @@
 
 import type { ApiStructure, ConstructiveAPIToken } from './types';
 
+export const SECURITY_GUC_KEYS = [
+  'jwt.claims.access_level',
+  'jwt.claims.api_id',
+  'jwt.claims.database_id',
+  'jwt.claims.device_token',
+  'jwt.claims.email',
+  'jwt.claims.entity_id',
+  'jwt.claims.ip_address',
+  'jwt.claims.kind',
+  'jwt.claims.organization_id',
+  'jwt.claims.origin',
+  'jwt.claims.principal_id',
+  'jwt.claims.role_type',
+  'jwt.claims.session_id',
+  'jwt.claims.tenant_id',
+  'jwt.claims.token_id',
+  'jwt.claims.user_agent',
+  'jwt.claims.user_email',
+  'jwt.claims.user_id'
+] as const;
+
+export type SecurityGucKey = typeof SECURITY_GUC_KEYS[number];
+
+const SECURITY_GUC_KEY_SET: ReadonlySet<string> = new Set(SECURITY_GUC_KEYS);
+
+const applyTrustedClaims = (
+  settings: Record<string, string>,
+  trustedClaims: PgSettingsInput['trustedClaims']
+): void => {
+  if (trustedClaims === undefined) return;
+  if (
+    typeof trustedClaims !== 'object'
+    || trustedClaims === null
+    || Array.isArray(trustedClaims)
+  ) {
+    throw new TypeError('trustedClaims must be an object of security GUC strings');
+  }
+
+  for (const key of Reflect.ownKeys(trustedClaims)) {
+    if (typeof key !== 'string' || !SECURITY_GUC_KEY_SET.has(key)) {
+      throw new TypeError(`trustedClaims contains unsupported security GUC '${String(key)}'`);
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(trustedClaims, key);
+    if (!descriptor || !('value' in descriptor) || typeof descriptor.value !== 'string') {
+      throw new TypeError(`trustedClaims.${key} must be a string data property`);
+    }
+    settings[key] = descriptor.value;
+  }
+};
+
 export interface PgSettingsInput {
   /** Resolved API config (provides role names, database_id) */
   api: ApiStructure;
@@ -21,7 +71,20 @@ export interface PgSettingsInput {
   requestId: string;
   /** Client IP address (from request-ip middleware) */
   clientIp?: string;
+  /** Origin header captured by the server */
+  origin?: string;
+  /** User-Agent header captured by the server */
+  userAgent?: string;
+  /** Trusted device cookie resolved by authentication middleware */
+  deviceToken?: string;
+  /** Server-derived claims for trusted private surfaces */
+  trustedClaims?: Partial<Record<SecurityGucKey, string>>;
+  /** Ordered, audited extension/shared schemas needed for runtime operators and functions. */
+  dependencySchemas?: readonly string[];
 }
+
+const quoteIdentifier = (identifier: string): string =>
+  `"${identifier.replace(/"/g, '""')}"`;
 
 /**
  * Build pgSettings from the resolved API + auth token.
@@ -30,8 +93,10 @@ export interface PgSettingsInput {
  * making them available to RLS policies and SQL functions.
  */
 export function buildPgSettings(input: PgSettingsInput): Record<string, string> {
-  const { api, token, requestId, clientIp } = input;
-  const settings: Record<string, string> = {};
+  const { api, token, requestId, clientIp, origin, userAgent, deviceToken } = input;
+  const settings: Record<string, string> = Object.fromEntries(
+    SECURITY_GUC_KEYS.map((key) => [key, ''])
+  );
 
   // Role: from token (authenticated) or api (anonymous fallback)
   if (token?.user_id) {
@@ -41,14 +106,24 @@ export function buildPgSettings(input: PgSettingsInput): Record<string, string> 
     settings['role'] = api.anonRole || 'anonymous';
   }
 
+  if (token?.id) settings['jwt.claims.token_id'] = token.id;
+  if (token?.access_level) settings['jwt.claims.access_level'] = token.access_level;
+  if (token?.kind) settings['jwt.claims.kind'] = token.kind;
+  if (typeof token?.email === 'string') settings['jwt.claims.email'] = token.email;
+  if (typeof token?.user_email === 'string') settings['jwt.claims.user_email'] = token.user_email;
+  if (typeof token?.entity_id === 'string') settings['jwt.claims.entity_id'] = token.entity_id;
+  if (typeof token?.organization_id === 'string') settings['jwt.claims.organization_id'] = token.organization_id;
+  if (typeof token?.tenant_id === 'string') settings['jwt.claims.tenant_id'] = token.tenant_id;
+  if (typeof token?.role_type === 'string') settings['jwt.claims.role_type'] = token.role_type;
+
   // Session claims
   if (token?.session_id) {
     settings['jwt.claims.session_id'] = token.session_id;
   }
 
   // Principal identity (service accounts / bots)
-  if (token?.principal_id) {
-    settings['jwt.claims.principal_id'] = token.principal_id;
+  if (token?.principal_id || token?.user_id) {
+    settings['jwt.claims.principal_id'] = token.principal_id || token.user_id || '';
   }
 
   // Database context
@@ -71,6 +146,28 @@ export function buildPgSettings(input: PgSettingsInput): Record<string, string> 
   if (clientIp) {
     settings['jwt.claims.ip_address'] = clientIp;
   }
+
+  if (origin) settings['jwt.claims.origin'] = origin;
+  if (userAgent) settings['jwt.claims.user_agent'] = userAgent;
+  if (deviceToken) settings['jwt.claims.device_token'] = deviceToken;
+  // This is an exported boundary and TypeScript types do not constrain runtime
+  // objects. Reject extra keys/accessors so a future caller cannot smuggle
+  // role, search_path, or other session state through this trusted seam.
+  applyTrustedClaims(settings, input.trustedClaims);
+
+  // Explicitly undo read-only state inherited from a previous request.
+  settings['transaction_read_only'] = token?.access_level === 'read_only' ? 'on' : 'off';
+  // Pin name resolution after SET ROLE. DISCARD ALL resets to role/database
+  // defaults, which are mutable control-plane state and must not route a
+  // request into an unapproved schema.
+  settings['search_path'] = [
+    'pg_catalog',
+    ...[...new Set(input.dependencySchemas ?? [])].map(quoteIdentifier),
+    ...api.schema.map(quoteIdentifier)
+  ].join(', ');
+  // Owners and BYPASSRLS logins are rejected separately, but this makes the
+  // intended RLS state explicit for every transaction and clears prior state.
+  settings['row_security'] = 'on';
 
   return settings;
 }

--- a/packages/express-context/src/sql-identifiers.ts
+++ b/packages/express-context/src/sql-identifiers.ts
@@ -1,0 +1,31 @@
+import { QuoteUtils } from '@pgsql/quotes';
+
+const POSTGRES_IDENTIFIER_MAX_BYTES = 63;
+
+/**
+ * Quote a metadata-derived PostgreSQL identifier without accepting values that
+ * PostgreSQL would truncate or that cannot be identifiers at all. Request data
+ * must still be passed as query parameters.
+ */
+export const quoteSqlIdentifier = (
+  identifier: string,
+  label = 'SQL identifier'
+): string => {
+  if (
+    typeof identifier !== 'string'
+    || identifier.length === 0
+    || identifier.includes('\0')
+    || Buffer.byteLength(identifier, 'utf8') > POSTGRES_IDENTIFIER_MAX_BYTES
+  ) {
+    throw new Error(`Invalid ${label}`);
+  }
+  const quoted = QuoteUtils.quoteIdentifier(identifier);
+  return quoted.startsWith('"') ? quoted : `"${quoted}"`;
+};
+
+export const quoteQualifiedSqlIdentifier = (
+  schema: string,
+  object: string,
+  label = 'qualified SQL identifier'
+): string =>
+  `${quoteSqlIdentifier(schema, `${label} schema`)}.${quoteSqlIdentifier(object, `${label} object`)}`;

--- a/packages/express-context/src/types.ts
+++ b/packages/express-context/src/types.ts
@@ -204,12 +204,54 @@ export interface ComputeModuleConfig {
   invocationsEntityField: string | null;
 }
 
+export interface ComputeBindingConfig {
+  bindingId: string;
+  alias: string;
+  config: Record<string, unknown> | null;
+  functionDefinitionId: string;
+  taskIdentifier: string;
+  description: string | null;
+  payloadArgs: Array<{ name: string; type: string }> | null;
+  module: ComputeModuleConfig;
+}
+
 /**
  * All function modules provisioned on the database. A database may have one
  * per scope; every module is exposed and RLS governs access to each.
  */
 export interface ComputeConfig {
   modules: ComputeModuleConfig[];
+  /** API-scoped binding metadata loaded with the control-plane tenant pool. */
+  bindings: ComputeBindingConfig[];
+}
+
+/** Immutable storage-module routing metadata loaded through the control plane. */
+export interface StorageModuleConfig {
+  id: string;
+  bucketsQualifiedName: string;
+  filesQualifiedName: string;
+  schemaName: string;
+  bucketsTableName: string;
+  filesTableName: string;
+  scope: string;
+  entityTableId: string | null;
+  entityQualifiedName: string | null;
+  endpoint: string | null;
+  publicUrlPrefix: string | null;
+  provider: string | null;
+  allowedOrigins: string[] | null;
+  uploadUrlExpirySeconds: number;
+  downloadUrlExpirySeconds: number;
+  defaultMaxFileSize: number;
+  maxFilenameLength: number;
+  cacheTtlSeconds: number;
+  hasPathShares: boolean;
+  maxBulkFiles: number;
+  maxBulkTotalSize: number;
+}
+
+export interface StorageConfig {
+  modules: StorageModuleConfig[];
 }
 
 export interface LlmConfig {
@@ -249,6 +291,7 @@ export interface BuiltinModuleMap {
   agentChat: AgentChatConfig;
   llm: LlmConfig;
   compute: ComputeConfig;
+  storage: StorageConfig;
 }
 
 // ─── Constructive Context ───────────────────────────────────────────────────
@@ -280,14 +323,16 @@ export interface ConstructiveContext {
   requestId: string;
   /** Tenant database connection pool */
   pool: Pool;
+  /** Opaque exact identity of the tenant execution pool. */
+  runtimePoolIdentity: string;
   /** Execute a function within a tenant-scoped RLS transaction */
   withPgClient: WithPgClient;
 
   /**
-   * Resolve a per-database module on demand (lazy, cached).
+   * Resolve a per-database module on demand.
    *
-   * Only fires the SQL query on the first call per databaseId per TTL window.
-   * Subsequent calls return the cached result instantly.
+   * Each loader owns its freshness policy. Security-sensitive built-ins read
+   * authoritatively on every call; nonsecurity loaders may use a hard TTL.
    *
    * Built-in modules are typed:
    *   const rls = await ctx.useModule('rlsModule');     // RlsModule | undefined
@@ -340,6 +385,9 @@ declare global {
       clientIp?: string;
       requestId?: string;
       token?: ConstructiveAPIToken;
+      deviceToken?: string;
+      /** Set by the GraphQL ingress after authenticating reserved internal headers. */
+      internalTrusted?: boolean;
       constructive?: ConstructiveContext;
     }
   }

--- a/packages/server-utils/src/__tests__/lru.test.ts
+++ b/packages/server-utils/src/__tests__/lru.test.ts
@@ -1,0 +1,97 @@
+import {
+  configureSvcCache,
+  DEFAULT_SVC_CACHE_MAX_ENTRIES,
+  getSvcCacheStats,
+  resetSvcCacheCounters,
+  resolveSvcCacheMaxEntries,
+  svcCache
+} from '../lru';
+
+describe('routing service cache', () => {
+  beforeEach(() => {
+    svcCache.clear();
+    configureSvcCache({ maxEntries: DEFAULT_SVC_CACHE_MAX_ENTRIES });
+    resetSvcCacheCounters();
+  });
+
+  afterEach(() => {
+    svcCache.clear();
+    configureSvcCache({ maxEntries: DEFAULT_SVC_CACHE_MAX_ENTRIES });
+    resetSvcCacheCounters();
+  });
+
+  it('uses at least the required resident capacity by default', () => {
+    expect(resolveSvcCacheMaxEntries({ minimumEntries: 8 })).toBe(
+      DEFAULT_SVC_CACHE_MAX_ENTRIES
+    );
+    expect(resolveSvcCacheMaxEntries({ minimumEntries: 2048 })).toBe(2048);
+  });
+
+  it('rejects an explicit capacity below the required resident floor', () => {
+    expect(() => resolveSvcCacheMaxEntries({
+      maxEntries: 63,
+      minimumEntries: 64
+    })).toThrow('must be at least the required minimum (64)');
+  });
+
+  it.each([0, -1, 1.5, Number.NaN])(
+    'rejects invalid capacity %s',
+    (maxEntries) => {
+      expect(() => resolveSvcCacheMaxEntries({ maxEntries })).toThrow(
+        'must be a positive safe integer'
+      );
+    }
+  );
+
+  it('reports lookups, capacity eviction, and current residency', () => {
+    configureSvcCache({ maxEntries: 2 });
+    svcCache.set('label-a', { apiId: 'api-a' });
+    svcCache.set('label-b', { apiId: 'api-b' });
+
+    expect(svcCache.get('label-a')).toEqual({ apiId: 'api-a' });
+    expect(svcCache.get('missing')).toBeUndefined();
+    svcCache.set('label-c', { apiId: 'api-c' });
+
+    expect(svcCache.has('label-a')).toBe(true);
+    expect(svcCache.has('label-b')).toBe(false);
+    expect(svcCache.has('label-c')).toBe(true);
+    expect(getSvcCacheStats()).toMatchObject({
+      size: 2,
+      max: 2,
+      hits: 1,
+      misses: 1,
+      evictions: 1,
+      evictionsByReason: {
+        capacity: 1,
+        ttl: 0
+      }
+    });
+  });
+
+  it('does not classify explicit invalidation as cache pressure eviction', () => {
+    configureSvcCache({ maxEntries: 2 });
+    svcCache.set('label-a', { apiId: 'api-a' });
+    svcCache.delete('label-a');
+    svcCache.set('label-b', { apiId: 'api-b' });
+    svcCache.clear();
+
+    expect(getSvcCacheStats()).toMatchObject({
+      size: 0,
+      evictions: 0,
+      evictionsByReason: {
+        capacity: 0,
+        ttl: 0
+      }
+    });
+  });
+
+  it('refuses to resize a live process cache instead of silently evicting metadata', () => {
+    svcCache.set('label-a', { apiId: 'api-a' });
+
+    expect(() => configureSvcCache({ maxEntries: 2048 })).toThrow(
+      'cannot be reconfigured while routing metadata is resident'
+    );
+    expect(svcCache.peek('label-a')).toEqual({ apiId: 'api-a' });
+    expect(svcCache.max).toBe(DEFAULT_SVC_CACHE_MAX_ENTRIES);
+  });
+});

--- a/packages/server-utils/src/lru.ts
+++ b/packages/server-utils/src/lru.ts
@@ -1,21 +1,204 @@
 import { Logger } from '@pgpmjs/logger';
 import { LRUCache } from 'lru-cache';
 
-const log = new Logger('pg-cache');
+const log = new Logger('routing-service-cache');
 
 const ONE_HOUR_IN_MS = 1000 * 60 * 60;
 const ONE_DAY = ONE_HOUR_IN_MS * 24;
 const ONE_YEAR = ONE_DAY * 366;
 
 export const SVC_CACHE_TTL_MS = ONE_YEAR;
+export const DEFAULT_SVC_CACHE_MAX_ENTRIES = 1024;
 
-// --- Service Cache ---
-// Keep max aligned with PG_CACHE_MAX and GRAPHILE_CACHE_MAX (default: 50)
-export const svcCache = new LRUCache<string, any>({
-  max: 50,
-  ttl: SVC_CACHE_TTL_MS,
-  updateAgeOnGet: true,
-  dispose: (_, key) => {
-    log.debug(`Disposing service[${key}]`);
+export type SvcCacheEvictionReason = 'capacity' | 'ttl';
+
+export interface SvcCacheStats {
+  size: number;
+  max: number;
+  ttlMs: number;
+  hits: number;
+  misses: number;
+  evictions: number;
+  evictionsByReason: Record<SvcCacheEvictionReason, number>;
+  oldestKeyAgeMs: number | null;
+  keys: string[];
+}
+
+export interface ConfigureSvcCacheOptions {
+  /** Exact operator ceiling. Omit to use the safe process default. */
+  maxEntries?: number;
+  /** Capacity floor imposed by the caller, such as resident Graphile capacity. */
+  minimumEntries?: number;
+}
+
+const assertPositiveSafeInteger = (value: number, label: string): void => {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${label} must be a positive safe integer`);
   }
-});
+};
+
+export const resolveSvcCacheMaxEntries = ({
+  maxEntries,
+  minimumEntries = 1
+}: ConfigureSvcCacheOptions = {}): number => {
+  assertPositiveSafeInteger(minimumEntries, 'svcCache minimumEntries');
+  if (maxEntries === undefined) {
+    return Math.max(DEFAULT_SVC_CACHE_MAX_ENTRIES, minimumEntries);
+  }
+
+  assertPositiveSafeInteger(maxEntries, 'svcCache maxEntries');
+  if (maxEntries < minimumEntries) {
+    throw new Error(
+      `svcCache maxEntries (${maxEntries}) must be at least the required minimum (${minimumEntries})`
+    );
+  }
+  return maxEntries;
+};
+
+/**
+ * Process-wide routing-label metadata cache.
+ *
+ * This cache deliberately owns only resolved routing metadata. Capacity or TTL
+ * eviction never disposes a PostGraphile instance; a later request simply
+ * resolves the label again and reuses the independently keyed Graphile build.
+ */
+class RoutingServiceCache<T = unknown> {
+  private cache: LRUCache<string, T>;
+  private hits = 0;
+  private misses = 0;
+  private readonly evictionsByReason: Record<SvcCacheEvictionReason, number> = {
+    capacity: 0,
+    ttl: 0
+  };
+
+  constructor(maxEntries: number) {
+    this.cache = this.createCache(maxEntries);
+  }
+
+  private createCache(maxEntries: number): LRUCache<string, T> {
+    return new LRUCache<string, T>({
+      max: maxEntries,
+      ttl: SVC_CACHE_TTL_MS,
+      updateAgeOnGet: true,
+      dispose: (_, key, reason) => {
+        if (reason === 'evict') {
+          this.evictionsByReason.capacity++;
+          log.debug(`Evicting routing metadata[${key}] (capacity)`);
+        } else if (reason === 'expire') {
+          this.evictionsByReason.ttl++;
+          log.debug(`Evicting routing metadata[${key}] (ttl)`);
+        }
+      }
+    });
+  }
+
+  configure(maxEntries: number): void {
+    assertPositiveSafeInteger(maxEntries, 'svcCache maxEntries');
+    if (maxEntries === this.cache.max) return;
+    if (this.cache.size > 0) {
+      throw new Error(
+        'svcCache cannot be reconfigured while routing metadata is resident; clear it first'
+      );
+    }
+    this.cache = this.createCache(maxEntries);
+  }
+
+  get size(): number {
+    return this.cache.size;
+  }
+
+  get max(): number {
+    return this.cache.max;
+  }
+
+  get(key: string): T | undefined {
+    const value = this.cache.get(key);
+    if (value === undefined) this.misses++;
+    else this.hits++;
+    return value;
+  }
+
+  /** Existence inspection is intentionally not counted as a request lookup. */
+  has(key: string): boolean {
+    return this.cache.has(key);
+  }
+
+  /** Non-mutating inspection that does not affect LRU age or lookup counters. */
+  peek(key: string): T | undefined {
+    return this.cache.peek(key);
+  }
+
+  set(key: string, value: T): this {
+    this.cache.set(key, value);
+    return this;
+  }
+
+  delete(key: string): boolean {
+    return this.cache.delete(key);
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+
+  keys(): IterableIterator<string> {
+    return this.cache.keys();
+  }
+
+  entries(): IterableIterator<[string, T]> {
+    return this.cache.entries();
+  }
+
+  getRemainingTTL(key: string): number {
+    return this.cache.getRemainingTTL(key);
+  }
+
+  resetCounters(): void {
+    this.hits = 0;
+    this.misses = 0;
+    this.evictionsByReason.capacity = 0;
+    this.evictionsByReason.ttl = 0;
+  }
+
+  getStats(maxKeys = 200): SvcCacheStats {
+    assertPositiveSafeInteger(maxKeys, 'svcCache stats maxKeys');
+    let minRemaining = Infinity;
+    for (const key of this.cache.keys()) {
+      const remaining = this.cache.getRemainingTTL(key);
+      if (remaining < minRemaining) minRemaining = remaining;
+    }
+    const evictionsByReason = { ...this.evictionsByReason };
+
+    return {
+      size: this.cache.size,
+      max: this.cache.max,
+      ttlMs: SVC_CACHE_TTL_MS,
+      hits: this.hits,
+      misses: this.misses,
+      evictions: evictionsByReason.capacity + evictionsByReason.ttl,
+      evictionsByReason,
+      oldestKeyAgeMs: Number.isFinite(minRemaining)
+        ? Math.max(0, SVC_CACHE_TTL_MS - minRemaining)
+        : null,
+      keys: [...this.cache.keys()].slice(0, maxKeys)
+    };
+  }
+}
+
+export const svcCache = new RoutingServiceCache(
+  DEFAULT_SVC_CACHE_MAX_ENTRIES
+);
+
+export const configureSvcCache = (
+  options: ConfigureSvcCacheOptions = {}
+): SvcCacheStats => {
+  svcCache.configure(resolveSvcCacheMaxEntries(options));
+  return svcCache.getStats();
+};
+
+export const getSvcCacheStats = (maxKeys = 200): SvcCacheStats =>
+  svcCache.getStats(maxKeys);
+
+export const resetSvcCacheCounters = (): void => {
+  svcCache.resetCounters();
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -378,6 +378,9 @@ importers:
       '@dataplan/pg':
         specifier: 1.0.3
         version: 1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      '@pgsql/quotes':
+        specifier: ^18.1.0
+        version: 18.2.1
       grafast:
         specifier: 1.0.2
         version: 1.0.2(graphql@16.13.0)
@@ -601,6 +604,9 @@ importers:
       '@dataplan/pg':
         specifier: 1.0.3
         version: 1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      '@pgsql/quotes':
+        specifier: ^18.1.0
+        version: 18.2.1
       accept-language-parser:
         specifier: ^1.5.0
         version: 1.5.0
@@ -663,6 +669,9 @@ importers:
       '@dataplan/pg':
         specifier: 1.0.3
         version: 1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      '@pgsql/quotes':
+        specifier: ^18.1.0
+        version: 18.2.1
       grafast:
         specifier: 1.0.2
         version: 1.0.2(graphql@16.13.0)
@@ -1132,6 +1141,9 @@ importers:
       '@dataplan/pg':
         specifier: 1.0.3
         version: 1.0.3(@dataplan/json@1.0.0(grafast@1.0.2(graphql@16.13.0)))(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      '@pgsql/quotes':
+        specifier: ^18.1.0
+        version: 18.2.1
       graphile-build:
         specifier: 5.0.2
         version: 5.0.2(grafast@1.0.2(graphql@16.13.0))(graphile-config@1.0.1)(graphql@16.13.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2531,6 +2531,9 @@ importers:
       '@pgpmjs/types':
         specifier: workspace:^
         version: link:../../pgpm/types/dist
+      '@pgsql/quotes':
+        specifier: ^18.2.0
+        version: 18.2.1
       lru-cache:
         specifier: ^11.2.7
         version: 11.2.7

--- a/postgres/pg-cache/README.md
+++ b/postgres/pg-cache/README.md
@@ -22,8 +22,11 @@ npm install pg-cache
 
 ## Features
 
-- LRU cache for PostgreSQL connection pools
+- Lease-aware LRU registry for PostgreSQL connection pools
+- Fail-closed capacity admission for long-lived production consumers
 - Automatic pool cleanup and disposal
+- Pool identity, lease, and disposal observability
+- Checkout queue/sanitation timing and fast-path counters
 - Extensible cleanup callback system
 - Service cache for general use
 - Graceful shutdown handling
@@ -51,6 +54,105 @@ const result = await pool.query('SELECT NOW()');
 // Pool is automatically cached and reused
 const samePool = getPgPool({ database: 'mydb' }); // Returns cached pool
 ```
+
+`getPgPool()` remains the synchronous compatibility API. A component that keeps
+a pool across requests or asynchronous lifecycle boundaries should hold a lease:
+
+```typescript
+import { acquirePgPool, PgPoolCapacityError } from 'pg-cache';
+
+try {
+  const lease = acquirePgPool(
+    { database: 'tenant_a', user: 'graphql_runtime' },
+    { purpose: 'runtime', sanitizeOnCheckout: true }
+  );
+
+  // Retain lease.pool for the owning handler or request lifecycle.
+  // release() is idempotent and must run only after the owner has drained.
+  lease.release();
+} catch (error) {
+  if (error instanceof PgPoolCapacityError) {
+    // Map error.code === 'PG_POOL_CAPACITY' to HTTP 503 and Retry-After.
+  }
+}
+```
+
+Acquisition is synchronous and atomic. Reusing an existing exact identity costs
+no new slot; a new identity evicts only an unleased pool. If every slot is
+leased, admission throws before constructing a pool or ending an existing one.
+
+Sanitized default-driver pools issue `DISCARD ALL` before every reused checkout
+and clear node-postgres/Graphile prepared-statement bookkeeping. The first
+checkout of a brand-new factory-owned connection skips that redundant round
+trip only when its trusted startup baseline is pinned and no other `connect`
+listener could have changed the session. `getPgCheckoutSanitizerStats()` exposes
+checkout wait, queue, sanitation, failure, and virgin-fast-path counters.
+For alternate pool factories, pg-cache replaces direct `pool.query()` calls
+with a sanitized checkout/query/release cycle; a custom sanitized pool must
+therefore provide a replaceable `query()` method and Promise-based client
+queries. Query failures destroy the checked-out client before the error is
+returned through either the Promise or callback API.
+
+Pool sizing accepts `max`, `idleTimeoutMillis`, `connectionTimeoutMillis`,
+`allowExitOnIdle`, and native pg-pool `maxUses`. Set `maxUses: 1` to retire a
+client after every checkout, or leave it unset/use `0` for unlimited reuse.
+The equivalent environment setting is `PG_POOL_MAX_USES`; it accepts only a
+canonical decimal integer, so alternate numeric spellings, negative,
+fractional, and unsafe-integer values fail before a pool identity is published.
+Because `maxUses` changes connection lifecycle and latency, it participates in
+the opaque exact-pool identity and should be benchmarked under the real request
+rate before production use.
+
+Exact-pool and physical-target identities use a process-random keyed HMAC. They
+are stable for the lifetime of one pool registry, but intentionally differ in
+another process; this prevents an emitted identity from becoming an offline
+password verifier. Connection and pool identity inputs must be primitive,
+canonical data, and node-postgres password callbacks are rejected because a
+callback's captured credential cannot be represented without risking an alias.
+
+### Shared Notification Broker
+
+`acquirePgNotificationBroker(listenerPgConfig, { topics })` leases one
+process-local LISTEN connection per opaque, versioned pool identity. The
+identity includes the canonical connection, credentials, pool, driver,
+sanitation, and data-only TLS settings. The broker LISTENs only to each lease's
+exact channel allowlist, rejects identifiers PostgreSQL would truncate past 63
+UTF-8 bytes, and awaits UNLISTEN plus connection and pool-lease release.
+The final lease destroys its listener client after UNLISTEN, so an inactive
+database does not retain an idle PostgreSQL backend until the pool timeout.
+
+Production broker acquisition performs a fresh, read-only catalog audit on the
+same pinned client before each listener lease is admitted, so a pool with
+`max: 1` cannot deadlock waiting for a second checkout. The attested lease's
+narrow `revalidateRole()` capability serializes TTL audits on that client and
+never exposes general SQL access. A conforming login may
+CONNECT only to that exact database and has no role memberships, privileged
+role attributes, database CREATE/TEMP, or effective privileges on non-system
+schemas, relations, routines, and sequences. The returned audit contains only
+the role, database, stable violation codes, and audit version; callers must keep
+the separate `PgConfig` credentials in their secret store. Use
+`normalizePgNotificationRoleContracts()` to reject one login spanning physical
+databases or multiple listener logins targeting one physical database.
+The live contract test is opt-in with
+`PG_CACHE_RUN_NOTIFICATION_ROLE_INTEGRATION=1` and uses the standard `PG*`
+connection settings for a pre-provisioned conforming notification login.
+
+Every role-audit, `LISTEN`, and `UNLISTEN` command has the same bounded deadline
+as the listener pool's `connectionTimeoutMillis`. Configure it through the
+listener's `pool.connectionTimeoutMillis`, or through
+`PG_POOL_CONNECTION_TIMEOUT_MS` when the pool setting is omitted; the default is
+5 seconds. The broker rejects zero, fractional, negative, or setTimeout-unsafe
+values before publishing an identity. A command that exceeds the deadline
+fatally closes every lease and destroys the pinned client, so TTL refresh and
+shutdown cannot wait forever on an abandoned driver query.
+
+Each GraphQL subscriber has a fixed 256-message queue. A slow subscriber that
+overflows is failed independently; a listener connection error fails every
+lease and is never reconnected while any failed owner remains. The caller must
+provide a dedicated least-privilege listener login and remains responsible for
+the deployment's certificate and role policy. `lease.terminated` and
+`getPgNotificationBrokerStats()` expose failure and lifecycle state without
+revealing connection credentials.
 
 ### Direct Cache Access
 
@@ -103,7 +205,7 @@ const service = svcCache.get('my-service');
 ```typescript
 import { close, teardownPgPools } from 'pg-cache';
 
-// In your shutdown handler
+// The executable owns process signals; importing pg-cache never installs one.
 process.on('SIGTERM', async () => {
   await close(); // or teardownPgPools()
   process.exit(0);
@@ -119,13 +221,27 @@ The main PostgreSQL pool cache instance.
 - `get(key: string): Pool | undefined` - Get a cached pool
 - `set(key: string, pool: Pool): void` - Cache a pool
 - `has(key: string): boolean` - Check if a pool is cached
-- `delete(key: string): void` - Remove and dispose a pool
-- `clear(): void` - Remove and dispose all pools
+- `delete(key: string): void` - Remove an unleased pool
+- `clear(): void` - Remove all currently unleased pools
+- `acquire(key: string, factory: () => Pool): PgPoolLease` - Atomically acquire a lease
+- `getStats(): PgPoolCacheStats` - Read capacity and lifecycle counters
 - `registerCleanupCallback(callback: (key: string) => void): () => void` - Register a cleanup callback
 
 ### getPgPool(config: Partial<PgConfig>): Pool
 
 Get or create a cached PostgreSQL pool using the provided configuration.
+
+### acquirePgPool(config, options): PgPoolLease
+
+Get or create the exact pool identity and protect it from TTL/LRU disposal until
+the returned idempotent `release()` is called.
+
+### Capacity
+
+`PG_CACHE_MAX` limits lazy pool identities, not eagerly allocated connections.
+The default is 2064: two identities for each of 1024 database-per-tenant Graphile
+contracts plus a 16-identity operational reserve. `PG_CACHE_TTL_MS` applies only
+while an identity has zero leases.
 
 ### svcCache
 

--- a/postgres/pg-cache/src/__tests__/driver.test.ts
+++ b/postgres/pg-cache/src/__tests__/driver.test.ts
@@ -3,13 +3,17 @@
 // lets an alternate backend (e.g. PGlite) plug in without any change to pgpm /
 // pgsql-* — and guarantees the default path is untouched when nothing registers.
 
-import { randomUUID } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import pg from 'pg';
 
 import {
+  acquirePgPool,
   defaultPgPoolFactory,
   getActivePgPoolFactory,
   getPgPool,
+  getPgPoolConfig,
+  getPgPoolDriverIdentity,
+  getPgPoolIdentity,
   hasPgPoolFactory,
   PgPoolFactory,
   registerPgPoolFactory
@@ -55,10 +59,10 @@ describe('pg-cache pool-factory seam', () => {
     expect(factory).toHaveBeenCalledTimes(1);
     expect(pool).toBe(mock);
 
-    pgCache.delete(cfg.database);
+    pgCache.delete(getPgPoolIdentity(cfg));
   });
 
-  it('caches by database: a second call reuses the pool and does not re-invoke the factory', () => {
+  it('caches by exact pool identity: an identical call reuses the pool', () => {
     const cfg = freshConfig();
     const factory = jest.fn<pg.Pool, [any]>(() => createMockPool());
     registerPgPoolFactory(factory);
@@ -69,7 +73,324 @@ describe('pg-cache pool-factory seam', () => {
     expect(first).toBe(second);
     expect(factory).toHaveBeenCalledTimes(1);
 
-    pgCache.delete(cfg.database);
+    pgCache.delete(getPgPoolIdentity(cfg));
+  });
+
+  it('acquires an idempotently releasable lease for the exact pool identity', () => {
+    const cfg = freshConfig();
+    const mock = createMockPool();
+    const factory = jest.fn<pg.Pool, [any]>(() => mock);
+    registerPgPoolFactory(factory);
+
+    const first = acquirePgPool(cfg, { purpose: 'runtime' });
+    const second = acquirePgPool(cfg, { purpose: 'runtime' });
+
+    expect(first.identity).toBe(getPgPoolIdentity(cfg, { purpose: 'runtime' }));
+    expect(first.pool).toBe(mock);
+    expect(second.pool).toBe(mock);
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    first.release();
+    first.release();
+    second.release();
+    pgCache.delete(first.identity);
+  });
+
+  it('separates credentials, purpose, and sanitation mode for the same database', () => {
+    const cfg = freshConfig();
+    const factory = jest.fn<pg.Pool, [any, any]>(() => createMockPool());
+    registerPgPoolFactory(factory);
+
+    const control = getPgPool(cfg, { purpose: 'control' });
+    const runtime = getPgPool({ ...cfg, user: 'runtime' }, {
+      purpose: 'runtime',
+      sanitizeOnCheckout: true
+    });
+    const unsanitizedRuntime = getPgPool({ ...cfg, user: 'runtime' }, {
+      purpose: 'runtime'
+    });
+
+    expect(control).not.toBe(runtime);
+    expect(runtime).not.toBe(unsanitizedRuntime);
+    expect(factory).toHaveBeenCalledTimes(3);
+
+    pgCache.delete(getPgPoolIdentity(cfg, { purpose: 'control' }));
+    pgCache.delete(getPgPoolIdentity({ ...cfg, user: 'runtime' }, {
+      purpose: 'runtime',
+      sanitizeOnCheckout: true
+    }));
+    pgCache.delete(getPgPoolIdentity({ ...cfg, user: 'runtime' }, { purpose: 'runtime' }));
+  });
+
+  it('normalizes maxUses into the exact pool identity', () => {
+    const cfg = freshConfig();
+    const unlimited = getPgPoolIdentity(cfg);
+    const explicitUnlimited = getPgPoolIdentity({ ...cfg, pool: { maxUses: 0 } });
+    const singleUse = getPgPoolIdentity({ ...cfg, pool: { maxUses: 1 } });
+    const doubleUse = getPgPoolIdentity({ ...cfg, pool: { maxUses: 2 } });
+
+    expect(explicitUnlimited).toBe(unlimited);
+    expect(singleUse).not.toBe(unlimited);
+    expect(doubleUse).not.toBe(singleUse);
+  });
+
+  it('uses a process-keyed identity instead of an offline password verifier', () => {
+    const cfg = {
+      ...freshConfig(),
+      pool: {
+        max: 3,
+        idleTimeoutMillis: 1234,
+        connectionTimeoutMillis: 5678,
+        allowExitOnIdle: true
+      }
+    };
+    const identity = getPgPoolIdentity(cfg, {
+      purpose: 'runtime',
+      sanitizeOnCheckout: true
+    });
+    const unkeyedInput = JSON.stringify({
+      version: 1,
+      driver: getPgPoolDriverIdentity(),
+      host: cfg.host,
+      port: cfg.port,
+      database: cfg.database,
+      user: cfg.user,
+      password: cfg.password,
+      ssl: null,
+      pool: {
+        max: 3,
+        maxUses: null,
+        idleTimeoutMillis: 1234,
+        connectionTimeoutMillis: 5678,
+        allowExitOnIdle: true
+      },
+      purpose: 'runtime',
+      sanitizeOnCheckout: true
+    });
+    const offlineDigest = `pg:v1:${createHash('sha256')
+      .update(unkeyedInput)
+      .digest('hex')}`;
+
+    expect(getPgPoolIdentity(cfg, {
+      purpose: 'runtime',
+      sanitizeOnCheckout: true
+    })).toBe(identity);
+    expect(identity).toMatch(/^pg:v1:[a-f0-9]{64}$/);
+    expect(identity).not.toBe(offlineDigest);
+  });
+
+  it('rejects password callbacks before they can alias a pool identity', () => {
+    const cfg = freshConfig();
+    const first = async () => 'first-secret';
+    const second = async () => 'second-secret';
+    const factory = jest.fn<pg.Pool, [any]>(() => createMockPool());
+    registerPgPoolFactory(factory);
+
+    for (const password of [first, second]) {
+      const invalid = {
+        ...cfg,
+        password: password as unknown as string
+      };
+      expect(() => getPgPoolIdentity(invalid)).toThrow(
+        'pg.password must be a string'
+      );
+      expect(() => getPgPool(invalid)).toThrow(
+        'pg.password must be a string'
+      );
+    }
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  it('rejects noncanonical exact-identity inputs', () => {
+    const cfg = freshConfig();
+    const accessorSsl = {} as Record<string, unknown>;
+    Object.defineProperty(accessorSsl, 'ca', { get: () => 'dynamic-ca' });
+    const symbolSsl = { ca: 'tenant-ca' } as Record<PropertyKey, unknown>;
+    symbolSsl[Symbol('hidden')] = 'untracked';
+    const sparseCa = new Array<string>(2);
+    sparseCa[1] = 'tenant-ca';
+    const undefinedSsl: { ca: undefined } = { ca: undefined };
+
+    expect(() => getPgPoolIdentity({
+      ...cfg,
+      port: '5432' as unknown as number
+    })).toThrow('pg.port must be a safe integer');
+    expect(() => getPgPoolIdentity({
+      ...cfg,
+      pool: { max: '2' as unknown as number }
+    })).toThrow('pool.max must be a safe integer');
+    expect(() => getPgPoolIdentity(cfg, {
+      purpose: {} as unknown as string
+    })).toThrow('pg pool purpose must be a non-empty string');
+    expect(() => getPgPoolIdentity(cfg, {
+      sanitizeOnCheckout: 'false' as unknown as boolean
+    })).toThrow('pg pool sanitizeOnCheckout must be a boolean');
+    expect(() => getPgPoolIdentity({
+      ...cfg,
+      ssl: accessorSsl as never
+    })).toThrow('pg.ssl.ca must be a data property');
+    expect(() => getPgPoolIdentity({
+      ...cfg,
+      ssl: symbolSsl as never
+    })).toThrow('pg.ssl must not contain symbol properties');
+    expect(() => getPgPoolIdentity({
+      ...cfg,
+      ssl: { ca: sparseCa } as never
+    })).toThrow('pg.ssl.ca must be a dense array without custom properties');
+    expect(() => getPgPoolIdentity({
+      ...cfg,
+      ssl: undefinedSsl as never
+    })).toThrow('pg.ssl.ca must not be undefined');
+  });
+
+  it('parses PG_POOL_MAX_USES as an unlimited sentinel or positive safe integer', () => {
+    const previous = process.env.PG_POOL_MAX_USES;
+    try {
+      process.env.PG_POOL_MAX_USES = '0';
+      expect(getPgPoolConfig().maxUses).toBeUndefined();
+
+      process.env.PG_POOL_MAX_USES = '17';
+      expect(getPgPoolConfig().maxUses).toBe(17);
+
+      for (const invalid of [
+        '-1',
+        '1.5',
+        '01',
+        '1e2',
+        '0x10',
+        ' 1',
+        '1 ',
+        ' ',
+        'not-a-number',
+        '9007199254740992'
+      ]) {
+        process.env.PG_POOL_MAX_USES = invalid;
+        expect(() => getPgPoolConfig()).toThrow(
+          'PG_POOL_MAX_USES must be 0 or a positive safe integer'
+        );
+      }
+    } finally {
+      if (previous === undefined) delete process.env.PG_POOL_MAX_USES;
+      else process.env.PG_POOL_MAX_USES = previous;
+    }
+  });
+
+  it('validates explicit maxUses overrides before constructing an identity or pool', () => {
+    expect(getPgPoolConfig({ maxUses: 0 }).maxUses).toBeUndefined();
+    expect(getPgPoolConfig({ maxUses: 23 }).maxUses).toBe(23);
+
+    for (const invalid of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, 9007199254740992]) {
+      expect(() => getPgPoolConfig({ maxUses: invalid })).toThrow(
+        'pool.maxUses must be 0 or a positive safe integer'
+      );
+    }
+    for (const invalid of [true, null, {}]) {
+      expect(() => getPgPoolConfig({
+        maxUses: invalid as unknown as number
+      })).toThrow('pool.maxUses must be 0 or a positive safe integer');
+    }
+  });
+
+  it('replaces a sanitized custom factory query that bypasses connect', async () => {
+    const cfg = freshConfig();
+    const queryResult = { rows: [{ value: 42 }] };
+    const client = {
+      query: jest.fn(async (text: string) => text === 'SELECT $1::int AS value'
+        ? queryResult
+        : { rows: [] }),
+      release: jest.fn()
+    };
+    const bypassingQuery = jest.fn(async () => ({ rows: [{ value: -1 }] }));
+    const connect = jest.fn(async () => client);
+    const pool = {
+      query: bypassingQuery,
+      connect,
+      end: jest.fn(async (): Promise<void> => undefined)
+    } as unknown as pg.Pool;
+    const factory = jest.fn(() => pool);
+    registerPgPoolFactory(factory);
+    const options = { purpose: 'runtime', sanitizeOnCheckout: true } as const;
+    const identity = getPgPoolIdentity(cfg, options);
+
+    try {
+      const sanitizedPool = getPgPool(cfg, options);
+
+      await expect(sanitizedPool.query(
+        'SELECT $1::int AS value',
+        [42]
+      )).resolves.toBe(queryResult);
+      expect(bypassingQuery).not.toHaveBeenCalled();
+      expect(connect).toHaveBeenCalledTimes(1);
+      expect(client.query).toHaveBeenNthCalledWith(1, 'DISCARD ALL');
+      expect(client.query).toHaveBeenNthCalledWith(
+        2,
+        'SET search_path TO pg_catalog; SET row_security TO on; SET jit_optimize_above_cost TO -1'
+      );
+      expect(client.query).toHaveBeenNthCalledWith(3, 'SELECT $1::int AS value', [42]);
+      expect(client.release).toHaveBeenCalledTimes(1);
+      expect(client.release).toHaveBeenCalledWith();
+    } finally {
+      pgCache.delete(identity);
+      await pgCache.waitForDisposals();
+    }
+  });
+
+  it('separates TLS trust contracts for the same database and role', () => {
+    const cfg = freshConfig();
+
+    const verified = getPgPoolIdentity({
+      ...cfg,
+      ssl: { ca: 'tenant-ca', rejectUnauthorized: true, servername: 'db.internal' }
+    });
+    const insecure = getPgPoolIdentity({
+      ...cfg,
+      ssl: { ca: 'tenant-ca', rejectUnauthorized: false, servername: 'db.internal' }
+    });
+    const plaintext = getPgPoolIdentity(cfg);
+
+    expect(verified).not.toBe(insecure);
+    expect(verified).not.toBe(plaintext);
+    expect(insecure).not.toBe(plaintext);
+  });
+
+  it('canonicalizes TLS data and rejects identity inputs JSON would omit', () => {
+    const cfg = freshConfig();
+    const first = getPgPoolIdentity({
+      ...cfg,
+      ssl: { ca: 'tenant-ca', rejectUnauthorized: true }
+    });
+    const second = getPgPoolIdentity({
+      ...cfg,
+      ssl: { rejectUnauthorized: true, ca: 'tenant-ca' }
+    });
+
+    expect(first).toBe(second);
+    expect(() => getPgPoolIdentity({
+      ...cfg,
+      ssl: { checkServerIdentity: (): undefined => undefined } as any
+    })).toThrow('pg.ssl.checkServerIdentity must contain only deterministic data values');
+
+    const bufferIdentity = getPgPoolIdentity({
+      ...cfg,
+      ssl: { ca: Buffer.from('tenant-ca') }
+    });
+    const mimickedBufferIdentity = getPgPoolIdentity({
+      ...cfg,
+      ssl: {
+        ca: {
+          bufferSha256: 'b60c1883ea3c4bf71a5959468ac16f36e2aa4f5c8702ca157fbbae61415f2f10'
+        }
+      } as any
+    });
+    expect(bufferIdentity).not.toBe(mimickedBufferIdentity);
+  });
+
+  it('uses opaque identities that never disclose credentials', () => {
+    const cfg = { ...freshConfig(), password: 'top-secret-password' };
+    const identity = getPgPoolIdentity(cfg, { purpose: 'runtime' });
+    expect(identity).toMatch(/^pg:v1:[a-f0-9]{64}$/);
+    expect(identity).not.toContain(cfg.user);
+    expect(identity).not.toContain(cfg.password);
   });
 
   it('falls back to defaultPgPoolFactory when nothing is registered', () => {
@@ -78,12 +399,68 @@ describe('pg-cache pool-factory seam', () => {
     // query runs, so this is safe without a live server.
     const pool = getPgPool(cfg);
     expect(pool).toBeInstanceOf(pg.Pool);
-    pgCache.delete(cfg.database);
+    pgCache.delete(getPgPoolIdentity(cfg));
   });
 
   it('defaultPgPoolFactory returns a pg.Pool', () => {
     const pool = defaultPgPoolFactory(freshConfig());
     expect(pool).toBeInstanceOf(pg.Pool);
     return pool.end();
+  });
+
+  it('passes credentials as discrete fields instead of reparsing them as a URI', async () => {
+    const cfg = {
+      ...freshConfig(),
+      user: 'runtime@tenant',
+      password: 'x@evil.example/other?sslmode=require',
+      database: 'tenant/database'
+    };
+    const pool = defaultPgPoolFactory(cfg);
+    const options = (pool as pg.Pool & { options: pg.PoolConfig }).options;
+
+    expect(options.host).toBe(cfg.host);
+    expect(options.port).toBe(cfg.port);
+    expect(options.database).toBe(cfg.database);
+    expect(options.user).toBe(cfg.user);
+    expect(options.password).toBe(cfg.password);
+    await pool.end();
+  });
+
+  it('passes maxUses to the native pg.Pool driver', async () => {
+    const pool = defaultPgPoolFactory({ ...freshConfig(), pool: { maxUses: 1 } });
+    const options = (pool as pg.Pool & { options: pg.PoolConfig }).options;
+
+    expect(options.maxUses).toBe(1);
+    await pool.end();
+  });
+
+  it('passes the exact TLS contract to node-postgres', async () => {
+    const ssl = {
+      ca: 'tenant-ca',
+      cert: 'runtime-cert',
+      key: 'runtime-key',
+      rejectUnauthorized: true,
+      servername: 'db.internal',
+      minVersion: 'TLSv1.2' as const
+    };
+    const pool = defaultPgPoolFactory({ ...freshConfig(), ssl });
+    const options = (pool as pg.Pool & { options: pg.PoolConfig }).options;
+
+    expect(options.ssl).toEqual(ssl);
+    await pool.end();
+  });
+
+  it('pins the trusted baseline in sanitized node-postgres startup options', async () => {
+    const pool = defaultPgPoolFactory(freshConfig(), {
+      purpose: 'runtime',
+      sanitizeOnCheckout: true
+    });
+    const options = (pool as pg.Pool & { options: pg.PoolConfig }).options;
+
+    expect(options.options).toContain('-c search_path=pg_catalog');
+    expect(options.options).toContain('-c row_security=on');
+    expect(options.options).toContain('-c jit_optimize_above_cost=-1');
+    expect(pool.query).toBe(pg.Pool.prototype.query);
+    await pool.end();
   });
 });

--- a/postgres/pg-cache/src/__tests__/lru.test.ts
+++ b/postgres/pg-cache/src/__tests__/lru.test.ts
@@ -1,15 +1,26 @@
-// Guards against the pg-cache close() resource leak fixed in feat/observability.
-//
-// Previously, close() reset this.closed = false after shutdown, allowing
-// set() to silently accept new pools that were never cleaned up. The module-
-// level closePromise also reset to null, enabling double-shutdown.
-//
-// These tests lock the fix: close() is final, set() rejects, and repeated
-// close() calls are idempotent. See pg-cache-close-leak.md for full details.
-
 import pg from 'pg';
 
-import { PgPoolCacheManager } from '../lru';
+import {
+  DEFAULT_PG_CACHE_MAX,
+  PG_CACHE_GRAPHILE_CONTRACT_CAPACITY,
+  PG_CACHE_OPERATIONAL_RESERVE,
+  PgPoolCacheManager,
+  PgPoolCapacityError
+} from '../lru';
+
+describe('process lifecycle ownership', () => {
+  it('does not install process signal handlers from a library import', () => {
+    const beforeSigterm = process.listenerCount('SIGTERM');
+    const beforeSigint = process.listenerCount('SIGINT');
+
+    jest.isolateModules(() => {
+      jest.requireActual('../lru');
+    });
+
+    expect(process.listenerCount('SIGTERM')).toBe(beforeSigterm);
+    expect(process.listenerCount('SIGINT')).toBe(beforeSigint);
+  });
+});
 
 // Minimal mock — we only need pool.end() and pool.ended
 const createMockPool = (): pg.Pool => {
@@ -45,8 +56,11 @@ describe('PgPoolCacheManager', () => {
   });
 
   describe('configuration', () => {
-    it('uses env-var defaults (max=50) when no overrides given', () => {
-      expect(cache.config.max).toBe(50);
+    it('reserves two identities per supported Graphile contract plus operations', () => {
+      expect(DEFAULT_PG_CACHE_MAX).toBe(
+        PG_CACHE_GRAPHILE_CONTRACT_CAPACITY * 2 + PG_CACHE_OPERATIONAL_RESERVE
+      );
+      expect(cache.config.max).toBe(2064);
     });
 
     it('accepts constructor overrides', () => {
@@ -86,6 +100,157 @@ describe('PgPoolCacheManager', () => {
       expect(small.has('b')).toBe(true);
       expect(small.has('c')).toBe(true);
 
+      await small.close();
+    });
+  });
+
+  describe('leases and fail-closed admission', () => {
+    it('counts an existing exact identity as zero new slots', async () => {
+      const small = new PgPoolCacheManager({ max: 1 });
+      const pool = createMockPool();
+      const factory = jest.fn(() => pool);
+
+      const first = small.acquire('runtime-a', factory);
+      const second = small.acquire('runtime-a', factory);
+
+      expect(first.pool).toBe(pool);
+      expect(second.pool).toBe(pool);
+      expect(factory).toHaveBeenCalledTimes(1);
+      expect(small.getStats()).toMatchObject({
+        size: 1,
+        leasedPools: 1,
+        activeLeases: 2,
+        leasesAcquired: 2
+      });
+
+      first.release();
+      first.release();
+      expect(small.getStats().activeLeases).toBe(1);
+      second.release();
+      await small.close();
+    });
+
+    it('refuses before constructing or ending when every slot is leased', async () => {
+      const small = new PgPoolCacheManager({ max: 1 });
+      const firstPool = createMockPool();
+      const first = small.acquire('runtime-a', () => firstPool);
+      const rejectedFactory = jest.fn(() => createMockPool());
+
+      let capacityError: PgPoolCapacityError | undefined;
+      try {
+        small.acquire('runtime-b', rejectedFactory);
+      } catch (error) {
+        capacityError = error as PgPoolCapacityError;
+      }
+
+      expect(capacityError).toBeInstanceOf(PgPoolCapacityError);
+      expect(capacityError).toMatchObject({
+        code: 'PG_POOL_CAPACITY',
+        retryAfterSeconds: 15,
+        max: 1,
+        size: 1,
+        leased: 1
+      });
+      expect(rejectedFactory).not.toHaveBeenCalled();
+      expect(firstPool.end).not.toHaveBeenCalled();
+      expect(small.getStats().capacityRefusals).toBe(1);
+
+      first.release();
+      await small.close();
+    });
+
+    it('evicts only the least-recent zero-lease identity', async () => {
+      const small = new PgPoolCacheManager({ max: 2 });
+      const leasedPool = createMockPool();
+      const idlePool = createMockPool();
+      const replacementPool = createMockPool();
+      const lease = small.acquire('leased', () => leasedPool);
+      small.set('idle', idlePool);
+
+      small.set('replacement', replacementPool);
+      await small.waitForDisposals();
+
+      expect(small.has('leased')).toBe(true);
+      expect(leasedPool.end).not.toHaveBeenCalled();
+      expect(small.has('idle')).toBe(false);
+      expect(idlePool.end).toHaveBeenCalledTimes(1);
+      expect(small.has('replacement')).toBe(true);
+
+      lease.release();
+      await small.close();
+    });
+
+    it('keeps an expired leased identity until release', async () => {
+      jest.useFakeTimers();
+      const small = new PgPoolCacheManager({ max: 1, ttl: 50 });
+      const pool = createMockPool();
+      const lease = small.acquire('runtime', () => pool);
+      try {
+        jest.advanceTimersByTime(51);
+        expect(small.has('runtime')).toBe(true);
+        expect(pool.end).not.toHaveBeenCalled();
+
+        lease.release();
+        await small.waitForDisposals();
+
+        expect(small.has('runtime')).toBe(false);
+        expect(pool.end).toHaveBeenCalledTimes(1);
+        expect(small.getStats().ttlExpirations).toBe(1);
+      } finally {
+        jest.useRealTimers();
+        await small.close();
+      }
+    });
+
+    it('deterministically gives the final slot to the first synchronous acquisition', async () => {
+      const small = new PgPoolCacheManager({ max: 1 });
+      const firstFactory = jest.fn(() => createMockPool());
+      const secondFactory = jest.fn(() => createMockPool());
+
+      const outcomes = await Promise.allSettled([
+        Promise.resolve().then(() => small.acquire('first', firstFactory)),
+        Promise.resolve().then(() => small.acquire('second', secondFactory))
+      ]);
+
+      expect(outcomes[0].status).toBe('fulfilled');
+      expect(outcomes[1].status).toBe('rejected');
+      expect((outcomes[1] as PromiseRejectedResult).reason).toBeInstanceOf(
+        PgPoolCapacityError
+      );
+      expect(firstFactory).toHaveBeenCalledTimes(1);
+      expect(secondFactory).not.toHaveBeenCalled();
+
+      if (outcomes[0].status === 'fulfilled') outcomes[0].value.release();
+      await small.close();
+    });
+
+    it('rolls back its reservation if pool construction fails', async () => {
+      const small = new PgPoolCacheManager({ max: 1 });
+      const retained = createMockPool();
+      small.set('retained', retained);
+
+      expect(() => small.acquire('broken', () => {
+        throw new Error('factory failed');
+      })).toThrow('factory failed');
+
+      expect(small.has('retained')).toBe(true);
+      expect(retained.end).not.toHaveBeenCalled();
+      expect(small.getStats()).toMatchObject({ size: 1, reservations: 0 });
+      await small.close();
+    });
+
+    it('does not end a physical pool retained under another exact identity', async () => {
+      const small = new PgPoolCacheManager({ max: 1 });
+      const sharedPool = createMockPool();
+
+      small.set('identity-a', sharedPool);
+      small.set('identity-b', sharedPool);
+      await small.waitForDisposals();
+      expect(sharedPool.end).not.toHaveBeenCalled();
+
+      small.delete('identity-b');
+      await small.waitForDisposals();
+      expect(sharedPool.end).toHaveBeenCalledTimes(1);
       await small.close();
     });
   });

--- a/postgres/pg-cache/src/__tests__/notification-broker.integration.test.ts
+++ b/postgres/pg-cache/src/__tests__/notification-broker.integration.test.ts
@@ -1,0 +1,154 @@
+import type pg from 'pg';
+import { getPgEnvOptions, type PgConfig } from 'pg-env';
+
+import { teardownPgPools } from '../lru';
+import {
+  acquirePgNotificationBroker,
+  getPgNotificationBrokerStats,
+  PgNotificationTopicError,
+  teardownPgNotificationBrokers
+} from '../notification-broker';
+import { defaultPgPoolFactory, getPgPool } from '../pg';
+
+// Production acquisition always audits the login on its pinned listener, so
+// this test requires the dedicated least-privilege notification fixture.
+const describeWithPostgres =
+  process.env.PG_CACHE_RUN_NOTIFICATION_ROLE_INTEGRATION === '1'
+    ? describe
+    : describe.skip;
+
+describeWithPostgres('notification broker against PostgreSQL', () => {
+  let observerPool: pg.Pool;
+  let listenerPgConfig: PgConfig & { pool: { max: number } };
+
+  beforeAll(() => {
+    listenerPgConfig = {
+      ...getPgEnvOptions(),
+      pool: { max: 1 }
+    };
+    observerPool = defaultPgPoolFactory(
+      { ...listenerPgConfig, pool: { max: 1 } },
+      {
+        purpose: 'notification-broker-integration-observer',
+        sanitizeOnCheckout: false
+      }
+    ) as pg.Pool;
+  });
+
+  afterAll(async () => {
+    await teardownPgNotificationBrokers();
+    await teardownPgPools();
+    await observerPool?.end();
+  });
+
+  it('shares one LISTEN backend across three isolated generation leases and releases it', async () => {
+    const nonce = `${process.pid.toString(36)}_${Date.now().toString(36)}`;
+    const topics = [
+      `pg_cache_it_${nonce}_a`,
+      `pg_cache_it_${nonce}_b`,
+      `pg_cache_it_${nonce}_c`
+    ];
+    const listenQueries = topics.map((topic) => `LISTEN "${topic}"`);
+
+    const first = await acquirePgNotificationBroker(listenerPgConfig, {
+      topics: [topics[0]]
+    });
+    const second = await acquirePgNotificationBroker(listenerPgConfig, {
+      topics: [topics[1]]
+    });
+    const third = await acquirePgNotificationBroker(listenerPgConfig, {
+      topics: [topics[2]]
+    });
+    const brokerPool = getPgPool(listenerPgConfig, {
+      purpose: 'notification-broker',
+      sanitizeOnCheckout: true
+    });
+
+    expect(new Set([first.identity, second.identity, third.identity]).size).toBe(1);
+    expect(getPgNotificationBrokerStats()).toMatchObject({
+      brokers: 1,
+      listenerConnections: 1,
+      leases: 3,
+      topics: 3
+    });
+    expect(brokerPool.totalCount).toBe(1);
+    expect(brokerPool.idleCount).toBe(0);
+
+    const activeListeners = await observerPool.query<{
+      pid: number;
+      query: string;
+    }>(`
+      SELECT pid, query
+      FROM pg_stat_activity
+      WHERE datname = current_database()
+        AND usename = current_user
+        AND pid <> pg_backend_pid()
+        AND query = ANY($1::text[])
+    `, [listenQueries]);
+    expect(activeListeners.rows).toEqual([
+      { pid: expect.any(Number), query: listenQueries[2] }
+    ]);
+    const listenerPid = activeListeners.rows[0].pid;
+
+    expect(() => first.subscribe(topics[1])).toThrow(PgNotificationTopicError);
+    const firstStream = first.subscribe(topics[0]);
+    const secondStream = second.subscribe(topics[1]);
+    const thirdStream = third.subscribe(topics[2]);
+    let firstResolved = false;
+    let thirdResolved = false;
+    const firstNext = firstStream.next().then((result) => {
+      firstResolved = true;
+      return result;
+    });
+    const secondNext = secondStream.next();
+    const thirdNext = thirdStream.next().then((result) => {
+      thirdResolved = true;
+      return result;
+    });
+
+    await observerPool.query('SELECT pg_notify($1, $2)', [topics[1], 'for-second']);
+    await expect(secondNext).resolves.toEqual({ done: false, value: 'for-second' });
+    // Delivery to every lease happens synchronously inside one notification
+    // callback, so these flags prove the second topic did not reach its peers.
+    expect(firstResolved).toBe(false);
+    expect(thirdResolved).toBe(false);
+
+    await observerPool.query('SELECT pg_notify($1, $2)', [topics[0], 'for-first']);
+    await observerPool.query('SELECT pg_notify($1, $2)', [topics[2], 'for-third']);
+    await expect(firstNext).resolves.toEqual({ done: false, value: 'for-first' });
+    await expect(thirdNext).resolves.toEqual({ done: false, value: 'for-third' });
+
+    await second.release();
+    await first.release();
+    expect(getPgNotificationBrokerStats()).toMatchObject({
+      brokers: 1,
+      listenerConnections: 1,
+      leases: 1,
+      topics: 1
+    });
+    expect(brokerPool.idleCount).toBe(0);
+
+    await third.release();
+    expect(getPgNotificationBrokerStats()).toMatchObject({
+      brokers: 0,
+      listenerConnections: 0,
+      leases: 0,
+      topics: 0
+    });
+    expect(brokerPool.totalCount).toBe(0);
+    expect(brokerPool.idleCount).toBe(0);
+
+    let releasedListenerRows: Array<{ pid: number }> = [];
+    for (let attempt = 0; attempt < 50; attempt++) {
+      const releasedListener = await observerPool.query<{ pid: number }>(`
+        SELECT pid
+        FROM pg_stat_activity
+        WHERE pid = $1
+      `, [listenerPid]);
+      releasedListenerRows = releasedListener.rows;
+      if (releasedListenerRows.length === 0) break;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    expect(releasedListenerRows).toEqual([]);
+  });
+});

--- a/postgres/pg-cache/src/__tests__/notification-broker.test.ts
+++ b/postgres/pg-cache/src/__tests__/notification-broker.test.ts
@@ -1,0 +1,855 @@
+import { EventEmitter } from 'node:events';
+
+import {
+  DEFAULT_PG_NOTIFICATION_OPERATION_TIMEOUT_MS,
+  getPgNotificationBrokerIdentity,
+  getPgNotificationDatabaseIdentity,
+  PgNotificationBrokerFailedError,
+  PgNotificationBrokerRegistry,
+  PgNotificationConnectionSource,
+  PgNotificationOperationTimeoutError,
+  PgNotificationQueueOverflowError,
+  PgNotificationTopicError
+} from '../notification-broker';
+import {
+  PG_NOTIFICATION_ROLE_AUDIT_SQL,
+  UnsafePgNotificationRoleError
+} from '../notification-role';
+
+const roleContract = {
+  role: 'tenant_a_notify',
+  database: 'tenant_a'
+};
+
+const safeRoleAuditRow = {
+  expected_role: roleContract.role,
+  session_role: roleContract.role,
+  active_role: roleContract.role,
+  active_database: roleContract.database,
+  rolcanlogin: true,
+  rolinherit: false,
+  rolsuper: false,
+  rolbypassrls: false,
+  rolcreaterole: false,
+  rolcreatedb: false,
+  rolreplication: false,
+  membership_count: 0,
+  target_database_exists: true,
+  target_connect: true,
+  other_database_connect_count: 0,
+  target_database_owner: false,
+  target_database_create: false,
+  target_database_temp: false,
+  schema_owner_count: 0,
+  schema_create_count: 0,
+  schema_usage_count: 0,
+  relation_privilege_count: 0,
+  function_privilege_count: 0,
+  sequence_privilege_count: 0
+};
+
+class MockNotificationClient extends EventEmitter {
+  readonly queries: string[] = [];
+  roleAuditRow: Record<string, unknown> | undefined = safeRoleAuditRow;
+  readonly query = jest.fn(async (
+    text: string,
+    _values?: readonly unknown[]
+  ): Promise<unknown> => {
+    this.queries.push(text);
+    if (text === PG_NOTIFICATION_ROLE_AUDIT_SQL) {
+      return { rows: this.roleAuditRow ? [this.roleAuditRow] : [] };
+    }
+    return { rows: [] };
+  });
+  readonly release = jest.fn(async (_error?: Error | boolean): Promise<void> => {});
+
+  notification(channel: string, payload?: string): void {
+    this.emit('notification', { channel, payload });
+  }
+}
+
+const createSource = (client = new MockNotificationClient()) => {
+  const source: PgNotificationConnectionSource = {
+    connect: jest.fn(async () => client),
+    release: jest.fn(async () => {})
+  };
+  return { client, source };
+};
+
+const deferred = <T>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+};
+
+const flushMicrotasks = async (): Promise<void> => {
+  for (let index = 0; index < 20; index++) await Promise.resolve();
+};
+
+describe('PgNotificationBrokerRegistry', () => {
+  it('shares one dedicated listener and reference-counts exact topics', async () => {
+    const registry = new PgNotificationBrokerRegistry(4);
+    const { client, source } = createSource();
+    const sourceFactory = jest.fn(() => source);
+
+    const [first, second] = await Promise.all([
+      registry.acquireForTests('opaque-a', sourceFactory, ['tenant.a', 'shared']),
+      registry.acquireForTests('opaque-a', sourceFactory, ['shared', 'tenant.b'])
+    ]);
+
+    expect(sourceFactory).toHaveBeenCalledTimes(1);
+    expect(source.connect).toHaveBeenCalledTimes(1);
+    expect(client.queries).toEqual([
+      'LISTEN "tenant.a"',
+      'LISTEN "shared"',
+      'LISTEN "tenant.b"'
+    ]);
+    expect(registry.stats()).toMatchObject({
+      brokers: 1,
+      listenerConnections: 1,
+      leases: 2,
+      topics: 3
+    });
+
+    await first.release();
+    expect(client.queries).toContain('UNLISTEN "tenant.a"');
+    expect(client.queries).not.toContain('UNLISTEN "shared"');
+    expect(client.release).not.toHaveBeenCalled();
+
+    await second.release();
+    expect(client.queries.slice(-2)).toEqual([
+      'UNLISTEN "shared"',
+      'UNLISTEN "tenant.b"'
+    ]);
+    expect(client.release).toHaveBeenCalledWith(true);
+    expect(source.release).toHaveBeenCalledTimes(1);
+    expect(registry.stats()).toMatchObject({ brokers: 0, leases: 0, topics: 0 });
+  });
+
+  it('audits three generations on the one pinned listener before admission', async () => {
+    const registry = new PgNotificationBrokerRegistry(4);
+    const { client, source } = createSource();
+    const sourceFactory = jest.fn(() => source);
+
+    const first = await registry.acquireAttestedForTests(
+      'opaque-attested', sourceFactory, ['tenant.a'], roleContract
+    );
+    const second = await registry.acquireAttestedForTests(
+      'opaque-attested', sourceFactory, ['tenant.b'], roleContract
+    );
+    const third = await registry.acquireAttestedForTests(
+      'opaque-attested', sourceFactory, ['tenant.c'], roleContract
+    );
+
+    expect(sourceFactory).toHaveBeenCalledTimes(1);
+    expect(source.connect).toHaveBeenCalledTimes(1);
+    expect(client.queries.filter(
+      (query) => query === PG_NOTIFICATION_ROLE_AUDIT_SQL
+    )).toHaveLength(3);
+    expect(client.queries).toEqual([
+      'BEGIN READ ONLY',
+      'SET LOCAL jit TO off',
+      PG_NOTIFICATION_ROLE_AUDIT_SQL,
+      'COMMIT',
+      'LISTEN "tenant.a"',
+      'BEGIN READ ONLY',
+      'SET LOCAL jit TO off',
+      PG_NOTIFICATION_ROLE_AUDIT_SQL,
+      'COMMIT',
+      'LISTEN "tenant.b"',
+      'BEGIN READ ONLY',
+      'SET LOCAL jit TO off',
+      PG_NOTIFICATION_ROLE_AUDIT_SQL,
+      'COMMIT',
+      'LISTEN "tenant.c"'
+    ]);
+    expect(first.roleAudit).toMatchObject({ ...roleContract, safe: true });
+    expect(second.roleAudit).toMatchObject({ ...roleContract, safe: true });
+    expect(third.roleAudit).toMatchObject({ ...roleContract, safe: true });
+    expect(registry.stats()).toMatchObject({
+      listenerConnections: 1,
+      leases: 3,
+      roleAuditAttempts: 3,
+      roleAuditFailures: 0
+    });
+
+    await Promise.all([first.release(), second.release(), third.release()]);
+  });
+
+  it('serializes concurrent admission audits without another connection', async () => {
+    const registry = new PgNotificationBrokerRegistry(4);
+    const { client, source } = createSource();
+    const firstCatalogAudit = deferred<void>();
+    let catalogAuditsStarted = 0;
+    let activeCatalogAudits = 0;
+    let peakCatalogAudits = 0;
+    client.query.mockImplementation(async (text: string) => {
+      client.queries.push(text);
+      if (text === PG_NOTIFICATION_ROLE_AUDIT_SQL) {
+        catalogAuditsStarted++;
+        activeCatalogAudits++;
+        peakCatalogAudits = Math.max(peakCatalogAudits, activeCatalogAudits);
+        if (catalogAuditsStarted === 1) await firstCatalogAudit.promise;
+        activeCatalogAudits--;
+        return { rows: [safeRoleAuditRow] };
+      }
+      return { rows: [] };
+    });
+
+    const acquisitions = [
+      registry.acquireAttestedForTests(
+        'opaque-attested', () => source, ['a'], roleContract
+      ),
+      registry.acquireAttestedForTests(
+        'opaque-attested', () => source, ['b'], roleContract
+      ),
+      registry.acquireAttestedForTests(
+        'opaque-attested', () => source, ['c'], roleContract
+      )
+    ];
+    await flushMicrotasks();
+    expect(catalogAuditsStarted).toBe(1);
+    expect(source.connect).toHaveBeenCalledTimes(1);
+
+    firstCatalogAudit.resolve();
+    const leases = await Promise.all(acquisitions);
+    expect(catalogAuditsStarted).toBe(3);
+    expect(peakCatalogAudits).toBe(1);
+    expect(source.connect).toHaveBeenCalledTimes(1);
+    await Promise.all(leases.map((lease) => lease.release()));
+  });
+
+  it('bounds a never-resolving admission audit and destroys its client', async () => {
+    jest.useFakeTimers();
+    try {
+      const registry = new PgNotificationBrokerRegistry(4, 25);
+      const { client, source } = createSource();
+      client.query.mockImplementation((text: string) => {
+        client.queries.push(text);
+        if (text === 'BEGIN READ ONLY') return new Promise(() => undefined);
+        return Promise.resolve({ rows: [] });
+      });
+
+      const acquiring = registry.acquireAttestedForTests(
+        'opaque-timeout',
+        () => source,
+        ['a'],
+        roleContract
+      );
+      const rejected = expect(acquiring).rejects.toBeInstanceOf(
+        PgNotificationOperationTimeoutError
+      );
+      await flushMicrotasks();
+      await jest.advanceTimersByTimeAsync(25);
+      await rejected;
+
+      expect(client.queries).toEqual(['BEGIN READ ONLY']);
+      expect(client.release).toHaveBeenCalledWith(
+        expect.any(PgNotificationBrokerFailedError)
+      );
+      expect(source.release).toHaveBeenCalledTimes(1);
+      expect(registry.stats()).toMatchObject({
+        brokers: 0,
+        listenerConnections: 0,
+        leases: 0,
+        fatalFailures: 1,
+        roleAuditAttempts: 1,
+        roleAuditFailures: 1
+      });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('revalidates on the pinned listener and fails every lease closed on drift', async () => {
+    const registry = new PgNotificationBrokerRegistry(4);
+    const { client, source } = createSource();
+    const first = await registry.acquireAttestedForTests(
+      'opaque-attested', () => source, ['a'], roleContract
+    );
+    const second = await registry.acquireAttestedForTests(
+      'opaque-attested', () => source, ['b'], roleContract
+    );
+
+    await expect(first.revalidateRole()).resolves.toMatchObject({ safe: true });
+    expect(source.connect).toHaveBeenCalledTimes(1);
+    expect(registry.stats()).toMatchObject({
+      roleAuditAttempts: 3,
+      roleAuditFailures: 0
+    });
+
+    const firstNext = first.subscribe('a').next();
+    const secondNext = second.subscribe('b').next();
+    client.roleAuditRow = { ...safeRoleAuditRow, rolsuper: true };
+    await expect(second.revalidateRole()).rejects.toBeInstanceOf(
+      UnsafePgNotificationRoleError
+    );
+    await expect(firstNext).rejects.toBeInstanceOf(PgNotificationBrokerFailedError);
+    await expect(secondNext).rejects.toBeInstanceOf(PgNotificationBrokerFailedError);
+    await expect(first.terminated).resolves.toBeInstanceOf(
+      PgNotificationBrokerFailedError
+    );
+    await expect(second.terminated).resolves.toBeInstanceOf(
+      PgNotificationBrokerFailedError
+    );
+    expect(source.connect).toHaveBeenCalledTimes(1);
+    expect(client.release).toHaveBeenCalledWith(
+      expect.any(PgNotificationBrokerFailedError)
+    );
+    expect(registry.stats()).toMatchObject({
+      listenerConnections: 0,
+      leases: 2,
+      fatalFailures: 1,
+      roleAuditAttempts: 4,
+      roleAuditFailures: 1
+    });
+
+    await Promise.all([first.release(), second.release()]);
+  });
+
+  it('bounds a never-resolving TTL role refresh on the pinned listener', async () => {
+    jest.useFakeTimers();
+    try {
+      const registry = new PgNotificationBrokerRegistry(4, 25);
+      const { client, source } = createSource();
+      const lease = await registry.acquireAttestedForTests(
+        'opaque-refresh-timeout',
+        () => source,
+        ['a'],
+        roleContract
+      );
+      client.query.mockImplementation((text: string) => {
+        client.queries.push(text);
+        if (text === 'BEGIN READ ONLY') return new Promise(() => undefined);
+        return Promise.resolve({ rows: [] });
+      });
+
+      const refreshing = lease.revalidateRole();
+      const rejected = expect(refreshing).rejects.toBeInstanceOf(
+        PgNotificationOperationTimeoutError
+      );
+      await flushMicrotasks();
+      await jest.advanceTimersByTimeAsync(25);
+      await rejected;
+      await expect(lease.terminated).resolves.toBeInstanceOf(
+        PgNotificationBrokerFailedError
+      );
+
+      expect(client.release).toHaveBeenCalledWith(
+        expect.any(PgNotificationBrokerFailedError)
+      );
+      expect(registry.stats()).toMatchObject({
+        listenerConnections: 0,
+        leases: 1,
+        fatalFailures: 1,
+        roleAuditAttempts: 2,
+        roleAuditFailures: 1
+      });
+      await lease.release();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('uses exact topic equality for prefix and quoted-identifier channels', async () => {
+    const registry = new PgNotificationBrokerRegistry(4);
+    const { client, source } = createSource();
+    const hostileButValid = 'tenant"; UNLISTEN *;--';
+    const lease = await registry.acquireForTests(
+      'opaque-a',
+      () => source,
+      ['tenant', 'tenant.longer', hostileButValid]
+    );
+    const exact = lease.subscribe('tenant');
+    const longer = lease.subscribe('tenant.longer');
+    const hostile = lease.subscribe(hostileButValid);
+
+    expect(() => lease.subscribe('ten')).toThrow(PgNotificationTopicError);
+    expect(client.queries).toContain(
+      'LISTEN "tenant""; UNLISTEN *;--"'
+    );
+
+    client.notification('ten', 'wrong-prefix');
+    client.notification('tenant.longer', 'longer');
+    client.notification(hostileButValid, 'quoted');
+    client.notification('tenant', 'exact');
+
+    await expect(exact.next()).resolves.toEqual({ done: false, value: 'exact' });
+    await expect(longer.next()).resolves.toEqual({ done: false, value: 'longer' });
+    await expect(hostile.next()).resolves.toEqual({ done: false, value: 'quoted' });
+    expect(registry.stats().ignoredNotifications).toBe(1);
+    await lease.release();
+  });
+
+  it('rejects channels PostgreSQL would truncate, including multi-byte Unicode', async () => {
+    const registry = new PgNotificationBrokerRegistry();
+    const { source } = createSource();
+
+    const ascii63 = 'a'.repeat(63);
+    const unicode63 = '界'.repeat(21);
+    const lease = await registry.acquireForTests(
+      'opaque-a',
+      () => source,
+      [ascii63, unicode63]
+    );
+    expect(lease.topics).toEqual([ascii63, unicode63]);
+
+    await expect(
+      registry.acquireForTests('opaque-b', () => source, ['a'.repeat(64)])
+    ).rejects.toBeInstanceOf(PgNotificationTopicError);
+    await expect(
+      registry.acquireForTests('opaque-b', () => source, ['界'.repeat(22)])
+    ).rejects.toBeInstanceOf(PgNotificationTopicError);
+    await expect(
+      registry.acquireForTests(
+        'opaque-b',
+        () => source,
+        [`bad${String.fromCharCode(0xd800)}`]
+      )
+    ).rejects.toBeInstanceOf(PgNotificationTopicError);
+    await lease.release();
+  });
+
+  it('does not normalize canonically equivalent Unicode topics', async () => {
+    const registry = new PgNotificationBrokerRegistry(4);
+    const { client, source } = createSource();
+    const composed = 'réaltime';
+    const decomposed = 're\u0301altime';
+    const lease = await registry.acquireForTests(
+      'opaque-a',
+      () => source,
+      [composed, decomposed]
+    );
+    const composedStream = lease.subscribe(composed);
+    const decomposedStream = lease.subscribe(decomposed);
+
+    client.notification(composed, 'composed-only');
+    client.notification(decomposed, 'decomposed-only');
+
+    await expect(composedStream.next()).resolves.toMatchObject({ value: 'composed-only' });
+    await expect(decomposedStream.next()).resolves.toMatchObject({ value: 'decomposed-only' });
+    await lease.release();
+  });
+
+  it('fans out only to subscribers for the exact allowed topic', async () => {
+    const registry = new PgNotificationBrokerRegistry(4);
+    const { client, source } = createSource();
+    const first = await registry.acquireForTests('opaque-a', () => source, ['a']);
+    const second = await registry.acquireForTests('opaque-a', () => source, ['a', 'b']);
+    const firstA = first.subscribe('a');
+    const secondA = second.subscribe('a');
+    const secondB = second.subscribe('b');
+
+    client.notification('a', 'for-a');
+    client.notification('b', 'for-b');
+
+    await expect(firstA.next()).resolves.toMatchObject({ value: 'for-a' });
+    await expect(secondA.next()).resolves.toMatchObject({ value: 'for-a' });
+    await expect(secondB.next()).resolves.toMatchObject({ value: 'for-b' });
+    await Promise.all([first.release(), second.release()]);
+  });
+
+  it('fails only the slow subscriber when its bounded queue overflows', async () => {
+    const registry = new PgNotificationBrokerRegistry(1);
+    const { client, source } = createSource();
+    const lease = await registry.acquireForTests('opaque-a', () => source, ['events']);
+    const slow = lease.subscribe('events');
+    const fast = lease.subscribe('events');
+
+    const fastFirst = fast.next();
+    client.notification('events', 'one');
+    const fastSecond = fast.next();
+    client.notification('events', 'two');
+
+    await expect(fastFirst).resolves.toMatchObject({ value: 'one' });
+    await expect(fastSecond).resolves.toMatchObject({ value: 'two' });
+    await expect(slow.next()).rejects.toBeInstanceOf(PgNotificationQueueOverflowError);
+    expect(registry.stats()).toMatchObject({ subscribers: 1, queueOverflows: 1 });
+    await lease.release();
+  });
+
+  it('fails every active subscriber and never silently reconnects', async () => {
+    const registry = new PgNotificationBrokerRegistry(4);
+    const { client, source } = createSource();
+    const sourceFactory = jest.fn(() => source);
+    const first = await registry.acquireForTests('opaque-a', sourceFactory, ['a']);
+    const second = await registry.acquireForTests('opaque-a', sourceFactory, ['b']);
+    const firstNext = first.subscribe('a').next();
+    const secondNext = second.subscribe('b').next();
+
+    client.emit('error', new Error('socket lost'));
+
+    await expect(firstNext).rejects.toBeInstanceOf(PgNotificationBrokerFailedError);
+    await expect(secondNext).rejects.toBeInstanceOf(PgNotificationBrokerFailedError);
+    await expect(first.terminated).resolves.toBeInstanceOf(
+      PgNotificationBrokerFailedError
+    );
+    await expect(
+      registry.acquireForTests('opaque-a', sourceFactory, ['a'])
+    ).rejects.toBeInstanceOf(PgNotificationBrokerFailedError);
+    expect(source.connect).toHaveBeenCalledTimes(1);
+    expect(client.release).toHaveBeenCalledWith(expect.any(PgNotificationBrokerFailedError));
+
+    await Promise.all([first.release(), second.release()]);
+    const replacement = createSource();
+    const explicitReplacement = await registry.acquireForTests(
+      'opaque-a',
+      () => replacement.source,
+      ['a']
+    );
+    expect(replacement.source.connect).toHaveBeenCalledTimes(1);
+    await explicitReplacement.release();
+  });
+
+  it('bounds a never-resolving LISTEN and fails admission closed', async () => {
+    jest.useFakeTimers();
+    try {
+      const registry = new PgNotificationBrokerRegistry(4, 25);
+      const { client, source } = createSource();
+      client.query.mockImplementation((text: string) => {
+        client.queries.push(text);
+        if (text.startsWith('LISTEN')) return new Promise(() => undefined);
+        return Promise.resolve({ rows: [] });
+      });
+
+      const acquiring = registry.acquireForTests('opaque-listen-timeout', () => source, ['a']);
+      const rejected = expect(acquiring).rejects.toMatchObject({
+        code: 'PG_NOTIFICATION_BROKER_FAILED',
+        cause: { code: 'PG_NOTIFICATION_OPERATION_TIMEOUT' }
+      });
+      await flushMicrotasks();
+      await jest.advanceTimersByTimeAsync(25);
+      await rejected;
+
+      expect(client.release).toHaveBeenCalledWith(
+        expect.any(PgNotificationBrokerFailedError)
+      );
+      expect(source.release).toHaveBeenCalledTimes(1);
+      expect(registry.stats()).toMatchObject({
+        brokers: 0,
+        listenerConnections: 0,
+        fatalFailures: 1
+      });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('fails closed when a listener emits a malformed notification', async () => {
+    const registry = new PgNotificationBrokerRegistry(4);
+    const { client, source } = createSource();
+    const lease = await registry.acquireForTests('opaque-a', () => source, ['a']);
+    const next = lease.subscribe('a').next();
+
+    client.emit('notification', { channel: 'a', payload: { hostile: true } });
+
+    await expect(next).rejects.toBeInstanceOf(PgNotificationBrokerFailedError);
+    await expect(lease.terminated).resolves.toBeInstanceOf(
+      PgNotificationBrokerFailedError
+    );
+    await lease.release();
+  });
+
+  it('makes double release idempotent and awaits UNLISTEN plus both releases', async () => {
+    const registry = new PgNotificationBrokerRegistry(4);
+    const { client, source } = createSource();
+    const unlisten = deferred<void>();
+    const clientReleased = deferred<void>();
+    const sourceReleased = deferred<void>();
+    client.query.mockImplementation(async (text: string) => {
+      client.queries.push(text);
+      if (text.startsWith('UNLISTEN')) await unlisten.promise;
+      return { rows: [] };
+    });
+    client.release.mockImplementation(async () => clientReleased.promise);
+    (source.release as jest.Mock).mockImplementation(async () => sourceReleased.promise);
+    const lease = await registry.acquireForTests('opaque-a', () => source, ['a']);
+
+    const firstRelease = lease.release();
+    const secondRelease = lease.release();
+    expect(firstRelease).toBe(secondRelease);
+    await flushMicrotasks();
+    expect(client.queries).toContain('UNLISTEN "a"');
+
+    let settled = false;
+    void firstRelease.then(() => {
+      settled = true;
+    });
+    unlisten.resolve();
+    await flushMicrotasks();
+    expect(settled).toBe(false);
+    clientReleased.resolve();
+    await flushMicrotasks();
+    expect(settled).toBe(false);
+    sourceReleased.resolve();
+    await firstRelease;
+    await expect(lease.terminated).resolves.toBeNull();
+    expect(settled).toBe(true);
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(source.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('serializes a final release against a concurrent new acquisition', async () => {
+    const registry = new PgNotificationBrokerRegistry(4);
+    const firstSource = createSource();
+    const unlisten = deferred<void>();
+    firstSource.client.query.mockImplementation(async (text: string) => {
+      firstSource.client.queries.push(text);
+      if (text.startsWith('UNLISTEN')) await unlisten.promise;
+      return { rows: [] };
+    });
+    const first = await registry.acquireForTests(
+      'opaque-a',
+      () => firstSource.source,
+      ['a']
+    );
+    const releasing = first.release();
+    await flushMicrotasks();
+
+    const secondSource = createSource();
+    const acquiring = registry.acquireForTests(
+      'opaque-a',
+      () => secondSource.source,
+      ['a']
+    );
+    await flushMicrotasks();
+    expect(secondSource.source.connect).not.toHaveBeenCalled();
+
+    unlisten.resolve();
+    await releasing;
+    const second = await acquiring;
+    expect(secondSource.source.connect).toHaveBeenCalledTimes(1);
+    await second.release();
+  });
+
+  it('makes concurrent registry close calls await the same teardown', async () => {
+    const registry = new PgNotificationBrokerRegistry(4);
+    const { source } = createSource();
+    const sourceReleased = deferred<void>();
+    (source.release as jest.Mock).mockImplementation(async () => sourceReleased.promise);
+    await registry.acquireForTests('opaque-a', () => source, ['a']);
+
+    const firstClose = registry.close();
+    const secondClose = registry.close();
+    let firstSettled = false;
+    let secondSettled = false;
+    void firstClose.then(() => {
+      firstSettled = true;
+    });
+    void secondClose.then(() => {
+      secondSettled = true;
+    });
+    await flushMicrotasks();
+
+    expect(firstSettled).toBe(false);
+    expect(secondSettled).toBe(false);
+    sourceReleased.resolve();
+    await Promise.all([firstClose, secondClose]);
+    expect(source.release).toHaveBeenCalledTimes(1);
+    expect(registry.stats()).toMatchObject({ brokers: 0, leases: 0 });
+  });
+
+  it('bounds a never-resolving UNLISTEN so teardown cannot hang', async () => {
+    jest.useFakeTimers();
+    try {
+      const registry = new PgNotificationBrokerRegistry(4, 25);
+      const { client, source } = createSource();
+      await registry.acquireForTests('opaque-unlisten-timeout', () => source, ['a']);
+      client.query.mockImplementation((text: string) => {
+        client.queries.push(text);
+        if (text.startsWith('UNLISTEN')) return new Promise(() => undefined);
+        return Promise.resolve({ rows: [] });
+      });
+
+      const closing = registry.close();
+      const rejected = expect(closing).rejects.toMatchObject({
+        code: 'PG_NOTIFICATION_BROKER_FAILED',
+        cause: { code: 'PG_NOTIFICATION_OPERATION_TIMEOUT' }
+      });
+      await flushMicrotasks();
+      await jest.advanceTimersByTimeAsync(25);
+      await rejected;
+
+      expect(client.release).toHaveBeenCalledWith(
+        expect.any(PgNotificationBrokerFailedError)
+      );
+      expect(source.release).toHaveBeenCalledTimes(1);
+      expect(registry.stats()).toMatchObject({
+        brokers: 0,
+        listenerConnections: 0,
+        leases: 0,
+        fatalFailures: 1
+      });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('drains an in-flight acquisition before registry close resolves', async () => {
+    const registry = new PgNotificationBrokerRegistry(4);
+    const { client, source } = createSource();
+    const connected = deferred<MockNotificationClient>();
+    const sourceReleased = deferred<void>();
+    (source.connect as jest.Mock).mockImplementation(async () => connected.promise);
+    (source.release as jest.Mock).mockImplementation(async () => sourceReleased.promise);
+    const acquiring = registry.acquireForTests('opaque-a', () => source, ['a']);
+    await flushMicrotasks();
+    expect(source.connect).toHaveBeenCalledTimes(1);
+
+    const closing = registry.close();
+    let closeSettled = false;
+    void closing.then(() => {
+      closeSettled = true;
+    });
+    connected.resolve(client);
+    await flushMicrotasks();
+    const closeSettledBeforeSourceRelease = closeSettled;
+    const issuedListenDuringClose = client.queries.includes('LISTEN "a"');
+    sourceReleased.resolve();
+    await expect(acquiring).rejects.toThrow(
+      'PostgreSQL notification broker registry is closed'
+    );
+    await closing;
+    expect(closeSettledBeforeSourceRelease).toBe(false);
+    expect(issuedListenDuringClose).toBe(false);
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(source.release).toHaveBeenCalledTimes(1);
+    expect(registry.stats()).toMatchObject({ brokers: 0, leases: 0 });
+  });
+
+  it('UNLISTENs a provisional topic when close races an in-flight LISTEN', async () => {
+    const registry = new PgNotificationBrokerRegistry(4);
+    const { client, source } = createSource();
+    const listened = deferred<void>();
+    client.query.mockImplementation(async (text: string) => {
+      client.queries.push(text);
+      if (text === 'LISTEN "a"') await listened.promise;
+      return { rows: [] };
+    });
+    const acquiring = registry.acquireForTests('opaque-a', () => source, ['a']);
+    await flushMicrotasks();
+    expect(client.queries).toEqual(['LISTEN "a"']);
+
+    const closing = registry.close();
+    listened.resolve();
+    await expect(acquiring).rejects.toThrow(
+      'PostgreSQL notification broker registry is closed'
+    );
+    await closing;
+
+    expect(client.queries).toEqual(['LISTEN "a"', 'UNLISTEN *']);
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(source.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a failed UNLISTEN only after finishing registry teardown', async () => {
+    const registry = new PgNotificationBrokerRegistry(4);
+    const { client, source } = createSource();
+    client.query.mockImplementation(async (text: string) => {
+      client.queries.push(text);
+      if (text.startsWith('UNLISTEN')) throw new Error('unlisten failed');
+      return { rows: [] };
+    });
+    await registry.acquireForTests('opaque-a', () => source, ['a']);
+
+    await expect(registry.close()).rejects.toBeInstanceOf(
+      PgNotificationBrokerFailedError
+    );
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(source.release).toHaveBeenCalledTimes(1);
+    expect(registry.stats()).toMatchObject({ brokers: 0, leases: 0 });
+  });
+});
+
+describe('getPgNotificationBrokerIdentity', () => {
+  const baseConfig = {
+    host: 'db.internal',
+    port: 5432,
+    database: 'customer',
+    user: 'listener',
+    password: 'secret'
+  };
+
+  it('is versioned, opaque, stable, and includes the canonical SSL contract', () => {
+    const first = getPgNotificationBrokerIdentity({
+      ...baseConfig,
+      ssl: { rejectUnauthorized: true, ca: 'ca-one' },
+      pool: { connectionTimeoutMillis: DEFAULT_PG_NOTIFICATION_OPERATION_TIMEOUT_MS }
+    });
+    const reordered = getPgNotificationBrokerIdentity({
+      ...baseConfig,
+      ssl: { ca: 'ca-one', rejectUnauthorized: true },
+      pool: { connectionTimeoutMillis: DEFAULT_PG_NOTIFICATION_OPERATION_TIMEOUT_MS }
+    });
+    const changedTls = getPgNotificationBrokerIdentity({
+      ...baseConfig,
+      ssl: { rejectUnauthorized: false, ca: 'ca-one' },
+      pool: { connectionTimeoutMillis: DEFAULT_PG_NOTIFICATION_OPERATION_TIMEOUT_MS }
+    });
+    const changedDeadline = getPgNotificationBrokerIdentity({
+      ...baseConfig,
+      ssl: { rejectUnauthorized: true, ca: 'ca-one' },
+      pool: {
+        connectionTimeoutMillis:
+          DEFAULT_PG_NOTIFICATION_OPERATION_TIMEOUT_MS + 1
+      }
+    });
+
+    expect(first).toBe(reordered);
+    expect(first).not.toBe(changedTls);
+    expect(first).not.toBe(changedDeadline);
+    expect(first).toMatch(/^pg-notification-broker:v1:pg:v1:[a-f0-9]{64}$/);
+    expect(first).not.toContain('listener');
+    expect(first).not.toContain('secret');
+  });
+
+  it.each([0, -1, 1.5, 2_147_483_648])(
+    'rejects invalid notification operation timeout %p before identity publication',
+    (connectionTimeoutMillis) => {
+      expect(() => getPgNotificationBrokerIdentity({
+        ...baseConfig,
+        pool: { connectionTimeoutMillis }
+      })).toThrow('notification operation timeout');
+    }
+  );
+
+  it('uses one credential-free identity for the same physical database target', () => {
+    const first = getPgNotificationDatabaseIdentity({
+      ...baseConfig,
+      ssl: { rejectUnauthorized: true, ca: 'ca-one' },
+      pool: { max: 2 }
+    });
+    const rotated = getPgNotificationDatabaseIdentity({
+      ...baseConfig,
+      user: 'rotated-listener',
+      password: 'rotated-secret',
+      ssl: { ca: 'different-ca', rejectUnauthorized: false },
+      pool: { max: 20, idleTimeoutMillis: 99_000 }
+    });
+    const otherHost = getPgNotificationDatabaseIdentity({
+      ...baseConfig,
+      host: 'other-db.internal'
+    });
+    const otherPort = getPgNotificationDatabaseIdentity({
+      ...baseConfig,
+      port: 5433
+    });
+    const otherDatabase = getPgNotificationDatabaseIdentity({
+      ...baseConfig,
+      database: 'other-customer',
+      ssl: { rejectUnauthorized: true, ca: 'ca-one' }
+    });
+
+    expect(first).toBe(rotated);
+    expect(first).not.toBe(otherHost);
+    expect(first).not.toBe(otherPort);
+    expect(first).not.toBe(otherDatabase);
+    expect(first).toMatch(/^pg-notification-database:v1:pg-target:v1:[a-f0-9]{64}$/);
+    expect(first).not.toContain('listener');
+    expect(first).not.toContain('secret');
+  });
+});

--- a/postgres/pg-cache/src/__tests__/notification-role.integration.test.ts
+++ b/postgres/pg-cache/src/__tests__/notification-role.integration.test.ts
@@ -1,0 +1,120 @@
+import type pg from 'pg';
+import { getPgEnvOptions } from 'pg-env';
+
+import { teardownPgPools } from '../lru';
+import {
+  acquirePgNotificationBroker,
+  getPgNotificationBrokerStats,
+  teardownPgNotificationBrokers
+} from '../notification-broker';
+import {
+  assertPgNotificationRole,
+  auditPgNotificationRole
+} from '../notification-role';
+import { defaultPgPoolFactory, getPgPool } from '../pg';
+
+const describeWithNotificationRole =
+  process.env.PG_CACHE_RUN_NOTIFICATION_ROLE_INTEGRATION === '1'
+    ? describe
+    : describe.skip;
+
+describeWithNotificationRole('dedicated notification role against PostgreSQL', () => {
+  const pgConfig = getPgEnvOptions();
+  let pool: pg.Pool;
+
+  beforeAll(() => {
+    pool = defaultPgPoolFactory(
+      { ...pgConfig, pool: { max: 1 } },
+      { purpose: 'notification-role-integration', sanitizeOnCheckout: true }
+    ) as pg.Pool;
+  });
+
+  afterAll(async () => {
+    await teardownPgNotificationBrokers();
+    await teardownPgPools();
+    await pool?.end();
+  });
+
+  it('accepts only the exact credential-free role/database contract', async () => {
+    const audit = await assertPgNotificationRole(pool, {
+      role: pgConfig.user,
+      database: pgConfig.database
+    });
+
+    expect(audit).toMatchObject({
+      role: pgConfig.user,
+      database: pgConfig.database,
+      safe: true,
+      violations: []
+    });
+    expect(Object.keys(audit).sort()).toEqual([
+      'database',
+      'role',
+      'safe',
+      'version',
+      'violations'
+    ]);
+    expect(audit).not.toHaveProperty('password');
+    expect(audit).not.toHaveProperty('host');
+
+    const wrongRole = await auditPgNotificationRole(pool, {
+      role: `wrong_${process.pid}`,
+      database: pgConfig.database
+    });
+    expect(wrongRole).toMatchObject({
+      safe: false,
+      violations: expect.arrayContaining(['LOGIN_ROLE_MISMATCH'])
+    });
+
+    const wrongDatabase = await auditPgNotificationRole(pool, {
+      role: pgConfig.user,
+      database: `wrong_${process.pid}`
+    });
+    expect(wrongDatabase).toMatchObject({
+      safe: false,
+      violations: expect.arrayContaining([
+        'DATABASE_MISMATCH',
+        'TARGET_DATABASE_MISSING',
+        'TARGET_CONNECT_REQUIRED',
+        'CROSS_DATABASE_CONNECT'
+      ])
+    });
+  });
+
+  it('retains enough privilege for isolated LISTEN and NOTIFY delivery', async () => {
+    const nonce = `${process.pid}_${Date.now().toString(36)}`;
+    const topics = [0, 1, 2].map((index) => `notify_role_it_${nonce}_${index}`);
+    const listenerConfig = { ...pgConfig, pool: { max: 1 } };
+    const statsBefore = getPgNotificationBrokerStats();
+    const [first, second, third] = await Promise.all(topics.map((topic) =>
+      acquirePgNotificationBroker(listenerConfig, { topics: [topic] })
+    ));
+    const brokerPool = getPgPool(listenerConfig, {
+      purpose: 'notification-broker',
+      sanitizeOnCheckout: true
+    });
+    await first.revalidateRole();
+    const next = second.subscribe(topics[1]).next();
+
+    await pool.query('SELECT pg_notify($1, $2)', [topics[1], 'safe-listener']);
+    await expect(next).resolves.toEqual({ done: false, value: 'safe-listener' });
+    expect(getPgNotificationBrokerStats()).toMatchObject({
+      brokers: 1,
+      listenerConnections: 1,
+      leases: 3,
+      topics: 3,
+      roleAuditAttempts: statsBefore.roleAuditAttempts + 4,
+      roleAuditFailures: statsBefore.roleAuditFailures
+    });
+    expect(brokerPool.totalCount).toBe(1);
+    expect(brokerPool.idleCount).toBe(0);
+
+    await Promise.all([first.release(), second.release(), third.release()]);
+    expect(getPgNotificationBrokerStats()).toMatchObject({
+      brokers: 0,
+      listenerConnections: 0,
+      leases: 0,
+      topics: 0
+    });
+  });
+});

--- a/postgres/pg-cache/src/__tests__/notification-role.test.ts
+++ b/postgres/pg-cache/src/__tests__/notification-role.test.ts
@@ -1,0 +1,262 @@
+import type { Pool } from 'pg';
+
+import {
+  assertPgNotificationRole,
+  assertPgNotificationRoleClient,
+  auditPgNotificationRole,
+  auditPgNotificationRoleClient,
+  normalizePgNotificationRoleContracts,
+  PG_NOTIFICATION_ROLE_AUDIT_SQL,
+  PG_NOTIFICATION_ROLE_AUDIT_VERSION,
+  type PgNotificationRoleClient,
+  PgNotificationRoleContractError,
+  type PgNotificationRoleViolationCode,
+  UnsafePgNotificationRoleError
+} from '../notification-role';
+
+const contract = {
+  role: 'tenant_001_notification',
+  database: 'tenant_001'
+};
+
+const safeRow = {
+  expected_role: contract.role,
+  session_role: contract.role,
+  active_role: contract.role,
+  active_database: contract.database,
+  rolcanlogin: true,
+  rolinherit: false,
+  rolsuper: false,
+  rolbypassrls: false,
+  rolcreaterole: false,
+  rolcreatedb: false,
+  rolreplication: false,
+  membership_count: 0,
+  target_database_exists: true,
+  target_connect: true,
+  other_database_connect_count: 0,
+  target_database_owner: false,
+  target_database_create: false,
+  target_database_temp: false,
+  schema_owner_count: 0,
+  schema_create_count: 0,
+  schema_usage_count: 0,
+  relation_privilege_count: 0,
+  function_privilege_count: 0,
+  sequence_privilege_count: 0
+};
+
+const poolWithRow = (row: Record<string, unknown> | undefined) => {
+  const client = {
+    query: jest.fn(async (query: string) => query === PG_NOTIFICATION_ROLE_AUDIT_SQL
+      ? { rows: row ? [row] : [] }
+      : { rows: [] }),
+    release: jest.fn()
+  };
+  return {
+    pool: { connect: jest.fn(async () => client) } as unknown as Pool,
+    client
+  };
+};
+
+describe('PostgreSQL notification-role audit', () => {
+  it('returns a frozen credential-free attestation for an exact safe login', async () => {
+    const { pool, client } = poolWithRow(safeRow);
+    const audit = await assertPgNotificationRole(
+      pool,
+      { ...contract, password: 'must-not-escape' } as typeof contract
+    );
+
+    expect(audit).toEqual({
+      version: PG_NOTIFICATION_ROLE_AUDIT_VERSION,
+      ...contract,
+      safe: true,
+      violations: []
+    });
+    expect(Object.isFrozen(audit)).toBe(true);
+    expect(Object.isFrozen(audit.violations)).toBe(true);
+    expect(JSON.stringify(audit)).not.toContain('must-not-escape');
+    expect(client.query).toHaveBeenNthCalledWith(
+      1,
+      'BEGIN READ ONLY'
+    );
+    expect(client.query).toHaveBeenNthCalledWith(2, 'SET LOCAL jit TO off');
+    expect(client.query).toHaveBeenNthCalledWith(3, PG_NOTIFICATION_ROLE_AUDIT_SQL, [
+      contract.role,
+      contract.database
+    ]);
+    expect(client.query).toHaveBeenNthCalledWith(4, 'COMMIT');
+    expect(client.release).toHaveBeenCalledWith(false);
+  });
+
+  it('audits an already-owned listener client without releasing it', async () => {
+    const { client } = poolWithRow(safeRow);
+
+    await expect(assertPgNotificationRoleClient(
+      client as unknown as PgNotificationRoleClient,
+      contract
+    )).resolves
+      .toMatchObject({ ...contract, safe: true });
+    expect(client.release).not.toHaveBeenCalled();
+  });
+
+  it('rolls back a failed pinned-client audit without taking ownership of release', async () => {
+    const failure = new Error('catalog unavailable');
+    const client = {
+      query: jest.fn()
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockRejectedValueOnce(failure)
+        .mockResolvedValueOnce({ rows: [] }),
+      release: jest.fn()
+    };
+
+    await expect(auditPgNotificationRoleClient(client, contract)).rejects.toBe(failure);
+    expect(client.query).toHaveBeenNthCalledWith(4, 'ROLLBACK');
+    expect(client.release).not.toHaveBeenCalled();
+  });
+
+  it.each<[
+  keyof typeof safeRow,
+  unknown,
+  PgNotificationRoleViolationCode
+  ]>([
+    ['session_role', 'different_login', 'LOGIN_ROLE_MISMATCH'],
+    ['active_role', 'set_role_target', 'CURRENT_ROLE_MISMATCH'],
+    ['active_database', 'different_database', 'DATABASE_MISMATCH'],
+    ['rolcanlogin', false, 'LOGIN_REQUIRED'],
+    ['rolinherit', true, 'NOINHERIT_REQUIRED'],
+    ['rolsuper', true, 'SUPERUSER'],
+    ['rolbypassrls', true, 'BYPASSRLS'],
+    ['rolcreaterole', true, 'CREATEROLE'],
+    ['rolcreatedb', true, 'CREATEDB'],
+    ['rolreplication', true, 'REPLICATION'],
+    ['membership_count', 1, 'ROLE_MEMBERSHIP'],
+    ['target_database_exists', false, 'TARGET_DATABASE_MISSING'],
+    ['target_connect', false, 'TARGET_CONNECT_REQUIRED'],
+    ['other_database_connect_count', 1, 'CROSS_DATABASE_CONNECT'],
+    ['target_database_owner', true, 'DATABASE_OWNER'],
+    ['target_database_create', true, 'DATABASE_CREATE'],
+    ['target_database_temp', true, 'DATABASE_TEMP'],
+    ['schema_owner_count', 1, 'SCHEMA_OWNER'],
+    ['schema_create_count', 1, 'SCHEMA_CREATE'],
+    ['schema_usage_count', 1, 'SCHEMA_USAGE'],
+    ['relation_privilege_count', 1, 'RELATION_PRIVILEGE'],
+    ['function_privilege_count', 1, 'FUNCTION_PRIVILEGE'],
+    ['sequence_privilege_count', 1, 'SEQUENCE_PRIVILEGE']
+  ])('maps %s to its stable violation code', async (field, unsafeValue, code) => {
+    const { pool } = poolWithRow({ ...safeRow, [field]: unsafeValue });
+    const audit = await auditPgNotificationRole(pool, contract);
+
+    expect(audit.safe).toBe(false);
+    expect(audit.violations).toContain(code);
+    await expect(assertPgNotificationRole(
+      poolWithRow({ ...safeRow, [field]: unsafeValue }).pool,
+      contract
+    )).rejects.toMatchObject({
+      code: 'PG_NOTIFICATION_ROLE_UNSAFE',
+      audit: expect.objectContaining({ violations: expect.arrayContaining([code]) })
+    });
+  });
+
+  it('fails closed when the catalog audit returns no role row', async () => {
+    const { pool } = poolWithRow(undefined);
+    const audit = await auditPgNotificationRole(pool, contract);
+
+    expect(audit).toMatchObject({ safe: false, violations: ['AUDIT_NO_RESULT'] });
+    await expect(assertPgNotificationRole(poolWithRow(undefined).pool, contract))
+      .rejects.toBeInstanceOf(UnsafePgNotificationRoleError);
+  });
+
+  it('rolls back and destroys the client when the catalog query fails', async () => {
+    const failure = new Error('catalog unavailable');
+    const client = {
+      query: jest.fn()
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockRejectedValueOnce(failure)
+        .mockResolvedValueOnce({ rows: [] }),
+      release: jest.fn()
+    };
+    const pool = { connect: jest.fn(async () => client) } as unknown as Pool;
+
+    await expect(auditPgNotificationRole(pool, contract)).rejects.toBe(failure);
+    expect(client.query).toHaveBeenNthCalledWith(4, 'ROLLBACK');
+    expect(client.release).toHaveBeenCalledWith(true);
+  });
+
+  it('audits exact database scope, membership edges, and every prohibited ACL class', () => {
+    expect(PG_NOTIFICATION_ROLE_AUDIT_SQL).toContain(
+      'membership.member = r.oid OR membership.roleid = r.oid'
+    );
+    expect(PG_NOTIFICATION_ROLE_AUDIT_SQL).toContain(
+      'database_record.datname <> $2::text'
+    );
+    expect(PG_NOTIFICATION_ROLE_AUDIT_SQL).toContain("'CONNECT'");
+    expect(PG_NOTIFICATION_ROLE_AUDIT_SQL).toContain("'CREATE'");
+    expect(PG_NOTIFICATION_ROLE_AUDIT_SQL).toContain("'TEMP'");
+    expect(PG_NOTIFICATION_ROLE_AUDIT_SQL).toContain('schema_record.nspowner = r.oid');
+    expect(PG_NOTIFICATION_ROLE_AUDIT_SQL).toContain("'USAGE'");
+    expect(PG_NOTIFICATION_ROLE_AUDIT_SQL).toContain(
+      'pg_catalog.has_table_privilege'
+    );
+    expect(PG_NOTIFICATION_ROLE_AUDIT_SQL).toContain(
+      'pg_catalog.has_any_column_privilege'
+    );
+    expect(PG_NOTIFICATION_ROLE_AUDIT_SQL).toContain(
+      'pg_catalog.has_function_privilege'
+    );
+    expect(PG_NOTIFICATION_ROLE_AUDIT_SQL).toContain(
+      'pg_catalog.has_sequence_privilege'
+    );
+    expect(PG_NOTIFICATION_ROLE_AUDIT_SQL).toContain("n.nspname !~ '^pg_'");
+  });
+});
+
+describe('notification-role fleet contract', () => {
+  it('collapses exact generation duplicates and returns a deterministic frozen mapping', () => {
+    const normalized = normalizePgNotificationRoleContracts([
+      { role: 'notify_b', database: 'tenant_b' },
+      { ...contract },
+      { ...contract }
+    ]);
+
+    expect(normalized).toEqual([
+      contract,
+      { role: 'notify_b', database: 'tenant_b' }
+    ]);
+    expect(Object.isFrozen(normalized)).toBe(true);
+    expect(normalized.every(Object.isFrozen)).toBe(true);
+  });
+
+  it('rejects multiple logins for one database and one login spanning databases', () => {
+    expect(() => normalizePgNotificationRoleContracts([
+      contract,
+      { role: 'another_notification', database: contract.database }
+    ])).toThrow('maps to multiple login roles');
+    expect(() => normalizePgNotificationRoleContracts([
+      contract,
+      { role: contract.role, database: 'tenant_002' }
+    ])).toThrow('maps to multiple databases');
+  });
+
+  const malformedContracts: Array<{
+    contracts: readonly { role: string; database: string }[];
+  }> = [
+    { contracts: [] },
+    { contracts: [{ role: '', database: 'tenant_001' }] },
+    { contracts: [{ role: 'notify', database: '' }] },
+    { contracts: [{ role: 'n'.repeat(64), database: 'tenant_001' }] },
+    {
+      contracts: [{
+        role: 'notify',
+        database: `bad${String.fromCharCode(0xd800)}`
+      }]
+    }
+  ];
+
+  it.each(malformedContracts)('rejects malformed contract input', ({ contracts }) => {
+    expect(() => normalizePgNotificationRoleContracts(contracts))
+      .toThrow(PgNotificationRoleContractError);
+  });
+});

--- a/postgres/pg-cache/src/__tests__/sanitizer.integration.test.ts
+++ b/postgres/pg-cache/src/__tests__/sanitizer.integration.test.ts
@@ -1,0 +1,103 @@
+import type pg from 'pg';
+
+import { defaultPgPoolFactory, getPgCheckoutSanitizerStats } from '../pg';
+
+const describeWithPostgres = process.env.PG_CACHE_RUN_PG_INTEGRATION === '1'
+  ? describe
+  : describe.skip;
+
+describeWithPostgres('runtime checkout sanitation against PostgreSQL', () => {
+  let pool: pg.Pool;
+
+  beforeAll(() => {
+    pool = defaultPgPoolFactory(
+      { pool: { max: 1 } },
+      { purpose: 'runtime', sanitizeOnCheckout: true }
+    ) as pg.Pool;
+  });
+
+  afterAll(async () => {
+    await pool?.end();
+  });
+
+  it('restores the startup baseline and clears poisoned prepared state', async () => {
+    const poisoned = await pool.connect();
+    const poisonedPid = await poisoned.query<{ pid: number }>(
+      'SELECT pg_catalog.pg_backend_pid()::integer AS pid'
+    );
+    await poisoned.query('SET search_path TO public');
+    await poisoned.query('SET row_security TO off');
+    await poisoned.query('SET jit_optimize_above_cost TO 123');
+    await poisoned.query("SET application_name TO 'poisoned-tenant-session'");
+    await poisoned.query({ name: 'tenant_cache_canary', text: 'SELECT 1 AS value' });
+    poisoned.release();
+    expect(getPgCheckoutSanitizerStats(pool)).toMatchObject({
+      virginFastPathCheckouts: 1,
+      sanitizedReuseCheckouts: 0
+    });
+
+    const clean = await pool.connect();
+    try {
+      const cleanPid = await clean.query<{ pid: number }>(
+        'SELECT pg_catalog.pg_backend_pid()::integer AS pid'
+      );
+      expect(cleanPid.rows[0]?.pid).toBe(poisonedPid.rows[0]?.pid);
+      const settings = await clean.query<{
+        search_path: string;
+        row_security: string;
+        jit_optimize_above_cost: string;
+        application_name: string;
+      }>(`
+        SELECT
+          current_setting('search_path') AS search_path,
+          current_setting('row_security') AS row_security,
+          current_setting('jit_optimize_above_cost') AS jit_optimize_above_cost,
+          current_setting('application_name') AS application_name
+      `);
+      expect(settings.rows[0]).toMatchObject({
+        search_path: 'pg_catalog',
+        row_security: 'on',
+        jit_optimize_above_cost: '-1'
+      });
+      expect(settings.rows[0].application_name).not.toBe('poisoned-tenant-session');
+
+      await expect(clean.query({
+        name: 'tenant_cache_canary',
+        text: 'SELECT 2 AS value'
+      })).resolves.toMatchObject({ rows: [{ value: 2 }] });
+      expect(getPgCheckoutSanitizerStats(pool)).toMatchObject({
+        virginFastPathCheckouts: 1,
+        sanitizedReuseCheckouts: 1,
+        sanitationFailures: 0
+      });
+    } finally {
+      clean.release();
+    }
+  });
+
+  it('proves maxUses=1 rotates the PostgreSQL backend instead of reusing it', async () => {
+    const rotatingPool = defaultPgPoolFactory(
+      { pool: { max: 1, maxUses: 1 } },
+      { purpose: 'runtime-max-uses-one', sanitizeOnCheckout: true }
+    ) as pg.Pool;
+    try {
+      const first = await rotatingPool.connect();
+      const firstPid = await first.query<{ pid: number }>(
+        'SELECT pg_catalog.pg_backend_pid()::integer AS pid'
+      );
+      first.release();
+
+      const second = await rotatingPool.connect();
+      try {
+        const secondPid = await second.query<{ pid: number }>(
+          'SELECT pg_catalog.pg_backend_pid()::integer AS pid'
+        );
+        expect(secondPid.rows[0]?.pid).not.toBe(firstPid.rows[0]?.pid);
+      } finally {
+        second.release();
+      }
+    } finally {
+      await rotatingPool.end();
+    }
+  });
+});

--- a/postgres/pg-cache/src/__tests__/sanitizer.test.ts
+++ b/postgres/pg-cache/src/__tests__/sanitizer.test.ts
@@ -1,0 +1,285 @@
+import { EventEmitter } from 'node:events';
+
+import type pg from 'pg';
+
+import {
+  getPgCheckoutSanitizerStats,
+  installCheckoutSanitizer,
+  sanitizePgClient
+} from '../pg';
+
+const mockClient = () => ({
+  query: jest.fn(async () => ({ rows: [] as unknown[] })),
+  release: jest.fn(),
+  connection: {
+    parsedStatements: { tenant_query: 'select 1' },
+    _graphilePreparedStatementCache: { reset: jest.fn() }
+  }
+}) as unknown as pg.PoolClient & {
+  connection: {
+    parsedStatements: Record<string, string>;
+    _graphilePreparedStatementCache?: { reset: jest.Mock };
+  };
+};
+
+describe('runtime checkout sanitation', () => {
+  it('discards server state and clears both prepared-statement caches', async () => {
+    const client = mockClient();
+
+    await expect(sanitizePgClient(client)).resolves.toBe(client);
+
+    expect(client.query).toHaveBeenNthCalledWith(1, 'DISCARD ALL');
+    expect(client.query).toHaveBeenNthCalledWith(
+      2,
+      'SET search_path TO pg_catalog; SET row_security TO on; SET jit_optimize_above_cost TO -1'
+    );
+    expect(client.connection.parsedStatements).toEqual({});
+    expect(client.connection).not.toHaveProperty('_graphilePreparedStatementCache');
+    expect(client.release).not.toHaveBeenCalled();
+  });
+
+  it('does not run Dataplan LRU disposers after DISCARD ALL', async () => {
+    const client = mockClient();
+    const reset = client.connection._graphilePreparedStatementCache!.reset;
+
+    await sanitizePgClient(client, true);
+
+    expect(reset).not.toHaveBeenCalled();
+    expect(client.query).toHaveBeenCalledTimes(1);
+    expect(client.query).toHaveBeenCalledWith('DISCARD ALL');
+  });
+
+  it('uses one checkout query when DISCARD restores a pinned startup baseline', async () => {
+    const client = mockClient();
+
+    await expect(sanitizePgClient(client, true)).resolves.toBe(client);
+
+    expect(client.query).toHaveBeenCalledTimes(1);
+    expect(client.query).toHaveBeenCalledWith('DISCARD ALL');
+    expect(client.connection.parsedStatements).toEqual({});
+  });
+
+  it('destroys a connection when DISCARD ALL fails', async () => {
+    const client = mockClient();
+    (client.query as jest.Mock).mockRejectedValueOnce(new Error('idle in transaction'));
+
+    await expect(sanitizePgClient(client)).rejects.toThrow('idle in transaction');
+    expect(client.release).toHaveBeenCalledWith(true);
+  });
+
+  it('destroys a connection when restoring the trusted baseline fails', async () => {
+    const client = mockClient();
+    (client.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [] })
+      .mockRejectedValueOnce(new Error('baseline rejected'));
+
+    await expect(sanitizePgClient(client)).rejects.toThrow('baseline rejected');
+    expect(client.release).toHaveBeenCalledWith(true);
+  });
+
+  it('skips DISCARD only for a factory-marked virgin with no competing connect hook', async () => {
+    const client = mockClient();
+    let connected = false;
+    const pool = Object.assign(new EventEmitter(), {
+      waitingCount: 0,
+      query: jest.fn(),
+      connect: jest.fn(async () => {
+        if (!connected) {
+          connected = true;
+          pool.emit('connect', client);
+        }
+        return client;
+      })
+    }) as unknown as pg.Pool;
+
+    installCheckoutSanitizer(pool, true, true);
+
+    await expect(pool.connect()).resolves.toBe(client);
+    expect(client.query).not.toHaveBeenCalled();
+    expect(getPgCheckoutSanitizerStats(pool)).toMatchObject({
+      checkoutAttempts: 1,
+      virginFastPathCheckouts: 1,
+      sanitizedReuseCheckouts: 0
+    });
+
+    await expect(pool.connect()).resolves.toBe(client);
+    expect(client.query).toHaveBeenCalledTimes(1);
+    expect(client.query).toHaveBeenCalledWith('DISCARD ALL');
+    expect(getPgCheckoutSanitizerStats(pool)).toMatchObject({
+      checkoutAttempts: 2,
+      virginFastPathCheckouts: 1,
+      sanitizedReuseCheckouts: 1,
+      sanitationFailures: 0
+    });
+  });
+
+  it('fully sanitizes a virgin after a self-removing connect hook can touch it', async () => {
+    const client = mockClient();
+    let connected = false;
+    const pool = Object.assign(new EventEmitter(), {
+      waitingCount: 0,
+      query: jest.fn(),
+      connect: jest.fn(async () => {
+        if (!connected) {
+          connected = true;
+          pool.emit('connect', client);
+        }
+        return client;
+      })
+    }) as unknown as pg.Pool;
+
+    installCheckoutSanitizer(pool, true, true);
+    pool.prependOnceListener('connect', () => undefined);
+
+    await expect(pool.connect()).resolves.toBe(client);
+    expect(client.query).toHaveBeenCalledWith('DISCARD ALL');
+    expect(getPgCheckoutSanitizerStats(pool)).toMatchObject({
+      virginFastPathCheckouts: 0,
+      sanitizedReuseCheckouts: 1
+    });
+  });
+
+  it('fully sanitizes a minimal custom pool without EventEmitter methods', async () => {
+    const client = mockClient();
+    const pool = {
+      waitingCount: 0,
+      query: jest.fn(),
+      connect: jest.fn(async () => client)
+    } as unknown as pg.Pool;
+
+    installCheckoutSanitizer(pool);
+
+    await expect(pool.connect()).resolves.toBe(client);
+    expect(client.query).toHaveBeenNthCalledWith(1, 'DISCARD ALL');
+    expect(client.query).toHaveBeenNthCalledWith(
+      2,
+      'SET search_path TO pg_catalog; SET row_security TO on; SET jit_optimize_above_cost TO -1'
+    );
+    expect(getPgCheckoutSanitizerStats(pool)).toMatchObject({
+      checkoutAttempts: 1,
+      virginFastPathCheckouts: 0,
+      sanitizedReuseCheckouts: 1
+    });
+  });
+
+  it('routes a custom pool query through one sanitized checkout', async () => {
+    const client = mockClient();
+    const queryResult = { rows: [{ value: 7 }] };
+    (client.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce(queryResult);
+    const bypassingQuery = jest.fn(async () => ({ rows: [{ value: -1 }] }));
+    const connect = jest.fn(async () => client);
+    const pool = {
+      waitingCount: 0,
+      query: bypassingQuery,
+      connect
+    } as unknown as pg.Pool;
+
+    installCheckoutSanitizer(pool);
+
+    await expect(pool.query('SELECT $1::int AS value', [7])).resolves.toBe(queryResult);
+    expect(bypassingQuery).not.toHaveBeenCalled();
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(client.query).toHaveBeenNthCalledWith(1, 'DISCARD ALL');
+    expect(client.query).toHaveBeenNthCalledWith(
+      2,
+      'SET search_path TO pg_catalog; SET row_security TO on; SET jit_optimize_above_cost TO -1'
+    );
+    expect(client.query).toHaveBeenNthCalledWith(3, 'SELECT $1::int AS value', [7]);
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(client.release).toHaveBeenCalledWith();
+  });
+
+  it('preserves callback queries without executing the custom pool bypass', async () => {
+    const client = mockClient();
+    const queryResult = { rows: [{ value: 9 }] };
+    (client.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce(queryResult);
+    const bypassingQuery = jest.fn();
+    const pool = {
+      waitingCount: 0,
+      query: bypassingQuery,
+      connect: jest.fn(async () => client)
+    } as unknown as pg.Pool;
+
+    installCheckoutSanitizer(pool);
+
+    const callbackResult = await new Promise((resolve, reject) => {
+      const returned = pool.query(
+        'SELECT $1::int AS value',
+        [9],
+        (error, result) => error ? reject(error) : resolve(result)
+      );
+      expect(returned).toBeUndefined();
+    });
+
+    expect(callbackResult).toBe(queryResult);
+    expect(bypassingQuery).not.toHaveBeenCalled();
+    expect(client.query).toHaveBeenCalledTimes(3);
+    expect(client.query).toHaveBeenNthCalledWith(3, 'SELECT $1::int AS value', [9]);
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroys the checked-out custom client when a direct query fails', async () => {
+    const client = mockClient();
+    const queryError = new Error('query rejected');
+    (client.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockRejectedValueOnce(queryError);
+    const bypassingQuery = jest.fn();
+    const pool = {
+      waitingCount: 0,
+      query: bypassingQuery,
+      connect: jest.fn(async () => client)
+    } as unknown as pg.Pool;
+
+    installCheckoutSanitizer(pool);
+
+    await expect(pool.query('SELECT broken')).rejects.toBe(queryError);
+    expect(bypassingQuery).not.toHaveBeenCalled();
+    expect(client.query).toHaveBeenCalledTimes(3);
+    expect(client.query).toHaveBeenNthCalledWith(3, 'SELECT broken');
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(client.release).toHaveBeenCalledWith(queryError);
+  });
+
+  it('does not release twice when direct-query sanitation fails', async () => {
+    const client = mockClient();
+    const sanitationError = new Error('discard rejected');
+    (client.query as jest.Mock).mockRejectedValueOnce(sanitationError);
+    const bypassingQuery = jest.fn();
+    const pool = {
+      waitingCount: 0,
+      query: bypassingQuery,
+      connect: jest.fn(async () => client)
+    } as unknown as pg.Pool;
+
+    installCheckoutSanitizer(pool);
+
+    await expect(pool.query('SELECT unsafe')).rejects.toBe(sanitationError);
+    expect(bypassingQuery).not.toHaveBeenCalled();
+    expect(client.query).toHaveBeenCalledTimes(1);
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(client.release).toHaveBeenCalledWith(true);
+  });
+
+  it('rejects a custom sanitized pool whose query method cannot be replaced', () => {
+    const pool = {
+      waitingCount: 0,
+      connect: jest.fn()
+    } as unknown as pg.Pool;
+    Object.defineProperty(pool, 'query', {
+      value: jest.fn(),
+      writable: false
+    });
+
+    expect(() => installCheckoutSanitizer(pool)).toThrow(
+      'A sanitized custom PostgreSQL pool must expose a replaceable query() method'
+    );
+  });
+});

--- a/postgres/pg-cache/src/driver.ts
+++ b/postgres/pg-cache/src/driver.ts
@@ -14,10 +14,15 @@ import type { PgConfig, PgPoolConfig } from 'pg-env';
  * `end()` (plus an `ended` flag for disposal), so a factory may return anything
  * implementing that subset — `QueryablePool`. A real `pg.Pool` structurally
  * satisfies it, so the default path is unchanged and fully backward-compatible.
+ * When checkout sanitation is requested, pg-cache replaces a custom pool's
+ * `query()` method so direct queries also use a sanitized `connect()`/`release()`
+ * cycle. Custom pools must therefore expose a replaceable `query()` property,
+ * and connected clients must implement the Promise-based contract below.
  */
 export interface QueryableClient {
   query(text: string, values?: any[]): Promise<any>;
-  release(...args: any[]): void;
+  /** A truthy error argument must permanently discard this client. */
+  release(error?: Error | boolean): void;
 }
 
 export interface QueryablePool {
@@ -27,10 +32,17 @@ export interface QueryablePool {
 }
 
 export type PgPoolFactory = (
-  config: Partial<PgConfig> & { pool?: PgPoolConfig }
+  config: Partial<PgConfig> & { pool?: PgPoolConfig },
+  options?: PgPoolFactoryOptions
 ) => pg.Pool | QueryablePool;
 
+export interface PgPoolFactoryOptions {
+  purpose: string;
+  sanitizeOnCheckout: boolean;
+}
+
 let activeFactory: PgPoolFactory | undefined;
+let driverGeneration = 0;
 
 /**
  * Register the factory `getPgPool` uses to build new pools. Pass `undefined`
@@ -42,6 +54,7 @@ let activeFactory: PgPoolFactory | undefined;
  */
 export const registerPgPoolFactory = (factory: PgPoolFactory | undefined): void => {
   activeFactory = factory;
+  driverGeneration++;
 };
 
 /** The currently-registered factory, or `undefined` when using the default. */
@@ -49,3 +62,7 @@ export const getActivePgPoolFactory = (): PgPoolFactory | undefined => activeFac
 
 /** Whether a non-default pool factory is currently registered. */
 export const hasPgPoolFactory = (): boolean => activeFactory !== undefined;
+
+/** Stable until the active factory registration changes. */
+export const getPgPoolDriverIdentity = (): string =>
+  activeFactory ? `registered:${driverGeneration}` : 'node-postgres';

--- a/postgres/pg-cache/src/index.ts
+++ b/postgres/pg-cache/src/index.ts
@@ -1,23 +1,91 @@
 // Main exports from pg-cache package
 export {
   getActivePgPoolFactory,
+  getPgPoolDriverIdentity,
   hasPgPoolFactory,
   registerPgPoolFactory
 } from './driver';
-export { 
+export {
   close,
+  DEFAULT_PG_CACHE_MAX,
   getPgCacheConfig,
-  pgCache, 
-  PgPoolCacheManager, 
+  getPgCacheStats,
+  PG_CACHE_GRAPHILE_CONTRACT_CAPACITY,
+  PG_CACHE_OPERATIONAL_RESERVE,
+  PG_POOL_CAPACITY_ERROR_CODE,
+  pgCache,
+  PgPoolCacheManager,
+  PgPoolCapacityError,
   teardownPgPools
 } from './lru';
 export {
+  acquirePgNotificationBroker,
+  assertValidPgNotificationTopic,
+  DEFAULT_PG_NOTIFICATION_OPERATION_TIMEOUT_MS,
+  getPgNotificationBrokerIdentity,
+  getPgNotificationBrokerStats,
+  getPgNotificationDatabaseIdentity,
+  PG_NOTIFICATION_BROKER_FAILED_ERROR_CODE,
+  PG_NOTIFICATION_BROKER_IDENTITY_VERSION,
+  PG_NOTIFICATION_DATABASE_IDENTITY_VERSION,
+  PG_NOTIFICATION_LEASE_RELEASED_ERROR_CODE,
+  PG_NOTIFICATION_OPERATION_TIMEOUT_ERROR_CODE,
+  PG_NOTIFICATION_QUEUE_CAPACITY,
+  PG_NOTIFICATION_QUEUE_OVERFLOW_ERROR_CODE,
+  PG_NOTIFICATION_TOPIC_ERROR_CODE,
+  PgNotificationBrokerFailedError,
+  PgNotificationLeaseReleasedError,
+  PgNotificationOperationTimeoutError,
+  PgNotificationQueueOverflowError,
+  PgNotificationTopicError,
+  teardownPgNotificationBrokers
+} from './notification-broker';
+export {
+  assertPgNotificationRole,
+  assertPgNotificationRoleClient,
+  auditPgNotificationRole,
+  auditPgNotificationRoleClient,
+  normalizePgNotificationRoleContracts,
+  PG_NOTIFICATION_ROLE_AUDIT_SQL,
+  PG_NOTIFICATION_ROLE_AUDIT_VERSION,
+  PG_NOTIFICATION_ROLE_CONTRACT_ERROR_CODE,
+  PG_NOTIFICATION_ROLE_UNSAFE_ERROR_CODE,
+  PgNotificationRoleContractError,
+  UnsafePgNotificationRoleError
+} from './notification-role';
+export {
+  acquirePgPool,
   buildConnectionString,
+  clearPreparedStatementBookkeeping,
   defaultPgPoolFactory,
+  getPgCheckoutSanitizerStats,
   getPgPool,
-  getPgPoolConfig
+  getPgPoolConfig,
+  getPgPoolIdentity,
+  installCheckoutSanitizer,
+  sanitizePgClient
 } from './pg';
 
 // Re-export types
-export type { PgPoolFactory, QueryableClient, QueryablePool } from './driver';
-export type { PgCacheConfig, PoolCleanupCallback } from './lru';
+export type { PgPoolFactory, PgPoolFactoryOptions, QueryableClient, QueryablePool } from './driver';
+export type {
+  PgCacheConfig,
+  PgPoolCacheStats,
+  PgPoolDisposalReason,
+  PgPoolLease,
+  PoolCleanupCallback
+} from './lru';
+export type {
+  AcquirePgNotificationBrokerOptions,
+  PgAttestedNotificationBrokerLease,
+  PgNotificationBrokerLease,
+  PgNotificationBrokerStats,
+  PgNotificationListenerConfig
+} from './notification-broker';
+export type {
+  PgNotificationRoleAudit,
+  PgNotificationRoleClient,
+  PgNotificationRoleContract,
+  PgNotificationRoleViolationCode
+} from './notification-role';
+export type { GetPgPoolOptions, PgCheckoutSanitizerStats } from './pg';

--- a/postgres/pg-cache/src/lru.ts
+++ b/postgres/pg-cache/src/lru.ts
@@ -1,6 +1,5 @@
 import { Logger } from '@pgpmjs/logger';
 import { parseEnvNumber } from '12factor-env';
-import { LRUCache } from 'lru-cache';
 import pg from 'pg';
 
 const log = new Logger('pg-cache');
@@ -9,58 +8,141 @@ const ONE_HOUR_IN_MS = 1000 * 60 * 60;
 const ONE_DAY = ONE_HOUR_IN_MS * 24;
 const ONE_YEAR = ONE_DAY * 366;
 
-// Kubernetes sends only SIGTERM on pod shutdown
-const SYS_EVENTS = ['SIGTERM'];
+// One runtime and one control identity per database-per-tenant Graphile
+// contract, plus room for routing, diagnostics, listeners, and build overlap.
+export const PG_CACHE_GRAPHILE_CONTRACT_CAPACITY = 1024;
+export const PG_CACHE_OPERATIONAL_RESERVE = 16;
+export const DEFAULT_PG_CACHE_MAX =
+  PG_CACHE_GRAPHILE_CONTRACT_CAPACITY * 2 + PG_CACHE_OPERATIONAL_RESERVE;
 
 type PgPoolKey = string;
+type PoolFactory = () => pg.Pool;
 
-// Cleanup callback type - called when a pg pool is disposed
+export type PgPoolDisposalReason =
+  | 'capacity'
+  | 'ttl'
+  | 'delete'
+  | 'clear'
+  | 'close'
+  | 'replace';
+
+// Called only when an identity is actually removed from the registry.
 export type PoolCleanupCallback = (pgPoolKey: string) => void;
 
-// --- Cache Configuration ---
+export interface PgPoolLease {
+  pool: pg.Pool;
+  identity: string;
+  /** Idempotently release this exact ownership claim. */
+  release(): void;
+}
 
 export interface PgCacheConfig {
-  /** Maximum number of pools in the LRU cache (env: PG_CACHE_MAX, default: 50) */
+  /** Maximum number of lazy pool identities retained by this process. */
   max: number;
-  /** TTL for cached pools in ms (default: ONE_YEAR) */
+  /** Idle identity TTL in milliseconds. Leased identities never expire. */
   ttl: number;
 }
 
-/**
- * Read cache configuration from environment variables.
- *
- * Supports:
- * - PG_CACHE_MAX: Maximum number of pools (default: 50)
- * - PG_CACHE_TTL_MS: TTL in milliseconds (default: ONE_YEAR)
- */
+export interface PgPoolCacheStats {
+  size: number;
+  max: number;
+  ttl: number;
+  leasedPools: number;
+  idlePools: number;
+  activeLeases: number;
+  reservations: number;
+  pendingDisposals: number;
+  hits: number;
+  misses: number;
+  poolsCreated: number;
+  leasesAcquired: number;
+  leasesReleased: number;
+  capacityEvictions: number;
+  ttlExpirations: number;
+  capacityRefusals: number;
+  disposalsStarted: number;
+  disposalsCompleted: number;
+  disposalFailures: number;
+}
+
+interface PgPoolCacheCounters {
+  hits: number;
+  misses: number;
+  poolsCreated: number;
+  leasesAcquired: number;
+  leasesReleased: number;
+  capacityEvictions: number;
+  ttlExpirations: number;
+  capacityRefusals: number;
+  disposalsStarted: number;
+  disposalsCompleted: number;
+  disposalFailures: number;
+}
+
+interface SlotReservation {
+  key: PgPoolKey;
+  victims: ManagedPgPool[];
+}
+
+export const PG_POOL_CAPACITY_ERROR_CODE = 'PG_POOL_CAPACITY';
+
+/** Fail-closed pool admission error suitable for a stable HTTP 503 mapping. */
+export class PgPoolCapacityError extends Error {
+  readonly code = PG_POOL_CAPACITY_ERROR_CODE;
+  readonly retryAfterSeconds = 15;
+
+  constructor(
+    readonly max: number,
+    readonly size: number,
+    readonly leased: number
+  ) {
+    super(
+      `PostgreSQL pool capacity exhausted: ${size}/${max} identities are retained `
+      + `and ${leased} are leased`
+    );
+    this.name = 'PgPoolCapacityError';
+  }
+}
+
+/** Read cache configuration without allocating any pools or connections. */
 export function getPgCacheConfig(): PgCacheConfig {
   return {
-    max: parseEnvNumber(process.env.PG_CACHE_MAX) ?? 50,
+    max: parseEnvNumber(process.env.PG_CACHE_MAX) ?? DEFAULT_PG_CACHE_MAX,
     ttl: parseEnvNumber(process.env.PG_CACHE_TTL_MS) ?? ONE_YEAR,
   };
 }
 
 class ManagedPgPool {
   public isDisposed = false;
+  public leaseCount = 0;
+  public lastAccessOrder = 0;
+  public expiresAt = 0;
   private disposePromise: Promise<void> | null = null;
 
-  constructor(public readonly pool: pg.Pool, public readonly key: string) {}
+  constructor(
+    public readonly pool: pg.Pool,
+    public readonly key: string
+  ) {}
+
+  touch(order: number, now: number, ttl: number): void {
+    this.lastAccessOrder = order;
+    this.expiresAt = now + ttl;
+  }
+
+  isExpired(now: number): boolean {
+    return now >= this.expiresAt;
+  }
 
   async dispose(): Promise<void> {
     if (this.isDisposed) return this.disposePromise;
 
     this.isDisposed = true;
     this.disposePromise = (async () => {
-      try {
-        if (!this.pool.ended) {
-          await this.pool.end();
-          log.success(`pg.Pool ${this.key} ended.`);
-        } else {
-          log.info(`pg.Pool ${this.key} already ended.`);
-        }
-      } catch (err) {
-        log.error(`Error ending pg.Pool ${this.key}: ${(err as Error).message}`);
-        throw err;
+      if (!this.pool.ended) {
+        await this.pool.end();
+        log.success(`pg.Pool ${this.key} ended.`);
+      } else {
+        log.info(`pg.Pool ${this.key} already ended.`);
       }
     })();
 
@@ -68,37 +150,55 @@ class ManagedPgPool {
   }
 }
 
+/**
+ * A lease-aware, lazy pool registry.
+ *
+ * JavaScript executes acquisition synchronously, including slot reservation and
+ * factory invocation. Two callers therefore cannot both claim the final slot.
+ * Pools may finish ending asynchronously after a zero-lease identity is removed.
+ */
 export class PgPoolCacheManager {
-  private cleanupTasks: Promise<void>[] = [];
+  private readonly records = new Map<PgPoolKey, ManagedPgPool>();
+  private readonly cleanupTasks = new Set<Promise<void>>();
+  private readonly cleanupCallbacks = new Set<PoolCleanupCallback>();
+  private readonly reservedKeys = new Set<PgPoolKey>();
+  private reservations = 0;
+  private accessOrder = 0;
   private closed = false;
-  private cleanupCallbacks: Set<PoolCleanupCallback> = new Set();
   readonly config: PgCacheConfig;
 
-  private readonly pgCache: LRUCache<PgPoolKey, ManagedPgPool>;
+  private readonly counters: PgPoolCacheCounters = {
+    hits: 0,
+    misses: 0,
+    poolsCreated: 0,
+    leasesAcquired: 0,
+    leasesReleased: 0,
+    capacityEvictions: 0,
+    ttlExpirations: 0,
+    capacityRefusals: 0,
+    disposalsStarted: 0,
+    disposalsCompleted: 0,
+    disposalFailures: 0
+  };
 
   constructor(config?: Partial<PgCacheConfig>) {
     const defaults = getPgCacheConfig();
     this.config = { ...defaults, ...config };
-
-    this.pgCache = new LRUCache<PgPoolKey, ManagedPgPool>({
-      max: this.config.max,
-      ttl: this.config.ttl,
-      updateAgeOnGet: true,
-      dispose: (managedPool, key, reason) => {
-        log.debug(`Disposing pg pool [${key}] (${reason})`);
-        this.notifyCleanup(key);
-        this.disposePool(managedPool);
-      }
-    });
+    if (!Number.isSafeInteger(this.config.max) || this.config.max <= 0) {
+      throw new Error('pg-cache max must be a positive safe integer');
+    }
+    if (!Number.isFinite(this.config.ttl) || this.config.ttl <= 0) {
+      throw new Error('pg-cache ttl must be a positive number');
+    }
   }
 
-  // Register a cleanup callback to be called when pools are disposed
+  get size(): number {
+    return this.records.size;
+  }
+
   registerCleanupCallback(callback: PoolCleanupCallback): () => void {
     this.cleanupCallbacks.add(callback);
-    // Return unregister function
-    return () => {
-      this.cleanupCallbacks.delete(callback);
-    };
+    return () => this.cleanupCallbacks.delete(callback);
   }
 
   get(key: PgPoolKey): pg.Pool | undefined {
@@ -106,72 +206,314 @@ export class PgPoolCacheManager {
       log.warn(`Cache is closed, ignoring get(${key})`);
       return undefined;
     }
-    return this.pgCache.get(key)?.pool;
+    const managedPool = this.getLiveRecord(key, true);
+    if (!managedPool) {
+      this.counters.misses++;
+      return undefined;
+    }
+    this.counters.hits++;
+    return managedPool.pool;
   }
 
   has(key: PgPoolKey): boolean {
-    return this.pgCache.has(key);
+    if (this.closed) return false;
+    return Boolean(this.getLiveRecord(key, false));
   }
 
+  /**
+   * Legacy direct insertion. Prefer getOrCreate/acquire so capacity is checked
+   * before the caller constructs a pool.
+   */
   set(key: PgPoolKey, pool: pg.Pool): void {
-    if (this.closed) throw new Error(`Cannot add to cache after it has been closed (key: ${key})`);
-    this.pgCache.set(key, new ManagedPgPool(pool, key));
-  }
-
-  delete(key: PgPoolKey): void {
-    const managedPool = this.pgCache.get(key);
-    const existed = this.pgCache.delete(key);
-    if (!existed && managedPool) {
-      this.notifyCleanup(key);
-      this.disposePool(managedPool);
+    this.assertOpen(key);
+    const existing = this.records.get(key);
+    if (existing?.pool === pool) {
+      this.touch(existing);
+      return;
     }
+    if (existing?.leaseCount) {
+      throw new Error(`Cannot replace leased pg pool identity ${key}`);
+    }
+    if (existing) this.removeRecord(existing, 'replace');
+
+    const reservation = this.reserveSlot(key);
+    this.commitReservation(reservation, pool, 0);
   }
 
+  /** Atomically capacity-check, synchronously construct, and cache an idle pool. */
+  getOrCreate(key: PgPoolKey, factory: PoolFactory): pg.Pool {
+    this.assertOpen(key);
+    const existing = this.getLiveRecord(key, true);
+    if (existing) {
+      this.counters.hits++;
+      return existing.pool;
+    }
+
+    this.counters.misses++;
+    return this.createWithReservation(key, factory, 0).pool;
+  }
+
+  /**
+   * Atomically get/create and lease an exact identity. A leased identity cannot
+   * be selected by capacity or TTL eviction until every lease is released.
+   */
+  acquire(key: PgPoolKey, factory: PoolFactory): PgPoolLease {
+    this.assertOpen(key);
+    let managedPool = this.getLiveRecord(key, true);
+    if (managedPool) {
+      this.counters.hits++;
+      managedPool.leaseCount++;
+    } else {
+      this.counters.misses++;
+      managedPool = this.createWithReservation(key, factory, 1);
+    }
+    this.counters.leasesAcquired++;
+    return this.makeLease(managedPool);
+  }
+
+  /** Explicit deletion never interrupts a lease; callers may retry after release. */
+  delete(key: PgPoolKey): void {
+    const managedPool = this.records.get(key);
+    if (!managedPool || managedPool.leaseCount > 0) return;
+    this.removeRecord(managedPool, 'delete');
+  }
+
+  /** Clear every currently unleased identity. */
   clear(): void {
-    const entries = [...this.pgCache.entries()];
-    this.pgCache.clear();
-    for (const [key, managedPool] of entries) {
-      this.notifyCleanup(key);
-      this.disposePool(managedPool);
+    for (const managedPool of [...this.records.values()]) {
+      if (managedPool.leaseCount === 0) this.removeRecord(managedPool, 'clear');
     }
   }
 
   async close(): Promise<void> {
     if (this.closed) return;
     this.closed = true;
-    this.clear();
+    // Explicit process teardown is the only operation that may override leases.
+    for (const managedPool of [...this.records.values()]) {
+      this.removeRecord(managedPool, 'close');
+    }
     await this.waitForDisposals();
-    // Re-open the cache so it can accept new entries if the process
-    // survives the shutdown signal (e.g. during provisioning or restart).
+    // Preserve the established restart/provisioning behavior.
     this.closed = false;
   }
 
   async waitForDisposals(): Promise<void> {
-    if (this.cleanupTasks.length === 0) return;
-    const tasks = [...this.cleanupTasks];
-    this.cleanupTasks = [];
-    await Promise.allSettled(tasks);
+    while (this.cleanupTasks.size > 0) {
+      await Promise.allSettled([...this.cleanupTasks]);
+    }
+  }
+
+  getStats(): PgPoolCacheStats {
+    let leasedPools = 0;
+    let activeLeases = 0;
+    for (const managedPool of this.records.values()) {
+      if (managedPool.leaseCount > 0) leasedPools++;
+      activeLeases += managedPool.leaseCount;
+    }
+    return {
+      size: this.records.size,
+      max: this.config.max,
+      ttl: this.config.ttl,
+      leasedPools,
+      idlePools: this.records.size - leasedPools,
+      activeLeases,
+      reservations: this.reservations,
+      pendingDisposals: this.cleanupTasks.size,
+      ...this.counters
+    };
+  }
+
+  private assertOpen(key: PgPoolKey): void {
+    if (this.closed) {
+      throw new Error(`Cannot access pg cache while it is closed (key: ${key})`);
+    }
+  }
+
+  private touch(managedPool: ManagedPgPool): void {
+    managedPool.touch(++this.accessOrder, Date.now(), this.config.ttl);
+  }
+
+  private getLiveRecord(key: PgPoolKey, updateAge: boolean): ManagedPgPool | undefined {
+    const managedPool = this.records.get(key);
+    if (!managedPool) return undefined;
+    if (managedPool.leaseCount === 0 && managedPool.isExpired(Date.now())) {
+      this.removeRecord(managedPool, 'ttl');
+      return undefined;
+    }
+    if (updateAge) this.touch(managedPool);
+    return managedPool;
+  }
+
+  private idleRecordsByAge(): ManagedPgPool[] {
+    return [...this.records.values()]
+      .filter((managedPool) => managedPool.leaseCount === 0)
+      .sort((a, b) => a.lastAccessOrder - b.lastAccessOrder);
+  }
+
+  private reserveSlot(key: PgPoolKey): SlotReservation {
+    if (this.reservedKeys.has(key)) {
+      throw new Error(`Re-entrant pg pool acquisition for identity ${key}`);
+    }
+
+    const overflow = Math.max(
+      0,
+      this.records.size + this.reservations + 1 - this.config.max
+    );
+    const candidates = this.idleRecordsByAge();
+    if (candidates.length < overflow) {
+      this.counters.capacityRefusals++;
+      throw new PgPoolCapacityError(
+        this.config.max,
+        this.records.size + this.reservations,
+        this.countLeasedPools()
+      );
+    }
+
+    const victims = candidates.slice(0, overflow);
+    for (const victim of victims) this.records.delete(victim.key);
+    this.reservations++;
+    this.reservedKeys.add(key);
+    return { key, victims };
+  }
+
+  private rollbackReservation(reservation: SlotReservation): void {
+    this.reservations = Math.max(0, this.reservations - 1);
+    this.reservedKeys.delete(reservation.key);
+    for (const victim of reservation.victims) {
+      this.records.set(victim.key, victim);
+    }
+  }
+
+  private commitReservation(
+    reservation: SlotReservation,
+    pool: pg.Pool,
+    leaseCount: number
+  ): ManagedPgPool {
+    const managedPool = new ManagedPgPool(pool, reservation.key);
+    managedPool.leaseCount = leaseCount;
+    this.touch(managedPool);
+    this.records.set(reservation.key, managedPool);
+    this.reservations = Math.max(0, this.reservations - 1);
+    this.reservedKeys.delete(reservation.key);
+    this.counters.poolsCreated++;
+
+    for (const victim of reservation.victims) {
+      this.counters.capacityEvictions++;
+      this.disposeRemovedRecord(victim);
+    }
+    return managedPool;
+  }
+
+  private createWithReservation(
+    key: PgPoolKey,
+    factory: PoolFactory,
+    leaseCount: number
+  ): ManagedPgPool {
+    const reservation = this.reserveSlot(key);
+    let pool: pg.Pool;
+    try {
+      pool = factory();
+    } catch (error) {
+      this.rollbackReservation(reservation);
+      throw error;
+    }
+    return this.commitReservation(reservation, pool, leaseCount);
+  }
+
+  private makeLease(managedPool: ManagedPgPool): PgPoolLease {
+    let released = false;
+    return {
+      pool: managedPool.pool,
+      identity: managedPool.key,
+      release: () => {
+        if (released) return;
+        released = true;
+        this.counters.leasesReleased++;
+        managedPool.leaseCount = Math.max(0, managedPool.leaseCount - 1);
+
+        // close() may already have detached this record.
+        if (this.records.get(managedPool.key) !== managedPool) return;
+        if (managedPool.leaseCount > 0) return;
+        if (managedPool.isExpired(Date.now())) {
+          this.removeRecord(managedPool, 'ttl');
+          return;
+        }
+        this.enforceCapacity();
+      }
+    };
+  }
+
+  private enforceCapacity(): void {
+    while (this.records.size > this.config.max) {
+      const victim = this.idleRecordsByAge()[0];
+      if (!victim) return;
+      this.removeRecord(victim, 'capacity');
+    }
+  }
+
+  private countLeasedPools(): number {
+    let leased = 0;
+    for (const managedPool of this.records.values()) {
+      if (managedPool.leaseCount > 0) leased++;
+    }
+    return leased;
+  }
+
+  private removeRecord(
+    managedPool: ManagedPgPool,
+    reason: PgPoolDisposalReason
+  ): void {
+    if (this.records.get(managedPool.key) !== managedPool) return;
+    this.records.delete(managedPool.key);
+    if (reason === 'capacity') this.counters.capacityEvictions++;
+    if (reason === 'ttl') this.counters.ttlExpirations++;
+    this.disposeRemovedRecord(managedPool);
+  }
+
+  private disposeRemovedRecord(managedPool: ManagedPgPool): void {
+    this.notifyCleanup(managedPool.key);
+
+    // Alternate drivers may intentionally return one physical pool for multiple
+    // exact identities. Never end it while another retained identity owns it.
+    if ([...this.records.values()].some((entry) => entry.pool === managedPool.pool)) {
+      return;
+    }
+    if (managedPool.isDisposed) return;
+
+    this.counters.disposalsStarted++;
+    let task: Promise<void>;
+    task = managedPool.dispose()
+      .then(() => {
+        this.counters.disposalsCompleted++;
+      })
+      .catch((error) => {
+        this.counters.disposalFailures++;
+        log.error(
+          `Error ending pg.Pool ${managedPool.key}: ${(error as Error).message}`
+        );
+      })
+      .finally(() => this.cleanupTasks.delete(task));
+    this.cleanupTasks.add(task);
   }
 
   private notifyCleanup(pgPoolKey: string): void {
     this.cleanupCallbacks.forEach(callback => {
       try {
         callback(pgPoolKey);
-      } catch (err) {
-        log.error(`Error in cleanup callback for pool ${pgPoolKey}: ${(err as Error).message}`);
+      } catch (error) {
+        log.error(
+          `Error in cleanup callback for pool ${pgPoolKey}: ${(error as Error).message}`
+        );
       }
     });
   }
-
-  private disposePool(managedPool: ManagedPgPool): void {
-    if (managedPool.isDisposed) return;
-    const task = managedPool.dispose();
-    this.cleanupTasks.push(task);
-  }
 }
 
-// Create the singleton instance
+// Process-wide registry. Its large capacity is only a key limit; pools and
+// PostgreSQL connections remain lazily allocated on first use.
 export const pgCache = new PgPoolCacheManager();
+
+export const getPgCacheStats = (): PgPoolCacheStats => pgCache.getStats();
 
 // --- Graceful Shutdown ---
 const closePromise: { promise: Promise<void> | null } = { promise: null };
@@ -185,20 +527,12 @@ export const close = async (verbose = false): Promise<void> => {
       await pgCache.close();
       if (verbose) log.success('PG cache disposed.');
     } finally {
-      // Reset so close() can be called again if the process survives.
       closePromise.promise = null;
     }
   })();
 
   return closePromise.promise;
 };
-
-SYS_EVENTS.forEach(event => {
-  process.on(event, () => {
-    log.info(`Received ${event}`);
-    close();
-  });
-});
 
 export const teardownPgPools = async (verbose = false): Promise<void> => {
   return close(verbose);

--- a/postgres/pg-cache/src/notification-broker.ts
+++ b/postgres/pg-cache/src/notification-broker.ts
@@ -1,0 +1,1087 @@
+import type { PgConfig, PgPoolConfig } from 'pg-env';
+
+import {
+  assertPgNotificationRoleClient,
+  type PgNotificationRoleAudit,
+  type PgNotificationRoleClient,
+  type PgNotificationRoleContract
+} from './notification-role';
+import {
+  acquirePgPool,
+  getPgDatabaseTargetIdentity,
+  getPgPoolConfig,
+  getPgPoolIdentity
+} from './pg';
+
+export const PG_NOTIFICATION_BROKER_IDENTITY_VERSION = 'pg-notification-broker:v1';
+export const PG_NOTIFICATION_DATABASE_IDENTITY_VERSION = 'pg-notification-database:v1';
+export const PG_NOTIFICATION_QUEUE_CAPACITY = 256;
+export const DEFAULT_PG_NOTIFICATION_OPERATION_TIMEOUT_MS = 5_000;
+
+export const PG_NOTIFICATION_TOPIC_ERROR_CODE = 'PG_NOTIFICATION_TOPIC_INVALID';
+export const PG_NOTIFICATION_BROKER_FAILED_ERROR_CODE = 'PG_NOTIFICATION_BROKER_FAILED';
+export const PG_NOTIFICATION_QUEUE_OVERFLOW_ERROR_CODE = 'PG_NOTIFICATION_QUEUE_OVERFLOW';
+export const PG_NOTIFICATION_LEASE_RELEASED_ERROR_CODE = 'PG_NOTIFICATION_LEASE_RELEASED';
+export const PG_NOTIFICATION_OPERATION_TIMEOUT_ERROR_CODE =
+  'PG_NOTIFICATION_OPERATION_TIMEOUT';
+
+type PromiseOrDirect<T> = T | Promise<T>;
+
+export interface PgNotification {
+  channel: string;
+  payload?: string;
+}
+
+export interface PgNotificationClient {
+  query(text: string, values?: readonly unknown[]): Promise<unknown>;
+  on(event: string, listener: (...args: any[]) => void): unknown;
+  off(event: string, listener: (...args: any[]) => void): unknown;
+  release(error?: Error | boolean): PromiseOrDirect<void>;
+}
+
+export interface PgNotificationConnectionSource {
+  connect(): Promise<PgNotificationClient>;
+  release(): PromiseOrDirect<void>;
+}
+
+export interface PgNotificationBrokerLease {
+  /** Versioned digest of the complete listener connection contract. */
+  readonly identity: string;
+  /** Frozen, exact PostgreSQL channels this lease may subscribe to. */
+  readonly topics: readonly string[];
+  /** Resolves on fatal broker failure or with null after graceful release. */
+  readonly terminated: Promise<PgNotificationBrokerFailedError | null>;
+  subscribe(topic: string): AsyncIterableIterator<string>;
+  /** Idempotent and awaited through UNLISTEN and connection release. */
+  release(): Promise<void>;
+}
+
+/**
+ * A production lease whose login was audited on the same pinned PostgreSQL
+ * client before admission. Arbitrary SQL and the client itself stay private.
+ */
+export interface PgAttestedNotificationBrokerLease
+extends PgNotificationBrokerLease {
+  readonly roleAudit: PgNotificationRoleAudit;
+  revalidateRole(): Promise<PgNotificationRoleAudit>;
+}
+
+export interface AcquirePgNotificationBrokerOptions {
+  /** Every channel this generation may observe. Prefix matching is never used. */
+  topics: readonly string[];
+}
+
+export type PgNotificationListenerConfig = PgConfig & { pool?: PgPoolConfig };
+
+export interface PgNotificationBrokerStats {
+  brokers: number;
+  listenerConnections: number;
+  leases: number;
+  topics: number;
+  subscribers: number;
+  acquisitions: number;
+  releases: number;
+  notifications: number;
+  ignoredNotifications: number;
+  queueOverflows: number;
+  fatalFailures: number;
+  roleAuditAttempts: number;
+  roleAuditFailures: number;
+}
+
+interface MutableBrokerCounters {
+  acquisitions: number;
+  releases: number;
+  notifications: number;
+  ignoredNotifications: number;
+  queueOverflows: number;
+  fatalFailures: number;
+  roleAuditAttempts: number;
+  roleAuditFailures: number;
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+}
+
+const deferred = <T>(): Deferred<T> => {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+};
+
+export class PgNotificationTopicError extends Error {
+  readonly code = PG_NOTIFICATION_TOPIC_ERROR_CODE;
+
+  constructor(readonly topic: unknown, reason: string) {
+    super(`Invalid PostgreSQL notification topic: ${reason}`);
+    this.name = 'PgNotificationTopicError';
+  }
+}
+
+export class PgNotificationBrokerFailedError extends Error {
+  readonly code = PG_NOTIFICATION_BROKER_FAILED_ERROR_CODE;
+
+  constructor(reason: unknown) {
+    const cause = reason instanceof Error ? reason : new Error(String(reason));
+    super('PostgreSQL notification broker failed; all subscribers were terminated', {
+      cause
+    });
+    this.name = 'PgNotificationBrokerFailedError';
+  }
+}
+
+export class PgNotificationQueueOverflowError extends Error {
+  readonly code = PG_NOTIFICATION_QUEUE_OVERFLOW_ERROR_CODE;
+
+  constructor(
+    readonly topic: string,
+    readonly capacity: number
+  ) {
+    super(
+      `PostgreSQL notification subscriber queue for ${JSON.stringify(topic)} `
+      + `exceeded its fixed capacity of ${capacity}`
+    );
+    this.name = 'PgNotificationQueueOverflowError';
+  }
+}
+
+export class PgNotificationLeaseReleasedError extends Error {
+  readonly code = PG_NOTIFICATION_LEASE_RELEASED_ERROR_CODE;
+
+  constructor() {
+    super('PostgreSQL notification broker lease has been released');
+    this.name = 'PgNotificationLeaseReleasedError';
+  }
+}
+
+export class PgNotificationOperationTimeoutError extends Error {
+  readonly code = PG_NOTIFICATION_OPERATION_TIMEOUT_ERROR_CODE;
+
+  constructor(
+    readonly operation: 'role-audit' | 'listen' | 'unlisten',
+    readonly timeoutMs: number
+  ) {
+    super(
+      `PostgreSQL notification ${operation} exceeded its fixed ${timeoutMs}ms deadline`
+    );
+    this.name = 'PgNotificationOperationTimeoutError';
+  }
+}
+
+class BrokerClosedError extends Error {}
+
+const containsUnpairedSurrogate = (value: string): boolean => {
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) return true;
+      index++;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+};
+
+/**
+ * PostgreSQL identifiers are limited to 63 UTF-8 bytes. PostgreSQL truncates
+ * longer identifiers, so accepting them here could collapse distinct tenant
+ * topics onto one physical LISTEN channel.
+ */
+export function assertValidPgNotificationTopic(topic: unknown): asserts topic is string {
+  if (typeof topic !== 'string') {
+    throw new PgNotificationTopicError(topic, 'the topic must be a string');
+  }
+  if (topic.length === 0) {
+    throw new PgNotificationTopicError(topic, 'the topic must not be empty');
+  }
+  if (topic.includes('\0')) {
+    throw new PgNotificationTopicError(topic, 'NUL bytes are not allowed');
+  }
+  if (containsUnpairedSurrogate(topic)) {
+    throw new PgNotificationTopicError(topic, 'unpaired UTF-16 surrogates are not allowed');
+  }
+  const bytes = Buffer.byteLength(topic, 'utf8');
+  if (bytes > 63) {
+    throw new PgNotificationTopicError(
+      topic,
+      `the UTF-8 encoding is ${bytes} bytes; PostgreSQL allows at most 63`
+    );
+  }
+}
+
+const normalizeTopics = (topics: readonly string[]): readonly string[] => {
+  if (!Array.isArray(topics) || topics.length === 0) {
+    throw new PgNotificationTopicError(topics, 'at least one exact topic is required');
+  }
+  for (const topic of topics) assertValidPgNotificationTopic(topic);
+  return Object.freeze([...new Set(topics)]);
+};
+
+const quoteIdentifier = (identifier: string): string =>
+  `"${identifier.replace(/"/g, '""')}"`;
+
+class BoundedNotificationQueue implements AsyncIterableIterator<string> {
+  private readonly buffered: string[] = [];
+  private readonly waiting: Deferred<IteratorResult<string>>[] = [];
+  private terminal: 'open' | 'complete' | 'failed' = 'open';
+  private failure: Error | null = null;
+
+  constructor(
+    private readonly topic: string,
+    private readonly capacity: number,
+    private readonly onClose: () => void,
+    private readonly onOverflow: () => void
+  ) {}
+
+  [Symbol.asyncIterator](): AsyncIterableIterator<string> {
+    return this;
+  }
+
+  next(): Promise<IteratorResult<string>> {
+    const buffered = this.buffered.shift();
+    if (buffered !== undefined) {
+      return Promise.resolve({ done: false, value: buffered });
+    }
+    if (this.terminal === 'failed') return Promise.reject(this.failure);
+    if (this.terminal === 'complete') {
+      return Promise.resolve({ done: true, value: undefined });
+    }
+
+    const result = deferred<IteratorResult<string>>();
+    this.waiting.push(result);
+    return result.promise;
+  }
+
+  return(value?: unknown): Promise<IteratorResult<string>> {
+    this.complete();
+    return Promise.resolve({ done: true, value: value as string });
+  }
+
+  throw(error?: unknown): Promise<IteratorResult<string>> {
+    const failure = error instanceof Error ? error : new Error(String(error));
+    this.fail(failure);
+    return Promise.reject(failure);
+  }
+
+  push(payload: string): void {
+    if (this.terminal !== 'open') return;
+    const waiter = this.waiting.shift();
+    if (waiter) {
+      waiter.resolve({ done: false, value: payload });
+      return;
+    }
+    if (this.buffered.length >= this.capacity) {
+      this.onOverflow();
+      this.fail(new PgNotificationQueueOverflowError(this.topic, this.capacity));
+      return;
+    }
+    this.buffered.push(payload);
+  }
+
+  complete(): void {
+    if (this.terminal !== 'open') return;
+    this.terminal = 'complete';
+    this.buffered.length = 0;
+    for (const waiter of this.waiting.splice(0)) {
+      waiter.resolve({ done: true, value: undefined });
+    }
+    this.onClose();
+  }
+
+  fail(error: Error): void {
+    if (this.terminal !== 'open') return;
+    this.terminal = 'failed';
+    this.failure = error;
+    this.buffered.length = 0;
+    for (const waiter of this.waiting.splice(0)) waiter.reject(error);
+    this.onClose();
+  }
+}
+
+type BrokerState = 'new' | 'active' | 'failed' | 'closing' | 'closed';
+type ConnectionSourceFactory = () => PromiseOrDirect<PgNotificationConnectionSource>;
+type NotificationOperation = PgNotificationOperationTimeoutError['operation'];
+
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+const assertNotificationOperationTimeoutMs = (timeoutMs: number): number => {
+  if (
+    !Number.isSafeInteger(timeoutMs)
+    || timeoutMs <= 0
+    || timeoutMs > MAX_TIMER_DELAY_MS
+  ) {
+    throw new TypeError(
+      'PostgreSQL notification operation timeout must be an integer '
+      + `between 1 and ${MAX_TIMER_DELAY_MS}`
+    );
+  }
+  return timeoutMs;
+};
+
+const getNotificationOperationTimeoutMs = (
+  listenerPgConfig: PgNotificationListenerConfig
+): number => {
+  // Preserve this API's narrower deadline contract and stable error before the
+  // generic pool validator runs as part of identity construction.
+  const configured = listenerPgConfig.pool?.connectionTimeoutMillis;
+  return assertNotificationOperationTimeoutMs(
+    configured ?? getPgPoolConfig(listenerPgConfig.pool).connectionTimeoutMillis
+      ?? DEFAULT_PG_NOTIFICATION_OPERATION_TIMEOUT_MS
+  );
+};
+
+class NotificationBrokerLease implements PgAttestedNotificationBrokerLease {
+  readonly topics: readonly string[];
+  readonly terminated: Promise<PgNotificationBrokerFailedError | null>;
+  private readonly allowedTopics: ReadonlySet<string>;
+  private readonly termination = deferred<PgNotificationBrokerFailedError | null>();
+  private readonly queues = new Map<string, Set<BoundedNotificationQueue>>();
+  private audit: PgNotificationRoleAudit | null = null;
+  private released = false;
+  private releasePromise: Promise<void> | null = null;
+
+  constructor(
+    readonly identity: string,
+    topics: readonly string[],
+    private readonly broker: NotificationBrokerRecord,
+    private readonly queueCapacity: number,
+    private readonly counters: MutableBrokerCounters,
+    readonly roleContract: Readonly<PgNotificationRoleContract> | null
+  ) {
+    this.topics = topics;
+    this.terminated = this.termination.promise;
+    this.allowedTopics = new Set(topics);
+  }
+
+  get subscriberCount(): number {
+    let count = 0;
+    for (const topicQueues of this.queues.values()) count += topicQueues.size;
+    return count;
+  }
+
+  get isReleased(): boolean {
+    return this.released;
+  }
+
+  get roleAudit(): PgNotificationRoleAudit {
+    if (!this.audit) {
+      throw new Error('PostgreSQL notification broker lease is not role-attested');
+    }
+    return this.audit;
+  }
+
+  setRoleAudit(audit: PgNotificationRoleAudit): void {
+    this.audit = audit;
+  }
+
+  revalidateRole(): Promise<PgNotificationRoleAudit> {
+    if (this.released) return Promise.reject(new PgNotificationLeaseReleasedError());
+    if (!this.roleContract) {
+      return Promise.reject(
+        new Error('PostgreSQL notification broker lease is not role-attested')
+      );
+    }
+    return this.broker.revalidateLeaseRole(this);
+  }
+
+  subscribe(topic: string): AsyncIterableIterator<string> {
+    if (this.released) throw new PgNotificationLeaseReleasedError();
+    this.broker.assertAvailable();
+    if (!this.allowedTopics.has(topic)) {
+      throw new PgNotificationTopicError(
+        topic,
+        'the topic is not in this lease\'s exact allowlist'
+      );
+    }
+
+    let topicQueues = this.queues.get(topic);
+    if (!topicQueues) {
+      topicQueues = new Set();
+      this.queues.set(topic, topicQueues);
+    }
+    let queue!: BoundedNotificationQueue;
+    queue = new BoundedNotificationQueue(
+      topic,
+      this.queueCapacity,
+      () => {
+        topicQueues!.delete(queue);
+        if (topicQueues!.size === 0) this.queues.delete(topic);
+      },
+      () => {
+        this.counters.queueOverflows++;
+      }
+    );
+    topicQueues.add(queue);
+    return queue;
+  }
+
+  dispatch(topic: string, payload: string): void {
+    const queues = this.queues.get(topic);
+    if (!queues) return;
+    for (const queue of [...queues]) queue.push(payload);
+  }
+
+  fail(error: PgNotificationBrokerFailedError): void {
+    this.termination.resolve(error);
+    for (const queues of [...this.queues.values()]) {
+      for (const queue of [...queues]) queue.fail(error);
+    }
+  }
+
+  release(): Promise<void> {
+    if (this.releasePromise) return this.releasePromise;
+    this.released = true;
+    for (const queues of [...this.queues.values()]) {
+      for (const queue of [...queues]) queue.complete();
+    }
+    this.releasePromise = this.broker.releaseLease(this);
+    void this.releasePromise.then(
+      () => this.termination.resolve(null),
+      (error) => this.termination.resolve(
+        error instanceof PgNotificationBrokerFailedError
+          ? error
+          : new PgNotificationBrokerFailedError(error)
+      )
+    );
+    return this.releasePromise;
+  }
+}
+
+class NotificationBrokerRecord {
+  private state: BrokerState = 'new';
+  private acceptingLeases = true;
+  private operation: Promise<void> = Promise.resolve();
+  private source: PgNotificationConnectionSource | null = null;
+  private client: PgNotificationClient | null = null;
+  private clientCleanup: Promise<void> | null = null;
+  private sourceCleanup: Promise<void> | null = null;
+  private fatalError: PgNotificationBrokerFailedError | null = null;
+  private readonly leases = new Set<NotificationBrokerLease>();
+  private readonly topicReferences = new Map<string, number>();
+  /** Includes provisional LISTENs whose lease admission has not committed yet. */
+  private readonly listenedTopics = new Set<string>();
+
+  private readonly onNotification = (notification: PgNotification): void => {
+    if (this.state !== 'active') return;
+    if (
+      !notification
+      || typeof notification.channel !== 'string'
+      || (
+        notification.payload !== undefined
+        && typeof notification.payload !== 'string'
+      )
+    ) {
+      this.markFailed(new Error('PostgreSQL listener emitted a malformed notification'));
+      return;
+    }
+    if (!this.topicReferences.has(notification.channel)) {
+      this.counters.ignoredNotifications++;
+      return;
+    }
+    this.counters.notifications++;
+    const payload = notification.payload ?? '';
+    for (const lease of [...this.leases]) {
+      lease.dispatch(notification.channel, payload);
+    }
+  };
+
+  private readonly onClientError = (error: unknown): void => {
+    this.markFailed(error);
+  };
+
+  private readonly onClientEnd = (): void => {
+    this.markFailed(new Error('PostgreSQL notification listener connection ended'));
+  };
+
+  constructor(
+    readonly identity: string,
+    private readonly sourcePromise: Promise<PgNotificationConnectionSource>,
+    private readonly queueCapacity: number,
+    private readonly operationTimeoutMs: number,
+    private readonly counters: MutableBrokerCounters,
+    private readonly onTerminal: (record: NotificationBrokerRecord) => void
+  ) {}
+
+  get snapshot(): Pick<
+  PgNotificationBrokerStats,
+  'listenerConnections' | 'leases' | 'topics' | 'subscribers'
+  > {
+    let subscribers = 0;
+    for (const lease of this.leases) subscribers += lease.subscriberCount;
+    return {
+      listenerConnections: this.client ? 1 : 0,
+      leases: this.leases.size,
+      topics: this.topicReferences.size,
+      subscribers
+    };
+  }
+
+  assertAvailable(): void {
+    if (this.state === 'failed') throw this.fatalError!;
+    if (this.state !== 'active') throw new PgNotificationLeaseReleasedError();
+  }
+
+  async acquire(
+    topics: readonly string[],
+    roleContract: Readonly<PgNotificationRoleContract> | null = null
+  ): Promise<NotificationBrokerLease> {
+    const lease = new NotificationBrokerLease(
+      this.identity,
+      topics,
+      this,
+      this.queueCapacity,
+      this.counters,
+      roleContract
+    );
+    await this.enqueue(async () => {
+      if (!this.acceptingLeases) throw new BrokerClosedError();
+      if (this.state === 'failed') throw this.fatalError!;
+      if (this.state === 'closing' || this.state === 'closed') {
+        throw new BrokerClosedError();
+      }
+      const client = await this.ensureClient();
+      if (!this.acceptingLeases) throw new BrokerClosedError();
+      if (roleContract) {
+        lease.setRoleAudit(await this.auditRole(client, roleContract));
+      }
+      if (!this.acceptingLeases) throw new BrokerClosedError();
+      for (const topic of topics) {
+        if ((this.topicReferences.get(topic) ?? 0) === 0) {
+          await this.executeListenerQuery(client, `LISTEN ${quoteIdentifier(topic)}`);
+          this.listenedTopics.add(topic);
+        }
+      }
+      if (!this.acceptingLeases || this.state !== 'active') {
+        if (this.fatalError) throw this.fatalError;
+        throw new BrokerClosedError();
+      }
+      for (const topic of topics) {
+        this.topicReferences.set(topic, (this.topicReferences.get(topic) ?? 0) + 1);
+      }
+      this.leases.add(lease);
+      this.counters.acquisitions++;
+    });
+    return lease;
+  }
+
+  async revalidateLeaseRole(
+    lease: NotificationBrokerLease
+  ): Promise<PgNotificationRoleAudit> {
+    return this.enqueue(async () => {
+      if (lease.isReleased || !this.leases.has(lease)) {
+        throw new PgNotificationLeaseReleasedError();
+      }
+      if (this.state === 'failed') throw this.fatalError!;
+      if (this.state !== 'active' || !this.client || !lease.roleContract) {
+        throw new PgNotificationLeaseReleasedError();
+      }
+      const audit = await this.auditRole(this.client, lease.roleContract);
+      lease.setRoleAudit(audit);
+      return audit;
+    });
+  }
+
+  async releaseLease(lease: NotificationBrokerLease): Promise<void> {
+    return this.enqueue(async () => {
+      if (!this.leases.delete(lease)) return;
+      this.counters.releases++;
+
+      const topicsToUnlisten: string[] = [];
+      for (const topic of lease.topics) {
+        const next = (this.topicReferences.get(topic) ?? 0) - 1;
+        if (next <= 0) {
+          this.topicReferences.delete(topic);
+          topicsToUnlisten.push(topic);
+        } else {
+          this.topicReferences.set(topic, next);
+        }
+      }
+
+      let releaseError: Error | null = null;
+      if (this.state === 'active' && this.client) {
+        for (const topic of topicsToUnlisten) {
+          try {
+            await this.executeListenerQuery(
+              this.client,
+              `UNLISTEN ${quoteIdentifier(topic)}`
+            );
+            this.listenedTopics.delete(topic);
+          } catch (error) {
+            releaseError = this.fatalError
+              ?? new PgNotificationBrokerFailedError(error);
+            break;
+          }
+        }
+      }
+
+      if (this.leases.size === 0) await this.closeUnused();
+      if (releaseError) throw releaseError;
+    });
+  }
+
+  async closeAll(): Promise<void> {
+    this.acceptingLeases = false;
+    // Cross the serialized-operation barrier before snapshotting leases. This
+    // either rejects an acquisition already waiting on connect/LISTEN or makes
+    // its completed lease visible to the release snapshot below.
+    await this.enqueue((): void => undefined);
+    const releases = [...this.leases].map((lease) => lease.release());
+    const releaseResults = await Promise.allSettled(releases);
+    let finalCleanupError: unknown;
+    let finalCleanupFailed = false;
+    try {
+      await this.enqueue(() => this.closeUnused());
+    } catch (error) {
+      finalCleanupError = error;
+      finalCleanupFailed = true;
+    }
+    const failedRelease = releaseResults.find(
+      (result): result is PromiseRejectedResult => result.status === 'rejected'
+    );
+    if (failedRelease) throw failedRelease.reason;
+    if (finalCleanupFailed) throw finalCleanupError;
+  }
+
+  async closeIfUnused(): Promise<void> {
+    await this.enqueue(() => this.closeUnused());
+  }
+
+  private enqueue<T>(operation: () => PromiseOrDirect<T>): Promise<T> {
+    const pending = this.operation.then(operation, operation);
+    this.operation = pending.then(
+      (): void => undefined,
+      (): void => undefined
+    );
+    return pending;
+  }
+
+  private async ensureClient(): Promise<PgNotificationClient> {
+    if (this.client) return this.client;
+    try {
+      this.source = await this.sourcePromise;
+      if (this.fatalError) throw this.fatalError;
+      const client = await this.source.connect();
+      this.client = client;
+      client.on('notification', this.onNotification);
+      client.on('error', this.onClientError);
+      client.on('end', this.onClientEnd);
+      this.state = 'active';
+      return client;
+    } catch (error) {
+      this.markFailed(error);
+      await this.clientCleanup;
+      throw this.fatalError!;
+    }
+  }
+
+  private async executeListenerQuery(
+    client: PgNotificationClient,
+    text: string
+  ): Promise<void> {
+    try {
+      await this.runWithOperationDeadline(
+        text.startsWith('UNLISTEN') ? 'unlisten' : 'listen',
+        () => client.query(text)
+      );
+      if (this.state === 'failed') throw this.fatalError!;
+    } catch (error) {
+      this.markFailed(error);
+      await this.clientCleanup;
+      throw this.fatalError!;
+    }
+  }
+
+  private async auditRole(
+    client: PgNotificationClient,
+    contract: Readonly<PgNotificationRoleContract>
+  ): Promise<PgNotificationRoleAudit> {
+    this.counters.roleAuditAttempts++;
+    try {
+      const audit = await this.runWithOperationDeadline(
+        'role-audit',
+        () => assertPgNotificationRoleClient(
+          client as unknown as PgNotificationRoleClient,
+          contract
+        )
+      );
+      if (this.state === 'failed') throw this.fatalError!;
+      return audit;
+    } catch (error) {
+      this.counters.roleAuditFailures++;
+      this.markFailed(error);
+      await this.clientCleanup;
+      // Preserve the stable unsafe-role error for startup and attestation
+      // diagnostics. Active leases separately observe the broker-failed latch.
+      throw error;
+    }
+  }
+
+  private async runWithOperationDeadline<T>(
+    operation: NotificationOperation,
+    task: () => PromiseOrDirect<T>
+  ): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => {
+        const error = new PgNotificationOperationTimeoutError(
+          operation,
+          this.operationTimeoutMs
+        );
+        // Latch failure and start client destruction at the exact deadline. The
+        // driver promise remains observed below, so a later rejection is safe.
+        this.markFailed(error);
+        reject(error);
+      }, this.operationTimeoutMs);
+      timer.unref?.();
+    });
+    // Promise.race installs a rejection handler on the driver query. If the
+    // deadline wins, destroying the client may settle that abandoned query
+    // later without producing an unhandled rejection.
+    const operationPromise = Promise.resolve().then(task);
+    try {
+      return await Promise.race([operationPromise, timeout]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
+  private markFailed(reason: unknown): void {
+    if (
+      this.state === 'failed'
+      || this.state === 'closing'
+      || this.state === 'closed'
+    ) return;
+    this.state = 'failed';
+    this.fatalError = reason instanceof PgNotificationBrokerFailedError
+      ? reason
+      : new PgNotificationBrokerFailedError(reason);
+    this.counters.fatalFailures++;
+    for (const lease of [...this.leases]) lease.fail(this.fatalError);
+
+    const client = this.client;
+    this.client = null;
+    if (client) this.clientCleanup = this.releaseClient(client, this.fatalError);
+  }
+
+  private async releaseClient(
+    client: PgNotificationClient,
+    error?: Error,
+    destroy = false
+  ): Promise<void> {
+    client.off('notification', this.onNotification);
+    client.off('end', this.onClientEnd);
+    try {
+      await client.release(error ?? (destroy ? true : undefined));
+    } catch (releaseError) {
+      // The broker is already failed or closing. Source cleanup below remains
+      // mandatory, and the original delivery failure is the useful error.
+      if (!error) throw releaseError;
+    } finally {
+      client.off('error', this.onClientError);
+    }
+  }
+
+  private async closeUnused(): Promise<void> {
+    if (this.leases.size > 0 || this.state === 'closed') return;
+
+    let cleanupError: unknown;
+    let cleanupFailed = false;
+    if (this.client && this.listenedTopics.size > 0) {
+      try {
+        // This also covers a shutdown racing between a successful LISTEN and
+        // lease admission, where no committed topic reference exists yet.
+        await this.executeListenerQuery(
+          this.client,
+          'UNLISTEN *'
+        );
+        this.listenedTopics.clear();
+      } catch (error) {
+        cleanupError = error;
+        cleanupFailed = true;
+      }
+    }
+    if (this.state !== 'failed') this.state = 'closing';
+
+    const client = this.client;
+    this.client = null;
+    if (client) {
+      const releaseError = cleanupFailed
+        ? new PgNotificationBrokerFailedError(cleanupError)
+        : undefined;
+      // Once the last exact-generation lease is gone, retaining an idle
+      // listener backend only delays PostgreSQL memory reclamation. Destroy it
+      // after UNLISTEN; the identity-only pool can create a fresh client later.
+      this.clientCleanup = this.releaseClient(client, releaseError, true);
+    }
+    try {
+      if (this.clientCleanup) await this.clientCleanup;
+    } catch (error) {
+      cleanupError = error;
+      cleanupFailed = true;
+    }
+
+    if (this.source && !this.sourceCleanup) {
+      const source = this.source;
+      this.source = null;
+      this.sourceCleanup = Promise.resolve(source.release());
+    }
+    try {
+      if (this.sourceCleanup) await this.sourceCleanup;
+    } catch (error) {
+      if (!cleanupFailed) cleanupError = error;
+      cleanupFailed = true;
+    }
+
+    this.state = 'closed';
+    this.onTerminal(this);
+    if (cleanupFailed) throw cleanupError;
+  }
+}
+
+/**
+ * Registry implementation exposed for deterministic unit tests. Production
+ * callers must use acquirePgNotificationBroker so identity and pool ownership
+ * always come from the canonical PgConfig path.
+ *
+ * @internal
+ */
+export class PgNotificationBrokerRegistry {
+  private readonly records = new Map<string, NotificationBrokerRecord>();
+  private closed = false;
+  private closePromise: Promise<void> | null = null;
+  private readonly counters: MutableBrokerCounters = {
+    acquisitions: 0,
+    releases: 0,
+    notifications: 0,
+    ignoredNotifications: 0,
+    queueOverflows: 0,
+    fatalFailures: 0,
+    roleAuditAttempts: 0,
+    roleAuditFailures: 0
+  };
+
+  constructor(
+    private readonly queueCapacity = PG_NOTIFICATION_QUEUE_CAPACITY,
+    private readonly defaultOperationTimeoutMs =
+    DEFAULT_PG_NOTIFICATION_OPERATION_TIMEOUT_MS
+  ) {
+    if (!Number.isSafeInteger(queueCapacity) || queueCapacity <= 0) {
+      throw new Error('PostgreSQL notification queue capacity must be a positive safe integer');
+    }
+    assertNotificationOperationTimeoutMs(defaultOperationTimeoutMs);
+  }
+
+  async acquireForTests(
+    identity: string,
+    sourceFactory: ConnectionSourceFactory,
+    topics: readonly string[],
+    operationTimeoutMs = this.defaultOperationTimeoutMs
+  ): Promise<PgNotificationBrokerLease> {
+    return this.acquireInternal(
+      identity,
+      sourceFactory,
+      topics,
+      null,
+      operationTimeoutMs
+    );
+  }
+
+  /** @internal Exercise production attestation without constructing PgConfig. */
+  async acquireAttestedForTests(
+    identity: string,
+    sourceFactory: ConnectionSourceFactory,
+    topics: readonly string[],
+    roleContract: PgNotificationRoleContract,
+    operationTimeoutMs = this.defaultOperationTimeoutMs
+  ): Promise<PgAttestedNotificationBrokerLease> {
+    return this.acquireInternal(
+      identity,
+      sourceFactory,
+      topics,
+      roleContract,
+      operationTimeoutMs
+    );
+  }
+
+  private async acquireInternal(
+    identity: string,
+    sourceFactory: ConnectionSourceFactory,
+    topics: readonly string[],
+    roleContract: PgNotificationRoleContract | null,
+    operationTimeoutMs: number
+  ): Promise<NotificationBrokerLease> {
+    if (this.closed) throw new Error('PostgreSQL notification broker registry is closed');
+    if (typeof identity !== 'string' || identity.length === 0) {
+      throw new Error('PostgreSQL notification broker identity must be a non-empty string');
+    }
+    const normalizedTopics = normalizeTopics(topics);
+    const normalizedOperationTimeoutMs = assertNotificationOperationTimeoutMs(
+      operationTimeoutMs
+    );
+
+    for (;;) {
+      let record = this.records.get(identity);
+      if (!record) {
+        const sourcePromise = Promise.resolve(sourceFactory());
+        // Acquisition consumes this immediately, but guard the small interval
+        // before its serialized operation attaches a rejection handler.
+        void sourcePromise.catch(() => {});
+        record = new NotificationBrokerRecord(
+          identity,
+          sourcePromise,
+          this.queueCapacity,
+          normalizedOperationTimeoutMs,
+          this.counters,
+          (terminal) => {
+            if (this.records.get(identity) === terminal) this.records.delete(identity);
+          }
+        );
+        this.records.set(identity, record);
+      }
+      try {
+        const lease = await record.acquire(normalizedTopics, roleContract);
+        if (this.closed) {
+          await lease.release();
+          throw new Error('PostgreSQL notification broker registry is closed');
+        }
+        return lease;
+      } catch (error) {
+        if (error instanceof BrokerClosedError && !this.closed) continue;
+        // A failed broker remains pinned until every existing owner explicitly
+        // releases it. This prevents an acquisition attempt from silently
+        // replacing a listener after a possible notification gap.
+        await record.closeIfUnused();
+        if (error instanceof BrokerClosedError && this.closed) {
+          throw new Error('PostgreSQL notification broker registry is closed');
+        }
+        throw error;
+      }
+    }
+  }
+
+  stats(): PgNotificationBrokerStats {
+    let listenerConnections = 0;
+    let leases = 0;
+    let topics = 0;
+    let subscribers = 0;
+    for (const record of this.records.values()) {
+      const snapshot = record.snapshot;
+      listenerConnections += snapshot.listenerConnections;
+      leases += snapshot.leases;
+      topics += snapshot.topics;
+      subscribers += snapshot.subscribers;
+    }
+    return {
+      brokers: this.records.size,
+      listenerConnections,
+      leases,
+      topics,
+      subscribers,
+      ...this.counters
+    };
+  }
+
+  close(): Promise<void> {
+    if (this.closePromise) return this.closePromise;
+    this.closed = true;
+    this.closePromise = (async () => {
+      const closeResults = await Promise.allSettled(
+        [...this.records.values()].map((record) => record.closeAll())
+      );
+      this.records.clear();
+      const failedClose = closeResults.find(
+        (result): result is PromiseRejectedResult => result.status === 'rejected'
+      );
+      if (failedClose) throw failedClose.reason;
+    })();
+    return this.closePromise;
+  }
+}
+
+let brokerRegistry = new PgNotificationBrokerRegistry();
+let brokerTeardownTail: Promise<void> = Promise.resolve();
+
+/** Opaque identity over the complete canonical listener pool contract. */
+export const getPgNotificationBrokerIdentity = (
+  listenerPgConfig: PgNotificationListenerConfig
+): string => {
+  // The operation deadline is represented by the pool connection timeout in
+  // the identity below. Validate it before publishing an apparently usable key.
+  getNotificationOperationTimeoutMs(listenerPgConfig);
+  const poolIdentity = getPgPoolIdentity(listenerPgConfig, {
+    purpose: 'notification-broker',
+    sanitizeOnCheckout: true
+  });
+  return `${PG_NOTIFICATION_BROKER_IDENTITY_VERSION}:${poolIdentity}`;
+};
+
+/**
+ * Opaque identity for one physical database target, deliberately excluding
+ * credentials, TLS policy, pool sizing, and checkout behavior. Those inputs
+ * split listener pools, but must not let two active listener contracts silently
+ * fragment one database's broker.
+ */
+export const getPgNotificationDatabaseIdentity = (
+  listenerPgConfig: PgNotificationListenerConfig
+): string => {
+  const targetIdentity = getPgDatabaseTargetIdentity(listenerPgConfig);
+  return `${PG_NOTIFICATION_DATABASE_IDENTITY_VERSION}:${targetIdentity}`;
+};
+
+/**
+ * Acquire a generation lease over one process-local listener. The supplied
+ * config must name the dedicated least-privilege notification login; this API
+ * never falls back to a request runtime or control-plane credential.
+ */
+export const acquirePgNotificationBroker = async (
+  listenerPgConfig: PgNotificationListenerConfig,
+  options: AcquirePgNotificationBrokerOptions
+): Promise<PgAttestedNotificationBrokerLease> => {
+  const operationTimeoutMs = getNotificationOperationTimeoutMs(listenerPgConfig);
+  const identity = getPgNotificationBrokerIdentity(listenerPgConfig);
+  return brokerRegistry.acquireAttestedForTests(
+    identity,
+    () => {
+      const poolLease = acquirePgPool(listenerPgConfig, {
+        purpose: 'notification-broker',
+        sanitizeOnCheckout: true
+      });
+      return {
+        connect: () => poolLease.pool.connect() as Promise<PgNotificationClient>,
+        release: () => poolLease.release()
+      };
+    },
+    options.topics,
+    {
+      role: listenerPgConfig.user,
+      database: listenerPgConfig.database
+    },
+    operationTimeoutMs
+  );
+};
+
+export const getPgNotificationBrokerStats = (): PgNotificationBrokerStats =>
+  brokerRegistry.stats();
+
+/** Await every UNLISTEN and checked-out connection release, then reset. */
+export const teardownPgNotificationBrokers = (): Promise<void> => {
+  const closing = brokerRegistry;
+  brokerRegistry = new PgNotificationBrokerRegistry();
+  const teardown = brokerTeardownTail.then(() => closing.close());
+  // A later teardown must wait until this registry has fully drained even when
+  // this caller observes a cleanup failure.
+  brokerTeardownTail = teardown.then(
+    (): void => undefined,
+    (): void => undefined
+  );
+  return teardown;
+};

--- a/postgres/pg-cache/src/notification-role.ts
+++ b/postgres/pg-cache/src/notification-role.ts
@@ -1,0 +1,419 @@
+import type { Pool, PoolClient, QueryResult } from 'pg';
+
+export const PG_NOTIFICATION_ROLE_AUDIT_VERSION = 'pg-notification-role:v1';
+export const PG_NOTIFICATION_ROLE_UNSAFE_ERROR_CODE = 'PG_NOTIFICATION_ROLE_UNSAFE';
+export const PG_NOTIFICATION_ROLE_CONTRACT_ERROR_CODE =
+  'PG_NOTIFICATION_ROLE_CONTRACT_INVALID';
+
+export type PgNotificationRoleViolationCode =
+  | 'LOGIN_ROLE_MISMATCH'
+  | 'CURRENT_ROLE_MISMATCH'
+  | 'DATABASE_MISMATCH'
+  | 'LOGIN_REQUIRED'
+  | 'NOINHERIT_REQUIRED'
+  | 'SUPERUSER'
+  | 'BYPASSRLS'
+  | 'CREATEROLE'
+  | 'CREATEDB'
+  | 'REPLICATION'
+  | 'ROLE_MEMBERSHIP'
+  | 'TARGET_DATABASE_MISSING'
+  | 'TARGET_CONNECT_REQUIRED'
+  | 'CROSS_DATABASE_CONNECT'
+  | 'DATABASE_OWNER'
+  | 'DATABASE_CREATE'
+  | 'DATABASE_TEMP'
+  | 'SCHEMA_OWNER'
+  | 'SCHEMA_CREATE'
+  | 'SCHEMA_USAGE'
+  | 'RELATION_PRIVILEGE'
+  | 'FUNCTION_PRIVILEGE'
+  | 'SEQUENCE_PRIVILEGE'
+  | 'AUDIT_NO_RESULT';
+
+/** Credential-free identity expected from one dedicated listener login. */
+export interface PgNotificationRoleContract {
+  role: string;
+  database: string;
+}
+
+/** Safe to persist in diagnostics: connection secrets/config are never copied. */
+export interface PgNotificationRoleAudit {
+  version: typeof PG_NOTIFICATION_ROLE_AUDIT_VERSION;
+  role: string;
+  database: string;
+  safe: boolean;
+  violations: readonly PgNotificationRoleViolationCode[];
+}
+
+/** Catalog-query capability used by the broker's pinned LISTEN client. */
+export type PgNotificationRoleClient = Pick<PoolClient, 'query'>;
+
+interface PgNotificationRoleAuditRow {
+  expected_role: string;
+  session_role: string;
+  active_role: string;
+  active_database: string;
+  rolcanlogin: boolean;
+  rolinherit: boolean;
+  rolsuper: boolean;
+  rolbypassrls: boolean;
+  rolcreaterole: boolean;
+  rolcreatedb: boolean;
+  rolreplication: boolean;
+  membership_count: number;
+  target_database_exists: boolean;
+  target_connect: boolean;
+  other_database_connect_count: number;
+  target_database_owner: boolean;
+  target_database_create: boolean;
+  target_database_temp: boolean;
+  schema_owner_count: number;
+  schema_create_count: number;
+  schema_usage_count: number;
+  relation_privilege_count: number;
+  function_privilege_count: number;
+  sequence_privilege_count: number;
+}
+
+/**
+ * Audit only the session login's effective privileges. PostgreSQL system
+ * schemas/objects are excluded because ordinary logins necessarily use the
+ * catalog; every non-system schema and object remains in scope.
+ */
+export const PG_NOTIFICATION_ROLE_AUDIT_SQL = `
+WITH login_role AS MATERIALIZED (
+  SELECT r.oid, r.rolname, r.rolcanlogin, r.rolinherit, r.rolsuper,
+         r.rolbypassrls, r.rolcreaterole, r.rolcreatedb, r.rolreplication
+  FROM pg_catalog.pg_roles r
+  WHERE r.rolname = session_user
+), target_database AS MATERIALIZED (
+  SELECT d.oid, d.datname, d.datdba
+  FROM pg_catalog.pg_database d
+  WHERE d.datname = $2::text
+), application_schemas AS MATERIALIZED (
+  SELECT n.oid, n.nspname, n.nspowner
+  FROM pg_catalog.pg_namespace n
+  WHERE n.nspname <> 'information_schema'
+    AND n.nspname !~ '^pg_'
+)
+SELECT $1::text AS expected_role,
+       session_user AS session_role,
+       current_user AS active_role,
+       pg_catalog.current_database() AS active_database,
+       r.rolcanlogin,
+       r.rolinherit,
+       r.rolsuper,
+       r.rolbypassrls,
+       r.rolcreaterole,
+       r.rolcreatedb,
+       r.rolreplication,
+       (
+         SELECT count(*)::int
+         FROM pg_catalog.pg_auth_members membership
+         WHERE membership.member = r.oid OR membership.roleid = r.oid
+       ) AS membership_count,
+       (target.oid IS NOT NULL) AS target_database_exists,
+       COALESCE(
+         pg_catalog.has_database_privilege(r.rolname, target.oid, 'CONNECT'),
+         false
+       ) AS target_connect,
+       (
+         SELECT count(*)::int
+         FROM pg_catalog.pg_database database_record
+         WHERE database_record.datname <> $2::text
+           AND pg_catalog.has_database_privilege(
+             r.rolname,
+             database_record.oid,
+             'CONNECT'
+           )
+       ) AS other_database_connect_count,
+       COALESCE(target.datdba = r.oid, false) AS target_database_owner,
+       COALESCE(
+         pg_catalog.has_database_privilege(r.rolname, target.oid, 'CREATE'),
+         false
+       ) AS target_database_create,
+       COALESCE(
+         pg_catalog.has_database_privilege(r.rolname, target.oid, 'TEMP'),
+         false
+       ) AS target_database_temp,
+       (
+         SELECT count(*)::int
+         FROM application_schemas schema_record
+         WHERE schema_record.nspowner = r.oid
+       ) AS schema_owner_count,
+       (
+         SELECT count(*)::int
+         FROM application_schemas schema_record
+         WHERE pg_catalog.has_schema_privilege(
+           r.rolname,
+           schema_record.oid,
+           'CREATE'
+         )
+       ) AS schema_create_count,
+       (
+         SELECT count(*)::int
+         FROM application_schemas schema_record
+         WHERE pg_catalog.has_schema_privilege(
+           r.rolname,
+           schema_record.oid,
+           'USAGE'
+         )
+       ) AS schema_usage_count,
+       (
+         SELECT count(*)::int
+         FROM application_schemas schema_record
+         INNER JOIN pg_catalog.pg_class relation
+           ON relation.relnamespace = schema_record.oid
+         WHERE CASE WHEN relation.relkind IN ('r', 'p', 'v', 'm', 'f')
+           THEN pg_catalog.has_table_privilege(
+             r.rolname,
+             relation.oid,
+             'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER'
+           )
+           OR pg_catalog.has_any_column_privilege(
+             r.rolname,
+             relation.oid,
+             'SELECT,INSERT,UPDATE,REFERENCES'
+           )
+           ELSE false
+         END
+       ) AS relation_privilege_count,
+       (
+         SELECT count(*)::int
+         FROM application_schemas schema_record
+         INNER JOIN pg_catalog.pg_proc routine
+           ON routine.pronamespace = schema_record.oid
+         WHERE pg_catalog.has_function_privilege(
+           r.rolname,
+           routine.oid,
+           'EXECUTE'
+         )
+       ) AS function_privilege_count,
+       (
+         SELECT count(*)::int
+         FROM application_schemas schema_record
+         INNER JOIN pg_catalog.pg_class sequence_record
+           ON sequence_record.relnamespace = schema_record.oid
+         WHERE CASE WHEN sequence_record.relkind = 'S'
+           THEN pg_catalog.has_sequence_privilege(
+             r.rolname,
+             sequence_record.oid,
+             'USAGE,SELECT,UPDATE'
+           )
+           ELSE false
+         END
+       ) AS sequence_privilege_count
+FROM login_role r
+LEFT JOIN target_database target ON true
+`;
+
+const containsUnpairedSurrogate = (value: string): boolean => {
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) return true;
+      index++;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const assertIdentifier = (kind: 'role' | 'database', value: unknown): string => {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new PgNotificationRoleContractError(`${kind} must be a non-empty string`);
+  }
+  if (value.includes('\0') || containsUnpairedSurrogate(value)) {
+    throw new PgNotificationRoleContractError(`${kind} is not a valid PostgreSQL name`);
+  }
+  const bytes = Buffer.byteLength(value, 'utf8');
+  if (bytes > 63) {
+    throw new PgNotificationRoleContractError(
+      `${kind} is ${bytes} UTF-8 bytes; PostgreSQL allows at most 63`
+    );
+  }
+  return value;
+};
+
+const normalizeContract = (
+  contract: PgNotificationRoleContract
+): Readonly<PgNotificationRoleContract> => Object.freeze({
+  role: assertIdentifier('role', contract?.role),
+  database: assertIdentifier('database', contract?.database)
+});
+
+export class PgNotificationRoleContractError extends Error {
+  readonly code = PG_NOTIFICATION_ROLE_CONTRACT_ERROR_CODE;
+
+  constructor(reason: string) {
+    super(`Invalid PostgreSQL notification-role contract: ${reason}`);
+    this.name = 'PgNotificationRoleContractError';
+  }
+}
+
+export class UnsafePgNotificationRoleError extends Error {
+  readonly code = PG_NOTIFICATION_ROLE_UNSAFE_ERROR_CODE;
+
+  constructor(
+    readonly audit: PgNotificationRoleAudit
+  ) {
+    super(
+      `PostgreSQL notification role ${JSON.stringify(audit.role)} for database `
+      + `${JSON.stringify(audit.database)} is unsafe: ${audit.violations.join(',')}`
+    );
+    this.name = 'UnsafePgNotificationRoleError';
+  }
+}
+
+/**
+ * Enforce a one-to-one role/database mapping without accepting connection
+ * config. Exact duplicate pairs are collapsed for multi-generation reuse.
+ */
+export const normalizePgNotificationRoleContracts = (
+  contracts: readonly PgNotificationRoleContract[]
+): readonly Readonly<PgNotificationRoleContract>[] => {
+  if (!Array.isArray(contracts) || contracts.length === 0) {
+    throw new PgNotificationRoleContractError('at least one role/database pair is required');
+  }
+  const byDatabase = new Map<string, string>();
+  const byRole = new Map<string, string>();
+  const unique = new Map<string, Readonly<PgNotificationRoleContract>>();
+  for (const candidate of contracts) {
+    const contract = normalizeContract(candidate);
+    const databaseRole = byDatabase.get(contract.database);
+    if (databaseRole && databaseRole !== contract.role) {
+      throw new PgNotificationRoleContractError(
+        `database ${JSON.stringify(contract.database)} maps to multiple login roles`
+      );
+    }
+    const roleDatabase = byRole.get(contract.role);
+    if (roleDatabase && roleDatabase !== contract.database) {
+      throw new PgNotificationRoleContractError(
+        `login role ${JSON.stringify(contract.role)} maps to multiple databases`
+      );
+    }
+    byDatabase.set(contract.database, contract.role);
+    byRole.set(contract.role, contract.database);
+    unique.set(`${contract.database}\0${contract.role}`, contract);
+  }
+  return Object.freeze(
+    [...unique.values()].sort((left, right) => {
+      if (left.database !== right.database) {
+        return left.database < right.database ? -1 : 1;
+      }
+      if (left.role === right.role) return 0;
+      return left.role < right.role ? -1 : 1;
+    })
+  );
+};
+
+const violationCodes = (
+  row: PgNotificationRoleAuditRow | undefined,
+  contract: Readonly<PgNotificationRoleContract>
+): PgNotificationRoleViolationCode[] => {
+  if (!row) return ['AUDIT_NO_RESULT'];
+  const violations: PgNotificationRoleViolationCode[] = [];
+  if (row.session_role !== contract.role) violations.push('LOGIN_ROLE_MISMATCH');
+  if (row.active_role !== row.session_role) violations.push('CURRENT_ROLE_MISMATCH');
+  if (row.active_database !== contract.database) violations.push('DATABASE_MISMATCH');
+  if (!row.rolcanlogin) violations.push('LOGIN_REQUIRED');
+  if (row.rolinherit) violations.push('NOINHERIT_REQUIRED');
+  if (row.rolsuper) violations.push('SUPERUSER');
+  if (row.rolbypassrls) violations.push('BYPASSRLS');
+  if (row.rolcreaterole) violations.push('CREATEROLE');
+  if (row.rolcreatedb) violations.push('CREATEDB');
+  if (row.rolreplication) violations.push('REPLICATION');
+  if (row.membership_count > 0) violations.push('ROLE_MEMBERSHIP');
+  if (!row.target_database_exists) violations.push('TARGET_DATABASE_MISSING');
+  if (!row.target_connect) violations.push('TARGET_CONNECT_REQUIRED');
+  if (row.other_database_connect_count > 0) violations.push('CROSS_DATABASE_CONNECT');
+  if (row.target_database_owner) violations.push('DATABASE_OWNER');
+  if (row.target_database_create) violations.push('DATABASE_CREATE');
+  if (row.target_database_temp) violations.push('DATABASE_TEMP');
+  if (row.schema_owner_count > 0) violations.push('SCHEMA_OWNER');
+  if (row.schema_create_count > 0) violations.push('SCHEMA_CREATE');
+  if (row.schema_usage_count > 0) violations.push('SCHEMA_USAGE');
+  if (row.relation_privilege_count > 0) violations.push('RELATION_PRIVILEGE');
+  if (row.function_privilege_count > 0) violations.push('FUNCTION_PRIVILEGE');
+  if (row.sequence_privilege_count > 0) violations.push('SEQUENCE_PRIVILEGE');
+  return violations;
+};
+
+/** Execute one fresh audit on an already-owned client without releasing it. */
+export const auditPgNotificationRoleClient = async (
+  client: PgNotificationRoleClient,
+  candidate: PgNotificationRoleContract
+): Promise<PgNotificationRoleAudit> => {
+  const contract = normalizeContract(candidate);
+  let inTransaction = false;
+  let result: QueryResult<PgNotificationRoleAuditRow>;
+  try {
+    await client.query('BEGIN READ ONLY');
+    inTransaction = true;
+    await client.query('SET LOCAL jit TO off');
+    result = await client.query<PgNotificationRoleAuditRow>(
+      PG_NOTIFICATION_ROLE_AUDIT_SQL,
+      [contract.role, contract.database]
+    );
+    await client.query('COMMIT');
+    inTransaction = false;
+  } catch (error) {
+    if (inTransaction) {
+      try {
+        await client.query('ROLLBACK');
+      } catch {
+        // Preserve the catalog-audit failure; the owning broker destroys the client.
+      }
+    }
+    throw error;
+  }
+
+  const violations = Object.freeze(violationCodes(result.rows[0], contract));
+  return Object.freeze({
+    version: PG_NOTIFICATION_ROLE_AUDIT_VERSION,
+    role: contract.role,
+    database: contract.database,
+    safe: violations.length === 0,
+    violations
+  });
+};
+
+/** Execute one fresh, read-only catalog audit. Successful results are not cached. */
+export const auditPgNotificationRole = async (
+  pool: Pool,
+  candidate: PgNotificationRoleContract
+): Promise<PgNotificationRoleAudit> => {
+  const client: PoolClient = await pool.connect();
+  let destroyClient = false;
+  try {
+    return await auditPgNotificationRoleClient(client, candidate);
+  } catch (error) {
+    destroyClient = true;
+    throw error;
+  } finally {
+    client.release(destroyClient);
+  }
+};
+
+/** Fail closed on a pinned client without exposing general query access. */
+export const assertPgNotificationRoleClient = async (
+  client: PgNotificationRoleClient,
+  contract: PgNotificationRoleContract
+): Promise<PgNotificationRoleAudit> => {
+  const audit = await auditPgNotificationRoleClient(client, contract);
+  if (!audit.safe) throw new UnsafePgNotificationRoleError(audit);
+  return audit;
+};
+
+/** Fail closed with a stable code while retaining a credential-free audit. */
+export const assertPgNotificationRole = async (
+  pool: Pool,
+  contract: PgNotificationRoleContract
+): Promise<PgNotificationRoleAudit> => {
+  const audit = await auditPgNotificationRole(pool, contract);
+  if (!audit.safe) throw new UnsafePgNotificationRoleError(audit);
+  return audit;
+};

--- a/postgres/pg-cache/src/pg.ts
+++ b/postgres/pg-cache/src/pg.ts
@@ -1,12 +1,252 @@
+import { createHash, createHmac, randomBytes } from 'node:crypto';
+import type { EventEmitter } from 'node:events';
+import { performance } from 'node:perf_hooks';
+
 import { Logger } from '@pgpmjs/logger';
 import { parseEnvNumber } from '12factor-env';
 import pg from 'pg';
 import { getPgEnvOptions, PgConfig, PgPoolConfig } from 'pg-env';
 
-import { getActivePgPoolFactory, PgPoolFactory } from './driver';
-import { pgCache } from './lru';
+import { getActivePgPoolFactory, getPgPoolDriverIdentity, PgPoolFactory } from './driver';
+import { pgCache, type PgPoolLease } from './lru';
 
 const log = new Logger('pg-cache');
+
+export interface GetPgPoolOptions {
+  /** Separates pools used by different trust boundaries. */
+  purpose?: string;
+  /** Reset all server and driver session state before every checkout. */
+  sanitizeOnCheckout?: boolean;
+}
+
+interface NodePostgresConnection {
+  parsedStatements?: Record<string, string>;
+  _graphilePreparedStatementCache?: unknown;
+}
+
+interface NodePostgresClient extends pg.PoolClient {
+  connection?: NodePostgresConnection;
+}
+
+type PoolQueryCallback = (error: Error | undefined, result?: unknown) => void;
+
+const requireSanitizableClient = (value: unknown): NodePostgresClient => {
+  const client = value as Partial<NodePostgresClient> | null | undefined;
+  if (
+    client
+    && typeof client.query === 'function'
+    && typeof client.release === 'function'
+  ) {
+    return client as NodePostgresClient;
+  }
+  if (client && typeof client.release === 'function') {
+    try {
+      client.release(true);
+    } catch {
+      // The factory contract is already invalid; never hand this client out.
+    }
+  }
+  throw new TypeError(
+    'A sanitized PostgreSQL pool must return clients with callable query() and release() methods'
+  );
+};
+
+export interface PgCheckoutSanitizerStats {
+  checkoutAttempts: number;
+  checkoutFailures: number;
+  queuedCheckouts: number;
+  virginFastPathCheckouts: number;
+  sanitizedReuseCheckouts: number;
+  sanitationFailures: number;
+  checkoutWaitMsTotal: number;
+  checkoutWaitMsMax: number;
+  sanitationMsTotal: number;
+  sanitationMsMax: number;
+}
+
+const makeCheckoutSanitizerStats = (): PgCheckoutSanitizerStats => ({
+  checkoutAttempts: 0,
+  checkoutFailures: 0,
+  queuedCheckouts: 0,
+  virginFastPathCheckouts: 0,
+  sanitizedReuseCheckouts: 0,
+  sanitationFailures: 0,
+  checkoutWaitMsTotal: 0,
+  checkoutWaitMsMax: 0,
+  sanitationMsTotal: 0,
+  sanitationMsMax: 0
+});
+
+const aggregateCheckoutSanitizerStats = makeCheckoutSanitizerStats();
+const poolCheckoutSanitizerStats = new WeakMap<pg.Pool, PgCheckoutSanitizerStats>();
+
+const recordCount = (
+  stats: PgCheckoutSanitizerStats,
+  key: 'checkoutAttempts'
+    | 'checkoutFailures'
+    | 'queuedCheckouts'
+    | 'virginFastPathCheckouts'
+    | 'sanitizedReuseCheckouts'
+    | 'sanitationFailures'
+): void => {
+  stats[key]++;
+  aggregateCheckoutSanitizerStats[key]++;
+};
+
+const recordDuration = (
+  stats: PgCheckoutSanitizerStats,
+  totalKey: 'checkoutWaitMsTotal' | 'sanitationMsTotal',
+  maxKey: 'checkoutWaitMsMax' | 'sanitationMsMax',
+  durationMs: number
+): void => {
+  stats[totalKey] += durationMs;
+  stats[maxKey] = Math.max(stats[maxKey], durationMs);
+  aggregateCheckoutSanitizerStats[totalKey] += durationMs;
+  aggregateCheckoutSanitizerStats[maxKey] = Math.max(
+    aggregateCheckoutSanitizerStats[maxKey],
+    durationMs
+  );
+};
+
+/** Aggregate checkout/sanitation telemetry, or telemetry for one exact pool. */
+export const getPgCheckoutSanitizerStats = (
+  pool?: pg.Pool
+): Readonly<PgCheckoutSanitizerStats> => ({
+  ...(pool ? poolCheckoutSanitizerStats.get(pool) : aggregateCheckoutSanitizerStats)
+    ?? makeCheckoutSanitizerStats()
+});
+
+const normalizePoolOptions = (options: GetPgPoolOptions = {}) => ({
+  purpose: options.purpose ?? 'default',
+  sanitizeOnCheckout: options.sanitizeOnCheckout ?? false
+});
+
+// Pool identities may be emitted through diagnostics and cache lifecycle logs.
+// A plain digest over a known connection shape would let that digest act as an
+// offline password verifier. Keep the key private and process-local: identities
+// remain deterministic for this registry's lifetime but are intentionally not
+// portable evidence across processes.
+const pgIdentityHmacKey = randomBytes(32);
+
+const hmacIdentity = (prefix: string, identity: string): string =>
+  `${prefix}:${createHmac('sha256', pgIdentityHmacKey)
+    .update(identity)
+    .digest('hex')}`;
+
+const requireIdentityString = (value: unknown, path: string): string => {
+  if (typeof value !== 'string') {
+    throw new TypeError(`${path} must be a string`);
+  }
+  return value;
+};
+
+const requireIdentityInteger = (
+  value: unknown,
+  path: string,
+  minimum: number,
+  maximum = Number.MAX_SAFE_INTEGER
+): number => {
+  if (
+    typeof value !== 'number'
+    || !Number.isSafeInteger(value)
+    || value < minimum
+    || value > maximum
+  ) {
+    throw new TypeError(
+      `${path} must be a safe integer between ${minimum} and ${maximum}`
+    );
+  }
+  return value;
+};
+
+const normalizeIdentityOptions = (
+  options: GetPgPoolOptions = {}
+): Required<GetPgPoolOptions> => {
+  const purpose = options.purpose ?? 'default';
+  const sanitizeOnCheckout = options.sanitizeOnCheckout ?? false;
+  if (typeof purpose !== 'string' || purpose.length === 0) {
+    throw new TypeError('pg pool purpose must be a non-empty string');
+  }
+  if (typeof sanitizeOnCheckout !== 'boolean') {
+    throw new TypeError('pg pool sanitizeOnCheckout must be a boolean');
+  }
+  return { purpose, sanitizeOnCheckout };
+};
+
+const canonicalizeIdentityValue = (
+  value: unknown,
+  path: string,
+  ancestors = new Set<object>()
+): unknown => {
+  if (
+    value === null
+    || typeof value === 'string'
+    || typeof value === 'boolean'
+  ) {
+    return value;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new TypeError(`${path} must not contain a non-finite number`);
+    }
+    return Object.is(value, -0) ? ['number', '-0'] : value;
+  }
+  if (Buffer.isBuffer(value)) {
+    return ['buffer-sha256', createHash('sha256').update(value).digest('hex')];
+  }
+  if (Array.isArray(value)) {
+    if (ancestors.has(value)) throw new TypeError(`${path} must not be cyclic`);
+    const ownKeys = Reflect.ownKeys(value);
+    if (
+      ownKeys.some((key) => typeof key !== 'string')
+      || ownKeys.some((key) => key !== 'length' && !/^(?:0|[1-9]\d*)$/.test(key as string))
+      || value.some((_entry, index) => !Object.prototype.hasOwnProperty.call(value, index))
+      || Object.keys(value).length !== value.length
+    ) {
+      throw new TypeError(`${path} must be a dense array without custom properties`);
+    }
+    ancestors.add(value);
+    const result = value.map((entry, index) => {
+      if (entry === undefined) {
+        throw new TypeError(`${path}[${index}] must not be undefined`);
+      }
+      return canonicalizeIdentityValue(entry, `${path}[${index}]`, ancestors);
+    });
+    ancestors.delete(value);
+    return ['array', result];
+  }
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    const prototype = Object.getPrototypeOf(record);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new TypeError(`${path} must contain only data values`);
+    }
+    if (ancestors.has(record)) throw new TypeError(`${path} must not be cyclic`);
+    ancestors.add(record);
+    const result: Array<[string, unknown]> = [];
+    const ownKeys = Reflect.ownKeys(record);
+    if (ownKeys.some((key) => typeof key !== 'string')) {
+      throw new TypeError(`${path} must not contain symbol properties`);
+    }
+    for (const key of (ownKeys as string[]).sort()) {
+      const descriptor = Object.getOwnPropertyDescriptor(record, key);
+      if (!descriptor || !('value' in descriptor)) {
+        throw new TypeError(`${path}.${key} must be a data property`);
+      }
+      const entry = descriptor.value;
+      if (entry === undefined) {
+        throw new TypeError(`${path}.${key} must not be undefined`);
+      }
+      result.push([
+        key,
+        canonicalizeIdentityValue(entry, `${path}.${key}`, ancestors)
+      ]);
+    }
+    ancestors.delete(record);
+    return ['object', result];
+  }
+  throw new TypeError(`${path} must contain only deterministic data values`);
+};
 
 export const buildConnectionString = (
   user: string,
@@ -14,36 +254,466 @@ export const buildConnectionString = (
   host: string,
   port: string | number,
   database: string
-): string =>
-  `postgres://${user}:${password}@${host}:${port}/${database}`;
+): string => {
+  const encodedHost = host.includes(':') && !host.startsWith('[')
+    ? `[${host}]`
+    : encodeURIComponent(host);
+  return `postgres://${encodeURIComponent(user)}:${encodeURIComponent(password)}`
+    + `@${encodedHost}:${port}/${encodeURIComponent(database)}`;
+};
 
 /**
  * Read per-pool configuration from environment variables.
  *
  * Supports:
  * - PG_POOL_MAX: Maximum clients per pool (default: 5)
+ * - PG_POOL_MAX_USES: Retire a client after this many checkouts (0/unset: unlimited)
  * - PG_POOL_IDLE_TIMEOUT_MS: Close idle clients after ms (default: 30000)
  * - PG_POOL_CONNECTION_TIMEOUT_MS: Fail connect() after ms (default: 5000)
  */
+const normalizeMaxUses = (
+  value: number | string | undefined,
+  source: 'pool.maxUses' | 'PG_POOL_MAX_USES'
+): number | undefined => {
+  if (value === undefined || value === '') {
+    return undefined;
+  }
+  if (typeof value !== 'number' && typeof value !== 'string') {
+    throw new TypeError(`${source} must be 0 or a positive safe integer`);
+  }
+  if (typeof value === 'string' && !/^(?:0|[1-9]\d*)$/.test(value)) {
+    throw new TypeError(`${source} must be 0 or a positive safe integer`);
+  }
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new TypeError(`${source} must be 0 or a positive safe integer`);
+  }
+  return parsed === 0 ? undefined : parsed;
+};
+
 export function getPgPoolConfig(overrides?: PgPoolConfig): pg.PoolConfig {
-  return {
+  const maxUses = overrides?.maxUses !== undefined
+    ? normalizeMaxUses(overrides.maxUses, 'pool.maxUses')
+    : normalizeMaxUses(process.env.PG_POOL_MAX_USES, 'PG_POOL_MAX_USES');
+  const pool = {
     max: overrides?.max ?? parseEnvNumber(process.env.PG_POOL_MAX) ?? 5,
+    ...(maxUses !== undefined && { maxUses }),
     idleTimeoutMillis: overrides?.idleTimeoutMillis ?? parseEnvNumber(process.env.PG_POOL_IDLE_TIMEOUT_MS) ?? 30000,
     connectionTimeoutMillis: overrides?.connectionTimeoutMillis ?? parseEnvNumber(process.env.PG_POOL_CONNECTION_TIMEOUT_MS) ?? 5000,
     ...(overrides?.allowExitOnIdle !== undefined && { allowExitOnIdle: overrides.allowExitOnIdle }),
   };
+  requireIdentityInteger(pool.max, 'pool.max', 1);
+  if (pool.maxUses !== undefined) {
+    requireIdentityInteger(pool.maxUses, 'pool.maxUses', 1);
+  }
+  requireIdentityInteger(pool.idleTimeoutMillis, 'pool.idleTimeoutMillis', 0);
+  requireIdentityInteger(
+    pool.connectionTimeoutMillis,
+    'pool.connectionTimeoutMillis',
+    0
+  );
+  if (
+    pool.allowExitOnIdle !== undefined
+    && typeof pool.allowExitOnIdle !== 'boolean'
+  ) {
+    throw new TypeError('pool.allowExitOnIdle must be a boolean');
+  }
+  return pool;
+}
+
+const normalizeIdentityConfig = (
+  pgConfig: Partial<PgConfig> & { pool?: PgPoolConfig }
+): {
+  config: PgConfig;
+  ssl: unknown;
+} => {
+  const config = getPgEnvOptions(pgConfig);
+  requireIdentityString(config.host, 'pg.host');
+  requireIdentityInteger(config.port, 'pg.port', 1, 65_535);
+  requireIdentityString(config.database, 'pg.database');
+  requireIdentityString(config.user, 'pg.user');
+  // node-postgres also accepts password callbacks at runtime, despite the
+  // narrower public PgConfig type. A callback's captured secret cannot be
+  // represented exactly, so accepting it could alias two security principals.
+  requireIdentityString(config.password, 'pg.password');
+  return {
+    config,
+    ssl: canonicalizeIdentityValue(config.ssl ?? null, 'pg.ssl')
+  };
+};
+
+/**
+ * Opaque identity for the exact connection and checkout contract.
+ *
+ * The digest deliberately includes credentials: two roles that happen to
+ * connect to the same database must never share a pool. Only the digest is
+ * exposed, so passwords cannot leak through cache keys or logs.
+ */
+export function getPgPoolIdentity(
+  pgConfig: Partial<PgConfig> & { pool?: PgPoolConfig },
+  options: GetPgPoolOptions = {}
+): string {
+  const { config, ssl } = normalizeIdentityConfig(pgConfig);
+  const pool = getPgPoolConfig(pgConfig.pool);
+  const normalizedOptions = normalizeIdentityOptions(options);
+  const driver = requireIdentityString(
+    getPgPoolDriverIdentity(),
+    'pg driver identity'
+  );
+  const identity = JSON.stringify({
+    version: 1,
+    driver,
+    host: config.host,
+    port: config.port,
+    database: config.database,
+    user: config.user,
+    password: config.password,
+    ssl,
+    pool: {
+      max: pool.max,
+      maxUses: pool.maxUses ?? null,
+      idleTimeoutMillis: pool.idleTimeoutMillis,
+      connectionTimeoutMillis: pool.connectionTimeoutMillis,
+      allowExitOnIdle: pool.allowExitOnIdle ?? false
+    },
+    ...normalizedOptions
+  });
+  return hmacIdentity('pg:v1', identity);
+}
+
+/**
+ * Opaque identity for one configured physical PostgreSQL database target.
+ *
+ * Credentials, TLS policy, pool sizing, and checkout behavior deliberately do
+ * not participate: those inputs must split connection pools, but they must not
+ * let two active listener contracts evade a one-target reservation.
+ */
+export function getPgDatabaseTargetIdentity(
+  pgConfig: Partial<PgConfig>
+): string {
+  const { config } = normalizeIdentityConfig(pgConfig);
+  const driver = requireIdentityString(
+    getPgPoolDriverIdentity(),
+    'pg driver identity'
+  );
+  const identity = JSON.stringify({
+    version: 1,
+    driver,
+    host: config.host,
+    port: config.port,
+    database: config.database
+  });
+  return hmacIdentity('pg-target:v1', identity);
+}
+
+/** Clear client-side state whose server-side counterpart DISCARD ALL removed. */
+export function clearPreparedStatementBookkeeping(client: NodePostgresClient): void {
+  const connection = client.connection;
+  if (!connection) return;
+
+  if (connection.parsedStatements) {
+    for (const statementName of Object.keys(connection.parsedStatements)) {
+      delete connection.parsedStatements[statementName];
+    }
+  }
+  // Dataplan's LRU disposer issues asynchronous DEALLOCATE queries. DISCARD
+  // ALL has already removed every server-side prepared statement, so invoking
+  // that disposer here would race those cleanup queries with the next tenant
+  // transaction on this client. Drop the now-invalid client-side LRU instead;
+  // Dataplan will create a fresh one on demand.
+  delete connection._graphilePreparedStatementCache;
+}
+
+const SANITIZED_SESSION_BASELINE = [
+  'SET search_path TO pg_catalog',
+  'SET row_security TO on'
+] as string[];
+
+const sanitizedStartupOptions = (): string => {
+  const settings = [
+    '-c search_path=pg_catalog',
+    '-c row_security=on'
+  ];
+  if (process.env.DATAPLAN_PG_DONT_DISABLE_JIT !== '1') {
+    settings.push('-c jit_optimize_above_cost=-1');
+  }
+  return settings.join(' ');
+};
+
+const sanitizedSessionBaseline = (): string => {
+  const statements = [...SANITIZED_SESSION_BASELINE];
+  if (process.env.DATAPLAN_PG_DONT_DISABLE_JIT !== '1') {
+    statements.push('SET jit_optimize_above_cost TO -1');
+  }
+  return statements.join('; ');
+};
+
+/**
+ * Reset a checked-out connection before it crosses a request boundary.
+ * A failed reset destroys the connection; it is never returned to a caller.
+ */
+export async function sanitizePgClient(
+  client: NodePostgresClient,
+  baselineRestoredByDiscard = false
+): Promise<NodePostgresClient> {
+  try {
+    await client.query('DISCARD ALL');
+    clearPreparedStatementBookkeeping(client);
+    if (!baselineRestoredByDiscard) {
+      // Custom drivers may not support PostgreSQL startup options. Restore all
+      // trusted defaults in one simple-query round trip after DISCARD ALL.
+      await client.query(sanitizedSessionBaseline());
+    }
+    return client;
+  } catch (error) {
+    client.release(true);
+    throw error;
+  }
+}
+
+/** Sanitize Promise/callback checkouts and every custom-pool direct query. */
+export function installCheckoutSanitizer(
+  pool: pg.Pool,
+  baselineRestoredByDiscard = false,
+  /** @internal Only the default factory may assert this startup contract. */
+  factoryOwnedVirginFastPath = false
+): pg.Pool {
+  if (typeof pool.connect !== 'function' || typeof pool.query !== 'function') {
+    throw new TypeError(
+      'A sanitized PostgreSQL pool must expose callable connect() and query() methods'
+    );
+  }
+  const stats = makeCheckoutSanitizerStats();
+  poolCheckoutSanitizerStats.set(pool, stats);
+  const virginClients = new WeakSet<pg.PoolClient>();
+  const eventPool = pool as unknown as Partial<EventEmitter>;
+  const canProveFactoryListenerContract =
+    typeof eventPool.rawListeners === 'function'
+    && typeof eventPool.on === 'function'
+    && typeof eventPool.prependListener === 'function';
+  const connectListeners = (): Function[] => canProveFactoryListenerContract
+    ? eventPool.rawListeners!('connect')
+    : [];
+  // A non-EventEmitter custom QueryablePool can still use full sanitation, but
+  // it can never qualify for the default node-postgres virgin fast path.
+  let factoryContractContaminated = factoryOwnedVirginFastPath
+    && (!canProveFactoryListenerContract || connectListeners().length > 0);
+  const markFactoryOwnedVirgin = (client: pg.PoolClient): void => {
+    const listeners = connectListeners();
+    if (
+      !factoryContractContaminated
+      && listeners.length === 1
+      && listeners[0] === markFactoryOwnedVirgin
+    ) {
+      virginClients.add(client);
+    }
+  };
+  if (factoryOwnedVirginFastPath && canProveFactoryListenerContract) {
+    // Remember that an untrusted connect hook has existed even if it is a
+    // self-removing once/prependOnce listener and disappears during emission.
+    eventPool.on!('newListener', (eventName, listener) => {
+      if (eventName === 'connect' && listener !== markFactoryOwnedVirgin) {
+        factoryContractContaminated = true;
+      }
+    });
+    // This listener is installed before the lazy pool can open a connection.
+    // A second connect listener disables the fast path because that listener
+    // could mutate session state before the checkout reaches this wrapper.
+    eventPool.prependListener!('connect', markFactoryOwnedVirgin);
+  }
+  const originalConnect = pool.connect.bind(pool);
+  const sanitizedConnect = async (): Promise<pg.PoolClient> => {
+    recordCount(stats, 'checkoutAttempts');
+    const checkoutStartedAt = performance.now();
+    const waitingBefore = pool.waitingCount;
+    const pending = originalConnect();
+    if (pool.waitingCount > waitingBefore) recordCount(stats, 'queuedCheckouts');
+
+    let client: pg.PoolClient;
+    try {
+      client = requireSanitizableClient(await pending);
+    } catch (error) {
+      recordDuration(
+        stats,
+        'checkoutWaitMsTotal',
+        'checkoutWaitMsMax',
+        performance.now() - checkoutStartedAt
+      );
+      recordCount(stats, 'checkoutFailures');
+      throw error;
+    }
+    recordDuration(
+      stats,
+      'checkoutWaitMsTotal',
+      'checkoutWaitMsMax',
+      performance.now() - checkoutStartedAt
+    );
+
+    const virgin = virginClients.delete(client);
+    const markerIsExclusive = factoryOwnedVirginFastPath
+      && !factoryContractContaminated
+      && connectListeners().length === 1
+      && connectListeners()[0] === markFactoryOwnedVirgin;
+    if (virgin && markerIsExclusive) {
+      // The default factory supplies the trusted baseline in the startup
+      // packet. With no other connect listener and no prior checkout, neither
+      // server nor driver state exists to discard.
+      clearPreparedStatementBookkeeping(client as NodePostgresClient);
+      recordCount(stats, 'virginFastPathCheckouts');
+      return client;
+    }
+
+    const sanitationStartedAt = performance.now();
+    try {
+      const sanitized = await sanitizePgClient(
+        client as NodePostgresClient,
+        baselineRestoredByDiscard
+      );
+      recordCount(stats, 'sanitizedReuseCheckouts');
+      return sanitized;
+    } catch (error) {
+      recordCount(stats, 'sanitationFailures');
+      throw error;
+    } finally {
+      recordDuration(
+        stats,
+        'sanitationMsTotal',
+        'sanitationMsMax',
+        performance.now() - sanitationStartedAt
+      );
+    }
+  };
+
+  pool.connect = ((callback?: (
+    error: Error | undefined,
+    client: pg.PoolClient | undefined,
+    done: ((release?: boolean | Error) => void) | undefined
+  ) => void) => {
+    const pending = sanitizedConnect();
+    if (!callback) return pending;
+    pending.then(
+      (client) => callback(undefined, client, client.release.bind(client)),
+      (error) => callback(error as Error, undefined, undefined)
+    );
+  }) as typeof pool.connect;
+
+  if (!factoryOwnedVirginFastPath) {
+    // node-postgres' own pool.query dynamically calls this.connect(), so the
+    // default factory already reaches the sanitizer while retaining the full
+    // native query contract. An arbitrary QueryablePool may bypass connect()
+    // in its query implementation, so never trust that method in sanitized
+    // mode: acquire the sanitized client here and execute the query once.
+    const sanitizedQuery = ((...args: unknown[]) => {
+      if (typeof args[0] === 'function') {
+        const callback = args[0] as PoolQueryCallback;
+        queueMicrotask(() => callback(
+          new TypeError('Passing a function as the first parameter to pool.query is not supported')
+        ));
+        return undefined;
+      }
+
+      const callback = typeof args[args.length - 1] === 'function'
+        ? args.pop() as PoolQueryCallback
+        : undefined;
+      const execute = async (): Promise<unknown> => {
+        const client = await sanitizedConnect() as NodePostgresClient;
+        let settled = false;
+        const canObserveErrors =
+          typeof client.once === 'function'
+          && typeof client.removeListener === 'function';
+
+        return new Promise<unknown>((resolve, reject) => {
+          const removeErrorListener = (): void => {
+            if (!canObserveErrors) return;
+            try {
+              client.removeListener('error', onClientError);
+            } catch {
+              // A broken optional EventEmitter surface must not prevent release.
+            }
+          };
+          const releaseAfterError = (error: unknown): void => {
+            client.release(error instanceof Error ? error : true);
+          };
+          const fail = (error: unknown): void => {
+            if (settled) return;
+            settled = true;
+            removeErrorListener();
+            try {
+              releaseAfterError(error);
+            } catch {
+              // Preserve the query/connection error; release errors cannot make
+              // an already unsafe client eligible for reuse.
+            }
+            reject(error);
+          };
+          const succeed = (result: unknown): void => {
+            if (settled) return;
+            settled = true;
+            removeErrorListener();
+            try {
+              client.release();
+              resolve(result);
+            } catch (error) {
+              reject(error);
+            }
+          };
+          const onClientError = (error: Error): void => fail(error);
+
+          try {
+            if (canObserveErrors) client.once('error', onClientError);
+            Promise.resolve((client.query as (...queryArgs: unknown[]) => unknown)(...args))
+              .then(succeed, fail);
+          } catch (error) {
+            fail(error);
+          }
+        });
+      };
+
+      const pending = execute();
+      if (!callback) return pending;
+      pending.then(
+        (result) => callback(undefined, result),
+        (error) => callback(error as Error)
+      );
+      return undefined;
+    }) as typeof pool.query;
+
+    try {
+      pool.query = sanitizedQuery;
+    } catch {
+      throw new TypeError(
+        'A sanitized custom PostgreSQL pool must expose a replaceable query() method'
+      );
+    }
+    if (pool.query !== sanitizedQuery) {
+      throw new TypeError(
+        'A sanitized custom PostgreSQL pool must expose a replaceable query() method'
+      );
+    }
+  }
+
+  return pool;
 }
 
 /**
  * Default pool factory: builds a real `pg.Pool` over TCP. This is the behavior
  * used whenever no alternate driver is registered (see `./driver`).
  */
-export const defaultPgPoolFactory: PgPoolFactory = (pgConfig): pg.Pool => {
-  const config = getPgEnvOptions(pgConfig);
-  const { user, password, host, port, database } = config;
-  const connectionString = buildConnectionString(user, password, host, port, database);
+export const defaultPgPoolFactory: PgPoolFactory = (pgConfig, options): pg.Pool => {
+  const { config } = normalizeIdentityConfig(pgConfig);
+  normalizeIdentityOptions(options);
+  const { user, password, host, port, database, ssl } = config;
   const poolConfig = getPgPoolConfig(pgConfig.pool);
-  const pgPool = new pg.Pool({ connectionString, ...poolConfig });
+  const pgPool = new pg.Pool({
+    host,
+    port: Number(port),
+    database,
+    user,
+    password,
+    ...(ssl !== undefined && { ssl }),
+    ...(options?.sanitizeOnCheckout && { options: sanitizedStartupOptions() }),
+    ...poolConfig
+  });
 
   /**
    * IMPORTANT: Pool-level error handler for idle connection errors.
@@ -97,23 +767,57 @@ export const defaultPgPoolFactory: PgPoolFactory = (pgConfig): pg.Pool => {
     }
   });
 
-  return pgPool;
+  // DISCARD ALL restores startup parameters. Pinning the security baseline in
+  // the startup packet makes the default driver a one-round-trip checkout;
+  // custom drivers use the explicit post-DISCARD fallback above.
+  return options?.sanitizeOnCheckout
+    ? installCheckoutSanitizer(pgPool, true, true)
+    : pgPool;
 };
 
-export const getPgPool = (pgConfig: Partial<PgConfig> & { pool?: PgPoolConfig }): pg.Pool => {
-  const config = getPgEnvOptions(pgConfig);
-  const { database } = config;
-  if (pgCache.has(database)) {
-    const cached = pgCache.get(database);
-    if (cached) return cached;
-  }
-
+const createPgPool = (
+  pgConfig: Partial<PgConfig> & { pool?: PgPoolConfig },
+  normalizedOptions: ReturnType<typeof normalizePoolOptions>
+): pg.Pool => {
   // Route through the registered driver (default = pg.Pool over TCP). A custom
   // factory may return any QueryablePool (e.g. an in-process PGlite pool); it is
   // treated as a pg.Pool since that is the only surface consumers use.
   const factory = getActivePgPoolFactory() ?? defaultPgPoolFactory;
-  const pgPool = factory(pgConfig) as pg.Pool;
-
-  pgCache.set(database, pgPool);
+  const pgPool = factory(pgConfig, normalizedOptions) as pg.Pool;
+  if (normalizedOptions.sanitizeOnCheckout && factory !== defaultPgPoolFactory) {
+    installCheckoutSanitizer(pgPool);
+  }
   return pgPool;
+};
+
+/** Synchronously get or create an unleased pool for backwards compatibility. */
+export const getPgPool = (
+  pgConfig: Partial<PgConfig> & { pool?: PgPoolConfig },
+  options: GetPgPoolOptions = {}
+): pg.Pool => {
+  const normalizedOptions = normalizePoolOptions(options);
+  const poolIdentity = getPgPoolIdentity(pgConfig, normalizedOptions);
+  return pgCache.getOrCreate(
+    poolIdentity,
+    () => createPgPool(pgConfig, normalizedOptions)
+  );
+};
+
+/**
+ * Atomically get/create and lease the exact connection identity.
+ *
+ * Callers that retain a pool beyond the current stack frame should use this
+ * production API and release only after their final request or long-lived
+ * resource has drained.
+ */
+export const acquirePgPool = (
+  pgConfig: Partial<PgConfig> & { pool?: PgPoolConfig },
+  options: GetPgPoolOptions = {}
+): PgPoolLease => {
+  const normalizedOptions = normalizePoolOptions(options);
+  const poolIdentity = getPgPoolIdentity(pgConfig, normalizedOptions);
+  return pgCache.acquire(
+    poolIdentity,
+    () => createPgPool(pgConfig, normalizedOptions)
+  );
 };

--- a/postgres/pg-env/README.md
+++ b/postgres/pg-env/README.md
@@ -97,8 +97,30 @@ interface PgConfig {
   user: string;
   password: string;
   database: string;
+  ssl?: boolean | PgSslOptions;
 }
 ```
+
+`ssl` is a data-only subset of Node TLS options (`ca`, `cert`, `key`,
+`passphrase`, hostname verification, protocol bounds, and ciphers). Callback
+and pre-opened-socket TLS options are deliberately excluded so connection pool
+identities can account for the complete trust contract deterministically.
+
+#### `PgPoolConfig`
+
+```typescript
+interface PgPoolConfig {
+  max?: number;
+  maxUses?: number;
+  idleTimeoutMillis?: number;
+  connectionTimeoutMillis?: number;
+  allowExitOnIdle?: boolean;
+}
+```
+
+`maxUses` is passed to native pg-pool by `pg-cache`. Its
+`PG_POOL_MAX_USES` parser treats `0` or an unset value as unlimited reuse and
+accepts only canonical positive decimal safe integers otherwise.
 
 ### Functions
 

--- a/postgres/pg-env/src/index.ts
+++ b/postgres/pg-env/src/index.ts
@@ -4,4 +4,10 @@ export {
   getSpawnEnvWithPg,
   toPgEnvVars} from './env';
 export { getPgClientCommand,PgClientTool } from './pg-client';
-export { defaultPgConfig,PgConfig,PgPoolConfig } from './pg-config';
+export {
+  defaultPgConfig,
+  PgConfig,
+  PgPoolConfig,
+  PgSslConfig,
+  PgSslOptions
+} from './pg-config';

--- a/postgres/pg-env/src/pg-config.ts
+++ b/postgres/pg-env/src/pg-config.ts
@@ -1,9 +1,33 @@
+import type { SecureVersion } from 'node:tls';
+
+/**
+ * Serializable TLS options supported by the shared PostgreSQL connection
+ * contract. Keeping this surface data-only is intentional: pool identities
+ * must account for every TLS input, which callback and socket objects cannot
+ * do deterministically.
+ */
+export interface PgSslOptions {
+  ca?: string | Buffer | Array<string | Buffer>;
+  cert?: string | Buffer | Array<string | Buffer>;
+  key?: string | Buffer | Array<string | Buffer | { pem: string | Buffer; passphrase?: string }>;
+  passphrase?: string;
+  rejectUnauthorized?: boolean;
+  servername?: string;
+  minVersion?: SecureVersion;
+  maxVersion?: SecureVersion;
+  ciphers?: string;
+}
+
+export type PgSslConfig = boolean | PgSslOptions;
+
 export interface PgConfig {
   host: string;
   port: number;
   user: string;
   password: string;
   database: string;
+  /** TLS settings passed directly to node-postgres. */
+  ssl?: PgSslConfig;
 }
 
 /**
@@ -15,6 +39,8 @@ export interface PgConfig {
 export interface PgPoolConfig {
   /** Maximum number of clients in the pool (env: PG_POOL_MAX, default: 5) */
   max?: number;
+  /** Retire a client after this many checkouts (env: PG_POOL_MAX_USES, 0/unset: unlimited) */
+  maxUses?: number;
   /** Close idle clients after this many ms (env: PG_POOL_IDLE_TIMEOUT_MS, default: 30000) */
   idleTimeoutMillis?: number;
   /** Reject pool.connect() after this many ms (env: PG_POOL_CONNECTION_TIMEOUT_MS, default: 5000) */

--- a/postgres/pg-query-context/README.md
+++ b/postgres/pg-query-context/README.md
@@ -24,7 +24,8 @@ npm install pg-query-context
 
 ## Features
 
-* Sets session-level context (e.g., role, user ID) using `set_config`.
+* Sets the complete transaction-local context (e.g., role, user ID) with one
+  parameterized `set_config` batch.
 * Automatically wraps execution in a transaction (`BEGIN`/`COMMIT`).
 * Automatically rolls back on error.
 * Supports both `Pool` and `Client` from `pg`.
@@ -91,7 +92,12 @@ const user = await withPgClient(
 | `pool`    | `Pool`                        | ✅        | The PostgreSQL pool to acquire a client from           |
 | `context` | `Record<string, string>`      | ✅        | Session variables set via `set_config`                 |
 | `fn`      | `(client: PoolClient) => T`   | ✅        | Callback receiving the connected client                |
-| `opts`    | `{ skipTransaction?: boolean }` | ❌      | Skip BEGIN/COMMIT wrapping (e.g., inside existing txn) |
+| `opts`    | `{ skipTransaction?: boolean }` | ❌      | Skip BEGIN/COMMIT only when no context is supplied; pooled transaction-local context fails closed |
+
+`set_config(..., true)` is transaction-local. A checked-out PostgreSQL client may
+use the one-query API with `skipTransaction` inside a transaction managed by its
+caller, but a pool cannot prove that transaction ownership. Both pooled APIs
+therefore reject `skipTransaction` when the context is non-empty.
 
 ## Example with `express`
 

--- a/postgres/pg-query-context/src/__tests__/index.test.ts
+++ b/postgres/pg-query-context/src/__tests__/index.test.ts
@@ -1,0 +1,151 @@
+import type { Pool, PoolClient } from 'pg';
+
+import pgQueryContext, {
+  UNSAFE_POOLED_CONTEXT_ERROR_CODE,
+  UnsafePooledContextError,
+  withPgClient
+} from '../index';
+
+const SETTINGS_SQL =
+  'SELECT pg_catalog.set_config(setting->>0, setting->>1, true) '
+  + 'FROM pg_catalog.json_array_elements($1::json) AS setting';
+
+const makePool = () => {
+  const client = {
+    query: jest.fn(async () => ({ rows: [] as unknown[] })),
+    release: jest.fn()
+  } as unknown as PoolClient;
+  const pool = {
+    connect: jest.fn(async () => client)
+  } as unknown as Pool;
+  return { client, pool };
+};
+
+describe('pg query context', () => {
+  it('applies the complete ordered context in one parameterized round trip', async () => {
+    const { client, pool } = makePool();
+    const context = {
+      'jwt.claims.user_id': '',
+      role: 'tenant_runtime',
+      transaction_read_only: 'off',
+      search_path: 'pg_catalog, "tenant_api"',
+      row_security: 'on'
+    };
+    const callback = jest.fn(async () => 'ok');
+
+    await expect(withPgClient(pool, context, callback)).resolves.toBe('ok');
+
+    expect(client.query).toHaveBeenNthCalledWith(1, 'BEGIN');
+    expect(client.query).toHaveBeenNthCalledWith(2, SETTINGS_SQL, [
+      JSON.stringify(Object.entries(context))
+    ]);
+    expect(client.query).toHaveBeenNthCalledWith(3, 'COMMIT');
+    expect(callback).toHaveBeenCalledWith(client);
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not issue a context query for an empty context', async () => {
+    const { client, pool } = makePool();
+
+    await withPgClient(pool, {}, async (): Promise<void> => undefined);
+
+    expect(client.query).toHaveBeenCalledTimes(2);
+    expect(client.query).toHaveBeenNthCalledWith(1, 'BEGIN');
+    expect(client.query).toHaveBeenNthCalledWith(2, 'COMMIT');
+  });
+
+  it('fails closed instead of coercing non-string security settings', async () => {
+    const { client, pool } = makePool();
+
+    await expect(withPgClient(
+      pool,
+      { 'jwt.claims.user_id': null } as unknown as Record<string, string>,
+      async (): Promise<void> => undefined
+    )).rejects.toThrow(
+      "PostgreSQL context setting 'jwt.claims.user_id' must be a string"
+    );
+
+    expect(client.query).toHaveBeenNthCalledWith(1, 'BEGIN');
+    expect(client.query).toHaveBeenNthCalledWith(2, 'ROLLBACK');
+    expect(client.query).toHaveBeenCalledTimes(2);
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('rolls back and releases when the batched context is rejected', async () => {
+    const { client, pool } = makePool();
+    (client.query as jest.Mock)
+      .mockResolvedValueOnce({ rows: [] })
+      .mockRejectedValueOnce(new Error('invalid role'))
+      .mockResolvedValueOnce({ rows: [] });
+
+    await expect(withPgClient(
+      pool,
+      { role: 'missing_role' },
+      async (): Promise<void> => undefined
+    )).rejects.toThrow('invalid role');
+
+    expect(client.query).toHaveBeenNthCalledWith(3, 'ROLLBACK');
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the same single context batch for the one-query API', async () => {
+    const { client, pool } = makePool();
+    (client.query as jest.Mock).mockImplementation(async (query: unknown) => ({
+      rows: [query === 'SELECT tenant_id FROM documents' ? { tenant_id: 'a' } : undefined]
+        .filter(Boolean)
+    }));
+
+    await pgQueryContext({
+      client: pool,
+      context: { role: 'tenant_runtime', 'jwt.claims.tenant_id': 'a' },
+      query: 'SELECT tenant_id FROM documents'
+    });
+
+    expect(client.query).toHaveBeenNthCalledWith(2, SETTINGS_SQL, [
+      JSON.stringify([
+        ['role', 'tenant_runtime'],
+        ['jwt.claims.tenant_id', 'a']
+      ])
+    ]);
+    expect(client.query).toHaveBeenCalledTimes(4);
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects transaction-local context through a pool without a transaction', async () => {
+    const { pool } = makePool();
+
+    await expect(withPgClient(
+      pool,
+      { role: 'tenant_runtime' },
+      async (): Promise<void> => undefined,
+      { skipTransaction: true }
+    )).rejects.toMatchObject({
+      name: UnsafePooledContextError.name,
+      code: UNSAFE_POOLED_CONTEXT_ERROR_CODE
+    });
+
+    expect(pool.connect).not.toHaveBeenCalled();
+
+    await expect(pgQueryContext({
+      client: pool,
+      context: { 'jwt.claims.tenant_id': 'tenant-a' },
+      query: 'SELECT 1',
+      skipTransaction: true
+    })).rejects.toBeInstanceOf(UnsafePooledContextError);
+    expect(pool.connect).not.toHaveBeenCalled();
+  });
+
+  it('allows transaction-free pooled execution only when no context is requested', async () => {
+    const { client, pool } = makePool();
+
+    await expect(withPgClient(
+      pool,
+      {},
+      async () => 'ok',
+      { skipTransaction: true }
+    )).resolves.toBe('ok');
+
+    expect(client.query).not.toHaveBeenCalled();
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/postgres/pg-query-context/src/__tests__/integration.test.ts
+++ b/postgres/pg-query-context/src/__tests__/integration.test.ts
@@ -1,0 +1,131 @@
+import { Pool, PoolClient } from 'pg';
+
+import { withPgClient } from '../index';
+
+const describeWithPostgres = process.env.PG_QUERY_CONTEXT_RUN_PG_INTEGRATION === '1'
+  ? describe
+  : describe.skip;
+
+interface SessionState {
+  role: string;
+  transaction_read_only: string;
+  search_path: string;
+  row_security: string;
+  user_id: string | null;
+}
+
+async function readSessionState(client: PoolClient): Promise<SessionState> {
+  const result = await client.query<SessionState>(`
+    SELECT
+      current_setting('role') AS role,
+      current_setting('transaction_read_only') AS transaction_read_only,
+      current_setting('search_path') AS search_path,
+      current_setting('row_security') AS row_security,
+      current_setting('jwt.claims.user_id', true) AS user_id
+  `);
+  return result.rows[0];
+}
+
+describeWithPostgres('transaction-local PostgreSQL context', () => {
+  let pool: Pool;
+  let runtimeRole: string;
+
+  beforeAll(async () => {
+    pool = new Pool({ max: 1 });
+    const client = await pool.connect();
+    try {
+      const identity = await client.query<{ current_user: string }>(
+        'SELECT current_user'
+      );
+      runtimeRole = identity.rows[0].current_user;
+
+      // Deliberately establish a visibly different session baseline. With a
+      // one-client pool, every assertion below observes the same backend.
+      await client.query('RESET ROLE');
+      await client.query('SET transaction_read_only TO off');
+      await client.query('SET search_path TO public');
+      await client.query('SET row_security TO off');
+      await client.query(
+        "SELECT pg_catalog.set_config('jwt.claims.user_id', 'baseline-user', false)"
+      );
+    } finally {
+      client.release();
+    }
+  });
+
+  afterAll(async () => {
+    if (!pool) return;
+    const client = await pool.connect();
+    try {
+      await client.query('RESET ROLE');
+      await client.query('RESET ALL');
+    } finally {
+      client.release();
+      await pool.end();
+    }
+  });
+
+  it('applies every security setting locally and restores the session after commit and rollback', async () => {
+    const committedInside = await withPgClient(pool, {
+      role: runtimeRole,
+      transaction_read_only: 'on',
+      search_path: 'pg_catalog',
+      row_security: 'on',
+      'jwt.claims.user_id': ''
+    }, readSessionState);
+
+    expect(committedInside).toEqual({
+      role: runtimeRole,
+      transaction_read_only: 'on',
+      search_path: 'pg_catalog',
+      row_security: 'on',
+      user_id: ''
+    });
+
+    const afterCommitClient = await pool.connect();
+    try {
+      await expect(readSessionState(afterCommitClient)).resolves.toEqual({
+        role: 'none',
+        transaction_read_only: 'off',
+        search_path: 'public',
+        row_security: 'off',
+        user_id: 'baseline-user'
+      });
+    } finally {
+      afterCommitClient.release();
+    }
+
+    let rolledBackInside: SessionState | undefined;
+    await expect(withPgClient(pool, {
+      role: runtimeRole,
+      transaction_read_only: 'on',
+      search_path: 'pg_catalog',
+      row_security: 'on',
+      'jwt.claims.user_id': 'rollback-canary'
+    }, async (client) => {
+      rolledBackInside = await readSessionState(client);
+      throw new Error('force rollback');
+    })).rejects.toThrow('force rollback');
+
+    expect(rolledBackInside).toEqual({
+      role: runtimeRole,
+      transaction_read_only: 'on',
+      search_path: 'pg_catalog',
+      row_security: 'on',
+      user_id: 'rollback-canary'
+    });
+
+    const afterRollbackClient = await pool.connect();
+    try {
+      await expect(readSessionState(afterRollbackClient)).resolves.toEqual({
+        role: 'none',
+        transaction_read_only: 'off',
+        search_path: 'public',
+        row_security: 'off',
+        user_id: 'baseline-user'
+      });
+    } finally {
+      afterRollbackClient.release();
+    }
+  });
+});

--- a/postgres/pg-query-context/src/index.ts
+++ b/postgres/pg-query-context/src/index.ts
@@ -2,18 +2,54 @@ import { ClientBase, Pool, PoolClient, QueryResult } from 'pg';
 
 // --- Internal helpers ---
 
-function setContext(ctx: Record<string, string>): { query: string; values: string[] }[] {
-  return Object.keys(ctx || {}).reduce<{ query: string; values: string[] }[]>((m, el) => {
-    m.push({ query: 'SELECT set_config($1, $2, true)', values: [el, ctx[el]] });
-    return m;
-  }, []);
+export const UNSAFE_POOLED_CONTEXT_ERROR_CODE =
+  'PG_QUERY_CONTEXT_UNSAFE_POOLED_CONTEXT';
+
+export class UnsafePooledContextError extends Error {
+  readonly code = UNSAFE_POOLED_CONTEXT_ERROR_CODE;
+
+  constructor() {
+    super(
+      'Transaction-local PostgreSQL context cannot be applied through a pool '
+        + 'when skipTransaction is enabled'
+    );
+    this.name = 'UnsafePooledContextError';
+  }
+}
+
+function assertContextHasTransaction(
+  usesPool: boolean,
+  skipTransaction: boolean,
+  context: Record<string, string>
+): void {
+  if (usesPool && skipTransaction && Object.keys(context).length > 0) {
+    throw new UnsafePooledContextError();
+  }
 }
 
 async function execContext(client: ClientBase, ctx: Record<string, string>): Promise<void> {
-  const local = setContext(ctx);
-  for (const { query, values } of local) {
-    await client.query(query, values);
+  const entries = Object.entries(ctx || {});
+  if (entries.length === 0) return;
+
+  for (const [key, value] of entries) {
+    // This API establishes the request's security boundary. Runtime callers
+    // can still bypass TypeScript, so reject ambiguous null/object values
+    // instead of silently installing literal "null" or "[object Object]"
+    // session settings.
+    if (typeof value !== 'string') {
+      throw new TypeError(`PostgreSQL context setting '${key}' must be a string`);
+    }
   }
+
+  // Apply the complete request context in one parameterized round trip. The
+  // array preserves insertion order (including role, read-only, search_path,
+  // and every explicitly-empty security claim), while set_config(..., true)
+  // keeps every value transaction-local exactly as the former per-key loop did.
+  await client.query(
+    'SELECT pg_catalog.set_config(setting->>0, setting->>1, true) '
+      + 'FROM pg_catalog.json_array_elements($1::json) AS setting',
+    [JSON.stringify(entries)]
+  );
 }
 
 // --- Single-query API (original) ---
@@ -30,6 +66,8 @@ async function pgQueryContext({ client, context = {}, query = '', variables = []
   const isPool = 'connect' in client;
   const shouldRelease = isPool;
   let pgClient: ClientBase | PoolClient | null = null;
+
+  assertContextHasTransaction(isPool, skipTransaction, context);
 
   try {
     pgClient = isPool ? await (client as Pool).connect() : client as ClientBase;
@@ -80,6 +118,7 @@ export async function withPgClient<T>(
   fn: (client: PoolClient) => Promise<T>,
   opts: WithPgClientOptions = {},
 ): Promise<T> {
+  assertContextHasTransaction(true, opts.skipTransaction === true, context);
   const client = await pool.connect();
   try {
     if (!opts.skipTransaction) {


### PR DESCRIPTION
## Context

Part 2 of 6 in the draft tenant-density stack: #1654 → **#1655 (this PR)** → #1656 → #1657 → #1658 → #1659. It depends on #1654's exact runtime/pool boundary.

The old #1330 fixes were useful, but the later #1333/#1334 strategy required exhaustive SQL rewriting. This PR keeps the plugin fixes while removing that assumption: every built-in operates on the actual physical tenant schemas and exact runtime client. RLS is still row-level defense in depth, not proof that a plugin selected the right object.

## What changes

- Audits and hardens the built-in raw-SQL paths in bulk mutations, function bindings, i18n, LLM/RAG, ltree, PostGIS, search, bucket provisioning, and presigned storage.
- Quotes and schema-qualifies identifiers instead of relying on canonical schema substitution.
- Makes plugin caches exact-build/request scoped and ambiguity-failing, including immutable storage snapshots and database/API-filtered fallback lookup.
- Keeps BM25, tsvector, trigram, vector, PostGIS, and ltree enabled. BM25 binds the physical schema-qualified index name; it has no rewrite exclusion.
- Removes global mutable BM25/storage-style state and closes the old `withPgClient(null)`/missing-request-context paths. The final Constructive preset wiring is grouped with central build composition in #1657.

## Validation

- Frozen lockfile installation and builds passed for all nine affected plugin packages.
- Focused suites passed: bulk mutations 13, function bindings 3, i18n 7, LLM/RAG 9 changed-path tests, ltree 7, search 43, presigned storage 28, PostGIS 253, and bucket provisioning 62.
- External provider/database cases that require local PostgreSQL, MinIO, or Ollama remain explicit integration gates; they were not converted into silent passes.

## Why this remains a draft

Built-in coverage does not sandbox arbitrary Node plugins. Production caller presets are denied by default in #1657, and any explicit opt-in makes that code part of the process/database trusted computing base. Full production-schema grants, multipart byte roundtrips, provider integrations, and hostile cross-tenant runs still have to pass on the final stack.

