### PR TITLE
chore(fixtures): bump the pinned pgpm fixture modules to the capabilities release

### DIFF
--- a/pgpm.json
+++ b/pgpm.json
@@ -3,16 +3,16 @@
     "testing/*"
   ],
   "dependencies": {
-    "@constructive-db/apps": "5.0.0",
-    "@constructive-db/catalog": "5.0.0",
-    "@constructive-db/routing": "6.0.0",
-    "@constructive-db/routing-platform": "5.0.0",
-    "@pgpm/database-jobs": "0.33.1",
-    "@pgpm/function-resolution": "0.33.1",
-    "@pgpm/jwt-claims": "0.33.0",
-    "@pgpm/metaschema-modules": "0.33.1",
-    "@pgpm/metaschema-schema": "0.33.1",
-    "@pgpm/stamps": "0.33.0",
-    "@pgpm/uuid": "0.33.0"
+    "@constructive-db/apps": "5.1.0",
+    "@constructive-db/catalog": "5.1.0",
+    "@constructive-db/routing": "6.1.0",
+    "@constructive-db/routing-platform": "5.1.0",
+    "@pgpm/database-jobs": "0.41.0",
+    "@pgpm/function-resolution": "0.41.0",
+    "@pgpm/jwt-claims": "0.41.0",
+    "@pgpm/metaschema-modules": "0.41.0",
+    "@pgpm/metaschema-schema": "0.41.0",
+    "@pgpm/stamps": "0.41.0",
+    "@pgpm/uuid": "0.41.0"
   }
 }


### PR DESCRIPTION
## Summary

The integration suites that seed with `seed.pgpm(repoRoot)` (`graphql/server-test`, `graphql/playwright-test`, `graphile/graphile-function-bindings`) deploy the **published** modules pinned in the root `pgpm.json`, not local SQL. Those pins were still pre-rename, so every one of those tests was exercising the old `permissions`-era platform schema even though the renamed modules are published.

```diff
-"@constructive-db/apps": "5.0.0",        +"5.1.0"
-"@constructive-db/catalog": "5.0.0",     +"5.1.0"
-"@constructive-db/routing": "6.0.0",     +"6.1.0"
-"@constructive-db/routing-platform": "5.0.0", +"5.1.0"
-"@pgpm/*": "0.33.x"                      +"0.41.0"
```

Verified after `pnpm fixtures:install`: the installed `@pgpm/metaschema-modules` DDL now carries `capabilit*` columns, and both DB-backed suites are green — `graphql/server-test` 152/152, `graphile/graphile-function-bindings` 22/22.


Link to Devin session: https://app.devin.ai/sessions/8f89acc9280e4cef880921d966e0e8fc
Requested by: @pyramation