### PR TITLE
Add temporary scoped Graphile introspection

### DIFF
--- a/graphile/graphile-settings/README.md
+++ b/graphile/graphile-settings/README.md
@@ -40,6 +40,11 @@ const preset = {
     makePgService({
       connectionString: 'postgres://user:pass@localhost/mydb',
       schemas: ['app_public'],
+      // Temporary until Graphile's progressive introspection is available.
+      introspectionMode: 'scoped-required',
+      introspectionScopedCatalogTypes: 'dependency-closure',
+      // Retire only the exact connection used for the catalog query.
+      introspectionClientReleaseMode: 'destroy',
     }),
   ],
 };
@@ -51,6 +56,13 @@ const httpServer = require('http').createServer(app);
 serv.addTo(app, httpServer);
 httpServer.listen(5000);
 ```
+
+Scoped introspection is an explicit, temporary compatibility seam. It fails
+closed when a required schema is missing, when dependency closure crosses an
+unapproved schema, or when an adaptor cannot prove it owns the exact client
+requested for destruction. Runtime request connections keep their normal pool
+reuse behavior. This seam should be removed after migrating to Graphile's
+progressive introspection support.
 
 ## Features
 

--- a/graphile/graphile-settings/__tests__/introspection-client-release.test.ts
+++ b/graphile/graphile-settings/__tests__/introspection-client-release.test.ts
@@ -1,0 +1,263 @@
+import { withPgClientFromPgService } from '@dataplan/pg';
+import { makeSchema } from 'graphile-build';
+import { Pool } from 'pg';
+
+import { assertIntrospectionClientReleaseCapabilities } from '../src/introspection-client-release';
+import { MinimalPreset } from '../src/plugins';
+
+type TestWithPgClient = {
+  <T>(
+    pgSettings: Record<string, string | undefined> | null,
+    callback: (client: { rawClient: unknown }) => T | Promise<T>,
+    options?: { clientReleaseMode?: 'reuse' | 'destroy' }
+  ): Promise<T>;
+  supportedClientReleaseModes?: readonly ('reuse' | 'destroy')[];
+};
+
+const {
+  makePgAdaptorWithPgClient,
+  makeWithPgClientViaPgClientAlreadyInTransaction,
+} = require('@dataplan/pg/adaptors/pg') as {
+  makePgAdaptorWithPgClient(pool: unknown): TestWithPgClient;
+  makeWithPgClientViaPgClientAlreadyInTransaction(
+    client: unknown
+  ): TestWithPgClient;
+};
+
+const { makePgService: makePostGraphilePgService } =
+  require('postgraphile/adaptors/pg') as {
+    makePgService(options: Record<string, unknown>): Record<string, unknown>;
+  };
+
+const makeRawClient = () => ({
+  query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+  release: jest.fn(),
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+});
+
+const makeNodePostgresPool = (rawClient: ReturnType<typeof makeRawClient>) => {
+  const pool = Object.create(Pool.prototype) as Pool & {
+    connect: jest.Mock;
+  };
+  pool.connect = jest.fn().mockResolvedValue(rawClient);
+  return pool;
+};
+
+describe('published dependency capability gate', () => {
+  const supported = {
+    dataplanPg: 'dataplan-pg-exact-client-destroy-v1',
+    graphileBuildPg: 'graphile-build-pg-exact-client-destroy-v1',
+  };
+
+  it('allows reuse without patched downstream dependencies', () => {
+    expect(() =>
+      assertIntrospectionClientReleaseCapabilities('reuse', {
+        dataplanPg: undefined,
+        graphileBuildPg: undefined,
+      })
+    ).not.toThrow();
+  });
+
+  it('requires both exact destroy protocol capabilities', () => {
+    expect(() =>
+      assertIntrospectionClientReleaseCapabilities('destroy', supported)
+    ).not.toThrow();
+    expect(() =>
+      assertIntrospectionClientReleaseCapabilities('destroy', {
+        ...supported,
+        dataplanPg: undefined,
+      })
+    ).toThrow('GRAPHILE_INTROSPECTION_CLIENT_DESTROY_UNSUPPORTED:@dataplan/pg');
+    expect(() =>
+      assertIntrospectionClientReleaseCapabilities('destroy', {
+        ...supported,
+        graphileBuildPg: undefined,
+      })
+    ).toThrow(
+      'GRAPHILE_INTROSPECTION_CLIENT_DESTROY_UNSUPPORTED:graphile-build-pg'
+    );
+  });
+});
+
+describe('per-use PostgreSQL client release mode', () => {
+  it('destroys the exact successful checkout once', async () => {
+    const rawClient = makeRawClient();
+    const pool = makeNodePostgresPool(rawClient);
+    const withPgClient = makePgAdaptorWithPgClient(pool as never);
+
+    expect(withPgClient.supportedClientReleaseModes).toEqual([
+      'reuse',
+      'destroy',
+    ]);
+    await expect(
+      withPgClient(null, async (client) => client.rawClient, {
+        clientReleaseMode: 'destroy',
+      })
+    ).resolves.toBe(rawClient);
+
+    expect(pool.connect).toHaveBeenCalledTimes(1);
+    expect(rawClient.release.mock.calls).toEqual([[true]]);
+  });
+
+  it('destroys the exact failed checkout once', async () => {
+    const marker = new Error('callback failed');
+    const rawClient = makeRawClient();
+    const pool = makeNodePostgresPool(rawClient);
+    const withPgClient = makePgAdaptorWithPgClient(pool as never);
+
+    await expect(
+      withPgClient(
+        null,
+        async () => {
+          throw marker;
+        },
+        { clientReleaseMode: 'destroy' }
+      )
+    ).rejects.toBe(marker);
+
+    expect(pool.connect).toHaveBeenCalledTimes(1);
+    expect(rawClient.release.mock.calls).toEqual([[true]]);
+  });
+
+  it('destroys the exact checkout when first-use setup throws synchronously', async () => {
+    const marker = new Error('client setup failed');
+    const rawClient = makeRawClient();
+    rawClient.query.mockImplementationOnce(() => {
+      throw marker;
+    });
+    const pool = makeNodePostgresPool(rawClient);
+    const callback = jest.fn();
+    const withPgClient = makePgAdaptorWithPgClient(pool as never);
+
+    await expect(
+      withPgClient(null, callback, { clientReleaseMode: 'destroy' })
+    ).rejects.toBe(marker);
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(pool.connect).toHaveBeenCalledTimes(1);
+    expect(rawClient.release.mock.calls).toEqual([[true]]);
+  });
+
+  it('rejects destroy mode for a structurally compatible custom pool', async () => {
+    const rawClient = makeRawClient();
+    const pool = { connect: jest.fn().mockResolvedValue(rawClient) };
+    const callback = jest.fn();
+    const withPgClient = makePgAdaptorWithPgClient(pool as never);
+
+    expect(withPgClient.supportedClientReleaseModes).toEqual(['reuse']);
+    await expect(
+      withPgClient(null, callback, { clientReleaseMode: 'destroy' })
+    ).rejects.toThrow(
+      'Exact PostgreSQL client destruction requires a node-postgres Pool'
+    );
+
+    expect(pool.connect).not.toHaveBeenCalled();
+    expect(callback).not.toHaveBeenCalled();
+    expect(rawClient.release).not.toHaveBeenCalled();
+  });
+
+  it('reuses the exact checkout once by default', async () => {
+    const rawClient = makeRawClient();
+    const pool = makeNodePostgresPool(rawClient);
+    const withPgClient = makePgAdaptorWithPgClient(pool as never);
+
+    await withPgClient(null, async (client) => client.rawClient);
+
+    expect(pool.connect).toHaveBeenCalledTimes(1);
+    expect(rawClient.release.mock.calls).toEqual([[]]);
+  });
+
+  it('fails closed before invoking an adaptor that does not advertise destruction', async () => {
+    const callback = jest.fn();
+    const originalWithPgClient = Object.assign(
+      jest.fn(async (): Promise<void> => undefined),
+      { release: jest.fn() }
+    );
+    const service = {
+      name: 'unsupported-adaptor',
+      adaptor: {
+        createWithPgClient: jest.fn().mockReturnValue(originalWithPgClient),
+      },
+    };
+
+    await expect(
+      withPgClientFromPgService(service as never, null, callback, {
+        clientReleaseMode: 'destroy',
+      })
+    ).rejects.toThrow(
+      "PostgreSQL service 'unsupported-adaptor' does not support exact client destruction"
+    );
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(originalWithPgClient).not.toHaveBeenCalled();
+  });
+
+  it('refuses to destroy a caller-owned client', async () => {
+    const callback = jest.fn();
+    const rawClient = makeRawClient();
+    const withPgClient = makeWithPgClientViaPgClientAlreadyInTransaction(
+      rawClient as never
+    );
+
+    expect(withPgClient.supportedClientReleaseModes).toEqual(['reuse']);
+    await expect(
+      withPgClient(null, callback, { clientReleaseMode: 'destroy' })
+    ).rejects.toThrow('Cannot destroy a caller-owned PostgreSQL client');
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(rawClient.release).not.toHaveBeenCalled();
+  });
+});
+
+describe('introspection client release forwarding', () => {
+  it.each([
+    ['destroy', 'destroy', [[true]]],
+    ['default reuse', undefined, [[]]],
+  ] as const)(
+    'uses %s for the introspection checkout',
+    async (_label, clientReleaseMode, expectedReleaseCalls) => {
+      const marker = new Error('captured introspection query');
+      let sawIntrospection = false;
+      const rawClient = makeRawClient();
+      rawClient.query.mockImplementation(
+        async (query: string | { text: string }) => {
+          if (
+            typeof query === 'object' &&
+            query.text.includes('requested_schema_names')
+          ) {
+            sawIntrospection = true;
+            throw marker;
+          }
+          return { rows: [], rowCount: 0 };
+        }
+      );
+      const pool = makeNodePostgresPool(rawClient);
+
+      await expect(
+        makeSchema({
+          extends: [MinimalPreset],
+          pgServices: [
+            Object.assign(
+              makePostGraphilePgService({
+                pool: pool as never,
+                pubsub: false,
+                schemas: ['tenant_a'],
+              }),
+              {
+                introspectionMode: 'scoped-required',
+                ...(clientReleaseMode === undefined
+                  ? {}
+                  : { introspectionClientReleaseMode: clientReleaseMode }),
+              }
+            ) as never,
+          ],
+        })
+      ).rejects.toBe(marker);
+
+      expect(sawIntrospection).toBe(true);
+      expect(pool.connect).toHaveBeenCalledTimes(1);
+      expect(rawClient.release.mock.calls).toEqual(expectedReleaseCalls);
+    }
+  );
+});

--- a/graphile/graphile-settings/__tests__/make-pg-service.test.ts
+++ b/graphile/graphile-settings/__tests__/make-pg-service.test.ts
@@ -1,0 +1,47 @@
+import {
+  normalizeIntrospectionDependencySchemas,
+  resolveIntrospectionSettings,
+} from '../src/introspection-settings';
+
+describe('resolveIntrospectionSettings', () => {
+  it('disables JIT only for scoped introspection', () => {
+    const scoped = resolveIntrospectionSettings('scoped-required', {
+      statement_timeout: '5000',
+      jit: 'on',
+      work_mem: '16MB',
+    });
+    const stock = resolveIntrospectionSettings('stock', {
+      statement_timeout: '5000',
+    });
+    const defaultBound = resolveIntrospectionSettings('stock', undefined);
+
+    expect(scoped).toEqual({
+      statement_timeout: '5000',
+      jit: 'off',
+      work_mem: '512kB',
+    });
+    expect(stock).toEqual({ statement_timeout: '5000' });
+    expect(defaultBound).toEqual({ statement_timeout: '120s' });
+  });
+});
+
+describe('normalizeIntrospectionDependencySchemas', () => {
+  it('preserves lookup order while trimming and deduplicating', () => {
+    expect(
+      normalizeIntrospectionDependencySchemas([
+        ' extensions ',
+        'shared_api',
+        'extensions',
+      ])
+    ).toEqual(['extensions', 'shared_api']);
+  });
+
+  it.each(['pg_catalog', 'pg_toast', 'information_schema'])(
+    'rejects system dependency schema %s',
+    (schema) => {
+      expect(() => normalizeIntrospectionDependencySchemas([schema])).toThrow(
+        'must not be a system schema'
+      );
+    }
+  );
+});

--- a/graphile/graphile-settings/__tests__/scoped-introspection-cache-lifecycle.test.ts
+++ b/graphile/graphile-settings/__tests__/scoped-introspection-cache-lifecycle.test.ts
@@ -1,0 +1,221 @@
+import { watchGather } from 'graphile-build';
+import { PgIntrospectionPlugin } from 'graphile-build-pg';
+import type { GraphileConfig } from 'graphile-config';
+
+const SCHEMA = 'tenant_a';
+
+const introspectionText = JSON.stringify({
+  database: { datdba: '10', datacl: null },
+  namespaces: [
+    {
+      _id: '2200',
+      oid: '2200',
+      nspname: SCHEMA,
+      nspowner: '10',
+      nspacl: null,
+    },
+  ],
+  classes: [],
+  attributes: [],
+  constraints: [],
+  procs: [],
+  roles: [
+    {
+      _id: '10',
+      oid: '10',
+      rolname: 'postgres',
+      rolsuper: true,
+      rolinherit: true,
+      rolcreaterole: true,
+      rolcreatedb: true,
+      rolcanlogin: true,
+      rolreplication: true,
+      rolconnlimit: -1,
+      rolpassword: null,
+      rolvaliduntil: null,
+      rolbypassrls: true,
+      rolconfig: null,
+    },
+  ],
+  auth_members: [],
+  types: [],
+  enums: [],
+  extensions: [],
+  indexes: [],
+  languages: [],
+  ranges: [],
+  depends: [],
+  descriptions: [],
+  inherits: [],
+  am: [],
+  catalog_by_oid: {
+    2615: 'pg_namespace',
+    1259: 'pg_class',
+    1255: 'pg_proc',
+    1247: 'pg_type',
+    2606: 'pg_constraint',
+    3079: 'pg_extension',
+  },
+  current_user: 'postgres',
+  server_version_num: 180004,
+});
+const missingSchemaIntrospectionText = JSON.stringify({
+  ...JSON.parse(introspectionText),
+  namespaces: [],
+});
+
+interface GatherResult {
+  input: Record<string, unknown> | null;
+  error?: Error;
+}
+
+function makeResultQueue() {
+  const queued: GatherResult[] = [];
+  const waiters: Array<(result: GatherResult) => void> = [];
+
+  return {
+    push(result: GatherResult) {
+      const waiter = waiters.shift();
+      if (waiter) waiter(result);
+      else queued.push(result);
+    },
+    next(): Promise<GatherResult> {
+      const result = queued.shift();
+      if (result) return Promise.resolve(result);
+      return new Promise((resolve) => waiters.push(resolve));
+    },
+  };
+}
+
+describe('scoped introspection raw-text lifecycle', () => {
+  it('releases raw text, re-queries fresh data, and fails closed on regather errors', async () => {
+    let cache: { introspectionResultsPromise: Promise<unknown> | null } | null =
+      null;
+    let triggerRegather: (() => void) | null = null;
+    let queryError: Error | null = null;
+    let nextIntrospectionText = introspectionText;
+    const seenNamespaceNames: string[] = [];
+    const query = jest.fn(async () => {
+      if (queryError) {
+        const error = queryError;
+        queryError = null;
+        throw error;
+      }
+      return { rows: [{ introspection: nextIntrospectionText }] };
+    });
+    const withPgClient = Object.assign(
+      async (
+        _settings: Record<string, string> | null,
+        callback: (client: { query: typeof query }) => unknown
+      ) => callback({ query }),
+      { release: jest.fn() }
+    );
+    const adaptor = {
+      createWithPgClient: jest.fn(async () => withPgClient),
+    };
+
+    const originalGather = PgIntrospectionPlugin.gather!;
+    const capturingIntrospectionPlugin = {
+      ...PgIntrospectionPlugin,
+      gather: {
+        ...originalGather,
+        initialCache(info: never) {
+          cache = originalGather.initialCache!(info) as typeof cache;
+          return cache;
+        },
+        // A deterministic test trigger drives the same persistent gather cache
+        // without needing a live LISTEN/NOTIFY subscriber.
+        watch: undefined,
+      },
+    } as unknown as GraphileConfig.Plugin;
+    const observerPlugin = {
+      name: 'ScopedIntrospectionCacheObserverPlugin',
+      gather: {
+        namespace: 'scopedIntrospectionCacheObserver',
+        async main(output: Record<string, unknown>, info: any) {
+          const [result] =
+            await info.helpers.pgIntrospection.getIntrospection();
+          const namespace = result.introspection.namespaces[0];
+          seenNamespaceNames.push(namespace.nspname);
+          output.namespaceName = namespace.nspname;
+          // Graphile plugins may mutate their gather-local parsed graph. A later
+          // gather must never observe this mutation.
+          namespace.nspname = 'mutated_by_plugin';
+        },
+        watch(_info: never, callback: () => void) {
+          triggerRegather = callback;
+          return (): void => undefined;
+        },
+      },
+    } as unknown as GraphileConfig.Plugin;
+    const pgService = {
+      name: 'main',
+      schemas: [SCHEMA],
+      introspectionMode: 'scoped-required',
+      introspectionAllowedDependencySchemas: [] as readonly string[],
+      adaptor,
+      adaptorSettings: {},
+      withPgClientKey: 'withPgClient',
+      pgSettingsKey: 'pgSettings',
+    };
+    const results = makeResultQueue();
+
+    const stopWatching = await watchGather(
+      {
+        plugins: [capturingIntrospectionPlugin, observerPlugin],
+        pgServices: [pgService as never],
+      },
+      undefined,
+      (input, error) => {
+        results.push({
+          input: input as unknown as Record<string, unknown> | null,
+          error: error as Error | undefined,
+        });
+      }
+    );
+
+    try {
+      const first = await results.next();
+      expect(first.error).toBeUndefined();
+      expect(first.input).toMatchObject({ namespaceName: SCHEMA });
+      expect(query).toHaveBeenCalledTimes(1);
+      expect(cache!.introspectionResultsPromise).toBeNull();
+
+      triggerRegather!();
+      const second = await results.next();
+      expect(second.error).toBeUndefined();
+      expect(second.input).toMatchObject({ namespaceName: SCHEMA });
+      expect(query).toHaveBeenCalledTimes(2);
+      expect(seenNamespaceNames).toEqual([SCHEMA, SCHEMA]);
+      expect(cache!.introspectionResultsPromise).toBeNull();
+
+      nextIntrospectionText = missingSchemaIntrospectionText;
+      triggerRegather!();
+      const invalid = await results.next();
+      expect(invalid.input).toBeNull();
+      expect(invalid.error?.message).toContain(
+        `did not find required schema(s): ${SCHEMA}`
+      );
+      expect(query).toHaveBeenCalledTimes(3);
+      expect(cache!.introspectionResultsPromise).toBeNull();
+
+      nextIntrospectionText = introspectionText;
+      triggerRegather!();
+      const recovered = await results.next();
+      expect(recovered.error).toBeUndefined();
+      expect(recovered.input).toMatchObject({ namespaceName: SCHEMA });
+      expect(query).toHaveBeenCalledTimes(4);
+
+      const marker = new Error('scoped introspection re-query failed');
+      queryError = marker;
+      triggerRegather!();
+      const failed = await results.next();
+      expect(failed.input).toBeNull();
+      expect(failed.error).toBe(marker);
+      expect(query).toHaveBeenCalledTimes(5);
+      expect(cache!.introspectionResultsPromise).toBeNull();
+    } finally {
+      stopWatching();
+    }
+  });
+});

--- a/graphile/graphile-settings/__tests__/scoped-introspection-runtime.test.ts
+++ b/graphile/graphile-settings/__tests__/scoped-introspection-runtime.test.ts
@@ -1,0 +1,148 @@
+import { makeSchema } from 'graphile-build';
+
+import { MinimalPreset } from '../src/plugins';
+
+const { makePgService: makePostGraphilePgService } =
+  require('postgraphile/adaptors/pg') as {
+    makePgService(options: Record<string, unknown>): Record<string, unknown>;
+  };
+
+describe('schema-scoped introspection runtime integration', () => {
+  it.each([
+    ['all catalog types by default', undefined, true],
+    ['dependency-closure catalog types', 'dependency-closure', false],
+  ] as const)(
+    'executes the parameterized scoped query with %s',
+    async (_label, scopedCatalogTypes, retainsAllCatalogTypes) => {
+      const marker = new Error('captured introspection query');
+      let captured: { text: string; values?: unknown[] } | null = null;
+      const client = {
+        query: jest.fn(
+          async (query: string | { text: string; values?: unknown[] }) => {
+            if (typeof query === 'string') return { rows: [] as unknown[] };
+            captured = query;
+            throw marker;
+          }
+        ),
+        release: jest.fn(),
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+      };
+      const pool = {
+        connect: jest.fn().mockResolvedValue(client),
+      };
+
+      await expect(
+        makeSchema({
+          extends: [MinimalPreset],
+          pgServices: [
+            Object.assign(
+              makePostGraphilePgService({
+                pool: pool as never,
+                schemas: ['tenant_a'],
+              }),
+              {
+                introspectionMode: 'scoped-required',
+                introspectionCapabilityExtensions: ['pg_trgm'],
+                ...(scopedCatalogTypes === undefined
+                  ? {}
+                  : { introspectionScopedCatalogTypes: scopedCatalogTypes }),
+              }
+            ) as never,
+          ],
+        })
+      ).rejects.toBe(marker);
+
+      expect(captured).not.toBeNull();
+      expect(captured!.text).toContain('requested_schema_names');
+      expect(captured!.text).not.toBe('select introspection');
+      expect(captured!.values).toEqual([['tenant_a'], ['pg_trgm']]);
+      expect(
+        captured!.text.includes(
+          "or pg_type.typnamespace = 'pg_catalog'::regnamespace"
+        )
+      ).toBe(retainsAllCatalogTypes);
+      expect(client.release).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it('fails closed when a retained entity references a missing type', async () => {
+    const introspection = JSON.stringify({
+      database: {},
+      namespaces: [
+        {
+          _id: '100',
+          nspname: 'tenant_a',
+          nspowner: '10',
+          nspacl: null,
+        },
+      ],
+      classes: [
+        {
+          _id: '200',
+          relname: 'broken_items',
+          relnamespace: '100',
+          reltype: '999',
+          reloftype: null,
+        },
+      ],
+      attributes: [],
+      constraints: [],
+      procs: [],
+      roles: [],
+      auth_members: [],
+      types: [],
+      enums: [],
+      extensions: [],
+      indexes: [],
+      inherits: [],
+      languages: [],
+      policies: [],
+      ranges: [],
+      depends: [],
+      descriptions: [],
+      am: [],
+      catalog_by_oid: {
+        1255: 'pg_proc',
+        1247: 'pg_type',
+        1259: 'pg_class',
+        2606: 'pg_constraint',
+        2615: 'pg_namespace',
+        3079: 'pg_extension',
+      },
+      current_user: 'runtime_role',
+      pg_version: 'PostgreSQL test fixture',
+      introspection_version: 1,
+    });
+    const client = {
+      query: jest.fn().mockResolvedValue({ rows: [{ introspection }] }),
+      release: jest.fn(),
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+    };
+    const pool = {
+      connect: jest.fn().mockResolvedValue(client),
+    };
+
+    await expect(
+      makeSchema({
+        extends: [MinimalPreset],
+        pgServices: [
+          Object.assign(
+            makePostGraphilePgService({
+              pool: pool as never,
+              schemas: ['tenant_a'],
+            }),
+            {
+              introspectionMode: 'scoped-required',
+              introspectionScopedCatalogTypes: 'dependency-closure',
+            }
+          ) as never,
+        ],
+      })
+    ).rejects.toThrow(
+      /service '.+' retained pg_class 'broken_items \(200\)' field 'reltype' referencing missing pg_type OID '999'/
+    );
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/graphile/graphile-settings/src/index.ts
+++ b/graphile/graphile-settings/src/index.ts
@@ -35,7 +35,15 @@
 import 'postgraphile/grafserv';
 import 'graphile-build';
 
-import { makePgService } from 'postgraphile/adaptors/pg';
+import { makePgService as makePostGraphilePgService } from 'postgraphile/adaptors/pg';
+
+import { assertIntrospectionClientReleaseCapabilities } from './introspection-client-release';
+import {
+  normalizeIntrospectionDependencySchemas,
+  resolveIntrospectionSettings,
+} from './introspection-settings';
+
+export * from './introspection-client-release';
 
 // ============================================================================
 // Re-export all plugins and presets
@@ -43,7 +51,10 @@ import { makePgService } from 'postgraphile/adaptors/pg';
 
 // Main preset + factory
 export type { ConstructivePresetOptions } from './presets/constructive-preset';
-export { ConstructivePreset, createConstructivePreset } from './presets/constructive-preset';
+export {
+  ConstructivePreset,
+  createConstructivePreset,
+} from './presets/constructive-preset';
 
 // Re-export all plugins for convenience
 export * from './plugins/index';
@@ -55,8 +66,119 @@ export * from './presets/index';
 // Utilities
 // ============================================================================
 
-// Re-export makePgService for convenience
-export { makePgService };
+export type ConstructivePgServiceOptions = Parameters<
+  typeof makePostGraphilePgService
+>[0] & {
+  introspectionMode?: 'stock' | 'scoped-required';
+  introspectionScopedCatalogTypes?: 'all' | 'dependency-closure';
+  introspectionAllowedDependencySchemas?: readonly string[];
+  introspectionCapabilityExtensions?: readonly string[];
+  introspectionClientReleaseMode?: 'reuse' | 'destroy';
+};
+
+const normalizeIntrospectionCapabilityExtensions = (
+  extensions: readonly string[] | undefined
+): readonly string[] => {
+  if (extensions === undefined) return [];
+  if (!Array.isArray(extensions)) {
+    throw new Error('introspectionCapabilityExtensions must be an array');
+  }
+  return [
+    ...new Set(
+      extensions.map((extension) => {
+        if (
+          typeof extension !== 'string' ||
+          extension.length === 0 ||
+          extension.trim() !== extension ||
+          extension.includes('\0')
+        ) {
+          throw new Error(
+            'introspectionCapabilityExtensions must contain exact non-empty extension names'
+          );
+        }
+        return extension;
+      })
+    ),
+  ];
+};
+
+/**
+ * Constructive's pgService factory adds the explicit catalog-introspection mode
+ * consumed by Graphile's gather phase.
+ */
+export const makePgService = (options: ConstructivePgServiceOptions) => {
+  const introspectionMode = options.introspectionMode ?? 'stock';
+  const introspectionScopedCatalogTypes =
+    options.introspectionScopedCatalogTypes;
+  const introspectionCapabilityExtensions =
+    normalizeIntrospectionCapabilityExtensions(
+      options.introspectionCapabilityExtensions
+    );
+  const introspectionClientReleaseMode =
+    options.introspectionClientReleaseMode ?? 'reuse';
+  if (
+    introspectionScopedCatalogTypes !== undefined &&
+    introspectionScopedCatalogTypes !== 'all' &&
+    introspectionScopedCatalogTypes !== 'dependency-closure'
+  ) {
+    throw new Error(
+      `Unsupported scoped catalog type policy '${introspectionScopedCatalogTypes}'`
+    );
+  }
+  if (
+    introspectionMode === 'stock' &&
+    introspectionScopedCatalogTypes !== undefined
+  ) {
+    throw new Error(
+      'introspectionScopedCatalogTypes requires scoped-required introspection'
+    );
+  }
+  if (
+    introspectionMode === 'stock' &&
+    options.introspectionCapabilityExtensions !== undefined
+  ) {
+    throw new Error(
+      'introspectionCapabilityExtensions requires scoped-required introspection'
+    );
+  }
+  if (
+    introspectionClientReleaseMode !== 'reuse' &&
+    introspectionClientReleaseMode !== 'destroy'
+  ) {
+    throw new Error(
+      `Unsupported introspection client release mode '${introspectionClientReleaseMode}'`
+    );
+  }
+  assertIntrospectionClientReleaseCapabilities(introspectionClientReleaseMode);
+  const introspectionAllowedDependencySchemas =
+    normalizeIntrospectionDependencySchemas(
+      options.introspectionAllowedDependencySchemas
+    );
+  const pgSettingsForIntrospection = resolveIntrospectionSettings(
+    introspectionMode,
+    options.pgSettingsForIntrospection
+  );
+  const service = makePostGraphilePgService({
+    ...options,
+    pgSettingsForIntrospection,
+  });
+  return Object.assign(service, {
+    introspectionMode,
+    ...(introspectionScopedCatalogTypes === undefined
+      ? {}
+      : { introspectionScopedCatalogTypes }),
+    introspectionAllowedDependencySchemas,
+    ...(introspectionMode === 'scoped-required'
+      ? { introspectionCapabilityExtensions }
+      : {}),
+    introspectionClientReleaseMode,
+  });
+};
+
+export {
+  normalizeIntrospectionDependencySchemas,
+  resolveIntrospectionSettings,
+} from './introspection-settings';
 
 // Presigned URL utilities
 export { getPresignedUrlS3Config } from './presigned-url-resolver';

--- a/graphile/graphile-settings/src/introspection-client-release.ts
+++ b/graphile/graphile-settings/src/introspection-client-release.ts
@@ -1,0 +1,49 @@
+import * as dataplanPg from '@dataplan/pg';
+import * as graphileBuildPg from 'graphile-build-pg';
+
+export type IntrospectionClientReleaseMode = 'reuse' | 'destroy';
+
+export interface IntrospectionClientReleaseCapabilities {
+  dataplanPg: unknown;
+  graphileBuildPg: unknown;
+}
+
+const REQUIRED_DATAPLAN_PG_RELEASE_CAPABILITY =
+  'dataplan-pg-exact-client-destroy-v1';
+const REQUIRED_GRAPHILE_BUILD_PG_RELEASE_CAPABILITY =
+  'graphile-build-pg-exact-client-destroy-v1';
+
+const runtimeIntrospectionClientReleaseCapabilities = Object.freeze({
+  dataplanPg: (dataplanPg as Record<string, unknown>)
+    .exactClientReleaseCapability,
+  graphileBuildPg: (graphileBuildPg as Record<string, unknown>)
+    .introspectionClientReleaseCapability,
+});
+
+/**
+ * Dependency patches do not propagate through a published package. Destroy
+ * mode is accepted only when both upstream seams advertise the exact protocol
+ * this package was tested against.
+ */
+export function assertIntrospectionClientReleaseCapabilities(
+  mode: IntrospectionClientReleaseMode,
+  capabilities: IntrospectionClientReleaseCapabilities = runtimeIntrospectionClientReleaseCapabilities
+): void {
+  if (mode === 'reuse') return;
+
+  const missing: string[] = [];
+  if (capabilities.dataplanPg !== REQUIRED_DATAPLAN_PG_RELEASE_CAPABILITY) {
+    missing.push('@dataplan/pg');
+  }
+  if (
+    capabilities.graphileBuildPg !==
+    REQUIRED_GRAPHILE_BUILD_PG_RELEASE_CAPABILITY
+  ) {
+    missing.push('graphile-build-pg');
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `GRAPHILE_INTROSPECTION_CLIENT_DESTROY_UNSUPPORTED:${missing.join(',')}`
+    );
+  }
+}

--- a/graphile/graphile-settings/src/introspection-settings.ts
+++ b/graphile/graphile-settings/src/introspection-settings.ts
@@ -1,0 +1,47 @@
+export type GraphileIntrospectionMode = 'stock' | 'scoped-required';
+
+export const DEFAULT_INTROSPECTION_STATEMENT_TIMEOUT = '120s';
+
+export const normalizeIntrospectionDependencySchemas = (
+  schemas: readonly string[] | null | undefined
+): string[] => [
+  ...new Set(
+    (schemas ?? []).map((schema) => {
+      if (typeof schema !== 'string' || schema.trim().length === 0) {
+        throw new Error(
+          'Introspection dependency schemas must be non-empty strings'
+        );
+      }
+      const normalized = schema.trim();
+      if (normalized === 'information_schema' || normalized.startsWith('pg_')) {
+        throw new Error(
+          `Introspection dependency schema '${normalized}' must not be a system schema`
+        );
+      }
+      if (normalized.includes('\0')) {
+        throw new Error(
+          'Introspection dependency schemas must not contain NUL bytes'
+        );
+      }
+      return normalized;
+    })
+  ),
+];
+
+export const resolveIntrospectionSettings = (
+  mode: GraphileIntrospectionMode,
+  settings: Record<string, string | undefined> | null | undefined
+): Record<string, string | undefined> => {
+  const boundedSettings = { ...settings };
+  if (!boundedSettings.statement_timeout) {
+    boundedSettings.statement_timeout = DEFAULT_INTROSPECTION_STATEMENT_TIMEOUT;
+  }
+  if (mode === 'scoped-required') {
+    return {
+      ...boundedSettings,
+      jit: 'off',
+      work_mem: '512kB',
+    };
+  }
+  return boundedSettings;
+};

--- a/graphql/server/package.json
+++ b/graphql/server/package.json
@@ -93,6 +93,7 @@
     "graphile-test": "workspace:*",
     "makage": "^0.3.0",
     "nodemon": "^3.1.14",
+    "pg-introspection": "1.0.1",
     "supertest": "^7.2.2",
     "ts-node": "^10.9.2"
   }

--- a/graphql/server/src/middleware/__tests__/scoped-introspection.test.ts
+++ b/graphql/server/src/middleware/__tests__/scoped-introspection.test.ts
@@ -1,0 +1,127 @@
+import { createHash } from 'node:crypto';
+
+import {
+  makeIntrospectionQuery,
+  makeSchemaScopedIntrospectionQuery,
+} from 'pg-introspection';
+
+const makeScopedQueryWithCatalogTypes =
+  makeSchemaScopedIntrospectionQuery as unknown as (
+    schemas: readonly string[],
+    options?: {
+      catalogTypes?: 'all' | 'dependency-closure';
+      capabilityExtensions?: readonly string[];
+    }
+  ) => ReturnType<typeof makeSchemaScopedIntrospectionQuery>;
+
+describe('schema-scoped PostgreSQL introspection', () => {
+  it('preserves the stock query byte for byte', () => {
+    const stock = makeIntrospectionQuery();
+    expect(stock).toHaveLength(7332);
+    expect(createHash('sha256').update(stock).digest('hex')).toBe(
+      'c0ed817b912f78e1ea68c70d89ff4b7f9cb4c02d88112a69ac4109d5b996e4c5'
+    );
+  });
+
+  it('keeps schema names in bind values and includes dependency closure', () => {
+    const schemas = ['tenant_a', "tenant_'quoted", 'tenant_a'];
+    const query = makeSchemaScopedIntrospectionQuery(schemas);
+
+    expect(query.values).toEqual([['tenant_a', "tenant_'quoted"], []]);
+    expect(query.text).toContain('$1::text[]');
+    expect(query.text).toContain('$2::text[]');
+    expect(query.text).not.toContain('tenant_a');
+    expect(query.text).not.toContain("tenant_'quoted");
+    expect(query.text).toContain('object_closure(object_class, object_id)');
+    expect(query.text).toContain('installed_extensions(_id, extnamespace)');
+    expect(query.text).toContain('pg_depend.refclassid');
+    expect(query.text).toContain("where deptype IN ('a', 'e')");
+    expect(query.text).toContain(
+      'pg_constraint.conrelid = object_closure.object_id'
+    );
+    expect(query.text).toContain('pg_proc.proallargtypes');
+    expect(query.text).toContain('pg_type.typbasetype');
+    expect(query.text).toContain('pg_inherits.inhparent');
+    expect(query.text).toContain('pg_extension.extnamespace');
+    expect(query.text).toContain(
+      'pg_extension.oid = any (array(select installed_extensions._id'
+    );
+    // ACL evaluation walks every grant entry, including roles unrelated to the
+    // runtime login. Keep the stock role and membership result sets complete so
+    // PgRBACPlugin cannot fail on a retained object's unrelated ACL grantee.
+    expect(query.text).toContain('from pg_catalog.pg_roles\n  ),');
+    expect(query.text).toContain(
+      'where roleid in (select roles._id from roles)'
+    );
+    expect(query.text).not.toContain('pg_roles.rolname = current_user');
+    expect(query.text).not.toContain(
+      'and member in (select roles._id from roles)'
+    );
+    expect(query.text).toMatch(/from pg_catalog\.pg_language\s+where true/);
+    expect(query.text).toMatch(/from pg_catalog\.pg_am\s+where true/);
+    expect(query.text).not.toContain('namespace_closure');
+    expect(query.text).not.toContain(
+      'pg_inherits.inhparent = object_closure.object_id'
+    );
+    expect(query.text).toContain(
+      "or pg_type.typnamespace = 'pg_catalog'::regnamespace"
+    );
+  });
+
+  it('can retain only catalog types reached by the dependency closure', () => {
+    const query = makeScopedQueryWithCatalogTypes(['tenant_a'], {
+      catalogTypes: 'dependency-closure',
+      capabilityExtensions: ['pg_trgm', 'vector', 'pg_trgm'],
+    });
+
+    expect(query.values).toEqual([['tenant_a'], ['pg_trgm', 'vector']]);
+    expect(query.text).not.toContain('pg_trgm');
+    expect(query.text).not.toContain('vector');
+    expect(query.text).toContain(
+      'pg_extension.extname in (\n      select capability_extension_names.extension_name'
+    );
+    expect(query.text).toContain(
+      "pg_type.oid = any (array(select object_id from object_closure where object_class = 'pg_catalog.pg_type'::regclass))"
+    );
+    expect(query.text).not.toContain(
+      "or pg_type.typnamespace = 'pg_catalog'::regnamespace"
+    );
+    expect(query.text).toContain(
+      'retained_index_support_objects(object_class, object_id)'
+    );
+    expect(query.text).toContain('retained_index_metadata.indclass::oid[]');
+    expect(query.text).toContain("'pg_catalog.pg_opclass'::regclass::oid");
+    expect(query.text).toContain("'pg_catalog.pg_opfamily'::regclass::oid");
+    expect(query.text).toContain("'pg_catalog.pg_operator'::regclass::oid");
+    expect(query.text).toContain('pg_catalog.pg_amop');
+    expect(query.text).toContain('pg_catalog.pg_amproc');
+    expect(query.text).toContain('retained_index_metadata.indcollation::oid[]');
+  });
+
+  it('rejects empty and system-schema scopes', () => {
+    expect(() => makeSchemaScopedIntrospectionQuery([])).toThrow(
+      'requires at least one schema'
+    );
+    expect(() => makeSchemaScopedIntrospectionQuery(['pg_catalog'])).toThrow(
+      'cannot expose system schema'
+    );
+    expect(() =>
+      makeSchemaScopedIntrospectionQuery(['information_schema'])
+    ).toThrow('cannot expose system schema');
+    expect(() =>
+      makeScopedQueryWithCatalogTypes(['tenant_a'], {
+        catalogTypes: 'unknown',
+      } as never)
+    ).toThrow('Unsupported schema-scoped catalog type policy');
+    expect(() =>
+      makeScopedQueryWithCatalogTypes(['tenant_a'], {
+        catalogType: 'dependency-closure',
+      } as never)
+    ).toThrow('Unsupported schema-scoped introspection option');
+    expect(() =>
+      makeScopedQueryWithCatalogTypes(['tenant_a'], {
+        capabilityExtensions: [' pg_trgm'],
+      })
+    ).toThrow('must contain exact non-empty extension names');
+  });
+});

--- a/patches/@dataplan__pg.patch
+++ b/patches/@dataplan__pg.patch
@@ -1,0 +1,192 @@
+diff --git a/dist/adaptors/pg.js b/dist/adaptors/pg.js
+index afa172c99d66784cbefb9aad271978d87e0d4277..b2dd01c87b6dfd308942bd52e4048622ba5417a1 100644
+--- a/dist/adaptors/pg.js
++++ b/dist/adaptors/pg.js
+@@ -26,6 +26,15 @@ const cacheSizeFromEnv = process.env.DATAPLAN_PG_PREPARED_STATEMENT_CACHE_SIZE
+  */
+ const PREPARED_STATEMENT_CACHE_SIZE = !!cacheSizeFromEnv || cacheSizeFromEnv === 0 ? cacheSizeFromEnv : 100;
+ const $$isSetup = Symbol("isConfiguredForDataplanPg");
++const REUSABLE_CLIENT_RELEASE_MODES = Object.freeze(["reuse"]);
++const DESTROYABLE_CLIENT_RELEASE_MODES = Object.freeze(["reuse", "destroy"]);
++function getClientReleaseMode(options) {
++    const mode = options?.clientReleaseMode ?? "reuse";
++    if (mode !== "reuse" && mode !== "destroy") {
++        throw new Error(`Unsupported PostgreSQL client release mode '${mode}'`);
++    }
++    return mode;
++}
+ /**
+  * \> JIT compilation is beneficial primarily for long-running CPU-bound
+  * \> queries. Frequently these will be analytical queries. For short
+@@ -253,25 +262,38 @@ async function makeNodePostgresWithPgClient_inner(pgClient, pgSettings, callback
+  * Returns a `withPgClient` for the given `Pool` instance.
+  */
+ function makePgAdaptorWithPgClient(pool, release = () => { }) {
+-    const withPgClient = async (pgSettings, callback) => {
+-        const pgClient = await pool.connect();
+-        if (!pgClient[$$isSetup]) {
+-            pgClient[$$isSetup] = true;
+-            if (!DONT_DISABLE_JIT) {
+-                // We don't actually disable JIT, it's the optimization that's expensive so we disable that.
+-                pgClient.query("set jit_optimize_above_cost = -1;").catch((e) => {
+-                    console.error(`Error occurred applying @dataplan/pg global Postgres settings: ${e}`);
+-                });
+-            }
++    const withPgClient = async (pgSettings, callback, options) => {
++        const clientReleaseMode = getClientReleaseMode(options);
++        const supportsExactClientDestruction = typeof PgPool === "function" && pool instanceof PgPool;
++        if (clientReleaseMode === "destroy" && !supportsExactClientDestruction) {
++            throw new Error("Exact PostgreSQL client destruction requires a node-postgres Pool");
+         }
++        const pgClient = await pool.connect();
+         try {
++            if (!pgClient[$$isSetup]) {
++                pgClient[$$isSetup] = true;
++                if (!DONT_DISABLE_JIT) {
++                    // We don't actually disable JIT, it's the optimization that's expensive so we disable that.
++                    pgClient.query("set jit_optimize_above_cost = -1;").catch((e) => {
++                        console.error(`Error occurred applying @dataplan/pg global Postgres settings: ${e}`);
++                    });
++                }
++            }
+             return await makeNodePostgresWithPgClient_inner(pgClient, pgSettings, callback, false, false);
+         }
+         finally {
+             // NOTE: have decided not to `RESET ALL` here; otherwise timezone,jit,etc will reset
+-            pgClient.release();
++            if (clientReleaseMode === "destroy") {
++                pgClient.release(true);
++            }
++            else {
++                pgClient.release();
++            }
+         }
+     };
++    withPgClient.supportedClientReleaseModes = typeof PgPool === "function" && pool instanceof PgPool
++        ? DESTROYABLE_CLIENT_RELEASE_MODES
++        : REUSABLE_CLIENT_RELEASE_MODES;
+     let released = false;
+     const releaseOnce = () => {
+         if (released) {
+@@ -292,11 +314,16 @@ function makePgAdaptorWithPgClient(pool, release = () => { }) {
+  */
+ function makeWithPgClientViaPgClientAlreadyInTransaction(pgClient, alreadyInTransaction = false) {
+     const release = () => { };
+-    const withPgClient = async (pgSettings, callback) => {
+-        return makeNodePostgresWithPgClient_inner(pgClient, pgSettings, callback, 
++    const withPgClient = async (pgSettings, callback, options) => {
++        const clientReleaseMode = getClientReleaseMode(options);
++        if (clientReleaseMode !== "reuse") {
++            throw new Error("Cannot destroy a caller-owned PostgreSQL client");
++        }
++        return makeNodePostgresWithPgClient_inner(pgClient, pgSettings, callback,
+         // Ensure only one withPgClient can run at a time, since we only have on pgClient.
+         true, alreadyInTransaction);
+     };
++    withPgClient.supportedClientReleaseModes = REUSABLE_CLIENT_RELEASE_MODES;
+     let released = false;
+     const releaseOnce = () => {
+         if (released) {
+diff --git a/dist/executor.d.ts b/dist/executor.d.ts
+index 27ea278eede0ce3bfa8257f43f26747b374cc11b..04761af3fbc7df43f71c2b4d01d138491ec810f0 100644
+--- a/dist/executor.d.ts
++++ b/dist/executor.d.ts
+@@ -62,8 +62,13 @@ export interface PgClient {
+     query<TData>(opts: PgClientQuery): Promise<PgClientResult<TData>>;
+     withTransaction<T>(callback: (client: this) => Promise<T>): Promise<T>;
+ }
++export type PgClientReleaseMode = "reuse" | "destroy";
++export interface WithPgClientUseOptions {
++    clientReleaseMode?: PgClientReleaseMode;
++}
+ export interface WithPgClient<TPgClient extends PgClient = PgClient> {
+-    <T>(pgSettings: Record<string, string | undefined> | null, callback: (client: TPgClient) => T | Promise<T>): Promise<T>;
++    <T>(pgSettings: Record<string, string | undefined> | null, callback: (client: TPgClient) => T | Promise<T>, options?: WithPgClientUseOptions): Promise<T>;
++    supportedClientReleaseModes?: readonly PgClientReleaseMode[];
+     release?(): PromiseOrDirect<void>;
+ }
+ export type PgExecutorContext<TSettings = any, TPgClient extends PgClient = PgClient> = {
+diff --git a/dist/index.d.ts b/dist/index.d.ts
+index 6ced845a369b1e8fd258649da985f79c5ad7f592..678aa1a40d02dc8e160305492dc6dd890d2568bd 100644
+--- a/dist/index.d.ts
++++ b/dist/index.d.ts
+@@ -1,4 +1,5 @@
+ import type { GrafastSubscriber } from "grafast";
++export declare const exactClientReleaseCapability: "dataplan-pg-exact-client-destroy-v1";
+ export { sql } from "pg-sql2";
+ import type { ObjectFromPgCodecAttributes, PgCodecAttribute, PgCodecAttributeExtensions, PgCodecAttributes, PgCodecAttributeVia, PgCodecAttributeViaExplicit, PgEnumCodecSpec, PgRecordTypeCodecSpec } from "./codecs.ts";
+ import { domainOfCodec, enumCodec, getCodecByPgCatalogTypeName, getInnerCodec, isEnumCodec, LIST_TYPES, listOfCodec, rangeOfCodec, recordCodec, sqlValueWithCodec, TYPES } from "./codecs.ts";
+@@ -39,6 +40,7 @@ import type { SideEffectWithPgClientStepCallback } from "./steps/withPgClient.ts
+ import { loadManyWithPgClient, loadOneWithPgClient, sideEffectWithPgClient, SideEffectWithPgClientStep, sideEffectWithPgClientTransaction, withPgClient, withPgClientTransaction } from "./steps/withPgClient.ts";
+ import { assertPgClassSingleStep } from "./utils.ts";
+ export type { GetPgCodecAttributes, GetPgRegistryCodecRelations, GetPgRegistryCodecs, GetPgRegistrySources, GetPgResourceAttributes, GetPgResourceCodec, GetPgResourceRegistry, GetPgResourceRelations, GetPgResourceUniques, KeysOfType, MakePgServiceOptions, ObjectFromPgCodecAttributes, PgAdaptor, PgBox, PgCircle, PgClassSingleStep, PgClient, PgClientQuery, PgClientResult, PgCodec, PgCodecAnyScalar, PgCodecAttribute, PgCodecAttributeExtensions, PgCodecAttributes, PgCodecAttributeVia, PgCodecAttributeViaExplicit, PgCodecExtensions, PgCodecList, PgCodecPolymorphism, PgCodecPolymorphismRelational, PgCodecPolymorphismRelationalTypeSpec, PgCodecPolymorphismSingle, PgCodecPolymorphismSingleTypeAttributeSpec, PgCodecPolymorphismSingleTypeSpec, PgCodecPolymorphismUnion, PgCodecRef, PgCodecRefExtensions, PgCodecRefPath, PgCodecRefPathEntry, PgCodecRefs, PgCodecRelation, PgCodecRelationConfig, PgCodecRelationExtensions, PgCodecWithAttributes, PgConditionCapableParent, PgConditionLike, PgDecode, PgDeleteSingleQueryBuilder, PgEncode, PgEnumCodec, PgEnumCodecSpec, PgEnumValue, PgExecutorContext, PgExecutorContextPlans, PgExecutorInput, PgExecutorMutationOptions, PgExecutorOptions, PgFunctionResourceOptions, PgGroupDetails, PgGroupSpec, PgHavingConditionSpec, PgHStore, PgInsertSingleQueryBuilder, PgInterval, PgLine, PgLockableParameter, PgLockCallback, PgLseg, PgOrderSpec, PgPath, PgPoint, PgPolygon, PgRecordTypeCodecSpec, PgRefDefinition, PgRefDefinitionExtensions, PgRefDefinitions, PgRegistry, PgRegistryBuilder, PgResourceExtensions, PgResourceOptions, PgResourceParameter, PgResourceUnique, PgResourceUniqueExtensions, PgRootStep, PgSelectArgumentDigest, PgSelectArgumentRuntimeValue, PgSelectArgumentSpec, PgSelectIdentifierSpec, PgSelectMode, PgSelectOptions, PgSelectParsedCursorStep, PgSelectQueryBuilder, PgSelectQueryBuilderCallback, PgSelectSinglePlanOptions, PgTypedStep, PgUnionAllQueryBuilder, PgUnionAllQueryBuilderCallback, PgUnionAllStepCondition, PgUnionAllStepConfig, PgUnionAllStepConfigAttributes, PgUnionAllStepMember, PgUnionAllStepOrder, PgUpdateSingleQueryBuilder, PgWhereConditionSpec, PlanByUniques, SideEffectWithPgClientStepCallback, TuplePlanMap, WithPgClient, };
++export type { PgClientReleaseMode, WithPgClientUseOptions } from "./executor.ts";
+ export { assertPgClassSingleStep, domainOfCodec, enumCodec, generatePgParameterAnalysis, getCodecByPgCatalogTypeName, getInnerCodec, getWithPgClientFromPgService, isEnumCodec, LIST_TYPES, listOfCodec, loadManyWithPgClient, loadOneWithPgClient, pgResourceOptions as makePgResourceOptions, makeRegistry, makeRegistryBuilder, PgBooleanFilter, pgClassExpression, PgClassExpressionStep, PgClassFilter, PgCondition, PgContextPlugin, PgCursorStep, pgDeleteSingle, PgDeleteSingleStep, PgExecutor, pgFromExpression, pgFromExpressionRuntime, pgInsertSingle, PgInsertSingleStep, PgManyFilter, PgOrFilter, PgResource, pgResourceOptions, pgSelect, pgSelectFromRecord, pgSelectFromRecords, PgSelectRowsStep, pgSelectSingleFromRecord, PgSelectSingleStep, PgSelectStep, PgTempTable, pgUnionAll, PgUnionAllRowsStep, PgUnionAllSingleStep, PgUnionAllStep, pgUpdateSingle, PgUpdateSingleStep, pgValidateParsedCursor, PgValidateParsedCursorStep, pgWhereConditionSpecListToSQL, rangeOfCodec, recordCodec, sideEffectWithPgClient, SideEffectWithPgClientStep, sideEffectWithPgClientTransaction, sqlFromArgDigests, sqlValueWithCodec, toPg, ToPgStep, TYPES, withPgClient, withPgClientFromPgService, withPgClientTransaction, withSuperuserPgClientFromPgService, };
+ export { version } from "./version.ts";
+ declare global {
+diff --git a/dist/index.js b/dist/index.js
+index 58a910480352fb55c702f7b963b3ae77923a7482..470c18c3af08de5d94286725d2cd29c5cdbf8f92 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -1,5 +1,6 @@
+ "use strict";
+ Object.defineProperty(exports, "__esModule", { value: true });
++exports.exactClientReleaseCapability = "dataplan-pg-exact-client-destroy-v1";
+ exports.PgValidateParsedCursorStep = exports.pgValidateParsedCursor = exports.PgUpdateSingleStep = exports.pgUpdateSingle = exports.PgUnionAllStep = exports.PgUnionAllSingleStep = exports.PgUnionAllRowsStep = exports.pgUnionAll = exports.PgTempTable = exports.PgSelectStep = exports.PgSelectSingleStep = exports.pgSelectSingleFromRecord = exports.PgSelectRowsStep = exports.pgSelectFromRecords = exports.pgSelectFromRecord = exports.pgSelect = exports.pgResourceOptions = exports.PgResource = exports.PgOrFilter = exports.PgManyFilter = exports.PgInsertSingleStep = exports.pgInsertSingle = exports.pgFromExpressionRuntime = exports.pgFromExpression = exports.PgExecutor = exports.PgDeleteSingleStep = exports.pgDeleteSingle = exports.PgCursorStep = exports.PgContextPlugin = exports.PgCondition = exports.PgClassFilter = exports.PgClassExpressionStep = exports.pgClassExpression = exports.PgBooleanFilter = exports.makeRegistryBuilder = exports.makeRegistry = exports.makePgResourceOptions = exports.loadOneWithPgClient = exports.loadManyWithPgClient = exports.listOfCodec = exports.LIST_TYPES = exports.isEnumCodec = exports.getWithPgClientFromPgService = exports.getInnerCodec = exports.getCodecByPgCatalogTypeName = exports.generatePgParameterAnalysis = exports.enumCodec = exports.domainOfCodec = exports.assertPgClassSingleStep = exports.sql = void 0;
+ exports.version = exports.withSuperuserPgClientFromPgService = exports.withPgClientTransaction = exports.withPgClientFromPgService = exports.withPgClient = exports.TYPES = exports.ToPgStep = exports.toPg = exports.sqlValueWithCodec = exports.sqlFromArgDigests = exports.sideEffectWithPgClientTransaction = exports.SideEffectWithPgClientStep = exports.sideEffectWithPgClient = exports.recordCodec = exports.rangeOfCodec = exports.pgWhereConditionSpecListToSQL = void 0;
+ const grafast_1 = require("grafast");
+diff --git a/dist/pgServices.d.ts b/dist/pgServices.d.ts
+index 87e592a338f9ffba50cd4bd56ac40a3c136b64a5..08dc18f058b7b8e06435995166ec22f26067932a 100644
+--- a/dist/pgServices.d.ts
++++ b/dist/pgServices.d.ts
+@@ -1,4 +1,4 @@
+-import type { PgClient, WithPgClient } from "./executor.ts";
++import type { PgClient, WithPgClient, WithPgClientUseOptions } from "./executor.ts";
+ type PromiseOrDirect<T> = T | PromiseLike<T>;
+ /** @experimental */
+ export interface PgAdaptor<TAdaptor extends keyof GraphileConfig.PgAdaptors = keyof GraphileConfig.PgAdaptors> {
+@@ -14,7 +14,7 @@ export declare function isPromiseLike<T>(t: T | Promise<T> | PromiseLike<T>): t
+  * config, caching it to make future lookups faster.
+  */
+ export declare function getWithPgClientFromPgService<TAdaptor extends keyof GraphileConfig.PgAdaptors = keyof GraphileConfig.PgAdaptors>(config: GraphileConfig.PgServiceConfiguration<TAdaptor>): PromiseOrDirect<WithPgClient<GraphileConfig.PgAdaptors[TAdaptor]["client"]>>;
+-export declare function withPgClientFromPgService<T>(config: GraphileConfig.PgServiceConfiguration, pgSettings: Record<string, string | undefined> | null, callback: (client: PgClient) => T | Promise<T>): Promise<T>;
++export declare function withPgClientFromPgService<T>(config: GraphileConfig.PgServiceConfiguration, pgSettings: Record<string, string | undefined> | null, callback: (client: PgClient) => T | Promise<T>, options?: WithPgClientUseOptions): Promise<T>;
+ export declare function withSuperuserPgClientFromPgService<T>(config: GraphileConfig.PgServiceConfiguration, pgSettings: Record<string, string | undefined> | null, callback: (client: PgClient) => T | Promise<T>): Promise<T>;
+ export {};
+ //# sourceMappingURL=pgServices.d.ts.map
+diff --git a/dist/pgServices.js b/dist/pgServices.js
+index b0361cc63868d18161a68207b28cce8d0c286e13..4b9e828a204a81f737ea172611d8d369f9d35b92 100644
+--- a/dist/pgServices.js
++++ b/dist/pgServices.js
+@@ -38,6 +38,7 @@ function getWithPgClientFromPgService(config) {
+             }
+             const originalWithPgClient = await factory(config.adaptorSettings);
+             const withPgClient = ((...args) => originalWithPgClient.apply(null, args));
++            withPgClient.supportedClientReleaseModes = originalWithPgClient.supportedClientReleaseModes;
+             const cachedValue = {
+                 withPgClient,
+                 retainers: 1,
+@@ -70,13 +71,21 @@ function getWithPgClientFromPgService(config) {
+         return promise.then((v) => v.withPgClient);
+     }
+ }
+-async function withPgClientFromPgService(config, pgSettings, callback) {
++async function withPgClientFromPgService(config, pgSettings, callback, options) {
+     const withPgClientFromPgService = getWithPgClientFromPgService(config);
+     const withPgClient = isPromiseLike(withPgClientFromPgService)
+         ? await withPgClientFromPgService
+         : withPgClientFromPgService;
+     try {
+-        return await withPgClient(pgSettings, callback);
++        const clientReleaseMode = options?.clientReleaseMode ?? "reuse";
++        if (clientReleaseMode !== "reuse" && clientReleaseMode !== "destroy") {
++            throw new Error(`Unsupported PostgreSQL client release mode '${clientReleaseMode}' for service '${config.name}'`);
++        }
++        if (clientReleaseMode === "destroy" &&
++            !withPgClient.supportedClientReleaseModes?.includes("destroy")) {
++            throw new Error(`PostgreSQL service '${config.name}' does not support exact client destruction`);
++        }
++        return await withPgClient(pgSettings, callback, options);
+     }
+     finally {
+         withPgClient.release();

--- a/patches/graphile-build-pg.patch
+++ b/patches/graphile-build-pg.patch
@@ -1,0 +1,229 @@
+diff --git a/dist/index.d.ts b/dist/index.d.ts
+index c4fd418656c8f063c74113471835538120e2f215..5853aa3c5fec0a578d9f49fa7b5a2b663755f6d0 100644
+--- a/dist/index.d.ts
++++ b/dist/index.d.ts
+@@ -1,5 +1,6 @@
+ import type { PgRegistry } from "@dataplan/pg";
+ import type { PartitionExpose } from "./interfaces.ts";
++export declare const introspectionClientReleaseCapability: "graphile-build-pg-exact-client-destroy-v1";
+ export { PgAllRowsPlugin } from "./plugins/PgAllRowsPlugin.ts";
+ export { PgAttributeDeprecationPlugin } from "./plugins/PgAttributeDeprecationPlugin.ts";
+ export { PgAttributesPlugin } from "./plugins/PgAttributesPlugin.ts";
+diff --git a/dist/index.js b/dist/index.js
+index 94611d28be45c9fdd696923f4affac86a25544e4..f6431a22e6e329827748d1057bf0be776e67deb4 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -1,5 +1,6 @@
+ "use strict";
+ Object.defineProperty(exports, "__esModule", { value: true });
++exports.introspectionClientReleaseCapability = "graphile-build-pg-exact-client-destroy-v1";
+ exports.sql = exports.withPgClientFromPgService = exports.getWithPgClientFromPgService = exports.version = exports.parseDatabaseIdentifiers = exports.parseDatabaseIdentifier = exports.defaultPreset = exports.PgTypesPlugin = exports.PgTablesPlugin = exports.PgTableNodePlugin = exports.PgRowByUniquePlugin = exports.PgRemoveExtensionResourcesPlugin = exports.PgRelationsPlugin = exports.PgRegistryReductionPlugin = exports.PgRegistryPlugin = exports.PgRefsPlugin = exports.PgRBACPlugin = exports.PgProceduresPlugin = exports.PgPolymorphismPlugin = exports.PgPolymorphismOnlyArgumentPlugin = exports.PgOrderCustomFieldsPlugin = exports.PgOrderByPrimaryKeyPlugin = exports.PgOrderAllAttributesPlugin = exports.PgNodeIdAttributesPlugin = exports.PgMutationUpdateDeletePlugin = exports.PgMutationPayloadEdgePlugin = exports.PgMutationCreatePlugin = exports.PgLtreePlugin = exports.PgJWTPlugin = exports.PgIntrospectionPlugin = exports.PgInterfaceModeUnionAllRowsPlugin = exports.PgIndexBehaviorsPlugin = exports.PgFirstLastBeforeAfterArgsPlugin = exports.PgFakeConstraintsPlugin = exports.PgEnumTablesPlugin = exports.PgEnumDomainsPlugin = exports.PgCustomTypeFieldPlugin = exports.PgConnectionTotalCountPlugin = exports.PgConnectionArgOrderByPlugin = exports.PgConnectionArgOrderByDefaultValuePlugin = exports.PgConditionCustomFieldsPlugin = exports.PgConditionArgumentPlugin = exports.PgCodecsPlugin = exports.PgBasicsPlugin = exports.PgAttributesPlugin = exports.PgAttributeDeprecationPlugin = exports.PgAllRowsPlugin = void 0;
+ var PgAllRowsPlugin_ts_1 = require("./plugins/PgAllRowsPlugin.js");
+ Object.defineProperty(exports, "PgAllRowsPlugin", { enumerable: true, get: function () { return PgAllRowsPlugin_ts_1.PgAllRowsPlugin; } });
+diff --git a/dist/plugins/PgIntrospectionPlugin.d.ts b/dist/plugins/PgIntrospectionPlugin.d.ts
+index 821629b96574c90ff58804be3aa3b98c4443c7a0..cf861c4ef564f8f1cdac16610cd2559c38e1421f 100644
+--- a/dist/plugins/PgIntrospectionPlugin.d.ts
++++ b/dist/plugins/PgIntrospectionPlugin.d.ts
+@@ -1,6 +1,22 @@
+ import { PgExecutor } from "@dataplan/pg";
+ import type { PromiseOrDirect } from "grafast";
+ import type { Introspection, PgAttribute, PgAuthMembers, PgClass, PgConstraint, PgDepend, PgDescription, PgEnum, PgExtension, PgIndex, PgInherits, PgLanguage, PgNamespace, PgProc, PgRange, PgRoles, PgType } from "pg-introspection";
++declare global {
++    namespace GraphileConfig {
++        interface PgServiceConfiguration<TAdaptor extends keyof GraphileConfig.PgAdaptors = keyof GraphileConfig.PgAdaptors> {
++            /** Selects the catalog query used during this service's gather phase. */
++            introspectionMode?: "stock" | "scoped-required";
++            /** Catalog types retained by scoped introspection; defaults to all for compatibility. */
++            introspectionScopedCatalogTypes?: "all" | "dependency-closure";
++            /** Non-root schemas that scoped dependency closure may retain. */
++            introspectionAllowedDependencySchemas?: readonly string[];
++            /** Exact installed extension names whose optional capability metadata is required. */
++            introspectionCapabilityExtensions?: readonly string[];
++            /** How to release the exact client after its catalog query. */
++            introspectionClientReleaseMode?: "reuse" | "destroy";
++        }
++    }
++}
+ export type PgEntityWithId = PgNamespace | PgClass | PgConstraint | PgProc | PgRoles | PgType | PgEnum | PgExtension | PgExtension | PgIndex | PgLanguage;
+ declare global {
+     namespace GraphileBuild {
+diff --git a/dist/plugins/PgIntrospectionPlugin.js b/dist/plugins/PgIntrospectionPlugin.js
+index a1597b1dc9a4f76d3debc80f5ef151f4e58bc2cd..0714e4f1aa6b9a5f60373f868942b2e054eebf95 100644
+--- a/dist/plugins/PgIntrospectionPlugin.js
++++ b/dist/plugins/PgIntrospectionPlugin.js
+@@ -42,6 +42,118 @@ function makeGetEntities(loc) {
+         return list;
+     };
+ }
++function getIntrospectionQuery(pgService) {
++    const mode = pgService.introspectionMode ?? "stock";
++    const configuredCatalogTypes = pgService.introspectionScopedCatalogTypes;
++    const configuredCapabilityExtensions = pgService.introspectionCapabilityExtensions;
++    const scopedCatalogTypes = configuredCatalogTypes ?? "all";
++    if (scopedCatalogTypes !== "all" && scopedCatalogTypes !== "dependency-closure") {
++        throw new Error(`Unsupported scoped catalog type policy '${scopedCatalogTypes}' for service '${pgService.name}'`);
++    }
++    if (mode === "stock") {
++        if (configuredCatalogTypes !== undefined) {
++            throw new Error(`Scoped catalog type policy is only valid with scoped-required introspection for service '${pgService.name}'`);
++        }
++        if (configuredCapabilityExtensions !== undefined) {
++            throw new Error(`Scoped extension capabilities are only valid with scoped-required introspection for service '${pgService.name}'`);
++        }
++        return {
++            query: { text: (0, pg_introspection_1.makeIntrospectionQuery)() },
++            requiredSchemas: null,
++            allowedSchemas: null,
++            scopedCatalogTypes: null,
++        };
++    }
++    if (mode === "scoped-required") {
++        const requiredSchemas = pgService.schemas ?? [];
++        const dependencySchemas = pgService.introspectionAllowedDependencySchemas ?? [];
++        const capabilityExtensions = configuredCapabilityExtensions ?? [];
++        return {
++            query: (0, pg_introspection_1.makeSchemaScopedIntrospectionQuery)(requiredSchemas, {
++                catalogTypes: scopedCatalogTypes,
++                capabilityExtensions,
++            }),
++            requiredSchemas,
++            allowedSchemas: [...new Set([...requiredSchemas, ...dependencySchemas, "pg_catalog"])],
++            scopedCatalogTypes,
++        };
++    }
++    throw new Error(`Unsupported PostgreSQL introspection mode '${mode}' for service '${pgService.name}'`);
++}
++function assertScopedNamespaces(introspection, requiredSchemas, allowedSchemas, serviceName) {
++    if (requiredSchemas === null) {
++        return;
++    }
++    const found = new Set(introspection.namespaces.map((namespace) => namespace.nspname));
++    const missing = requiredSchemas.filter((schema) => !found.has(schema));
++    if (missing.length > 0) {
++        throw new Error(`Schema-scoped introspection for service '${serviceName}' did not find required schema(s): ${missing.join(", ")}`);
++    }
++    const allowed = new Set(allowedSchemas);
++    const unexpected = [...found].filter((schema) => !allowed.has(schema));
++    if (unexpected.length > 0) {
++        throw new Error(`Schema-scoped introspection for service '${serviceName}' crossed into unapproved dependency schema(s): ${unexpected.join(", ")}`);
++    }
++}
++function assertDependencyClosureTypes(introspection, scopedCatalogTypes, serviceName) {
++    if (scopedCatalogTypes !== "dependency-closure") {
++        return;
++    }
++    const retainedTypeOids = new Set(introspection.types.map((type) => String(type._id)));
++    const requireType = (oid, objectKind, objectContext, field) => {
++        if (oid === null || oid === undefined || String(oid) === "0") {
++            return;
++        }
++        const normalizedOid = String(oid);
++        // pg-introspection deliberately removes extension-owned composite
++        // resources from the public arrays after constructing its lookup maps.
++        // Array and user-object dependencies still resolve through that exact
++        // lookup, so validate the same runtime resolution surface instead of
++        // rejecting a coherent extension-pruned result.
++        const resolvesThroughIntrospection = retainedTypeOids.has(normalizedOid) ||
++            introspection._lookups?.typeById?.has(normalizedOid) === true;
++        if (!resolvesThroughIntrospection) {
++            throw new Error(`Dependency-closure introspection for service '${serviceName}' retained ${objectKind} '${objectContext}' field '${field}' referencing missing pg_type OID '${normalizedOid}'`);
++        }
++    };
++    const requireTypes = (oids, objectKind, objectContext, field) => {
++        for (const oid of oids ?? []) {
++            requireType(oid, objectKind, objectContext, field);
++        }
++    };
++    for (const entity of introspection.classes) {
++        const context = `${entity.relname} (${entity._id})`;
++        requireType(entity.reltype, "pg_class", context, "reltype");
++        requireType(entity.reloftype, "pg_class", context, "reloftype");
++    }
++    for (const entity of introspection.attributes) {
++        requireType(entity.atttypid, "pg_attribute", `${entity.attrelid}.${entity.attname}`, "atttypid");
++    }
++    for (const entity of introspection.constraints) {
++        requireType(entity.contypid, "pg_constraint", `${entity.conname} (${entity._id})`, "contypid");
++    }
++    for (const entity of introspection.procs) {
++        const context = `${entity.proname} (${entity._id})`;
++        requireType(entity.prorettype, "pg_proc", context, "prorettype");
++        requireTypes(entity.proargtypes, "pg_proc", context, "proargtypes");
++        requireTypes(entity.proallargtypes, "pg_proc", context, "proallargtypes");
++    }
++    for (const entity of introspection.types) {
++        const context = `${entity.typname} (${entity._id})`;
++        requireType(entity.typbasetype, "pg_type", context, "typbasetype");
++        requireType(entity.typelem, "pg_type", context, "typelem");
++        requireType(entity.typarray, "pg_type", context, "typarray");
++    }
++    for (const entity of introspection.enums) {
++        requireType(entity.enumtypid, "pg_enum", `${entity.enumlabel} (${entity._id})`, "enumtypid");
++    }
++    for (const entity of introspection.ranges) {
++        const context = `range ${entity.rngtypid ?? "unknown"}`;
++        requireType(entity.rngtypid, "pg_range", context, "rngtypid");
++        requireType(entity.rngsubtype, "pg_range", context, "rngsubtype");
++        requireType(entity.rngmultitypid, "pg_range", context, "rngmultitypid");
++    }
++}
+ exports.PgIntrospectionPlugin = {
+     name: "PgIntrospectionPlugin",
+     description: "Introspects PostgreSQL databases and makes the results available to other plugins",
+@@ -171,8 +283,8 @@ exports.PgIntrospectionPlugin = {
+                 return type?.getEnumValues() ?? [];
+             },
+             async getRangeByType(info, serviceName, typeId) {
+-                const type = await info.helpers.pgIntrospection.getType(serviceName, typeId);
+-                return type?.getRange();
++                const relevant = await getDb(info, serviceName);
++                return relevant.introspection.ranges.find((range) => range.rngtypid === typeId || range.rngmultitypid === typeId);
+             },
+             async getExtensionByName(info, serviceName, extensionName) {
+                 const relevant = await getDb(info, serviceName);
+@@ -198,11 +310,20 @@ exports.PgIntrospectionPlugin = {
+                             info.cache.introspectionResultsPromise = null;
+                         });
+                         const rawIntrospections = await introspectionPromise;
+-                        const introspections = rawIntrospections.map(({ pgService, introspectionText }) => ({
+-                            pgService,
++                        // Scoped mode keeps raw text only in this gather's async frame.
++                        // Clear only the exact promise we consumed so every later gather
++                        // re-queries, while concurrent helpers still share parsed state.
++                        if (rawIntrospections.some(({ requiredSchemas }) => requiredSchemas !== null) &&
++                            info.cache.introspectionResultsPromise === introspectionPromise) {
++                            info.cache.introspectionResultsPromise = null;
++                        }
++                        const introspections = rawIntrospections.map(({ pgService, introspectionText, requiredSchemas, allowedSchemas, scopedCatalogTypes }) => {
+                             // IMPORTANT: parseIntrospectionResults must NOT be cached, because other plugins mutate it.
+-                            introspection: (0, pg_introspection_1.parseIntrospectionResults)(introspectionText),
+-                        }));
++                            const introspection = (0, pg_introspection_1.parseIntrospectionResults)(introspectionText);
++                            assertScopedNamespaces(introspection, requiredSchemas, allowedSchemas, pgService.name);
++                            assertDependencyClosureTypes(introspection, scopedCatalogTypes, pgService.name);
++                            return { pgService, introspection };
++                        });
+                         // Store the resolved state, so access during announcements doesn't cause the system to hang
+                         info.state.getIntrospectionPromise = introspections;
+                         // Announce the introspection results.
+@@ -416,14 +537,16 @@ function introspectPgServices(pgServices) {
+             seenPgSettingsKeys.set(pgSettingsKey, i);
+         }
+         // Do the introspection
+-        const introspectionQuery = (0, pg_introspection_1.makeIntrospectionQuery)();
++        const { query, requiredSchemas, allowedSchemas, scopedCatalogTypes } = getIntrospectionQuery(pgService);
++        const clientReleaseMode = pgService.introspectionClientReleaseMode ?? "reuse";
+         const { rows: [row], } = await (0, pg_1.withPgClientFromPgService)(pgService, pgService.pgSettingsForIntrospection ?? null, (client) => client.query({
+-            text: introspectionQuery,
+-        }));
++            text: query.text,
++            values: query.values,
++        }), clientReleaseMode === "reuse" ? undefined : { clientReleaseMode });
+         if (!row) {
+             throw new Error("Introspection failed");
+         }
+-        return { pgService, introspectionText: row.introspection };
++        return { pgService, introspectionText: row.introspection, requiredSchemas, allowedSchemas, scopedCatalogTypes };
+     }));
+ }
+ //# sourceMappingURL=PgIntrospectionPlugin.js.map

--- a/patches/pg-introspection@1.0.1.patch
+++ b/patches/pg-introspection@1.0.1.patch
@@ -1,0 +1,552 @@
+diff --git a/dist/index.d.ts b/dist/index.d.ts
+index 8b378fb1edcdf727c35d86360b38baf042b29476..363901770cb19ef77f97420c61bba6a5a283f04d 100644
+--- a/dist/index.d.ts
++++ b/dist/index.d.ts
+@@ -1,5 +1,5 @@
+ import type { Introspection, PgAttribute, PgAuthMembers, PgClass, PgConstraint, PgDatabase, PgDepend, PgDescription, PgEntity, PgEnum, PgExtension, PgIndex, PgInherits, PgLanguage, PgNamespace, PgProc, PgProcArgument, PgRange, PgRoles, PgType } from "./introspection.ts";
+-export { makeIntrospectionQuery } from "./introspection.ts";
++export { makeIntrospectionQuery, makeSchemaScopedIntrospectionQuery, type SchemaScopedCatalogTypes, type SchemaScopedIntrospectionOptions } from "./introspection.ts";
+ import type { AclObject } from "./acl.ts";
+ import { aclContainsRole, entityPermissions, expandRoles, resolvePermissions } from "./acl.ts";
+ import type { PgSmartTagsAndDescription, PgSmartTagsDict } from "./smartComments.ts";
+diff --git a/dist/index.js b/dist/index.js
+index e74695ac2c2469f423637837ac454c26f1ea03d9..313806728156f576fd1a688679f6702a73f5aea8 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -1,10 +1,11 @@
+ "use strict";
+ Object.defineProperty(exports, "__esModule", { value: true });
+-exports.resolvePermissions = exports.expandRoles = exports.entityPermissions = exports.aclContainsRole = exports.parseSmartComment = exports.reservedWords = exports.makeIntrospectionQuery = void 0;
++exports.resolvePermissions = exports.expandRoles = exports.entityPermissions = exports.aclContainsRole = exports.parseSmartComment = exports.reservedWords = exports.makeSchemaScopedIntrospectionQuery = exports.makeIntrospectionQuery = void 0;
+ exports.parseIntrospectionResults = parseIntrospectionResults;
+ const tslib_1 = require("tslib");
+ var introspection_ts_1 = require("./introspection.js");
+ Object.defineProperty(exports, "makeIntrospectionQuery", { enumerable: true, get: function () { return introspection_ts_1.makeIntrospectionQuery; } });
++Object.defineProperty(exports, "makeSchemaScopedIntrospectionQuery", { enumerable: true, get: function () { return introspection_ts_1.makeSchemaScopedIntrospectionQuery; } });
+ const acl_ts_1 = require("./acl.js");
+ Object.defineProperty(exports, "aclContainsRole", { enumerable: true, get: function () { return acl_ts_1.aclContainsRole; } });
+ Object.defineProperty(exports, "entityPermissions", { enumerable: true, get: function () { return acl_ts_1.entityPermissions; } });
+diff --git a/dist/introspection.d.ts b/dist/introspection.d.ts
+index d4d1dd52e4e53dcbbd13c206b62309991ab38d2d..62a7f2da73138604907137f0869360bfc4ee8483 100644
+--- a/dist/introspection.d.ts
++++ b/dist/introspection.d.ts
+@@ -1224,5 +1224,20 @@ export type PgEntity = PgDatabase | PgNamespace | PgClass | PgAttribute | PgCons
+  * Builds a PostgreSQL introspection SQL query to return an object with the same shape as `Introspection` above.
+  */
+ export declare const makeIntrospectionQuery: () => string;
++/**
++ * Builds a parameterized introspection query scoped to the requested schemas
++ * and the transitive object dependencies required by their objects.
++ */
++export type SchemaScopedCatalogTypes = "all" | "dependency-closure";
++export interface SchemaScopedIntrospectionOptions {
++    /** Catalog type retention policy. Defaults to the compatibility-safe `all`. */
++    catalogTypes?: SchemaScopedCatalogTypes;
++    /** Exact installed extension names whose optional capability metadata is required. */
++    capabilityExtensions?: readonly string[];
++}
++export declare const makeSchemaScopedIntrospectionQuery: (schemas: readonly string[], options?: SchemaScopedIntrospectionOptions) => {
++    text: string;
++    values: [string[], string[]];
++};
+ export {};
+ //# sourceMappingURL=introspection.d.ts.map
+diff --git a/dist/introspection.js b/dist/introspection.js
+index b21ef287be6d529c1801bba6b7c2096758849884..7ade0aa53a74b28d32f70c90f940189cdc3e3e3e 100644
+--- a/dist/introspection.js
++++ b/dist/introspection.js
+@@ -5,13 +5,341 @@
+  * DO NOT EDIT!
+  */
+ Object.defineProperty(exports, "__esModule", { value: true });
+-exports.makeIntrospectionQuery = void 0;
++exports.makeSchemaScopedIntrospectionQuery = exports.makeIntrospectionQuery = void 0;
++const STOCK_NAMESPACE_PREDICATE = "nspname <> 'information_schema'";
++const STOCK_OBJECT_NAMESPACE_PREDICATE = "in (select namespaces._id from namespaces where nspname <> 'information_schema' and nspname not like 'pg\\_%')";
++const SCOPED_CTES = `recursive
++  requested_schema_names(schema_name) as (
++    select distinct requested.schema_name
++    from pg_catalog.unnest($1::text[]) as requested(schema_name)
++  ),
++
++  capability_extension_names(extension_name) as (
++    select distinct capability.extension_name
++    from pg_catalog.unnest($2::text[]) as capability(extension_name)
++  ),
++
++  requested_namespaces as (
++    select pg_namespace.oid as _id, pg_namespace.nspname
++    from pg_catalog.pg_namespace
++    inner join requested_schema_names
++      on requested_schema_names.schema_name = pg_namespace.nspname
++  ),
++
++  root_objects(object_class, object_id) as (
++    select 'pg_catalog.pg_class'::regclass::oid, pg_class.oid
++    from pg_catalog.pg_class
++    where pg_class.relnamespace in (select requested_namespaces._id from requested_namespaces)
++
++    union
++
++    select 'pg_catalog.pg_constraint'::regclass::oid, pg_constraint.oid
++    from pg_catalog.pg_constraint
++    where pg_constraint.connamespace in (select requested_namespaces._id from requested_namespaces)
++
++    union
++
++    select 'pg_catalog.pg_proc'::regclass::oid, pg_proc.oid
++    from pg_catalog.pg_proc
++    where pg_proc.pronamespace in (select requested_namespaces._id from requested_namespaces)
++      and pg_proc.prorettype operator(pg_catalog.<>) 2279
++
++    union
++
++    select 'pg_catalog.pg_type'::regclass::oid, pg_type.oid
++    from pg_catalog.pg_type
++    where pg_type.typnamespace in (select requested_namespaces._id from requested_namespaces)
++  ),
++
++  object_closure(object_class, object_id) as (
++    select root_objects.object_class, root_objects.object_id
++    from root_objects
++
++    union
++
++    select dependency.object_class, dependency.object_id
++    from object_closure
++    cross join lateral (
++      select
++        'pg_catalog.pg_type'::regclass::oid as object_class,
++        pg_class.reltype as object_id
++      from pg_catalog.pg_class
++      where object_closure.object_class = 'pg_catalog.pg_class'::regclass
++        and pg_class.oid = object_closure.object_id
++
++      union all
++
++      select 'pg_catalog.pg_type'::regclass::oid, pg_class.reloftype
++      from pg_catalog.pg_class
++      where object_closure.object_class = 'pg_catalog.pg_class'::regclass
++        and pg_class.oid = object_closure.object_id
++
++      union all
++
++      select 'pg_catalog.pg_type'::regclass::oid, pg_attribute.atttypid
++      from pg_catalog.pg_attribute
++      where object_closure.object_class = 'pg_catalog.pg_class'::regclass
++        and pg_attribute.attrelid = object_closure.object_id
++
++      union all
++
++      select 'pg_catalog.pg_constraint'::regclass::oid, pg_constraint.oid
++      from pg_catalog.pg_constraint
++      where object_closure.object_class = 'pg_catalog.pg_class'::regclass
++        and pg_constraint.conrelid = object_closure.object_id
++
++      union all
++
++      select 'pg_catalog.pg_class'::regclass::oid, pg_index.indexrelid
++      from pg_catalog.pg_index
++      where object_closure.object_class = 'pg_catalog.pg_class'::regclass
++        and pg_index.indrelid = object_closure.object_id
++
++      union all
++
++      select 'pg_catalog.pg_class'::regclass::oid, pg_inherits.inhparent
++      from pg_catalog.pg_inherits
++      where object_closure.object_class = 'pg_catalog.pg_class'::regclass
++        and pg_inherits.inhrelid = object_closure.object_id
++
++      union all
++
++      select 'pg_catalog.pg_class'::regclass::oid, constraint_class.oid
++      from pg_catalog.pg_constraint
++      cross join lateral pg_catalog.unnest(
++        array[
++          pg_constraint.conrelid,
++          pg_constraint.confrelid,
++          pg_constraint.conindid
++        ]::oid[]
++      ) as constraint_class(oid)
++      where object_closure.object_class = 'pg_catalog.pg_constraint'::regclass
++        and pg_constraint.oid = object_closure.object_id
++
++      union all
++
++      select 'pg_catalog.pg_type'::regclass::oid, pg_constraint.contypid
++      from pg_catalog.pg_constraint
++      where object_closure.object_class = 'pg_catalog.pg_constraint'::regclass
++        and pg_constraint.oid = object_closure.object_id
++
++      union all
++
++      select 'pg_catalog.pg_constraint'::regclass::oid, pg_constraint.conparentid
++      from pg_catalog.pg_constraint
++      where object_closure.object_class = 'pg_catalog.pg_constraint'::regclass
++        and pg_constraint.oid = object_closure.object_id
++
++      union all
++
++      select 'pg_catalog.pg_type'::regclass::oid, procedure_type.oid
++      from pg_catalog.pg_proc
++      cross join lateral pg_catalog.unnest(
++        coalesce(pg_proc.proallargtypes, pg_proc.proargtypes::oid[])
++        || array[pg_proc.prorettype]::oid[]
++      ) as procedure_type(oid)
++      where object_closure.object_class = 'pg_catalog.pg_proc'::regclass
++        and pg_proc.oid = object_closure.object_id
++
++      union all
++
++      select 'pg_catalog.pg_type'::regclass::oid, dependency_type.oid
++      from pg_catalog.pg_type
++      cross join lateral pg_catalog.unnest(
++        array[
++          pg_type.typbasetype,
++          pg_type.typelem,
++          pg_type.typarray
++        ]::oid[]
++      ) as dependency_type(oid)
++      where object_closure.object_class = 'pg_catalog.pg_type'::regclass
++        and pg_type.oid = object_closure.object_id
++
++      union all
++
++      select 'pg_catalog.pg_class'::regclass::oid, pg_type.typrelid
++      from pg_catalog.pg_type
++      where object_closure.object_class = 'pg_catalog.pg_type'::regclass
++        and pg_type.oid = object_closure.object_id
++
++      union all
++
++      select 'pg_catalog.pg_constraint'::regclass::oid, pg_constraint.oid
++      from pg_catalog.pg_constraint
++      where object_closure.object_class = 'pg_catalog.pg_type'::regclass
++        and pg_constraint.contypid = object_closure.object_id
++
++      union all
++
++      select 'pg_catalog.pg_type'::regclass::oid, range_type.oid
++      from pg_catalog.pg_range
++      cross join lateral pg_catalog.unnest(
++        array[
++          pg_range.rngtypid,
++          pg_range.rngsubtype,
++          pg_range.rngmultitypid
++        ]::oid[]
++      ) as range_type(oid)
++      where object_closure.object_class = 'pg_catalog.pg_type'::regclass
++        and object_closure.object_id in (pg_range.rngtypid, pg_range.rngmultitypid)
++    ) as dependency
++    where dependency.object_id operator(pg_catalog.<>) 0
++  ),
++
++  retained_index_metadata(indexrelid, indclass, indcollation) as (
++    select pg_index.indexrelid, pg_index.indclass, pg_index.indcollation
++    from object_closure
++    inner join pg_catalog.pg_class retained_index
++      on object_closure.object_class = 'pg_catalog.pg_class'::regclass
++      and retained_index.oid = object_closure.object_id
++      and retained_index.relkind in ('i', 'I')
++    inner join pg_catalog.pg_index
++      on pg_index.indexrelid = retained_index.oid
++  ),
++
++  retained_index_opclasses(_id, opcfamily) as (
++    select pg_opclass.oid, pg_opclass.opcfamily
++    from retained_index_metadata
++    cross join lateral pg_catalog.unnest(
++      retained_index_metadata.indclass::oid[]
++    ) as index_opclass(_id)
++    inner join pg_catalog.pg_opclass
++      on pg_opclass.oid = index_opclass._id
++  ),
++
++  retained_index_support_objects(object_class, object_id) as (
++    select 'pg_catalog.pg_opclass'::regclass::oid, retained_index_opclasses._id
++    from retained_index_opclasses
++
++    union
++
++    select 'pg_catalog.pg_opfamily'::regclass::oid, retained_index_opclasses.opcfamily
++    from retained_index_opclasses
++
++    union
++
++    select 'pg_catalog.pg_operator'::regclass::oid, pg_amop.amopopr
++    from retained_index_opclasses
++    inner join pg_catalog.pg_amop
++      on pg_amop.amopfamily = retained_index_opclasses.opcfamily
++
++    union
++
++    select 'pg_catalog.pg_proc'::regclass::oid, pg_amproc.amproc
++    from retained_index_opclasses
++    inner join pg_catalog.pg_amproc
++      on pg_amproc.amprocfamily = retained_index_opclasses.opcfamily
++
++    union
++
++    select 'pg_catalog.pg_collation'::regclass::oid, index_collation._id
++    from retained_index_metadata
++    cross join lateral pg_catalog.unnest(
++      retained_index_metadata.indcollation::oid[]
++    ) as index_collation(_id)
++    where index_collation._id operator(pg_catalog.<>) 0
++  ),
++
++  installed_extensions(_id, extnamespace) as (
++    select pg_extension.oid, pg_extension.extnamespace
++    from pg_catalog.pg_extension
++    where pg_extension.extname in (
++      select capability_extension_names.extension_name
++      from capability_extension_names
++    )
++    or exists (
++      select 1
++      from object_closure
++      inner join pg_catalog.pg_depend
++        on pg_depend.classid = object_closure.object_class
++        and pg_depend.objid = object_closure.object_id
++        and pg_depend.refclassid = 'pg_catalog.pg_extension'::regclass
++        and pg_depend.refobjid = pg_extension.oid
++        and pg_depend.deptype = 'e'
++    )
++    or exists (
++      select 1
++      from retained_index_support_objects
++      inner join pg_catalog.pg_depend
++        on pg_depend.classid = retained_index_support_objects.object_class
++        and pg_depend.objid = retained_index_support_objects.object_id
++        and pg_depend.refclassid = 'pg_catalog.pg_extension'::regclass
++        and pg_depend.refobjid = pg_extension.oid
++        and pg_depend.deptype = 'e'
++    )
++    or exists (
++      select 1
++      from object_closure
++      inner join pg_catalog.pg_class retained_index
++        on object_closure.object_class = 'pg_catalog.pg_class'::regclass
++        and retained_index.oid = object_closure.object_id
++        and retained_index.relkind = 'i'
++      inner join pg_catalog.pg_depend
++        on pg_depend.classid = 'pg_catalog.pg_am'::regclass
++        and pg_depend.objid = retained_index.relam
++        and pg_depend.refclassid = 'pg_catalog.pg_extension'::regclass
++        and pg_depend.refobjid = pg_extension.oid
++        and pg_depend.deptype = 'e'
++    )
++  ),
++
++  scoped_namespaces(_id) as (
++    select requested_namespaces._id
++    from requested_namespaces
++
++    union
++
++    select pg_class.relnamespace
++    from object_closure
++    inner join pg_catalog.pg_class
++      on object_closure.object_class = 'pg_catalog.pg_class'::regclass
++      and pg_class.oid = object_closure.object_id
++
++    union
++
++    select pg_constraint.connamespace
++    from object_closure
++    inner join pg_catalog.pg_constraint
++      on object_closure.object_class = 'pg_catalog.pg_constraint'::regclass
++      and pg_constraint.oid = object_closure.object_id
++
++    union
++
++    select pg_proc.pronamespace
++    from object_closure
++    inner join pg_catalog.pg_proc
++      on object_closure.object_class = 'pg_catalog.pg_proc'::regclass
++      and pg_proc.oid = object_closure.object_id
++
++    union
++
++    select pg_type.typnamespace
++    from object_closure
++    inner join pg_catalog.pg_type
++      on object_closure.object_class = 'pg_catalog.pg_type'::regclass
++      and pg_type.oid = object_closure.object_id
++
++    union
++
++    select installed_extensions.extnamespace
++    from installed_extensions
++    where installed_extensions.extnamespace operator(pg_catalog.<>) 0
++
++    union
++
++    select pg_namespace.oid
++    from pg_catalog.pg_namespace
++    where pg_namespace.nspname = 'pg_catalog'
++  ),
++
++`;
+ // We might want this to take options in future, so we've made it a function.
+ /**
+  * Builds a PostgreSQL introspection SQL query to return an object with the same shape as `Introspection` above.
+  */
+-const makeIntrospectionQuery = () => `\
++const buildIntrospectionQuery = (scope) => `\
+ with
++${scope?.ctes ?? ""}\
+   database as (
+     select pg_database.oid as _id, *
+     from pg_catalog.pg_database
+@@ -21,14 +349,14 @@ with
+   namespaces as (
+     select pg_namespace.oid as _id, *
+     from pg_catalog.pg_namespace
+-    where nspname <> 'information_schema'
++    where ${scope?.namespacePredicate ?? STOCK_NAMESPACE_PREDICATE}
+   ),
+ 
+   classes as (
+     select pg_class.oid as _id, *,
+       pg_catalog.pg_relation_is_updatable(oid, true)::bit(8)::int4 as "updatable_mask"
+     from pg_catalog.pg_class
+-    where relnamespace in (select namespaces._id from namespaces where nspname <> 'information_schema' and nspname not like 'pg\\_%')
++    where ${scope?.classPredicate ?? `relnamespace ${STOCK_OBJECT_NAMESPACE_PREDICATE}`}
+   ),
+ 
+   attributes as (
+@@ -40,32 +368,34 @@ with
+   constraints as (
+     select pg_constraint.oid as _id, *
+     from pg_catalog.pg_constraint
+-    where connamespace in (select namespaces._id from namespaces where nspname <> 'information_schema' and nspname not like 'pg\\_%')
++    where ${scope?.constraintPredicate ?? `connamespace ${STOCK_OBJECT_NAMESPACE_PREDICATE}`}
+   ),
+ 
+   procs as (
+     select pg_proc.oid as _id, *
+     from pg_catalog.pg_proc
+-    where pronamespace in (select namespaces._id from namespaces where nspname <> 'information_schema' and nspname not like 'pg\\_%')
++    where ${scope?.procPredicate ?? `pronamespace ${STOCK_OBJECT_NAMESPACE_PREDICATE}`}
+     and prorettype operator(pg_catalog.<>) 2279
+   ),
+ 
+   roles as (
+     select pg_roles.oid as _id, *
+     from pg_catalog.pg_roles
++${scope?.rolePredicate ? `    where ${scope.rolePredicate}
++` : ""}\
+   ),
+ 
+   auth_members as (
+     select *
+     from pg_catalog.pg_auth_members
+-    where roleid in (select roles._id from roles)
++    where ${scope?.authMemberPredicate ?? "roleid in (select roles._id from roles)"}
+   ),
+ 
+   types as (
+     select pg_type.oid as _id, *
+     from pg_catalog.pg_type
+-    where (typnamespace in (select namespaces._id from namespaces where nspname <> 'information_schema' and nspname not like 'pg\\_%'))
+-    or (typnamespace = 'pg_catalog'::regnamespace)
++    where ${scope?.typePredicate ?? `(typnamespace ${STOCK_OBJECT_NAMESPACE_PREDICATE})
++    or (typnamespace = 'pg_catalog'::regnamespace)`}
+   ),
+ 
+   enums as (
+@@ -77,6 +407,8 @@ with
+   extensions as (
+     select pg_extension.oid as _id, *
+     from pg_catalog.pg_extension
++${scope?.extensionPredicate ? `    where ${scope.extensionPredicate}
++` : ""}\
+   ),
+ 
+   indexes as (
+@@ -94,6 +426,8 @@ with
+   languages as (
+     select pg_language.oid as _id, *
+     from pg_catalog.pg_language
++${scope?.languagePredicate ? `    where ${scope.languagePredicate}
++` : ""}\
+   ),
+ 
+   policies as (
+@@ -141,7 +475,7 @@ with
+   am as (
+     select pg_am.oid as _id, *
+     from pg_catalog.pg_am
+-    where true
++    where ${scope?.accessMethodPredicate ?? "true"}
+   )
+ select json_build_object(
+   'database',
+@@ -221,5 +555,66 @@ select json_build_object(
+   1
+ )::text as introspection
+ `;
++const makeIntrospectionQuery = () => buildIntrospectionQuery();
+ exports.makeIntrospectionQuery = makeIntrospectionQuery;
++/**
++ * Builds a parameterized introspection query scoped to the requested schemas
++ * and the transitive object dependencies required by their objects.
++ */
++const makeSchemaScopedIntrospectionQuery = (schemas, options = {}) => {
++    if (!Array.isArray(schemas) || schemas.length === 0) {
++        throw new Error("Schema-scoped introspection requires at least one schema");
++    }
++    if (options === null || typeof options !== "object" || Array.isArray(options)) {
++        throw new Error("Schema-scoped introspection options must be an object");
++    }
++    const unsupportedOptions = Object.keys(options).filter((key) => key !== "catalogTypes" && key !== "capabilityExtensions");
++    if (unsupportedOptions.length > 0) {
++        throw new Error(`Unsupported schema-scoped introspection option(s): ${unsupportedOptions.join(", ")}`);
++    }
++    const catalogTypes = options.catalogTypes ?? "all";
++    if (catalogTypes !== "all" && catalogTypes !== "dependency-closure") {
++        throw new Error(`Unsupported schema-scoped catalog type policy '${catalogTypes}'`);
++    }
++    const capabilityExtensions = options.capabilityExtensions ?? [];
++    if (!Array.isArray(capabilityExtensions)) {
++        throw new Error("Schema-scoped introspection capabilityExtensions must be an array");
++    }
++    const normalizedCapabilityExtensions = Array.from(new Set(capabilityExtensions.map((extension) => {
++        if (typeof extension !== "string" || extension.length === 0 || extension.trim() !== extension || extension.includes("\0")) {
++            throw new Error("Schema-scoped introspection capabilityExtensions must contain exact non-empty extension names");
++        }
++        return extension;
++    })));
++    const normalized = Array.from(new Set(schemas.map((schema) => {
++        if (typeof schema !== "string" || schema.length === 0) {
++            throw new Error("Schema-scoped introspection schemas must be non-empty strings");
++        }
++        if (schema.includes("\0")) {
++            throw new Error("Schema-scoped introspection schemas must not contain NUL bytes");
++        }
++        if (schema === "information_schema" || schema.startsWith("pg_")) {
++            throw new Error(`Schema-scoped introspection cannot expose system schema '${schema}'`);
++        }
++        return schema;
++    })));
++    const dependencyClosureTypePredicate = "pg_type.oid = any (array(select object_id from object_closure where object_class = 'pg_catalog.pg_type'::regclass))";
++    return {
++        text: buildIntrospectionQuery({
++            ctes: SCOPED_CTES,
++            namespacePredicate: "pg_namespace.oid = any (array(select scoped_namespaces._id from scoped_namespaces))",
++            classPredicate: "pg_class.oid = any (array(select object_id from object_closure where object_class = 'pg_catalog.pg_class'::regclass))",
++            constraintPredicate: "pg_constraint.oid = any (array(select object_id from object_closure where object_class = 'pg_catalog.pg_constraint'::regclass))",
++            procPredicate: "pg_proc.oid = any (array(select object_id from object_closure where object_class = 'pg_catalog.pg_proc'::regclass))",
++            typePredicate: catalogTypes === "all"
++                ? `${dependencyClosureTypePredicate} or pg_type.typnamespace = 'pg_catalog'::regnamespace`
++                : dependencyClosureTypePredicate,
++            extensionPredicate: "pg_extension.oid = any (array(select installed_extensions._id from installed_extensions))",
++            languagePredicate: "true",
++            accessMethodPredicate: "true",
++        }),
++        values: [normalized, normalizedCapabilityExtensions],
++    };
++};
++exports.makeSchemaScopedIntrospectionQuery = makeSchemaScopedIntrospectionQuery;
+ //# sourceMappingURL=introspection.js.map

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,24 +5,35 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@dataplan/json': 1.0.1
+  '@dataplan/pg': 1.1.1
+  '@graphile-contrib/pg-many-to-many': 2.0.0-rc.2
+  '@graphile/lru': 5.0.0
+  '@smithy/node-http-handler': <4.5.0
   grafast: 1.1.2
   grafserv: 1.0.1
   graphile-build: 5.1.1
   graphile-build-pg: 5.1.3
   graphile-config: 1.1.0
   graphile-utils: 5.0.3
