### PR TITLE
feat!: read the catalog projection from catalog_private

### DIFF
--- a/__fixtures__/seed/scoped/test-data.sql
+++ b/__fixtures__/seed/scoped/test-data.sql
@@ -2,7 +2,7 @@
 --
 -- Scoped routing plane test data: models the "simple-pets" tenant as rows in
 -- the published modules
---   - @constructive-db/catalog -> catalog_public
+--   - @constructive-db/catalog -> catalog_private
 --   - @constructive-db/routing -> routing_public (incl. resolve_route())
 --   - @constructive-db/apps    -> apps_public
 --
@@ -72,7 +72,7 @@ VALUES (
 ) ON CONFLICT (id) DO NOTHING;
 
 -- =====================================================
--- CATALOG DATA (catalog_public)
+-- CATALOG DATA (catalog_private)
 -- =====================================================
 --
 -- `apis.config` carries the api surface projection the server folds into
@@ -80,7 +80,7 @@ VALUES (
 -- is_public, schemas); name/dbname/role_name/anon_role are merged in by the
 -- resolver from the columns below.
 
-INSERT INTO catalog_public.apis
+INSERT INTO catalog_private.apis
   (id, owner_scope, owner_key, is_visible, database_id, name, dbname, role_name, anon_role, config)
 VALUES
   (
@@ -136,7 +136,7 @@ VALUES
 ON CONFLICT (id) DO NOTHING;
 
 -- Catalog domains: globally-claimed hostnames (same ids as services domains)
-INSERT INTO catalog_public.domains
+INSERT INTO catalog_private.domains
   (id, owner_scope, owner_key, is_visible, database_id, hostname, is_wildcard, parent_hostname, managed, verification_status, tls_status)
 VALUES
   (
@@ -178,7 +178,7 @@ ON CONFLICT (id) DO NOTHING;
 
 -- Routing-side domains (source rows for the compiled hostname index).
 -- Triggers are re-enabled here: the published modules attach only the
--- catalog-sync propagation triggers, whose upserts into catalog_public are
+-- catalog-sync propagation triggers, whose upserts into catalog_private are
 -- idempotent with the direct catalog seeds above. Binding-sync triggers are
 -- NOT published, so the compiled hostname_bindings/route_bindings rows are
 -- still seeded directly below.

--- a/graphql/playwright-test/__tests__/scoped-server.playwright.test.ts
+++ b/graphql/playwright-test/__tests__/scoped-server.playwright.test.ts
@@ -21,7 +21,7 @@ const pgpmWorkspace = path.join(sharedSeedRoot, '..', '..');
 
 const schemas = ['simple-pets-public', 'simple-pets-pets-public'];
 const scopedMetaSchemas = [
-  'catalog_public',
+  'catalog_private',
   'routing_public',
   'apps_public',
   'metaschema_public',

--- a/graphql/server-test/__tests__/express-context.integration.test.ts
+++ b/graphql/server-test/__tests__/express-context.integration.test.ts
@@ -29,7 +29,7 @@ const shared = (...segments: string[]) =>
 const pgpmWorkspace = path.join(sharedSeedRoot, '..', '..');
 const schemas = ['simple-pets-public', 'simple-pets-pets-public'];
 const metaSchemas = [
-  'catalog_public',
+  'catalog_private',
   'routing_public',
   'apps_public',
   'metaschema_public',

--- a/graphql/server-test/__tests__/fn-routes.integration.test.ts
+++ b/graphql/server-test/__tests__/fn-routes.integration.test.ts
@@ -30,7 +30,7 @@ const shared = (...segments: string[]) =>
 const pgpmWorkspace = path.join(sharedSeedRoot, '..', '..');
 const schemas = ['simple-pets-public', 'simple-pets-pets-public'];
 const metaSchemas = [
-  'catalog_public',
+  'catalog_private',
   'routing_public',
   'apps_public',
   'metaschema_public',

--- a/graphql/server-test/__tests__/scoped-routing.integration.test.ts
+++ b/graphql/server-test/__tests__/scoped-routing.integration.test.ts
@@ -2,7 +2,7 @@
  * Scoped Routing Integration Tests (simple-seed-scoped)
  *
  * Exercises the new schema-only pgpm modules
- *   @constructive-db/catalog → catalog_public
+ *   @constructive-db/catalog → catalog_private
  *   @constructive-db/routing → routing_public
  *   @constructive-db/apps    → apps_public
  * seeded from `__fixtures__/seed/scoped/*` for the same "simple-pets" tenant
@@ -29,7 +29,7 @@ const scopedDatabaseId = '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9';
 const appApiId = '6c9997a4-591b-4cb3-9313-4ef45d6f134e';
 const privateApiId = 'e257c53d-6ba6-40de-b679-61b37188a316';
 const scopedMetaSchemas = [
-  'catalog_public',
+  'catalog_private',
   'routing_public',
   'apps_public',
   'metaschema_public',
@@ -88,12 +88,12 @@ describe('simple-seed-scoped: resolve_route (SQL level)', () => {
   it('deploys the scoped catalog/routing/apps schemas', async () => {
     const rows = await pg.any<{ nspname: string }>(
       `SELECT nspname FROM pg_namespace
-       WHERE nspname IN ('apps_public', 'catalog_public', 'routing_public', 'routing_private')
+       WHERE nspname IN ('apps_public', 'catalog_private', 'routing_public', 'routing_private')
        ORDER BY nspname`
     );
     expect(rows.map((r) => r.nspname)).toEqual([
       'apps_public',
-      'catalog_public',
+      'catalog_private',
       'routing_private',
       'routing_public'
     ]);

--- a/graphql/server-test/__tests__/server.integration.test.ts
+++ b/graphql/server-test/__tests__/server.integration.test.ts
@@ -26,7 +26,7 @@ const pgpmWorkspace = path.join(sharedSeedRoot, '..', '..');
 const schemas = ['simple-pets-public', 'simple-pets-pets-public'];
 const scopedDatabaseId = '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9';
 const scopedMetaSchemas = [
-  'catalog_public',
+  'catalog_private',
   'routing_public',
   'apps_public',
   'metaschema_public',

--- a/graphql/server-test/__tests__/upload.integration.test.ts
+++ b/graphql/server-test/__tests__/upload.integration.test.ts
@@ -65,7 +65,7 @@ const malloryPublicFileId = 'fa99fa99-0000-0000-0000-000000000001';
 const malloryPublicBucketId = 'fa77fa77-0000-0000-0000-000000000001';
 
 const metaSchemas = [
-  'catalog_public',
+  'catalog_private',
   'routing_public',
   'apps_public',
   'metaschema_public',

--- a/pgpm.json
+++ b/pgpm.json
@@ -3,10 +3,10 @@
     "testing/*"
   ],
   "dependencies": {
-    "@constructive-db/apps": "4.4.0",
-    "@constructive-db/catalog": "4.4.0",
-    "@constructive-db/routing": "5.4.0",
-    "@constructive-db/routing-platform": "4.4.0",
+    "@constructive-db/apps": "5.0.0",
+    "@constructive-db/catalog": "5.0.0",
+    "@constructive-db/routing": "6.0.0",
+    "@constructive-db/routing-platform": "5.0.0",
     "@pgpm/database-jobs": "0.33.1",
     "@pgpm/function-resolution": "0.33.1",
     "@pgpm/jwt-claims": "0.33.0",

--- a/pgpm/export/__tests__/cross-flow-parity.test.ts
+++ b/pgpm/export/__tests__/cross-flow-parity.test.ts
@@ -520,7 +520,7 @@ describe('Cross-flow parity: exportMeta vs exportGraphQLMeta', () => {
         // surface module config tables (catalog / routing planes)
         await pg.query(`
           INSERT INTO metaschema_modules_public.catalog_module (id, database_id, schema_id, public_schema_name, domains_table_name, apis_table_name, sites_table_name, apps_table_name, scope, policies)
-          VALUES ($1, $2, $3, 'catalog_public', 'domains', 'apis', 'sites', 'apps', 'platform', '{"select": "public"}'::jsonb)
+          VALUES ($1, $2, $3, 'catalog_private', 'domains', 'apis', 'sites', 'apps', 'platform', '{"select": "public"}'::jsonb)
         `, [CATALOG_MODULE_ID, DATABASE_ID, SCHEMA_ID_PUB]);
 
         await pg.query(`

--- a/pgpm/export/__tests__/export-flow.test.ts
+++ b/pgpm/export/__tests__/export-flow.test.ts
@@ -595,7 +595,7 @@ INSERT INTO routing_public.api_schemas (id, database_id, schema_id, api_id) VALU
 
 -- Surface module configuration
 INSERT INTO metaschema_modules_public.catalog_module (id, database_id, schema_id, public_schema_name, domains_table_name, apis_table_name, sites_table_name, apps_table_name, api_name, scope) VALUES
-  ('2222aaaa-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'aaaa0001-0000-0000-0000-000000000001', 'catalog_public', 'domains', 'apis', 'sites', 'apps', 'public', 'platform');
+  ('2222aaaa-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'aaaa0001-0000-0000-0000-000000000001', 'catalog_private', 'domains', 'apis', 'sites', 'apps', 'public', 'platform');
 
 INSERT INTO metaschema_modules_public.domain_module (id, database_id, schema_id, catalog_module_id, domains_table_name, managed_domains_table_name, scope, prefix) VALUES
   ('2222bbbb-0000-0000-0000-000000000001', 'a1b2c3d4-e5f6-4708-b250-000000000001', 'aaaa0001-0000-0000-0000-000000000001', '2222aaaa-0000-0000-0000-000000000001', 'domains', 'managed_domains', 'platform', '');

--- a/pgpm/export/__tests__/export-utils.test.ts
+++ b/pgpm/export/__tests__/export-utils.test.ts
@@ -71,7 +71,7 @@ describe('META_TABLE_CONFIG and META_TABLE_ORDER consistency', () => {
     const validSchemas = [
       'metaschema_public',
       'metaschema_modules_public',
-      'catalog_public',
+      'catalog_private',
       'routing_public',
       'apps_public'
     ];

--- a/pgpm/export/src/export-graphql-meta.ts
+++ b/pgpm/export/src/export-graphql-meta.ts
@@ -149,7 +149,7 @@ export const exportGraphQLMeta = async ({
     const tableConfig = META_TABLE_CONFIG[key];
     if (!tableConfig) return;
 
-    // Schema-qualified manifest keys (e.g. catalog_public.apis)
+    // Schema-qualified manifest keys (e.g. catalog_private.apis)
     // mark tables whose name collides with a table in another plane. GraphQL
     // type/query names are derived from the bare table name, so these cannot
     // be addressed unambiguously through the meta API — only the SQL flow

--- a/pgpm/export/src/meta-export-tables.json
+++ b/pgpm/export/src/meta-export-tables.json
@@ -332,6 +332,11 @@
       "table": "rls_module"
     },
     {
+      "key": "scope_types_module",
+      "schema": "metaschema_modules_public",
+      "table": "scope_types_module"
+    },
+    {
       "key": "secure_table_provision",
       "schema": "metaschema_modules_public",
       "table": "secure_table_provision"
@@ -642,73 +647,78 @@
       "table": "apps"
     },
     {
-      "key": "catalog_public.apis",
-      "schema": "catalog_public",
+      "key": "catalog_private.apis",
+      "schema": "catalog_private",
       "table": "apis"
     },
     {
-      "key": "catalog_public.apps",
-      "schema": "catalog_public",
+      "key": "catalog_private.apps",
+      "schema": "catalog_private",
       "table": "apps"
     },
     {
+      "key": "bindings",
+      "schema": "catalog_private",
+      "table": "bindings"
+    },
+    {
       "key": "buckets",
-      "schema": "catalog_public",
+      "schema": "catalog_private",
       "table": "buckets"
     },
     {
-      "key": "catalog_public.domains",
-      "schema": "catalog_public",
+      "key": "catalog_private.domains",
+      "schema": "catalog_private",
       "table": "domains"
     },
     {
       "key": "functions",
-      "schema": "catalog_public",
+      "schema": "catalog_private",
       "table": "functions"
     },
     {
       "key": "namespaces",
-      "schema": "catalog_public",
+      "schema": "catalog_private",
       "table": "namespaces"
     },
     {
       "key": "resource_definitions",
-      "schema": "catalog_public",
+      "schema": "catalog_private",
       "table": "resource_definitions"
     },
     {
       "key": "resource_installations",
-      "schema": "catalog_public",
+      "schema": "catalog_private",
       "table": "resource_installations"
     },
     {
       "key": "resources",
-      "schema": "catalog_public",
+      "schema": "catalog_private",
       "table": "resources"
     },
     {
-      "key": "catalog_public.sites",
-      "schema": "catalog_public",
+      "key": "catalog_private.sites",
+      "schema": "catalog_private",
       "table": "sites"
     },
     {
       "key": "sites_app_links",
-      "schema": "catalog_public",
+      "schema": "catalog_private",
       "table": "sites_app_links"
     },
     {
       "key": "sites_deep_links",
-      "schema": "catalog_public",
+      "schema": "catalog_private",
       "table": "sites_deep_links"
     },
     {
       "key": "sites_error_pages",
-      "schema": "catalog_public",
+      "schema": "catalog_private",
       "table": "sites_error_pages"
     },
     {
       "key": "sites_web_config",
-      "schema": "catalog_public",
+      "schema": "catalog_private",
       "table": "sites_web_config"
     }
   ],
@@ -721,59 +731,63 @@
       "created_at",
       "updated_at"
     ],
-    "catalog_public.apis": [
+    "catalog_private.apis": [
       "created_at",
       "updated_at"
     ],
-    "catalog_public.apps": [
+    "catalog_private.apps": [
       "created_at",
       "updated_at"
     ],
-    "catalog_public.buckets": [
+    "catalog_private.bindings": [
       "created_at",
       "updated_at"
     ],
-    "catalog_public.domains": [
+    "catalog_private.buckets": [
       "created_at",
       "updated_at"
     ],
-    "catalog_public.functions": [
+    "catalog_private.domains": [
       "created_at",
       "updated_at"
     ],
-    "catalog_public.namespaces": [
+    "catalog_private.functions": [
       "created_at",
       "updated_at"
     ],
-    "catalog_public.resource_definitions": [
+    "catalog_private.namespaces": [
       "created_at",
       "updated_at"
     ],
-    "catalog_public.resource_installations": [
+    "catalog_private.resource_definitions": [
       "created_at",
       "updated_at"
     ],
-    "catalog_public.resources": [
+    "catalog_private.resource_installations": [
       "created_at",
       "updated_at"
     ],
-    "catalog_public.sites": [
+    "catalog_private.resources": [
       "created_at",
       "updated_at"
     ],
-    "catalog_public.sites_app_links": [
+    "catalog_private.sites": [
       "created_at",
       "updated_at"
     ],
-    "catalog_public.sites_deep_links": [
+    "catalog_private.sites_app_links": [
       "created_at",
       "updated_at"
     ],
-    "catalog_public.sites_error_pages": [
+    "catalog_private.sites_deep_links": [
       "created_at",
       "updated_at"
     ],
-    "catalog_public.sites_web_config": [
+    "catalog_private.sites_error_pages": [
+      "created_at",
+      "updated_at"
+    ],
+    "catalog_private.sites_web_config": [
       "created_at",
       "updated_at"
     ],


### PR DESCRIPTION
## Summary

Lockstep half of the catalog rename published as `@constructive-db/catalog@5.0.0` (constructive-io/constructive-platform#14). The catalog is a projection resolvers read, not an API surface, so it no longer sits behind a `_public` name.

The pin bump can't be catalog-only: the `tg_*_catalog_sync` / `tg_*_catalog_del` **attachments** live on the scoped source tables in `apps` / `routing` / `routing-platform`, so a mixed install would attach triggers naming a schema the catalog module didn't create.

```diff
-"@constructive-db/apps":             "4.4.0",
-"@constructive-db/catalog":          "4.4.0",
-"@constructive-db/routing":          "5.4.0",
-"@constructive-db/routing-platform": "4.4.0",
+"@constructive-db/apps":             "5.0.0",
+"@constructive-db/catalog":          "5.0.0",
+"@constructive-db/routing":          "6.0.0",
+"@constructive-db/routing-platform": "5.0.0",
```

`meta-export-tables.json` is re-synced from `constructive-db`'s generated manifest rather than edited: besides moving the catalog keys to `catalog_private`, it picks up the entries that manifest gained since the last sync — `catalog_private.bindings` (capability bindings became a catalog kind) and `metaschema_modules_public.scope_types_module`.

**What deliberately did not change:** the routing plane, the `express-context` loaders, and safegres' exposure adapters. They resolve through `routing_public.{apis,api_schemas}` and `resolve_route`, which did not move — `DEFAULT_ROUTING_SCHEMA` is still `routing_public`. The rename touches only the projection the resolvers read behind that.

### Verification

Against `postgres-plus:18` with the 5.0.0/6.0.0 modules installed into `extensions/`:

- `pgpm/export` — 176 tests, 9 suites green (this is the suite that consumes the manifest).
- `graphql/server-test` — 140 green, including `scoped-routing`, `express-context`, `fn-routes`, `server`, and `anon-grant-minimum`.
- `packages/express-context` (27), `postgres/pg-codegen` (5), `pgpm/core` (489) green.

`upload.integration` fails 12 tests here for want of an S3/MinIO endpoint — identical failures on a clean checkout of `main` with these changes stashed, so it's environmental, not from this change.

One thing left stale on purpose: `__fixtures__/output/` still names `constructive_catalog_public`. It's a committed pg-codegen snapshot of a fixture database, regenerated by its own flow, and `postgres/pg-codegen`'s suite passes against it — I'd rather it be regenerated by that flow than hand-edited here.


Link to Devin session: https://app.devin.ai/sessions/12ca02ecefab4a49a7d375452a86efdb
Requested by: @pyramation