### PR TITLE
feat(coerce): add @constructive-io/coerce and re-base 12factor-env's lenient parsers on it

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -107,7 +107,7 @@ jobs:
           - batch: uploads
             packages: 'uploads/mime-bytes uploads/uuid-hash uploads/uuid-stream uploads/etag-hash uploads/etag-stream uploads/stream-to-etag uploads/content-type-stream uploads/upload-names uploads/s3-utils'
           - batch: packages-core
-            packages: 'packages/url-domains postgres/query-builder packages/csrf packages/oauth packages/12factor-env packages/orm packages/express-context packages/errors packages/llm-env packages/node-type-registry packages/query-spec packages/server-utils postgres/pg-cache postgres/pg-env'
+            packages: 'packages/url-domains packages/coerce postgres/query-builder packages/csrf packages/oauth packages/12factor-env packages/orm packages/express-context packages/errors packages/llm-env packages/node-type-registry packages/query-spec packages/server-utils postgres/pg-cache postgres/pg-env'
           - batch: packages-services
             packages: 'packages/postmaster packages/smtppostmaster packages/csv-to-pg packages/cli postgres/pgsql-client postgres/pg-ast'
           - batch: graphql

--- a/packages/12factor-env/__tests__/env.test.ts
+++ b/packages/12factor-env/__tests__/env.test.ts
@@ -246,6 +246,13 @@ describe('env', () => {
       expect(parseEnvBoolean('')).toBeUndefined();
     });
 
