### PR TITLE
feat(harness): make the confirm gate's gated-tool set injectable

### DIFF
--- a/agentic/harness/__tests__/gating.test.ts
+++ b/agentic/harness/__tests__/gating.test.ts
@@ -1,6 +1,6 @@
 import { ConfirmGate, ConfirmGateDeps, createConfirmGate, GateHost } from '../src/gating/confirm-gate';
 import { createDeclineGuard } from '../src/gating/decline-guard';
-import { buildConfirmPrompt } from '../src/gating/prompts';
+import { buildConfirmPrompt, MUTATING_DB_TOOLS } from '../src/gating/prompts';
 
 type Harness = {
   gate: ConfirmGate;
@@ -215,6 +215,72 @@ describe('confirm gate: declines are respected', () => {
     );
     expect(result?.block).toBe(true);
     expect(withToken.confirmCalls()).toBe(1);
+  });
+});
+
+describe('confirm gate: the gated-tool set is injectable', () => {
+  it('gates the default MUTATING_DB_TOOLS set when none is injected', async () => {
+    const { gate, host, confirmCalls } = createHarness({ isProjectRunnable: async () => true });
+    for (const toolName of MUTATING_DB_TOOLS) {
+      if (toolName === 'add_records' || toolName === 'create_api_key') continue; // tokenless: skipped
+      const result = await gate.onToolCall(call(toolName, `tc-${toolName}`, {}), host, CWD);
+      expect(result?.block).toBe(true);
+    }
+    expect(confirmCalls()).toBe(MUTATING_DB_TOOLS.size - 2);
+  });
+
+  it('gates only the injected set: a custom tool is gated, a default one is not', async () => {
+    const { gate, host, confirmCalls } = createHarness({
+      isProjectRunnable: async () => true,
+      gatedTools: new Set(['bash']),
+    });
+
+    const gated = await gate.onToolCall(call('bash', 'tc-1', { command: 'rm -rf /' }), host, CWD);
+    expect(gated?.block).toBe(true);
+    expect(gated?.reason).toMatch(/declined it/);
+    expect(confirmCalls()).toBe(1);
+
+    // delete_table is in MUTATING_DB_TOOLS but not in the injected set.
+    const ungated = await gate.onToolCall(
+      call('delete_table', 'tc-2', { table_name: 'users' }),
+      host,
+      CWD
+    );
+    expect(ungated).toBeUndefined();
+    expect(confirmCalls()).toBe(1);
+  });
+
+  it('applies the decline guard and headless block to injected tools too', async () => {
+    const { gate, host, confirmCalls, skipNotices } = createHarness({
+      isProjectRunnable: async () => true,
+      gatedTools: new Set(['bash']),
+    });
+    const input = { command: 'git push --force' };
+
+    await gate.onToolCall(call('bash', 'tc-1', input), host, CWD);
+    const retry = await gate.onToolCall(call('bash', 'tc-2', input), host, CWD);
+    expect(retry?.reason).toMatch(/already declined/);
+    expect(confirmCalls()).toBe(1);
+    expect(skipNotices()).toEqual(['tc-2']);
+
+    const headless: GateHost = {
+      hasUI: false,
+      confirmTool: async () => true,
+      notifyToolSkipped: () => undefined,
+    };
+    const blocked = await gate.onToolCall(call('bash', 'tc-3', {}), headless, CWD);
+    expect(blocked?.reason).toMatch(/no confirmation UI/);
+  });
+
+  it('gates nothing when an empty set is injected', async () => {
+    const { gate, host, confirmCalls } = createHarness({
+      isProjectRunnable: async () => true,
+      gatedTools: new Set<string>(),
+    });
+    expect(
+      await gate.onToolCall(call('provision_database', 'tc-1', {}), host, CWD)
+    ).toBeUndefined();
+    expect(confirmCalls()).toBe(0);
   });
 });
 

--- a/agentic/harness/src/gating/confirm-gate.ts
+++ b/agentic/harness/src/gating/confirm-gate.ts
@@ -51,6 +51,13 @@ export type ConfirmGateDeps = {
     blueprintName: string | undefined,
     displayName: string
   ): Promise<ConfirmPreview | undefined>;
