### PR TITLE
Add a reusable Graphile performance harness

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -109,7 +109,7 @@ jobs:
           - batch: packages-core
             packages: 'packages/url-domains packages/coerce packages/csrf packages/oauth packages/12factor-env packages/orm packages/express-context packages/errors packages/llm-env packages/node-type-registry packages/query-spec packages/server-utils packages/site-deploy examples/site-deploy-ssg postgres/pg-cache postgres/pg-env'
           - batch: packages-services
-            packages: 'packages/postmaster packages/smtppostmaster packages/csv-to-pg packages/cli postgres/pgsql-client postgres/pg-ast'
+            packages: 'packages/postmaster packages/smtppostmaster packages/csv-to-pg packages/cli packages/perf-harness postgres/pgsql-client postgres/pg-ast'
           - batch: graphql
             packages: 'graphql/query graphql/codegen'
           - batch: graphile-unit

--- a/packages/perf-harness/README.md
+++ b/packages/perf-harness/README.md
@@ -32,8 +32,11 @@ await runBenchmarkSuite(suite, options, workerPath);
 entry rather than serializing functions across process boundaries.
 
 The package includes `stock-worker.js` as a minimal upstream Graphile baseline.
-Database credentials are supplied through `CPERF_DATABASE_URL` and are redacted
-from worker failures and JSON reports.
+The top-level commands require `--database-url`; the runner forwards it and the
+opaque case configuration to each short-lived worker as CLI arguments. Database
+credentials are redacted from worker failures and JSON reports. This harness is
+intended for local development on a trusted machine because command arguments
+may be visible to other local processes.
 
 The PostgreSQL fixture command only creates a previously absent schema whose
 name starts with `cperf_`; it never drops or replaces schemas.

--- a/packages/perf-harness/README.md
+++ b/packages/perf-harness/README.md
@@ -1,0 +1,39 @@
+# Graphile performance harness
+
+Reusable infrastructure for measuring Graphile schema builds in fresh Node
+processes. The core accepts any list of serializable benchmark cases; it does not
+interpret case names or optimization-specific configuration.
+
+Each measurement receives a new PID, starts Node with `--expose-gc`, runs a
+deterministic GC sequence, records build time and memory metrics, validates a
+runtime query, and reports a schema hash. Cases can opt into schema equivalence
+groups and provide their own lifecycle validation through the worker result.
+
+## Extending the harness
+
+Define a suite and provide a dedicated worker entry point:
+
+```ts
+const suite = {
+  name: 'example',
+  cases: [
+    {
+      name: 'baseline',
+      workerConfig: { schemas: ['cperf_example'] },
+      expectedSchemaGroup: 'example-schema',
+    },
+  ],
+};
+
+await runBenchmarkSuite(suite, options, workerPath);
+```
+
+`workerConfig` must be JSON-serializable. Logic is implemented in the worker
+entry rather than serializing functions across process boundaries.
+
+The package includes `stock-worker.js` as a minimal upstream Graphile baseline.
+Database credentials are supplied through `CPERF_DATABASE_URL` and are redacted
+from worker failures and JSON reports.
+
+The PostgreSQL fixture command only creates a previously absent schema whose
+name starts with `cperf_`; it never drops or replaces schemas.

--- a/packages/perf-harness/README.md
+++ b/packages/perf-harness/README.md
@@ -31,6 +31,19 @@ await runBenchmarkSuite(suite, options, workerPath);
 `workerConfig` must be JSON-serializable. Logic is implemented in the worker
 entry rather than serializing functions across process boundaries.
 
+Each worker has a five-minute wall-clock deadline, including startup, database
+access, validation, and cleanup. Set `options.workerTimeoutMs` or pass
+`--worker-timeout-ms` to `cperf run` to override it with a positive integer
+(maximum 2,147,483,647 ms). The effective deadline is recorded in `report.config`;
+it does not change the build-only `buildMs` measurement.
+
+A timed-out worker is killed and must finish closing before the next case starts.
+Its failure is recorded even if it already printed a successful result. If its
+process and stdio cannot be confirmed closed within another five seconds, the
+suite stops scheduling cases and writes a failed report containing the completed
+runs. Earlier successful samples may remain in summaries, but the report's
+validation fails. The CLI exits nonzero for either kind of failure.
+
 The package includes `stock-worker.js` as a minimal upstream Graphile baseline.
 The top-level commands require `--database-url`; the runner forwards it and the
 opaque case configuration to each short-lived worker as CLI arguments. Database

--- a/packages/perf-harness/__tests__/fixture.test.ts
+++ b/packages/perf-harness/__tests__/fixture.test.ts
@@ -1,0 +1,22 @@
+import {
+  validateFixtureSchema,
+  validateFixtureTableCount,
+} from '../src/fixture';
+
+describe('fixture safety', () => {
+  test('only accepts narrowly scoped benchmark schema names', () => {
+    expect(validateFixtureSchema('cperf_example_1')).toBe('cperf_example_1');
+    expect(() => validateFixtureSchema('public')).toThrow(
+      'must start with cperf_'
+    );
+    expect(() =>
+      validateFixtureSchema('cperf_example; drop schema public')
+    ).toThrow('must start with cperf_');
+  });
+
+  test('bounds generated fixture size', () => {
+    expect(validateFixtureTableCount(64)).toBe(64);
+    expect(() => validateFixtureTableCount(0)).toThrow('between 1 and 500');
+    expect(() => validateFixtureTableCount(501)).toThrow('between 1 and 500');
+  });
+});

--- a/packages/perf-harness/__tests__/fixture.test.ts
+++ b/packages/perf-harness/__tests__/fixture.test.ts
@@ -1,7 +1,66 @@
+import { Pool } from 'pg';
+
 import {
+  prepareFixture,
   validateFixtureSchema,
   validateFixtureTableCount,
 } from '../src/fixture';
+
+jest.mock('pg', () => ({
+  Pool: jest.fn(),
+}));
+
+type MockClient = {
+  query: jest.Mock;
+  release: jest.Mock;
+};
+
+type MockPool = {
+  connect: jest.Mock;
+  end: jest.Mock;
+};
+
+const fixtureOptions = {
+  databaseUrl: 'postgres://fixture-test',
+  schema: 'cperf_fixture_test',
+  tables: 1,
+};
+
+const queryResult = (text: string) => {
+  if (text.includes('pg_namespace')) {
+    return { rows: [{ exists: false }] };
+  }
+  if (text.includes('current_database')) {
+    return { rows: [{ database: 'fixture_db', server_version: '16' }] };
+  }
+  return { rows: [] };
+};
+
+const createMocks = (): { client: MockClient; pool: MockPool } => {
+  const client: MockClient = {
+    query: jest.fn(async (text: string) => queryResult(text)),
+    release: jest.fn(),
+  };
+  const pool: MockPool = {
+    connect: jest.fn().mockResolvedValue(client),
+    end: jest.fn().mockResolvedValue(undefined),
+  };
+  (Pool as unknown as jest.Mock).mockImplementation(() => pool);
+  return { client, pool };
+};
+
+const rejected = async (promise: Promise<unknown>): Promise<unknown> => {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error('expected prepareFixture to reject');
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 describe('fixture safety', () => {
   test('only accepts narrowly scoped benchmark schema names', () => {
@@ -18,5 +77,157 @@ describe('fixture safety', () => {
     expect(validateFixtureTableCount(64)).toBe(64);
     expect(() => validateFixtureTableCount(0)).toThrow('between 1 and 500');
     expect(() => validateFixtureTableCount(501)).toThrow('between 1 and 500');
+  });
+});
+
+describe('fixture resource lifecycle', () => {
+  test('ends the pool when connecting fails without releasing a client', async () => {
+    const { client, pool } = createMocks();
+    const connectError = new Error('connect failed');
+    pool.connect.mockRejectedValue(connectError);
+
+    await expect(prepareFixture(fixtureOptions)).rejects.toBe(connectError);
+
+    expect(client.release).not.toHaveBeenCalled();
+    expect(pool.end).toHaveBeenCalledTimes(1);
+  });
+
+  test('retains a falsy connection failure when ending the pool also fails', async () => {
+    const { client, pool } = createMocks();
+    const endError = new Error('end failed');
+    pool.connect.mockRejectedValue(undefined);
+    pool.end.mockRejectedValue(endError);
+
+    const error = await rejected(prepareFixture(fixtureOptions));
+
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors).toEqual([undefined, endError]);
+    expect(
+      (error as AggregateError & { cause: unknown }).cause
+    ).toBeUndefined();
+    expect(client.release).not.toHaveBeenCalled();
+    expect(pool.end).toHaveBeenCalledTimes(1);
+  });
+
+  test('commits and releases the client before ending the pool on success', async () => {
+    const { client, pool } = createMocks();
+
+    await expect(prepareFixture(fixtureOptions)).resolves.toEqual(
+      expect.objectContaining({
+        database: 'fixture_db',
+        tableCount: 2,
+        functionCount: 1,
+      })
+    );
+
+    expect(client.query).toHaveBeenCalledWith('commit');
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(pool.end).toHaveBeenCalledTimes(1);
+    expect(client.release.mock.invocationCallOrder[0]).toBeLessThan(
+      pool.end.mock.invocationCallOrder[0]
+    );
+  });
+
+  test('rolls back, releases, and ends resources after a SQL failure', async () => {
+    const { client, pool } = createMocks();
+    const queryError = new Error('create schema failed');
+    client.query.mockImplementation(async (text: string) => {
+      if (text.includes('create schema')) {
+        throw queryError;
+      }
+      return queryResult(text);
+    });
+
+    await expect(prepareFixture(fixtureOptions)).rejects.toBe(queryError);
+
+    expect(client.query).toHaveBeenCalledWith('rollback');
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(pool.end).toHaveBeenCalledTimes(1);
+  });
+
+  test('retains a rollback failure with the original SQL failure', async () => {
+    const { client, pool } = createMocks();
+    const queryError = new Error('create schema failed');
+    const rollbackError = new Error('rollback failed');
+    client.query.mockImplementation(async (text: string) => {
+      if (text.includes('create schema')) {
+        throw queryError;
+      }
+      if (text === 'rollback') {
+        throw rollbackError;
+      }
+      return queryResult(text);
+    });
+
+    const error = await rejected(prepareFixture(fixtureOptions));
+
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors).toEqual([
+      queryError,
+      rollbackError,
+    ]);
+    expect((error as AggregateError & { cause: unknown }).cause).toBe(
+      queryError
+    );
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(pool.end).toHaveBeenCalledTimes(1);
+  });
+
+  test('still ends the pool when releasing the client fails', async () => {
+    const { client, pool } = createMocks();
+    const releaseError = new Error('release failed');
+    client.release.mockImplementation(() => {
+      throw releaseError;
+    });
+
+    await expect(prepareFixture(fixtureOptions)).rejects.toBe(releaseError);
+
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(pool.end).toHaveBeenCalledTimes(1);
+  });
+
+  test('surfaces a pool end failure after releasing the client', async () => {
+    const { client, pool } = createMocks();
+    const endError = new Error('end failed');
+    pool.end.mockRejectedValue(endError);
+
+    await expect(prepareFixture(fixtureOptions)).rejects.toBe(endError);
+
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(pool.end).toHaveBeenCalledTimes(1);
+  });
+
+  test('orders the primary and cleanup failures and preserves the primary cause', async () => {
+    const { client, pool } = createMocks();
+    const queryError = new Error('create schema failed');
+    const rollbackError = new Error('rollback failed');
+    const releaseError = new Error('release failed');
+    const endError = new Error('end failed');
+    client.query.mockImplementation(async (text: string) => {
+      if (text.includes('create schema')) {
+        throw queryError;
+      }
+      if (text === 'rollback') {
+        throw rollbackError;
+      }
+      return queryResult(text);
+    });
+    client.release.mockImplementation(() => {
+      throw releaseError;
+    });
+    pool.end.mockRejectedValue(endError);
+
+    const error = await rejected(prepareFixture(fixtureOptions));
+
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors).toEqual([
+      queryError,
+      rollbackError,
+      releaseError,
+      endError,
+    ]);
+    expect((error as AggregateError & { cause: unknown }).cause).toBe(
+      queryError
+    );
   });
 });

--- a/packages/perf-harness/__tests__/fixtures/fake-worker.js
+++ b/packages/perf-harness/__tests__/fixtures/fake-worker.js
@@ -1,7 +1,17 @@
 'use strict';
 