-  postgraphile: 5.1.4
-  pg-sql2: 5.0.1
-  pg-introspection: 1.0.1
-  tamedevil: 0.1.1
-  '@dataplan/pg': 1.1.1
-  '@dataplan/json': 1.0.1
-  '@graphile/lru': 5.0.0
-  '@graphile-contrib/pg-many-to-many': 2.0.0-rc.2
   graphql: 16.13.0
-  '@smithy/node-http-handler': <4.5.0
+  pg-introspection: 1.0.1
+  pg-sql2: 5.0.1
+  postgraphile: 5.1.4
+  tamedevil: 0.1.1
 
 packageExtensionsChecksum: sha256-x8B4zkJ4KLRX+yspUWxuggXWlz6zrBLSIh72pNhpPiE=
+
+patchedDependencies:
+  '@dataplan/pg':
+    hash: a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2
+    path: patches/@dataplan__pg.patch
+  graphile-build-pg:
+    hash: 8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5
+    path: patches/graphile-build-pg.patch
+  pg-introspection@1.0.1:
+    hash: 004a0acc578342e50b175514c03b45108e9d3a85e8928696b0fdaef995ec4b25
+    path: patches/pg-introspection@1.0.1.patch
 
 importers:
   .:
@@ -373,19 +384,19 @@ importers:
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
       graphile-utils:
         specifier: 5.0.3
