### PR TITLE
Add CNC-owned Graphile build-state retirement

### DIFF
--- a/.changeset/slow-dogs-retire.md
+++ b/.changeset/slow-dogs-retire.md
@@ -1,0 +1,8 @@
+---
+'graphile-connection-filter': patch
+'graphile-meta': patch
+'graphile-search': patch
+'graphile-settings': patch
+---
+
+Add CNC-owned build-state retirement with owner-specific cleanup after successful schema validation.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 # SQL, plans and control files are content-addressed and compared verbatim in
 # tests, so the working tree must use LF on every platform.
 * text=auto eol=lf
+
+# pnpm patches retain upstream whitespace in context lines.
+patches/*.patch whitespace=-blank-at-eol

--- a/graphile/graphile-connection-filter/__tests__/build-state-disposal.test.ts
+++ b/graphile/graphile-connection-filter/__tests__/build-state-disposal.test.ts
@@ -1,0 +1,23 @@
+import { ConnectionFilterCustomOperatorsPlugin } from '../src/plugins/ConnectionFilterCustomOperatorsPlugin';
+import { $$filters } from '../src/types';
+
+describe('connection-filter build-state ownership', () => {
+  it('clears the custom operator registry through the build lifecycle', () => {
+    let dispose: (() => void) | undefined;
+    const build: any = {
+      registerBuildStateDisposer(callback: () => void) {
+        dispose = callback;
+      },
+    };
+    const buildHook = ConnectionFilterCustomOperatorsPlugin.schema!.hooks!
+      .build as (build: any) => any;
+    buildHook(build);
+
+    const operators = new Map([['equalTo', { resolve: jest.fn() }]]);
+    build[$$filters].set('StringFilter', operators);
+    dispose!();
+
+    expect(operators.size).toBe(0);
+    expect(build[$$filters].size).toBe(0);
+  });
+});

--- a/graphile/graphile-connection-filter/src/plugins/ConnectionFilterCustomOperatorsPlugin.ts
+++ b/graphile/graphile-connection-filter/src/plugins/ConnectionFilterCustomOperatorsPlugin.ts
@@ -51,10 +51,17 @@ export const ConnectionFilterCustomOperatorsPlugin: GraphileConfig.Plugin = {
     hooks: {
       build(build) {
         // Initialize the filter registry
-        build[$$filters] = new Map<
+        const filters = new Map<
           string,
           Map<string, ConnectionFilterOperatorSpec>
         >();
+        build[$$filters] = filters;
+        build.registerBuildStateDisposer(() => {
+          for (const operators of filters.values()) {
+            operators.clear();
+          }
+          filters.clear();
+        });
 
         return build;
       },

--- a/graphile/graphile-meta/__tests__/meta-schema.test.ts
+++ b/graphile/graphile-meta/__tests__/meta-schema.test.ts
@@ -136,6 +136,14 @@ function callGraphQLObjectTypeFieldsHook(
   });
 }
 
+function callFinalizeHook(schema: GraphQLSchema, build: any): GraphQLSchema {
+  const finalizeHook = MetaSchemaPlugin.schema!.hooks!.finalize as (
+    schema: GraphQLSchema,
+    build: any
+  ) => GraphQLSchema;
+  return finalizeHook(schema, build);
+}
+
 function deepClone<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }
@@ -2016,6 +2024,7 @@ describe('MetaSchemaPlugin', () => {
         }),
         types: [userType]
       });
+      callFinalizeHook(schema, build);
       const result = await graphql({
         schema,
         source: `
@@ -2086,6 +2095,7 @@ describe('MetaSchemaPlugin', () => {
             })
           ]
         });
+        callFinalizeHook(schema, build);
         return schema;
       };
 
@@ -2112,7 +2122,7 @@ describe('MetaSchemaPlugin', () => {
       ).toEqual(['Project']);
     });
 
-    it('validates metadata against schema changes made by later finalizers', async () => {
+    it('snapshots metadata from the finalized executable schema', async () => {
       const codec = createMockCodec('user', {
         id: createMockAttribute('text')
       });
@@ -2144,11 +2154,11 @@ describe('MetaSchemaPlugin', () => {
       });
       const schema = new GraphQLSchema({ query: queryType });
 
-      // Before later finalizers mutate the schema, the metadata resolves the
-      // list entry-point; the resolver must recompute from the final schema.
+      // Simulate an earlier finalizer removing an entry-point before the meta
+      // plugin snapshots the executable schema.
       expect((collectTablesMeta(build, schema) as any[])[0].query.all).toBe('users');
-
       delete queryType.getFields().users;
+      callFinalizeHook(schema, build);
       const result = await graphql({
         schema,
         source: '{ _meta { tables { query { all } } } }'

--- a/graphile/graphile-meta/src/plugin.ts
+++ b/graphile/graphile-meta/src/plugin.ts
@@ -10,22 +10,19 @@ import type { MetaBuild, TableMeta } from './types';
 
 const runtimeTablesBySchema = new WeakMap<GraphQLSchema, TableMeta[]>();
 
-function getRuntimeTablesMeta(
-  build: MetaBuild,
-  schema: GraphQLSchema
-): TableMeta[] {
-  let tables = runtimeTablesBySchema.get(schema);
+function getRuntimeTablesMeta(schema: GraphQLSchema): TableMeta[] {
+  const tables = runtimeTablesBySchema.get(schema);
   if (!tables) {
-    tables = collectTablesMeta(build, schema);
-    runtimeTablesBySchema.set(schema, tables);
+    throw new Error(
+      'Meta schema runtime state was not finalized for this GraphQL schema'
+    );
   }
   return tables;
 }
 
 /**
  * Returns the table metadata memoized for the given executable schema, or
- * `undefined` if `_meta` has not been resolved against that schema (e.g. the
- * meta plugin is disabled or `_meta` was never executed).
+ * `undefined` when the meta plugin was not installed for that schema.
  */
 export function getTablesMetaForSchema(
   schema: GraphQLSchema
@@ -41,11 +38,15 @@ export const MetaSchemaPlugin: GraphileConfig.Plugin = {
     hooks: {
       GraphQLObjectType_fields(rawFields, rawBuild, rawContext) {
         if (!rawContext.scope.isRootQuery) return rawFields;
-        const build = rawBuild as unknown as MetaBuild;
         return extendQueryWithMetaField(
           rawFields as unknown as Record<string, unknown>,
-          (schema) => getRuntimeTablesMeta(build, schema),
+          getRuntimeTablesMeta
         ) as typeof rawFields;
+      },
+      finalize(schema, rawBuild) {
+        const build = rawBuild as unknown as MetaBuild;
+        runtimeTablesBySchema.set(schema, collectTablesMeta(build, schema));
+        return schema;
       },
     },
   },

--- a/graphile/graphile-search/src/__tests__/build-state-disposal.test.ts
+++ b/graphile/graphile-search/src/__tests__/build-state-disposal.test.ts
@@ -1,0 +1,39 @@
+import { createUnifiedSearchPlugin } from '../plugin';
+
+function getBuildHook(plugin: GraphileConfig.Plugin): (build: any) => any {
+  return plugin.schema!.hooks!.build as (build: any) => any;
+}
+
+describe('graphile-search build-state ownership', () => {
+  it('clears the unified-search codec cache through the build lifecycle', () => {
+    const detectColumns = jest.fn((): never[] => []);
+    const plugin = createUnifiedSearchPlugin({
+      adapters: [
+        {
+          name: 'test',
+          detectColumns,
+          registerTypes: jest.fn(),
+          scoreSemantics: { metric: 'score', lowerIsBetter: false },
+        } as never,
+      ],
+    });
+    let dispose: (() => void) | undefined;
+    const build = {
+      registerBuildStateDisposer(callback: () => void) {
+        dispose = callback;
+      },
+    };
+    getBuildHook(plugin)(build);
+
+    const inferred = (plugin.schema!.entityBehavior!.pgCodecAttribute as any)
+      .inferred.callback;
+    const codec = { name: 'document', attributes: { body: {} } };
+    inferred([], [codec, 'body'], build);
+    inferred([], [codec, 'body'], build);
+    expect(detectColumns).toHaveBeenCalledTimes(1);
+
+    dispose!();
+    inferred([], [codec, 'body'], build);
+    expect(detectColumns).toHaveBeenCalledTimes(2);
+  });
+});

--- a/graphile/graphile-search/src/plugin.ts
+++ b/graphile/graphile-search/src/plugin.ts
@@ -328,6 +328,11 @@ export function createUnifiedSearchPlugin(
       },
 
       hooks: {
+        build(build) {
+          build.registerBuildStateDisposer(() => codecCache.clear());
+          return build;
+        },
+
         /**
          * Register all adapter-specific GraphQL types during init.
          */

--- a/graphile/graphile-settings/__tests__/build-state-retirement.test.ts
+++ b/graphile/graphile-settings/__tests__/build-state-retirement.test.ts
@@ -1,0 +1,189 @@
+import {
+  buildSchema,
+  defaultPreset,
+  QueryPlugin,
+  QueryQueryPlugin,
+} from 'graphile-build';
+import { resolvePreset } from 'graphile-config';
+import { GraphQLSchema, graphqlSync } from 'graphql';
+
+import { BuildStateRetirementPlugin } from '../src/plugins/build-state-retirement';
+import { ConstructivePreset } from '../src/presets/constructive-preset';
+
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      BuildStateRetirementTestOwnerPlugin: true;
+      BuildStateRetirementInvalidSchemaPlugin: true;
+    }
+  }
+}
+
+function makeOwnerPlugin(
+  owned: string[],
+  capture: (build: GraphileBuild.BuildBase) => void
+): GraphileConfig.Plugin {
+  return {
+    name: 'BuildStateRetirementTestOwnerPlugin',
+    schema: {
+      hooks: {
+        build(build) {
+          capture(build);
+          build.registerBuildStateDisposer(() => owned.push('first'));
+          build.registerBuildStateDisposer(() => owned.push('second'));
+          return build;
+        },
+      },
+    },
+  };
+}
+
+describe('Constructive build-state retirement', () => {
+  it('opts Constructive in without changing the Graphile default preset', () => {
+    expect(resolvePreset(ConstructivePreset).plugins).toContain(
+      BuildStateRetirementPlugin
+    );
+    expect(resolvePreset(defaultPreset).plugins).not.toContain(
+      BuildStateRetirementPlugin
+    );
+  });
+
+  it('retains build state when the CNC plugin is not installed', () => {
+    const disposed: string[] = [];
+    let capturedBuild: GraphileBuild.BuildBase | undefined;
+
+    buildSchema(
+      {
+        plugins: [
+          QueryPlugin,
+          QueryQueryPlugin,
+          makeOwnerPlugin(disposed, (build) => {
+            capturedBuild = build;
+          }),
+        ],
+      },
+      Object.create(null)
+    );
+
+    expect(disposed).toEqual([]);
+    expect(capturedBuild!.input).toEqual(Object.create(null));
+  });
+
+  it('retires after validation, in reverse disposer order, and preserves execution', () => {
+    const disposed: string[] = [];
+    let capturedBuild: GraphileBuild.BuildBase | undefined;
+    const schema = buildSchema(
+      {
+        plugins: [
+          QueryPlugin,
+          QueryQueryPlugin,
+          makeOwnerPlugin(disposed, (build) => {
+            capturedBuild = build;
+          }),
+          BuildStateRetirementPlugin,
+        ],
+      },
+      Object.create(null)
+    );
+
+    expect(disposed).toEqual(['second', 'first']);
+    expect(() => capturedBuild!.input).toThrow(
+      expect.objectContaining({ code: 'GRAPHILE_BUILD_STATE_RELEASED' })
+    );
+    expect(() => capturedBuild!.getAllTypes()).toThrow(
+      expect.objectContaining({ code: 'GRAPHILE_BUILD_STATE_RELEASED' })
+    );
+    expect(() =>
+      (capturedBuild as any).behavior.entityMatches('test', {}, '*')
+    ).toThrow(
+      expect.objectContaining({ code: 'GRAPHILE_BUILD_STATE_RELEASED' })
+    );
+    expect(graphqlSync({ schema, source: '{ __typename }' })).toEqual({
+      data: { __typename: 'Query' },
+    });
+  });
+
+  it('does not retire when schema validation fails', () => {
+    const disposed: string[] = [];
+    let capturedBuild: GraphileBuild.BuildBase | undefined;
+    const InvalidSchemaPlugin: GraphileConfig.Plugin = {
+      name: 'BuildStateRetirementInvalidSchemaPlugin',
+      schema: {
+        hooks: {
+          finalize() {
+            return new GraphQLSchema({});
+          },
+        },
+      },
+    };
+
+    expect(() =>
+      buildSchema(
+        {
+          plugins: [
+            QueryPlugin,
+            QueryQueryPlugin,
+            makeOwnerPlugin(disposed, (build) => {
+              capturedBuild = build;
+            }),
+            BuildStateRetirementPlugin,
+            InvalidSchemaPlugin,
+          ],
+        },
+        Object.create(null)
+      )
+    ).toThrow(/validation failure/);
+    expect(disposed).toEqual([]);
+    expect(capturedBuild!.input).toEqual(Object.create(null));
+  });
+
+  it('attempts every disposer and aggregates failures before failing closed', () => {
+    const calls: string[] = [];
+    let capturedBuild: GraphileBuild.BuildBase | undefined;
+    const FailingOwnerPlugin: GraphileConfig.Plugin = {
+      name: 'BuildStateRetirementTestOwnerPlugin',
+      schema: {
+        hooks: {
+          build(build) {
+            capturedBuild = build;
+            build.registerBuildStateDisposer(() => {
+              calls.push('first');
+              throw new Error('first failed');
+            });
+            build.registerBuildStateDisposer(() => {
+              calls.push('second');
+              throw new Error('second failed');
+            });
+            return build;
+          },
+        },
+      },
+    };
+
+    expect(() =>
+      buildSchema(
+        {
+          plugins: [
+            QueryPlugin,
+            QueryQueryPlugin,
+            FailingOwnerPlugin,
+            BuildStateRetirementPlugin,
+          ],
+        },
+        Object.create(null)
+      )
+    ).toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining('2 disposal errors'),
+        errors: [
+          expect.objectContaining({ message: 'second failed' }),
+          expect.objectContaining({ message: 'first failed' }),
+        ],
+      })
+    );
+    expect(calls).toEqual(['second', 'first']);
+    expect(() => capturedBuild!.input).toThrow(
+      expect.objectContaining({ code: 'GRAPHILE_BUILD_STATE_RELEASED' })
+    );
+  });
+});