+const valueFor = (name) => {
+  const flag = `--${name}`;
+  const index = process.argv.indexOf(flag);
+  if (index < 0 || !process.argv[index + 1]) {
+    throw new Error(`${flag} is required`);
+  }
+  return process.argv[index + 1];
+};
+
+valueFor('database-url');
 const envelope = JSON.parse(
-  Buffer.from(process.env.CPERF_WORKER_CONFIG, 'base64url').toString('utf8')
+  Buffer.from(valueFor('worker-config'), 'base64url').toString('utf8')
 );
 const value = envelope.workerConfig.value;
 const memory = {

--- a/packages/perf-harness/__tests__/fixtures/fake-worker.js
+++ b/packages/perf-harness/__tests__/fixtures/fake-worker.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const envelope = JSON.parse(
+  Buffer.from(process.env.CPERF_WORKER_CONFIG, 'base64url').toString('utf8')
+);
+const value = envelope.workerConfig.value;
+const memory = {
+  rss: value,
+  heapTotal: value,
+  heapUsed: value,
+  external: value,
+  arrayBuffers: value,
+};
+const result = {
+  status: 'ok',
+  pid: process.pid,
+  caseName: envelope.caseName,
+  buildMs: value,
+  schemaHash: envelope.workerConfig.schemaHash,
+  schemaTypeCount: 10,
+  runtimeVerified: true,
+  caseValidation: { passed: true, errors: [] },
+  memory: {
+    baseline: memory,
+    afterBuild: memory,
+    delta: memory,
+    processPeakRss: value,
+  },
+};
+process.stdout.write(`CPERF_RESULT ${JSON.stringify(result)}\n`);

--- a/packages/perf-harness/__tests__/fixtures/fake-worker.js
+++ b/packages/perf-harness/__tests__/fixtures/fake-worker.js
@@ -9,10 +9,16 @@ const valueFor = (name) => {
   return process.argv[index + 1];
 };
 
-valueFor('database-url');
+const databaseUrl = valueFor('database-url');
 const envelope = JSON.parse(
   Buffer.from(valueFor('worker-config'), 'base64url').toString('utf8')
 );
+if (envelope.workerConfig.pidFile) {
+  require('node:fs').writeFileSync(
+    envelope.workerConfig.pidFile,
+    String(process.pid)
+  );
+}
 const value = envelope.workerConfig.value;
 const memory = {
   rss: value,
@@ -37,4 +43,10 @@ const result = {
     processPeakRss: value,
   },
 };
-process.stdout.write(`CPERF_RESULT ${JSON.stringify(result)}\n`);
+if (envelope.workerConfig.mode !== 'hang') {
+  process.stdout.write(`CPERF_RESULT ${JSON.stringify(result)}\n`);
+}
+if (['hang', 'result-then-hang'].includes(envelope.workerConfig.mode)) {
+  process.stderr.write(`connecting to ${databaseUrl}\n`);
+  setInterval(() => undefined, 1_000);
+}

--- a/packages/perf-harness/__tests__/process.test.ts
+++ b/packages/perf-harness/__tests__/process.test.ts
@@ -1,6 +1,55 @@
 import { resolve } from 'node:path';
 
-import { runWorkerProcess } from '../src/process';
+import { parseWorkerProcessArgs, runWorkerProcess } from '../src/process';
+
+describe('worker CLI protocol', () => {
+  const encodedConfig = Buffer.from(
+    JSON.stringify({ caseName: 'baseline', workerConfig: { value: 1 } })
+  ).toString('base64url');
+
+  test('parses the database URL and worker envelope from CLI arguments', () => {
+    expect(
+      parseWorkerProcessArgs([
+        '--database-url',
+        'postgres:///benchmark',
+        '--worker-config',
+        encodedConfig,
+      ])
+    ).toEqual({
+      databaseUrl: 'postgres:///benchmark',
+      envelope: { caseName: 'baseline', workerConfig: { value: 1 } },
+    });
+  });
+
+  test('rejects missing, duplicate, and unsupported worker arguments', () => {
+    expect(() =>
+      parseWorkerProcessArgs(['--worker-config', encodedConfig])
+    ).toThrow('--database-url is required');
+    expect(() =>
+      parseWorkerProcessArgs(['--database-url', 'postgres:///benchmark'])
+    ).toThrow('--worker-config is required');
+    expect(() =>
+      parseWorkerProcessArgs([
+        '--database-url',
+        'postgres:///one',
+        '--database-url',
+        'postgres:///two',
+        '--worker-config',
+        encodedConfig,
+      ])
+    ).toThrow('--database-url may only be specified once');
+    expect(() =>
+      parseWorkerProcessArgs([
+        '--database-url',
+        'postgres:///benchmark',
+        '--worker-config',
+        encodedConfig,
+        '--unexpected',
+        'value',
+      ])
+    ).toThrow("unsupported worker argument '--unexpected'");
+  });
+});
 
 describe('fresh worker process', () => {
   test('uses distinct PIDs and does not expose the database URL', async () => {

--- a/packages/perf-harness/__tests__/process.test.ts
+++ b/packages/perf-harness/__tests__/process.test.ts
@@ -1,0 +1,22 @@
+import { resolve } from 'node:path';
+
+import { runWorkerProcess } from '../src/process';
+
+describe('fresh worker process', () => {
+  test('uses distinct PIDs and does not expose the database URL', async () => {
+    const worker = resolve(__dirname, 'fixtures/fake-worker.js');
+    const definition = {
+      name: 'baseline',
+      workerConfig: { value: 1, schemaHash: 'same' },
+    };
+    const databaseUrl = 'postgres://secret@example.test/database';
+    const first = await runWorkerProcess(worker, databaseUrl, definition);
+    const second = await runWorkerProcess(worker, databaseUrl, definition);
+    expect(first.pid).not.toBe(process.pid);
+    expect(second.pid).not.toBe(process.pid);
+    expect(first.pid).not.toBe(second.pid);
+    expect(JSON.stringify([first.result, second.result])).not.toContain(
+      databaseUrl
+    );
+  });
+});

--- a/packages/perf-harness/__tests__/process.test.ts
+++ b/packages/perf-harness/__tests__/process.test.ts
@@ -1,6 +1,17 @@
+import childProcess from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
+import { PassThrough } from 'node:stream';
 
-import { parseWorkerProcessArgs, runWorkerProcess } from '../src/process';
+import {
+  DEFAULT_WORKER_TIMEOUT_MS,
+  parseWorkerProcessArgs,
+  runWorkerProcess,
+  validateWorkerTimeoutMs,
+  WorkerCleanupError,
+} from '../src/process';
 
 describe('worker CLI protocol', () => {
   const encodedConfig = Buffer.from(
@@ -67,5 +78,203 @@ describe('fresh worker process', () => {
     expect(JSON.stringify([first.result, second.result])).not.toContain(
       databaseUrl
     );
+  });
+
+  test.each(['hang', 'result-then-hang'])(
+    'reaps a %s worker before rejecting and redacts its diagnostics',
+    async (mode) => {
+      const directory = await mkdtemp(resolve(tmpdir(), 'cperf-timeout-'));
+      const pidFile = resolve(directory, 'worker.pid');
+      const spawn = jest.spyOn(childProcess, 'spawn');
+      const databaseUrl = 'postgres://secret@example.test/database';
+      const running = runWorkerProcess(
+        resolve(__dirname, 'fixtures/fake-worker.js'),
+        databaseUrl,
+        { name: mode, workerConfig: { mode, pidFile, value: 1 } },
+        2_000
+      );
+      const child = spawn.mock.results[0].value as childProcess.ChildProcess;
+      let closed = false;
+      child.once('close', () => {
+        closed = true;
+      });
+      // Keep a regression in timeout handling from orphaning the test child.
+      const watchdog = setTimeout(() => child.kill('SIGKILL'), 5_000);
+      try {
+        const error = await running.catch((failure: Error) => failure);
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toContain('timed out after 2000ms');
+        expect((error as Error).stack).not.toContain(databaseUrl);
+        expect(closed).toBe(true);
+        expect(Number(await readFile(pidFile, 'utf8'))).toBe(child.pid);
+      } finally {
+        clearTimeout(watchdog);
+        spawn.mockRestore();
+        await rm(directory, { recursive: true, force: true });
+      }
+    },
+    10_000
+  );
+});
+
+describe('worker deadline lifecycle', () => {
+  const definition = { name: 'baseline', workerConfig: {} };
+  const databaseUrl = 'postgres://secret@example.test/database';
+  let child: EventEmitter & {
+    pid: number | undefined;
+    stdout: PassThrough;
+    stderr: PassThrough;
+    kill: jest.Mock;
+    unref: jest.Mock;
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    child = Object.assign(new EventEmitter(), {
+      pid: 12345,
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      kill: jest.fn(() => true),
+      unref: jest.fn(),
+    });
+    jest
+      .spyOn(childProcess, 'spawn')
+      .mockReturnValue(
+        child as unknown as ReturnType<typeof childProcess.spawn>
+      );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  const writeSuccess = (): void => {
+    child.stdout.write(
+      `CPERF_RESULT ${JSON.stringify({
+        status: 'ok',
+        pid: child.pid,
+        caseName: definition.name,
+      })}\n`
+    );
+  };
+
+  test('clears its deadline on normal close', async () => {
+    const running = runWorkerProcess('worker.js', databaseUrl, definition, 100);
+    writeSuccess();
+    jest.advanceTimersByTime(99);
+    child.emit('close', 0, null);
+    await expect(running).resolves.toMatchObject({ pid: child.pid });
+    jest.advanceTimersByTime(10_000);
+    expect(child.kill).not.toHaveBeenCalled();
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  test('keeps a timeout latched until close, even after a success result', async () => {
+    const running = runWorkerProcess('worker.js', databaseUrl, definition, 100);
+    writeSuccess();
+    let settled = false;
+    const observed = running.catch((error: Error) => {
+      settled = true;
+      return error;
+    });
+    jest.advanceTimersByTime(100);
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    child.emit('close', 0, null);
+    expect(((await observed) as Error).message).toContain('timed out');
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  test('rejects spawn failure without waiting for the deadline', async () => {
+    child.pid = undefined;
+    const running = runWorkerProcess('worker.js', databaseUrl, definition, 100);
+    child.emit('error', new Error(`cannot spawn ${databaseUrl}`));
+    await expect(running).rejects.toThrow('could not start');
+    expect(child.kill).not.toHaveBeenCalled();
+    expect(jest.getTimerCount()).toBe(0);
+    expect(() => child.emit('error', new Error('late error'))).not.toThrow();
+  });
+
+  test('redacts synchronous spawn failures', async () => {
+    jest.mocked(childProcess.spawn).mockImplementationOnce(() => {
+      throw new Error(databaseUrl);
+    });
+    const error = await runWorkerProcess(
+      'worker.js',
+      databaseUrl,
+      definition
+    ).catch((failure: Error) => failure);
+    expect((error as Error).message).toContain('could not start');
+    expect((error as Error).stack).not.toContain(databaseUrl);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  test('reaps a worker after a post-spawn error before rejecting', async () => {
+    const running = runWorkerProcess('worker.js', databaseUrl, definition, 100);
+    let settled = false;
+    const observed = running.catch((error: Error) => {
+      settled = true;
+      return error;
+    });
+    child.emit('error', new Error(`stream failed: ${databaseUrl}`));
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    child.emit('close', 1, null);
+    expect(((await observed) as Error).message).not.toContain(databaseUrl);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  test.each(['false', 'throw', 'no-close'])(
+    'bounds cleanup when kill produces %s and tolerates late events',
+    async (outcome) => {
+      if (outcome === 'false') child.kill.mockReturnValue(false);
+      if (outcome === 'throw')
+        child.kill.mockImplementation(() => {
+          throw new Error(`cannot kill ${databaseUrl}`);
+        });
+      const running = runWorkerProcess(
+        'worker.js',
+        databaseUrl,
+        definition,
+        100
+      );
+      const observed = running.catch((error: Error) => error);
+      child.stderr.write(databaseUrl);
+      jest.advanceTimersByTime(100);
+      expect(child.stdout.destroyed).toBe(false);
+      jest.advanceTimersByTime(5_000);
+      const error = (await observed) as Error;
+      expect(error).toBeInstanceOf(WorkerCleanupError);
+      expect(error.message).toContain('cleanup was not confirmed');
+      expect(error.stack).not.toContain(databaseUrl);
+      expect(child.stdout.destroyed).toBe(true);
+      expect(child.stderr.destroyed).toBe(true);
+      expect(child.unref).toHaveBeenCalledTimes(1);
+      expect(() => {
+        child.emit('close', 0, null);
+        child.emit('error', new Error('late child error'));
+        child.stdout.emit('error', new Error('late stream error'));
+      }).not.toThrow();
+      jest.runAllTicks();
+      expect(jest.getTimerCount()).toBe(0);
+    }
+  );
+
+  test.each([0, -1, 1.5, NaN, Infinity, 2_147_483_648, null])(
+    'rejects invalid timeout %s before spawning',
+    async (timeout) => {
+      await expect(
+        runWorkerProcess('worker.js', databaseUrl, definition, timeout)
+      ).rejects.toThrow('workerTimeoutMs');
+      expect(childProcess.spawn).not.toHaveBeenCalled();
+      expect(jest.getTimerCount()).toBe(0);
+    }
+  );
+
+  test('normalizes the default timeout', () => {
+    expect(validateWorkerTimeoutMs()).toBe(DEFAULT_WORKER_TIMEOUT_MS);
   });
 });

--- a/packages/perf-harness/__tests__/report.test.ts
+++ b/packages/perf-harness/__tests__/report.test.ts
@@ -1,0 +1,78 @@
+import {
+  compareCases,
+  summarizeCase,
+  validateSchemaGroups,
+} from '../src/report';
+import type { BenchmarkRun, SuccessfulWorkerResult } from '../src/types';
+
+const result = (caseName: string, value: number): SuccessfulWorkerResult => ({
+  status: 'ok',
+  pid: value,
+  caseName,
+  buildMs: value,
+  schemaHash: 'same',
+  schemaTypeCount: 10,
+  runtimeVerified: true,
+  caseValidation: { passed: true, errors: [] },
+  memory: {
+    baseline: {
+      rss: 10,
+      heapTotal: 10,
+      heapUsed: 10,
+      external: 10,
+      arrayBuffers: 10,
+    },
+    afterBuild: {
+      rss: value,
+      heapTotal: value,
+      heapUsed: value,
+      external: value,
+      arrayBuffers: value,
+    },
+    delta: {
+      rss: value - 10,
+      heapTotal: value - 10,
+      heapUsed: value - 10,
+      external: value - 10,
+      arrayBuffers: value - 10,
+    },
+    processPeakRss: value,
+  },
+});
+
+describe('generic reports', () => {
+  test('summarizes arbitrary cases and compares medians', () => {
+    const runs: BenchmarkRun[] = [10, 30, 20].map((value, index) => ({
+      repetition: index + 1,
+      position: 1,
+      caseName: 'base',
+      result: result('base', value),
+    }));
+    runs.push(
+      ...[5, 15, 10].map((value, index) => ({
+        repetition: index + 1,
+        position: 2,
+        caseName: 'candidate',
+        result: result('candidate', value),
+      }))
+    );
+    const base = summarizeCase(runs, 'base')!;
+    const candidate = summarizeCase(runs, 'candidate')!;
+    expect(
+      compareCases('base', 'candidate', base, candidate).buildMs.percentChange
+    ).toBe(-50);
+    expect(
+      validateSchemaGroups(
+        [
+          { name: 'base', workerConfig: null, expectedSchemaGroup: 'schema' },
+          {
+            name: 'candidate',
+            workerConfig: null,
+            expectedSchemaGroup: 'schema',
+          },
+        ],
+        runs
+      )
+    ).toEqual({ equivalent: true, hashes: { schema: 'same' }, errors: [] });
+  });
+});

--- a/packages/perf-harness/__tests__/run.test.ts
+++ b/packages/perf-harness/__tests__/run.test.ts
@@ -1,8 +1,14 @@
 import { resolve } from 'node:path';
 
-import { runBenchmarkSuite } from '../src/run';
+import { cliMain, runBenchmarkSuite } from '../src/run';
 
 describe('generic suite runner', () => {
+  test('requires the database URL as an explicit CLI argument', async () => {
+    await expect(
+      cliMain(['prepare', '--schema', 'cperf_explicit_cli'])
+    ).rejects.toThrow('--database-url is required');
+  });
+
   test('validates fresh processes and schema groups without fixed case names', async () => {
     const report = await runBenchmarkSuite(
       {

--- a/packages/perf-harness/__tests__/run.test.ts
+++ b/packages/perf-harness/__tests__/run.test.ts
@@ -1,0 +1,37 @@
+import { resolve } from 'node:path';
+
+import { runBenchmarkSuite } from '../src/run';
+
+describe('generic suite runner', () => {
+  test('validates fresh processes and schema groups without fixed case names', async () => {
+    const report = await runBenchmarkSuite(
+      {
+        name: 'test-suite',
+        cases: ['alpha', 'beta', 'gamma'].map((name, index) => ({
+          name,
+          workerConfig: { value: index + 1, schemaHash: 'same' },
+          expectedSchemaGroup: 'schema',
+        })),
+      },
+      {
+        databaseUrl: 'postgres:///not-used-by-fake-worker',
+        repetitions: 1,
+        seed: 1,
+        order: ['alpha', 'beta', 'gamma'],
+      },
+      resolve(__dirname, 'fixtures/fake-worker.js')
+    );
+    expect(report.validation).toEqual(
+      expect.objectContaining({
+        allRunsSucceeded: true,
+        freshProcessPerRun: true,
+        caseValidationPassed: true,
+        schemaGroupsEquivalent: true,
+        schemaGroups: { schema: 'same' },
+        errors: [],
+      })
+    );
+    expect(new Set(report.runs.map((run) => run.result.pid)).size).toBe(3);
+    expect(JSON.stringify(report)).not.toContain('postgres:///');
+  });
+});

--- a/packages/perf-harness/__tests__/run.test.ts
+++ b/packages/perf-harness/__tests__/run.test.ts
@@ -1,8 +1,48 @@
+import childProcess from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 
+import * as workerProcess from '../src/process';
 import { cliMain, runBenchmarkSuite } from '../src/run';
+import type { BenchmarkReport } from '../src/types';
 
 describe('generic suite runner', () => {
+  test('redacts errors returned by custom workers before recording them', async () => {
+    const databaseUrl = 'postgres://secret@example.test/database';
+    const run = jest
+      .spyOn(workerProcess, 'runWorkerProcess')
+      .mockResolvedValue({
+        pid: 12345,
+        result: {
+          status: 'error',
+          pid: 12345,
+          caseName: 'broken',
+          error: `could not connect to ${databaseUrl}; retrying ${databaseUrl}`,
+        },
+      });
+    try {
+      const report = await runBenchmarkSuite(
+        {
+          name: 'custom-worker-error',
+          cases: [{ name: 'broken', workerConfig: {} }],
+        },
+        { databaseUrl, repetitions: 1, seed: 1, order: null },
+        'custom-worker.js'
+      );
+      expect(report.runs[0].result).toMatchObject({
+        status: 'error',
+        error:
+          'could not connect to <redacted database URL>; retrying <redacted database URL>',
+      });
+      expect(report.validation.allRunsSucceeded).toBe(false);
+      expect(report.summaries).toEqual({});
+      expect(JSON.stringify(report)).not.toContain(databaseUrl);
+    } finally {
+      run.mockRestore();
+    }
+  });
+
   test('requires the database URL as an explicit CLI argument', async () => {
     await expect(
       cliMain(['prepare', '--schema', 'cperf_explicit_cli'])
@@ -38,6 +78,141 @@ describe('generic suite runner', () => {
       })
     );
     expect(new Set(report.runs.map((run) => run.result.pid)).size).toBe(3);
+    expect(report.config.workerTimeoutMs).toBe(
+      workerProcess.DEFAULT_WORKER_TIMEOUT_MS
+    );
     expect(JSON.stringify(report)).not.toContain('postgres:///');
   });
+});
+
+describe('suite timeout reporting', () => {
+  const worker = resolve(__dirname, 'fixtures/fake-worker.js');
+  const options = {
+    databaseUrl: 'postgres://secret@example.test/database',
+    repetitions: 1,
+    seed: 1,
+    order: ['hung', 'healthy'],
+    workerTimeoutMs: 2_000,
+  };
+  const suite = {
+    name: 'timeout-suite',
+    cases: [
+      { name: 'hung', workerConfig: { mode: 'hang', value: 1 } },
+      { name: 'healthy', workerConfig: { value: 2, schemaHash: 'same' } },
+    ],
+  };
+  let watchdog: ReturnType<typeof setTimeout>;
+  let originalExitCode: typeof process.exitCode;
+
+  beforeEach(() => {
+    originalExitCode = process.exitCode;
+    const spawn = jest.spyOn(childProcess, 'spawn');
+    watchdog = setTimeout(() => {
+      for (const result of spawn.mock.results) {
+        if (result.type === 'return') result.value.kill('SIGKILL');
+      }
+    }, 5_000);
+  });
+
+  afterEach(() => {
+    clearTimeout(watchdog);
+    process.exitCode = originalExitCode;
+    jest.restoreAllMocks();
+  });
+
+  test('continues after a reaped timeout and excludes it from successful samples', async () => {
+    const report = await runBenchmarkSuite(suite, options, worker);
+    expect(report.config.workerTimeoutMs).toBe(2_000);
+    expect(report.runs.map((run) => run.result.status)).toEqual([
+      'error',
+      'ok',
+    ]);
+    expect(report.validation.allRunsSucceeded).toBe(false);
+    expect(report.validation.errors.join('\n')).toContain(
+      'timed out after 2000ms'
+    );
+    expect(report.summaries.hung).toBeUndefined();
+    expect(report.summaries.healthy.sampleCount).toBe(1);
+    expect(JSON.stringify(report)).not.toContain(options.databaseUrl);
+  }, 10_000);
+
+  test('stops scheduling when cleanup cannot be confirmed, retaining a failed partial report', async () => {
+    const run = jest
+      .spyOn(workerProcess, 'runWorkerProcess')
+      .mockRejectedValue(
+        new workerProcess.WorkerCleanupError('cleanup was not confirmed', 12345)
+      );
+    const report = await runBenchmarkSuite(suite, options, worker);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(report.schedule).toHaveLength(2);
+    expect(report.runs).toHaveLength(1);
+    expect(report.runs[0].result).toMatchObject({
+      status: 'error',
+      pid: 12345,
+    });
+    expect(report.validation.allRunsSucceeded).toBe(false);
+    expect(report.validation.errors.join('\n')).toContain(
+      'cleanup was not confirmed'
+    );
+    expect(report.summaries).toEqual({});
+  });
+
+  test('validates suite timeout before spawning', async () => {
+    await expect(
+      runBenchmarkSuite(suite, { ...options, workerTimeoutMs: NaN }, worker)
+    ).rejects.toThrow('workerTimeoutMs');
+    expect(childProcess.spawn).not.toHaveBeenCalled();
+  });
+
+  const cliArgs = (): string[] => [
+    'run',
+    '--database-url',
+    options.databaseUrl,
+    '--cases',
+    Buffer.from(JSON.stringify(suite.cases)).toString('base64url'),
+    '--worker',
+    worker,
+    '--repetitions',
+    '1',
+    '--order',
+    'hung,healthy',
+  ];
+
+  test('writes the timeout report and sets a failing CLI exit code', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'cperf-report-'));
+    const output = resolve(directory, 'report.json');
+    jest.spyOn(process.stdout, 'write').mockReturnValue(true);
+    try {
+      await cliMain([
+        ...cliArgs(),
+        '--worker-timeout-ms',
+        '2000',
+        '--output',
+        output,
+      ]);
+      const report: BenchmarkReport = JSON.parse(
+        await readFile(output, 'utf8')
+      );
+      expect(report.config.workerTimeoutMs).toBe(2_000);
+      expect(report.runs.map((run) => run.result.status)).toEqual([
+        'error',
+        'ok',
+      ]);
+      expect(report.validation.allRunsSucceeded).toBe(false);
+      expect(process.exitCode).toBe(1);
+      expect(JSON.stringify(report)).not.toContain(options.databaseUrl);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  }, 10_000);
+
+  test.each(['0', '-1', '1.5', 'NaN', '2147483648'])(
+    'rejects invalid CLI timeout %s',
+    async (value) => {
+      await expect(
+        cliMain([...cliArgs(), '--worker-timeout-ms', value])
+      ).rejects.toThrow('worker-timeout-ms');
+      expect(childProcess.spawn).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/packages/perf-harness/__tests__/schedule.test.ts
+++ b/packages/perf-harness/__tests__/schedule.test.ts
@@ -1,0 +1,29 @@
+import { makeSchedule } from '../src/schedule';
+
+const cases = [
+  { name: 'a', workerConfig: null },
+  { name: 'b', workerConfig: null },
+  { name: 'c', workerConfig: null },
+];
+
+describe('generic benchmark scheduling', () => {
+  test('is deterministic and supports any case list', () => {
+    const first = makeSchedule(cases, 4, 1234);
+    expect(makeSchedule(cases, 4, 1234)).toEqual(first);
+    expect(makeSchedule(cases, 4, 4321)).not.toEqual(first);
+    for (let repetition = 1; repetition <= 4; repetition += 1) {
+      expect(
+        first
+          .filter((item) => item.repetition === repetition)
+          .map((item) => item.caseName)
+          .sort()
+      ).toEqual(['a', 'b', 'c']);
+    }
+  });
+
+  test('accepts an exact order containing each case once', () => {
+    expect(
+      makeSchedule(cases, 2, 1, ['c', 'a', 'b']).map((item) => item.caseName)
+    ).toEqual(['c', 'a', 'b', 'c', 'a', 'b']);
+  });
+});

--- a/packages/perf-harness/jest.config.js
+++ b/packages/perf-harness/jest.config.js
@@ -1,0 +1,12 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }],
+  },
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  modulePathIgnorePatterns: ['dist/*'],
+  testPathIgnorePatterns: ['/__tests__/fixtures/'],
+};

--- a/packages/perf-harness/package.json
+++ b/packages/perf-harness/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@constructive-io/perf-harness",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Reusable fresh-process Graphile performance harness",
+  "main": "index.js",
+  "module": "esm/index.js",
+  "types": "index.d.ts",
+  "bin": {
+    "cperf": "index.js"
+  },
+  "scripts": {
+    "clean": "makage clean",
+    "build": "makage build",
+    "build:dev": "makage build --dev",
+    "lint": "eslint . --fix",
+    "test": "jest"
+  },
+  "dependencies": {
+    "graphile-build": "5.1.1",
+    "graphile-build-pg": "5.1.3",
+    "graphile-config": "1.1.0",
+    "graphql": "16.13.0",
+    "pg": "^8.21.0",
+    "postgraphile": "5.1.4"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.11",
+    "@types/pg": "^8.20.4",
+    "makage": "^0.3.0"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "license": "MIT"
+}

--- a/packages/perf-harness/package.json
+++ b/packages/perf-harness/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@types/node": "^22.19.11",
     "@types/pg": "^8.20.4",
-    "makage": "^0.3.0"
+    "makage": "^0.8.0"
   },
   "engines": {
     "node": ">=22"

--- a/packages/perf-harness/src/fixture.ts
+++ b/packages/perf-harness/src/fixture.ts
@@ -1,0 +1,127 @@
+import { Pool } from 'pg';
+
+export const FIXTURE_VERSION = 1;
+
+export interface PrepareFixtureOptions {
+  databaseUrl: string;
+  schema: string;
+  tables: number;
+}
+
+export interface PreparedFixture {
+  fixtureVersion: number;
+  database: string;
+  serverVersion: string;
+  schema: string;
+  tableCount: number;
+  functionCount: number;
+}
+
+export const validateFixtureSchema = (schema: string): string => {
+  if (
+    !/^cperf_[a-z0-9_]*$/.test(schema) ||
+    schema.length > 63 ||
+    schema.includes('\0')
+  ) {
+    throw new Error(
+      'fixture schema must start with cperf_, use only lowercase letters, digits, and underscores, and fit PostgreSQL identifiers'
+    );
+  }
+  return schema;
+};
+
+export const validateFixtureTableCount = (tables: number): number => {
+  if (!Number.isSafeInteger(tables) || tables < 1 || tables > 500) {
+    throw new Error('fixture table count must be an integer between 1 and 500');
+  }
+  return tables;
+};
+
+const quoteIdentifier = (identifier: string): string =>
+  `"${identifier.replaceAll('"', '""')}"`;
+
+export const prepareFixture = async (
+  options: PrepareFixtureOptions
+): Promise<PreparedFixture> => {
+  const schema = validateFixtureSchema(options.schema);
+  const tables = validateFixtureTableCount(options.tables);
+  const quotedSchema = quoteIdentifier(schema);
+  const pool = new Pool({ connectionString: options.databaseUrl, max: 1 });
+  const client = await pool.connect();
+  try {
+    await client.query('begin');
+    const existing = await client.query<{ exists: boolean }>(
+      'select exists(select 1 from pg_catalog.pg_namespace where nspname = $1) as exists',
+      [schema]
+    );
+    if (existing.rows[0]?.exists) {
+      throw new Error(
+        `fixture schema '${schema}' already exists; this command never replaces schemas`
+      );
+    }
+    await client.query(`create schema ${quotedSchema}`);
+    await client.query(
+      `comment on schema ${quotedSchema} is 'cperf fixture version ${FIXTURE_VERSION}'`
+    );
+    await client.query(
+      `create type ${quotedSchema}."entity_status" as enum ('draft', 'active', 'archived')`
+    );
+    await client.query(`
+      create table ${quotedSchema}."account" (
+        id bigint generated always as identity primary key,
+        external_id uuid not null unique,
+        name text not null,
+        metadata jsonb not null default '{}'::jsonb,
+        created_at timestamptz not null default now()
+      )
+    `);
+    for (let index = 1; index <= tables; index += 1) {
+      const table = quoteIdentifier(`entity_${index}`);
+      const functionName = quoteIdentifier(`entity_${index}_by_account`);
+      const indexName = quoteIdentifier(`entity_${index}_account_created_idx`);
+      await client.query(`
+        create table ${quotedSchema}.${table} (
+          id bigint generated always as identity primary key,
+          account_id bigint not null references ${quotedSchema}."account"(id),
+          status ${quotedSchema}."entity_status" not null default 'draft',
+          title text not null,
+          tags text[] not null default array[]::text[],
+          metadata jsonb not null default '{}'::jsonb,
+          created_at timestamptz not null default now(),
+          unique (account_id, title)
+        );
+        create index ${indexName}
+          on ${quotedSchema}.${table} (account_id, created_at desc);
+        create function ${quotedSchema}.${functionName}(requested_account_id bigint)
+          returns setof ${quotedSchema}.${table}
+          language sql stable
+          as 'select * from ${quotedSchema}.${table} where account_id = requested_account_id';
+      `);
+    }
+    const identity = await client.query<{
+      database: string;
+      server_version: string;
+    }>(
+      "select current_database() as database, current_setting('server_version') as server_version"
+    );
+    await client.query('commit');
+    return {
+      fixtureVersion: FIXTURE_VERSION,
+      database: identity.rows[0].database,
+      serverVersion: identity.rows[0].server_version,
+      schema,
+      tableCount: tables + 1,
+      functionCount: tables,
+    };
+  } catch (error) {
+    try {
+      await client.query('rollback');
+    } catch {
+      // Preserve the fixture preparation error; the client is discarded below.
+    }
+    throw error;
+  } finally {
+    client.release();
+    await pool.end();
+  }
+};

--- a/packages/perf-harness/src/fixture.ts
+++ b/packages/perf-harness/src/fixture.ts
@@ -1,4 +1,4 @@
-import { Pool } from 'pg';
+import { Pool, type PoolClient } from 'pg';
 
 export const FIXTURE_VERSION = 1;
 
@@ -40,6 +40,15 @@ export const validateFixtureTableCount = (tables: number): number => {
 const quoteIdentifier = (identifier: string): string =>
   `"${identifier.replaceAll('"', '""')}"`;
 
+const throwFixtureErrors = (errors: unknown[]): never => {
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+  throw new AggregateError(errors, 'fixture preparation failed', {
+    cause: errors[0],
+  });
+};
+
 export const prepareFixture = async (
   options: PrepareFixtureOptions
 ): Promise<PreparedFixture> => {
@@ -47,8 +56,12 @@ export const prepareFixture = async (
   const tables = validateFixtureTableCount(options.tables);
   const quotedSchema = quoteIdentifier(schema);
   const pool = new Pool({ connectionString: options.databaseUrl, max: 1 });
-  const client = await pool.connect();
+  const errors: unknown[] = [];
+  let client: PoolClient | undefined;
+  let result: PreparedFixture | undefined;
+
   try {
+    client = await pool.connect();
     await client.query('begin');
     const existing = await client.query<{ exists: boolean }>(
       'select exists(select 1 from pg_catalog.pg_namespace where nspname = $1) as exists',
@@ -105,7 +118,7 @@ export const prepareFixture = async (
       "select current_database() as database, current_setting('server_version') as server_version"
     );
     await client.query('commit');
-    return {
+    result = {
       fixtureVersion: FIXTURE_VERSION,
       database: identity.rows[0].database,
       serverVersion: identity.rows[0].server_version,
@@ -114,14 +127,32 @@ export const prepareFixture = async (
       functionCount: tables,
     };
   } catch (error) {
-    try {
-      await client.query('rollback');
-    } catch {
-      // Preserve the fixture preparation error; the client is discarded below.
+    errors.push(error);
+    if (client) {
+      try {
+        await client.query('rollback');
+      } catch (rollbackError) {
+        errors.push(rollbackError);
+      }
     }
-    throw error;
   } finally {
-    client.release();
-    await pool.end();
+    if (client) {
+      try {
+        await client.release();
+      } catch (releaseError) {
+        errors.push(releaseError);
+      }
+    }
+    try {
+      await pool.end();
+    } catch (endError) {
+      errors.push(endError);
+    }
   }
+
+  if (errors.length > 0) {
+    throwFixtureErrors(errors);
+  }
+
+  return result as PreparedFixture;
 };

--- a/packages/perf-harness/src/index.ts
+++ b/packages/perf-harness/src/index.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+export * from './fixture';
+export * from './metrics';
+export * from './process';
+export * from './report';
+export * from './run';
+export * from './schedule';
+export * from './types';
+
+import { cliMain } from './run';
+
+if (require.main === module) {
+  void cliMain().catch((error: unknown) => {
+    process.stderr.write(
+      `${error instanceof Error ? error.message : String(error)}\n`
+    );
+    process.exitCode = 1;
+  });
+}

--- a/packages/perf-harness/src/metrics.ts
+++ b/packages/perf-harness/src/metrics.ts
@@ -1,0 +1,79 @@
+import { performance } from 'node:perf_hooks';
+
+import type {
+  CaseValidation,
+  JsonValue,
+  MemorySnapshot,
+  SuccessfulWorkerResult,
+} from './types';
+
+export interface MeasuredCaseResult {
+  schemaHash: string;
+  schemaTypeCount: number;
+  runtimeVerified: true;
+  caseValidation?: CaseValidation;
+  metadata?: Record<string, JsonValue>;
+}
+
+const collectGarbage = (): void => {
+  if (typeof global.gc !== 'function') {
+    throw new Error('benchmark worker requires Node --expose-gc');
+  }
+  global.gc();
+  global.gc();
+  global.gc();
+};
+
+const memorySnapshot = (): MemorySnapshot => {
+  const memory = process.memoryUsage();
+  return {
+    rss: memory.rss,
+    heapTotal: memory.heapTotal,
+    heapUsed: memory.heapUsed,
+    external: memory.external,
+    arrayBuffers: memory.arrayBuffers,
+  };
+};
+
+const memoryDelta = (
+  baseline: MemorySnapshot,
+  afterBuild: MemorySnapshot
+): MemorySnapshot => ({
+  rss: afterBuild.rss - baseline.rss,
+  heapTotal: afterBuild.heapTotal - baseline.heapTotal,
+  heapUsed: afterBuild.heapUsed - baseline.heapUsed,
+  external: afterBuild.external - baseline.external,
+  arrayBuffers: afterBuild.arrayBuffers - baseline.arrayBuffers,
+});
+
+export const measureBenchmarkCase = async <Built>(
+  caseName: string,
+  build: () => Promise<Built>,
+  validate: (built: Built) => Promise<MeasuredCaseResult>
+): Promise<SuccessfulWorkerResult> => {
+  collectGarbage();
+  const baseline = memorySnapshot();
+  const startedAt = performance.now();
+  const built = await build();
+  const buildMs = performance.now() - startedAt;
+  const measured = await validate(built);
+  collectGarbage();
+  const afterBuild = memorySnapshot();
+  return {
+    status: 'ok',
+    pid: process.pid,
+    caseName,
+    buildMs,
+    schemaHash: measured.schemaHash,
+    schemaTypeCount: measured.schemaTypeCount,
+    runtimeVerified: measured.runtimeVerified,
+    caseValidation: measured.caseValidation ?? { passed: true, errors: [] },
+    ...(measured.metadata ? { metadata: measured.metadata } : {}),
+    memory: {
+      baseline,
+      afterBuild,
+      delta: memoryDelta(baseline, afterBuild),
+      processPeakRss: process.resourceUsage().maxRSS * 1024,
+    },
+  };
+};

--- a/packages/perf-harness/src/process.ts
+++ b/packages/perf-harness/src/process.ts
@@ -7,8 +7,17 @@ import type {
 } from './types';
 
 export const WORKER_RESULT_PREFIX = 'CPERF_RESULT ';
-export const DATABASE_URL_ENV = 'CPERF_DATABASE_URL';
-export const WORKER_CONFIG_ENV = 'CPERF_WORKER_CONFIG';
+export const DATABASE_URL_ARGUMENT = 'database-url';
+export const WORKER_CONFIG_ARGUMENT = 'worker-config';
+
+export interface ParsedValueArgs {
+  values: Map<string, string>;
+}
+
+export interface WorkerProcessArgs {
+  databaseUrl: string;
+  envelope: WorkerConfigEnvelope;
+}
 
 export interface SpawnedWorkerResult {
   pid: number;
@@ -21,6 +30,43 @@ const lastLines = (value: string, count = 20): string =>
 export const redactSecret = (value: string, secret: string): string =>
   secret ? value.replaceAll(secret, '<redacted database URL>') : value;
 
+export const parseValueArgs = (args: readonly string[]): ParsedValueArgs => {
+  const values = new Map<string, string>();
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (
+      !flag?.startsWith('--') ||
+      value === undefined ||
+      value.startsWith('--')
+    ) {
+      throw new Error(`expected --name value near '${flag ?? '<end>'}'`);
+    }
+    const name = flag.slice(2);
+    if (values.has(name))
+      throw new Error(`--${name} may only be specified once`);
+    values.set(name, value);
+  }
+  return { values };
+};
+
+export const parseWorkerProcessArgs = (
+  args: readonly string[]
+): WorkerProcessArgs => {
+  const parsed = parseValueArgs(args);
+  for (const name of parsed.values.keys()) {
+    if (name !== DATABASE_URL_ARGUMENT && name !== WORKER_CONFIG_ARGUMENT) {
+      throw new Error(`unsupported worker argument '--${name}'`);
+    }
+  }
+  const databaseUrl = parsed.values.get(DATABASE_URL_ARGUMENT);
+  if (!databaseUrl) throw new Error('--database-url is required');
+  return {
+    databaseUrl,
+    envelope: parseWorkerEnvelope(parsed.values.get(WORKER_CONFIG_ARGUMENT)),
+  };
+};
+
 export const runWorkerProcess = (
   workerPath: string,
   databaseUrl: string,
@@ -31,18 +77,25 @@ export const runWorkerProcess = (
       caseName: definition.name,
       workerConfig: definition.workerConfig,
     };
-    const child = spawn(process.execPath, ['--expose-gc', workerPath], {
-      env: {
-        ...process.env,
-        NODE_ENV: 'production',
-        GRAPHILE_ENV: 'production',
-        [DATABASE_URL_ENV]: databaseUrl,
-        [WORKER_CONFIG_ENV]: Buffer.from(JSON.stringify(config)).toString(
-          'base64url'
-        ),
-      },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
+    const child = spawn(
+      process.execPath,
+      [
+        '--expose-gc',
+        workerPath,
+        `--${DATABASE_URL_ARGUMENT}`,
+        databaseUrl,
+        `--${WORKER_CONFIG_ARGUMENT}`,
+        Buffer.from(JSON.stringify(config)).toString('base64url'),
+      ],
+      {
+        env: {
+          ...process.env,
+          NODE_ENV: 'production',
+          GRAPHILE_ENV: 'production',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }
+    );
     const pid = child.pid;
     let stdout = '';
     let stderr = '';
@@ -111,7 +164,7 @@ export const runWorkerProcess = (
 export const parseWorkerEnvelope = (
   encoded: string | undefined
 ): WorkerConfigEnvelope => {
-  if (!encoded) throw new Error(`${WORKER_CONFIG_ENV} is required`);
+  if (!encoded) throw new Error('--worker-config is required');
   const parsed = JSON.parse(
     Buffer.from(encoded, 'base64url').toString('utf8')
   ) as Partial<WorkerConfigEnvelope>;

--- a/packages/perf-harness/src/process.ts
+++ b/packages/perf-harness/src/process.ts
@@ -1,0 +1,130 @@
+import { spawn } from 'node:child_process';
+
+import type {
+  BenchmarkCaseDefinition,
+  WorkerConfigEnvelope,
+  WorkerResult,
+} from './types';
+
+export const WORKER_RESULT_PREFIX = 'CPERF_RESULT ';
+export const DATABASE_URL_ENV = 'CPERF_DATABASE_URL';
+export const WORKER_CONFIG_ENV = 'CPERF_WORKER_CONFIG';
+
+export interface SpawnedWorkerResult {
+  pid: number;
+  result: WorkerResult;
+}
+
+const lastLines = (value: string, count = 20): string =>
+  value.trim().split('\n').slice(-count).join('\n');
+
+export const redactSecret = (value: string, secret: string): string =>
+  secret ? value.replaceAll(secret, '<redacted database URL>') : value;
+
+export const runWorkerProcess = (
+  workerPath: string,
+  databaseUrl: string,
+  definition: BenchmarkCaseDefinition
+): Promise<SpawnedWorkerResult> =>
+  new Promise((resolve, reject) => {
+    const config: WorkerConfigEnvelope = {
+      caseName: definition.name,
+      workerConfig: definition.workerConfig,
+    };
+    const child = spawn(process.execPath, ['--expose-gc', workerPath], {
+      env: {
+        ...process.env,
+        NODE_ENV: 'production',
+        GRAPHILE_ENV: 'production',
+        [DATABASE_URL_ENV]: databaseUrl,
+        [WORKER_CONFIG_ENV]: Buffer.from(JSON.stringify(config)).toString(
+          'base64url'
+        ),
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const pid = child.pid;
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk;
+    });
+    child.once('error', reject);
+    child.once('close', (code, signal) => {
+      const resultLine = stdout
+        .split('\n')
+        .reverse()
+        .find((line) => line.startsWith(WORKER_RESULT_PREFIX));
+      if (!resultLine) {
+        reject(
+          new Error(
+            redactSecret(
+              `benchmark worker ${pid ?? 'unknown'} exited without a result ` +
+                `(code=${String(code)}, signal=${String(signal)})` +
+                (stderr.trim() ? `\n${lastLines(stderr)}` : ''),
+              databaseUrl
+            )
+          )
+        );
+        return;
+      }
+      try {
+        const result = JSON.parse(
+          resultLine.slice(WORKER_RESULT_PREFIX.length)
+        ) as WorkerResult;
+        if (typeof pid !== 'number' || result.pid !== pid) {
+          throw new Error(
+            `worker PID mismatch: spawned ${String(pid)}, reported ${String(
+              result.pid
+            )}`
+          );
+        }
+        if (result.caseName !== definition.name) {
+          throw new Error(
+            `worker case mismatch: expected ${definition.name}, reported ${result.caseName}`
+          );
+        }
+        if (result.status === 'ok' && code !== 0) {
+          throw new Error(`successful worker exited with code ${String(code)}`);
+        }
+        resolve({ pid, result });
+      } catch (error) {
+        reject(
+          new Error(
+            redactSecret(
+              `invalid result from benchmark worker ${String(pid)}: ${String(
+                error instanceof Error ? error.message : error
+              )}`,
+              databaseUrl
+            )
+          )
+        );
+      }
+    });
+  });
+
+export const parseWorkerEnvelope = (
+  encoded: string | undefined
+): WorkerConfigEnvelope => {
+  if (!encoded) throw new Error(`${WORKER_CONFIG_ENV} is required`);
+  const parsed = JSON.parse(
+    Buffer.from(encoded, 'base64url').toString('utf8')
+  ) as Partial<WorkerConfigEnvelope>;
+  if (
+    typeof parsed.caseName !== 'string' ||
+    parsed.caseName.length === 0 ||
+    parsed.workerConfig === undefined
+  ) {
+    throw new Error('worker configuration envelope is invalid');
+  }
+  return parsed as WorkerConfigEnvelope;
+};
+
+export const writeWorkerResult = (result: WorkerResult): void => {
+  process.stdout.write(`${WORKER_RESULT_PREFIX}${JSON.stringify(result)}\n`);
+};

--- a/packages/perf-harness/src/process.ts
+++ b/packages/perf-harness/src/process.ts
@@ -9,6 +9,35 @@ import type {
 export const WORKER_RESULT_PREFIX = 'CPERF_RESULT ';
 export const DATABASE_URL_ARGUMENT = 'database-url';
 export const WORKER_CONFIG_ARGUMENT = 'worker-config';
+export const DEFAULT_WORKER_TIMEOUT_MS = 300_000;
+export const MAX_WORKER_TIMEOUT_MS = 2_147_483_647;
+const WORKER_CLEANUP_TIMEOUT_MS = 5_000;
+
+export const validateWorkerTimeoutMs = (
+  value = DEFAULT_WORKER_TIMEOUT_MS
+): number => {
+  if (
+    !Number.isSafeInteger(value) ||
+    value < 1 ||
+    value > MAX_WORKER_TIMEOUT_MS
+  ) {
+    throw new Error(
+      `workerTimeoutMs must be an integer between 1 and ${MAX_WORKER_TIMEOUT_MS}`
+    );
+  }
+  return value;
+};
+
+/** The suite must stop: another measurement could overlap this worker. */
+export class WorkerCleanupError extends Error {
+  constructor(
+    message: string,
+    readonly pid: number | undefined
+  ) {
+    super(message);
+    this.name = 'WorkerCleanupError';
+  }
+}
 
 export interface ParsedValueArgs {
   values: Map<string, string>;
@@ -70,51 +99,143 @@ export const parseWorkerProcessArgs = (
 export const runWorkerProcess = (
   workerPath: string,
   databaseUrl: string,
-  definition: BenchmarkCaseDefinition
+  definition: BenchmarkCaseDefinition,
+  timeoutMs = DEFAULT_WORKER_TIMEOUT_MS
 ): Promise<SpawnedWorkerResult> =>
   new Promise((resolve, reject) => {
+    validateWorkerTimeoutMs(timeoutMs);
     const config: WorkerConfigEnvelope = {
       caseName: definition.name,
       workerConfig: definition.workerConfig,
     };
-    const child = spawn(
-      process.execPath,
-      [
-        '--expose-gc',
-        workerPath,
-        `--${DATABASE_URL_ARGUMENT}`,
-        databaseUrl,
-        `--${WORKER_CONFIG_ARGUMENT}`,
-        Buffer.from(JSON.stringify(config)).toString('base64url'),
-      ],
-      {
-        env: {
-          ...process.env,
-          NODE_ENV: 'production',
-          GRAPHILE_ENV: 'production',
-        },
-        stdio: ['ignore', 'pipe', 'pipe'],
-      }
-    );
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(
+        process.execPath,
+        [
+          '--expose-gc',
+          workerPath,
+          `--${DATABASE_URL_ARGUMENT}`,
+          databaseUrl,
+          `--${WORKER_CONFIG_ARGUMENT}`,
+          Buffer.from(JSON.stringify(config)).toString('base64url'),
+        ],
+        {
+          env: {
+            ...process.env,
+            NODE_ENV: 'production',
+            GRAPHILE_ENV: 'production',
+          },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        }
+      );
+    } catch (error) {
+      reject(
+        new Error(
+          redactSecret(
+            `benchmark worker could not start: ${String(
+              error instanceof Error ? error.message : error
+            )}`,
+            databaseUrl
+          )
+        )
+      );
+      return;
+    }
     const pid = child.pid;
     let stdout = '';
     let stderr = '';
+    let settled = false;
+    let failure: string | undefined;
+    let deadline: ReturnType<typeof setTimeout> | undefined;
+    let cleanupDeadline: ReturnType<typeof setTimeout> | undefined;
+    const diagnostics: string[] = [];
+    const ignoreLateError = (): undefined => undefined;
+    const onStdout = (chunk: string): void => {
+      stdout += chunk;
+    };
+    const onStderr = (chunk: string): void => {
+      stderr += chunk;
+    };
+    const failureMessage = (reason: string): string =>
+      redactSecret(
+        `benchmark worker ${pid ?? 'unknown'} (${definition.name}) ${reason}` +
+          (diagnostics.length ? `\n${diagnostics.join('\n')}` : '') +
+          (stderr.trim() ? `\n${lastLines(stderr)}` : ''),
+        databaseUrl
+      );
+    const finish = (error?: Error, result?: SpawnedWorkerResult): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(deadline);
+      clearTimeout(cleanupDeadline);
+      child.removeListener('close', onClose);
+      child.removeListener('error', onError);
+      child.on('error', ignoreLateError);
+      child.stdout.removeListener('data', onStdout);
+      child.stderr.removeListener('data', onStderr);
+      for (const stream of [child.stdout, child.stderr]) {
+        stream.removeListener('error', onError);
+        stream.on('error', ignoreLateError);
+      }
+      if (error) reject(error);
+      else resolve(result!);
+    };
+    const terminate = (reason: string): void => {
+      if (settled || failure !== undefined) return;
+      failure = reason;
+      clearTimeout(deadline);
+      cleanupDeadline = setTimeout(() => {
+        finish(
+          new WorkerCleanupError(
+            failureMessage(
+              `${failure}; cleanup was not confirmed within ${WORKER_CLEANUP_TIMEOUT_MS}ms`
+            ),
+            pid
+          )
+        );
+        // The suite stops on this error. Release our handles even if the OS
+        // cannot reap the worker, so the CLI can write its failed report.
+        child.stdout.destroy();
+        child.stderr.destroy();
+        child.unref();
+      }, WORKER_CLEANUP_TIMEOUT_MS);
+      try {
+        if (!child.kill('SIGKILL'))
+          diagnostics.push('SIGKILL could not be sent');
+      } catch (error) {
+        diagnostics.push(
+          redactSecret(
+            `SIGKILL failed: ${String(error instanceof Error ? error.message : error)}`,
+            databaseUrl
+          )
+        );
+      }
+    };
+    const onError = (error: Error): void => {
+      if (settled) return;
+      const detail = redactSecret(error.message, databaseUrl);
+      if (typeof pid !== 'number') {
+        finish(new Error(failureMessage(`could not start: ${detail}`)));
+        return;
+      }
+      diagnostics.push(detail);
+      terminate('failed before its process and stdio closed');
+    };
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
-    child.stdout.on('data', (chunk: string) => {
-      stdout += chunk;
-    });
-    child.stderr.on('data', (chunk: string) => {
-      stderr += chunk;
-    });
-    child.once('error', reject);
-    child.once('close', (code, signal) => {
+    const onClose = (code: number | null, signal: string | null): void => {
+      if (settled) return;
+      if (failure !== undefined) {
+        finish(new Error(failureMessage(failure)));
+        return;
+      }
       const resultLine = stdout
         .split('\n')
         .reverse()
         .find((line) => line.startsWith(WORKER_RESULT_PREFIX));
       if (!resultLine) {
-        reject(
+        finish(
           new Error(
             redactSecret(
               `benchmark worker ${pid ?? 'unknown'} exited without a result ` +
@@ -145,9 +266,9 @@ export const runWorkerProcess = (
         if (result.status === 'ok' && code !== 0) {
           throw new Error(`successful worker exited with code ${String(code)}`);
         }
-        resolve({ pid, result });
+        finish(undefined, { pid, result });
       } catch (error) {
-        reject(
+        finish(
           new Error(
             redactSecret(
               `invalid result from benchmark worker ${String(pid)}: ${String(
@@ -158,7 +279,16 @@ export const runWorkerProcess = (
           )
         );
       }
-    });
+    };
+    child.stdout.on('data', onStdout);
+    child.stderr.on('data', onStderr);
+    child.stdout.on('error', onError);
+    child.stderr.on('error', onError);
+    child.on('error', onError);
+    child.once('close', onClose);
+    deadline = setTimeout(() => {
+      terminate(`timed out after ${timeoutMs}ms`);
+    }, timeoutMs);
   });
 
 export const parseWorkerEnvelope = (

--- a/packages/perf-harness/src/report.ts
+++ b/packages/perf-harness/src/report.ts
@@ -1,0 +1,123 @@
+import type {
+  BenchmarkCaseDefinition,
+  BenchmarkRun,
+  CaseComparison,
+  CaseSummary,
+  MetricComparison,
+  MetricSummary,
+  SuccessfulWorkerResult,
+} from './types';
+
+const median = (values: readonly number[]): number => {
+  if (values.length === 0) throw new Error('cannot summarize zero values');
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[middle];
+};
+
+const metricSummary = (values: number[]): MetricSummary => ({
+  median: median(values),
+  min: Math.min(...values),
+  max: Math.max(...values),
+  samples: values,
+});
+
+const successfulResultsFor = (
+  runs: readonly BenchmarkRun[],
+  caseName: string
+): SuccessfulWorkerResult[] =>
+  runs
+    .filter((run) => run.caseName === caseName && run.result.status === 'ok')
+    .map((run) => run.result as SuccessfulWorkerResult);
+
+export const summarizeCase = (
+  runs: readonly BenchmarkRun[],
+  caseName: string
+): CaseSummary | undefined => {
+  const results = successfulResultsFor(runs, caseName);
+  if (results.length === 0) return undefined;
+  return {
+    sampleCount: results.length,
+    buildMs: metricSummary(results.map((result) => result.buildMs)),
+    heapUsedAfterBuild: metricSummary(
+      results.map((result) => result.memory.afterBuild.heapUsed)
+    ),
+    heapUsedDelta: metricSummary(
+      results.map((result) => result.memory.delta.heapUsed)
+    ),
+    rssAfterBuild: metricSummary(
+      results.map((result) => result.memory.afterBuild.rss)
+    ),
+    rssDelta: metricSummary(results.map((result) => result.memory.delta.rss)),
+    processPeakRss: metricSummary(
+      results.map((result) => result.memory.processPeakRss)
+    ),
+  };
+};
+
+const compareMetric = (
+  baseline: MetricSummary,
+  candidate: MetricSummary
+): MetricComparison => ({
+  baseline: baseline.median,
+  candidate: candidate.median,
+  difference: candidate.median - baseline.median,
+  percentChange:
+    baseline.median === 0
+      ? null
+      : ((candidate.median - baseline.median) / Math.abs(baseline.median)) *
+        100,
+});
+
+export const compareCases = (
+  baselineCase: string,
+  candidateCase: string,
+  baseline: CaseSummary,
+  candidate: CaseSummary
+): CaseComparison => ({
+  baselineCase,
+  candidateCase,
+  buildMs: compareMetric(baseline.buildMs, candidate.buildMs),
+  heapUsedAfterBuild: compareMetric(
+    baseline.heapUsedAfterBuild,
+    candidate.heapUsedAfterBuild
+  ),
+  heapUsedDelta: compareMetric(baseline.heapUsedDelta, candidate.heapUsedDelta),
+  rssAfterBuild: compareMetric(baseline.rssAfterBuild, candidate.rssAfterBuild),
+  rssDelta: compareMetric(baseline.rssDelta, candidate.rssDelta),
+  processPeakRss: compareMetric(
+    baseline.processPeakRss,
+    candidate.processPeakRss
+  ),
+});
+
+export const validateSchemaGroups = (
+  definitions: readonly BenchmarkCaseDefinition[],
+  runs: readonly BenchmarkRun[]
+): {
+  equivalent: boolean;
+  hashes: Record<string, string | null>;
+  errors: string[];
+} => {
+  const groups = new Map<string, Set<string>>();
+  for (const definition of definitions) {
+    if (!definition.expectedSchemaGroup) continue;
+    const hashes =
+      groups.get(definition.expectedSchemaGroup) ?? new Set<string>();
+    for (const result of successfulResultsFor(runs, definition.name)) {
+      hashes.add(result.schemaHash);
+    }
+    groups.set(definition.expectedSchemaGroup, hashes);
+  }
+  const output: Record<string, string | null> = {};
+  const errors: string[] = [];
+  for (const [group, hashes] of groups) {
+    output[group] = hashes.size === 1 ? [...hashes][0] : null;
+    if (hashes.size !== 1) {
+      errors.push(`schema group '${group}' did not produce one schema hash`);
+    }
+  }
+  return { equivalent: errors.length === 0, hashes: output, errors };
+};

--- a/packages/perf-harness/src/run.ts
+++ b/packages/perf-harness/src/run.ts
@@ -1,0 +1,274 @@
+import { mkdir, rename, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+import { prepareFixture } from './fixture';
+import { DATABASE_URL_ENV, redactSecret, runWorkerProcess } from './process';
+import { summarizeCase, validateSchemaGroups } from './report';
+import { makeSchedule, validateCaseDefinitions } from './schedule';
+import type {
+  BenchmarkCaseDefinition,
+  BenchmarkReport,
+  BenchmarkRun,
+  BenchmarkSuiteDefinition,
+} from './types';
+
+export interface RunSuiteOptions {
+  databaseUrl: string;
+  repetitions: number;
+  seed: number;
+  order: string[] | null;
+  output?: string;
+}
+
+export const runBenchmarkSuite = async (
+  suite: BenchmarkSuiteDefinition,
+  options: RunSuiteOptions,
+  workerPath: string
+): Promise<BenchmarkReport> => {
+  validateCaseDefinitions(suite.cases);
+  const byName = new Map(
+    suite.cases.map((definition) => [definition.name, definition])
+  );
+  const schedule = makeSchedule(
+    suite.cases,
+    options.repetitions,
+    options.seed,
+    options.order
+  );
+  const runs: BenchmarkRun[] = [];
+  for (const coordinate of schedule) {
+    const definition = byName.get(coordinate.caseName)!;
+    process.stderr.write(
+      `[${runs.length + 1}/${schedule.length}] repetition ${
+        coordinate.repetition
+      }, ${coordinate.caseName}\n`
+    );
+    try {
+      const spawned = await runWorkerProcess(
+        workerPath,
+        options.databaseUrl,
+        definition
+      );
+      runs.push({ ...coordinate, result: spawned.result });
+    } catch (error) {
+      runs.push({
+        ...coordinate,
+        result: {
+          status: 'error',
+          pid: -1,
+          caseName: coordinate.caseName,
+          error: redactSecret(
+            error instanceof Error ? error.message : String(error),
+            options.databaseUrl
+          ),
+        },
+      });
+    }
+  }
+  const successfulRuns = runs.filter((run) => run.result.status === 'ok');
+  const allRunsSucceeded = successfulRuns.length === schedule.length;
+  const pids = successfulRuns.map((run) => run.result.pid);
+  const freshProcessPerRun =
+    allRunsSucceeded &&
+    pids.every((pid) => pid > 0 && pid !== process.pid) &&
+    new Set(pids).size === pids.length;
+  const caseValidationPassed =
+    allRunsSucceeded &&
+    successfulRuns.every(
+      (run) => run.result.status === 'ok' && run.result.caseValidation.passed
+    );
+  const schemaGroups = validateSchemaGroups(suite.cases, runs);
+  const errors: string[] = [];
+  for (const run of runs) {
+    if (run.result.status === 'error') {
+      errors.push(
+        `${run.caseName} repetition ${run.repetition}: ${run.result.error}`
+      );
+    } else {
+      for (const error of run.result.caseValidation.errors) {
+        errors.push(`${run.caseName} repetition ${run.repetition}: ${error}`);
+      }
+    }
+  }
+  if (!freshProcessPerRun) {
+    errors.push('fresh-process validation did not pass for every run');
+  }
+  errors.push(...schemaGroups.errors);
+  const summaries: Record<
+    string,
+    NonNullable<ReturnType<typeof summarizeCase>>
+  > = {};
+  for (const definition of suite.cases) {
+    const summary = summarizeCase(runs, definition.name);
+    if (summary) summaries[definition.name] = summary;
+  }
+  return {
+    format: 'constructive-performance-suite/v1',
+    generatedAt: new Date().toISOString(),
+    node: process.version,
+    platform: process.platform,
+    architecture: process.arch,
+    suite,
+    config: {
+      repetitions: options.repetitions,
+      seed: options.seed,
+      order: options.order,
+    },
+    schedule,
+    runs,
+    validation: {
+      allRunsSucceeded,
+      freshProcessPerRun,
+      caseValidationPassed,
+      schemaGroupsEquivalent: schemaGroups.equivalent,
+      schemaGroups: schemaGroups.hashes,
+      errors,
+    },
+    summaries,
+  };
+};
+
+export const writeJsonAtomically = async (
+  output: string,
+  value: unknown
+): Promise<string> => {
+  const absoluteOutput = resolve(output);
+  await mkdir(dirname(absoluteOutput), { recursive: true });
+  const temporary = `${absoluteOutput}.tmp-${process.pid}`;
+  await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, {
+    encoding: 'utf8',
+    mode: 0o600,
+  });
+  await rename(temporary, absoluteOutput);
+  return absoluteOutput;
+};
+
+interface ParsedArgs {
+  values: Map<string, string>;
+}
+
+const parseArgs = (args: readonly string[]): ParsedArgs => {
+  const values = new Map<string, string>();
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (
+      !flag?.startsWith('--') ||
+      value === undefined ||
+      value.startsWith('--')
+    ) {
+      throw new Error(`expected --name value near '${flag ?? '<end>'}'`);
+    }
+    const name = flag.slice(2);
+    if (values.has(name))
+      throw new Error(`--${name} may only be specified once`);
+    values.set(name, value);
+  }
+  return { values };
+};
+
+const positiveInteger = (
+  value: string | undefined,
+  name: string,
+  defaultValue: number,
+  maximum: number
+): number => {
+  if (value === undefined) return defaultValue;
+  if (!/^\d+$/.test(value)) throw new Error(`--${name} must be an integer`);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > maximum) {
+    throw new Error(`--${name} must be between 1 and ${maximum}`);
+  }
+  return parsed;
+};
+
+const databaseUrl = (args: ParsedArgs): string => {
+  const value =
+    args.values.get('database-url') ?? process.env[DATABASE_URL_ENV];
+  if (!value) {
+    throw new Error(
+      `--database-url or the ${DATABASE_URL_ENV} environment variable is required`
+    );
+  }
+  return value;
+};
+
+const stringList = (value: string | undefined): string[] | null => {
+  if (value === undefined) return null;
+  const result = value.split(',');
+  if (
+    result.some((item) => item.length === 0 || item.trim() !== item) ||
+    new Set(result).size !== result.length
+  ) {
+    throw new Error('list values must be unique exact non-empty strings');
+  }
+  return result;
+};
+
+const parseCases = (encoded: string): BenchmarkCaseDefinition[] => {
+  const parsed = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8'));
+  if (!Array.isArray(parsed))
+    throw new Error('--cases must encode a JSON array');
+  return parsed as BenchmarkCaseDefinition[];
+};
+
+export const cliMain = async (args = process.argv.slice(2)): Promise<void> => {
+  const [command, ...rest] = args;
+  const parsed = parseArgs(rest);
+  if (command === 'prepare') {
+    const schema = parsed.values.get('schema');
+    if (!schema) throw new Error('--schema is required');
+    const result = await prepareFixture({
+      databaseUrl: databaseUrl(parsed),
+      schema,
+      tables: positiveInteger(parsed.values.get('tables'), 'tables', 64, 500),
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return;
+  }
+  if (command !== 'run') {
+    throw new Error('expected prepare or run command');
+  }
+  const cases = parsed.values.get('cases');
+  const worker = parsed.values.get('worker');
+  if (!cases || !worker) throw new Error('--cases and --worker are required');
+  const report = await runBenchmarkSuite(
+    {
+      name: parsed.values.get('suite') ?? 'benchmark-suite',
+      cases: parseCases(cases),
+    },
+    {
+      databaseUrl: databaseUrl(parsed),
+      repetitions: positiveInteger(
+        parsed.values.get('repetitions'),
+        'repetitions',
+        3,
+        50
+      ),
+      seed: positiveInteger(
+        parsed.values.get('seed'),
+        'seed',
+        20260813,
+        0xffffffff
+      ),
+      order: stringList(parsed.values.get('order')),
+      output: parsed.values.get('output'),
+    },
+    resolve(worker)
+  );
+  const output = await writeJsonAtomically(
+    parsed.values.get('output') ?? 'performance-report.json',
+    report
+  );
+  process.stdout.write(
+    `${JSON.stringify({ output, validation: report.validation })}\n`
+  );
+  if (
+    !report.validation.allRunsSucceeded ||
+    !report.validation.freshProcessPerRun ||
+    !report.validation.caseValidationPassed ||
+    !report.validation.schemaGroupsEquivalent
+  ) {
+    process.exitCode = 1;
+  }
+};

--- a/packages/perf-harness/src/run.ts
+++ b/packages/perf-harness/src/run.ts
@@ -2,7 +2,7 @@ import { mkdir, rename, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
 import { prepareFixture } from './fixture';
-import { DATABASE_URL_ENV, redactSecret, runWorkerProcess } from './process';
+import { parseValueArgs, redactSecret, runWorkerProcess } from './process';
 import { summarizeCase, validateSchemaGroups } from './report';
 import { makeSchedule, validateCaseDefinitions } from './schedule';
 import type {
@@ -143,30 +143,6 @@ export const writeJsonAtomically = async (
   return absoluteOutput;
 };
 
-interface ParsedArgs {
-  values: Map<string, string>;
-}
-
-const parseArgs = (args: readonly string[]): ParsedArgs => {
-  const values = new Map<string, string>();
-  for (let index = 0; index < args.length; index += 2) {
-    const flag = args[index];
-    const value = args[index + 1];
-    if (
-      !flag?.startsWith('--') ||
-      value === undefined ||
-      value.startsWith('--')
-    ) {
-      throw new Error(`expected --name value near '${flag ?? '<end>'}'`);
-    }
-    const name = flag.slice(2);
-    if (values.has(name))
-      throw new Error(`--${name} may only be specified once`);
-    values.set(name, value);
-  }
-  return { values };
-};
-
 const positiveInteger = (
   value: string | undefined,
   name: string,
@@ -182,14 +158,9 @@ const positiveInteger = (
   return parsed;
 };
 
-const databaseUrl = (args: ParsedArgs): string => {
-  const value =
-    args.values.get('database-url') ?? process.env[DATABASE_URL_ENV];
-  if (!value) {
-    throw new Error(
-      `--database-url or the ${DATABASE_URL_ENV} environment variable is required`
-    );
-  }
+const databaseUrl = (args: ReturnType<typeof parseValueArgs>): string => {
+  const value = args.values.get('database-url');
+  if (!value) throw new Error('--database-url is required');
   return value;
 };
 
@@ -214,7 +185,7 @@ const parseCases = (encoded: string): BenchmarkCaseDefinition[] => {
 
 export const cliMain = async (args = process.argv.slice(2)): Promise<void> => {
   const [command, ...rest] = args;
-  const parsed = parseArgs(rest);
+  const parsed = parseValueArgs(rest);
   if (command === 'prepare') {
     const schema = parsed.values.get('schema');
     if (!schema) throw new Error('--schema is required');

--- a/packages/perf-harness/src/run.ts
+++ b/packages/perf-harness/src/run.ts
@@ -2,7 +2,15 @@ import { mkdir, rename, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
 import { prepareFixture } from './fixture';
-import { parseValueArgs, redactSecret, runWorkerProcess } from './process';
+import {
+  DEFAULT_WORKER_TIMEOUT_MS,
+  MAX_WORKER_TIMEOUT_MS,
+  parseValueArgs,
+  redactSecret,
+  runWorkerProcess,
+  validateWorkerTimeoutMs,
+  WorkerCleanupError,
+} from './process';
 import { summarizeCase, validateSchemaGroups } from './report';
 import { makeSchedule, validateCaseDefinitions } from './schedule';
 import type {
@@ -18,6 +26,7 @@ export interface RunSuiteOptions {
   seed: number;
   order: string[] | null;
   output?: string;
+  workerTimeoutMs?: number;
 }
 
 export const runBenchmarkSuite = async (
@@ -25,6 +34,7 @@ export const runBenchmarkSuite = async (
   options: RunSuiteOptions,
   workerPath: string
 ): Promise<BenchmarkReport> => {
+  const workerTimeoutMs = validateWorkerTimeoutMs(options.workerTimeoutMs);
   validateCaseDefinitions(suite.cases);
   const byName = new Map(
     suite.cases.map((definition) => [definition.name, definition])
@@ -47,15 +57,23 @@ export const runBenchmarkSuite = async (
       const spawned = await runWorkerProcess(
         workerPath,
         options.databaseUrl,
-        definition
+        definition,
+        workerTimeoutMs
       );
-      runs.push({ ...coordinate, result: spawned.result });
+      let result = spawned.result;
+      if (result.status === 'error') {
+        result = {
+          ...result,
+          error: redactSecret(result.error, options.databaseUrl),
+        };
+      }
+      runs.push({ ...coordinate, result });
     } catch (error) {
       runs.push({
         ...coordinate,
         result: {
           status: 'error',
-          pid: -1,
+          pid: error instanceof WorkerCleanupError ? (error.pid ?? -1) : -1,
           caseName: coordinate.caseName,
           error: redactSecret(
             error instanceof Error ? error.message : String(error),
@@ -63,6 +81,7 @@ export const runBenchmarkSuite = async (
           ),
         },
       });
+      if (error instanceof WorkerCleanupError) break;
     }
   }
   const successfulRuns = runs.filter((run) => run.result.status === 'ok');
@@ -113,6 +132,7 @@ export const runBenchmarkSuite = async (
       repetitions: options.repetitions,
       seed: options.seed,
       order: options.order,
+      workerTimeoutMs,
     },
     schedule,
     runs,
@@ -224,6 +244,12 @@ export const cliMain = async (args = process.argv.slice(2)): Promise<void> => {
       ),
       order: stringList(parsed.values.get('order')),
       output: parsed.values.get('output'),
+      workerTimeoutMs: positiveInteger(
+        parsed.values.get('worker-timeout-ms'),
+        'worker-timeout-ms',
+        DEFAULT_WORKER_TIMEOUT_MS,
+        MAX_WORKER_TIMEOUT_MS
+      ),
     },
     resolve(worker)
   );

--- a/packages/perf-harness/src/schedule.ts
+++ b/packages/perf-harness/src/schedule.ts
@@ -1,0 +1,77 @@
+import type { BenchmarkCaseDefinition, BenchmarkCoordinate } from './types';
+
+const seededRandom = (seed: number): (() => number) => {
+  let state = seed >>> 0;
+  return () => {
+    state += 0x6d2b79f5;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+const shuffledCaseNames = (
+  definitions: readonly BenchmarkCaseDefinition[],
+  seed: number,
+  repetition: number
+): string[] => {
+  const result = definitions.map(({ name }) => name);
+  const random = seededRandom((seed ^ Math.imul(repetition, 0x9e3779b1)) >>> 0);
+  for (let index = result.length - 1; index > 0; index -= 1) {
+    const swapIndex = Math.floor(random() * (index + 1));
+    [result[index], result[swapIndex]] = [result[swapIndex], result[index]];
+  }
+  return result;
+};
+
+export const validateCaseDefinitions = (
+  definitions: readonly BenchmarkCaseDefinition[]
+): void => {
+  if (definitions.length === 0) {
+    throw new Error('benchmark suite must contain at least one case');
+  }
+  const names = definitions.map(({ name }) => name);
+  if (
+    names.some(
+      (name) => name.length === 0 || name.trim() !== name || name.includes('\0')
+    ) ||
+    new Set(names).size !== names.length
+  ) {
+    throw new Error(
+      'benchmark case names must be unique exact non-empty strings'
+    );
+  }
+};
+
+export const makeSchedule = (
+  definitions: readonly BenchmarkCaseDefinition[],
+  repetitions: number,
+  seed: number,
+  exactOrder: readonly string[] | null = null
+): BenchmarkCoordinate[] => {
+  validateCaseDefinitions(definitions);
+  if (!Number.isSafeInteger(repetitions) || repetitions < 1) {
+    throw new Error('repetitions must be a positive safe integer');
+  }
+  const expectedNames = definitions.map(({ name }) => name).sort();
+  const schedule: BenchmarkCoordinate[] = [];
+  for (let repetition = 1; repetition <= repetitions; repetition += 1) {
+    const order = exactOrder
+      ? [...exactOrder]
+      : shuffledCaseNames(definitions, seed, repetition);
+    if (
+      order.length !== definitions.length ||
+      new Set(order).size !== definitions.length ||
+      [...order].sort().some((name, index) => name !== expectedNames[index])
+    ) {
+      throw new Error(
+        'exact order must contain each benchmark case exactly once'
+      );
+    }
+    order.forEach((caseName, index) => {
+      schedule.push({ repetition, position: index + 1, caseName });
+    });
+  }
+  return schedule;
+};

--- a/packages/perf-harness/src/stock-worker.ts
+++ b/packages/perf-harness/src/stock-worker.ts
@@ -1,0 +1,94 @@
+import { createHash } from 'node:crypto';
+
+import {
+  defaultPreset as graphileBuildPreset,
+  makeSchema,
+} from 'graphile-build';
+import { defaultPreset as graphileBuildPgPreset } from 'graphile-build-pg';
+import { execute, lexicographicSortSchema, parse, printSchema } from 'graphql';
+import { makePgService } from 'postgraphile/adaptors/pg';
+
+import { measureBenchmarkCase } from './metrics';
+import {
+  DATABASE_URL_ENV,
+  parseWorkerEnvelope,
+  redactSecret,
+  WORKER_CONFIG_ENV,
+  writeWorkerResult,
+} from './process';
+
+interface StockConfig {
+  schemas: string[];
+}
+
+const validateConfig = (value: unknown): StockConfig => {
+  const schemas = (value as Partial<StockConfig>)?.schemas;
+  if (
+    !Array.isArray(schemas) ||
+    schemas.length === 0 ||
+    schemas.some((schema) => typeof schema !== 'string' || schema.length === 0)
+  ) {
+    throw new Error('stock worker requires a non-empty schemas array');
+  }
+  return { schemas };
+};
+
+const main = async (): Promise<void> => {
+  const databaseUrl = process.env[DATABASE_URL_ENV] ?? '';
+  let caseName = 'unknown';
+  try {
+    if (!databaseUrl) throw new Error(`${DATABASE_URL_ENV} is required`);
+    const envelope = parseWorkerEnvelope(process.env[WORKER_CONFIG_ENV]);
+    caseName = envelope.caseName;
+    const config = validateConfig(envelope.workerConfig);
+    const service = makePgService({
+      connectionString: databaseUrl,
+      schemas: config.schemas,
+      pubsub: false,
+    });
+    try {
+      const result = await measureBenchmarkCase(
+        caseName,
+        async () =>
+          makeSchema({
+            extends: [graphileBuildPreset, graphileBuildPgPreset],
+            pgServices: [service],
+          }),
+        async ({ schema }) => {
+          const execution = await execute({
+            schema,
+            document: parse('{ __typename }'),
+          });
+          if (
+            execution.errors?.length ||
+            execution.data?.__typename !== 'Query'
+          ) {
+            throw new Error('runtime verification query failed');
+          }
+          const schemaText = printSchema(lexicographicSortSchema(schema));
+          return {
+            schemaHash: createHash('sha256').update(schemaText).digest('hex'),
+            schemaTypeCount: Object.keys(schema.getTypeMap()).length,
+            runtimeVerified: true as const,
+          };
+        }
+      );
+      writeWorkerResult(result);
+    } finally {
+      await service.release();
+    }
+  } catch (error) {
+    writeWorkerResult({
+      status: 'error',
+      pid: process.pid,
+      caseName,
+      error: redactSecret(
+        error instanceof Error ? error.message : String(error),
+        databaseUrl
+      ),
+    });
+    process.exitCode = 1;
+  }
+};
+
+if (require.main === module) void main();

--- a/packages/perf-harness/src/stock-worker.ts
+++ b/packages/perf-harness/src/stock-worker.ts
@@ -10,10 +10,8 @@ import { makePgService } from 'postgraphile/adaptors/pg';
 
 import { measureBenchmarkCase } from './metrics';
 import {
-  DATABASE_URL_ENV,
-  parseWorkerEnvelope,
+  parseWorkerProcessArgs,
   redactSecret,
-  WORKER_CONFIG_ENV,
   writeWorkerResult,
 } from './process';
 
@@ -34,11 +32,12 @@ const validateConfig = (value: unknown): StockConfig => {
 };
 
 const main = async (): Promise<void> => {
-  const databaseUrl = process.env[DATABASE_URL_ENV] ?? '';
+  let databaseUrl = '';
   let caseName = 'unknown';
   try {
-    if (!databaseUrl) throw new Error(`${DATABASE_URL_ENV} is required`);
-    const envelope = parseWorkerEnvelope(process.env[WORKER_CONFIG_ENV]);
+    const workerArgs = parseWorkerProcessArgs(process.argv.slice(2));
+    databaseUrl = workerArgs.databaseUrl;
+    const { envelope } = workerArgs;
     caseName = envelope.caseName;
     const config = validateConfig(envelope.workerConfig);
     const service = makePgService({

--- a/packages/perf-harness/src/types.ts
+++ b/packages/perf-harness/src/types.ts
@@ -1,0 +1,129 @@
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue =
+  JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+export interface BenchmarkCaseDefinition {
+  name: string;
+  workerConfig: JsonValue;
+  expectedSchemaGroup?: string;
+}
+
+export interface BenchmarkSuiteDefinition {
+  name: string;
+  cases: BenchmarkCaseDefinition[];
+}
+
+export interface BenchmarkCoordinate {
+  repetition: number;
+  position: number;
+  caseName: string;
+}
+
+export interface WorkerConfigEnvelope {
+  caseName: string;
+  workerConfig: JsonValue;
+}
+
+export interface MemorySnapshot {
+  rss: number;
+  heapTotal: number;
+  heapUsed: number;
+  external: number;
+  arrayBuffers: number;
+}
+
+export interface CaseValidation {
+  passed: boolean;
+  errors: string[];
+}
+
+export interface SuccessfulWorkerResult {
+  status: 'ok';
+  pid: number;
+  caseName: string;
+  buildMs: number;
+  schemaHash: string;
+  schemaTypeCount: number;
+  runtimeVerified: true;
+  caseValidation: CaseValidation;
+  metadata?: Record<string, JsonValue>;
+  memory: {
+    baseline: MemorySnapshot;
+    afterBuild: MemorySnapshot;
+    delta: MemorySnapshot;
+    processPeakRss: number;
+  };
+}
+
+export interface FailedWorkerResult {
+  status: 'error';
+  pid: number;
+  caseName: string;
+  error: string;
+}
+
+export type WorkerResult = SuccessfulWorkerResult | FailedWorkerResult;
+
+export interface BenchmarkRun extends BenchmarkCoordinate {
+  result: WorkerResult;
+}
+
+export interface MetricSummary {
+  median: number;
+  min: number;
+  max: number;
+  samples: number[];
+}
+
+export interface CaseSummary {
+  sampleCount: number;
+  buildMs: MetricSummary;
+  heapUsedAfterBuild: MetricSummary;
+  heapUsedDelta: MetricSummary;
+  rssAfterBuild: MetricSummary;
+  rssDelta: MetricSummary;
+  processPeakRss: MetricSummary;
+}
+
+export interface MetricComparison {
+  baseline: number;
+  candidate: number;
+  difference: number;
+  percentChange: number | null;
+}
+
+export interface CaseComparison {
+  baselineCase: string;
+  candidateCase: string;
+  buildMs: MetricComparison;
+  heapUsedAfterBuild: MetricComparison;
+  heapUsedDelta: MetricComparison;
+  rssAfterBuild: MetricComparison;
+  rssDelta: MetricComparison;
+  processPeakRss: MetricComparison;
+}
+
+export interface BenchmarkReport {
+  format: 'constructive-performance-suite/v1';
+  generatedAt: string;
+  node: string;
+  platform: string;
+  architecture: string;
+  suite: BenchmarkSuiteDefinition;
+  config: {
+    repetitions: number;
+    seed: number;
+    order: string[] | null;
+  };
+  schedule: BenchmarkCoordinate[];
+  runs: BenchmarkRun[];
+  validation: {
+    allRunsSucceeded: boolean;
+    freshProcessPerRun: boolean;
+    caseValidationPassed: boolean;
+    schemaGroupsEquivalent: boolean;
+    schemaGroups: Record<string, string | null>;
+    errors: string[];
+  };
+  summaries: Record<string, CaseSummary>;
+}

--- a/packages/perf-harness/src/types.ts
+++ b/packages/perf-harness/src/types.ts
@@ -114,6 +114,7 @@ export interface BenchmarkReport {
     repetitions: number;
     seed: number;
     order: string[] | null;
+    workerTimeoutMs: number;
   };
   schedule: BenchmarkCoordinate[];
   runs: BenchmarkRun[];

--- a/packages/perf-harness/tsconfig.esm.json
+++ b/packages/perf-harness/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/esm",
+    "module": "esnext",
+    "moduleResolution": "bundler"
+  }
+}

--- a/packages/perf-harness/tsconfig.json
+++ b/packages/perf-harness/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "moduleResolution": "nodenext",
+    "module": "nodenext",
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2711,6 +2711,37 @@ importers:
         version: 0.8.0
     publishDirectory: dist
 
+  packages/perf-harness:
+    dependencies:
+      graphile-build:
+        specifier: 5.1.1
+        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+      graphile-build-pg:
+        specifier: 5.1.3
+        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-config:
+        specifier: 1.1.0
+        version: 1.1.0
+      graphql:
+        specifier: 16.13.0
+        version: 16.13.0
+      pg:
+        specifier: ^8.21.0
+        version: 8.21.0
+      postgraphile:
+        specifier: 5.1.4
+        version: 5.1.4(f282a162d8bd20a217e08c60f5396af8)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.11
+        version: 22.19.19
+      '@types/pg':
+        specifier: ^8.20.4
+        version: 8.20.4
+      makage:
+        specifier: ^0.3.0
+        version: 0.3.0
+
   packages/postmaster:
     dependencies:
       12factor-env:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2739,8 +2739,8 @@ importers:
         specifier: ^8.20.4
         version: 8.20.4
       makage:
-        specifier: ^0.3.0
-        version: 0.3.0
+        specifier: ^0.8.0
+        version: 0.8.0
 
   packages/postmaster:
     dependencies:


### PR DESCRIPTION
## Responsibility

Adds reusable fresh-process Graphile benchmarking infrastructure. The runner accepts arbitrary serializable case definitions and delegates case-specific build and lifecycle validation to a dedicated worker entry.

Included here:

- fresh Node process and unique PID per measurement
- configurable worker deadlines (five minutes by default), confirmed process closure before continuing, and bounded cleanup that stops the suite if closure cannot be confirmed
- `--expose-gc` with deterministic GC calls
- build-only wall-clock timing
- memory snapshots, deltas, and peak RSS
- seeded scheduling and repetitions
- schema groups and schema-hash validation
- runtime query and case-specific validation contracts
- PostgreSQL fixture preparation with pool cleanup on connection, SQL, and client-release failures; primary and cleanup errors are preserved together
- atomic JSON reports and database URL redaction, including errors returned by custom workers
- explicit `--database-url` and `--worker-config` worker arguments
- a minimal upstream Graphile baseline worker

## Stack

This is the first PR in the new performance stack and targets `main`. Later stacked PRs can add their own benchmark suites without changing the core runner.

## Not included

No product-specific benchmark suite, application preset, application plugin integration, dependency patch, or optimization conclusion is included.

## Validation

- Full CI on commit `3477f9371996`: [17/17 jobs passed](https://github.com/constructive-io/constructive/actions/runs/34099014087) (Linux, Windows, PostgreSQL, MinIO integration, and Ollama).
- unit tests: 46 passed across 5 suites, including real child-process timeouts, deadline/close races, failed partial reports, database URL redaction, and fixture cleanup failures
- CJS and ESM build: passed
- ESLint: passed
- Prettier and `git diff --check`: passed
- frozen-lockfile install: passed