-        version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+        version: 5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql:
         specifier: 16.13.0
         version: 16.13.0
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(138876491c004694bff1843ee79c8872)
+        version: 5.1.4(564ecc69f17f317514da2378ea0ee7d1)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -399,7 +410,7 @@ importers:
     dependencies:
       '@dataplan/pg':
         specifier: 1.1.1
-        version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+        version: 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       grafast:
         specifier: 1.1.2
         version: 1.1.2(graphql@16.13.0)
@@ -408,7 +419,7 @@ importers:
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -420,7 +431,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(138876491c004694bff1843ee79c8872)
+        version: 5.1.4(564ecc69f17f317514da2378ea0ee7d1)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -461,7 +472,7 @@ importers:
         version: link:../../postgres/pg-cache/dist
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(b3fb9399b7b000ca872a8f427cb73d08)
+        version: 5.1.4(d2fbc9214324995a9f19d45c874ffd17)
     devDependencies:
       '@types/express':
         specifier: ^5.0.6
@@ -481,13 +492,13 @@ importers:
     dependencies:
       '@dataplan/pg':
         specifier: 1.1.1
-        version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+        version: 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       graphile-build:
         specifier: 5.1.1
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -502,7 +513,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(f51a9bb2feb8b06fca136f1c2a1a2f6a)
+        version: 5.1.4(ba6398e917e9857a0084b873121de2c9)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -525,7 +536,7 @@ importers:
         version: link:../../postgres/query-builder/dist
       '@dataplan/pg':
         specifier: 1.1.1
