### PR TITLE
feat(pnpm-policy): quarantine third-party releases for two weeks

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -72,6 +72,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      # Fails when pnpm-workspace.yaml no longer matches pnpm-policy.yaml, or when
+      # a third-party waiver has passed its expiry date.
+      - name: Check supply-chain policy
+        run: pnpm run policy:check
+
       # A package with tests that no batch below claims runs nowhere, and until
       # this check existed nothing said so.
       - name: Check test coverage of the CI matrix

--- a/package.json
+++ b/package.json
@@ -22,10 +22,13 @@
     "internal:deps": "makage update-workspace",
     "deps": "pnpm up -r -i -L",
     "fixtures:install": "node pgpm/cli/dist/index.js install -W",
-    "fixtures:install:force": "node pgpm/cli/dist/index.js install -W --force"
+    "fixtures:install:force": "node pgpm/cli/dist/index.js install -W --force",
+    "policy": "pnpm-policy generate",
+    "policy:check": "pnpm-policy check"
   },
   "devDependencies": {
     "@constructive-io/eslint-config": "^0.2.0",
+    "@constructive-io/pnpm-policy": "0.2.0",
     "@jest/test-sequencer": "^30.4.1",
     "@types/jest": "^30.0.0",
     "@types/jest-in-case": "^1.0.9",
@@ -41,6 +44,7 @@
     "jest-in-case": "^1.0.2",
     "lerna": "^8.2.3",
     "makage": "^0.3.0",
+    "pnpm-policy": "^0.2.1",
     "prettier": "^3.9.6",
     "rimraf": "^6.1.3",
     "ts-jest": "^29.4.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@constructive-io/eslint-config':
         specifier: ^0.2.0
         version: 0.2.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      '@constructive-io/pnpm-policy':
+        specifier: 0.2.0
+        version: 0.2.0
       '@jest/test-sequencer':
         specifier: ^30.4.1
         version: 30.4.1
@@ -63,6 +66,9 @@ importers:
       makage:
         specifier: ^0.3.0
         version: 0.3.0
+      pnpm-policy:
+        specifier: ^0.2.1
+        version: 0.2.1
       prettier:
         specifier: ^3.9.6
         version: 3.9.6
@@ -4335,6 +4341,9 @@ packages:
 
   '@constructive-io/fetch@1.1.1':
     resolution: {integrity: sha512-kpus6sqQwMUTBNpqYvSejG27HJXDucV+BQUNUg3T5U92Qy94Q6of7OhbovICteDMmgcRKCdc5S2e2pXnIY8L5A==}
+
+  '@constructive-io/pnpm-policy@0.2.0':
+    resolution: {integrity: sha512-u1M7mHEPctHeHDIsxPhhYBN1ihjN/sUDZBFslM62emc5796Oxxqy16Bk7SclCkoeNnrSaEjmlpzVxImwNrWgkA==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -9168,6 +9177,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   mock-req@0.2.0:
     resolution: {integrity: sha512-IUuwS0W5GjoPyjhuXPQJXpaHfHW7UYFRia8Cchm/xRuyDDclpSQdEoakt3krOpSYvgVlQsbnf0ePDsTRDfp7Dg==}
 
@@ -9708,6 +9722,10 @@ packages:
   pluralize@7.0.0:
     resolution: {integrity: sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==}
     engines: {node: '>=4'}
+
+  pnpm-policy@0.2.1:
+    resolution: {integrity: sha512-2KWLQLCdXZYT3tOxjyG1upr2yY2hnk81fyvyDVI/1hzqkR6F9h+eQ5eIOv09GV2gUtLiH/t54yfeuQU+VTYkQw==}
+    hasBin: true
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
@@ -10938,6 +10956,9 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yamlize@0.12.1:
+    resolution: {integrity: sha512-rU2BN+gmyr0A4yK5i/Ps9JO1MjQGIGUelkaFglc9i4QqEDKU5HfDMdHhNhGMoeNeVw7nJqWpmDiFnxGb6FR5zA==}
+
   yanse@0.2.1:
     resolution: {integrity: sha512-SMi3ZO1IqsvPLLXuy8LBCP1orqcjOT8VygiuyAlplaGeH2g+n4ZSSyWlA/BZjuUuN58TyOcz89mVkflSqIPxxQ==}
 
@@ -11646,6 +11667,8 @@ snapshots:
       - typescript
 
   '@constructive-io/fetch@1.1.1': {}
+
+  '@constructive-io/pnpm-policy@0.2.0': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -17358,6 +17381,8 @@ snapshots:
 
   mkdirp@1.0.4: {}
 
+  mkdirp@3.0.1: {}
+
   mock-req@0.2.0: {}
 
   modify-values@1.0.1: {}
@@ -17972,6 +17997,11 @@ snapshots:
       - supports-color
 
   pluralize@7.0.0: {}
+
+  pnpm-policy@0.2.1:
+    dependencies:
+      yaml: 2.9.0
+      yamlize: 0.12.1
 
   postcss-selector-parser@6.1.2:
     dependencies:
@@ -19422,6 +19452,12 @@ snapshots:
   yallist@5.0.0: {}
 
   yaml@2.9.0: {}
+
+  yamlize@0.12.1:
+    dependencies:
+      mkdirp: 3.0.1
+      nested-obj: 0.2.3
+      yaml: 2.9.0
 
   yanse@0.2.1: {}
 

--- a/pnpm-policy.yaml
+++ b/pnpm-policy.yaml
@@ -1,0 +1,63 @@
+# Supply-chain policy for this workspace. The pnpm settings it produces live in
+# pnpm-workspace.yaml under the `Managed by pnpm-policy` marker — edit this file,
+# then run:
+#
+#   pnpm run policy
+#
+# `pnpm run policy:check` fails CI when the two drift apart.
+
+# Third-party releases wait two weeks before we can install them. Most malicious
+# releases are found and yanked well inside that window. Our own packages are
+# exempt (see `maintainers` below), so publishing does not lock us out of our own
+# workspace the way a blanket cooldown would.
+minimumReleaseAge: 14d
+
+# Off for now: turning it on rejects any transitive dependency resolved from git
+# or a URL, which is a separate re-resolution to make deliberately rather than
+# inside a policy rollout.
+blockExoticSubdeps: false
+
+# The npm accounts we publish under. Everything they publish skips the wait, so
+# this lists accounts we control — nobody else's.
+maintainers:
+  - pyramation
+
+# Scopes we own outright, emitted as `@scope/*`.
+scopes:
+  - "@constructive-io"
+  - "@constructive-db"
+  - "@launchql"
+  - "@pgpm"
+  - "@pgpmjs"
+  - "@pgsql"
+
+# Our published inventory, pinned as a dependency. Every unscoped and
+# other-scoped package we publish is listed there by name.
+inventory: "@constructive-io/pnpm-policy/inventory.json"
+
+# Exempt only the inventory names this workspace's lockfile actually resolves —
+# the list should describe this repo, not the whole npm account. Scope globs are
+# never intersected.
+#
+# The cost: adding one of our own packages this repo has never used is not in the
+# lockfile, so it is not exempt, so the wait blocks the install that would add
+# it. Run `pnpm run policy` and install again.
+intersect: true
+
+# Dependencies permitted to run install scripts. Empty is the status quo here:
+# nothing in this workspace has ever been approved, so @google/genai, esbuild,
+# nx, protobufjs and unrs-resolver install without their scripts and the build
+# works. An install script is arbitrary code at install time, so each addition is
+# a deliberate decision and the value is the reason.
+allowBuilds: []
+
+# Escape hatch for third-party packages that cannot wait — an urgent security
+# release, typically. A reason is required, and `until` makes the waiver expire
+# so `check` forces a re-justification instead of letting it become permanent:
+#
+#   exceptions:
+#     - package: lodash
+#       versions: ["4.17.21"]
+#       reason: CVE-2021-23337 fix, published today
+#       until: 2026-09-01
+exceptions: []

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,47 @@ packages:
   - 'postgres/*'
   - 'graphile/*'
   - 'agentic/*'
+
+# Managed by pnpm-policy — run `pnpm-policy generate` after editing pnpm-policy.yaml.
+
+# A third-party release must be 2w old before it can be installed.
+# Most malicious releases are found and yanked well inside that window.
+minimumReleaseAge: 20160
+
+# Exempt from the wait: 6 scope glob(s), 25 first-party package(s).
+# First-party membership comes from what pyramation publishes on npm — waiting on your own release protects nothing.
+minimumReleaseAgeExclude:
+  - "@constructive-db/*"
+  - "@constructive-io/*"
+  - "@launchql/*"
+  - "@pgpm/*"
+  - "@pgpmjs/*"
+  - "@pgsql/*"
+  - "@decryption/hashes"
+  - "@inquirerer/test"
+  - "@inquirerer/utils"
+  - appstash
+  - clean-ansi
+  - confstash
+  - find-and-require-package-json
+  - genomic
+  - git-changed
+  - inflekt
+  - inquirerer
+  - komoji
+  - libpg-query
+  - makage
+  - nested-obj
+  - pg-proto-parser
+  - pgsql-deparser
+  - pgsql-parser
+  - plpgsql-deparser
+  - plpgsql-parser
+  - pnpm-policy
+  - schema-typescript
+  - strfy-js
+  - yamlize
+  - yanse
+
+# Off: transitive dependencies may resolve from git or a URL.
+blockExoticSubdeps: false


### PR DESCRIPTION
## Summary

Third-party releases now wait 14 days before this workspace will install them; everything `pyramation` publishes is exempt, so the cooldown never blocks our own releases. Same setup as constructive-io/constructive-db#2774: `pnpm-policy.yaml` is the source of truth, the managed block in `pnpm-workspace.yaml` is generated from it, and the `build` job fails on drift.

The exemption list is intersected against this repo's lockfile (`intersect: true`), so it describes *this* workspace — 6 scope globs plus the 25 unscoped first-party names this lockfile resolves, not the 891 we publish. The cost is that adding one of our own packages this repo has never used is not in the lockfile, so it is not exempt: run `pnpm run policy`, then install again.

`allowBuilds: []` is deliberate and is the status quo, not a relaxation. Nothing in this repo has ever been build-approved, so `@google/genai`, `esbuild`, `nx`, `protobufjs` and `unrs-resolver` already install without their scripts and `pnpm build` passes — encoding that as an empty list keeps the decision explicit rather than inheriting it. `blockExoticSubdeps` stays off for the same reason it is off in constructive-db: turning it on re-resolves the tree over git-sourced transitives, which is its own change.

Verified locally: `pnpm run policy` is idempotent, `policy:check` clean, `pnpm install --frozen-lockfile` and a full `pnpm run build` both pass.


Link to Devin session: https://app.devin.ai/sessions/ffa3b012deac4eb7afb8f49a9af9f9ca
Requested by: @pyramation