### PR TITLE
fix(deps): widen graphile peer ranges and resolve connection-filter from the workspace

### DIFF
--- a/graphile/graphile-bucket-provisioner-plugin/package.json
+++ b/graphile/graphile-bucket-provisioner-plugin/package.json
@@ -45,13 +45,13 @@
     "@pgsql/quotes": "^18.2.1"
   },
   "peerDependencies": {
-    "grafast": "1.1.1",
-    "graphile-build": "5.1.1",
-    "graphile-build-pg": "5.1.3",
-    "graphile-config": "1.1.0",
-    "graphile-utils": "5.0.3",
-    "graphql": "16.13.0",
-    "postgraphile": "5.1.3"
+    "grafast": "^1.1.1",
+    "graphile-build": "^5.1.1",
+    "graphile-build-pg": "^5.1.3",
+    "graphile-config": "^1.1.0",
+    "graphile-utils": "^5.0.3",
+    "graphql": "^16.9.0",
+    "postgraphile": "^5.1.3"
   },
   "devDependencies": {
     "@types/node": "^22.19.11",

--- a/graphile/graphile-bulk-mutations/package.json
+++ b/graphile/graphile-bulk-mutations/package.json
@@ -48,13 +48,13 @@
     "pgsql-test": "workspace:^"
   },
   "peerDependencies": {
-    "@dataplan/pg": "1.1.1",
-    "grafast": "1.1.1",
-    "graphile-build": "5.1.1",
-    "graphile-build-pg": "5.1.3",
-    "graphile-config": "1.1.0",
-    "graphql": "16.13.0",
-    "pg-sql2": "5.0.1",
-    "postgraphile": "5.1.3"
+    "@dataplan/pg": "^1.1.1",
+    "grafast": "^1.1.1",
+    "graphile-build": "^5.1.1",
+    "graphile-build-pg": "^5.1.3",
+    "graphile-config": "^1.1.0",
+    "graphql": "^16.9.0",
+    "pg-sql2": "^5.0.1",
+    "postgraphile": "^5.1.3"
   }
 }

--- a/graphile/graphile-connection-filter/package.json
+++ b/graphile/graphile-connection-filter/package.json
@@ -49,12 +49,12 @@
     "pgsql-test": "workspace:^"
   },
   "peerDependencies": {
-    "@dataplan/pg": "1.1.1",
-    "graphile-build": "5.1.1",
-    "graphile-build-pg": "5.1.3",
-    "graphile-config": "1.1.0",
-    "graphql": "16.13.0",
-    "pg-sql2": "5.0.1",
-    "postgraphile": "5.1.3"
+    "@dataplan/pg": "^1.1.1",
+    "graphile-build": "^5.1.1",
+    "graphile-build-pg": "^5.1.3",
+    "graphile-config": "^1.1.0",
+    "graphql": "^16.9.0",
+    "pg-sql2": "^5.0.1",
+    "postgraphile": "^5.1.3"
   }
 }