-        version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+        version: 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       '@pgpmjs/logger':
         specifier: workspace:^
         version: link:../../pgpm/logger/dist
@@ -537,7 +548,7 @@ importers:
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -575,7 +586,7 @@ importers:
     dependencies:
       '@dataplan/pg':
         specifier: 1.1.1
-        version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+        version: 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       grafast:
         specifier: 1.1.2
         version: 1.1.2(graphql@16.13.0)
@@ -584,7 +595,7 @@ importers:
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -596,7 +607,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(f282a162d8bd20a217e08c60f5396af8)
+        version: 5.1.4(a8630eea9ec1b1fcc351d9a56a9502d8)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -622,7 +633,7 @@ importers:
     dependencies:
       '@dataplan/pg':
         specifier: 1.1.1
-        version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+        version: 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       accept-language-parser:
         specifier: ^1.5.0
         version: 1.5.0
@@ -634,7 +645,7 @@ importers:
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -646,7 +657,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(f282a162d8bd20a217e08c60f5396af8)
+        version: 5.1.4(a8630eea9ec1b1fcc351d9a56a9502d8)
     devDependencies:
       '@types/accept-language-parser':
         specifier: ^1.5.4
@@ -684,7 +695,7 @@ importers:
         version: link:../../packages/llm-env/dist
       '@dataplan/pg':
         specifier: 1.1.1