+    it('parseEnvBoolean inherits the shared spellings, unknown ones staying false', () => {
+      expect(parseEnvBoolean('on')).toBe(true);
+      expect(parseEnvBoolean('y')).toBe(true);
+      expect(parseEnvBoolean('off')).toBe(false);
+      expect(parseEnvBoolean('maybe')).toBe(false);
+    });
+
     it('parseEnvNumber parses finite numbers only', () => {
       expect(parseEnvNumber('42')).toBe(42);
       expect(parseEnvNumber('3.14')).toBe(3.14);

--- a/packages/12factor-env/src/index.ts
+++ b/packages/12factor-env/src/index.ts
@@ -1,3 +1,4 @@
+import { asBoolean, asNumber, asString, asStringList } from '@constructive-io/coerce';
 import type { CleanedEnv, CleanOptions, Spec,ValidatorSpec } from 'envalid';
 import {
   applyDefaultMiddleware,
@@ -197,47 +198,38 @@ const required = <T>(
 ): ValidatorSpec<T> => validator({ ...spec });
 
 // ── Lenient coercion helpers ─────────────────────────────────────────────────
+//
+// Thin env-shaped adapters over `@constructive-io/coerce`: the coercion rules
+// themselves are shared with every other runtime value in the house, and only
+// the env convention — "unset or blank means `undefined`, not a default" —
+// lives here.
 
 /**
- * Parse a boolean env value leniently: `true`/`1`/`yes` (case-insensitive) are
- * true, everything else (including unset/blank => undefined) is false. Matches
- * `@pgpmjs/env`'s `parseEnvBoolean`.
+ * Parse a boolean env value leniently: `true`/`1`/`yes`/`on`/`t`/`y`
+ * (case-insensitive) are true, an unrecognised spelling is false, and
+ * unset/blank is `undefined`. Matches `@pgpmjs/env`'s `parseEnvBoolean`.
  */
-const parseEnvBoolean = (val?: string): boolean | undefined => {
-  if (val === undefined || val === '') return undefined;
-  return ['true', '1', 'yes'].includes(val.trim().toLowerCase());
-};
+const parseEnvBoolean = (val?: string): boolean | undefined =>
+  asString(val) === null ? undefined : asBoolean(val) ?? false;
 
 /** Parse a numeric env value; unset/blank/non-finite => undefined. */
-const parseEnvNumber = (val?: string): number | undefined => {
-  if (val === undefined || val === '') return undefined;
-  const n = Number(val);
-  return Number.isFinite(n) ? n : undefined;
-};
+const parseEnvNumber = (val?: string): number | undefined =>
+  asString(val) === null ? undefined : asNumber(Number(val)) ?? undefined;
 
 /**
  * Parse a comma-separated env value into a trimmed, non-empty string list;
  * unset/blank => undefined.
  */
-const parseEnvList = (val?: string): string[] | undefined => {
-  if (!val) return undefined;
-  return val
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean);
-};
+const parseEnvList = (val?: string): string[] | undefined => asStringList(val) ?? undefined;
 
 /**
  * Lenient boolean validator. Unlike envalid's built-in `bool` (which rejects
- * e.g. `TRUE`/`yes`), this accepts `true`/`1`/`yes` case-insensitively. Safe to
+ * e.g. `TRUE`/`yes`), this accepts every spelling `asBoolean` knows
+ * (`true`/`1`/`yes`/`on`/`t`/`y`) case-insensitively. Safe to
  * combine with a boolean `default`/`devDefault` (envalid also runs the validator
  * against the typed default).
  */
-const boolish = makeValidator<boolean>((value: string) => {
-  const raw = value as unknown;
-  if (typeof raw === 'boolean') return raw;
-  return parseEnvBoolean(String(raw)) ?? false;
-});
+const boolish = makeValidator<boolean>((value: string) => asBoolean(value) ?? false);
 
 // Type for specs object
 type Specs = Record<string, ValidatorSpec<unknown>>;

--- a/packages/coerce/README.md
+++ b/packages/coerce/README.md
@@ -1,0 +1,81 @@
+# @constructive-io/coerce
+
+<p align="center" width="100%">
+  <img height="250" src="https://raw.githubusercontent.com/constructive-io/constructive/refs/heads/main/assets/outline-logo.svg" />
+</p>
+
+<p align="center" width="100%">
+  <a href="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml">
+    <img height="20" src="https://github.com/constructive-io/constructive/actions/workflows/run-tests.yaml/badge.svg" />
+  </a>
+   <a href="https://github.com/constructive-io/constructive/blob/main/LICENSE"><img height="20" src="https://img.shields.io/badge/license-MIT-blue.svg"/></a>
+   <a href="https://www.npmjs.com/package/@constructive-io/coerce"><img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/constructive?filename=packages%2Fcoerce%2Fpackage.json"/></a>
+</p>
+
+Coerce untrusted `unknown` values — JSON request bodies, database rows, Kubernetes specs, env strings — into narrow TypeScript types. Zero dependencies.
+
+## why?
+
+Because every service ends up re-typing the same four functions inline, each subtly different:
+
+```ts
+// don't
+const asString = (v: unknown) => (typeof v === 'string' && v ? v : null);
+const asInteger = (v: unknown) => (typeof v === 'number' && Number.isInteger(v) ? v : null);
+```
+
+## install
+
+```sh
+npm install @constructive-io/coerce
+```
+
+## usage
+
+Two families. `as*` is lenient and returns `null`; `require*` throws a labelled `CoerceError`.
+
+```ts
+import { asInteger, asOneOf, asString, requireString } from '@constructive-io/coerce';
+
+const model = asString(body.model);                            // string | null
+const attempt = asInteger(body.attempt);                       // number | null
+const role = asOneOf(body.author_role, ['user', 'assistant']);  // 'user' | 'assistant' | null
+const messageId = requireString(body.message_id, 'message_id'); // string, or throws
+```
+
+| lenient | strict | accepts |
+| --- | --- | --- |
+| `asString` | `requireString` | a non-empty, non-whitespace string |
+| `asNumber` | `requireNumber` | a finite number |
+| `asInteger` | `requireInteger` | an integer |
+| `asBoolean` | `requireBoolean` | a boolean, or `true/false`, `1/0`, `yes/no`, `on/off`, `t/f`, `y/n` |
+| `asStringArray` | `requireStringArray` | an array whose every entry is a non-empty string |
+| `asStringList` | `requireStringList` | an array, or a delimited string (`'a, b'`) |
+| `asRecord` | `requireRecord` | a plain object (not `null`, not an array) |
+| `asDate` | `requireDate` | a valid `Date`, or a parseable date string |
+| `asIsoString` | `requireIsoString` | a `Date` (serialised) or a string (verbatim) |
+| `asOneOf` | `requireOneOf` | one of the given string literals |
+
+## rules
+
+- **No guessing across types.** `'5'` is not an integer and `1` is not a string. Only `asBoolean` and `asDate` read strings, because env vars and query strings carry nothing else.
+- **A blank string is absent.** `''` and `'   '` coerce to `null`, so an empty value can never read as a supplied identifier.
+- **All-or-nothing lists.** `asStringArray` rejects the whole array rather than dropping bad entries — that is how a list of allowed origins quietly shrinks.
+- **No transport semantics.** `CoerceError` carries the `label` that failed, not an HTTP status. Map it at your boundary:
+
+```ts
+try {
+  return handle(requireString(body.message_id, 'message_id'));
+} catch (err) {
+  if (err instanceof CoerceError) throw new HttpError(400, err.message);
+  throw err;
+}
+```
+
+## related
+
+`12factor-env` builds on this package for its lenient env parsing, and adds envalid-backed environment *schemas* (`cleanEnv`, redaction, cross-field checks). Reach for `12factor-env` when validating `process.env` at boot, and for this package when validating a value at runtime.
+
+## license
+
+MIT

--- a/packages/coerce/__tests__/coerce.test.ts
+++ b/packages/coerce/__tests__/coerce.test.ts
@@ -1,0 +1,199 @@
+import {
+  asBoolean,
+  asDate,
+  asInteger,
+  asIsoString,
+  asNumber,
+  asOneOf,
+  asRecord,
+  asString,
+  asStringArray,
+  asStringList,
+  CoerceError,
+  requireInteger,
+  requireOneOf,
+  requireString
+} from '../src';
+
+describe('asString', () => {
+  it('accepts a non-empty string', () => {
+    expect(asString('thread-1')).toBe('thread-1');
+  });
+
+  it('rejects blank and whitespace-only strings so "" never reads as supplied', () => {
+    expect(asString('')).toBeNull();
+    expect(asString('   ')).toBeNull();
+  });
+
+  it('rejects non-strings without stringifying them', () => {
+    expect(asString(1)).toBeNull();
+    expect(asString(null)).toBeNull();
+    expect(asString(undefined)).toBeNull();
+    expect(asString({})).toBeNull();
+  });
+});
+
+describe('asNumber', () => {
+  it('accepts finite numbers including zero', () => {
+    expect(asNumber(0)).toBe(0);
+    expect(asNumber(-1.5)).toBe(-1.5);
+  });
+
+  it('rejects non-finite numbers and numeric strings', () => {
+    expect(asNumber(NaN)).toBeNull();
+    expect(asNumber(Infinity)).toBeNull();
+    expect(asNumber('5')).toBeNull();
+  });
+});
+
+describe('asInteger', () => {
+  it('accepts integers', () => {
+    expect(asInteger(0)).toBe(0);
+    expect(asInteger(42)).toBe(42);
+  });
+
+  it('rejects fractions, NaN and numeric strings', () => {
+    expect(asInteger(1.5)).toBeNull();
+    expect(asInteger(NaN)).toBeNull();
+    expect(asInteger('1')).toBeNull();
+  });
+});
+
+describe('asBoolean', () => {
+  it('passes booleans through', () => {
+    expect(asBoolean(true)).toBe(true);
+    expect(asBoolean(false)).toBe(false);
+  });
+
+  it.each(['true', 'TRUE', '1', 'yes', 'on', 't', 'y'])('reads %s as true', value => {
+    expect(asBoolean(value)).toBe(true);
+  });
+
+  it.each(['false', 'FALSE', '0', 'no', 'off', 'f', 'n'])('reads %s as false', value => {
+    expect(asBoolean(value)).toBe(false);
+  });
+
+  it('keeps unset distinguishable from false', () => {
+    expect(asBoolean('')).toBeNull();
+    expect(asBoolean(undefined)).toBeNull();
+    expect(asBoolean('maybe')).toBeNull();
+    expect(asBoolean(1)).toBeNull();
+  });
+});
+
+describe('asStringArray', () => {
+  it('accepts an array of non-empty strings, including empty', () => {
+    expect(asStringArray([])).toEqual([]);
+    expect(asStringArray(['a', 'b'])).toEqual(['a', 'b']);
+  });
+
+  it('rejects the whole list rather than silently dropping bad entries', () => {
+    expect(asStringArray(['a', ''])).toBeNull();
+    expect(asStringArray(['a', 2])).toBeNull();
+  });
+
+  it('rejects non-arrays', () => {
+    expect(asStringArray('a')).toBeNull();
+    expect(asStringArray({ 0: 'a' })).toBeNull();
+  });
+});
+
+describe('asStringList', () => {
+  it('splits a delimited string, trimming and dropping blanks', () => {
+    expect(asStringList('a, b,')).toEqual(['a', 'b']);
+    expect(asStringList('a:b', ':')).toEqual(['a', 'b']);
+  });
+
+  it('accepts an array form too', () => {
+    expect(asStringList(['a', 'b'])).toEqual(['a', 'b']);
+    expect(asStringList(['a', ''])).toBeNull();
+  });
+
+  it('rejects blanks and non-list values', () => {
+    expect(asStringList('')).toBeNull();
+    expect(asStringList(undefined)).toBeNull();
+    expect(asStringList(1)).toBeNull();
+  });
+});
+
+describe('asRecord', () => {
+  it('accepts a plain object', () => {
+    expect(asRecord({ a: 1 })).toEqual({ a: 1 });
+  });
+
+  it('rejects null and arrays, which are also typeof object', () => {
+    expect(asRecord(null)).toBeNull();
+    expect(asRecord([])).toBeNull();
+  });
+});
+
+describe('asDate', () => {
+  it('accepts a valid Date and an ISO string', () => {
+    const date = new Date('2026-01-01T00:00:00.000Z');
+    expect(asDate(date)).toBe(date);
+    expect(asDate('2026-01-01T00:00:00.000Z')).toEqual(date);
+  });
+
+  it('rejects an invalid Date and unparseable strings', () => {
+    expect(asDate(new Date('nope'))).toBeNull();
+    expect(asDate('nope')).toBeNull();
+    expect(asDate(0)).toBeNull();
+  });
+});
+
+describe('asIsoString', () => {
+  it('serialises a Date', () => {
+    expect(asIsoString(new Date('2026-01-01T00:00:00.000Z'))).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('passes a string through verbatim so a cursor survives byte-for-byte', () => {
+    expect(asIsoString('2026-01-01 00:00:00+00')).toBe('2026-01-01 00:00:00+00');
+  });
+
+  it('rejects an invalid Date and blanks', () => {
+    expect(asIsoString(new Date('nope'))).toBeNull();
+    expect(asIsoString('')).toBeNull();
+    expect(asIsoString(null)).toBeNull();
+  });
+});
+
+describe('asOneOf', () => {
+  it('narrows to the allowed literals', () => {
+    const role: 'user' | 'assistant' | null = asOneOf('user', ['user', 'assistant'] as const);
+    expect(role).toBe('user');
+  });
+
+  it('rejects values outside the set', () => {
+    expect(asOneOf('root', ['user', 'assistant'] as const)).toBeNull();
+    expect(asOneOf('', ['user'] as const)).toBeNull();
+  });
+});
+
+describe('require*', () => {
+  it('returns the coerced value', () => {
+    expect(requireString('a', 'message_id')).toBe('a');
+    expect(requireInteger(2, 'attempt')).toBe(2);
+    expect(requireOneOf('user', ['user'] as const, 'author_role')).toBe('user');
+  });
+
+  it('throws a labelled CoerceError naming what was expected', () => {
+    expect(() => requireString('', 'message_id')).toThrow(CoerceError);
+    expect(() => requireString('', 'message_id')).toThrow(
+      'message_id is required (expected a non-empty string)'
+    );
+    expect(() => requireInteger(1.5, 'attempt')).toThrow('attempt is required (expected an integer)');
+    expect(() => requireOneOf('root', ['user', 'assistant'] as const, 'author_role')).toThrow(
+      'author_role is required (expected one of user, assistant)'
+    );
+  });
+
+  it('carries the label for transports that map it to a status', () => {
+    try {
+      requireString(undefined, 'thread_id');
+      throw new Error('expected a throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(CoerceError);
+      expect((err as CoerceError).label).toBe('thread_id');
+    }
+  });
+});

--- a/packages/coerce/jest.config.js
+++ b/packages/coerce/jest.config.js
@@ -1,0 +1,18 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        babelConfig: false,
+        tsconfig: 'tsconfig.json',
+      },
+    ],
+  },
+  transformIgnorePatterns: [`/node_modules/*`],
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  modulePathIgnorePatterns: ['dist/*']
+};

--- a/packages/coerce/package.json
+++ b/packages/coerce/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "12factor-env",
-  "version": "1.28.0",
+  "name": "@constructive-io/coerce",
+  "version": "0.0.1",
   "author": "Constructive <developers@constructive.io>",
-  "description": "Environment variable validation for 12-factor apps",
+  "description": "Coerce untrusted unknown values into narrow TypeScript types",
   "main": "index.js",
   "module": "esm/index.js",
   "types": "index.d.ts",
@@ -28,20 +28,12 @@
     "test": "jest",
     "test:watch": "jest --watch"
   },
