### PR TITLE
feat(node-type-registry): mark all task-identifier fields as function-ref

### DIFF
--- a/packages/node-type-registry/src/data/search-unified.ts
+++ b/packages/node-type-registry/src/data/search-unified.ts
@@ -166,6 +166,7 @@ export const SearchUnified: NodeTypeDefinition = {
               },
               chunking_task_name: {
                 type: 'string',
+                format: 'function-ref',
                 description: 'Task identifier for the chunking job queue',
                 default: 'embedding:generate_chunks'
               }

--- a/packages/node-type-registry/src/process/chunks.ts
+++ b/packages/node-type-registry/src/process/chunks.ts
@@ -136,6 +136,7 @@ export const ProcessChunks: NodeTypeDefinition = {
       },
       chunking_task_name: {
         type: 'string',
+        format: 'function-ref',
         description: 'Task identifier for the chunking job queue',
         default: 'embedding:generate_chunks'
       }

--- a/packages/node-type-registry/src/process/extraction.ts
+++ b/packages/node-type-registry/src/process/extraction.ts
@@ -71,6 +71,7 @@ export const ProcessExtraction: NodeTypeDefinition = {
       // ── Job routing ───────────────────────────────────────────────
       task_identifier: {
         type: 'string',
+        format: 'function-ref',
         description: 'Job task identifier for the extraction worker',
         default: 'document:extract_file_text'
       },

--- a/packages/node-type-registry/src/process/file-embedding.ts
+++ b/packages/node-type-registry/src/process/file-embedding.ts
@@ -77,6 +77,7 @@ export const ProcessFileEmbedding: NodeTypeDefinition = {
       // ── Job routing ────────────────────────────────────────────────
       task_identifier: {
         type: 'string',
+        format: 'function-ref',
         description:
           'Job task identifier for the worker. In direct mode this is the ' +
           'embedding worker; in extract mode this is the extraction worker.',
@@ -252,6 +253,7 @@ export const ProcessFileEmbedding: NodeTypeDefinition = {
           },
           chunking_task_name: {
             type: 'string',
+            format: 'function-ref',
             description: 'Task identifier for the chunking job queue',
             default: 'embedding:generate_chunks'
           }

--- a/packages/node-type-registry/src/process/image-embedding.ts
+++ b/packages/node-type-registry/src/process/image-embedding.ts
@@ -85,6 +85,7 @@ export const ProcessImageEmbedding: NodeTypeDefinition = {
       // ── Job routing ────────────────────────────────────────────────
       task_identifier: {
         type: 'string',
+        format: 'function-ref',
         description: 'Job task identifier for the image embedding worker',
         default: 'embedding:process_image_embedding'
       },
@@ -187,7 +188,7 @@ export const ProcessImageEmbedding: NodeTypeDefinition = {
           },
           metadata_fields: { type: 'object' },
           enqueue_chunking_job: { type: 'boolean', default: true },
-          chunking_task_name: { type: 'string', default: 'embedding:generate_chunks' }
+          chunking_task_name: { type: 'string', format: 'function-ref', default: 'embedding:generate_chunks' }
         }
       }
     }

--- a/packages/node-type-registry/src/process/image-versions.ts
+++ b/packages/node-type-registry/src/process/image-versions.ts
@@ -87,6 +87,7 @@ export const ProcessImageVersions: NodeTypeDefinition = {
       // ── Job routing ───────────────────────────────────────────────
       task_identifier: {
         type: 'string',
+        format: 'function-ref',
         description: 'Job task identifier for the image processing worker',
         default: 'image:process_image_versions'
       },


### PR DESCRIPTION
## Summary
Only 3 of the ~11 task-identifier fields in the node-type registry carried `format: 'function-ref'` (`JobTrigger.task_identifier`, `SearchVector.job_task_name` + its nested `chunking_task_name`). This annotates the rest so a schema-driven UI can render a function picker uniformly (groundwork for the Triggers/Source UI plan, constructive-planning#1559):

- `ProcessExtraction.task_identifier`
- `ProcessFileEmbedding.task_identifier` + nested `chunks.chunking_task_name`
- `ProcessImageEmbedding.task_identifier` + nested `chunks.chunking_task_name`
- `ProcessImageVersions.task_identifier`
- `ProcessChunks.chunking_task_name`
- `SearchUnified` nested `vector.chunks.chunking_task_name`

Purely annotative — no generator behavior reads `format`. `blueprint-types.generated.ts` untouched: regenerating it produced only section reordering (its committed order is stale relative to `src/`), and format annotations don't affect the emitted TS types.

Mirrored in constructive-io/constructive-db (same source files, plus its regenerated SQL seed/fixture/bundle).

Link to Devin session: https://app.devin.ai/sessions/a57b6055309d4a50a24aaeee9c3b2399
Requested by: @pyramation