-        version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+        version: 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       grafast:
         specifier: 1.1.2
         version: 1.1.2(graphql@16.13.0)
@@ -693,7 +704,7 @@ importers:
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-cache:
         specifier: workspace:^
         version: link:../graphile-cache/dist
@@ -702,7 +713,7 @@ importers:
         version: 1.1.0
       graphile-utils:
         specifier: 5.0.3
-        version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+        version: 5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql:
         specifier: 16.13.0
         version: 16.13.0
@@ -711,7 +722,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(138876491c004694bff1843ee79c8872)
+        version: 5.1.4(564ecc69f17f317514da2378ea0ee7d1)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -737,7 +748,7 @@ importers:
     dependencies:
       '@dataplan/pg':
         specifier: 1.1.1
-        version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+        version: 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       grafast:
         specifier: 1.1.2
         version: 1.1.2(graphql@16.13.0)
@@ -746,7 +757,7 @@ importers:
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -758,7 +769,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(138876491c004694bff1843ee79c8872)
+        version: 5.1.4(564ecc69f17f317514da2378ea0ee7d1)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -784,7 +795,7 @@ importers:
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -793,7 +804,7 @@ importers:
         version: 16.13.0
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(f282a162d8bd20a217e08c60f5396af8)
+        version: 5.1.4(a8630eea9ec1b1fcc351d9a56a9502d8)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -807,7 +818,7 @@ importers:
     dependencies:
       '@dataplan/pg':
         specifier: 1.1.1
