### PR TITLE
chore: shorten the third-party wait to two days

### DIFF
--- a/pnpm-policy.yaml
+++ b/pnpm-policy.yaml
@@ -6,11 +6,11 @@
 #
 # `pnpm run policy:check` fails CI when the two drift apart.
 
-# Third-party releases wait two weeks before we can install them. Most malicious
-# releases are found and yanked well inside that window. Our own packages are
-# exempt (see `maintainers` below), so publishing does not lock us out of our own
-# workspace the way a blanket cooldown would.
-minimumReleaseAge: 14d
+# Third-party releases wait two days before we can install them. A compromised
+# release is normally reported and yanked within hours, so a short wait catches it
+# without stalling upgrades. Our own packages are exempt (see `maintainers` below),
+# so publishing does not lock us out of our own workspace.
+minimumReleaseAge: 2d
 
 # Off for now: turning it on rejects any transitive dependency resolved from git
 # or a URL, which is a separate re-resolution to make deliberately rather than

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,9 +11,9 @@ packages:
 
 # Managed by pnpm-policy — run `pnpm-policy generate` after editing pnpm-policy.yaml.
 
-# A third-party release must be 2w old before it can be installed.
+# A third-party release must be 2d old before it can be installed.
 # Most malicious releases are found and yanked well inside that window.
-minimumReleaseAge: 20160
+minimumReleaseAge: 2880
 
 # Exempt from the wait: 6 scope glob(s), 49 first-party package(s), 9 exception(s).
 # First-party membership comes from what pyramation, benjie publish on npm — waiting on your own release protects nothing.


### PR DESCRIPTION
## Summary

```diff
-minimumReleaseAge: 14d   # → 20160 in the managed block
+minimumReleaseAge: 2d    # → 2880
```

A compromised release is normally reported and yanked within hours, so nearly everything the cooldown buys us lands in the first day or two — while the remaining twelve days are what make an ordinary dependency bump need a waiver. Nothing else about the policy changes: the exemption list, the maintainers, and the build approvals regenerate byte-identical.

The lockfile is untouched: a shorter wait can never invalidate an already-resolved version.


Link to Devin session: https://app.devin.ai/sessions/ffa3b012deac4eb7afb8f49a9af9f9ca
Requested by: @pyramation