### PR TITLE
fix(pi-embed): start the extensions, and refuse a metered run that is not on the gateway model

### DIFF
--- a/agentic/pi-embed/__tests__/session.test.ts
+++ b/agentic/pi-embed/__tests__/session.test.ts
@@ -9,8 +9,19 @@ import { type PiModule, startRun } from '../src';
 
 const fakeLoader = {} as ResourceLoader;
 
-const fakePi = () => {
-  const session = { dispose: jest.fn() };
+const gatewayMetering = {
+  mode: 'gateway' as const,
+  gatewayUrl: 'https://agentic.example.com',
+  identity: { databaseId: 'db-1' },
+  models: [{ id: 'deepseek/deepseek-chat', contextWindow: 128_000, maxTokens: 8_192 }]
+};
+
+const fakePi = (model?: { provider: string; id: string }) => {
+  const session = {
+    dispose: jest.fn(),
+    bindExtensions: jest.fn(() => Promise.resolve()),
+    model
+  };
   const createAgentSession = jest.fn(
     (_options: CreateAgentSessionOptions): Promise<CreateAgentSessionResult> =>
       Promise.resolve({
@@ -35,6 +46,8 @@ const fakePi = () => {
 
   return { pi, session, createAgentSession, loaderOptions, reload };
 };
+
+const meteredSession = () => fakePi({ provider: 'constructive-gateway', id: 'deepseek/deepseek-chat' });
 
 describe('startRun', () => {
   it('hands the composed lanes to the resource loader, since that is how pi takes extensions', async () => {
@@ -70,6 +83,43 @@ describe('startRun', () => {
       { cwd: '/workspace', agentDir: '/default-agent-dir', extensionFactories: embedded.run.extensions }
     ]);
     expect(reload).toHaveBeenCalled();
+  });
+
+  it('binds the extensions, since pi emits session_start from there and not from createAgentSession', async () => {
+    const { pi, session } = fakePi();
+
+    await startRun({ runId: 'run-1', pi, log: { store: new MemoryRunLogStore() }, createResourceLoader: () => fakeLoader });
+
+    expect(session.bindExtensions).toHaveBeenCalledWith({});
+  });
+
+  it('refuses a metered run whose session did not end up on the gateway model', async () => {
+    const { pi } = fakePi({ provider: 'deepseek', id: 'deepseek-chat' });
+
+    await expect(
+      startRun({ runId: 'run-1', pi, metering: gatewayMetering, createResourceLoader: () => fakeLoader })
+    ).rejects.toThrow(/would leave outside the gateway and go unmetered/);
+  });
+
+  it('refuses a metered run that selected no model at all', async () => {
+    const { pi } = fakePi();
+
+    await expect(
+      startRun({ runId: 'run-1', pi, metering: gatewayMetering, createResourceLoader: () => fakeLoader })
+    ).rejects.toThrow(/no model/);
+  });
+
+  it('accepts a metered run once the session is on the gateway model', async () => {
+    const { pi } = meteredSession();
+
+    const embedded = await startRun({
+      runId: 'run-1',
+      pi,
+      metering: gatewayMetering,
+      createResourceLoader: () => fakeLoader
+    });
+
+    expect(embedded.run.lanes.meteredModel?.selectedModel).toBe('deepseek/deepseek-chat');
   });
 
   it('demands an agentDir when the injected pi module cannot supply one', async () => {

--- a/agentic/pi-embed/src/session.ts
+++ b/agentic/pi-embed/src/session.ts
@@ -84,6 +84,15 @@ export async function startRun(options: StartRunOptions): Promise<EmbeddedRun> {
 
   const result = await options.pi.createAgentSession({ ...options.session, cwd, agentDir, resourceLoader });
 
+  // pi emits `session_start` from `bindExtensions`, which its own CLI modes call
+  // once their UI exists — `createAgentSession` never does. An embedder that
+  // skips it loads the extensions but never starts them: the metered lane never
+  // selects the gateway model, so a cloud run's calls leave on whatever provider
+  // key the process happens to hold, unmetered, and the log lane never binds on
+  // resume. So the embedding, not the host, fires it.
+  await result.session.bindExtensions({});
+  assertMeteredModelSelected(run, result.session);
+
   return {
     run,
     session: result.session,
@@ -101,6 +110,25 @@ export async function startRun(options: StartRunOptions): Promise<EmbeddedRun> {
       if (failure !== undefined) throw failure;
     }
   };
+}
+
+/**
+ * The metered lane's whole purpose is that usage cannot be under-reported, so a
+ * session that ended up on some other provider must fail the run rather than
+ * quietly bill nothing.
+ */
+function assertMeteredModelSelected(run: ComposedRun, session: CreateAgentSessionResult['session']): void {
+  const lane = run.lanes.meteredModel;
+  if (!lane?.selectedModel) return;
+
+  const model = session.model;
+  if (model?.provider === lane.providerName && model.id === lane.selectedModel) return;
+
+  throw new Error(
+    `pi-embed: the metered lane selected "${lane.providerName}/${lane.selectedModel}" but the ` +
+    `session is on "${model ? `${model.provider}/${model.id}` : 'no model'}" — model calls would ` +
+    'leave outside the gateway and go unmetered'
+  );
 }
 
 const defaultResourceLoader =


### PR DESCRIPTION
## Summary

An embedded run loaded its extensions and never started them, so the metered lane silently didn't take effect.

pi emits `session_start` from `session.bindExtensions(...)` — a call its own CLI modes make once their UI exists, and `createAgentSession` never makes. The metered lane selects its model from exactly that event:

```ts
// @agentic-kit/pi-ext-metered-model
pi.registerProvider(providerName, config);
pi.on('session_start', async (_e, ctx) => pi.setModel(ctx.modelRegistry.find(providerName, modelId)));
```

So `startRun` returned a session on whatever provider key the process happened to hold — outside the gateway, unmetered, and indistinguishable from a healthy run. Verified against the installed pi: the same session reports `model: null` without the bind and `constructive-gateway/deepseek-v4-pro` with it.

`startRun` now fires it, then insists on the result:

```ts
const result = await pi.createAgentSession({ ... });
await result.session.bindExtensions({});
assertMeteredModelSelected(run, result.session);   // throws unless
                                                   // model === `${lane.providerName}/${lane.selectedModel}`
```

The assertion only applies when the metered lane selected a model (`selectModel: false` and log-only embeddings are unaffected). Under-reported usage is the failure this lane exists to prevent, so a session that ended up elsewhere fails the run rather than billing nothing.


Link to Devin session: https://app.devin.ai/sessions/450ce6d6659c47759c184ae6ec19a2a8
Requested by: @pyramation