### PR TITLE
chore(deps): inflekt ^0.8.1

### DIFF
--- a/graphile/graphile-function-bindings/package.json
+++ b/graphile/graphile-function-bindings/package.json
@@ -42,7 +42,7 @@
     "@constructive-io/query-builder": "workspace:^",
     "@pgpmjs/logger": "workspace:^",
     "graphile-plugin-utils": "workspace:^",
-    "inflekt": "^0.8.0",
+    "inflekt": "^0.8.1",
     "pg": "^8.21.0"
   },
   "peerDependencies": {

--- a/graphile/graphile-settings/package.json
+++ b/graphile/graphile-settings/package.json
@@ -65,7 +65,7 @@
     "graphile-upload-plugin": "workspace:^",
     "graphile-utils": "5.0.3",
     "graphql": "16.13.0",
-    "inflekt": "^0.8.0",
+    "inflekt": "^0.8.1",
     "lru-cache": "^11.2.7",
     "pg": "^8.21.0",
     "pg-query-context": "workspace:^",

--- a/graphql/codegen/package.json
+++ b/graphql/codegen/package.json
@@ -66,7 +66,7 @@
     "gql-ast": "workspace:^",
     "graphile-schema": "workspace:^",
     "graphql": "16.13.0",
-    "inflekt": "^0.8.0",
+    "inflekt": "^0.8.1",
     "inquirerer": "^4.9.3",
     "jiti": "^2.7.0",
     "oxfmt": "^0.51.0",

--- a/graphql/query/package.json
+++ b/graphql/query/package.json
@@ -41,7 +41,7 @@
     "graphile-settings": "workspace:^",
     "graphql": "16.13.0",
     "inflection": "^3.0.0",
-    "inflekt": "^0.8.0",
+    "inflekt": "^0.8.1",
     "lru-cache": "^11.2.7",
     "postgraphile": "5.1.3"
   },

--- a/graphql/server-test/__tests__/anon-grant-minimum.test.ts
+++ b/graphql/server-test/__tests__/anon-grant-minimum.test.ts
@@ -16,7 +16,7 @@
  * blanket `GRANT ALL ON FUNCTIONS TO anonymous` buys no Graphile functionality
  * whatsoever — it only widens what anon may execute.
  */
-import { PgTestClient } from 'pgsql-test';
+import { PgTestClient, seed } from 'pgsql-test';
 
 import { getConnections as getServerConnections } from '../src';
 
