### PR TITLE
fix(export): revert metaschema snapshot changes

### DIFF
--- a/pgpm/export/__tests__/export-flow.test.ts
+++ b/pgpm/export/__tests__/export-flow.test.ts
@@ -835,6 +835,22 @@ relocatable = false
       expect(databaseContent).toContain('session_replication_role');
     });
 
+    it('should have created revert/migrate/*.sql files that delete the snapshot rows', () => {
+      const revertPath = join(exportWorkspaceDir, 'packages', META_EXTENSION_NAME, 'revert', 'migrate', 'database.sql');
+      expect(existsSync(revertPath)).toBe(true);
+
+      // metaschema_public.database is keyed by id; every other snapshot table
+      // is scoped by database_id. Without these DELETEs the change reverts to a
+      // no-op and a redeploy fails on the snapshot's own primary keys.
+      const revertContent = readFileSync(revertPath, 'utf-8');
+      expect(revertContent).toContain(`DELETE FROM "metaschema_public"."database" WHERE "id" = '${DATABASE_ID}'`);
+      expect(revertContent).toContain('session_replication_role');
+
+      const schemaRevertPath = join(exportWorkspaceDir, 'packages', META_EXTENSION_NAME, 'revert', 'migrate', 'schema.sql');
+      expect(readFileSync(schemaRevertPath, 'utf-8'))
+        .toContain(`DELETE FROM "metaschema_public"."schema" WHERE "database_id" = '${DATABASE_ID}'`);
+    });
+
     it('should have created control files for both modules', () => {
       const dbControlPath = join(exportWorkspaceDir, 'packages', EXTENSION_NAME, EXTENSION_NAME + '.control');
       const svcControlPath = join(exportWorkspaceDir, 'packages', META_EXTENSION_NAME, META_EXTENSION_NAME + '.control');

--- a/pgpm/export/src/export-graphql.ts
+++ b/pgpm/export/src/export-graphql.ts
@@ -14,12 +14,14 @@ import { Inquirerer } from 'inquirerer';
 
 import { exportGraphQLMeta } from './export-graphql-meta';
 import {
+  buildMetaRevertScript,
   DB_REQUIRED_EXTENSIONS,
   detectMissingModules,
   installMissingModules,
   makeReplacer,
   META_COMMON_FOOTER,
   META_COMMON_HEADER,
+  META_TABLE_CONFIG,
   META_TABLE_ORDER,
   normalizeOutdir,
   preparePackage,
@@ -336,7 +338,8 @@ export const exportGraphQL = async ({
 ${replacedSql}
 
 ${META_COMMON_FOOTER}
-`
+`,
+          revert: buildMetaRevertScript(tableName, META_TABLE_CONFIG[tableName], databaseId)
         });
 
         tablesWithContent.push(tableName);

--- a/pgpm/export/src/export-migrations.ts
+++ b/pgpm/export/src/export-migrations.ts
@@ -6,12 +6,14 @@ import { getPgPool } from 'pg-cache';
 
 import { exportMeta } from './export-meta';
 import {
+  buildMetaRevertScript,
   DB_REQUIRED_EXTENSIONS,
   detectMissingModules,
   installMissingModules,
   makeReplacer,
   META_COMMON_FOOTER,
   META_COMMON_HEADER,
+  META_TABLE_CONFIG,
   META_TABLE_ORDER,
   normalizeOutdir,
   preparePackage,
@@ -366,7 +368,8 @@ const exportMigrationsToDisk = async ({
 ${replacedSql}
 
 ${META_COMMON_FOOTER}
-`
+`,
+        revert: buildMetaRevertScript(tableName, META_TABLE_CONFIG[tableName], databaseId)
       });
 
       tablesWithContent.push(tableName);

--- a/pgpm/export/src/export-utils.ts
+++ b/pgpm/export/src/export-utils.ts
@@ -140,6 +140,32 @@ $LQLMIGRATION$;`;
 export const META_COMMON_FOOTER = `
 SET session_replication_role TO DEFAULT;`;
 
+/**
+ * Revert body for a `migrate/<table>` metaschema snapshot change: delete the
+ * exported database's rows from that table.
+ *
+ * The snapshot INSERTs every row belonging to `database_id` (keyed by `id` for
+ * `metaschema_public.database` itself), so the inverse is a database-scoped
+ * DELETE. Without it the change reverts to a no-op and a redeploy fails on the
+ * snapshot's own primary keys.
+ *
+ * Runs with `session_replication_role = replica` like the deploy body: FKs are
+ * unenforced, so the plan's reverse order is sufficient and no cascade fires.
+ */
+export const buildMetaRevertScript = (
+  key: string,
+  tableConfig: Pick<TableConfig, 'schema' | 'table'>,
+  database_id: string
+): string => {
+  const column = key === 'database' ? 'id' : 'database_id';
+  return `SET session_replication_role TO replica;
+
+DELETE FROM "${tableConfig.schema}"."${tableConfig.table}" WHERE "${column}" = '${database_id}';
+
+SET session_replication_role TO DEFAULT;
+`;
+};
+
 // =============================================================================
 // Shared types for table config
 // =============================================================================


### PR DESCRIPTION
## Summary

Every `migrate/<table>` change the exporter emits carried a deploy and **no revert**, so `writePgpmFiles` wrote a header-only revert script. Reverting an exported package therefore left the whole metaschema snapshot in place, and the next deploy died on the snapshot's own primary keys:

```
duplicate key value violates unique constraint "database_pkey"
```

The snapshot is `SELECT * FROM <schema>.<table> WHERE database_id = $1` (keyed by `id` for `metaschema_public.database` itself), so the inverse is the same database-scoped `DELETE`:

```sql
SET session_replication_role TO replica;

DELETE FROM "metaschema_public"."database" WHERE "id" = '<database_id>';

SET session_replication_role TO DEFAULT;
```

`buildMetaRevertScript(key, tableConfig, database_id)` in `export-utils.ts` builds it and both flows now pass it as `revert:` alongside `content:` — `export-migrations.ts` (SQL) and `export-graphql.ts` (GraphQL), which build `metaPackage` identically.

Replica mode matters: FKs are unenforced, so plan-reverse order alone is enough and no cascade fires between snapshot tables.

Downstream: `constructive-db`'s generated `application/constructive/revert/migrate/*.sql` are empty today and pick this up on the next `generate:constructive` once this is published.


Link to Devin session: https://app.devin.ai/sessions/37a60838adfb4fd6ac8c29f09c2e2827
Requested by: @pyramation