### PR TITLE
chore(pnpm): pin pnpm@10.34.5 and move pnpm.* settings to workspace/policy

### DIFF
--- a/.github/workflows/examples-integration.yaml
+++ b/.github/workflows/examples-integration.yaml
@@ -18,9 +18,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 10
+      - uses: pnpm/action-setup@v4
       - run: pnpm install
       - name: Build codegen and dependencies
         run: pnpm run build

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -59,9 +59,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -133,9 +131,7 @@ jobs:
         run: tar -xzf workspace.tar.gz && rm workspace.tar.gz
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -179,9 +175,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -294,9 +288,7 @@ jobs:
           git config --global user.email "ci@example.com"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -416,9 +408,7 @@ jobs:
           git config --global user.email "ci@example.com"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -502,9 +492,7 @@ jobs:
           git config --global user.email "ci@example.com"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "constructive",
   "version": "2.0.0",
+  "packageManager": "pnpm@10.34.5",
   "author": "Constructive <developers@constructive.io>",
   "private": true,
   "repository": {
@@ -54,39 +55,5 @@
   },
   "overrides": {
     "graphql": "^16.9.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "grafast": "1.1.1",
-      "grafserv": "1.0.1",
-      "graphile-build": "5.1.1",
-      "graphile-build-pg": "5.1.3",
-      "graphile-config": "1.1.0",
-      "graphile-utils": "5.0.3",
-      "postgraphile": "5.1.3",
-      "pg-sql2": "5.0.1",
-      "pg-introspection": "1.0.1",
-      "tamedevil": "0.1.1",
-      "@dataplan/pg": "1.1.1",
-      "@dataplan/json": "1.0.1",
-      "@graphile/lru": "5.0.0",
-      "@graphile-contrib/pg-many-to-many": "2.0.0-rc.2",
-      "graphql": "16.13.0",
-      "@smithy/node-http-handler": "<4.5.0"
-    },
-    "publicHoistPattern": [
-      "@jest/test-sequencer"
-    ],
-    "packageExtensions": {
-      "jest-config@*": {
-        "dependencies": {
-          "@jest/test-sequencer": "^29.7.0"
-        }
-      }
-    },
-    "onlyBuiltDependencies": [
-      "@launchql/protobufjs",
-      "core-js-pure"
-    ]
   }
 }

--- a/pnpm-policy.yaml
+++ b/pnpm-policy.yaml
@@ -60,7 +60,9 @@ intersect: true
 # nx, protobufjs and unrs-resolver install without their scripts and the build
 # works. An install script is arbitrary code at install time, so each addition is
 # a deliberate decision and the value is the reason.
-allowBuilds: []
+allowBuilds:
+  '@launchql/protobufjs': true
+  core-js-pure: true
 
 # Escape hatch for third-party packages that cannot wait — an urgent security
 # release, typically. A reason is required, and `until` makes the waiver expire

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -77,3 +77,40 @@ minimumReleaseAgeExclude:
 
 # Off: transitive dependencies may resolve from git or a URL.
 blockExoticSubdeps: false
+
+# Moved from package.json `pnpm.*` — pnpm 11 no longer reads that field, and
+# pnpm 10 already honours these keys here, so this works on both majors.
+
+# The Graphile v5 stack is resolved as a set: grafast, graphile-build* and
+# @dataplan/* must agree, and a second copy of graphql produces
+# "Cannot use GraphQLSchema from another module or realm" at runtime.
+overrides:
+  grafast: 1.1.1
+  grafserv: 1.0.1
+  graphile-build: 5.1.1
+  graphile-build-pg: 5.1.3
+  graphile-config: 1.1.0
+  graphile-utils: 5.0.3
+  postgraphile: 5.1.3
+  pg-sql2: 5.0.1
+  pg-introspection: 1.0.1
+  tamedevil: 0.1.1
+  '@dataplan/pg': 1.1.1
+  '@dataplan/json': 1.0.1
+  '@graphile/lru': 5.0.0
+  '@graphile-contrib/pg-many-to-many': 2.0.0-rc.2
+  graphql: 16.13.0
+  '@smithy/node-http-handler': <4.5.0
+
+publicHoistPattern:
+  - '@jest/test-sequencer'
+
+packageExtensions:
+  'jest-config@*':
+    dependencies:
+      '@jest/test-sequencer': ^29.7.0
+
+# The only dependencies permitted to run install scripts.
+allowBuilds:
+  "@launchql/protobufjs": true
+  core-js-pure: true