-        version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+        version: 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       grafast:
         specifier: 1.1.2
         version: 1.1.2(graphql@16.13.0)
@@ -816,7 +827,7 @@ importers:
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -831,7 +842,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(138876491c004694bff1843ee79c8872)
+        version: 5.1.4(564ecc69f17f317514da2378ea0ee7d1)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -854,13 +865,13 @@ importers:
     dependencies:
       '@dataplan/pg':
         specifier: 1.1.1
-        version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+        version: 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       graphile-build:
         specifier: 5.1.1
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -872,7 +883,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(f282a162d8bd20a217e08c60f5396af8)
+        version: 5.1.4(a8630eea9ec1b1fcc351d9a56a9502d8)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -886,7 +897,7 @@ importers:
     dependencies:
       '@dataplan/pg':
         specifier: 1.1.1
-        version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+        version: 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       grafast:
         specifier: 1.1.2
         version: 1.1.2(graphql@16.13.0)
@@ -895,7 +906,7 @@ importers:
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -907,7 +918,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(f51a9bb2feb8b06fca136f1c2a1a2f6a)
+        version: 5.1.4(ba6398e917e9857a0084b873121de2c9)
     devDependencies:
       '@types/geojson':
         specifier: ^7946.0.14
@@ -951,13 +962,13 @@ importers:
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
       graphile-utils:
         specifier: 5.0.3
