### PR TITLE
refactor(core): drop verify_schema from the schema-name literal pass

### DIFF
--- a/pgpm/core/src/apply/materialize.ts
+++ b/pgpm/core/src/apply/materialize.ts
@@ -26,11 +26,10 @@ export interface MaterializeApplyOptions {
   outDir?: string;
 }
 
-// Functions that take a bare schema name as a string-literal first argument.
-// The AST pass only remaps dotted literals ('schema.object'); these helpers
-// (ubiquitous in verify scripts) name the schema alone, so a string-level
-// pre-pass remaps them.
-const SCHEMA_NAME_LITERAL_FUNCS = ['verify_schema', 'has_schema_privilege'];
+// has_schema_privilege takes a bare schema name as a string literal. The AST
+// pass only remaps dotted literals ('schema.object') and identity casts
+// ('schema'::regnamespace), so this one is remapped by a string pre-pass.
+const SCHEMA_NAME_LITERAL_FUNCS = ['has_schema_privilege'];
 
 const schemaNameLiteralPass: SchemaTransformPass = (content, schemaMapping) => {
   const pattern = new RegExp(

--- a/pgpm/core/src/apply/reuse.ts
+++ b/pgpm/core/src/apply/reuse.ts
@@ -38,9 +38,11 @@ const FOLDER_KIND: Record<string, SchemaObjectRoute['kind']> = {
   types: 'type'
 };
 
-// Mirrors materialize.ts: bare-schema-name literal helpers the AST pass can't
-// reach are remapped by a narrow string pre-pass.
-const SCHEMA_NAME_LITERAL_FUNCS = ['verify_schema', 'has_schema_privilege'];
+// Mirrors materialize.ts.
+// has_schema_privilege takes a bare schema name as a string literal. The AST
+// pass only remaps dotted literals ('schema.object') and identity casts
+// ('schema'::regnamespace), so this one is remapped by a string pre-pass.
+const SCHEMA_NAME_LITERAL_FUNCS = ['has_schema_privilege'];
 const schemaNameLiteralPass: SchemaTransformPass = (content, schemaMapping) => {
   const pattern = new RegExp(
     `\\b(${SCHEMA_NAME_LITERAL_FUNCS.join('|')})\\s*\\(\\s*'([^']+)'`,


### PR DESCRIPTION
## Summary

`SCHEMA_NAME_LITERAL_FUNCS` (duplicated in `apply/materialize.ts` and `apply/reuse.ts`) loses its `verify_schema` entry:

```diff
-const SCHEMA_NAME_LITERAL_FUNCS = ['verify_schema', 'has_schema_privilege'];
+const SCHEMA_NAME_LITERAL_FUNCS = ['has_schema_privilege'];
```

`verify_schema` no longer exists — constructive-db now emits `assert_schema('sch'::regnamespace)`, and `@pgsql/transform` routes identity casts by cast type, so the bare-name case the pre-pass existed for is handled by the AST walk. This is the pgpm half of removing the two parallel helper-name lists (`transformVerifyCalls` is the other, constructive-io/pgsql-parser#344).

I did **not** delete the pass outright, which was the original plan: `has_schema_privilege('users', 'usage')` really does take a bare schema name in a string literal (the apply fixtures use it), and nothing in the AST pass can reach it. Removing it made all five apply e2e suites fail on `Failed to verify schemas/tenant_a/schema`. The hazard worth removing was the *verify-helper* list that had to be extended per helper; a single Postgres builtin is not that.

## Validation

- `pgpm/core`: 489 tests / 77 suites passing (the five apply e2e suites exercise this pass)


Link to Devin session: https://app.devin.ai/sessions/37a60838adfb4fd6ac8c29f09c2e2827
Requested by: @pyramation