### PR DESCRIPTION
Part of standardising pnpm across the four platform repos. **This is the highest-risk of the set** — the ignored keys here are the whole Graphile v5 stack.

## The bug

pnpm 11 stopped reading the `pnpm` field in `package.json`:

```
[WARN] The "pnpm" field in package.json is no longer read by pnpm.
       The following keys were ignored: "pnpm.overrides"
```

It **warns, it does not fail** — the install exits 0 and all four key groups quietly stop applying:

| key | entries | what it holds |
|---|---|---|
| `overrides` | **16** | the Graphile v5 set + `graphql` single-copy + a `@smithy` pin |
| `publicHoistPattern` | 1 | `@jest/test-sequencer` hoist |
| `packageExtensions` | 1 | `jest-config` |
| `onlyBuiltDependencies` | 2 | `@launchql/protobufjs`, `core-js-pure` |

Two of the overrides are doing load-bearing work:

- **`graphql: 16.13.0`** — the single-copy guard. Two copies of `graphql` in one tree produce `Cannot use GraphQLSchema "[object GraphQLSchema]" from another module or realm` at runtime. grafast, graphile-build, graphile-build-pg and `@dataplan/*` are resolved *as a set* and break across minors.
- **`@smithy/node-http-handler: <4.5.0`** — a pin *away* from a known-bad release.

Nothing fails at install. It fails on the next re-resolution — a new dep, `pnpm up`, or `--no-frozen-lockfile` in an image build — and surfaces far from the cause.

This is not hypothetical: a local install on pnpm 11 in this repo produced a regenerated lockfile **with the `overrides:` block missing entirely**. The versions happened to still be right; the constraint was simply gone.

## What changed

- **`overrides` / `publicHoistPattern` / `packageExtensions` → `pnpm-workspace.yaml`.** pnpm 10 already honours them there (`constructive-db` runs this on 10.34.5), so it is correct today **and** forward-compatible with 11 — no flag day when we upgrade.
- **`onlyBuiltDependencies` → `pnpm-policy.yaml` `allowBuilds`,** regenerated via `pnpm-policy generate` rather than hand-edited, since that key is tool-managed.
- **`packageManager: pnpm@10.34.5`;** workflows `pnpm/action-setup@v2` → `v4` (7 call sites) and their `version: 10` removed.

On that last point: a bare `version: 10` floats to the newest 10.x **at run time**, so CI could move with no commit — and **v2 ignores `packageManager` entirely**, so local and CI had no way to agree. v4 reads `packageManager` when no `version` input is given, making it the single source of truth.

## The lockfile is deliberately untouched

`pnpm install --frozen-lockfile` passes against the committed lockfile with the new config, and its `overrides:` block is byte-identical — resolution is unchanged.

A full re-resolve additionally prunes ~1530 stale package entries (−7065 lines). That is real, but unrelated to this change and too large to bury in a version pin; worth its own PR.

## Verification

```
$ pnpm --version
10.34.5
$ pnpm pnpm-policy check
pnpm-workspace.yaml matches the policy
$ pnpm install --frozen-lockfile --lockfile-only
Scope: all 118 workspace projects
Done in 261ms using pnpm v10.34.5
```

The lockfile records all 16 overrides plus a `packageExtensionsChecksum`, so the pins are demonstrably **in force**, not merely present. Both edited workflows validated as parsing YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6watrJsLurfsr3uhnqibB