### PR TITLE
fix(pgpm dump): restore extension schemas to the dump's search_path

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -321,13 +321,18 @@ jobs:
         run: pnpm fixtures:install
 
       - name: Test ${{ matrix.batch }}
-        # `pgpm diff db:<name>` shells out to pg_dump, which must match the
-        # Postgres 18 server. Rather than install client tools on the runner,
-        # run pg_dump straight from the postgres-plus:18 service container.
+        # `pgpm diff db:<name>` shells out to pg_dump, and the dump restore
+        # test pipes an 18-format dump (`\restrict`) into psql; both clients
+        # must match the Postgres 18 server. Rather than install client tools
+        # on the runner, run them straight from the postgres-plus:18 service
+        # container.
         env:
           # -e PGUSER: docker exec does not inherit the runner env, and pg_dump
           # would otherwise default to the container's OS user (no such role).
           PGPM_PG_DUMP: docker exec -e PGUSER=postgres ${{ job.services.pg_db.id }} pg_dump
+          # -i: the dump arrives on stdin, since the runner's filesystem is not
+          # visible inside the container.
+          PGPM_PSQL: docker exec -i -e PGUSER=postgres ${{ job.services.pg_db.id }} psql
         run: |
           for pkg in ${{ matrix.packages }}; do
             echo "::group::Testing $pkg"

