### PR TITLE
perf(slice): compile each glob pattern once in findMatchingPattern

### DIFF
--- a/pgpm/slice/src/slice.ts
+++ b/pgpm/slice/src/slice.ts
@@ -1,7 +1,7 @@
 import { parsePlanFile } from '@pgpmjs/ast/files/plan/parser';
 import { generateChangeLineContent, generateTagLineContent } from '@pgpmjs/ast/files/plan/writer';
 import { Change, ExtendedPlanFile,Tag } from '@pgpmjs/ast/files/types';
-import { minimatch } from 'minimatch';
+import { Minimatch } from 'minimatch';
 
 import { buildAstEdges, expandClosures } from './closure';
 import {
@@ -117,6 +117,23 @@ export function extractPackageFromPath(
 }
 
 /**
+ * Compiling a glob costs far more than matching one, and assigning a plan
+ * evaluates every (change x pattern) pair — hundreds of thousands of pairs on
+ * a large plan over the same handful of patterns — so each pattern is
+ * compiled once and reused. `Minimatch` instances are stateless.
+ */
+const patternMatchers = new Map<string, Minimatch>();
+
+function patternMatcher(pattern: string): Minimatch {
+  let matcher = patternMatchers.get(pattern);
+  if (!matcher) {
+    matcher = new Minimatch(pattern, { dot: true });
+    patternMatchers.set(pattern, matcher);
+  }
+  return matcher;
+}
+
+/**
  * Find the matching package for a change using pattern-based strategy.
  * Returns the first matching slice's package name, or undefined if no match.
  */
@@ -126,7 +143,7 @@ export function findMatchingPattern(
 ): string | undefined {
   for (const slice of strategy.slices) {
     for (const pattern of slice.patterns) {
-      if (minimatch(changeName, pattern, { dot: true })) {
+      if (patternMatcher(pattern).match(changeName)) {
         return slice.packageName;
       }
     }


### PR DESCRIPTION
## Summary

`findMatchingPattern` calls minimatch's one-shot helper, which **compiles the glob into a regex on every call** and discards it. Pattern assignment evaluates every (change × pattern) pair, so slicing constructive-db's plan — ~24.5k changes × ~40 patterns — recompiles the same 40 globs roughly a million times. A CPU profile of `generate:constructive` attributes ~30s to glob compilation alone (`regExpEscape` 20.3s, `#parseGlob` 3.3s, `toRegExpSource` 2.7s), out of 56–62s spent in `slicePlan`.

```diff
-if (minimatch(changeName, pattern, { dot: true })) {
+if (patternMatcher(pattern).match(changeName)) {   // new Minimatch(...) memoized per pattern string
```

`Minimatch#match` is exactly what the one-shot helper invokes, so matching semantics are unchanged — only how often the regex is built. The cache is module-level and keyed by pattern string; `Minimatch` instances are stateless, so entries are safe to share across `slicePlan` calls.

### Measured (constructive-db `generate:constructive`, same machine)

| | before | after |
|---|---:|---:|
| `slicePlan` | 56–62s | 1.6s |
| whole generation | 3m06 | 1m56 |

Output equivalence: `application/constructive/` regenerated byte-identical across 24.5k files.

`pnpm test` in `pgpm/slice`: 59 passed, 6 suites.

Downstream, constructive-io/constructive-db#2799 carries this same change as a `pnpm patch`; that patch should be dropped once a release includes this.


Link to Devin session: https://app.devin.ai/sessions/b266e1e72e0a4182a53cdd048b59f740
Requested by: @pyramation