-        version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+        version: 5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql:
         specifier: 16.13.0
         version: 16.13.0
@@ -969,7 +980,7 @@ importers:
         version: link:../../uploads/mime-bytes/dist
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(138876491c004694bff1843ee79c8872)
+        version: 5.1.4(564ecc69f17f317514da2378ea0ee7d1)
     devDependencies:
       '@constructive-io/s3-utils':
         specifier: workspace:^
@@ -992,7 +1003,7 @@ importers:
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1007,7 +1018,7 @@ importers:
         version: 8.21.0
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(b3fb9399b7b000ca872a8f427cb73d08)
+        version: 5.1.4(d2fbc9214324995a9f19d45c874ffd17)
     devDependencies:
       '@types/pg':
         specifier: ^8.20.4
@@ -1036,19 +1047,19 @@ importers:
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
       graphile-utils:
         specifier: 5.0.3
-        version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+        version: 5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql:
         specifier: 16.13.0
         version: 16.13.0
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(138876491c004694bff1843ee79c8872)
+        version: 5.1.4(564ecc69f17f317514da2378ea0ee7d1)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -1068,7 +1079,7 @@ importers:
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1114,7 +1125,7 @@ importers:
         version: link:../../postgres/pgsql-test/dist
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(b3fb9399b7b000ca872a8f427cb73d08)
+        version: 5.1.4(d2fbc9214324995a9f19d45c874ffd17)
     publishDirectory: dist
 
   graphile/graphile-schema:
@@ -1156,13 +1167,13 @@ importers:
     dependencies:
       '@dataplan/pg':
         specifier: 1.1.1
-        version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+        version: 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       graphile-build:
         specifier: 5.1.1
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1177,7 +1188,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(f51a9bb2feb8b06fca136f1c2a1a2f6a)
+        version: 5.1.4(ba6398e917e9857a0084b873121de2c9)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -1230,7 +1241,7 @@ importers:
         version: 1.0.1(grafast@1.1.2(graphql@16.13.0))
       '@dataplan/pg':
         specifier: 1.1.1
