### PR TITLE
Own build-state retirement policy in CNC

### DIFF
--- a/graphile/graphile-connection-filter/__tests__/build-state-disposal.test.ts
+++ b/graphile/graphile-connection-filter/__tests__/build-state-disposal.test.ts
@@ -1,0 +1,23 @@
+import { ConnectionFilterCustomOperatorsPlugin } from '../src/plugins/ConnectionFilterCustomOperatorsPlugin';
+import { $$filters } from '../src/types';
+
+describe('connection-filter build-state ownership', () => {
+  it('clears the custom operator registry through the build lifecycle', () => {
+    let dispose: (() => void) | undefined;
+    const build: any = {
+      registerBuildStateDisposer(callback: () => void) {
+        dispose = callback;
+      },
+    };
+    const buildHook = ConnectionFilterCustomOperatorsPlugin.schema!.hooks!
+      .build as (build: any) => any;
+    buildHook(build);
+
+    const operators = new Map([['equalTo', { resolve: jest.fn() }]]);
+    build[$$filters].set('StringFilter', operators);
+    dispose!();
+
+    expect(operators.size).toBe(0);
+    expect(build[$$filters].size).toBe(0);
+  });
+});

--- a/graphile/graphile-connection-filter/src/plugins/ConnectionFilterCustomOperatorsPlugin.ts
+++ b/graphile/graphile-connection-filter/src/plugins/ConnectionFilterCustomOperatorsPlugin.ts
@@ -51,10 +51,17 @@ export const ConnectionFilterCustomOperatorsPlugin: GraphileConfig.Plugin = {
     hooks: {
       build(build) {
         // Initialize the filter registry
-        build[$$filters] = new Map<
+        const filters = new Map<
           string,
           Map<string, ConnectionFilterOperatorSpec>
         >();
+        build[$$filters] = filters;
+        build.registerBuildStateDisposer(() => {
+          for (const operators of filters.values()) {
+            operators.clear();
+          }
+          filters.clear();
+        });
 
         return build;
       },

--- a/graphile/graphile-meta/__tests__/meta-schema.test.ts
+++ b/graphile/graphile-meta/__tests__/meta-schema.test.ts
@@ -136,6 +136,14 @@ function callGraphQLObjectTypeFieldsHook(
   });
 }
 
+function callFinalizeHook(schema: GraphQLSchema, build: any): GraphQLSchema {
+  const finalizeHook = MetaSchemaPlugin.schema!.hooks!.finalize as (
+    schema: GraphQLSchema,
+    build: any
+  ) => GraphQLSchema;
+  return finalizeHook(schema, build);
+}
+
 function deepClone<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }
@@ -2016,6 +2024,7 @@ describe('MetaSchemaPlugin', () => {
         }),
         types: [userType]
       });