--- a/graphile/graphile-settings/__tests__/patched-pg-build-state-owners.test.ts
+++ b/graphile/graphile-settings/__tests__/patched-pg-build-state-owners.test.ts
@@ -1,0 +1,147 @@
+import {
+  PgBasicsPlugin,
+  PgCodecsPlugin,
+  PgPolymorphismPlugin,
+} from 'graphile-build-pg';
+import { GraphQLList, GraphQLNonNull } from 'graphql';
+
+type Disposer = () => void;
+
+const buildHook = (plugin: GraphileConfig.Plugin): ((build: any) => any) =>
+  plugin.schema!.hooks!.build as (build: any) => any;
+
+const disposerRegistration = () => {
+  let disposer: Disposer | undefined;
+  return {
+    registerBuildStateDisposer(callback: Disposer) {
+      disposer = callback;
+    },
+    dispose() {
+      expect(disposer).toBeDefined();
+      disposer!();
+    },
+  };
+};
+
+describe('patched graphile-build-pg state owners', () => {
+  it('PgBasics clears codec metadata and table-resource caches', () => {
+    const lifecycle = disposerRegistration();
+    const executor = {};
+    const codec = { executor, name: 'account' };
+    const resource = {
+      name: 'accounts',
+      codec,
+      executor,
+      getRelations: () => Object.create(null),
+      isUnique: false,
+      isVirtual: false,
+    };
+    const build: any = {
+      ...lifecycle,
+      extend(target: object, extra: object) {
+        return Object.assign(target, extra);
+      },
+      graphql: { GraphQLList, GraphQLNonNull },
+      input: {
+        pgRegistry: {
+          pgCodecs: { account: codec },
+          pgExecutors: { main: resource.executor },
+          pgRelations: Object.create(null),
+          pgResources: { accounts: resource },
+        },
+      },
+      lib: {
+        dataplanJson: { version: 'test' },
+        dataplanPg: { version: 'test' },
+        sql: {},
+      },
+      versions: Object.create(null),
+    };
+
+    const result = buildHook(PgBasicsPlugin)(build);
+    expect(result.pgCodecMetaLookup.size).toBe(1);
+    expect(result.pgTableResource(codec)).toBe(resource);
+
+    result.pgResources = Object.create(null);
+    lifecycle.dispose();
+
+    expect(result.pgCodecMetaLookup.size).toBe(0);
+    expect(result.pgTableResource(codec)).toBeNull();
+  });
+
+  it('PgCodecs clears the codec set and database-name lookup', () => {
+    const lifecycle = disposerRegistration();
+    const codec = {
+      name: 'account',
+      extensions: {
+        pg: { name: 'account', schemaName: 'app_public', serviceName: 'main' },
+      },
+    };
+    const build: any = {
+      ...lifecycle,
+      input: {
+        pgRegistry: {
+          pgResources: { accounts: { codec } },
+        },
+      },
+    };
+
+    const result = buildHook(PgCodecsPlugin)(build);
+    expect(result.allPgCodecs).toEqual(new Set([codec]));
+    expect(
+      result.getPgCodecByDatabaseName('main', 'app_public', 'account')
+    ).toBe(codec);
+
+    lifecycle.dispose();
+
+    expect(result.allPgCodecs.size).toBe(0);
+    expect(() =>
+      result.getPgCodecByDatabaseName('main', 'app_public', 'account')
+    ).toThrow('Failed to find codec');
+  });
+
+  it('PgPolymorphism clears resource and union-codec indexes', () => {
+    const lifecycle = disposerRegistration();
+    const implementedCodec = {
+      name: 'account',
+      extensions: { tags: { implements: 'Entity' } },
+    };
+    const unionCodec = {
+      name: 'search_result',
+      polymorphism: { mode: 'union' },
+    };
+    const build: any = {
+      ...lifecycle,
+      extend(target: object, extra: object) {
+        return Object.assign(target, extra);
+      },
+      inflection: { tableType: () => 'SearchResult' },
+      input: {
+        pgRegistry: {
+          pgCodecs: { searchResult: unionCodec },
+          pgResources: {
+            accounts: {
+              codec: implementedCodec,
+              from: 'app_public.accounts',
+            },
+          },
+        },
+      },
+    };
+
+    const result = buildHook(PgPolymorphismPlugin)(build);
+    expect(Object.keys(result.pgResourcesByPolymorphicTypeName).sort()).toEqual(
+      ['Entity', 'SearchResult']
+    );
+    expect(Object.keys(result.pgCodecByPolymorphicUnionModeTypeName)).toEqual([
+      'SearchResult',
+    ]);
+
+    lifecycle.dispose();
+
+    expect(Object.keys(result.pgResourcesByPolymorphicTypeName)).toEqual([]);
+    expect(Object.keys(result.pgCodecByPolymorphicUnionModeTypeName)).toEqual(
+      []
+    );
+  });
+});