-        version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+        version: 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       '@graphile-contrib/pg-many-to-many':
         specifier: 2.0.0-rc.2
         version: 2.0.0-rc.2
@@ -1263,7 +1274,7 @@ importers:
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-bulk-mutations:
         specifier: workspace:^
         version: link:../graphile-bulk-mutations/dist
@@ -1308,7 +1319,7 @@ importers:
         version: link:../graphile-upload-plugin/dist
       graphile-utils:
         specifier: 5.0.3
-        version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+        version: 5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql:
         specifier: 16.13.0
         version: 16.13.0
@@ -1332,7 +1343,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(b3fb9399b7b000ca872a8f427cb73d08)
+        version: 5.1.4(d2fbc9214324995a9f19d45c874ffd17)
       request-ip:
         specifier: ^3.3.0
         version: 3.3.0
@@ -1376,7 +1387,7 @@ importers:
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1417,7 +1428,7 @@ importers:
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1435,7 +1446,7 @@ importers:
         version: link:../../postgres/pgsql-test/dist
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(b3fb9399b7b000ca872a8f427cb73d08)
+        version: 5.1.4(d2fbc9214324995a9f19d45c874ffd17)
     devDependencies:
       '@types/pg':
         specifier: ^8.20.4
@@ -1455,7 +1466,7 @@ importers:
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1464,7 +1475,7 @@ importers:
         version: 16.13.0
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(f51a9bb2feb8b06fca136f1c2a1a2f6a)
+        version: 5.1.4(ba6398e917e9857a0084b873121de2c9)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -1606,7 +1617,7 @@ importers:
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-cache:
         specifier: workspace:^
         version: link:../../graphile/graphile-cache/dist
@@ -1618,7 +1629,7 @@ importers:
         version: link:../../graphile/graphile-settings/dist
       graphile-utils:
         specifier: 5.0.3
-        version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+        version: 5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql:
         specifier: 16.13.0
         version: 16.13.0
@@ -1636,7 +1647,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(b3fb9399b7b000ca872a8f427cb73d08)
+        version: 5.1.4(d2fbc9214324995a9f19d45c874ffd17)
     devDependencies:
       '@types/express':
         specifier: ^5.0.6
@@ -1709,7 +1720,7 @@ importers:
         version: link:../../postgres/pg-env/dist
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(b3fb9399b7b000ca872a8f427cb73d08)
+        version: 5.1.4(d2fbc9214324995a9f19d45c874ffd17)
     devDependencies:
       '@types/express':
         specifier: ^5.0.6
@@ -1853,7 +1864,7 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1874,7 +1885,7 @@ importers:
         version: 11.2.7
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(b3fb9399b7b000ca872a8f427cb73d08)
+        version: 5.1.4(d2fbc9214324995a9f19d45c874ffd17)
     devDependencies:
       makage:
         specifier: ^0.3.0
@@ -1894,7 +1905,7 @@ importers:
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1918,7 +1929,7 @@ importers:
         version: 8.20.0
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(cf7ef086788d1d3f644d1dc7345cb344)
+        version: 5.1.4(a2bc1f0f07e2072a3ead26bf7ded50e6)
       ws:
         specifier: ^8.20.0
         version: 8.20.1
@@ -2007,7 +2018,7 @@ importers:
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-cache:
         specifier: workspace:^
         version: link:../../graphile/graphile-cache/dist
@@ -2022,7 +2033,7 @@ importers:
         version: link:../../graphile/graphile-settings/dist
       graphile-utils:
         specifier: 5.0.3
-        version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+        version: 5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql:
         specifier: 16.13.0
         version: 16.13.0
@@ -2049,7 +2060,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(b3fb9399b7b000ca872a8f427cb73d08)
+        version: 5.1.4(d2fbc9214324995a9f19d45c874ffd17)
       request-ip:
         specifier: ^3.3.0
         version: 3.3.0
@@ -2090,6 +2101,9 @@ importers:
       nodemon:
         specifier: ^3.1.14
         version: 3.1.14
+      pg-introspection:
+        specifier: 1.0.1
+        version: 1.0.1(patch_hash=004a0acc578342e50b175514c03b45108e9d3a85e8928696b0fdaef995ec4b25)
       supertest:
         specifier: ^7.2.2
         version: 7.2.2
@@ -2203,7 +2217,7 @@ importers:
         version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -2227,7 +2241,7 @@ importers:
         version: link:../../postgres/pgsql-test/dist
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(b3fb9399b7b000ca872a8f427cb73d08)
+        version: 5.1.4(d2fbc9214324995a9f19d45c874ffd17)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -16140,7 +16154,7 @@ snapshots:
       grafast: 1.1.2(graphql@16.13.0)
       tslib: 2.8.1
 
-  '@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)':
+  '@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)':
     dependencies:
       '@dataplan/json': 1.0.1(grafast@1.1.2(graphql@16.13.0))
       '@graphile/lru': 5.0.0
@@ -16160,7 +16174,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)':
+  '@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)':
     dependencies:
       '@dataplan/json': 1.0.1(grafast@1.1.2(graphql@16.13.0))
       '@graphile/lru': 5.0.0
@@ -20241,9 +20255,9 @@ snapshots:
       - supports-color
       - use-sync-external-store
 
-  graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1):
+  graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1):
     dependencies:
-      '@dataplan/pg': 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)
+      '@dataplan/pg': 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)
       '@types/node': 22.19.19
       debug: 4.4.3(supports-color@5.5.0)
       grafast: 1.1.2(graphql@16.13.0)
@@ -20251,7 +20265,7 @@ snapshots:
       graphile-config: 1.1.0
       graphql: 16.13.0
       jsonwebtoken: 9.0.3
-      pg-introspection: 1.0.1
+      pg-introspection: 1.0.1(patch_hash=004a0acc578342e50b175514c03b45108e9d3a85e8928696b0fdaef995ec4b25)
       pg-sql2: 5.0.1
       tamedevil: 0.1.1
       tslib: 2.8.1
@@ -20260,9 +20274,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1):
+  graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1):
     dependencies:
-      '@dataplan/pg': 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      '@dataplan/pg': 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       '@types/node': 22.19.19
       debug: 4.4.3(supports-color@5.5.0)
       grafast: 1.1.2(graphql@16.13.0)
@@ -20270,7 +20284,7 @@ snapshots:
       graphile-config: 1.1.0
       graphql: 16.13.0
       jsonwebtoken: 9.0.3
-      pg-introspection: 1.0.1
+      pg-introspection: 1.0.1(patch_hash=004a0acc578342e50b175514c03b45108e9d3a85e8928696b0fdaef995ec4b25)
       pg-sql2: 5.0.1
       tamedevil: 0.1.1
       tslib: 2.8.1
@@ -20309,9 +20323,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  graphile-utils@5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1):
+  graphile-utils@5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1):
     dependencies:
-      '@dataplan/pg': 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)
+      '@dataplan/pg': 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)
       debug: 4.4.3(supports-color@5.5.0)
       grafast: 1.1.2(graphql@16.13.0)
       graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
@@ -20321,13 +20335,13 @@ snapshots:
       tamedevil: 0.1.1
       tslib: 2.8.1
     optionalDependencies:
-      graphile-build-pg: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1)
+      graphile-build-pg: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  graphile-utils@5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1):
+  graphile-utils@5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1):
     dependencies:
-      '@dataplan/pg': 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      '@dataplan/pg': 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       debug: 4.4.3(supports-color@5.5.0)
       grafast: 1.1.2(graphql@16.13.0)
       graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
@@ -20337,7 +20351,7 @@ snapshots:
       tamedevil: 0.1.1
       tslib: 2.8.1
     optionalDependencies:
-      graphile-build-pg: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-build-pg: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22196,7 +22210,7 @@ snapshots:
 
   pg-int8@1.0.1: {}
 
-  pg-introspection@1.0.1:
+  pg-introspection@1.0.1(patch_hash=004a0acc578342e50b175514c03b45108e9d3a85e8928696b0fdaef995ec4b25):
     dependencies:
       tslib: 2.8.1
 
@@ -22339,10 +22353,10 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postgraphile@5.1.4(138876491c004694bff1843ee79c8872):
+  postgraphile@5.1.4(564ecc69f17f317514da2378ea0ee7d1):
     dependencies:
       '@dataplan/json': 1.0.1(grafast@1.1.2(graphql@16.13.0))
-      '@dataplan/pg': 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      '@dataplan/pg': 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       '@graphile/lru': 5.0.0
       '@types/node': 22.19.19
       '@types/pg': 8.20.4
@@ -22350,9 +22364,9 @@ snapshots:
       grafast: 1.1.2(graphql@16.13.0)
       grafserv: 1.0.1(@types/node@22.19.15)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(ws@8.20.1)
       graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
-      graphile-build-pg: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-build-pg: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config: 1.1.0
-      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql: 16.13.0
       iterall: 1.3.0
       jsonwebtoken: 9.0.3
@@ -22366,10 +22380,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  postgraphile@5.1.4(b3fb9399b7b000ca872a8f427cb73d08):
+  postgraphile@5.1.4(a2bc1f0f07e2072a3ead26bf7ded50e6):
     dependencies:
       '@dataplan/json': 1.0.1(grafast@1.1.2(graphql@16.13.0))
-      '@dataplan/pg': 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      '@dataplan/pg': 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)
       '@graphile/lru': 5.0.0
       '@types/node': 22.19.19
       '@types/pg': 8.20.4
@@ -22377,36 +22391,9 @@ snapshots:
       grafast: 1.1.2(graphql@16.13.0)
       grafserv: 1.0.1(@types/node@25.9.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(ws@8.20.1)
       graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
-      graphile-build-pg: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-build-pg: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1)
       graphile-config: 1.1.0
-      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
-      graphql: 16.13.0
-      iterall: 1.3.0
-      jsonwebtoken: 9.0.3
-      pg: 8.21.0
-      pg-sql2: 5.0.1
-      tamedevil: 0.1.1
-      tslib: 2.8.1
-      ws: 8.20.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  postgraphile@5.1.4(cf7ef086788d1d3f644d1dc7345cb344):
-    dependencies:
-      '@dataplan/json': 1.0.1(grafast@1.1.2(graphql@16.13.0))
-      '@dataplan/pg': 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)
-      '@graphile/lru': 5.0.0
-      '@types/node': 22.19.19
-      '@types/pg': 8.20.4
-      debug: 4.4.3(supports-color@5.5.0)
-      grafast: 1.1.2(graphql@16.13.0)
-      grafserv: 1.0.1(@types/node@25.9.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(ws@8.20.1)
-      graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
-      graphile-build-pg: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1)
-      graphile-config: 1.1.0
-      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql: 16.13.0
       iterall: 1.3.0
       jsonwebtoken: 9.0.3
@@ -22420,10 +22407,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  postgraphile@5.1.4(f282a162d8bd20a217e08c60f5396af8):
+  postgraphile@5.1.4(a8630eea9ec1b1fcc351d9a56a9502d8):
     dependencies:
       '@dataplan/json': 1.0.1(grafast@1.1.2(graphql@16.13.0))
-      '@dataplan/pg': 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      '@dataplan/pg': 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       '@graphile/lru': 5.0.0
       '@types/node': 22.19.19
       '@types/pg': 8.20.4
@@ -22431,9 +22418,9 @@ snapshots:
       grafast: 1.1.2(graphql@16.13.0)
       grafserv: 1.0.1(@types/node@22.19.19)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(ws@8.20.1)
       graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
-      graphile-build-pg: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-build-pg: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config: 1.1.0
-      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql: 16.13.0
       iterall: 1.3.0
       jsonwebtoken: 9.0.3
@@ -22447,10 +22434,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  postgraphile@5.1.4(f51a9bb2feb8b06fca136f1c2a1a2f6a):
+  postgraphile@5.1.4(ba6398e917e9857a0084b873121de2c9):
     dependencies:
       '@dataplan/json': 1.0.1(grafast@1.1.2(graphql@16.13.0))
-      '@dataplan/pg': 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      '@dataplan/pg': 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       '@graphile/lru': 5.0.0
       '@types/node': 22.19.19
       '@types/pg': 8.20.4
@@ -22458,9 +22445,36 @@ snapshots:
       grafast: 1.1.2(graphql@16.13.0)
       grafserv: 1.0.1(@types/node@22.19.11)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(ws@8.20.1)
       graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
-      graphile-build-pg: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-build-pg: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config: 1.1.0
-      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+      graphql: 16.13.0
+      iterall: 1.3.0
+      jsonwebtoken: 9.0.3
+      pg: 8.21.0
+      pg-sql2: 5.0.1
+      tamedevil: 0.1.1
+      tslib: 2.8.1
+      ws: 8.20.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  postgraphile@5.1.4(d2fbc9214324995a9f19d45c874ffd17):
+    dependencies:
+      '@dataplan/json': 1.0.1(grafast@1.1.2(graphql@16.13.0))
+      '@dataplan/pg': 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      '@graphile/lru': 5.0.0
+      '@types/node': 22.19.19
+      '@types/pg': 8.20.4
+      debug: 4.4.3(supports-color@5.5.0)
+      grafast: 1.1.2(graphql@16.13.0)
+      grafserv: 1.0.1(@types/node@25.9.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(ws@8.20.1)
+      graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+      graphile-build-pg: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-config: 1.1.0
+      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql: 16.13.0
       iterall: 1.3.0
       jsonwebtoken: 9.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -108,6 +108,11 @@ packageExtensions:
     dependencies:
       '@jest/test-sequencer': ^29.7.0
 
+patchedDependencies:
+  '@dataplan/pg': patches/@dataplan__pg.patch
+  graphile-build-pg: patches/graphile-build-pg.patch
+  pg-introspection@1.0.1: patches/pg-introspection@1.0.1.patch
+
 # The only dependencies permitted to run install scripts.
 allowBuilds:
   "@launchql/protobufjs": true


### PR DESCRIPTION
## Stack

This is PR 1 of 3 and targets `main`.

1. **#1711 — temporary scoped introspection (this PR)**
2. #1712 — build-state retirement
3. #1713 — focused performance harness

## Summary

- add an explicit `stock` / `scoped-required` PostgreSQL introspection mode to `makePgService`
- add schema-scoped catalog queries with either complete catalog types or dependency-closure types
- validate required and allowed namespaces and referenced type closure fail-closed
- add exact node-postgres introspection-client reuse/destroy semantics and capability checks
- keep scoped raw introspection cache state limited to the gather that consumed it

## Motivation

The stock Graphile catalog query inspects substantially more PostgreSQL catalog state than a service exposing a bounded schema set needs. This introduces an explicit scoped path while preserving the stock path as the default and as the comparison baseline.

This is intentionally an interim pnpm-patch implementation. Graphile's planned progressive introspection should provide the upstream replacement; once it is available and validated, these patches and wrapper settings can be removed in favor of that implementation.

## Behavior and compatibility

- defaults remain `introspectionMode: 'stock'` and `introspectionClientReleaseMode: 'reuse'`
- scoped introspection must be explicitly requested
- scoped catalog type and capability settings are rejected in stock mode
- missing required schemas, unapproved dependency schemas, or incomplete type closure fail the build
- no application plugin behavior changes in this PR

## Validation

- graphile-settings service, runtime, cache-lifecycle, and exact-client-release tests
- graphql/server scoped-introspection middleware tests
- targeted package builds, type checks, and lint
- frozen-lockfile install

The focused test run covered 24 assertions across the settings and server suites.