-  "dependencies": {
-    "@constructive-io/coerce": "workspace:^",
-    "envalid": "^8.2.0"
-  },
   "devDependencies": {
-    "@types/node": "^22.19.11",
-    "makage": "^0.3.0",
-    "ts-node": "^10.9.2"
+    "makage": "^0.3.0"
   },
   "keywords": [
-    "environment",
-    "env",
+    "coerce",
     "validation",
-    "12factor",
-    "constructive"
+    "typescript"
   ]
 }

--- a/packages/coerce/src/coerce.ts
+++ b/packages/coerce/src/coerce.ts
@@ -1,0 +1,173 @@
+/**
+ * Coercion of untrusted `unknown` values — JSON request bodies, database rows,
+ * Kubernetes specs, env strings — into narrow TypeScript types.
+ *
+ * Two families, one rule each:
+ *
+ *   - `as*` is lenient: it answers "is this value already a usable T?" and
+ *     returns `null` when it is not. It never guesses across types (`'5'` is
+ *     not an integer, `1` is not a string) and never treats a blank string as
+ *     present, so a caller cannot mistake `''` for a supplied identifier.
+ *   - `require*` is strict: same test, but a miss throws {@link CoerceError}.
+ *
+ * Deliberately transport-agnostic: `CoerceError` carries the offending
+ * `label`, not an HTTP status. A server maps it to 400 at its own boundary,
+ * which keeps this package usable off the request path.
+ */
+
+/** A value that was required but absent or of the wrong shape. */
+export class CoerceError extends Error {
+  /** What the caller was asking for, e.g. `'message_id'`. */
+  readonly label: string;
+
+  constructor(label: string, expected: string) {
+    super(`${label} is required (expected ${expected})`);
+    this.name = 'CoerceError';
+    this.label = label;
+  }
+}
+
+/** A non-empty, non-whitespace string, else `null`. */
+export const asString = (value: unknown): string | null =>
+  typeof value === 'string' && value.trim() !== '' ? value : null;
+
+/** A finite number, else `null`. Strings are not parsed. */
+export const asNumber = (value: unknown): number | null =>
+  typeof value === 'number' && Number.isFinite(value) ? value : null;
+
+/** A safe integer, else `null`. `1.5` and `'1'` are both `null`. */
+export const asInteger = (value: unknown): number | null =>
+  typeof value === 'number' && Number.isInteger(value) ? value : null;
+
+/**
+ * A boolean. Booleans pass through; the string spellings people actually type
+ * (`true/false`, `1/0`, `yes/no`, `on/off`, `t/f`, `y/n`) are recognised
+ * case-insensitively, because env vars and query strings only carry strings.
+ * Anything else is `null` — notably `''`, so "unset" stays distinguishable
+ * from "false".
+ */
+export const asBoolean = (value: unknown): boolean | null => {
+  if (typeof value === 'boolean') return value;
+  const str = asString(value)?.trim().toLowerCase();
+  if (str === undefined) return null;
+  if (TRUTHY.has(str)) return true;
+  if (FALSY.has(str)) return false;
+  return null;
+};
+
+const TRUTHY = new Set(['1', 'on', 't', 'true', 'y', 'yes']);
+const FALSY = new Set(['0', 'f', 'false', 'n', 'no', 'off']);
+
+/**
+ * An array whose every entry is a non-empty string, else `null`.
+ *
+ * All-or-nothing on purpose: silently dropping the malformed entries of a
+ * list of role names or allowed origins is how a security list quietly
+ * shrinks.
+ */
+export const asStringArray = (value: unknown): string[] | null => {
+  if (!Array.isArray(value)) return null;
+  const strings: string[] = [];
+  for (const entry of value) {
+    const str = asString(entry);
+    if (str === null) return null;
+    strings.push(str);
+  }
+  return strings;
+};
+
+/**
+ * A list of non-empty strings from either an array (see
+ * {@link asStringArray}) or a delimited string, else `null`.
+ *
+ * Entries are trimmed and blanks dropped, because the delimited form is what a
+ * `PATH`-style env var, a query parameter or a header carries, and
+ * `'a, b,'` means two entries in all three.
+ */
+export const asStringList = (value: unknown, separator = ','): string[] | null => {
+  const str = asString(value);
+  if (str !== null) return str.split(separator).map(entry => entry.trim()).filter(Boolean);
+  return asStringArray(value);
+};
+
+/**
+ * A plain object, else `null`. Arrays and `null` are not records — both are
+ * `typeof 'object'`, and that check is the classic source of a `.length`
+ * lookup on something that was supposed to be a map.
+ */
+export const asRecord = (value: unknown): Record<string, unknown> | null =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+
+/** A valid `Date`, else `null`. An invalid date parse is not a `Date`. */
+export const asDate = (value: unknown): Date | null => {
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+  const str = asString(value);
+  if (str === null) return null;
+  const parsed = new Date(str);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+/**
+ * A timestamp as an ISO-8601 string, else `null`.
+ *
+ * A `Date` is serialised; a string is passed through **verbatim** rather than
+ * round-tripped through `Date`, so a caller's own cursor value survives
+ * byte-for-byte — the format a database returned is the format it compares
+ * against.
+ */
+export const asIsoString = (value: unknown): string | null =>
+  value instanceof Date ? asDate(value)?.toISOString() ?? null : asString(value);
+
+const require_ =
+  <T>(as: (value: unknown) => T | null, expected: string) =>
+    (value: unknown, label: string): T => {
+      const coerced = as(value);
+      if (coerced === null) throw new CoerceError(label, expected);
+      return coerced;
+    };
+
+/** {@link asString}, throwing {@link CoerceError} when absent. */
+export const requireString = require_(asString, 'a non-empty string');
+/** {@link asNumber}, throwing {@link CoerceError} when absent. */
+export const requireNumber = require_(asNumber, 'a finite number');
+/** {@link asInteger}, throwing {@link CoerceError} when absent. */
+export const requireInteger = require_(asInteger, 'an integer');
+/** {@link asBoolean}, throwing {@link CoerceError} when absent. */
+export const requireBoolean = require_(asBoolean, 'a boolean');
+/** {@link asStringArray}, throwing {@link CoerceError} when absent. */
+export const requireStringArray = require_(asStringArray, 'an array of non-empty strings');
+/** {@link asStringList}, throwing {@link CoerceError} when absent. */
+export const requireStringList = require_(asStringList, 'a list of non-empty strings');
+/** {@link asRecord}, throwing {@link CoerceError} when absent. */
+export const requireRecord = require_(asRecord, 'an object');
+/** {@link asDate}, throwing {@link CoerceError} when absent. */
+export const requireDate = require_(asDate, 'a date');
+/** {@link asIsoString}, throwing {@link CoerceError} when absent. */
+export const requireIsoString = require_(asIsoString, 'a timestamp');
+
+/**
+ * Narrow a value to one of `allowed`, else `null`.
+ *
+ * The literal tuple is preserved, so `asOneOf(body.role, ['user', 'admin'])`
+ * is typed `'user' | 'admin' | null` without a cast at the call site.
+ */
+export const asOneOf = <const T extends readonly string[]>(
+  value: unknown,
+  allowed: T
+): T[number] | null => {
+  const str = asString(value);
+  return str !== null && (allowed as readonly string[]).includes(str) ? (str as T[number]) : null;
+};
+
+/** {@link asOneOf}, throwing {@link CoerceError} when the value is not allowed. */
+export const requireOneOf = <const T extends readonly string[]>(
+  value: unknown,
+  allowed: T,
+  label: string
+): T[number] => {
+  const coerced = asOneOf(value, allowed);
+  if (coerced === null) throw new CoerceError(label, `one of ${allowed.join(', ')}`);
+  return coerced;
+};

--- a/packages/coerce/src/index.ts
+++ b/packages/coerce/src/index.ts
@@ -1,0 +1,1 @@
+export * from './coerce';

--- a/packages/coerce/tsconfig.esm.json
+++ b/packages/coerce/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/esm",
+    "module": "es2022",
+    "rootDir": "src/",
+    "declaration": false
+  }
+}

