### PR TITLE
fix(pg-codegen): read unqualified on an empty where, refuse an empty write filter

### DIFF
--- a/postgres/pg-codegen/__fixtures__/generated/client.ts
+++ b/postgres/pg-codegen/__fixtures__/generated/client.ts
@@ -182,7 +182,8 @@ export class TableClient<App> {
   ): Promise<SelectResult<App, S>[]> {
     const fields = this.selectedFields(args.select);
     const query = this.baseQuery().select(fields.map(field => this.column(field)));
-    if (args.where) query.where(this.filter(args.where));
+    const predicate = this.predicate(args.where);
+    if (predicate) query.where(predicate);
     this.applyOrderBy(query, args.orderBy);
     if (args.limit !== undefined) query.limit(args.limit);
     if (args.offset !== undefined) query.offset(args.offset);
@@ -208,7 +209,8 @@ export class TableClient<App> {
 
   async count(where?: Where<App>): Promise<number> {
     const query = this.baseQuery().select([]).selectExpr('count', fn('count', [lit(1)]));
-    if (where) query.where(this.filter(where));
+    const predicate = this.predicate(where);
+    if (predicate) query.where(predicate);
     const { text, values } = query.build();
     const { rows } = await this.db.query(text, values);
     const row = rows[0] as { count: string | number };
@@ -233,7 +235,7 @@ export class TableClient<App> {
     const fields = this.selectedFields(args.select);
     const query = this.baseQuery()
       .update(this.encodeData(args.data))
-      .where(this.filter(args.where))
+      .where(this.required(args.where, 'update'))
       .returning(fields.map(field => this.column(field)));
     const { text, values } = query.build();
     const { rows } = await this.db.query(text, values);
@@ -254,7 +256,7 @@ export class TableClient<App> {
     const fields = this.selectedFields(args.select);
     const query = this.baseQuery()
       .delete()
-      .where(this.filter(args.where))
+      .where(this.required(args.where, 'delete'))
       .returning(fields.map(field => this.column(field)));
     const { text, values } = query.build();
     const { rows } = await this.db.query(text, values);
@@ -291,6 +293,28 @@ export class TableClient<App> {
       decoded[field] = this.spec.fields[field](raw[this.column(field)]);
     }
     return decoded as SelectResult<App, S>;
+  }
+
+  /**
+   * The predicate to apply, or nothing to apply: a caller that spreads a
+   * conditional key column (a scope that records none) states an empty filter,
+   * and an unqualified read is what it asked for.
+   */
+  private predicate(where: Where<App> | undefined): Filter | undefined {
+    if (!where) return undefined;
+    const filter = this.filter(where);
+    return Object.keys(filter).length > 0 ? filter : undefined;
+  }
+
+  /** A write says which rows: an empty filter would mean the whole table. */
+  private required(where: Where<App>, operation: string): Filter {
+    const predicate = this.predicate(where);
+    if (!predicate) {
+      throw new Error(
+        `${this.spec.table}.${operation}: refusing an empty where filter, which would match every row`
+      );
+    }
+    return predicate;
   }
 
   private filter(where: Where<App>): Filter {

--- a/postgres/pg-codegen/__tests__/client.test.ts
+++ b/postgres/pg-codegen/__tests__/client.test.ts
@@ -120,6 +120,28 @@ it('findFirstOrThrow raises on no match', async () => {
   await expect(db.users.findFirstOrThrow({ where: { id: 999999 } })).rejects.toThrow(RowNotFoundError);
 });
 
+it('reads unqualified when a conditional filter spreads to nothing', async () => {
+  await db.users.create({ data: { username: 'karl' } });
+  const keyColumn: string | null = null;
+
+  const rows = await db.users.findMany({
+    where: { ...(keyColumn ? { username: keyColumn } : {}) },
+    select: { username: true }
+  });
+  expect(rows.map(u => u.username)).toEqual(['karl']);
+  expect(await db.users.count({})).toBe(1);
+});
+
+it('refuses a write whose filter would match every row', async () => {
+  await db.users.create({ data: { username: 'lena' } });
+
+  await expect(db.users.update({ where: {}, data: { email: 'x@example.com' } })).rejects.toThrow(
+    /refusing an empty where filter/
+  );
+  await expect(db.users.delete({ where: {} })).rejects.toThrow(/refusing an empty where filter/);
+  expect(await db.users.count()).toBe(1);
+});
+
 it('rebinds to another connection with $with', async () => {
   const rebound = db.$with(pg.client);
   await rebound.users.create({ data: { username: 'judy' } });

--- a/postgres/pg-codegen/src/emit/templates/client.ts
+++ b/postgres/pg-codegen/src/emit/templates/client.ts
@@ -182,7 +182,8 @@ export class TableClient<App> {
   ): Promise<SelectResult<App, S>[]> {
     const fields = this.selectedFields(args.select);
     const query = this.baseQuery().select(fields.map(field => this.column(field)));
-    if (args.where) query.where(this.filter(args.where));
+    const predicate = this.predicate(args.where);
+    if (predicate) query.where(predicate);
     this.applyOrderBy(query, args.orderBy);
     if (args.limit !== undefined) query.limit(args.limit);
     if (args.offset !== undefined) query.offset(args.offset);
@@ -208,7 +209,8 @@ export class TableClient<App> {
 
   async count(where?: Where<App>): Promise<number> {
     const query = this.baseQuery().select([]).selectExpr('count', fn('count', [lit(1)]));
-    if (where) query.where(this.filter(where));
+    const predicate = this.predicate(where);
+    if (predicate) query.where(predicate);
     const { text, values } = query.build();
     const { rows } = await this.db.query(text, values);
     const row = rows[0] as { count: string | number };
@@ -233,7 +235,7 @@ export class TableClient<App> {
     const fields = this.selectedFields(args.select);
     const query = this.baseQuery()
       .update(this.encodeData(args.data))
-      .where(this.filter(args.where))
+      .where(this.required(args.where, 'update'))
       .returning(fields.map(field => this.column(field)));
     const { text, values } = query.build();
     const { rows } = await this.db.query(text, values);
@@ -254,7 +256,7 @@ export class TableClient<App> {
     const fields = this.selectedFields(args.select);
     const query = this.baseQuery()
       .delete()
-      .where(this.filter(args.where))
+      .where(this.required(args.where, 'delete'))
       .returning(fields.map(field => this.column(field)));
     const { text, values } = query.build();
     const { rows } = await this.db.query(text, values);
@@ -291,6 +293,28 @@ export class TableClient<App> {
       decoded[field] = this.spec.fields[field](raw[this.column(field)]);
     }
     return decoded as SelectResult<App, S>;
+  }
+
+  /**
+   * The predicate to apply, or nothing to apply: a caller that spreads a
+   * conditional key column (a scope that records none) states an empty filter,
+   * and an unqualified read is what it asked for.
+   */
+  private predicate(where: Where<App> | undefined): Filter | undefined {
+    if (!where) return undefined;
+    const filter = this.filter(where);
+    return Object.keys(filter).length > 0 ? filter : undefined;
+  }
+
+  /** A write says which rows: an empty filter would mean the whole table. */
+  private required(where: Where<App>, operation: string): Filter {
+    const predicate = this.predicate(where);
+    if (!predicate) {
+      throw new Error(
+        `${this.spec.table}.${operation}: refusing an empty where filter, which would match every row`
+      );
+    }
+    return predicate;
   }
 
   private filter(where: Where<App>): Filter {


### PR DESCRIPTION
## Summary

A call site that qualifies a read with a *conditional* key column — the shape every scoped module read takes — states an empty filter when the scope records no key:

```ts
await db.identityProviders.findMany({
  where: module.entityField ? { [module.entityField]: frame.keyValue } : {},
  ...
});
```

The generated client passed that straight to `QueryBuilder.where({})`, which throws `Empty filter object.`, so the global-scope path of every such read failed at runtime rather than reading unqualified.

The client now distinguishes "no predicate" from "no rows asked for":

```diff
-  if (args.where) query.where(this.filter(args.where));
+  const predicate = this.predicate(args.where);   // undefined when the filter has no keys
+  if (predicate) query.where(predicate);
```

and because the same emptiness on a write would silently mean *every row*, `update`/`delete` route through `required(where, op)` and throw instead:

```
users.update: refusing an empty where filter, which would match every row
```

`findMany`/`findFirst`/`count` read unqualified; `update`/`delete` throw. Two live round-trip tests cover both, and the committed `__fixtures__/generated/client.ts` is regenerated.


Link to Devin session: https://app.devin.ai/sessions/b1fb8d90ec0a4cd1bd95e3c77c6f6680
Requested by: @pyramation