--- a/graphile/graphile-function-bindings/package.json
+++ b/graphile/graphile-function-bindings/package.json
@@ -46,12 +46,12 @@
     "pg": "^8.21.0"
   },
   "peerDependencies": {
-    "@dataplan/pg": "1.1.1",
-    "grafast": "1.1.1",
-    "graphile-build": "5.1.1",
-    "graphile-build-pg": "5.1.3",
-    "graphile-config": "1.1.0",
-    "graphql": "16.13.0"
+    "@dataplan/pg": "^1.1.1",
+    "grafast": "^1.1.1",
+    "graphile-build": "^5.1.1",
+    "graphile-build-pg": "^5.1.3",
+    "graphile-config": "^1.1.0",
+    "graphql": "^16.9.0"
   },
   "devDependencies": {
     "@types/node": "^22.19.11",

--- a/graphile/graphile-history/package.json
+++ b/graphile/graphile-history/package.json
@@ -29,14 +29,14 @@
     "url": "https://github.com/constructive-io/constructive/issues"
   },
   "peerDependencies": {
-    "@dataplan/pg": "1.1.1",
-    "grafast": "1.1.1",
-    "graphile-build": "5.1.1",
-    "graphile-build-pg": "5.1.3",
-    "graphile-config": "1.1.0",
-    "graphql": "16.13.0",
-    "pg-sql2": "5.0.1",
-    "postgraphile": "5.1.3"
+    "@dataplan/pg": "^1.1.1",
+    "grafast": "^1.1.1",
+    "graphile-build": "^5.1.1",
+    "graphile-build-pg": "^5.1.3",
+    "graphile-config": "^1.1.0",
+    "graphql": "^16.9.0",
+    "pg-sql2": "^5.0.1",
+    "postgraphile": "^5.1.3"
   },
   "devDependencies": {
     "@types/node": "^22.19.11",

--- a/graphile/graphile-i18n/package.json
+++ b/graphile/graphile-i18n/package.json
@@ -32,14 +32,14 @@
     "accept-language-parser": "^1.5.0"
   },
   "peerDependencies": {
-    "@dataplan/pg": "1.1.1",
-    "grafast": "1.1.1",
-    "graphile-build": "5.1.1",
-    "graphile-build-pg": "5.1.3",
-    "graphile-config": "1.1.0",
-    "graphql": "16.13.0",
-    "pg-sql2": "5.0.1",
-    "postgraphile": "5.1.3"
+    "@dataplan/pg": "^1.1.1",
+    "grafast": "^1.1.1",
+    "graphile-build": "^5.1.1",
+    "graphile-build-pg": "^5.1.3",
+    "graphile-config": "^1.1.0",
+    "graphql": "^16.9.0",
+    "pg-sql2": "^5.0.1",
+    "postgraphile": "^5.1.3"
   },
   "devDependencies": {
     "@types/accept-language-parser": "^1.5.4",

--- a/graphile/graphile-llm/package.json
+++ b/graphile/graphile-llm/package.json
@@ -35,16 +35,16 @@
     "graphile-cache": "workspace:^"
   },
   "peerDependencies": {
-    "@dataplan/pg": "1.1.1",
-    "grafast": "1.1.1",
-    "graphile-build": "5.1.1",
-    "graphile-build-pg": "5.1.3",
-    "graphile-config": "1.1.0",
+    "@dataplan/pg": "^1.1.1",
+    "grafast": "^1.1.1",
+    "graphile-build": "^5.1.1",
+    "graphile-build-pg": "^5.1.3",
+    "graphile-config": "^1.1.0",
     "graphile-search": "^1.18.0",
-    "graphile-utils": "5.0.3",
-    "graphql": "16.13.0",
-    "pg-sql2": "5.0.1",
-    "postgraphile": "5.1.3"
+    "graphile-utils": "^5.0.3",
+    "graphql": "^16.9.0",
+    "pg-sql2": "^5.0.1",
+    "postgraphile": "^5.1.3"
   },
   "peerDependenciesMeta": {
     "graphile-search": {

--- a/graphile/graphile-ltree/package.json
+++ b/graphile/graphile-ltree/package.json
@@ -29,15 +29,15 @@
     "url": "https://github.com/constructive-io/constructive/issues"
   },
   "peerDependencies": {
-    "@dataplan/pg": "1.1.1",
-    "grafast": "1.1.1",
-    "graphile-build": "5.1.1",
-    "graphile-build-pg": "5.1.3",
-    "graphile-config": "1.1.0",
-    "graphile-connection-filter": "^1.13.0",
-    "graphql": "16.13.0",
-    "pg-sql2": "5.0.1",
-    "postgraphile": "5.1.3"
+    "@dataplan/pg": "^1.1.1",
+    "grafast": "^1.1.1",
+    "graphile-build": "^5.1.1",
+    "graphile-build-pg": "^5.1.3",
+    "graphile-config": "^1.1.0",
+    "graphile-connection-filter": "^2.11.3",
+    "graphql": "^16.9.0",
+    "pg-sql2": "^5.0.1",
+    "postgraphile": "^5.1.3"
   },
   "peerDependenciesMeta": {
     "graphile-connection-filter": {
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.19.11",
+    "graphile-connection-filter": "workspace:^",
     "graphile-test": "workspace:^",
     "makage": "^0.3.0",
     "pgsql-test": "workspace:^"

--- a/graphile/graphile-meta/package.json
+++ b/graphile/graphile-meta/package.json
@@ -33,11 +33,11 @@
     "makage": "^0.3.0"
   },
   "peerDependencies": {
-    "graphile-build": "5.1.1",
-    "graphile-build-pg": "5.1.3",
-    "graphile-config": "1.1.0",
-    "graphql": "16.13.0",
-    "postgraphile": "5.1.3"
+    "graphile-build": "^5.1.1",
+    "graphile-build-pg": "^5.1.3",
+    "graphile-config": "^1.1.0",
+    "graphql": "^16.9.0",
+    "postgraphile": "^5.1.3"
   },
   "keywords": [
     "postgraphile",

--- a/graphile/graphile-pg-aggregates/package.json
+++ b/graphile/graphile-pg-aggregates/package.json
@@ -45,19 +45,20 @@
   },
   "devDependencies": {
     "@types/node": "^22.19.11",
+    "graphile-connection-filter": "workspace:^",
     "graphile-test": "workspace:^",
     "makage": "^0.3.0",
     "pgsql-test": "workspace:^"
   },
   "peerDependencies": {
-    "@dataplan/pg": "1.1.1",
-    "grafast": "1.1.1",
-    "graphile-build": "5.1.1",
-    "graphile-build-pg": "5.1.3",
-    "graphile-config": "1.1.0",
-    "graphile-connection-filter": "^1.13.0",
-    "graphql": "16.13.0",
-    "pg-sql2": "5.0.1",
-    "postgraphile": "5.1.3"
+    "@dataplan/pg": "^1.1.1",
+    "grafast": "^1.1.1",
+    "graphile-build": "^5.1.1",
+    "graphile-build-pg": "^5.1.3",
+    "graphile-config": "^1.1.0",
+    "graphile-connection-filter": "^2.11.3",
+    "graphql": "^16.9.0",
+    "pg-sql2": "^5.0.1",
+    "postgraphile": "^5.1.3"
   }
 }

--- a/graphile/graphile-plugin-utils/package.json
+++ b/graphile/graphile-plugin-utils/package.json
@@ -43,12 +43,12 @@
     "makage": "^0.3.0"
   },
   "peerDependencies": {
-    "@dataplan/pg": "1.1.1",
-    "graphile-build": "5.1.1",
-    "graphile-build-pg": "5.1.3",
-    "graphile-config": "1.1.0",
-    "graphql": "16.13.0",
-    "pg-sql2": "5.0.1",
-    "postgraphile": "5.1.3"
+    "@dataplan/pg": "^1.1.1",
+    "graphile-build": "^5.1.1",
+    "graphile-build-pg": "^5.1.3",
+    "graphile-config": "^1.1.0",
+    "graphql": "^16.9.0",
+    "pg-sql2": "^5.0.1",
+    "postgraphile": "^5.1.3"
   }
 }