--- a/packages/coerce/tsconfig.json
+++ b/packages/coerce/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src/"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules", "**/*.spec.*", "**/*.test.*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2320,6 +2320,9 @@ importers:
 
   packages/12factor-env:
     dependencies:
+      '@constructive-io/coerce':
+        specifier: workspace:^
+        version: link:../coerce/dist
       envalid:
         specifier: ^8.2.0
         version: 8.2.0
@@ -2447,6 +2450,13 @@ importers:
       '@types/pg':
         specifier: ^8.20.4
         version: 8.20.4
+      makage:
+        specifier: ^0.3.0
+        version: 0.3.0
+    publishDirectory: dist
+
+  packages/coerce:
+    devDependencies:
       makage:
         specifier: ^0.3.0
         version: 0.3.0


### PR DESCRIPTION
## Summary

Every service re-types the same four coercions inline, each subtly different — `asString`/`asInteger`/`requireString`/`iso` appeared again in [constructive-db#3081](https://github.com/constructive-io/constructive-db/pull/3081)'s gateway lane, and the same shapes already live in its webhook gateway, node runtime (`site`/`auth`/`email`), knative reconciler specs, and ~14 spots here. This adds the published home for them and makes `12factor-env` a consumer rather than a second implementation. Design + rationale: constructive-io/constructive-planning#1644 ([comment](https://github.com/constructive-io/constructive-planning/issues/1644#issuecomment-5287286365)).

**`packages/coerce` → `@constructive-io/coerce`**, zero dependencies. Two families over `unknown`: `as*` is lenient (`T | null`), `require*` throws a labelled `CoerceError`.

```ts
asString | asNumber | asInteger | asBoolean | asStringArray | asStringList
        | asRecord | asDate | asIsoString | asOneOf
require*  // one per as*, throws CoerceError { label }
```

The rules are the interesting part, and each is a bug we've shipped:

- **No guessing across types** — `'5'` is not an integer, `1` is not a string. Only `asBoolean`/`asDate`/`asStringList` read strings, because env vars and query strings carry nothing else.
- **A blank string is absent** — `''`/`'   '` → `null`, so an empty value can never read as a supplied identifier (the security property PR #3081 depends on).
- **All-or-nothing lists** — `asStringArray(['a', ''])` is `null`, not `['a']`: dropping bad entries is how an allowlist quietly shrinks.
- **No transport semantics** — `CoerceError` carries the failing `label`, never an HTTP status, so the package stays usable off the request path. A server maps it at its own boundary: `if (err instanceof CoerceError) throw new HttpError(400, err.message)`.
- `asIsoString` passes a **string through verbatim** rather than round-tripping it through `Date`, so a caller's cursor survives byte-for-byte.

**`12factor-env` layers on it** instead of being merged into it: the package keeps envalid schemas, redaction and cross-field checks, and its three lenient parsers become env-shaped adapters where only the env convention ("unset or blank is `undefined`, not a default") remains local.

```diff
-const parseEnvBoolean = (val?: string) => {
-  if (val === undefined || val === '') return undefined;
-  return ['true', '1', 'yes'].includes(val.trim().toLowerCase());
-};
+const parseEnvBoolean = (val?: string): boolean | undefined =>
+  asString(val) === null ? undefined : asBoolean(val) ?? false;
```

`boolish()` collapses to `asBoolean(value) ?? false`. Signatures and the existing 70 tests are unchanged; the one intentional widening is that `parseEnvBoolean`/`boolish` now also accept `on`/`t`/`y` (and read `off`/`f`/`n` as false), where before anything outside `true|1|yes` was false. `envalid`-backed `list()`/`num()` in `validators.ts` are untouched — their `EnvError` messages are schema-level.

Folding coerce *into* `12factor-env` was rejected: the name promises env vars, so payload coercion hidden there invites the next inline reinvention, and every consumer (e.g. the node gateway) would inherit envalid for four ten-line functions.

Follow-up, after this publishes: constructive-db depends on the package and deletes its inline copies. That swap is not a blocker for #3081.


Link to Devin session: https://app.devin.ai/sessions/4283bbf118594207ad8b1ef1ce856ce8
Requested by: @pyramation