--- a/pgpm/cli/__tests__/doctor.test.ts
+++ b/pgpm/cli/__tests__/doctor.test.ts
@@ -146,6 +146,24 @@ describe('parsePsqlMajor', () => {
 });
 
 describe('checkPsql', () => {
+  // checkPsql resolves the client through getPgClientCommand, so an ambient
+  // alias (CI points psql at the server container) would change the command
+  // the fake runner is keyed on.
+  const aliasEnv = ['PGPM_PSQL', 'PGPM_PG_CLIENT_PREFIX'];
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = Object.fromEntries(aliasEnv.map(key => [key, process.env[key]]));
+    for (const key of aliasEnv) delete process.env[key];
+  });
+
+  afterEach(() => {
+    for (const key of aliasEnv) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
   it('fails with OS guidance when psql is missing', async () => {
     const result = await checkPsql({ platform: 'macos' }, makeRunner({}));
     expect(result.status).toBe('fail');

--- a/pgpm/cli/__tests__/dump.test.ts
+++ b/pgpm/cli/__tests__/dump.test.ts
@@ -10,8 +10,10 @@ jest.mock('../src/utils', () => ({
 
 // mock the core pg_dump helper (the command's only dump seam)
 const mockPgDump = jest.fn().mockResolvedValue('');
+const mockApplySearchPath = jest.fn().mockResolvedValue(['extensions']);
 jest.mock('@pgpmjs/core', () => ({
-  pgDump: (...args: unknown[]) => mockPgDump(...args)
+  pgDump: (...args: unknown[]) => mockPgDump(...args),
+  applyExtensionSearchPathToFile: (...args: unknown[]) => mockApplySearchPath(...args)
 }));
 
 // mock quoteutils
@@ -62,6 +64,19 @@ describe('dump command', () => {
         noPrivileges: true,
         file: expect.stringContaining('output.sql')
       })
+    );
+  });
+
+  it('makes the written dump restorable before anything is appended to it', async () => {
+    jest.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined as any);
+    jest.spyOn(fs, 'writeFileSync').mockImplementation(() => undefined);
+    jest.spyOn(console, 'log').mockImplementation(() => { });
+
+    await dumpCmd({ database: 'test_db', out: 'output.sql', cwd: '/tmp' }, {} as any, {} as any);
+
+    expect(mockApplySearchPath).toHaveBeenCalledWith(
+      expect.objectContaining({ database: 'test_db' }),
+      expect.stringContaining('output.sql')
     );
   });
 

--- a/pgpm/cli/src/commands/dump.ts
+++ b/pgpm/cli/src/commands/dump.ts
@@ -1,4 +1,4 @@
-import { pgDump } from '@pgpmjs/core';
+import { applyExtensionSearchPathToFile, pgDump } from '@pgpmjs/core';
 import { Logger } from '@pgpmjs/logger';
 import { QuoteUtils } from '@pgsql/quotes';
 import fs from 'fs';
@@ -150,6 +150,13 @@ export default async (
     noPrivileges: true,
     file: outPath
   });
+
+  // pg_dump's empty search_path leaves extension operators unresolvable on
+  // restore (e.g. a trigger's `IS DISTINCT FROM` on a vector column).
+  const extensionSchemas = await applyExtensionSearchPathToFile(pgEnv, outPath);
+  if (extensionSchemas.length) {
+    log.info(`restore search_path set to ${extensionSchemas.join(', ')}`);
+  }
 
   if (databaseIdInfo) {
     const pruneSql = await buildPruneSql(dbname, databaseIdInfo.id);

--- a/pgpm/core/__tests__/dump/restorable-dump.test.ts
+++ b/pgpm/core/__tests__/dump/restorable-dump.test.ts
@@ -7,7 +7,7 @@
  * that goes through `search_path` and cannot be schema-qualified in the DDL.
  */
 import { spawn } from 'child_process';
-import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { teardownPgPools } from 'pg-cache';
@@ -15,7 +15,11 @@ import type { PgConfig } from 'pg-env';
 import { getPgClientCommand, getSpawnEnvWithPg } from 'pg-env';
 
 import { LEDGER_SCHEMAS, pgDump } from '../../src/dump/pg-dump';
-import { applyExtensionSearchPathToFile, getExtensionSchemas } from '../../src/dump/search-path';
+import {
+  applyExtensionSearchPath,
+  applyExtensionSearchPathToFile,
+  getExtensionSchemas
+} from '../../src/dump/search-path';
 import { MigrateTestFixture } from '../../test-utils/MigrateTestFixture';
 import { TestDatabase } from '../../test-utils/TestDatabase';
 
@@ -81,23 +85,23 @@ describe('a dump of a database with extension-typed triggers', () => {
     await teardownPgPools();
   });
 
-  const dumpToFile = async (name: string): Promise<string> => {
-    const file = join(tempDir, name);
-    await pgDump({
+  /**
+   * Captured rather than written with `--file`: the version-matched pg_dump
+   * may run inside the server's container, where a host path does not exist.
+   */
+  const dumpSource = (): Promise<string> =>
+    pgDump({
       config: source.config,
       format: 'plain',
       noOwner: true,
       noPrivileges: true,
       // Targets come from the same fixture, so they already carry the
       // migration ledger; it is not what is under test here.
-      excludeSchemas: [...LEDGER_SCHEMAS],
-      file
+      excludeSchemas: [...LEDGER_SCHEMAS]
     });
-    return file;
-  };
 
   it('does not restore as pg_dump emits it (the bug this guards)', async () => {
-    const dump = readFileSync(await dumpToFile('unpatched.sql'), 'utf8');
+    const dump = await dumpSource();
     const target = await fixture.setupTestDatabase();
     const { code, stderr } = await psqlRestore(target.config, dump);
     expect(code).not.toBe(0);
@@ -105,7 +109,8 @@ describe('a dump of a database with extension-typed triggers', () => {
   });
 
   it('restores with zero errors once the extension search_path is applied', async () => {
-    const file = await dumpToFile('patched.sql');
+    const file = join(tempDir, 'patched.sql');
+    writeFileSync(file, await dumpSource(), 'utf8');
     const schemas = await applyExtensionSearchPathToFile(source.config, file);
     expect(schemas).toEqual([...schemas].sort());
     expect(schemas).toContain('extensions');
@@ -126,5 +131,12 @@ describe('a dump of a database with extension-typed triggers', () => {
 
   it('reports the schemas its extensions actually live in', async () => {
     expect(await getExtensionSchemas(source.config)).toEqual(['extensions', 'pg_catalog']);
+  });
+
+  it('patches captured output as well as a file', async () => {
+    const patched = await applyExtensionSearchPath(source.config, await dumpSource());
+    expect(patched).toContain(
+      'SELECT pg_catalog.set_config(\'search_path\', \'"extensions", "pg_catalog"\', false);'
+    );
   });
 });

--- a/pgpm/core/__tests__/dump/restorable-dump.test.ts
+++ b/pgpm/core/__tests__/dump/restorable-dump.test.ts
@@ -1,0 +1,130 @@
+/**
+ * The restore contract: what `pgpm dump` writes must load into a fresh
+ * database under `psql -v ON_ERROR_STOP=1`.
+ *
+ * The fixture is the shape that broke it — a pgvector column and a trigger
+ * whose `WHEN` clause compares it with `IS DISTINCT FROM`, an operator lookup
+ * that goes through `search_path` and cannot be schema-qualified in the DDL.
+ */
+import { spawn } from 'child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { teardownPgPools } from 'pg-cache';
+import type { PgConfig } from 'pg-env';
+import { getPgClientCommand, getSpawnEnvWithPg } from 'pg-env';
+
+import { LEDGER_SCHEMAS, pgDump } from '../../src/dump/pg-dump';
+import { applyExtensionSearchPathToFile, getExtensionSchemas } from '../../src/dump/search-path';
+import { MigrateTestFixture } from '../../test-utils/MigrateTestFixture';
+import { TestDatabase } from '../../test-utils/TestDatabase';
+
+interface RestoreResult {
+  code: number;
+  stderr: string;
+}
+
+/**
+ * Feed a dump to `psql` on stdin rather than `--file`: the version-matched
+ * client may live in a container (PGPM_PSQL), where the host's path is
+ * meaningless.
+ */
+const psqlRestore = (config: PgConfig, sql: string): Promise<RestoreResult> => {
+  const [cmd, ...prefixArgs] = getPgClientCommand('psql');
+  const args = [...prefixArgs, '-v', 'ON_ERROR_STOP=1', '--quiet', '--dbname', config.database];
+  return new Promise<RestoreResult>((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      env: getSpawnEnvWithPg(config),
+      stdio: ['pipe', 'ignore', 'pipe']
+    });
+    let stderr = '';
+    child.stderr.on('data', chunk => { stderr += chunk; });
+    child.on('error', reject);
+    child.on('close', code => resolve({ code: code ?? -1, stderr }));
+    child.stdin.end(sql);
+  });
+};
+
+describe('a dump of a database with extension-typed triggers', () => {
+  const fixture = new MigrateTestFixture();
+  let source: TestDatabase;
+  let tempDir: string;
+
+  beforeAll(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'pgpm-dump-restore-'));
+    source = await fixture.setupTestDatabase();
+
+    // The extension deliberately does NOT live in `public`: the rewrite must
+    // read the source's actual extension schemas, not assume one.
+    await source.query('CREATE SCHEMA extensions');
+    await source.query('CREATE EXTENSION vector SCHEMA extensions');
+    await source.query('CREATE TABLE documents (id int PRIMARY KEY, embedding extensions.vector(3))');
+    await source.query(`
+      CREATE FUNCTION touch_document() RETURNS trigger LANGUAGE plpgsql AS $$
+      BEGIN RETURN new; END $$
+    `);
+    // The operator has to be on the path to create the trigger too — the very
+    // lookup the restore later has to be able to make.
+    await source.query(`
+      SET search_path TO extensions, public;
+      CREATE TRIGGER documents_embedding_changed
+        BEFORE UPDATE ON documents
+        FOR EACH ROW
+        WHEN (old.embedding IS DISTINCT FROM new.embedding)
+        EXECUTE FUNCTION touch_document()
+    `);
+  });
+
+  afterAll(async () => {
+    rmSync(tempDir, { recursive: true, force: true });
+    await fixture.cleanup();
+    await teardownPgPools();
+  });
+
+  const dumpToFile = async (name: string): Promise<string> => {
+    const file = join(tempDir, name);
+    await pgDump({
+      config: source.config,
+      format: 'plain',
+      noOwner: true,
+      noPrivileges: true,
+      // Targets come from the same fixture, so they already carry the
+      // migration ledger; it is not what is under test here.
+      excludeSchemas: [...LEDGER_SCHEMAS],
+      file
+    });
+    return file;
+  };
+
+  it('does not restore as pg_dump emits it (the bug this guards)', async () => {
+    const dump = readFileSync(await dumpToFile('unpatched.sql'), 'utf8');
+    const target = await fixture.setupTestDatabase();
+    const { code, stderr } = await psqlRestore(target.config, dump);
+    expect(code).not.toBe(0);
+    expect(stderr).toMatch(/operator does not exist: extensions\.vector = extensions\.vector/);
+  });
+
+  it('restores with zero errors once the extension search_path is applied', async () => {
+    const file = await dumpToFile('patched.sql');
+    const schemas = await applyExtensionSearchPathToFile(source.config, file);
+    expect(schemas).toEqual([...schemas].sort());
+    expect(schemas).toContain('extensions');
+    expect(readFileSync(file, 'utf8')).toContain(
+      `SELECT pg_catalog.set_config('search_path', '${schemas.map(s => `"${s}"`).join(', ')}', false);`
+    );
+
+    const target = await fixture.setupTestDatabase();
+    const { code, stderr } = await psqlRestore(target.config, readFileSync(file, 'utf8'));
+    expect(stderr).toBe('');
+    expect(code).toBe(0);
+
+    const restored = await target.query(
+      `SELECT tgname FROM pg_trigger WHERE tgname = 'documents_embedding_changed'`
+    );
+    expect(restored.rows).toHaveLength(1);
+  });
+
+  it('reports the schemas its extensions actually live in', async () => {
+    expect(await getExtensionSchemas(source.config)).toEqual(['extensions', 'pg_catalog']);
+  });
+});

--- a/pgpm/core/__tests__/dump/search-path.test.ts
+++ b/pgpm/core/__tests__/dump/search-path.test.ts
@@ -1,0 +1,36 @@
+import {
+  EMPTY_SEARCH_PATH_STATEMENT,
+  rewriteSearchPathStatement
+} from '../../src/dump/search-path';
+
+const preamble = (body: string) =>
+  ['SET client_encoding = \'UTF8\';', body, 'SET row_security = off;'].join('\n');
+
+describe('rewriteSearchPathStatement', () => {
+  it('names the extension schemas in the order given', () => {
+    const out = rewriteSearchPathStatement(preamble(EMPTY_SEARCH_PATH_STATEMENT), [
+      'extensions',
+      'public'
+    ]);
+    expect(out).toContain(
+      'SELECT pg_catalog.set_config(\'search_path\', \'"extensions", "public"\', false);'
+    );
+    expect(out).not.toContain(EMPTY_SEARCH_PATH_STATEMENT);
+  });
+
+  it('quotes schema names that need it', () => {
+    const out = rewriteSearchPathStatement(preamble(EMPTY_SEARCH_PATH_STATEMENT), ['My Ext']);
+    expect(out).toContain('SELECT pg_catalog.set_config(\'search_path\', \'"My Ext"\', false);');
+  });
+
+  it('leaves the empty path alone when the database has no extensions', () => {
+    const dump = preamble(EMPTY_SEARCH_PATH_STATEMENT);
+    expect(rewriteSearchPathStatement(dump, [])).toBe(dump);
+  });
+
+  it('throws rather than emitting a dump it could not patch', () => {
+    expect(() =>
+      rewriteSearchPathStatement(preamble('SET search_path = public;'), ['public'])
+    ).toThrow(/does not contain the expected preamble/);
+  });
+});

--- a/pgpm/core/src/dump/search-path.ts
+++ b/pgpm/core/src/dump/search-path.ts
@@ -1,0 +1,75 @@
+/**
+ * Making a `pg_dump` artifact restorable when extension operators are in play.
+ *
+ * `pg_dump` opens every plain dump with
+ * `SELECT pg_catalog.set_config('search_path', '', false);` (CVE-2018-1058
+ * hardening). Types are schema-qualified in the dump body, but operators are
+ * not always qualifiable in the source SQL: a trigger's
+ * `WHEN (old.embedding IS DISTINCT FROM new.embedding)` resolves its `=`
+ * through `search_path`, and `IS DISTINCT FROM` has no `OPERATOR(schema.=)`
+ * form. With an empty path the restore dies with
+ * `operator does not exist: public.vector = public.vector`.
+ *
+ * The fix is to put back exactly the schemas the source database's extensions
+ * live in — nothing else, so no user schema re-enters the path and the
+ * hardening intent survives.
+ */
+import { readFileSync, writeFileSync } from 'fs';
+import { getPgPool } from 'pg-cache';
+import type { PgConfig } from 'pg-env';
+
+/** The preamble line `pg_dump` emits, and the one this module rewrites. */
+export const EMPTY_SEARCH_PATH_STATEMENT =
+  "SELECT pg_catalog.set_config('search_path', '', false);";
+
+/** The schemas the source database's extensions live in, sorted. */
+export const getExtensionSchemas = async (config: PgConfig): Promise<string[]> => {
+  const pool = getPgPool(config);
+  const res = await pool.query(
+    'SELECT DISTINCT n.nspname FROM pg_extension e JOIN pg_namespace n ON n.oid = e.extnamespace'
+  );
+  return res.rows.map((row: { nspname: string }) => String(row.nspname)).sort();
+};
+
+const searchPathLiteral = (schemas: string[]): string => {
+  const path = schemas.map(schema => `"${schema.replace(/"/g, '""')}"`).join(', ');
+  return `'${path.replace(/'/g, "''")}'`;
+};
+
+/**
+ * Replace the dump's empty-`search_path` preamble with one naming `schemas`.
+ *
+ * Throws when the preamble is missing: a dump whose format we no longer
+ * recognize must not be written out as if it had been patched.
+ * With no extensions there is nothing an operator lookup could need, so the
+ * empty path is already correct and the dump is returned untouched.
+ */
+export const rewriteSearchPathStatement = (dump: string, schemas: string[]): string => {
+  if (!dump.includes(EMPTY_SEARCH_PATH_STATEMENT)) {
+    throw new Error(
+      `pg_dump output does not contain the expected preamble ${EMPTY_SEARCH_PATH_STATEMENT} — ` +
+      'refusing to write a dump whose search_path was not made restorable; ' +
+      'the pg_dump output format has changed and pgpm must be updated'
+    );
+  }
+  if (schemas.length === 0) return dump;
+  const replacement = `SELECT pg_catalog.set_config('search_path', ${searchPathLiteral(schemas)}, false);`;
+  return dump.split(EMPTY_SEARCH_PATH_STATEMENT).join(replacement);
+};
+
+/** Make a captured dump restorable against `config`'s extension schemas. */
+export const applyExtensionSearchPath = async (
+  config: PgConfig,
+  dump: string
+): Promise<string> => rewriteSearchPathStatement(dump, await getExtensionSchemas(config));
+
+/** Same, for a dump `pg_dump` wrote to disk itself. */
+export const applyExtensionSearchPathToFile = async (
+  config: PgConfig,
+  file: string
+): Promise<string[]> => {
+  const schemas = await getExtensionSchemas(config);
+  const dump = readFileSync(file, 'utf8');
+  writeFileSync(file, rewriteSearchPathStatement(dump, schemas), 'utf8');
+  return schemas;
+};

--- a/pgpm/core/src/index.ts
+++ b/pgpm/core/src/index.ts
@@ -4,6 +4,7 @@ export * from './core/class/pgpm';
 export * from './core/template-scaffold';
 export * from './diff';
 export * from './dump/pg-dump';
+export * from './dump/search-path';
 export * from './extensions';
 export * from './modules/modules';
 export * from './packaging/check';


### PR DESCRIPTION
## Summary

`pgpm dump` now owns its restore contract: what it writes loads into a fresh database under `psql -v ON_ERROR_STOP=1`.

`pg_dump` opens every plain dump with `SELECT pg_catalog.set_config('search_path', '', false);`. Types in the body are schema-qualified, but a trigger's `WHEN (old.embedding IS DISTINCT FROM new.embedding)` resolves its `=` through `search_path` and has no `OPERATOR(schema.=)` form — so any pgvector-backed generated trigger dies on restore with `operator does not exist: extensions.vector = extensions.vector`. Downstream consumers (constructive-testing-seeds' `restoreExtensionOperators`) were patching the preamble themselves; that belongs here.

New `pgpm/core/src/dump/search-path.ts`, applied by the dump command in the same post-processing layer as the `--database-id` prune append (before it, so the prune section is never part of what gets rewritten):

```ts
const schemas = await getExtensionSchemas(config);
//   SELECT DISTINCT n.nspname FROM pg_extension e JOIN pg_namespace n ON n.oid = e.extnamespace  → sorted
rewriteSearchPathStatement(dump, schemas)
//   SELECT pg_catalog.set_config('search_path', '', false);
// → SELECT pg_catalog.set_config('search_path', '"extensions", "pg_catalog"', false);
```

Only the schemas the source's extensions actually live in — no hardcoded `public`, so no user schema re-enters the path and the CVE-2018-1058 intent survives. A missing preamble **throws** rather than writing a dump that was silently not made restorable; with zero extensions the empty path is already correct and the dump is returned untouched. Both entry points exist: `applyExtensionSearchPath(config, dump)` for captured output and `applyExtensionSearchPathToFile(config, file)` for what `pg_dump --file` wrote.

## Tests

`pgpm/core/__tests__/dump/restorable-dump.test.ts` builds the failing shape against a live PG 18 — `vector` installed into `extensions` (not `public`), a `vector(3)` column, a trigger `WHEN (old.embedding IS DISTINCT FROM new.embedding)` — and asserts both directions: the raw `pg_dump` output fails to restore with the operator error, and the patched dump restores with empty stderr and exit 0.

The restore pipes the dump into `psql` on **stdin**, because the version-matched client may live in a container where the runner's file path means nothing. CI's pg-tests step gains `PGPM_PSQL: docker exec -i … psql` alongside the existing `PGPM_PG_DUMP` (an 18-format dump uses `\restrict`, which older psql rejects). `checkPsql`'s doctor test now clears the client-alias env it resolves through, which that ambient alias would otherwise change.

Fix 3 of constructive-io/constructive-planning#1471.


Link to Devin session: https://app.devin.ai/sessions/f96871142fd147db8657f72c1398ff0e
Requested by: @pyramation