+  /**
+   * Tool names that require a human decision. The policy belongs to the host,
+   * not the harness: Desktop/CLI gate Constructive's mutating db tools, a
+   * remote coding host gates a different set. Defaults to
+   * `MUTATING_DB_TOOLS`.
+   */
+  gatedTools?: ReadonlySet<string>;
 };
 
 export type ConfirmGate = {
@@ -60,6 +67,7 @@ export type ConfirmGate = {
 
 export function createConfirmGate(deps: ConfirmGateDeps): ConfirmGate {
   const declineGuard = createDeclineGuard();
+  const gatedTools = deps.gatedTools ?? MUTATING_DB_TOOLS;
 
   async function confirmOrDecline(
     event: GateToolCallEvent,
@@ -89,7 +97,7 @@ export function createConfirmGate(deps: ConfirmGateDeps): ConfirmGate {
     onAgentStart: () => declineGuard.clear(),
 
     onToolCall: async (event, host, cwd) => {
-      if (!MUTATING_DB_TOOLS.has(event.toolName)) return;
+      if (!gatedTools.has(event.toolName)) return;
 
       const input = event.input;
 

--- a/agentic/pi/src/confirm-gate.ts
+++ b/agentic/pi/src/confirm-gate.ts
@@ -35,6 +35,8 @@ export type ConfirmGateDeps = {
   resolveProjectContext: typeof resolveProjectContext;
   resolveDataToken: typeof resolveDataToken;
   createTemplatePreviewTables: typeof createTemplatePreviewTables;
+  /** Tool names to gate; defaults to the harness's `MUTATING_DB_TOOLS`. */
+  gatedTools?: ReadonlySet<string>;
 };
 
 export type ConfirmGate = {
@@ -47,6 +49,7 @@ export type ConfirmGate = {
 
 export function createConfirmGate(deps: ConfirmGateDeps): ConfirmGate {
   const gate: HarnessConfirmGate = createHarnessConfirmGate({
+    gatedTools: deps.gatedTools,
     isProjectRunnable: async (cwd) => {
       const resolved = await deps.resolveProjectContext(cwd);
       return resolved.context !== null;

--- a/pnpm-policy.yaml
+++ b/pnpm-policy.yaml
@@ -94,22 +94,10 @@ exceptions:
     versions: ["8.66.0"]
     reason: ^8.66.0 floor matches the newest release; nothing older satisfies it
     until: 2026-08-17
-  - package: "@playwright/test"
-    versions: ["1.62.1"]
-    reason: ^1.62.1 floor matches the newest release; nothing older satisfies it
-    until: 2026-08-13
   - package: "@types/pg"
     versions: ["8.20.4"]
     reason: ^8.20.4 floor matches the newest release; nothing older satisfies it
     until: 2026-08-18
-  - package: "@types/react"
-    versions: ["19.2.18"]
-    reason: ^19.2.18 floor matches the newest release; nothing older satisfies it
-    until: 2026-08-13
-  - package: "@types/react-dom"
-    versions: ["19.2.4"]
-    reason: ^19.2.4 floor matches the newest release; nothing older satisfies it
-    until: 2026-08-13
   - package: "@types/semver"
     versions: ["7.8.0"]
     reason: ^7.8.0 floor matches the newest release; nothing older satisfies it

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,7 @@ packages:
 # Most malicious releases are found and yanked well inside that window.
 minimumReleaseAge: 2880
 
-# Exempt from the wait: 6 scope glob(s), 41 first-party package(s), 7 exception(s).
+# Exempt from the wait: 6 scope glob(s), 41 first-party package(s), 4 exception(s).
 # First-party membership comes from the inventory.
 minimumReleaseAgeExclude:
   - "@constructive-db/*"
@@ -67,10 +67,7 @@ minimumReleaseAgeExclude:
   - yanse
   - "@typescript-eslint/eslint-plugin@8.66.0" # ^8.66.0 floor matches the newest release; nothing older satisfies it (expires 2026-08-17)
   - "@typescript-eslint/parser@8.66.0" # ^8.66.0 floor matches the newest release; nothing older satisfies it (expires 2026-08-17)
-  - "@playwright/test@1.62.1" # ^1.62.1 floor matches the newest release; nothing older satisfies it (expires 2026-08-13)
   - "@types/pg@8.20.4" # ^8.20.4 floor matches the newest release; nothing older satisfies it (expires 2026-08-18)
-  - "@types/react@19.2.18" # ^19.2.18 floor matches the newest release; nothing older satisfies it (expires 2026-08-13)
-  - "@types/react-dom@19.2.4" # ^19.2.4 floor matches the newest release; nothing older satisfies it (expires 2026-08-13)
   - "@types/semver@7.8.0" # ^7.8.0 floor matches the newest release; nothing older satisfies it (expires 2026-08-16)
 
 # Off: transitive dependencies may resolve from git or a URL.


### PR DESCRIPTION
## Summary

`createConfirmGate` hardcoded `MUTATING_DB_TOOLS` as the set of tool calls that need a human decision, making the *policy* a property of the harness rather than of the host. A remote coding host (constructive-planning#1633: pi in a Kubernetes Job against a cloned repo) wants to gate `bash`/force-push and auto-approve reads instead.

The set is now one more injected dependency in the existing `ConfirmGateDeps` bag, defaulting to `MUTATING_DB_TOOLS`:

```ts
export type ConfirmGateDeps = {
  isProjectRunnable(cwd: string): Promise<boolean>;
  hasDataToken(cwd: string): Promise<boolean>;
  resolveTemplatePreview(...): Promise<ConfirmPreview | undefined>;
+ /** Defaults to MUTATING_DB_TOOLS. */
+ gatedTools?: ReadonlySet<string>;
};

-if (!MUTATING_DB_TOOLS.has(event.toolName)) return;
+const gatedTools = deps.gatedTools ?? MUTATING_DB_TOOLS;   // resolved once, at construction
+if (!gatedTools.has(event.toolName)) return;
```

`agentic/pi`'s adapter forwards an optional `gatedTools` straight through, so a pi-based host can carry its own policy without reaching into the harness.

**Shape: `ReadonlySet<string>`, not a predicate.** Every current caller wants a set, a set is data (so a persona can carry it as JSON and it can be diffed/logged/sent over the wire), and it stays interchangeable with the exported default. A predicate is only more expressive for per-argument gating, which no caller needs today — and the gate already special-cases arguments internally (`manage_entity_types` `action: 'list'`, tokenless `add_records`/`create_api_key`), so a predicate would create two competing places to express the same rule. `ReadonlySet` rather than `Set` so the default constant can't be mutated by the gate. Widening to a predicate later is a superset of this signature and stays backwards-compatible.

`MUTATING_DB_TOOLS` stays exported and is still the default, so Desktop/CLI behaviour is unchanged.

### Call sites verified unchanged (none pass `gatedTools`)

- `agentic/pi/src/confirm-gate.ts` — only harness consumer of `createConfirmGate`; now forwards `deps.gatedTools` (`undefined` for all existing callers → default).
- `agentic/pi/src/index.ts` — wires the real resolvers, no `gatedTools`.
- `agentic/pi/__tests__/confirm-gate.test.ts` — passes.
- `agentic/harness/__tests__/gating.test.ts` — all pre-existing cases pass untouched.
- No other reference to `MUTATING_DB_TOOLS`, `createConfirmGate`, or `ConfirmGateDeps` exists in the monorepo (`agentic/cli` only imports the harness's skills/dirs helpers; the desktop host is not vendored here — it consumes `@agentic-kit/harness` via the pi adapter).

### Tests

Added to `agentic/harness/__tests__/gating.test.ts`: the whole default set is still gated when nothing is injected; with `gatedTools: new Set(['bash'])`, `bash` is gated (a tool the default never gates) and `delete_table` stops being gated; the decline guard and the headless "no confirmation UI" block apply to injected tools too; an empty set gates nothing.

### Incidental unblock: three expired release-age waivers removed

The `build` job failed on `pnpm run policy:check` before running any tests, identically on `main`: the `@playwright/test@1.62.1`, `@types/react@19.2.18` and `@types/react-dom@19.2.4` waivers in `pnpm-policy.yaml` carried `until: 2026-08-13`, i.e. today. Per the comment block above `exceptions:`, `until` is the day the pinned version turns two weeks old — so those waivers are now **obsolete, not in need of extension**. They are deleted, and `pnpm-workspace.yaml`'s derived `minimumReleaseAgeExclude` block and header count are regenerated with `npx pnpm-policy generate` (not hand-edited). The pinned versions now clear the 2-day `minimumReleaseAge` on their own: `policy:check` reports `pnpm-workspace.yaml matches the policy` and `pnpm install --frozen-lockfile` still resolves. No control was weakened — the exempt set shrank.


Link to Devin session: https://app.devin.ai/sessions/d57afe90832a4d7197b9b41ff4ca4f43
Requested by: @pyramation