--- a/graphile/graphile-postgis/package.json
+++ b/graphile/graphile-postgis/package.json
@@ -41,15 +41,15 @@
     "url": "https://github.com/constructive-io/constructive/issues"
   },
   "peerDependencies": {
-    "@dataplan/pg": "1.1.1",
-    "grafast": "1.1.1",
-    "graphile-build": "5.1.1",
-    "graphile-build-pg": "5.1.3",
-    "graphile-config": "1.1.0",
-    "graphile-connection-filter": "^1.13.0",
-    "graphql": "16.13.0",
-    "pg-sql2": "5.0.1",
-    "postgraphile": "5.1.3"
+    "@dataplan/pg": "^1.1.1",
+    "grafast": "^1.1.1",
+    "graphile-build": "^5.1.1",
+    "graphile-build-pg": "^5.1.3",
+    "graphile-config": "^1.1.0",
+    "graphile-connection-filter": "^2.11.3",
+    "graphql": "^16.9.0",
+    "pg-sql2": "^5.0.1",
+    "postgraphile": "^5.1.3"
   },
   "peerDependenciesMeta": {
     "graphile-connection-filter": {
@@ -59,6 +59,7 @@
   "devDependencies": {
     "@types/geojson": "^7946.0.14",
     "@types/node": "^22.19.11",
+    "graphile-connection-filter": "workspace:^",
     "graphile-test": "workspace:^",
     "makage": "^0.3.0",
     "pgsql-test": "workspace:^"

--- a/graphile/graphile-presigned-url-plugin/package.json
+++ b/graphile/graphile-presigned-url-plugin/package.json
@@ -47,13 +47,13 @@
     "lru-cache": "^11.2.7"
   },
   "peerDependencies": {
-    "grafast": "1.1.1",
-    "graphile-build": "5.1.1",
-    "graphile-build-pg": "5.1.3",
-    "graphile-config": "1.1.0",
-    "graphile-utils": "5.0.3",
-    "graphql": "16.13.0",
-    "postgraphile": "5.1.3"
+    "grafast": "^1.1.1",
+    "graphile-build": "^5.1.1",
+    "graphile-build-pg": "^5.1.3",
+    "graphile-config": "^1.1.0",
+    "graphile-utils": "^5.0.3",
+    "graphql": "^16.9.0",
+    "postgraphile": "^5.1.3"
   },
   "devDependencies": {
     "@constructive-io/s3-utils": "workspace:^",

--- a/graphile/graphile-realtime-subscriptions/package.json
+++ b/graphile/graphile-realtime-subscriptions/package.json
@@ -44,13 +44,13 @@
     "@pgsql/quotes": "^18.2.1"
   },
   "peerDependencies": {
-    "grafast": "1.1.1",
-    "graphile-build": "5.1.1",
-    "graphile-build-pg": "5.1.3",
-    "graphile-config": "1.1.0",
-    "graphile-utils": "5.0.3",
-    "graphql": "16.13.0",
-    "postgraphile": "5.1.3"
+    "grafast": "^1.1.1",
+    "graphile-build": "^5.1.1",
+    "graphile-build-pg": "^5.1.3",
+    "graphile-config": "^1.1.0",
+    "graphile-utils": "^5.0.3",
+    "graphql": "^16.9.0",
+    "postgraphile": "^5.1.3"
   },
   "devDependencies": {
     "@types/node": "^22.19.11",

--- a/graphile/graphile-realtime-test/package.json
+++ b/graphile/graphile-realtime-test/package.json
@@ -43,14 +43,14 @@
     "graphile-test": "workspace:^"
   },
   "peerDependencies": {
-    "grafast": "1.1.1",
-    "graphile-build": "5.1.1",
-    "graphile-build-pg": "5.1.3",
-    "graphile-config": "1.1.0",
-    "graphql": "16.13.0",
+    "grafast": "^1.1.1",
+    "graphile-build": "^5.1.1",
+    "graphile-build-pg": "^5.1.3",
+    "graphile-config": "^1.1.0",
+    "graphql": "^16.9.0",
     "graphql-ws": "^6.0.8",
     "pg": "^8.20.0",
-    "postgraphile": "5.1.3",
+    "postgraphile": "^5.1.3",
     "ws": "^8.20.0"
   },
   "devDependencies": {

--- a/graphile/graphile-search/package.json
+++ b/graphile/graphile-search/package.json
@@ -41,13 +41,13 @@
     "pgsql-test": "workspace:^"
   },
   "peerDependencies": {
-    "@dataplan/pg": "1.1.1",
-    "graphile-build": "5.1.1",
-    "graphile-build-pg": "5.1.3",
-    "graphile-config": "1.1.0",
-    "graphql": "16.13.0",
-    "pg-sql2": "5.0.1",
-    "postgraphile": "5.1.3"
+    "@dataplan/pg": "^1.1.1",
+    "graphile-build": "^5.1.1",
+    "graphile-build-pg": "^5.1.3",
+    "graphile-config": "^1.1.0",
+    "graphql": "^16.9.0",
+    "pg-sql2": "^5.0.1",
+    "postgraphile": "^5.1.3"
   },
   "keywords": [
     "postgraphile",

--- a/graphile/graphile-sql-expression-validator/package.json
+++ b/graphile/graphile-sql-expression-validator/package.json
@@ -46,11 +46,11 @@
     "pgsql-parser": "^18.2.3"
   },
   "peerDependencies": {
-    "grafast": "1.1.1",
-    "graphile-build": "5.1.1",
-    "graphile-build-pg": "5.1.3",
-    "graphile-config": "1.1.0",
-    "graphql": "16.13.0"
+    "grafast": "^1.1.1",
+    "graphile-build": "^5.1.1",
+    "graphile-build-pg": "^5.1.3",
+    "graphile-config": "^1.1.0",
+    "graphql": "^16.9.0"
   },
   "devDependencies": {
     "@types/node": "^22.19.11",

--- a/graphile/graphile-upload-plugin/package.json
+++ b/graphile/graphile-upload-plugin/package.json
@@ -39,11 +39,11 @@
     "url": "https://github.com/constructive-io/constructive/issues"
   },
   "peerDependencies": {
-    "graphile-build": "5.1.1",
-    "graphile-build-pg": "5.1.3",
-    "graphile-config": "1.1.0",
-    "graphql": "16.13.0",
-    "postgraphile": "5.1.3"
+    "graphile-build": "^5.1.1",
+    "graphile-build-pg": "^5.1.3",
+    "graphile-config": "^1.1.0",
+    "graphql": "^16.9.0",
+    "postgraphile": "^5.1.3"
   },
   "devDependencies": {
     "@types/node": "^22.19.11",

--- a/graphql/realtime-test/package.json
+++ b/graphql/realtime-test/package.json
@@ -35,14 +35,14 @@
     "graphile-test": "workspace:^"
   },
   "peerDependencies": {
-    "grafast": "1.1.1",
-    "graphile-build": "5.1.1",
-    "graphile-build-pg": "5.1.3",
-    "graphile-config": "1.1.0",
-    "graphql": "16.13.0",
+    "grafast": "^1.1.1",
+    "graphile-build": "^5.1.1",
+    "graphile-build-pg": "^5.1.3",
+    "graphile-config": "^1.1.0",
+    "graphql": "^16.9.0",
     "graphql-ws": "^6.0.8",
     "pg": "^8.20.0",
-    "postgraphile": "5.1.3",
+    "postgraphile": "^5.1.3",
     "ws": "^8.20.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,25 +345,25 @@ importers:
         specifier: ^18.2.1
         version: 18.2.1
       grafast:
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(graphql@16.13.0)
       graphile-build:
-        specifier: 5.1.1
+        specifier: ^5.1.1
         version: 5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
-        specifier: 1.1.0
+        specifier: ^1.1.0
         version: 1.1.0
       graphile-utils:
-        specifier: 5.0.3
+        specifier: ^5.0.3
         version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql:
         specifier: 16.13.0
         version: 16.13.0
       postgraphile:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(7557e4a1cfe40f60c0b4838946fa0360)
     devDependencies:
       '@types/node':
@@ -377,28 +377,28 @@ importers:
   graphile/graphile-bulk-mutations:
     dependencies:
       '@dataplan/pg':
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       grafast:
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(graphql@16.13.0)
       graphile-build:
-        specifier: 5.1.1
+        specifier: ^5.1.1
         version: 5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
-        specifier: 1.1.0
+        specifier: ^1.1.0
         version: 1.1.0
       graphql:
         specifier: 16.13.0
         version: 16.13.0
       pg-sql2:
-        specifier: 5.0.1
+        specifier: ^5.0.1
         version: 5.0.1
       postgraphile:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(7557e4a1cfe40f60c0b4838946fa0360)
     devDependencies:
       '@types/node':
@@ -459,16 +459,16 @@ importers:
   graphile/graphile-connection-filter:
     dependencies:
       '@dataplan/pg':
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       graphile-build:
-        specifier: 5.1.1
+        specifier: ^5.1.1
         version: 5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
-        specifier: 1.1.0
+        specifier: ^1.1.0
         version: 1.1.0
       graphile-plugin-utils:
         specifier: workspace:^
@@ -477,10 +477,10 @@ importers:
         specifier: 16.13.0
         version: 16.13.0
       pg-sql2:
-        specifier: 5.0.1
+        specifier: ^5.0.1
         version: 5.0.1
       postgraphile:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(8de07e0bfeedd489de45fb5bbda44a9a)
     devDependencies:
       '@types/node':
@@ -503,22 +503,22 @@ importers:
         specifier: workspace:^
         version: link:../../postgres/query-builder/dist
       '@dataplan/pg':
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       '@pgpmjs/logger':
         specifier: workspace:^
         version: link:../../pgpm/logger/dist
       grafast:
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(graphql@16.13.0)
       graphile-build:
-        specifier: 5.1.1
+        specifier: ^5.1.1
         version: 5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
-        specifier: 1.1.0
+        specifier: ^1.1.0
         version: 1.1.0
       graphile-plugin-utils:
         specifier: workspace:^
@@ -553,28 +553,28 @@ importers:
   graphile/graphile-history:
     dependencies:
       '@dataplan/pg':
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       grafast:
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(graphql@16.13.0)
       graphile-build:
-        specifier: 5.1.1
+        specifier: ^5.1.1
         version: 5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
-        specifier: 1.1.0
+        specifier: ^1.1.0
         version: 1.1.0
       graphql:
         specifier: 16.13.0
         version: 16.13.0
       pg-sql2:
-        specifier: 5.0.1
+        specifier: ^5.0.1
         version: 5.0.1
       postgraphile:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(45499f94cce392a322f154ab0f9516c9)
     devDependencies:
       '@types/node':
@@ -600,31 +600,31 @@ importers:
   graphile/graphile-i18n:
     dependencies:
       '@dataplan/pg':
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       accept-language-parser:
         specifier: ^1.5.0
         version: 1.5.0
       grafast:
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(graphql@16.13.0)
       graphile-build:
-        specifier: 5.1.1
+        specifier: ^5.1.1
         version: 5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
-        specifier: 1.1.0
+        specifier: ^1.1.0
         version: 1.1.0
       graphql:
         specifier: 16.13.0
         version: 16.13.0
       pg-sql2:
-        specifier: 5.0.1
+        specifier: ^5.0.1
         version: 5.0.1
       postgraphile:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(45499f94cce392a322f154ab0f9516c9)
     devDependencies:
       '@types/accept-language-parser':
@@ -662,34 +662,34 @@ importers:
         specifier: workspace:^
         version: link:../../packages/llm-env/dist
       '@dataplan/pg':
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       grafast:
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(graphql@16.13.0)
       graphile-build:
-        specifier: 5.1.1
+        specifier: ^5.1.1
         version: 5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-cache:
         specifier: workspace:^
         version: link:../graphile-cache/dist
       graphile-config:
-        specifier: 1.1.0
+        specifier: ^1.1.0
         version: 1.1.0
       graphile-utils:
-        specifier: 5.0.3
+        specifier: ^5.0.3
         version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql:
         specifier: 16.13.0
         version: 16.13.0
       pg-sql2:
-        specifier: 5.0.1
+        specifier: ^5.0.1
         version: 5.0.1
       postgraphile:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(7557e4a1cfe40f60c0b4838946fa0360)
     devDependencies:
       '@types/node':
@@ -715,36 +715,36 @@ importers:
   graphile/graphile-ltree:
     dependencies:
       '@dataplan/pg':
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       grafast:
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(graphql@16.13.0)
       graphile-build:
-        specifier: 5.1.1
+        specifier: ^5.1.1
         version: 5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
-        specifier: 1.1.0
+        specifier: ^1.1.0
         version: 1.1.0
-      graphile-connection-filter:
-        specifier: ^1.13.0
-        version: 1.14.0(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(postgraphile@5.1.3(7557e4a1cfe40f60c0b4838946fa0360))
       graphql:
         specifier: 16.13.0
         version: 16.13.0
       pg-sql2:
-        specifier: 5.0.1
+        specifier: ^5.0.1
         version: 5.0.1
       postgraphile:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(7557e4a1cfe40f60c0b4838946fa0360)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
         version: 22.19.15
+      graphile-connection-filter:
+        specifier: workspace:^
+        version: link:../graphile-connection-filter/dist
       graphile-test:
         specifier: workspace:^
         version: link:../graphile-test/dist
@@ -759,19 +759,19 @@ importers:
   graphile/graphile-meta:
     dependencies:
       graphile-build:
-        specifier: 5.1.1
+        specifier: ^5.1.1
         version: 5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
-        specifier: 1.1.0
+        specifier: ^1.1.0
         version: 1.1.0
       graphql:
         specifier: 16.13.0
         version: 16.13.0
       postgraphile:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(45499f94cce392a322f154ab0f9516c9)
     devDependencies:
       '@types/node':
@@ -785,23 +785,20 @@ importers:
   graphile/graphile-pg-aggregates:
     dependencies:
       '@dataplan/pg':
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       grafast:
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(graphql@16.13.0)
       graphile-build:
-        specifier: 5.1.1
+        specifier: ^5.1.1
         version: 5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
-        specifier: 1.1.0
+        specifier: ^1.1.0
         version: 1.1.0
-      graphile-connection-filter:
-        specifier: ^1.13.0
-        version: 1.14.0(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(postgraphile@5.1.3(7557e4a1cfe40f60c0b4838946fa0360))
       graphile-plugin-utils:
         specifier: workspace:^
         version: link:../graphile-plugin-utils/dist
@@ -809,15 +806,18 @@ importers:
         specifier: 16.13.0
         version: 16.13.0
       pg-sql2:
-        specifier: 5.0.1
+        specifier: ^5.0.1
         version: 5.0.1
       postgraphile:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(7557e4a1cfe40f60c0b4838946fa0360)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
         version: 22.19.15
+      graphile-connection-filter:
+        specifier: workspace:^
+        version: link:../graphile-connection-filter/dist
       graphile-test:
         specifier: workspace:^
         version: link:../graphile-test/dist
@@ -832,25 +832,25 @@ importers:
   graphile/graphile-plugin-utils:
     dependencies:
       '@dataplan/pg':
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       graphile-build:
-        specifier: 5.1.1
+        specifier: ^5.1.1
         version: 5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
-        specifier: 1.1.0
+        specifier: ^1.1.0
         version: 1.1.0
       graphql:
         specifier: 16.13.0
         version: 16.13.0
       pg-sql2:
-        specifier: 5.0.1
+        specifier: ^5.0.1
         version: 5.0.1
       postgraphile:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(45499f94cce392a322f154ab0f9516c9)
     devDependencies:
       '@types/node':
@@ -864,31 +864,28 @@ importers:
   graphile/graphile-postgis:
     dependencies:
       '@dataplan/pg':
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       grafast:
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(graphql@16.13.0)
       graphile-build:
-        specifier: 5.1.1
+        specifier: ^5.1.1
         version: 5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
-        specifier: 1.1.0
+        specifier: ^1.1.0
         version: 1.1.0
-      graphile-connection-filter:
-        specifier: ^1.13.0
-        version: 1.14.0(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(postgraphile@5.1.3(8de07e0bfeedd489de45fb5bbda44a9a))
       graphql:
         specifier: 16.13.0
         version: 16.13.0
       pg-sql2:
-        specifier: 5.0.1
+        specifier: ^5.0.1
         version: 5.0.1
       postgraphile:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(8de07e0bfeedd489de45fb5bbda44a9a)
     devDependencies:
       '@types/geojson':
@@ -897,6 +894,9 @@ importers:
       '@types/node':
         specifier: ^22.19.11
         version: 22.19.11
+      graphile-connection-filter:
+        specifier: workspace:^
+        version: link:../graphile-connection-filter/dist
       graphile-test:
         specifier: workspace:^
         version: link:../graphile-test/dist
@@ -923,19 +923,19 @@ importers:
         specifier: ^18.2.1
         version: 18.2.1
       grafast:
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(graphql@16.13.0)
       graphile-build:
-        specifier: 5.1.1
+        specifier: ^5.1.1
         version: 5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
-        specifier: 1.1.0
+        specifier: ^1.1.0
         version: 1.1.0
       graphile-utils:
-        specifier: 5.0.3
+        specifier: ^5.0.3
         version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql:
         specifier: 16.13.0
@@ -944,7 +944,7 @@ importers:
         specifier: ^11.2.7
         version: 11.2.7
       postgraphile:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(7557e4a1cfe40f60c0b4838946fa0360)
     devDependencies:
       '@constructive-io/s3-utils':
@@ -1005,25 +1005,25 @@ importers:
         specifier: ^18.2.1
         version: 18.2.1
       grafast:
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(graphql@16.13.0)
       graphile-build:
-        specifier: 5.1.1
+        specifier: ^5.1.1
         version: 5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
-        specifier: 1.1.0
+        specifier: ^1.1.0
         version: 1.1.0
       graphile-utils:
-        specifier: 5.0.3
+        specifier: ^5.0.3
         version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql:
         specifier: 16.13.0
         version: 16.13.0
       postgraphile:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(7557e4a1cfe40f60c0b4838946fa0360)
     devDependencies:
       '@types/node':
@@ -1037,16 +1037,16 @@ importers:
   graphile/graphile-realtime-test:
     dependencies:
       grafast:
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(graphql@16.13.0)
       graphile-build:
-        specifier: 5.1.1
+        specifier: ^5.1.1
         version: 5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
-        specifier: 1.1.0
+        specifier: ^1.1.0
         version: 1.1.0
       graphile-realtime-subscriptions:
         specifier: workspace:^
@@ -1131,16 +1131,16 @@ importers:
   graphile/graphile-search:
     dependencies:
       '@dataplan/pg':
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       graphile-build:
-        specifier: 5.1.1
+        specifier: ^5.1.1
         version: 5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
-        specifier: 1.1.0
+        specifier: ^1.1.0
         version: 1.1.0
       graphile-plugin-utils:
         specifier: workspace:^
@@ -1149,10 +1149,10 @@ importers:
         specifier: 16.13.0
         version: 16.13.0
       pg-sql2:
-        specifier: 5.0.1
+        specifier: ^5.0.1
         version: 5.0.1
       postgraphile:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(8de07e0bfeedd489de45fb5bbda44a9a)
     devDependencies:
       '@types/node':
@@ -1342,16 +1342,16 @@ importers:
   graphile/graphile-sql-expression-validator:
     dependencies:
       grafast:
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(graphql@16.13.0)
       graphile-build:
-        specifier: 5.1.1
+        specifier: ^5.1.1
         version: 5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
-        specifier: 1.1.0
+        specifier: ^1.1.0
         version: 1.1.0
       graphql:
         specifier: 16.13.0
@@ -1424,19 +1424,19 @@ importers:
   graphile/graphile-upload-plugin:
     dependencies:
       graphile-build:
-        specifier: 5.1.1
+        specifier: ^5.1.1
         version: 5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
-        specifier: 1.1.0
+        specifier: ^1.1.0
         version: 1.1.0
       graphql:
         specifier: 16.13.0
         version: 16.13.0
       postgraphile:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(8de07e0bfeedd489de45fb5bbda44a9a)
     devDependencies:
       '@types/node':
@@ -1895,16 +1895,16 @@ importers:
         specifier: workspace:^
         version: link:../test/dist
       grafast:
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1(graphql@16.13.0)
       graphile-build:
-        specifier: 5.1.1
+        specifier: ^5.1.1
         version: 5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1)
       graphile-config:
-        specifier: 1.1.0
+        specifier: ^1.1.0
         version: 1.1.0
       graphile-realtime-test:
         specifier: workspace:^
@@ -1925,7 +1925,7 @@ importers:
         specifier: ^8.20.0
         version: 8.20.0
       postgraphile:
-        specifier: 5.1.3
+        specifier: ^5.1.3
         version: 5.1.3(89a96374667d7440978839f87b6e0459)
       ws:
         specifier: ^8.20.0
@@ -8149,17 +8149,6 @@ packages:
   graphile-config@1.1.0:
     resolution: {integrity: sha512-R9q8a1MtxYLpQCw79GBxktdCFwM5y6RYgf92Nv1uOBKTL9bCy01iCsOSLuLkeSJ9Ol9Z+/lGQTCbJSXoR3QhpQ==}
     engines: {node: '>=22'}
-
-  graphile-connection-filter@1.14.0:
-    resolution: {integrity: sha512-4u1cRjHKQCSAzYfsQW6dBGQq/0X6HUdSFMaPnNX92ckUCfQoO9RiMyTrP9zxeVvMt5Y8rLvFfuTZIv2Gj6gC8A==}
-    peerDependencies:
-      '@dataplan/pg': 1.0.3
-      graphile-build: 5.0.2
-      graphile-build-pg: 5.0.2
-      graphile-config: 1.0.1
-      graphql: 16.13.0
-      pg-sql2: 5.0.1
-      postgraphile: 5.0.3
 
   graphile-utils@5.0.3:
     resolution: {integrity: sha512-imT1voKDD6qGtlYVLfye9Wo33zgV8LzT7hPxF4SZMekx+iyEH8PmR4gWMqScMPfo69cL49zGwy+0hETAr9kXrg==}
@@ -15929,26 +15918,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - supports-color
-
-  graphile-connection-filter@1.14.0(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(postgraphile@5.1.3(7557e4a1cfe40f60c0b4838946fa0360)):
-    dependencies:
-      '@dataplan/pg': 1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
-      graphile-build: 5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
-      graphile-build-pg: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
-      graphile-config: 1.1.0
-      graphql: 16.13.0
-      pg-sql2: 5.0.1
-      postgraphile: 5.1.3(7557e4a1cfe40f60c0b4838946fa0360)
-
-  graphile-connection-filter@1.14.0(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(postgraphile@5.1.3(8de07e0bfeedd489de45fb5bbda44a9a)):
-    dependencies:
-      '@dataplan/pg': 1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
-      graphile-build: 5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
-      graphile-build-pg: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
-      graphile-config: 1.1.0
-      graphql: 16.13.0
-      pg-sql2: 5.0.1
-      postgraphile: 5.1.3(8de07e0bfeedd489de45fb5bbda44a9a)
 
   graphile-utils@5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.1(graphql@16.13.0)))(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.1(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.1(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1):
     dependencies:


### PR DESCRIPTION
## Summary

Kills the `✕ unmet peer` warnings the graphile 5.1 bump surfaced. There were two independent causes.

**1. Our published packages pin peers to exact versions.** Every `graphile/*` package declared:

```diff
 "peerDependencies": {
-  "postgraphile": "5.1.3",
-  "graphile-build": "5.1.1",
-  "graphql": "16.13.0",
+  "postgraphile": "^5.1.3",
+  "graphile-build": "^5.1.1",
+  "graphql": "^16.9.0",
   ...
 }
```

An exact pin means *any* consumer not on precisely that version gets a warning, and it re-breaks on every graphile patch release. Widened to carets across all 19 packages (`graphql` follows postgraphile's own `^16.9.0` rather than our `16.13.0` install pin — the override still decides what actually gets installed).

**2. Three packages were pulling `graphile-connection-filter` from npm instead of the workspace.** `graphile-postgis`, `graphile-pg-aggregates` and `graphile-ltree` declared `peer: "^1.13.0"` while the workspace package is at `2.11.3`. pnpm dutifully downloaded the published `1.14.0` (whose peers are pinned to graphile 5.0.x) *alongside* our local copy — so the tree contained a stale duplicate of our own plugin, permanently mismatched against whatever graphile version we're on. Fixed by pointing the peer at `^2.11.3` and adding a `graphile-connection-filter: workspace:^` devDependency so the local copy satisfies it.

After this, `pnpm install` reports zero graphile peer warnings and the lockfile no longer references `graphile-connection-filter@1.14.0` or `graphile-plugin-utils@1.10.0` at all.

Still warning, and *not* addressed here: `graphql/react` depends on `react-query@3.39.3`, whose peer stops at React 18. That's a real v3 -> `@tanstack/react-query` v5 migration (`useQuery` signature, `keepPreviousData` -> `placeholderData`, `isLoading` -> `isPending`) across three hooks — happy to do it as a follow-up rather than smuggle it into a peer-range PR.

Verified: `pnpm build` clean; postgis (251), pg-aggregates (35), ltree (10), connection-filter (84) and settings (82) suites all pass.


Link to Devin session: https://app.devin.ai/sessions/c30aa3d900a943318bb1b32bb4e48ce2
Requested by: @pyramation