@@ -58,14 +58,21 @@ describe('minimum anonymous grants for Graphile', () => {
   let teardown: () => Promise<void>;
 
   beforeAll(async () => {
-    ({ pg, query, teardown } = await getServerConnections({
-      schemas: ['app_public'],
-      authRole: 'anonymous',
-      server: { useRouting: false }
-    }));
-
-    await pg.query(SETUP);
-    await pg.query(RESET_GRANTS);
+    // Seeded rather than created afterwards: the server can build its schema as
+    // soon as it starts, and would then introspect an empty database.
+    ({ pg, query, teardown } = await getServerConnections(
+      {
+        schemas: ['app_public'],
+        authRole: 'anonymous',
+        server: { useRouting: false }
+      },
+      [
+        seed.fn(async ({ pg: seedClient }) => {
+          await seedClient.query(SETUP);
+          await seedClient.query(RESET_GRANTS);
+        })
+      ]
+    ));
   });
 
   afterAll(async () => {

--- a/pgpm/cli/__tests__/__snapshots__/init.test.ts.snap
+++ b/pgpm/cli/__tests__/__snapshots__/init.test.ts.snap
@@ -36,6 +36,7 @@ exports[`cmds:init initializes module with no extensions by default: module-no-e
 [
   "tsconfig.json",
   "pnpm-workspace.yaml",
+  "pnpm-policy.yaml",
   "pgpm.json",
   "package.json",
   "lerna.json",
@@ -118,6 +119,7 @@ exports[`cmds:init initializes module: module-only - files 1`] = `
 [
   "tsconfig.json",
   "pnpm-workspace.yaml",
+  "pnpm-policy.yaml",
   "pgpm.json",
   "package.json",
   "lerna.json",
@@ -194,6 +196,7 @@ exports[`cmds:init initializes workspace: workspace - files 1`] = `
 [
   "my-workspace/tsconfig.json",
   "my-workspace/pnpm-workspace.yaml",
+  "my-workspace/pnpm-policy.yaml",
   "my-workspace/pgpm.json",
   "my-workspace/package.json",
   "my-workspace/lerna.json",

--- a/pgpm/export/package.json
+++ b/pgpm/export/package.json
@@ -52,7 +52,7 @@
     "@pgpmjs/types": "workspace:^",
     "csv-to-pg": "workspace:^",
     "glob": "^13.0.6",
-    "inflekt": "^0.8.0",
+    "inflekt": "^0.8.1",
     "inquirerer": "^4.9.3",
     "pg": "^8.21.0",
     "pg-cache": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -529,8 +529,8 @@ importers:
         specifier: 16.13.0
         version: 16.13.0
       inflekt:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.8.1
+        version: 0.8.1
       pg:
         specifier: ^8.21.0
         version: 8.21.0
@@ -1291,8 +1291,8 @@ importers:
         specifier: 16.13.0
         version: 16.13.0
       inflekt:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.8.1
+        version: 0.8.1
       lru-cache:
         specifier: ^11.2.7
         version: 11.2.7
@@ -1491,8 +1491,8 @@ importers:
         specifier: 16.13.0
         version: 16.13.0
       inflekt:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.8.1
+        version: 0.8.1
       inquirerer:
         specifier: ^4.9.3
         version: 4.9.3
@@ -1842,8 +1842,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.2
       inflekt:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.8.1
+        version: 0.8.1
       lru-cache:
         specifier: ^11.2.7
         version: 11.2.7
@@ -3029,8 +3029,8 @@ importers:
         specifier: ^13.0.6
         version: 13.0.6
       inflekt:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.8.1
+        version: 0.8.1
       inquirerer:
         specifier: ^4.9.3
         version: 4.9.3
@@ -3337,8 +3337,8 @@ importers:
         specifier: workspace:^
         version: link:../../pgpm/types/dist
       inflekt:
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.8.1
+        version: 0.8.1
       pg:
         specifier: ^8.21.0
         version: 8.21.0
@@ -10986,10 +10986,10 @@ packages:
       }
     engines: { node: '>=18.0.0' }
 
-  inflekt@0.8.0:
+  inflekt@0.8.1:
     resolution:
       {
-        integrity: sha512-Inc2K7CJZvUHJvn9Tj9YKoHu4eK4gFEvtQXz7cpL8ZFzB8vaxNVkUHWBrqR/00wLcp9xdhD/fmE6DJgN4E1oRw==,
+        integrity: sha512-HC0tqBX/gyiudcpmhxFirVIITGcqqPJDLGQIr9XktqS77EC+EK0JVabZpI8swtxC5ZjV1/PVdAXdhZG+CnrM4A==,
       }
 
   inflight@1.0.6:
@@ -20536,7 +20536,7 @@ snapshots:
 
   inflection@3.0.2: {}
 
-  inflekt@0.8.0:
+  inflekt@0.8.1:
     dependencies:
       inflection: 3.0.2
       komoji: 0.9.1

--- a/postgres/pg-codegen/package.json
+++ b/postgres/pg-codegen/package.json
@@ -44,7 +44,7 @@
     "@pgpmjs/logger": "workspace:^",
     "@pgpmjs/server-utils": "workspace:^",
     "@pgpmjs/types": "workspace:^",
-    "inflekt": "^0.8.0",
+    "inflekt": "^0.8.1",
     "pg": "^8.21.0",
     "pg-cache": "workspace:^",
     "pg-env": "workspace:^",


### PR DESCRIPTION
## Summary

Picks up inflekt 0.8.1 (constructive-io/dev-utils#114), which audits `pluralize` the way 0.8.0 audited `singularize`: both directions now go through a dictionary-proven exception table in front of suffix rules, and both are idempotent, so `pluralize` no longer coins non-words (`radius -> radius`, `bias -> bias`, `chassis -> chasses`) or double-pluralizes (`apis -> apises`).

Naming changes reaching this repo, all through `custom-inflector.ts` (which replaces PostGraphile's inflector with inflekt):

```
radius  -> radiuses    (was radius, i.e. singular == plural)
bias    -> biases      (was bias)
appendix -> appendices (was appendixes; -ex/-ix is now uniformly Latin, matching `index -> indices`)
deer, fish, moose      -> invariant (were deers, fishes, mooses)
API_KEY -> API_KEYS    (was API_KEYs)
```

Two CI failures fixed along the way, neither caused by the bump:

- `pgpm/cli` init snapshots: the workspace boilerplate now ships `pnpm-policy.yaml`, so scaffolding emits one more file. Also red on main (run 31063294976 at 5dc37ae9).
- `graphql/server-test`'s `anon-grant-minimum`: it created `app_public` in `beforeAll` *after* `getConnections` had started the server, so an eager schema build introspected an empty database and saw only `_meta`. Now seeded through `seed.fn`, which runs before the server starts. This is why the suite passed on one run of this PR and failed on the next.


Link to Devin session: https://app.devin.ai/sessions/c2c27132839a45219a440fd10cbf13a6
Requested by: @pyramation