--- a/graphile/graphile-settings/src/plugins/build-state-retirement.ts
+++ b/graphile/graphile-settings/src/plugins/build-state-retirement.ts
@@ -1,0 +1,47 @@
+import type { GraphileConfig } from 'graphile-config';
+
+const RETIRE_BUILD_STATE = Symbol.for(
+  'constructive.graphile-build.retireBuildState'
+);
+
+type RetireBuildState = () => boolean;
+
+function retireBuildState(build: GraphileBuild.BuildBase): boolean {
+  const capability = (
+    build as unknown as Record<symbol, RetireBuildState | undefined>
+  )[RETIRE_BUILD_STATE];
+  if (typeof capability !== 'function') {
+    throw new Error(
+      'Build-state retirement requires the Constructive graphile-build patch'
+    );
+  }
+  return capability();
+}
+
+/**
+ * Opts a schema build into Constructive's build-state retirement policy.
+ *
+ * The graphile-build patch owns the private state and cleanup implementation;
+ * this CNC-owned plugin controls whether and when that implementation runs.
+ */
+export const BuildStateRetirementPlugin: GraphileConfig.Plugin = {
+  name: 'BuildStateRetirementPlugin',
+  version: '1.0.0',
+  description: 'Retires construction-only state after schema validation',
+  schema: {
+    hooks: {
+      build(build) {
+        build.registerAfterSchemaValidation(() => retireBuildState(build));
+        return build;
+      },
+    },
+  },
+};
+
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      BuildStateRetirementPlugin: true;
+    }
+  }
+}

--- a/graphile/graphile-settings/src/plugins/index.ts
+++ b/graphile/graphile-settings/src/plugins/index.ts
@@ -7,6 +7,9 @@
 // Minimal preset - PostGraphile without Node/Relay features
 export { MinimalPreset } from './minimal-preset';
 