+      callFinalizeHook(schema, build);
       const result = await graphql({
         schema,
         source: `
@@ -2086,6 +2095,7 @@ describe('MetaSchemaPlugin', () => {
             })
           ]
         });
+        callFinalizeHook(schema, build);
         return schema;
       };
 
@@ -2112,7 +2122,7 @@ describe('MetaSchemaPlugin', () => {
       ).toEqual(['Project']);
     });
 
-    it('validates metadata against schema changes made by later finalizers', async () => {
+    it('snapshots metadata from the finalized executable schema', async () => {
       const codec = createMockCodec('user', {
         id: createMockAttribute('text')
       });
@@ -2143,12 +2153,11 @@ describe('MetaSchemaPlugin', () => {
         fields: queryFields
       });
       const schema = new GraphQLSchema({ query: queryType });
-
-      // Before later finalizers mutate the schema, the metadata resolves the
-      // list entry-point; the resolver must recompute from the final schema.
+      // Simulate an earlier finalizer removing an entry-point before the meta
+      // plugin snapshots the executable schema.
       expect((collectTablesMeta(build, schema) as any[])[0].query.all).toBe('users');
-
       delete queryType.getFields().users;
+      callFinalizeHook(schema, build);
       const result = await graphql({
         schema,
         source: '{ _meta { tables { query { all } } } }'

--- a/graphile/graphile-meta/src/plugin.ts
+++ b/graphile/graphile-meta/src/plugin.ts
@@ -10,22 +10,19 @@ import type { MetaBuild, TableMeta } from './types';
 
 const runtimeTablesBySchema = new WeakMap<GraphQLSchema, TableMeta[]>();
 
-function getRuntimeTablesMeta(
-  build: MetaBuild,
-  schema: GraphQLSchema
-): TableMeta[] {
-  let tables = runtimeTablesBySchema.get(schema);
+function getRuntimeTablesMeta(schema: GraphQLSchema): TableMeta[] {
+  const tables = runtimeTablesBySchema.get(schema);
   if (!tables) {
-    tables = collectTablesMeta(build, schema);
-    runtimeTablesBySchema.set(schema, tables);
+    throw new Error(
+      'Meta schema runtime state was not finalized for this GraphQL schema'
+    );
   }
   return tables;
 }
 
 /**
  * Returns the table metadata memoized for the given executable schema, or
- * `undefined` if `_meta` has not been resolved against that schema (e.g. the
- * meta plugin is disabled or `_meta` was never executed).
+ * `undefined` when the meta plugin was not installed for that schema.
  */
 export function getTablesMetaForSchema(
   schema: GraphQLSchema
@@ -41,11 +38,15 @@ export const MetaSchemaPlugin: GraphileConfig.Plugin = {
     hooks: {
       GraphQLObjectType_fields(rawFields, rawBuild, rawContext) {
         if (!rawContext.scope.isRootQuery) return rawFields;
-        const build = rawBuild as unknown as MetaBuild;
         return extendQueryWithMetaField(
           rawFields as unknown as Record<string, unknown>,
-          (schema) => getRuntimeTablesMeta(build, schema),
+          getRuntimeTablesMeta
         ) as typeof rawFields;
+      },
+      finalize(schema, rawBuild) {
+        const build = rawBuild as unknown as MetaBuild;
+        runtimeTablesBySchema.set(schema, collectTablesMeta(build, schema));
+        return schema;
       },
     },
   },

--- a/graphile/graphile-search/src/__tests__/build-state-disposal.test.ts
+++ b/graphile/graphile-search/src/__tests__/build-state-disposal.test.ts
@@ -1,0 +1,39 @@
+import { createUnifiedSearchPlugin } from '../plugin';
+
+function getBuildHook(plugin: GraphileConfig.Plugin): (build: any) => any {
+  return plugin.schema!.hooks!.build as (build: any) => any;
+}
+
+describe('graphile-search build-state ownership', () => {
+  it('clears the unified-search codec cache through the build lifecycle', () => {
+    const detectColumns = jest.fn((): never[] => []);
+    const plugin = createUnifiedSearchPlugin({
+      adapters: [
+        {
+          name: 'test',
+          detectColumns,
+          registerTypes: jest.fn(),
+          scoreSemantics: { metric: 'score', lowerIsBetter: false },
+        } as never,
+      ],
+    });
+    let dispose: (() => void) | undefined;
+    const build = {
+      registerBuildStateDisposer(callback: () => void) {
+        dispose = callback;
+      },
+    };
+    getBuildHook(plugin)(build);
+
+    const inferred = (plugin.schema!.entityBehavior!.pgCodecAttribute as any)
+      .inferred.callback;
+    const codec = { name: 'document', attributes: { body: {} } };
+    inferred([], [codec, 'body'], build);
+    inferred([], [codec, 'body'], build);
+    expect(detectColumns).toHaveBeenCalledTimes(1);
+
+    dispose!();
+    inferred([], [codec, 'body'], build);
+    expect(detectColumns).toHaveBeenCalledTimes(2);
+  });
+});

--- a/graphile/graphile-search/src/plugin.ts
+++ b/graphile/graphile-search/src/plugin.ts
@@ -328,6 +328,11 @@ export function createUnifiedSearchPlugin(
       },
 
       hooks: {
+        build(build) {
+          build.registerBuildStateDisposer(() => codecCache.clear());
+          return build;
+        },
+
         /**
          * Register all adapter-specific GraphQL types during init.
          */

--- a/graphile/graphile-settings/__tests__/build-state-retirement.test.ts
+++ b/graphile/graphile-settings/__tests__/build-state-retirement.test.ts
@@ -1,0 +1,181 @@
+import {
+  buildSchema,
+  defaultPreset,
+  QueryPlugin,
+  QueryQueryPlugin,
+} from 'graphile-build';
+import { resolvePreset } from 'graphile-config';
+import { GraphQLSchema, graphqlSync } from 'graphql';
+
+import { BuildStateRetirementPlugin } from '../src/plugins/build-state-retirement';
+import { ConstructivePreset } from '../src/presets/constructive-preset';
+
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      BuildStateRetirementTestOwnerPlugin: true;
+      BuildStateRetirementInvalidSchemaPlugin: true;
+    }
+  }
+}
+
+function makeOwnerPlugin(
+  owned: string[],
+  capture: (build: GraphileBuild.BuildBase) => void
+): GraphileConfig.Plugin {
+  return {
+    name: 'BuildStateRetirementTestOwnerPlugin',
+    schema: {
+      hooks: {
+        build(build) {
+          capture(build);
+          build.registerBuildStateDisposer(() => owned.push('first'));
+          build.registerBuildStateDisposer(() => owned.push('second'));
+          return build;
+        },
+      },
+    },
+  };
+}
+
+describe('Constructive build-state retirement', () => {
+  it('opts Constructive in without changing the Graphile default preset', () => {
+    expect(resolvePreset(ConstructivePreset).plugins).toContain(
+      BuildStateRetirementPlugin
+    );
+    expect(resolvePreset(defaultPreset).plugins).not.toContain(
+      BuildStateRetirementPlugin
+    );
+  });
+
+  it('retains build state when the CNC plugin is not installed', () => {
+    const disposed: string[] = [];
+    let capturedBuild: GraphileBuild.BuildBase | undefined;
+
+    buildSchema(
+      {
+        plugins: [
+          QueryPlugin,
+          QueryQueryPlugin,
+          makeOwnerPlugin(disposed, (build) => {
+            capturedBuild = build;
+          }),
+        ],
+      },
+      Object.create(null)
+    );
+
+    expect(disposed).toEqual([]);
+    expect(capturedBuild!.input).toEqual(Object.create(null));
+  });
+
+  it('retires after validation, in reverse disposer order, and preserves execution', () => {
+    const disposed: string[] = [];
+    let capturedBuild: GraphileBuild.BuildBase | undefined;
+    const schema = buildSchema(
+      {
+        plugins: [
+          QueryPlugin,
+          QueryQueryPlugin,
+          makeOwnerPlugin(disposed, (build) => {
+            capturedBuild = build;
+          }),
+          BuildStateRetirementPlugin,
+        ],
+      },
+      Object.create(null)
+    );
+
+    expect(disposed).toEqual(['second', 'first']);
+    expect(() => capturedBuild!.input).toThrow(
+      expect.objectContaining({ code: 'GRAPHILE_BUILD_STATE_RELEASED' })
+    );
+    expect(graphqlSync({ schema, source: '{ __typename }' })).toEqual({
+      data: { __typename: 'Query' },
+    });
+  });
+
+  it('does not retire when schema validation fails', () => {
+    const disposed: string[] = [];
+    let capturedBuild: GraphileBuild.BuildBase | undefined;
+    const InvalidSchemaPlugin: GraphileConfig.Plugin = {
+      name: 'BuildStateRetirementInvalidSchemaPlugin',
+      schema: {
+        hooks: {
+          finalize() {
+            return new GraphQLSchema({});
+          },
+        },
+      },
+    };
+
+    expect(() =>
+      buildSchema(
+        {
+          plugins: [
+            QueryPlugin,
+            QueryQueryPlugin,
+            makeOwnerPlugin(disposed, (build) => {
+              capturedBuild = build;
+            }),
+            BuildStateRetirementPlugin,
+            InvalidSchemaPlugin,
+          ],
+        },
+        Object.create(null)
+      )
+    ).toThrow(/validation failure/);
+    expect(disposed).toEqual([]);
+    expect(capturedBuild!.input).toEqual(Object.create(null));
+  });
+
+  it('attempts every disposer and aggregates failures before failing closed', () => {
+    const calls: string[] = [];
+    let capturedBuild: GraphileBuild.BuildBase | undefined;
+    const FailingOwnerPlugin: GraphileConfig.Plugin = {
+      name: 'BuildStateRetirementTestOwnerPlugin',
+      schema: {
+        hooks: {
+          build(build) {
+            capturedBuild = build;
+            build.registerBuildStateDisposer(() => {
+              calls.push('first');
+              throw new Error('first failed');
+            });
+            build.registerBuildStateDisposer(() => {
+              calls.push('second');
+              throw new Error('second failed');
+            });
+            return build;
+          },
+        },
+      },
+    };
+
+    expect(() =>
+      buildSchema(
+        {
+          plugins: [
+            QueryPlugin,
+            QueryQueryPlugin,
+            FailingOwnerPlugin,
+            BuildStateRetirementPlugin,
+          ],
+        },
+        Object.create(null)
+      )
+    ).toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining('2 disposal errors'),
+        errors: [
+          expect.objectContaining({ message: 'second failed' }),
+          expect.objectContaining({ message: 'first failed' }),
+        ],
+      })
+    );
+    expect(calls).toEqual(['second', 'first']);
+    expect(() => capturedBuild!.input).toThrow(
+      expect.objectContaining({ code: 'GRAPHILE_BUILD_STATE_RELEASED' })
+    );
+  });
+});

--- a/graphile/graphile-settings/src/plugins/build-state-retirement.ts
+++ b/graphile/graphile-settings/src/plugins/build-state-retirement.ts
@@ -1,0 +1,47 @@
+import type { GraphileConfig } from 'graphile-config';
+
+const RETIRE_BUILD_STATE = Symbol.for(
+  'constructive.graphile-build.retireBuildState'
+);
+
+type RetireBuildState = () => boolean;
+
+function retireBuildState(build: GraphileBuild.BuildBase): boolean {
+  const capability = (
+    build as unknown as Record<symbol, RetireBuildState | undefined>
+  )[RETIRE_BUILD_STATE];
+  if (typeof capability !== 'function') {
+    throw new Error(
+      'Build-state retirement requires the Constructive graphile-build patch'
+    );
+  }
+  return capability();
+}
+
+/**
+ * Opts a schema build into Constructive's build-state retirement policy.
+ *
+ * The graphile-build patch owns the private state and cleanup implementation;
+ * this CNC-owned plugin controls whether and when that implementation runs.
+ */
+export const BuildStateRetirementPlugin: GraphileConfig.Plugin = {
+  name: 'BuildStateRetirementPlugin',
+  version: '1.0.0',
+  description: 'Retires construction-only state after schema validation',
+  schema: {
+    hooks: {
+      build(build) {
+        build.registerAfterSchemaValidation(() => retireBuildState(build));
+        return build;
+      },
+    },
+  },
+};
+
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      BuildStateRetirementPlugin: true;
+    }
+  }
+}

--- a/graphile/graphile-settings/src/plugins/index.ts
+++ b/graphile/graphile-settings/src/plugins/index.ts
@@ -7,6 +7,9 @@
 // Minimal preset - PostGraphile without Node/Relay features
 export { MinimalPreset } from './minimal-preset';
 
+// CNC-owned opt-in for retiring construction-only Graphile state
+export { BuildStateRetirementPlugin } from './build-state-retirement';
+
 // Custom inflector using inflekt library
 export {
   InflektPlugin,

--- a/graphile/graphile-settings/src/presets/constructive-preset.ts
+++ b/graphile/graphile-settings/src/presets/constructive-preset.ts
@@ -15,6 +15,7 @@ import { UploadPreset } from 'graphile-upload-plugin';
 
 import { getBucketProvisionerConnection } from '../bucket-provisioner-resolver';
 import {
+  BuildStateRetirementPlugin,
   ConflictDetectorPreset,
   EnableAllFilterColumnsPreset,
   InflectorLoggerPreset,
@@ -107,6 +108,7 @@ const DEFAULTS: Required<ConstructivePresetOptions> = {
  * - MetaSchemaPreset (_meta introspection)
  * - PgTypeMappingsPreset (email, url, etc.)
  * - RequiredInputPreset (@requiredInput support)
+ * - BuildStateRetirementPlugin (release construction-only state after validation)
  *
  * FLAG-CONTROLLED PRESETS:
  * - enableConnectionFilter  -> ConnectionFilterPreset, EnableAllFilterColumnsPreset
@@ -285,7 +287,8 @@ export function createConstructivePreset(
   }
 
   const preset: GraphileConfig.Preset = {
-    extends: presets
+    extends: presets,
+    plugins: [BuildStateRetirementPlugin]
   };
 
   if (disablePlugins.length > 0) {

--- a/patches/graphile-build-pg.patch
+++ b/patches/graphile-build-pg.patch
@@ -20,6 +20,43 @@ index 94611d28be45c9fdd696923f4affac86a25544e4..f6431a22e6e329827748d1057bf0be77
  exports.sql = exports.withPgClientFromPgService = exports.getWithPgClientFromPgService = exports.version = exports.parseDatabaseIdentifiers = exports.parseDatabaseIdentifier = exports.defaultPreset = exports.PgTypesPlugin = exports.PgTablesPlugin = exports.PgTableNodePlugin = exports.PgRowByUniquePlugin = exports.PgRemoveExtensionResourcesPlugin = exports.PgRelationsPlugin = exports.PgRegistryReductionPlugin = exports.PgRegistryPlugin = exports.PgRefsPlugin = exports.PgRBACPlugin = exports.PgProceduresPlugin = exports.PgPolymorphismPlugin = exports.PgPolymorphismOnlyArgumentPlugin = exports.PgOrderCustomFieldsPlugin = exports.PgOrderByPrimaryKeyPlugin = exports.PgOrderAllAttributesPlugin = exports.PgNodeIdAttributesPlugin = exports.PgMutationUpdateDeletePlugin = exports.PgMutationPayloadEdgePlugin = exports.PgMutationCreatePlugin = exports.PgLtreePlugin = exports.PgJWTPlugin = exports.PgIntrospectionPlugin = exports.PgInterfaceModeUnionAllRowsPlugin = exports.PgIndexBehaviorsPlugin = exports.PgFirstLastBeforeAfterArgsPlugin = exports.PgFakeConstraintsPlugin = exports.PgEnumTablesPlugin = exports.PgEnumDomainsPlugin = exports.PgCustomTypeFieldPlugin = exports.PgConnectionTotalCountPlugin = exports.PgConnectionArgOrderByPlugin = exports.PgConnectionArgOrderByDefaultValuePlugin = exports.PgConditionCustomFieldsPlugin = exports.PgConditionArgumentPlugin = exports.PgCodecsPlugin = exports.PgBasicsPlugin = exports.PgAttributesPlugin = exports.PgAttributeDeprecationPlugin = exports.PgAllRowsPlugin = void 0;
  var PgAllRowsPlugin_ts_1 = require("./plugins/PgAllRowsPlugin.js");
  Object.defineProperty(exports, "PgAllRowsPlugin", { enumerable: true, get: function () { return PgAllRowsPlugin_ts_1.PgAllRowsPlugin; } });
+diff --git a/dist/plugins/PgBasicsPlugin.js b/dist/plugins/PgBasicsPlugin.js
+index c31c42d380ce1431a89983ca3bc99f7e44aaeece..a19cda24f555b01ad837b7e52b9a3c4aab3d21e4 100644
+--- a/dist/plugins/PgBasicsPlugin.js
++++ b/dist/plugins/PgBasicsPlugin.js
+@@ -276,6 +276,11 @@ exports.PgBasicsPlugin = {
+                 };
+                 const resourceByCodecCacheUnstrict = new Map();
+                 const resourceByCodecCacheStrict = new Map();
++                build.registerBuildStateDisposer(() => {
++                    pgCodecMetaLookup.clear();
++                    resourceByCodecCacheUnstrict.clear();
++                    resourceByCodecCacheStrict.clear();
++                });
+                 const pgTableResource = (codec, strict = true) => {
+                     const resourceByCodecCache = strict
+                         ? resourceByCodecCacheStrict
+diff --git a/dist/plugins/PgCodecsPlugin.js b/dist/plugins/PgCodecsPlugin.js
+index bc9893d3f853f77ba5204c295840467db29cd279..8d8e5ceb0f38fde014474e646a61da0851fcdf20 100644
+--- a/dist/plugins/PgCodecsPlugin.js
++++ b/dist/plugins/PgCodecsPlugin.js
+@@ -535,8 +535,15 @@ exports.PgCodecsPlugin = {
+     schema: {
+         hooks: {
+             build(build) {
+-                build.allPgCodecs = new Set();
++                const allPgCodecs = new Set();
++                build.allPgCodecs = allPgCodecs;
+                 const lookup = Object.create(null);
++                build.registerBuildStateDisposer(() => {
++                    allPgCodecs.clear();
++                    for (const serviceName of Object.keys(lookup)) {
++                        delete lookup[serviceName];
++                    }
++                });
+                 build.getPgCodecByDatabaseName = (serviceName, schemaName, typeName) => {
+                     const codec = lookup[serviceName]?.[schemaName]?.[typeName];
+                     if (codec == null) {
 diff --git a/dist/plugins/PgIntrospectionPlugin.d.ts b/dist/plugins/PgIntrospectionPlugin.d.ts
 index 821629b96574c90ff58804be3aa3b98c4443c7a0..cf861c4ef564f8f1cdac16610cd2559c38e1421f 100644
 --- a/dist/plugins/PgIntrospectionPlugin.d.ts
@@ -227,3 +264,22 @@ index a1597b1dc9a4f76d3debc80f5ef151f4e58bc2cd..0714e4f1aa6b9a5f60373f868942b2e0
      }));
  }
  //# sourceMappingURL=PgIntrospectionPlugin.js.map
+diff --git a/dist/plugins/PgPolymorphismPlugin.js b/dist/plugins/PgPolymorphismPlugin.js
+index b1892244aebf936cb697d9e664e6b3c2432e8c0e..6907c0d70640bebd87c93377c3e30f901b18efa9 100644
+--- a/dist/plugins/PgPolymorphismPlugin.js
++++ b/dist/plugins/PgPolymorphismPlugin.js
+@@ -554,6 +554,14 @@ exports.PgPolymorphismPlugin = {
+                     }
+                 }
+                 const pgCodecByPolymorphicUnionModeTypeName = Object.create(null);
++                build.registerBuildStateDisposer(() => {
++                    for (const key of Object.keys(pgResourcesByPolymorphicTypeName)) {
++                        delete pgResourcesByPolymorphicTypeName[key];
++                    }
++                    for (const key of Object.keys(pgCodecByPolymorphicUnionModeTypeName)) {
++                        delete pgCodecByPolymorphicUnionModeTypeName[key];
++                    }
++                });
+                 for (const codec of Object.values(pgRegistry.pgCodecs)) {
+                     if (!codec.polymorphism)
+                         continue;

--- a/patches/graphile-build@5.1.1.patch
+++ b/patches/graphile-build@5.1.1.patch
@@ -1,0 +1,396 @@
+diff --git a/dist/SchemaBuilder.js b/dist/SchemaBuilder.js
+index 551b884b615a094c50dec2a2c4acec5a4b303bcf..487c2b024536dabe171ed3c69ca671cab64a7008 100644
+--- a/dist/SchemaBuilder.js
++++ b/dist/SchemaBuilder.js
+@@ -8,7 +8,7 @@ const graphql_1 = require("grafast/graphql");
+ const graphile_config_1 = require("graphile-config");
+ const util_1 = require("util");
+ const behavior_ts_1 = require("./behavior.js");
+-const makeNewBuild_ts_1 = tslib_1.__importDefault(require("./makeNewBuild.js"));
++const makeNewBuild_ts_1 = tslib_1.__importStar(require("./makeNewBuild.js"));
+ const index_ts_1 = require("./newWithHooks/index.js");
+ const SchemaBuilderHooks_ts_1 = require("./SchemaBuilderHooks.js");
+ const utils_ts_1 = require("./utils.js");
+@@ -131,6 +131,8 @@ class SchemaBuilder extends events_1.EventEmitter {
+             scope: Object.create(null),
+             type: "build",
+         });
++        (0, makeNewBuild_ts_1.finalizeAfterSchemaValidationCallbackRegistration)(build);
++        (0, makeNewBuild_ts_1.finalizeBuildStateDisposalRegistration)(build);
+         // Bind all functions so they can be dereferenced
+         (0, utils_ts_1.bindAll)(build, Object.keys(build).filter((key) => typeof build[key] === "function"));
+         const finalBuild = build;
+@@ -182,6 +184,7 @@ class SchemaBuilder extends events_1.EventEmitter {
+         if (validationErrors.length) {
+             throw new AggregateError(validationErrors, `Schema construction failed due to ${validationErrors.length} validation failure(s). First failure was: ${String(validationErrors[0])}`);
+         }
++        (0, makeNewBuild_ts_1.runAfterSchemaValidationCallbacks)(build);
+         return schema;
+     }
+ }
+diff --git a/dist/behavior.js b/dist/behavior.js
+index 80d7ef5543ac45e3922ff9d16413d3372e4d0f1d..335a6ed232e0a7d71276b9ff9a348863fb6f0c8e 100644
+--- a/dist/behavior.js
++++ b/dist/behavior.js
+@@ -6,6 +6,7 @@ exports.joinResolvedBehaviors = joinResolvedBehaviors;
+ exports.isValidBehaviorString = isValidBehaviorString;
+ const grafast_1 = require("grafast");
+ const graphile_config_1 = require("graphile-config");
++const makeNewBuild_ts_1 = require("./makeNewBuild.js");
+ const NULL_BEHAVIOR = Object.freeze({
+     behaviorString: "",
+     stack: Object.freeze([]),
+@@ -202,6 +203,7 @@ class Behavior {
+         this[`${entityType}Behavior`] = (entity) => this.getBehaviorForEntity(entityType, entity).behaviorString;
+     }
+     assertEntity(entityType) {
++        (0, makeNewBuild_ts_1.assertBuildStateLive)(this.build, "build.behavior");
+         if (entityType === "string") {
+             throw new Error(`Runtime behaviors cannot be attached to strings, please use 'behavior.stringMatches' directly.`);
+         }
+@@ -216,6 +218,7 @@ class Behavior {
+      * @param filter - the behavior the plugin specifies
+      */
+     entityMatches(entityType, entity, filter) {
++        (0, makeNewBuild_ts_1.assertBuildStateLive)(this.build, "build.behavior.entityMatches");
+         if (!this.behaviorRegistry[filter]) {
+             // DIAGNOSTIC: enable for all filters
+             /*
+@@ -317,6 +320,7 @@ class Behavior {
+         return behavior;
+     }
+     getPreferencesAppliedBehaviors(entityType, inferredBehavior, overrideBehavior) {
++        (0, makeNewBuild_ts_1.assertBuildStateLive)(this.build, "build.behavior.getPreferencesAppliedBehaviors");
+         const defaultBehavior = this.getDefaultBehaviorFor(entityType);
+         const inferredBehaviorWithPreferencesApplied = multiplyBehavior(defaultBehavior, inferredBehavior.behaviorString, entityType);
+         const behaviorString = joinBehaviors([
+@@ -342,6 +346,7 @@ class Behavior {
+     }
+     /** @deprecated Please use entityMatches or stringMatches instead */
+     matches(localBehaviorSpecsString, filter, defaultBehavior = "") {
++        (0, makeNewBuild_ts_1.assertBuildStateLive)(this.build, "build.behavior.matches");
+         let err;
+         try {
+             throw new Error("Deprecated call happened here");
+@@ -371,6 +376,7 @@ class Behavior {
+     callbacks, ...args) {
++        (0, makeNewBuild_ts_1.assertBuildStateLive)(this.build, "build.behavior.resolveBehavior");
+         let behaviorString = initialBehavior.behaviorString;
+         const stack = [...initialBehavior.stack];
+         for (const [source, rawG] of callbacks) {
+             const oldBehavior = behaviorString;
+             const g = typeof rawG === "string" ? [rawG] : rawG;
+@@ -425,6 +431,7 @@ class Behavior {
+         }
+     }
+     getDefaultBehaviorFor(entityType) {
++        (0, makeNewBuild_ts_1.assertBuildStateLive)(this.build, "build.behavior.getDefaultBehaviorFor");
+         if (!this._defaultBehaviorByEntityTypeCache.has(entityType)) {
+             const supportedBehaviors = new Set();
+             for (const [behaviorString, spec] of Object.entries(this.behaviorRegistry)) {
+@@ -455,6 +462,29 @@ class Behavior {
+         }
+         return this._defaultBehaviorByEntityTypeCache.get(entityType);
+     }
++    /** @internal */
++    releaseBuildState() {
++        this._defaultBehaviorByEntityTypeCache.clear();
++        this.behaviorEntityTypes.length = 0;
++        for (const key of Object.keys(this.behaviorEntities)) {
++            const behaviorEntity = this.behaviorEntities[key];
++            behaviorEntity.listCache.clear();
++            behaviorEntity.inferredCache.clear();
++            behaviorEntity.overrideCache.clear();
++            behaviorEntity.fullCache.clear();
++            behaviorEntity.inferredBehaviorCallbacks.length = 0;
++            behaviorEntity.overrideBehaviorCallbacks.length = 0;
++            for (const behaviorString of Object.keys(behaviorEntity.behaviorStrings)) {
++                delete behaviorEntity.behaviorStrings[behaviorString];
++            }
++        }
++        for (const key of Object.keys(this.behaviorRegistry)) {
++            delete this.behaviorRegistry[key];
++        }
++        if (Array.isArray(this.globalDefaultBehavior.stack)) {
++            this.globalDefaultBehavior.stack.length = 0;
++        }
++    }
+ }
+ exports.Behavior = Behavior;
+ /**
+diff --git a/dist/global.d.ts b/dist/global.d.ts
+index 0ed37abdfdba94161735a1e0526e50d878458be9..761602b45cd5a5f68bffb34053e523a6199db422 100644
+--- a/dist/global.d.ts
++++ b/dist/global.d.ts
+@@ -211,6 +211,22 @@ declare global {
+              * influence what types/fields/etc are added to the GraphQL schema.
+              */
+             input: BuildInput;
++            /**
++             * Registers a synchronous callback that will be invoked after the schema
++             * has been constructed and validated successfully.
++             *
++             * Callbacks may only be registered from the `build` hook. They are
++             * invoked at most once, in registration order.
++             */
++            registerAfterSchemaValidation(callback: () => void): void;
++            /**
++             * Registers cleanup for state owned by a build-time plugin.
++             *
++             * Disposers may only be registered from the `build` hook. When CNC
++             * enables build-state retirement, they run once in reverse registration
++             * order. A disposer should only access state owned by its plugin.
++             */
++            registerBuildStateDisposer(disposer: () => void): void;
+             /**
+              * Returns true if `Build.versions` contains an entry for `packageName`
+              * compatible with the version range `range`, false otherwise.
+diff --git a/dist/makeNewBuild.js b/dist/makeNewBuild.js
+index 63186e206e044bbfd76d04d9159a3e4d7d77ee70..aad97a99ee36cbe0f92c38edd58dec270fe3c503 100644
+--- a/dist/makeNewBuild.js
++++ b/dist/makeNewBuild.js
+@@ -1,5 +1,9 @@
+ "use strict";
+ Object.defineProperty(exports, "__esModule", { value: true });
++exports.finalizeAfterSchemaValidationCallbackRegistration = finalizeAfterSchemaValidationCallbackRegistration;
++exports.runAfterSchemaValidationCallbacks = runAfterSchemaValidationCallbacks;
++exports.finalizeBuildStateDisposalRegistration = finalizeBuildStateDisposalRegistration;
++exports.assertBuildStateLive = assertBuildStateLive;
+ exports.default = makeNewBuild;
+ const tslib_1 = require("tslib");
+ require("./global.js");
+@@ -11,6 +15,94 @@ const extend_ts_1 = tslib_1.__importStar(require("./extend.js"));
+ const utils_ts_1 = require("./utils.js");
+ const version_ts_1 = require("./version.js");
+ const BUILTINS = ["Int", "Float", "Boolean", "ID", "String"];
++const BUILD_STATE_RELEASED_ERROR_CODE = "GRAPHILE_BUILD_STATE_RELEASED";
++const RETIRE_BUILD_STATE = Symbol.for("constructive.graphile-build.retireBuildState");
++const afterSchemaValidationStates = new WeakMap();
++const buildStateDisposals = new WeakMap();
++/** @internal */
++function finalizeAfterSchemaValidationCallbackRegistration(build) {
++    const state = afterSchemaValidationStates.get(build);
++    if (state?.status !== "registering") {
++        throw new Error("After-schema-validation callback registration was already finalized");
++    }
++    state.status = "ready";
++}
++/** @internal */
++function runAfterSchemaValidationCallbacks(build) {
++    const state = afterSchemaValidationStates.get(build);
++    if (!state || state.status === "complete") {
++        return;
++    }
++    if (state.status !== "ready") {
++        throw new Error("After-schema-validation callbacks cannot run before registration is finalized");
++    }
++    state.status = "running";
++    const callbacks = state.callbacks.splice(0);
++    try {
++        for (const callback of callbacks) {
++            callback();
++        }
++    }
++    finally {
++        state.status = "complete";
++    }
++}
++function buildStateReleasedError(api) {
++    const error = new Error(`Cannot use ${api} after Graphile build state has been released`);
++    error.code = BUILD_STATE_RELEASED_ERROR_CODE;
++    return error;
++}
++/** @internal */
++function assertBuildStateLive(build, api) {
++    const state = buildStateDisposals.get(build);
++    if (state?.status === "releasing" || state?.status === "released") {
++        throw buildStateReleasedError(api);
++    }
++}
++/** @internal */
++function finalizeBuildStateDisposalRegistration(build) {
++    const state = buildStateDisposals.get(build);
++    if (state?.status !== "registering") {
++        throw new Error("Build state disposal registration was already finalized");
++    }
++    state.status = "live";
++}
++/** @internal */
++function retireBuildState(build) {
++    const state = buildStateDisposals.get(build);
++    if (state?.status !== "live") {
++        return false;
++    }
++    state.status = "releasing";
++    const errors = [];
++    const disposers = state.disposers.splice(0).reverse();
++    for (const disposer of disposers) {
++        try {
++            disposer();
++        }
++        catch (error) {
++            errors.push(error);
++        }
++    }
++    try {
++        state.releaseCore?.();
++    }
++    catch (error) {
++        errors.push(error);
++    }
++    try {
++        build.behavior.releaseBuildState();
++    }
++    catch (error) {
++        errors.push(error);
++    }
++    state.status = "released";
++    state.releaseCore = null;
++    if (errors.length > 0) {
++        throw new AggregateError(errors, `Failed to retire Graphile build state (${errors.length} disposal error${errors.length === 1 ? "" : "s"})`);
++    }
++    return true;
++}
+ /** Have we warned the user they're using the 5-arg deprecated registerObjectType call? */
+ let registerObjectType5argsDeprecatedWarned = false;
+ /**
+@@ -18,15 +110,16 @@ let registerObjectType5argsDeprecatedWarned = false;
+  */
+ function makeNewBuild(builder, input, inflection) {
+     const lib = builder.resolvedPreset.lib ?? {};
+-    const building = new Set();
+-    const allTypes = {
++    let inputState = input;
++    let building = new Set();
++    let allTypes = {
+         Int: graphql_1.GraphQLInt,
+         Float: graphql_1.GraphQLFloat,
+         String: graphql_1.GraphQLString,
+         Boolean: graphql_1.GraphQLBoolean,
+         ID: graphql_1.GraphQLID,
+     };
+-    const allTypesSources = {
++    let allTypesSources = {
+         Int: "GraphQL Built-in",
+         Float: "GraphQL Built-in",
+         String: "GraphQL Built-in",
+@@ -36,10 +129,11 @@ function makeNewBuild(builder, input, inflection) {
+     /**
+      * Where the type factories are; so we don't construct types until they're needed.
+      */
+-    const typeRegistry = Object.create(null);
+-    const scopeByType = new Map();
++    let typeRegistry = Object.create(null);
++    let scopeByType = new Map();
+     // TODO: allow registering a previously constructed type.
+     function register(klass, typeName, scope, specGenerator, origin) {
++        assertBuildStateLive(build, "build.register*");
+         if (!this.status.isBuildPhaseComplete || this.status.isInitPhaseComplete) {
+             throw new Error("Types may only be registered in the 'init' phase");
+         }
+@@ -83,7 +177,36 @@ function makeNewBuild(builder, input, inflection) {
+             graphql: lib.graphql.version,
+             "graphile-build": version_ts_1.version,
+         },
+-        input,
++        get input() {
++            assertBuildStateLive(build, "build.input");
++            return inputState;
++        },
++        registerAfterSchemaValidation(callback) {
++            const state = afterSchemaValidationStates.get(build);
++            if (state?.status !== "registering" ||
++                build.status.currentHookEvent !== "build") {
++                throw new Error("After-schema-validation callbacks may only be registered during the 'build' hook");
++            }
++            if (typeof callback !== "function") {
++                throw new TypeError("build.registerAfterSchemaValidation requires a function");
++            }
++            state.callbacks.push(callback);
++        },
++        registerBuildStateDisposer(disposer) {
++            const state = buildStateDisposals.get(build);
++            if (state?.status !== "registering" ||
++                build.status.currentHookEvent !== "build") {
++                assertBuildStateLive(build, "build.registerBuildStateDisposer");
++                throw new Error("Build state disposers may only be registered during the 'build' hook");
++            }
++            if (typeof disposer !== "function") {
++                throw new TypeError("build.registerBuildStateDisposer requires a function");
++            }
++            state.disposers.push(disposer);
++        },
++        [RETIRE_BUILD_STATE]() {
++            return retireBuildState(build);
++        },
+         hasVersion(packageName, range, options = { includePrerelease: true }) {
+             const packageVersion = this.versions[packageName];
+             if (!packageVersion)
+@@ -119,9 +242,13 @@ function makeNewBuild(builder, input, inflection) {
+             }
+         },
+         getAllTypes() {
++            assertBuildStateLive(build, "build.getAllTypes");
+             return allTypes;
+         },
+-        scopeByType,
++        get scopeByType() {
++            assertBuildStateLive(build, "build.scopeByType");
++            return scopeByType;
++        },
+         inflection,
+         handleRecoverableError(e) {
+             e["recoverable"] = true;
+@@ -187,6 +314,7 @@ function makeNewBuild(builder, input, inflection) {
+         },
+         __postInitAssertions: [],
+         assertTypeName(typeName, deferrable = false) {
++            assertBuildStateLive(build, "build.assertTypeName");
+             if (!this.status.isBuildPhaseComplete) {
+                 throw new Error("Must not call build.assertTypeName before 'build' phase is complete; use 'init' phase instead");
+             }
+@@ -208,6 +336,7 @@ function makeNewBuild(builder, input, inflection) {
+             }
+         },
+         getTypeMetaByName(typeName) {
++            assertBuildStateLive(build, "build.getTypeMetaByName");
+             if (!this.status.isBuildPhaseComplete) {
+                 throw new Error("Must not call build.getTypeMetaByName before 'build' phase is complete; use 'init' phase instead");
+             }
+@@ -254,6 +383,7 @@ function makeNewBuild(builder, input, inflection) {
+             return null;
+         },
+         getTypeByName(typeName) {
++            assertBuildStateLive(build, "build.getTypeByName");
+             if (currentTypeDetails &&
+                 currentTypeDetails.klass !== graphql_1.GraphQLScalarType &&
+                 !BUILTINS.includes(typeName)) {
+@@ -385,6 +515,28 @@ style for these configuration options (e.g. change \`interfaces: \
+         },
+         _pluginMeta: Object.create(null),
+     };
++    afterSchemaValidationStates.set(build, {
++        status: "registering",
++        callbacks: [],
++    });
++    buildStateDisposals.set(build, {
++        status: "registering",
++        disposers: [],
++        releaseCore() {
++            inputState = undefined;
++            building?.clear();
++            building = undefined;
++            allTypes = undefined;
++            allTypesSources = undefined;
++            typeRegistry = undefined;
++            scopeByType?.clear();
++            scopeByType = undefined;
++            build.__postInitAssertions.length = 0;
++            for (const key of Object.keys(build._pluginMeta)) {
++                delete build._pluginMeta[key];
++            }
++        },
++    });
+     return build;
+ }
+ let currentTypeDetails = null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,11 @@ patchedDependencies:
     hash: a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2
     path: patches/@dataplan__pg.patch
   graphile-build-pg:
-    hash: 8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5
+    hash: 9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5
     path: patches/graphile-build-pg.patch
+  graphile-build@5.1.1:
+    hash: 3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c
+    path: patches/graphile-build@5.1.1.patch
   pg-introspection@1.0.1:
     hash: 004a0acc578342e50b175514c03b45108e9d3a85e8928696b0fdaef995ec4b25
     path: patches/pg-introspection@1.0.1.patch
@@ -381,22 +384,22 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
       graphile-utils:
         specifier: 5.0.3
-        version: 5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+        version: 5.0.3(96e1e4a05986e18faa31d4ab20cded84)
       graphql:
         specifier: 16.13.0
         version: 16.13.0
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(564ecc69f17f317514da2378ea0ee7d1)
+        version: 5.1.4(243e4c82dc2a579d1b8faaf0c8cd8ed5)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -416,10 +419,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -431,7 +434,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(564ecc69f17f317514da2378ea0ee7d1)
+        version: 5.1.4(243e4c82dc2a579d1b8faaf0c8cd8ed5)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -472,7 +475,7 @@ importers:
         version: link:../../postgres/pg-cache/dist
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(d2fbc9214324995a9f19d45c874ffd17)
+        version: 5.1.4(0e85600205586faffec9bc93cba6ae42)
     devDependencies:
       '@types/express':
         specifier: ^5.0.6
@@ -495,10 +498,10 @@ importers:
         version: 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -513,7 +516,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(ba6398e917e9857a0084b873121de2c9)
+        version: 5.1.4(4afb1bec211dc7c56f7912b2a5d9f0a5)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -545,10 +548,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -592,10 +595,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -607,7 +610,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(a8630eea9ec1b1fcc351d9a56a9502d8)
+        version: 5.1.4(30f6c21ce20175065337dc728508839f)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -642,10 +645,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -657,7 +660,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(a8630eea9ec1b1fcc351d9a56a9502d8)
+        version: 5.1.4(30f6c21ce20175065337dc728508839f)
     devDependencies:
       '@types/accept-language-parser':
         specifier: ^1.5.4
@@ -701,10 +704,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-cache:
         specifier: workspace:^
         version: link:../graphile-cache/dist
@@ -713,7 +716,7 @@ importers:
         version: 1.1.0
       graphile-utils:
         specifier: 5.0.3
-        version: 5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+        version: 5.0.3(96e1e4a05986e18faa31d4ab20cded84)
       graphql:
         specifier: 16.13.0
         version: 16.13.0
@@ -722,7 +725,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(564ecc69f17f317514da2378ea0ee7d1)
+        version: 5.1.4(243e4c82dc2a579d1b8faaf0c8cd8ed5)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -754,10 +757,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -769,7 +772,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(564ecc69f17f317514da2378ea0ee7d1)
+        version: 5.1.4(243e4c82dc2a579d1b8faaf0c8cd8ed5)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -792,10 +795,10 @@ importers:
     dependencies:
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -804,7 +807,7 @@ importers:
         version: 16.13.0
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(a8630eea9ec1b1fcc351d9a56a9502d8)
+        version: 5.1.4(30f6c21ce20175065337dc728508839f)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -824,10 +827,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -842,7 +845,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(564ecc69f17f317514da2378ea0ee7d1)
+        version: 5.1.4(243e4c82dc2a579d1b8faaf0c8cd8ed5)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -868,10 +871,10 @@ importers:
         version: 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -883,7 +886,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(a8630eea9ec1b1fcc351d9a56a9502d8)
+        version: 5.1.4(30f6c21ce20175065337dc728508839f)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -903,10 +906,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -918,7 +921,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(ba6398e917e9857a0084b873121de2c9)
+        version: 5.1.4(4afb1bec211dc7c56f7912b2a5d9f0a5)
     devDependencies:
       '@types/geojson':
         specifier: ^7946.0.14
@@ -959,16 +962,16 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
       graphile-utils:
         specifier: 5.0.3
-        version: 5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+        version: 5.0.3(96e1e4a05986e18faa31d4ab20cded84)
       graphql:
         specifier: 16.13.0
         version: 16.13.0
@@ -980,7 +983,7 @@ importers:
         version: link:../../uploads/mime-bytes/dist
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(564ecc69f17f317514da2378ea0ee7d1)
+        version: 5.1.4(243e4c82dc2a579d1b8faaf0c8cd8ed5)
     devDependencies:
       '@constructive-io/s3-utils':
         specifier: workspace:^
@@ -1000,10 +1003,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1018,7 +1021,7 @@ importers:
         version: 8.21.0
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(d2fbc9214324995a9f19d45c874ffd17)
+        version: 5.1.4(0e85600205586faffec9bc93cba6ae42)
     devDependencies:
       '@types/pg':
         specifier: ^8.20.4
@@ -1044,22 +1047,22 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
       graphile-utils:
         specifier: 5.0.3
-        version: 5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+        version: 5.0.3(96e1e4a05986e18faa31d4ab20cded84)
       graphql:
         specifier: 16.13.0
         version: 16.13.0
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(564ecc69f17f317514da2378ea0ee7d1)
+        version: 5.1.4(243e4c82dc2a579d1b8faaf0c8cd8ed5)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -1076,10 +1079,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1125,7 +1128,7 @@ importers:
         version: link:../../postgres/pgsql-test/dist
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(d2fbc9214324995a9f19d45c874ffd17)
+        version: 5.1.4(0e85600205586faffec9bc93cba6ae42)
     publishDirectory: dist
 
   graphile/graphile-schema:
@@ -1135,7 +1138,7 @@ importers:
         version: 4.3.1
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1170,10 +1173,10 @@ importers:
         version: 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1188,7 +1191,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(ba6398e917e9857a0084b873121de2c9)
+        version: 5.1.4(4afb1bec211dc7c56f7912b2a5d9f0a5)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -1271,10 +1274,10 @@ importers:
         version: link:../graphile-bucket-provisioner-plugin/dist
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-bulk-mutations:
         specifier: workspace:^
         version: link:../graphile-bulk-mutations/dist
@@ -1319,7 +1322,7 @@ importers:
         version: link:../graphile-upload-plugin/dist
       graphile-utils:
         specifier: 5.0.3
-        version: 5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+        version: 5.0.3(96e1e4a05986e18faa31d4ab20cded84)
       graphql:
         specifier: 16.13.0
         version: 16.13.0
@@ -1343,7 +1346,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(d2fbc9214324995a9f19d45c874ffd17)
+        version: 5.1.4(0e85600205586faffec9bc93cba6ae42)
       request-ip:
         specifier: ^3.3.0
         version: 3.3.0
@@ -1384,10 +1387,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1425,10 +1428,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1446,7 +1449,7 @@ importers:
         version: link:../../postgres/pgsql-test/dist
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(d2fbc9214324995a9f19d45c874ffd17)
+        version: 5.1.4(0e85600205586faffec9bc93cba6ae42)
     devDependencies:
       '@types/pg':
         specifier: ^8.20.4
@@ -1463,10 +1466,10 @@ importers:
     dependencies:
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1475,7 +1478,7 @@ importers:
         version: 16.13.0
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(ba6398e917e9857a0084b873121de2c9)
+        version: 5.1.4(4afb1bec211dc7c56f7912b2a5d9f0a5)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -1614,10 +1617,10 @@ importers:
         version: 1.0.1(@types/node@25.9.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(ws@8.20.1)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-cache:
         specifier: workspace:^
         version: link:../../graphile/graphile-cache/dist
@@ -1629,7 +1632,7 @@ importers:
         version: link:../../graphile/graphile-settings/dist
       graphile-utils:
         specifier: 5.0.3
-        version: 5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+        version: 5.0.3(96e1e4a05986e18faa31d4ab20cded84)
       graphql:
         specifier: 16.13.0
         version: 16.13.0
@@ -1647,7 +1650,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(d2fbc9214324995a9f19d45c874ffd17)
+        version: 5.1.4(0e85600205586faffec9bc93cba6ae42)
     devDependencies:
       '@types/express':
         specifier: ^5.0.6
@@ -1720,7 +1723,7 @@ importers:
         version: link:../../postgres/pg-env/dist
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(d2fbc9214324995a9f19d45c874ffd17)
+        version: 5.1.4(0e85600205586faffec9bc93cba6ae42)
     devDependencies:
       '@types/express':
         specifier: ^5.0.6
@@ -1864,7 +1867,7 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1885,7 +1888,7 @@ importers:
         version: 11.2.7
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(d2fbc9214324995a9f19d45c874ffd17)
+        version: 5.1.4(0e85600205586faffec9bc93cba6ae42)
     devDependencies:
       makage:
         specifier: ^0.3.0
@@ -1902,10 +1905,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1929,7 +1932,7 @@ importers:
         version: 8.20.0
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(a2bc1f0f07e2072a3ead26bf7ded50e6)
+        version: 5.1.4(f042e794f55cb7c62e14f2486718e7f4)
       ws:
         specifier: ^8.20.0
         version: 8.20.1
@@ -2015,10 +2018,10 @@ importers:
         version: 1.0.1(@types/node@25.9.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(ws@8.20.1)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-cache:
         specifier: workspace:^
         version: link:../../graphile/graphile-cache/dist
@@ -2033,7 +2036,7 @@ importers:
         version: link:../../graphile/graphile-settings/dist
       graphile-utils:
         specifier: 5.0.3
-        version: 5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+        version: 5.0.3(96e1e4a05986e18faa31d4ab20cded84)
       graphql:
         specifier: 16.13.0
         version: 16.13.0
@@ -2060,7 +2063,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(d2fbc9214324995a9f19d45c874ffd17)
+        version: 5.1.4(0e85600205586faffec9bc93cba6ae42)
       request-ip:
         specifier: ^3.3.0
         version: 3.3.0
@@ -2214,10 +2217,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -2241,7 +2244,7 @@ importers:
         version: link:../../postgres/pgsql-test/dist
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(d2fbc9214324995a9f19d45c874ffd17)
+        version: 5.1.4(0e85600205586faffec9bc93cba6ae42)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -20255,13 +20258,13 @@ snapshots:
       - supports-color
       - use-sync-external-store
 
-  graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1):
+  graphile-build-pg@5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1):
     dependencies:
       '@dataplan/pg': 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)
       '@types/node': 22.19.19
       debug: 4.4.3(supports-color@5.5.0)
       grafast: 1.1.2(graphql@16.13.0)
-      graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+      graphile-build: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-config: 1.1.0
       graphql: 16.13.0
       jsonwebtoken: 9.0.3
@@ -20274,13 +20277,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1):
+  graphile-build-pg@5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1):
     dependencies:
       '@dataplan/pg': 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       '@types/node': 22.19.19
       debug: 4.4.3(supports-color@5.5.0)
       grafast: 1.1.2(graphql@16.13.0)
-      graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+      graphile-build: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-config: 1.1.0
       graphql: 16.13.0
       jsonwebtoken: 9.0.3
@@ -20293,7 +20296,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0):
+  graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0):
     dependencies:
       '@types/node': 22.19.19
       '@types/pluralize': 0.0.33
@@ -20323,35 +20326,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  graphile-utils@5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1):
+  graphile-utils@5.0.3(18c54fc98696bfc2de7b77b84170db85):
     dependencies:
       '@dataplan/pg': 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)
       debug: 4.4.3(supports-color@5.5.0)
       grafast: 1.1.2(graphql@16.13.0)
-      graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+      graphile-build: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-config: 1.1.0
       graphql: 16.13.0
       json5: 2.2.3
       tamedevil: 0.1.1
       tslib: 2.8.1
     optionalDependencies:
-      graphile-build-pg: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1)
+      graphile-build-pg: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  graphile-utils@5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1):
+  graphile-utils@5.0.3(96e1e4a05986e18faa31d4ab20cded84):
     dependencies:
       '@dataplan/pg': 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       debug: 4.4.3(supports-color@5.5.0)
       grafast: 1.1.2(graphql@16.13.0)
-      graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+      graphile-build: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-config: 1.1.0
       graphql: 16.13.0
       json5: 2.2.3
       tamedevil: 0.1.1
       tslib: 2.8.1
     optionalDependencies:
-      graphile-build-pg: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-build-pg: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22353,7 +22356,34 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postgraphile@5.1.4(564ecc69f17f317514da2378ea0ee7d1):
+  postgraphile@5.1.4(0e85600205586faffec9bc93cba6ae42):
+    dependencies:
+      '@dataplan/json': 1.0.1(grafast@1.1.2(graphql@16.13.0))
+      '@dataplan/pg': 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      '@graphile/lru': 5.0.0
+      '@types/node': 22.19.19
+      '@types/pg': 8.20.4
+      debug: 4.4.3(supports-color@5.5.0)
+      grafast: 1.1.2(graphql@16.13.0)
+      grafserv: 1.0.1(@types/node@25.9.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(ws@8.20.1)
+      graphile-build: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+      graphile-build-pg: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-config: 1.1.0
+      graphile-utils: 5.0.3(96e1e4a05986e18faa31d4ab20cded84)
+      graphql: 16.13.0
+      iterall: 1.3.0
+      jsonwebtoken: 9.0.3
+      pg: 8.21.0
+      pg-sql2: 5.0.1
+      tamedevil: 0.1.1
+      tslib: 2.8.1
+      ws: 8.20.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  postgraphile@5.1.4(243e4c82dc2a579d1b8faaf0c8cd8ed5):
     dependencies:
       '@dataplan/json': 1.0.1(grafast@1.1.2(graphql@16.13.0))
       '@dataplan/pg': 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
@@ -22363,10 +22393,10 @@ snapshots:
       debug: 4.4.3(supports-color@5.5.0)
       grafast: 1.1.2(graphql@16.13.0)
       grafserv: 1.0.1(@types/node@22.19.15)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(ws@8.20.1)
-      graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
-      graphile-build-pg: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-build: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+      graphile-build-pg: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config: 1.1.0
-      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+      graphile-utils: 5.0.3(96e1e4a05986e18faa31d4ab20cded84)
       graphql: 16.13.0
       iterall: 1.3.0
       jsonwebtoken: 9.0.3
@@ -22380,34 +22410,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  postgraphile@5.1.4(a2bc1f0f07e2072a3ead26bf7ded50e6):
-    dependencies:
-      '@dataplan/json': 1.0.1(grafast@1.1.2(graphql@16.13.0))
-      '@dataplan/pg': 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)
-      '@graphile/lru': 5.0.0
-      '@types/node': 22.19.19
-      '@types/pg': 8.20.4
-      debug: 4.4.3(supports-color@5.5.0)
-      grafast: 1.1.2(graphql@16.13.0)
-      grafserv: 1.0.1(@types/node@25.9.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(ws@8.20.1)
-      graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
-      graphile-build-pg: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1)
-      graphile-config: 1.1.0
-      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
-      graphql: 16.13.0
-      iterall: 1.3.0
-      jsonwebtoken: 9.0.3
-      pg: 8.20.0
-      pg-sql2: 5.0.1
-      tamedevil: 0.1.1
-      tslib: 2.8.1
-      ws: 8.20.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  postgraphile@5.1.4(a8630eea9ec1b1fcc351d9a56a9502d8):
+  postgraphile@5.1.4(30f6c21ce20175065337dc728508839f):
     dependencies:
       '@dataplan/json': 1.0.1(grafast@1.1.2(graphql@16.13.0))
       '@dataplan/pg': 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
@@ -22417,10 +22420,10 @@ snapshots:
       debug: 4.4.3(supports-color@5.5.0)
       grafast: 1.1.2(graphql@16.13.0)
       grafserv: 1.0.1(@types/node@22.19.19)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(ws@8.20.1)
-      graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
-      graphile-build-pg: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-build: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+      graphile-build-pg: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config: 1.1.0
-      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+      graphile-utils: 5.0.3(96e1e4a05986e18faa31d4ab20cded84)
       graphql: 16.13.0
       iterall: 1.3.0
       jsonwebtoken: 9.0.3
@@ -22434,7 +22437,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  postgraphile@5.1.4(ba6398e917e9857a0084b873121de2c9):
+  postgraphile@5.1.4(4afb1bec211dc7c56f7912b2a5d9f0a5):
     dependencies:
       '@dataplan/json': 1.0.1(grafast@1.1.2(graphql@16.13.0))
       '@dataplan/pg': 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
@@ -22444,10 +22447,10 @@ snapshots:
       debug: 4.4.3(supports-color@5.5.0)
       grafast: 1.1.2(graphql@16.13.0)
       grafserv: 1.0.1(@types/node@22.19.11)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(ws@8.20.1)
-      graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
-      graphile-build-pg: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-build: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+      graphile-build-pg: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config: 1.1.0
-      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+      graphile-utils: 5.0.3(96e1e4a05986e18faa31d4ab20cded84)
       graphql: 16.13.0
       iterall: 1.3.0
       jsonwebtoken: 9.0.3
@@ -22461,24 +22464,24 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  postgraphile@5.1.4(d2fbc9214324995a9f19d45c874ffd17):
+  postgraphile@5.1.4(f042e794f55cb7c62e14f2486718e7f4):
     dependencies:
       '@dataplan/json': 1.0.1(grafast@1.1.2(graphql@16.13.0))
-      '@dataplan/pg': 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      '@dataplan/pg': 1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)
       '@graphile/lru': 5.0.0
       '@types/node': 22.19.19
       '@types/pg': 8.20.4
       debug: 4.4.3(supports-color@5.5.0)
       grafast: 1.1.2(graphql@16.13.0)
       grafserv: 1.0.1(@types/node@25.9.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(ws@8.20.1)
-      graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
-      graphile-build-pg: 5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-build: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+      graphile-build-pg: 5.1.3(patch_hash=9145c8e4ae69ef92f0812d00676cd3242fd16122ee922fb3b82584b23ff7e2e5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1)
       graphile-config: 1.1.0
-      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=8cce8579f3bee5e9919d3ebed74a4b07e94b8198951fc1a6b3bbf8444f5ad6a5)(@dataplan/pg@1.1.1(patch_hash=a7c958d2d1d134e846226ca965d40145679ae0d5d7970ab61e7a1638295e38a2)(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+      graphile-utils: 5.0.3(18c54fc98696bfc2de7b77b84170db85)
       graphql: 16.13.0
       iterall: 1.3.0
       jsonwebtoken: 9.0.3
-      pg: 8.21.0
+      pg: 8.20.0
       pg-sql2: 5.0.1
       tamedevil: 0.1.1
       tslib: 2.8.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -111,6 +111,7 @@ packageExtensions:
 patchedDependencies:
   '@dataplan/pg': patches/@dataplan__pg.patch
   graphile-build-pg: patches/graphile-build-pg.patch
+  graphile-build@5.1.1: patches/graphile-build@5.1.1.patch
   pg-introspection@1.0.1: patches/pg-introspection@1.0.1.patch
 
 # The only dependencies permitted to run install scripts.


### PR DESCRIPTION
## Architecture

This PR keeps the opt-in policy in CNC and the inaccessible Graphile internals in pnpm patches.

### CNC normal source

- Adds the independently importable `BuildStateRetirementPlugin` in graphile-settings.
- The plugin registers `build.registerAfterSchemaValidation(...)` and is the only component that decides whether and when retirement runs.
- `ConstructivePreset` explicitly installs the plugin.
- Graphile `defaultPreset` remains unchanged.

### CNC pnpm patches

- Mirrors Crystal PR #1 neutral after-schema-validation lifecycle in graphile-build dist.
- Keeps the retirement state machine, core and Behavior cleanup, owner disposer registration/execution, released-state guards, and aggregate disposal errors inside the patch.
- Uses a private symbol capability to let the CNC plugin trigger retirement without exporting a Graphile retirement plugin.
- Keeps PgBasics, PgCodecs, and PgPolymorphism owner cleanup in graphile-build-pg.
- Does not modify pg-many-to-many.

### CNC owners

- graphile-search clears its build codec cache.
- graphile-connection-filter clears its operator registry.
- graphile-meta snapshots runtime metadata from the finalized schema.

## Contracts

- no CNC plugin: retained state and original behavior
- validation failure: no retirement
- installed plugin: retirement only after successful validation
- disposers: deterministic reverse order; all attempted; failures aggregated
- retirement: fail-closed with `GRAPHILE_BUILD_STATE_RELEASED`
- executable schemas remain independent of retired build state

## Validation

- retirement contract tests: 5 passed
- graphile-search owner test: passed
- connection-filter owner test: passed
- graphile-meta tests: 131 passed, 3 snapshots
- real PostgreSQL ConstructivePreset integration: 38 passed
- graphile-settings/search/connection-filter/meta builds: passed
- ESLint on affected sources: no errors (one pre-existing graphile-search unused-variable warning)
- frozen-lockfile install: passed
- git diff --check: passed