+// CNC-owned opt-in for retiring construction-only Graphile state
+export { BuildStateRetirementPlugin } from './build-state-retirement';
+
 // Custom inflector using inflekt library
 export {
   InflektPlugin,

--- a/graphile/graphile-settings/src/presets/constructive-preset.ts
+++ b/graphile/graphile-settings/src/presets/constructive-preset.ts
@@ -16,6 +16,7 @@ import { UploadPreset } from 'graphile-upload-plugin';
 
 import { getBucketProvisionerConnection } from '../bucket-provisioner-resolver';
 import {
+  BuildStateRetirementPlugin,
   ConflictDetectorPreset,
   EnableAllFilterColumnsPreset,
   InflectorLoggerPreset,
@@ -108,6 +109,7 @@ const DEFAULTS: Required<ConstructivePresetOptions> = {
  * - MetaSchemaPreset (_meta introspection)
  * - PgTypeMappingsPreset (email, url, etc.)
  * - RequiredInputPreset (@requiredInput support)
+ * - BuildStateRetirementPlugin (release construction-only state after validation)
  *
  * FLAG-CONTROLLED PRESETS:
  * - enableConnectionFilter  -> ConnectionFilterPreset, EnableAllFilterColumnsPreset
@@ -288,7 +290,8 @@ export function createConstructivePreset(
   }
 
   const preset: GraphileConfig.Preset = {
-    extends: presets
+    extends: presets,
+    plugins: [BuildStateRetirementPlugin]
   };
 
   if (disablePlugins.length > 0) {

--- a/packages/perf-harness/__tests__/build-state-retirement-suite.test.ts
+++ b/packages/perf-harness/__tests__/build-state-retirement-suite.test.ts
@@ -1,0 +1,42 @@
+import { makeBuildStateRetirementSuite } from '../src/build-state-retirement-suite';
+
+describe('build-state retirement benchmark registration', () => {
+  it('adds four schema-equivalent attribution cases through the generic suite API', () => {
+    const suite = makeBuildStateRetirementSuite({
+      schemas: ['cperf_example'],
+    });
+
+    expect(suite.name).toBe('scoped-introspection-and-build-state-retirement');
+    expect(suite.cases.map(({ name }) => name)).toEqual([
+      'stock',
+      'scoped',
+      'retire',
+      'scoped-retire',
+    ]);
+    expect(suite.cases.map(({ workerConfig }) => workerConfig)).toEqual([
+      {
+        mode: 'stock',
+        retireBuildState: false,
+        schemas: ['cperf_example'],
+      },
+      {
+        mode: 'scoped',
+        retireBuildState: false,
+        schemas: ['cperf_example'],
+      },
+      {
+        mode: 'stock',
+        retireBuildState: true,
+        schemas: ['cperf_example'],
+      },
+      {
+        mode: 'scoped',
+        retireBuildState: true,
+        schemas: ['cperf_example'],
+      },
+    ]);
+    expect(
+      new Set(suite.cases.map(({ expectedSchemaGroup }) => expectedSchemaGroup))
+    ).toEqual(new Set(['retirement-equivalence']));
+  });
+});

--- a/packages/perf-harness/src/build-state-retirement-suite.ts
+++ b/packages/perf-harness/src/build-state-retirement-suite.ts
@@ -1,0 +1,50 @@
+import type { BenchmarkSuiteDefinition } from './types';
+
+export interface BuildStateRetirementSuiteOptions {
+  schemas: string[];
+}
+
+/** Register the four attribution cases without loading ConstructivePreset. */
+export const makeBuildStateRetirementSuite = (
+  options: BuildStateRetirementSuiteOptions
+): BenchmarkSuiteDefinition => ({
+  name: 'scoped-introspection-and-build-state-retirement',
+  cases: [
+    {
+      name: 'stock',
+      workerConfig: {
+        mode: 'stock',
+        retireBuildState: false,
+        schemas: options.schemas,
+      },
+      expectedSchemaGroup: 'retirement-equivalence',
+    },
+    {
+      name: 'scoped',
+      workerConfig: {
+        mode: 'scoped',
+        retireBuildState: false,
+        schemas: options.schemas,
+      },
+      expectedSchemaGroup: 'retirement-equivalence',
+    },
+    {
+      name: 'retire',
+      workerConfig: {
+        mode: 'stock',
+        retireBuildState: true,
+        schemas: options.schemas,
+      },
+      expectedSchemaGroup: 'retirement-equivalence',
+    },
+    {
+      name: 'scoped-retire',
+      workerConfig: {
+        mode: 'scoped',
+        retireBuildState: true,
+        schemas: options.schemas,
+      },
+      expectedSchemaGroup: 'retirement-equivalence',
+    },
+  ],
+});

--- a/packages/perf-harness/src/index.ts
+++ b/packages/perf-harness/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+export * from './build-state-retirement-suite';
 export * from './fixture';
 export * from './metrics';
 export * from './process';

--- a/packages/perf-harness/src/scoped-introspection-worker.ts
+++ b/packages/perf-harness/src/scoped-introspection-worker.ts
@@ -5,8 +5,10 @@ import {
   makeSchema,
 } from 'graphile-build';
 import { defaultPreset as graphileBuildPgPreset } from 'graphile-build-pg';
+import type { GraphileConfig } from 'graphile-config';
 import { ScopedIntrospectionPreset } from 'graphile-scoped-introspection';
 import { makePgService as makeConstructivePgService } from 'graphile-settings';
+import { BuildStateRetirementPlugin } from 'graphile-settings/plugins';
 import { execute, lexicographicSortSchema, parse, printSchema } from 'graphql';
 import { makePgService as makePostGraphilePgService } from 'postgraphile/adaptors/pg';
 
@@ -21,7 +23,30 @@ import {
 
 interface ScopedWorkerConfig {
   mode: 'stock' | 'scoped';
+  retireBuildState?: boolean;
   schemas: string[];
+}
+
+let capturedBuild: GraphileBuild.BuildBase | undefined;
+
+const PerformanceHarnessBuildCapturePlugin: GraphileConfig.Plugin = {
+  name: 'PerformanceHarnessBuildCapturePlugin',
+  schema: {
+    hooks: {
+      build(build) {
+        capturedBuild = build;
+        return build;
+      },
+    },
+  },
+};
+
+declare global {
+  namespace GraphileConfig {
+    interface Plugins {
+      PerformanceHarnessBuildCapturePlugin: true;
+    }
+  }
 }
 
 const validateConfig = (value: unknown): ScopedWorkerConfig => {
@@ -42,7 +67,36 @@ const validateConfig = (value: unknown): ScopedWorkerConfig => {
       'scoped introspection worker requires a non-empty schemas array'
     );
   }
-  return { mode: config.mode, schemas: config.schemas };
+  if (
+    config.retireBuildState !== undefined &&
+    typeof config.retireBuildState !== 'boolean'
+  ) {
+    throw new Error(
+      'scoped introspection worker retireBuildState must be a boolean'
+    );
+  }
+  return {
+    mode: config.mode,
+    retireBuildState: config.retireBuildState ?? false,
+    schemas: config.schemas,
+  };
+};
+
+const getBuildState = (): 'released' | 'retained' => {
+  if (!capturedBuild) throw new Error('benchmark build was not captured');
+  try {
+    void capturedBuild.input;
+    return 'retained';
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      (error as Error & { code?: string }).code ===
+        'GRAPHILE_BUILD_STATE_RELEASED'
+    ) {
+      return 'released';
+    }
+    throw error;
+  }
 };
 
 const main = async (): Promise<void> => {
@@ -74,15 +128,21 @@ const main = async (): Promise<void> => {
 
     const result = await measureBenchmarkCase(
       caseName,
-      async () =>
-        makeSchema({
+      async () => {
+        capturedBuild = undefined;
+        return makeSchema({
           extends: [
             graphileBuildPreset,
             graphileBuildPgPreset,
             ...(config.mode === 'scoped' ? [ScopedIntrospectionPreset] : []),
           ],
+          plugins: [
+            PerformanceHarnessBuildCapturePlugin,
+            ...(config.retireBuildState ? [BuildStateRetirementPlugin] : []),
+          ],
           pgServices: [service],
-        }),
+        });
+      },
       async ({ schema }) => {
         const execution = await execute({
           schema,
@@ -94,12 +154,26 @@ const main = async (): Promise<void> => {
         ) {
           throw new Error('runtime verification query failed');
         }
+        const buildState = getBuildState();
+        const expectedBuildState = config.retireBuildState
+          ? 'released'
+          : 'retained';
+        const caseValidationErrors: string[] = [];
+        if (buildState !== expectedBuildState) {
+          caseValidationErrors.push(
+            `expected build state ${expectedBuildState}, received ${buildState}`
+          );
+        }
         const schemaText = printSchema(lexicographicSortSchema(schema));
         return {
           schemaHash: createHash('sha256').update(schemaText).digest('hex'),
           schemaTypeCount: Object.keys(schema.getTypeMap()).length,
           runtimeVerified: true as const,
-          metadata: { introspectionMode: config.mode },
+          caseValidation: {
+            passed: caseValidationErrors.length === 0,
+            errors: caseValidationErrors,
+          },
+          metadata: { buildState, introspectionMode: config.mode },
         };
       }
     );

--- a/patches/graphile-build-pg@5.1.3.patch
+++ b/patches/graphile-build-pg@5.1.3.patch
@@ -1,0 +1,56 @@
+diff --git a/dist/plugins/PgBasicsPlugin.js b/dist/plugins/PgBasicsPlugin.js
+index c31c42d380ce1431a89983ca3bc99f7e44aaeece..a19cda24f555b01ad837b7e52b9a3c4aab3d21e4 100644
+--- a/dist/plugins/PgBasicsPlugin.js
++++ b/dist/plugins/PgBasicsPlugin.js
+@@ -276,6 +276,11 @@ exports.PgBasicsPlugin = {
+                 };
+                 const resourceByCodecCacheUnstrict = new Map();
+                 const resourceByCodecCacheStrict = new Map();
++                build.registerBuildStateDisposer(() => {
++                    pgCodecMetaLookup.clear();
++                    resourceByCodecCacheUnstrict.clear();
++                    resourceByCodecCacheStrict.clear();
++                });
+                 const pgTableResource = (codec, strict = true) => {
+                     const resourceByCodecCache = strict
+                         ? resourceByCodecCacheStrict
+diff --git a/dist/plugins/PgCodecsPlugin.js b/dist/plugins/PgCodecsPlugin.js
+index bc9893d3f853f77ba5204c295840467db29cd279..8d8e5ceb0f38fde014474e646a61da0851fcdf20 100644
+--- a/dist/plugins/PgCodecsPlugin.js
++++ b/dist/plugins/PgCodecsPlugin.js
+@@ -535,8 +535,15 @@ exports.PgCodecsPlugin = {
+     schema: {
+         hooks: {
+             build(build) {
+-                build.allPgCodecs = new Set();
++                const allPgCodecs = new Set();
++                build.allPgCodecs = allPgCodecs;
+                 const lookup = Object.create(null);
++                build.registerBuildStateDisposer(() => {
++                    allPgCodecs.clear();
++                    for (const serviceName of Object.keys(lookup)) {
++                        delete lookup[serviceName];
++                    }
++                });
+                 build.getPgCodecByDatabaseName = (serviceName, schemaName, typeName) => {
+                     const codec = lookup[serviceName]?.[schemaName]?.[typeName];
+                     if (codec == null) {
+diff --git a/dist/plugins/PgPolymorphismPlugin.js b/dist/plugins/PgPolymorphismPlugin.js
+index b1892244aebf936cb697d9e664e6b3c2432e8c0e..6907c0d70640bebd87c93377c3e30f901b18efa9 100644
+--- a/dist/plugins/PgPolymorphismPlugin.js
++++ b/dist/plugins/PgPolymorphismPlugin.js
+@@ -554,6 +554,14 @@ exports.PgPolymorphismPlugin = {
+                     }
+                 }
+                 const pgCodecByPolymorphicUnionModeTypeName = Object.create(null);
++                build.registerBuildStateDisposer(() => {
++                    for (const key of Object.keys(pgResourcesByPolymorphicTypeName)) {
++                        delete pgResourcesByPolymorphicTypeName[key];
++                    }
++                    for (const key of Object.keys(pgCodecByPolymorphicUnionModeTypeName)) {
++                        delete pgCodecByPolymorphicUnionModeTypeName[key];
++                    }
++                });
+                 for (const codec of Object.values(pgRegistry.pgCodecs)) {
+                     if (!codec.polymorphism)
+                         continue;

--- a/patches/graphile-build@5.1.1.patch
+++ b/patches/graphile-build@5.1.1.patch
@@ -1,0 +1,396 @@
+diff --git a/dist/SchemaBuilder.js b/dist/SchemaBuilder.js
+index 551b884b615a094c50dec2a2c4acec5a4b303bcf..487c2b024536dabe171ed3c69ca671cab64a7008 100644
+--- a/dist/SchemaBuilder.js
++++ b/dist/SchemaBuilder.js
+@@ -8,7 +8,7 @@ const graphql_1 = require("grafast/graphql");
+ const graphile_config_1 = require("graphile-config");
+ const util_1 = require("util");
+ const behavior_ts_1 = require("./behavior.js");
+-const makeNewBuild_ts_1 = tslib_1.__importDefault(require("./makeNewBuild.js"));
++const makeNewBuild_ts_1 = tslib_1.__importStar(require("./makeNewBuild.js"));
+ const index_ts_1 = require("./newWithHooks/index.js");
+ const SchemaBuilderHooks_ts_1 = require("./SchemaBuilderHooks.js");
+ const utils_ts_1 = require("./utils.js");
+@@ -131,6 +131,8 @@ class SchemaBuilder extends events_1.EventEmitter {
+             scope: Object.create(null),
+             type: "build",
+         });
++        (0, makeNewBuild_ts_1.finalizeAfterSchemaValidationCallbackRegistration)(build);
++        (0, makeNewBuild_ts_1.finalizeBuildStateDisposalRegistration)(build);
+         // Bind all functions so they can be dereferenced
+         (0, utils_ts_1.bindAll)(build, Object.keys(build).filter((key) => typeof build[key] === "function"));
+         const finalBuild = build;
+@@ -182,6 +184,7 @@ class SchemaBuilder extends events_1.EventEmitter {
+         if (validationErrors.length) {
+             throw new AggregateError(validationErrors, `Schema construction failed due to ${validationErrors.length} validation failure(s). First failure was: ${String(validationErrors[0])}`);
+         }
++        (0, makeNewBuild_ts_1.runAfterSchemaValidationCallbacks)(build);
+         return schema;
+     }
+ }
+diff --git a/dist/behavior.js b/dist/behavior.js
+index 80d7ef5543ac45e3922ff9d16413d3372e4d0f1d..335a6ed232e0a7d71276b9ff9a348863fb6f0c8e 100644
+--- a/dist/behavior.js
++++ b/dist/behavior.js
+@@ -6,6 +6,7 @@ exports.joinResolvedBehaviors = joinResolvedBehaviors;
+ exports.isValidBehaviorString = isValidBehaviorString;
+ const grafast_1 = require("grafast");
+ const graphile_config_1 = require("graphile-config");
++const makeNewBuild_ts_1 = require("./makeNewBuild.js");
+ const NULL_BEHAVIOR = Object.freeze({
+     behaviorString: "",
+     stack: Object.freeze([]),
+@@ -202,6 +203,7 @@ class Behavior {
+         this[`${entityType}Behavior`] = (entity) => this.getBehaviorForEntity(entityType, entity).behaviorString;
+     }
+     assertEntity(entityType) {
++        (0, makeNewBuild_ts_1.assertBuildStateLive)(this.build, "build.behavior");
+         if (entityType === "string") {
+             throw new Error(`Runtime behaviors cannot be attached to strings, please use 'behavior.stringMatches' directly.`);
+         }
+@@ -216,6 +218,7 @@ class Behavior {
+      * @param filter - the behavior the plugin specifies
+      */
+     entityMatches(entityType, entity, filter) {
++        (0, makeNewBuild_ts_1.assertBuildStateLive)(this.build, "build.behavior.entityMatches");
+         if (!this.behaviorRegistry[filter]) {
+             // DIAGNOSTIC: enable for all filters
+             /*
+@@ -317,6 +320,7 @@ class Behavior {
+         return behavior;
+     }
+     getPreferencesAppliedBehaviors(entityType, inferredBehavior, overrideBehavior) {
++        (0, makeNewBuild_ts_1.assertBuildStateLive)(this.build, "build.behavior.getPreferencesAppliedBehaviors");
+         const defaultBehavior = this.getDefaultBehaviorFor(entityType);
+         const inferredBehaviorWithPreferencesApplied = multiplyBehavior(defaultBehavior, inferredBehavior.behaviorString, entityType);
+         const behaviorString = joinBehaviors([
+@@ -342,6 +346,7 @@ class Behavior {
+     }
+     /** @deprecated Please use entityMatches or stringMatches instead */
+     matches(localBehaviorSpecsString, filter, defaultBehavior = "") {
++        (0, makeNewBuild_ts_1.assertBuildStateLive)(this.build, "build.behavior.matches");
+         let err;
+         try {
+             throw new Error("Deprecated call happened here");
+@@ -371,6 +376,7 @@ class Behavior {
+     callbacks, ...args) {
++        (0, makeNewBuild_ts_1.assertBuildStateLive)(this.build, "build.behavior.resolveBehavior");
+         let behaviorString = initialBehavior.behaviorString;
+         const stack = [...initialBehavior.stack];
+         for (const [source, rawG] of callbacks) {
+             const oldBehavior = behaviorString;
+             const g = typeof rawG === "string" ? [rawG] : rawG;
+@@ -425,6 +431,7 @@ class Behavior {
+         }
+     }
+     getDefaultBehaviorFor(entityType) {
++        (0, makeNewBuild_ts_1.assertBuildStateLive)(this.build, "build.behavior.getDefaultBehaviorFor");
+         if (!this._defaultBehaviorByEntityTypeCache.has(entityType)) {
+             const supportedBehaviors = new Set();
+             for (const [behaviorString, spec] of Object.entries(this.behaviorRegistry)) {
+@@ -455,6 +462,29 @@ class Behavior {
+         }
+         return this._defaultBehaviorByEntityTypeCache.get(entityType);
+     }
++    /** @internal */
++    releaseBuildState() {
++        this._defaultBehaviorByEntityTypeCache.clear();
++        this.behaviorEntityTypes.length = 0;
++        for (const key of Object.keys(this.behaviorEntities)) {
++            const behaviorEntity = this.behaviorEntities[key];
++            behaviorEntity.listCache.clear();
++            behaviorEntity.inferredCache.clear();
++            behaviorEntity.overrideCache.clear();
++            behaviorEntity.fullCache.clear();
++            behaviorEntity.inferredBehaviorCallbacks.length = 0;
++            behaviorEntity.overrideBehaviorCallbacks.length = 0;
++            for (const behaviorString of Object.keys(behaviorEntity.behaviorStrings)) {
++                delete behaviorEntity.behaviorStrings[behaviorString];
++            }
++        }
++        for (const key of Object.keys(this.behaviorRegistry)) {
++            delete this.behaviorRegistry[key];
++        }
++        if (Array.isArray(this.globalDefaultBehavior.stack)) {
++            this.globalDefaultBehavior.stack.length = 0;
++        }
++    }
+ }
+ exports.Behavior = Behavior;
+ /**
+diff --git a/dist/global.d.ts b/dist/global.d.ts
+index 0ed37abdfdba94161735a1e0526e50d878458be9..761602b45cd5a5f68bffb34053e523a6199db422 100644
+--- a/dist/global.d.ts
++++ b/dist/global.d.ts
+@@ -211,6 +211,22 @@ declare global {
+              * influence what types/fields/etc are added to the GraphQL schema.
+              */
+             input: BuildInput;
++            /**
++             * Registers a synchronous callback that will be invoked after the schema
++             * has been constructed and validated successfully.
++             *
++             * Callbacks may only be registered from the `build` hook. They are
++             * invoked at most once, in registration order.
++             */
++            registerAfterSchemaValidation(callback: () => void): void;
++            /**
++             * Registers cleanup for state owned by a build-time plugin.
++             *
++             * Disposers may only be registered from the `build` hook. When CNC
++             * enables build-state retirement, they run once in reverse registration
++             * order. A disposer should only access state owned by its plugin.
++             */
++            registerBuildStateDisposer(disposer: () => void): void;
+             /**
+              * Returns true if `Build.versions` contains an entry for `packageName`
+              * compatible with the version range `range`, false otherwise.
+diff --git a/dist/makeNewBuild.js b/dist/makeNewBuild.js
+index 63186e206e044bbfd76d04d9159a3e4d7d77ee70..aad97a99ee36cbe0f92c38edd58dec270fe3c503 100644
+--- a/dist/makeNewBuild.js
++++ b/dist/makeNewBuild.js
+@@ -1,5 +1,9 @@
+ "use strict";
+ Object.defineProperty(exports, "__esModule", { value: true });
++exports.finalizeAfterSchemaValidationCallbackRegistration = finalizeAfterSchemaValidationCallbackRegistration;
++exports.runAfterSchemaValidationCallbacks = runAfterSchemaValidationCallbacks;
++exports.finalizeBuildStateDisposalRegistration = finalizeBuildStateDisposalRegistration;
++exports.assertBuildStateLive = assertBuildStateLive;
+ exports.default = makeNewBuild;
+ const tslib_1 = require("tslib");
+ require("./global.js");
+@@ -11,6 +15,94 @@ const extend_ts_1 = tslib_1.__importStar(require("./extend.js"));
+ const utils_ts_1 = require("./utils.js");
+ const version_ts_1 = require("./version.js");
+ const BUILTINS = ["Int", "Float", "Boolean", "ID", "String"];
++const BUILD_STATE_RELEASED_ERROR_CODE = "GRAPHILE_BUILD_STATE_RELEASED";
++const RETIRE_BUILD_STATE = Symbol.for("constructive.graphile-build.retireBuildState");
++const afterSchemaValidationStates = new WeakMap();
++const buildStateDisposals = new WeakMap();
++/** @internal */
++function finalizeAfterSchemaValidationCallbackRegistration(build) {
++    const state = afterSchemaValidationStates.get(build);
++    if (state?.status !== "registering") {
++        throw new Error("After-schema-validation callback registration was already finalized");
++    }
++    state.status = "ready";
++}
++/** @internal */
++function runAfterSchemaValidationCallbacks(build) {
++    const state = afterSchemaValidationStates.get(build);
++    if (!state || state.status === "complete") {
++        return;
++    }
++    if (state.status !== "ready") {
++        throw new Error("After-schema-validation callbacks cannot run before registration is finalized");
++    }
++    state.status = "running";
++    const callbacks = state.callbacks.splice(0);
++    try {
++        for (const callback of callbacks) {
++            callback();
++        }
++    }
++    finally {
++        state.status = "complete";
++    }
++}
++function buildStateReleasedError(api) {
++    const error = new Error(`Cannot use ${api} after Graphile build state has been released`);
++    error.code = BUILD_STATE_RELEASED_ERROR_CODE;
++    return error;
++}
++/** @internal */
++function assertBuildStateLive(build, api) {
++    const state = buildStateDisposals.get(build);
++    if (state?.status === "releasing" || state?.status === "released") {
++        throw buildStateReleasedError(api);
++    }
++}
++/** @internal */
++function finalizeBuildStateDisposalRegistration(build) {
++    const state = buildStateDisposals.get(build);
++    if (state?.status !== "registering") {
++        throw new Error("Build state disposal registration was already finalized");
++    }
++    state.status = "live";
++}
++/** @internal */
++function retireBuildState(build) {
++    const state = buildStateDisposals.get(build);
++    if (state?.status !== "live") {
++        return false;
++    }
++    state.status = "releasing";
++    const errors = [];
++    const disposers = state.disposers.splice(0).reverse();
++    for (const disposer of disposers) {
++        try {
++            disposer();
++        }
++        catch (error) {
++            errors.push(error);
++        }
++    }
++    try {
++        state.releaseCore?.();
++    }
++    catch (error) {
++        errors.push(error);
++    }
++    try {
++        build.behavior.releaseBuildState();
++    }
++    catch (error) {
++        errors.push(error);
++    }
++    state.status = "released";
++    state.releaseCore = null;
++    if (errors.length > 0) {
++        throw new AggregateError(errors, `Failed to retire Graphile build state (${errors.length} disposal error${errors.length === 1 ? "" : "s"})`);
++    }
++    return true;
++}
+ /** Have we warned the user they're using the 5-arg deprecated registerObjectType call? */
+ let registerObjectType5argsDeprecatedWarned = false;
+ /**
+@@ -18,15 +110,16 @@ let registerObjectType5argsDeprecatedWarned = false;
+  */
+ function makeNewBuild(builder, input, inflection) {
+     const lib = builder.resolvedPreset.lib ?? {};
+-    const building = new Set();
+-    const allTypes = {
++    let inputState = input;
++    let building = new Set();
++    let allTypes = {
+         Int: graphql_1.GraphQLInt,
+         Float: graphql_1.GraphQLFloat,
+         String: graphql_1.GraphQLString,
+         Boolean: graphql_1.GraphQLBoolean,
+         ID: graphql_1.GraphQLID,
+     };
+-    const allTypesSources = {
++    let allTypesSources = {
+         Int: "GraphQL Built-in",
+         Float: "GraphQL Built-in",
+         String: "GraphQL Built-in",
+@@ -36,10 +129,11 @@ function makeNewBuild(builder, input, inflection) {
+     /**
+      * Where the type factories are; so we don't construct types until they're needed.
+      */
+-    const typeRegistry = Object.create(null);
+-    const scopeByType = new Map();
++    let typeRegistry = Object.create(null);
++    let scopeByType = new Map();
+     // TODO: allow registering a previously constructed type.
+     function register(klass, typeName, scope, specGenerator, origin) {
++        assertBuildStateLive(build, "build.register*");
+         if (!this.status.isBuildPhaseComplete || this.status.isInitPhaseComplete) {
+             throw new Error("Types may only be registered in the 'init' phase");
+         }
+@@ -83,7 +177,36 @@ function makeNewBuild(builder, input, inflection) {
+             graphql: lib.graphql.version,
+             "graphile-build": version_ts_1.version,
+         },
+-        input,
++        get input() {
++            assertBuildStateLive(build, "build.input");
++            return inputState;
++        },
++        registerAfterSchemaValidation(callback) {
++            const state = afterSchemaValidationStates.get(build);
++            if (state?.status !== "registering" ||
++                build.status.currentHookEvent !== "build") {
++                throw new Error("After-schema-validation callbacks may only be registered during the 'build' hook");
++            }
++            if (typeof callback !== "function") {
++                throw new TypeError("build.registerAfterSchemaValidation requires a function");
++            }
++            state.callbacks.push(callback);
++        },
++        registerBuildStateDisposer(disposer) {
++            const state = buildStateDisposals.get(build);
++            if (state?.status !== "registering" ||
++                build.status.currentHookEvent !== "build") {
++                assertBuildStateLive(build, "build.registerBuildStateDisposer");
++                throw new Error("Build state disposers may only be registered during the 'build' hook");
++            }
++            if (typeof disposer !== "function") {
++                throw new TypeError("build.registerBuildStateDisposer requires a function");
++            }
++            state.disposers.push(disposer);
++        },
++        [RETIRE_BUILD_STATE]() {
++            return retireBuildState(build);
++        },
+         hasVersion(packageName, range, options = { includePrerelease: true }) {
+             const packageVersion = this.versions[packageName];
+             if (!packageVersion)
+@@ -119,9 +242,13 @@ function makeNewBuild(builder, input, inflection) {
+             }
+         },
+         getAllTypes() {
++            assertBuildStateLive(build, "build.getAllTypes");
+             return allTypes;
+         },
+-        scopeByType,
++        get scopeByType() {
++            assertBuildStateLive(build, "build.scopeByType");
++            return scopeByType;
++        },
+         inflection,
+         handleRecoverableError(e) {
+             e["recoverable"] = true;
+@@ -187,6 +314,7 @@ function makeNewBuild(builder, input, inflection) {
+         },
+         __postInitAssertions: [],
+         assertTypeName(typeName, deferrable = false) {
++            assertBuildStateLive(build, "build.assertTypeName");
+             if (!this.status.isBuildPhaseComplete) {
+                 throw new Error("Must not call build.assertTypeName before 'build' phase is complete; use 'init' phase instead");
+             }
+@@ -208,6 +336,7 @@ function makeNewBuild(builder, input, inflection) {
+             }
+         },
+         getTypeMetaByName(typeName) {
++            assertBuildStateLive(build, "build.getTypeMetaByName");
+             if (!this.status.isBuildPhaseComplete) {
+                 throw new Error("Must not call build.getTypeMetaByName before 'build' phase is complete; use 'init' phase instead");
+             }
+@@ -254,6 +383,7 @@ function makeNewBuild(builder, input, inflection) {
+             return null;
+         },
+         getTypeByName(typeName) {
++            assertBuildStateLive(build, "build.getTypeByName");
+             if (currentTypeDetails &&
+                 currentTypeDetails.klass !== graphql_1.GraphQLScalarType &&
+                 !BUILTINS.includes(typeName)) {
+@@ -385,6 +515,28 @@ style for these configuration options (e.g. change \`interfaces: \
+         },
+         _pluginMeta: Object.create(null),
+     };
++    afterSchemaValidationStates.set(build, {
++        status: "registering",
++        callbacks: [],
++    });
++    buildStateDisposals.set(build, {
++        status: "registering",
++        disposers: [],
++        releaseCore() {
++            inputState = undefined;
++            building?.clear();
++            building = undefined;
++            allTypes = undefined;
++            allTypesSources = undefined;
++            typeRegistry = undefined;
++            scopeByType?.clear();
++            scopeByType = undefined;
++            build.__postInitAssertions.length = 0;
++            for (const key of Object.keys(build._pluginMeta)) {
++                delete build._pluginMeta[key];
++            }
++        },
++    });
+     return build;
+ }
+ let currentTypeDetails = null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,14 @@ overrides:
 
 packageExtensionsChecksum: sha256-x8B4zkJ4KLRX+yspUWxuggXWlz6zrBLSIh72pNhpPiE=
 
+patchedDependencies:
+  graphile-build-pg@5.1.3:
+    hash: 48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c
+    path: patches/graphile-build-pg@5.1.3.patch
+  graphile-build@5.1.1:
+    hash: 3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c
+    path: patches/graphile-build@5.1.1.patch
+
 importers:
 
   .:
@@ -371,22 +379,22 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
       graphile-utils:
         specifier: 5.0.3
-        version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+        version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql:
         specifier: 16.13.0
         version: 16.13.0
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(138876491c004694bff1843ee79c8872)
+        version: 5.1.4(e1810b1f3906d1d89fe524b7dc6976e9)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -406,10 +414,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -421,7 +429,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(138876491c004694bff1843ee79c8872)
+        version: 5.1.4(e1810b1f3906d1d89fe524b7dc6976e9)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -462,7 +470,7 @@ importers:
         version: link:../../postgres/pg-cache/dist
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(b3fb9399b7b000ca872a8f427cb73d08)
+        version: 5.1.4(46df385dabea1be3930bf251e0f0e48a)
     devDependencies:
       '@types/express':
         specifier: ^5.0.6
@@ -485,10 +493,10 @@ importers:
         version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -503,7 +511,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(f51a9bb2feb8b06fca136f1c2a1a2f6a)
+        version: 5.1.4(95e408361acbe6993a4718524ef81ab6)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -535,10 +543,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -582,10 +590,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -597,7 +605,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(f282a162d8bd20a217e08c60f5396af8)
+        version: 5.1.4(a962ae0e44fb7eb7e33e93480f549228)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -632,10 +640,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -647,7 +655,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(f282a162d8bd20a217e08c60f5396af8)
+        version: 5.1.4(a962ae0e44fb7eb7e33e93480f549228)
     devDependencies:
       '@types/accept-language-parser':
         specifier: ^1.5.4
@@ -691,10 +699,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-cache:
         specifier: workspace:^
         version: link:../graphile-cache/dist
@@ -703,7 +711,7 @@ importers:
         version: 1.1.0
       graphile-utils:
         specifier: 5.0.3
-        version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+        version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql:
         specifier: 16.13.0
         version: 16.13.0
@@ -712,7 +720,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(138876491c004694bff1843ee79c8872)
+        version: 5.1.4(e1810b1f3906d1d89fe524b7dc6976e9)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -744,10 +752,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -759,7 +767,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(138876491c004694bff1843ee79c8872)
+        version: 5.1.4(e1810b1f3906d1d89fe524b7dc6976e9)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -782,10 +790,10 @@ importers:
     dependencies:
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -794,7 +802,7 @@ importers:
         version: 16.13.0
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(f282a162d8bd20a217e08c60f5396af8)
+        version: 5.1.4(a962ae0e44fb7eb7e33e93480f549228)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -814,10 +822,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -832,7 +840,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(138876491c004694bff1843ee79c8872)
+        version: 5.1.4(e1810b1f3906d1d89fe524b7dc6976e9)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -858,10 +866,10 @@ importers:
         version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -873,7 +881,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(f282a162d8bd20a217e08c60f5396af8)
+        version: 5.1.4(a962ae0e44fb7eb7e33e93480f549228)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -893,10 +901,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -908,7 +916,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(f51a9bb2feb8b06fca136f1c2a1a2f6a)
+        version: 5.1.4(95e408361acbe6993a4718524ef81ab6)
     devDependencies:
       '@types/geojson':
         specifier: ^7946.0.14
@@ -949,16 +957,16 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
       graphile-utils:
         specifier: 5.0.3
-        version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+        version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql:
         specifier: 16.13.0
         version: 16.13.0
@@ -970,7 +978,7 @@ importers:
         version: link:../../uploads/mime-bytes/dist
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(138876491c004694bff1843ee79c8872)
+        version: 5.1.4(e1810b1f3906d1d89fe524b7dc6976e9)
     devDependencies:
       '@constructive-io/s3-utils':
         specifier: workspace:^
@@ -990,10 +998,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1008,7 +1016,7 @@ importers:
         version: 8.21.0
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(b3fb9399b7b000ca872a8f427cb73d08)
+        version: 5.1.4(46df385dabea1be3930bf251e0f0e48a)
     devDependencies:
       '@types/pg':
         specifier: ^8.20.4
@@ -1034,22 +1042,22 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
       graphile-utils:
         specifier: 5.0.3
-        version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+        version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql:
         specifier: 16.13.0
         version: 16.13.0
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(138876491c004694bff1843ee79c8872)
+        version: 5.1.4(e1810b1f3906d1d89fe524b7dc6976e9)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -1066,10 +1074,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1115,7 +1123,7 @@ importers:
         version: link:../../postgres/pgsql-test/dist
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(b3fb9399b7b000ca872a8f427cb73d08)
+        version: 5.1.4(46df385dabea1be3930bf251e0f0e48a)
     publishDirectory: dist
 
   graphile/graphile-schema:
@@ -1125,7 +1133,7 @@ importers:
         version: 4.3.1
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1160,10 +1168,10 @@ importers:
         version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1182,7 +1190,7 @@ importers:
         version: 0.3.0
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(f282a162d8bd20a217e08c60f5396af8)
+        version: 5.1.4(a962ae0e44fb7eb7e33e93480f549228)
     publishDirectory: dist
 
   graphile/graphile-search:
@@ -1192,10 +1200,10 @@ importers:
         version: 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1210,7 +1218,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(f51a9bb2feb8b06fca136f1c2a1a2f6a)
+        version: 5.1.4(95e408361acbe6993a4718524ef81ab6)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -1293,10 +1301,10 @@ importers:
         version: link:../graphile-bucket-provisioner-plugin/dist
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-bulk-mutations:
         specifier: workspace:^
         version: link:../graphile-bulk-mutations/dist
@@ -1344,7 +1352,7 @@ importers:
         version: link:../graphile-upload-plugin/dist
       graphile-utils:
         specifier: 5.0.3
-        version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+        version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql:
         specifier: 16.13.0
         version: 16.13.0
@@ -1371,7 +1379,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(b3fb9399b7b000ca872a8f427cb73d08)
+        version: 5.1.4(46df385dabea1be3930bf251e0f0e48a)
       request-ip:
         specifier: ^3.3.0
         version: 3.3.0
@@ -1412,10 +1420,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1453,10 +1461,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1474,7 +1482,7 @@ importers:
         version: link:../../postgres/pgsql-test/dist
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(b3fb9399b7b000ca872a8f427cb73d08)
+        version: 5.1.4(46df385dabea1be3930bf251e0f0e48a)
     devDependencies:
       '@types/pg':
         specifier: ^8.20.4
@@ -1491,10 +1499,10 @@ importers:
     dependencies:
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1503,7 +1511,7 @@ importers:
         version: 16.13.0
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(f51a9bb2feb8b06fca136f1c2a1a2f6a)
+        version: 5.1.4(95e408361acbe6993a4718524ef81ab6)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -1642,10 +1650,10 @@ importers:
         version: 1.0.1(@types/node@25.9.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(ws@8.20.1)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-cache:
         specifier: workspace:^
         version: link:../../graphile/graphile-cache/dist
@@ -1657,7 +1665,7 @@ importers:
         version: link:../../graphile/graphile-settings/dist
       graphile-utils:
         specifier: 5.0.3
-        version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+        version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql:
         specifier: 16.13.0
         version: 16.13.0
@@ -1675,7 +1683,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(b3fb9399b7b000ca872a8f427cb73d08)
+        version: 5.1.4(46df385dabea1be3930bf251e0f0e48a)
     devDependencies:
       '@types/express':
         specifier: ^5.0.6
@@ -1748,7 +1756,7 @@ importers:
         version: link:../../postgres/pg-env/dist
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(b3fb9399b7b000ca872a8f427cb73d08)
+        version: 5.1.4(46df385dabea1be3930bf251e0f0e48a)
     devDependencies:
       '@types/express':
         specifier: ^5.0.6
@@ -1892,7 +1900,7 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1913,7 +1921,7 @@ importers:
         version: 11.2.7
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(b3fb9399b7b000ca872a8f427cb73d08)
+        version: 5.1.4(46df385dabea1be3930bf251e0f0e48a)
     devDependencies:
       makage:
         specifier: ^0.3.0
@@ -1930,10 +1938,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -1957,7 +1965,7 @@ importers:
         version: 8.20.0
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(cf7ef086788d1d3f644d1dc7345cb344)
+        version: 5.1.4(02976047f7d1e742450945456790fe68)
       ws:
         specifier: ^8.20.0
         version: 8.20.1
@@ -2043,10 +2051,10 @@ importers:
         version: 1.0.1(@types/node@25.9.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(ws@8.20.1)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-cache:
         specifier: workspace:^
         version: link:../../graphile/graphile-cache/dist
@@ -2061,7 +2069,7 @@ importers:
         version: link:../../graphile/graphile-settings/dist
       graphile-utils:
         specifier: 5.0.3
-        version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+        version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql:
         specifier: 16.13.0
         version: 16.13.0
@@ -2088,7 +2096,7 @@ importers:
         version: 5.0.1
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(b3fb9399b7b000ca872a8f427cb73d08)
+        version: 5.1.4(46df385dabea1be3930bf251e0f0e48a)
       request-ip:
         specifier: ^3.3.0
         version: 3.3.0
@@ -2239,10 +2247,10 @@ importers:
         version: 1.1.2(graphql@16.13.0)
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -2266,7 +2274,7 @@ importers:
         version: link:../../postgres/pgsql-test/dist
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(b3fb9399b7b000ca872a8f427cb73d08)
+        version: 5.1.4(46df385dabea1be3930bf251e0f0e48a)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -2658,10 +2666,10 @@ importers:
     dependencies:
       graphile-build:
         specifier: 5.1.1
-        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+        version: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-build-pg:
         specifier: 5.1.3
-        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+        version: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
@@ -2679,7 +2687,7 @@ importers:
         version: 8.21.0
       postgraphile:
         specifier: 5.1.4
-        version: 5.1.4(f282a162d8bd20a217e08c60f5396af8)
+        version: 5.1.4(a962ae0e44fb7eb7e33e93480f549228)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -15729,13 +15737,13 @@ snapshots:
       - supports-color
       - use-sync-external-store
 
-  graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1):
+  graphile-build-pg@5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1):
     dependencies:
       '@dataplan/pg': 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)
       '@types/node': 22.19.19
       debug: 4.4.3(supports-color@5.5.0)
       grafast: 1.1.2(graphql@16.13.0)
-      graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+      graphile-build: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-config: 1.1.0
       graphql: 16.13.0
       jsonwebtoken: 9.0.3
@@ -15748,13 +15756,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1):
+  graphile-build-pg@5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1):
     dependencies:
       '@dataplan/pg': 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       '@types/node': 22.19.19
       debug: 4.4.3(supports-color@5.5.0)
       grafast: 1.1.2(graphql@16.13.0)
-      graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+      graphile-build: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-config: 1.1.0
       graphql: 16.13.0
       jsonwebtoken: 9.0.3
@@ -15767,7 +15775,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0):
+  graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0):
     dependencies:
       '@types/node': 22.19.19
       '@types/pluralize': 0.0.33
@@ -15797,35 +15805,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  graphile-utils@5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1):
+  graphile-utils@5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1):
     dependencies:
       '@dataplan/pg': 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)
       debug: 4.4.3(supports-color@5.5.0)
       grafast: 1.1.2(graphql@16.13.0)
-      graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+      graphile-build: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-config: 1.1.0
       graphql: 16.13.0
       json5: 2.2.3
       tamedevil: 0.1.1
       tslib: 2.8.1
     optionalDependencies:
-      graphile-build-pg: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1)
+      graphile-build-pg: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  graphile-utils@5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1):
+  graphile-utils@5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1):
     dependencies:
       '@dataplan/pg': 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
       debug: 4.4.3(supports-color@5.5.0)
       grafast: 1.1.2(graphql@16.13.0)
-      graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+      graphile-build: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
       graphile-config: 1.1.0
       graphql: 16.13.0
       json5: 2.2.3
       tamedevil: 0.1.1
       tslib: 2.8.1
     optionalDependencies:
-      graphile-build-pg: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-build-pg: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -17827,61 +17835,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postgraphile@5.1.4(138876491c004694bff1843ee79c8872):
-    dependencies:
-      '@dataplan/json': 1.0.1(grafast@1.1.2(graphql@16.13.0))
-      '@dataplan/pg': 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
-      '@graphile/lru': 5.0.0
-      '@types/node': 22.19.19
-      '@types/pg': 8.20.4
-      debug: 4.4.3(supports-color@5.5.0)
-      grafast: 1.1.2(graphql@16.13.0)
-      grafserv: 1.0.1(@types/node@22.19.15)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(ws@8.20.1)
-      graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
-      graphile-build-pg: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
-      graphile-config: 1.1.0
-      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
-      graphql: 16.13.0
-      iterall: 1.3.0
-      jsonwebtoken: 9.0.3
-      pg: 8.21.0
-      pg-sql2: 5.0.1
-      tamedevil: 0.1.1
-      tslib: 2.8.1
-      ws: 8.20.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  postgraphile@5.1.4(b3fb9399b7b000ca872a8f427cb73d08):
-    dependencies:
-      '@dataplan/json': 1.0.1(grafast@1.1.2(graphql@16.13.0))
-      '@dataplan/pg': 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
-      '@graphile/lru': 5.0.0
-      '@types/node': 22.19.19
-      '@types/pg': 8.20.4
-      debug: 4.4.3(supports-color@5.5.0)
-      grafast: 1.1.2(graphql@16.13.0)
-      grafserv: 1.0.1(@types/node@25.9.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(ws@8.20.1)
-      graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
-      graphile-build-pg: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
-      graphile-config: 1.1.0
-      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
-      graphql: 16.13.0
-      iterall: 1.3.0
-      jsonwebtoken: 9.0.3
-      pg: 8.21.0
-      pg-sql2: 5.0.1
-      tamedevil: 0.1.1
-      tslib: 2.8.1
-      ws: 8.20.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  postgraphile@5.1.4(cf7ef086788d1d3f644d1dc7345cb344):
+  postgraphile@5.1.4(02976047f7d1e742450945456790fe68):
     dependencies:
       '@dataplan/json': 1.0.1(grafast@1.1.2(graphql@16.13.0))
       '@dataplan/pg': 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)
@@ -17891,10 +17845,10 @@ snapshots:
       debug: 4.4.3(supports-color@5.5.0)
       grafast: 1.1.2(graphql@16.13.0)
       grafserv: 1.0.1(@types/node@25.9.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(ws@8.20.1)
-      graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
-      graphile-build-pg: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1)
+      graphile-build: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+      graphile-build-pg: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1)
       graphile-config: 1.1.0
-      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.20.0)(tamedevil@0.1.1))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql: 16.13.0
       iterall: 1.3.0
       jsonwebtoken: 9.0.3
@@ -17908,7 +17862,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  postgraphile@5.1.4(f282a162d8bd20a217e08c60f5396af8):
+  postgraphile@5.1.4(46df385dabea1be3930bf251e0f0e48a):
     dependencies:
       '@dataplan/json': 1.0.1(grafast@1.1.2(graphql@16.13.0))
       '@dataplan/pg': 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
@@ -17917,11 +17871,11 @@ snapshots:
       '@types/pg': 8.20.4
       debug: 4.4.3(supports-color@5.5.0)
       grafast: 1.1.2(graphql@16.13.0)
-      grafserv: 1.0.1(@types/node@22.19.19)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(ws@8.20.1)
-      graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
-      graphile-build-pg: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      grafserv: 1.0.1(@types/node@25.9.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(ws@8.20.1)
+      graphile-build: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+      graphile-build-pg: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config: 1.1.0
-      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql: 16.13.0
       iterall: 1.3.0
       jsonwebtoken: 9.0.3
@@ -17935,7 +17889,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  postgraphile@5.1.4(f51a9bb2feb8b06fca136f1c2a1a2f6a):
+  postgraphile@5.1.4(95e408361acbe6993a4718524ef81ab6):
     dependencies:
       '@dataplan/json': 1.0.1(grafast@1.1.2(graphql@16.13.0))
       '@dataplan/pg': 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
@@ -17945,10 +17899,64 @@ snapshots:
       debug: 4.4.3(supports-color@5.5.0)
       grafast: 1.1.2(graphql@16.13.0)
       grafserv: 1.0.1(@types/node@22.19.11)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(ws@8.20.1)
-      graphile-build: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
-      graphile-build-pg: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-build: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+      graphile-build-pg: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
       graphile-config: 1.1.0
-      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+      graphql: 16.13.0
+      iterall: 1.3.0
+      jsonwebtoken: 9.0.3
+      pg: 8.21.0
+      pg-sql2: 5.0.1
+      tamedevil: 0.1.1
+      tslib: 2.8.1
+      ws: 8.20.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  postgraphile@5.1.4(a962ae0e44fb7eb7e33e93480f549228):
+    dependencies:
+      '@dataplan/json': 1.0.1(grafast@1.1.2(graphql@16.13.0))
+      '@dataplan/pg': 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      '@graphile/lru': 5.0.0
+      '@types/node': 22.19.19
+      '@types/pg': 8.20.4
+      debug: 4.4.3(supports-color@5.5.0)
+      grafast: 1.1.2(graphql@16.13.0)
+      grafserv: 1.0.1(@types/node@22.19.19)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(ws@8.20.1)
+      graphile-build: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+      graphile-build-pg: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-config: 1.1.0
+      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
+      graphql: 16.13.0
+      iterall: 1.3.0
+      jsonwebtoken: 9.0.3
+      pg: 8.21.0
+      pg-sql2: 5.0.1
+      tamedevil: 0.1.1
+      tslib: 2.8.1
+      ws: 8.20.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  postgraphile@5.1.4(e1810b1f3906d1d89fe524b7dc6976e9):
+    dependencies:
+      '@dataplan/json': 1.0.1(grafast@1.1.2(graphql@16.13.0))
+      '@dataplan/pg': 1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)
+      '@graphile/lru': 5.0.0
+      '@types/node': 22.19.19
+      '@types/pg': 8.20.4
+      debug: 4.4.3(supports-color@5.5.0)
+      grafast: 1.1.2(graphql@16.13.0)
+      grafserv: 1.0.1(@types/node@22.19.15)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(ws@8.20.1)
+      graphile-build: 5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+      graphile-build-pg: 5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-config: 1.1.0
+      graphile-utils: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(patch_hash=48374282c0d9ca454c47e16f2e7dcc87275b6f4e8907eb78a2d005cdb3ddfb7c)(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(patch_hash=3988d3e8cb6efb11e654b6404b6b85d14e992d92a9f2316f3c7b8c0beaebed7c)(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
       graphql: 16.13.0
       iterall: 1.3.0
       jsonwebtoken: 9.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -105,6 +105,10 @@ packageExtensions:
     dependencies:
       '@jest/test-sequencer': ^29.7.0
 
+patchedDependencies:
+  'graphile-build-pg@5.1.3': patches/graphile-build-pg@5.1.3.patch
+  'graphile-build@5.1.1': patches/graphile-build@5.1.1.patch
+
 # The only dependencies permitted to run install scripts.
 allowBuilds:
   "@launchql/protobufjs": true


### PR DESCRIPTION
## Summary

This is the third PR in the replacement performance stack:

1. #1716 — generic fresh-process performance harness
2. #1719 — zero-patch CNC scoped introspection package
3. this PR — CNC-owned build-state retirement

It adds an opt-in `BuildStateRetirementPlugin` in normal CNC source. `ConstructivePreset` installs that plugin explicitly; Graphile's `defaultPreset` remains unchanged.

## Architecture boundary

Crystal #1 remains an independent upstream proposal for only the neutral `build.registerAfterSchemaValidation(callback)` lifecycle API. The `graphile-build` dist patch here mirrors that API because the current installed release does not contain it.

All concrete retirement behavior stays in CNC:

- normal CNC source decides whether and when retirement runs;
- the `graphile-build` pnpm patch owns the private retirement state machine, core/Behavior cleanup, disposer registration, fail-closed guards, aggregate-error handling, and `GRAPHILE_BUILD_STATE_RELEASED`;
- the `graphile-build-pg` pnpm patch adds owner cleanup only for PgBasics, PgCodecs, and PgPolymorphism;
- normal CNC owners clean up graphile-search and graphile-connection-filter state;
- graphile-meta snapshots runtime metadata onto the finalized schema before build state is retired.

This PR is rebased onto #1719's independent `graphile-scoped-introspection` package. It does not modify that package or reintroduce the removed `@dataplan/pg` and `pg-introspection` patches. The performance worker continues to import `ScopedIntrospectionPreset` directly from its owning package.

No `ReleaseBuildStatePlugin` is imported or exported. No retirement behavior is added to Graphile's default preset. No pg-many-to-many change is included, and the graphile-build-pg patch contains no scoped-introspection hunks.

## Performance harness integration

The generic harness from #1716 is extended with four attribution cases without loading `ConstructivePreset`:

- `stock`
- `scoped`
- `retire`
- `scoped-retire`

Each arm installs only its requested scoped-introspection and/or retirement plugin.

## Validation

- graphile-scoped-introspection: 6 suites / 18 tests
- graphile-settings non-integration suites: 8 suites / 56 tests
- build-state retirement contracts cover opt-in/default behavior, validation failure, reverse disposer order, aggregate errors/fail-closed state, guards, and runtime execution
- graphile-build-pg owner cleanup: PgBasics, PgCodecs, PgPolymorphism
- graphile-search and graphile-connection-filter owner cleanup tests
- graphile-meta: 131 tests / 3 snapshots
- performance harness: 7 suites / 9 tests
- affected packages: CJS and ESM builds pass
- affected packages: ESLint passes with no errors (existing unrelated warnings remain)
- Prettier and diff checks pass
- `pnpm install --frozen-lockfile --offline` passes
- real PostgreSQL `ConstructivePreset` integration: runtime query succeeds and captured build state is released
- real PostgreSQL four-arm smoke:
  - unique PIDs: `29571`, `29573`, `29585`, `29587`
  - all runtime and case validations passed
  - all schema hashes matched: `3b9dab5243611a57da1c0721ea3bc1aba455051124e43549e3c326178b3e97c1`
  - stock/scoped retained state
  - retire/scoped-retire released state
  - generated report contained no database URL or credential material

## Patch lifecycle

The neutral lifecycle portion can be removed when an equivalent API is available in the installed Graphile release. The concrete retirement implementation remains CNC-owned until suitable upstream ownership APIs exist.