### PR TITLE
feat(pg-codegen): state a select as exclusions, not only a key list

### DIFF
--- a/postgres/pg-codegen/__fixtures__/generated/client.ts
+++ b/postgres/pg-codegen/__fixtures__/generated/client.ts
@@ -33,18 +33,38 @@ export interface TableSpec<App> {
   jsonFields?: readonly string[];
 }
 
-/** Select shape: `{ id: true, name: true }` — same as the GraphQL ORM. */
+/**
+ * Select shape — same as the GraphQL ORM, stated either way round:
+ *
+ * - `{ id: true, name: true }` reads those fields and nothing else;
+ * - `{ databaseId: false }` reads every field except that one, for the field a
+ *   record has in general but this binding's table does not (a scope's copy of
+ *   a table without the scope key column) or that a caller must not carry (a
+ *   secret's id, row bookkeeping).
+ *
+ * Naming a field `true` is a projection and wins outright: the excluded ones
+ * are simply not in it.
+ */
 export type SelectShape<App> = { [K in keyof App]?: boolean };
 
 type TrueKeys<App, S> = {
   [K in keyof S]-?: S[K] extends true ? K & keyof App : never;
 }[keyof S];
 
-/** Rows narrow to the selected fields; no `select` returns the full record. */
+type FalseKeys<App, S> = {
+  [K in keyof S]-?: S[K] extends false ? K & keyof App : never;
+}[keyof S];
+
+/**
+ * Rows narrow to what the select states: the picked fields, else the record
+ * minus the excluded ones. No `select` returns the full record.
+ */
 export type SelectResult<App, S extends SelectShape<App> | undefined> =
   S extends SelectShape<App>
     ? [TrueKeys<App, S>] extends [never]
-      ? App
+      ? [FalseKeys<App, S>] extends [never]
+        ? App
+        : Omit<App, FalseKeys<App, S>>
       : Pick<App, TrueKeys<App, S>>
     : App;
 
@@ -280,7 +300,10 @@ export class TableClient<App> {
     const all = Object.keys(this.spec.columnByField) as (keyof App & string)[];
     if (!select) return all;
     const picked = all.filter(field => select[field] === true);
-    return picked.length > 0 ? picked : all;
+    if (picked.length > 0) return picked;
+    // Nothing picked: the select either excludes fields or says nothing at all,
+    // and both read what is left.
+    return all.filter(field => select[field] !== false);
   }
 
   private decodeRow<S extends SelectShape<App> | undefined>(

--- a/postgres/pg-codegen/__fixtures__/generated/client.ts
+++ b/postgres/pg-codegen/__fixtures__/generated/client.ts
@@ -34,44 +34,39 @@ export interface TableSpec<App> {
 }
 
 /**
- * `select: { id: true, name: true }` — read those fields and nothing else.
- * Same shape and same inference as the GraphQL ORM's select.
+ * Select shape — same as the GraphQL ORM, stated either way round:
+ *
+ * - `{ id: true, name: true }` reads those fields and nothing else;
+ * - `{ databaseId: false }` reads every field except that one, for the field a
+ *   record has in general but this binding's table does not (a scope's copy of
+ *   a table without the scope key column) or that a caller must not carry (a
+ *   secret's id, row bookkeeping).
+ *
+ * Naming a field `true` is a projection and wins outright: the excluded ones
+ * are simply not in it.
  */
 export type SelectShape<App> = { [K in keyof App]?: boolean };
-
-/**
- * `omit: { databaseId: true }` — read the record except those fields, for the
- * field a record has in general but this binding's table does not (a scope's
- * copy of a table without the scope key column) or that a caller must not
- * carry (a secret's id, row bookkeeping). Prisma's `omit`, and the reason it
- * exists there too: naming everything else is not the same statement.
- *
- * Mutually exclusive with `select` — a projection already says what it reads.
- */
-export type OmitShape<App> = { [K in keyof App]?: boolean };
 
 type TrueKeys<App, S> = {
   [K in keyof S]-?: S[K] extends true ? K & keyof App : never;
 }[keyof S];
 
-/** The record minus what `omit` names, which is the record when it names none. */
-type OmitResult<App, O> = O extends OmitShape<App>
-  ? [TrueKeys<App, O>] extends [never]
-    ? App
-    : Omit<App, TrueKeys<App, O>>
-  : App;
+type FalseKeys<App, S> = {
+  [K in keyof S]-?: S[K] extends false ? K & keyof App : never;
+}[keyof S];
 
-/** Rows narrow to what the args state: `select` picks, `omit` subtracts. */
-export type SelectResult<
-  App,
-  S extends SelectShape<App> | undefined,
-  O extends OmitShape<App> | undefined = undefined
-> =
+/**
+ * Rows narrow to what the select states: the picked fields, else the record
+ * minus the excluded ones. No `select` returns the full record.
+ */
+export type SelectResult<App, S extends SelectShape<App> | undefined> =
   S extends SelectShape<App>
     ? [TrueKeys<App, S>] extends [never]
-      ? OmitResult<App, O>
+      ? [FalseKeys<App, S>] extends [never]
+        ? App
+        : Omit<App, FalseKeys<App, S>>
       : Pick<App, TrueKeys<App, S>>
-    : OmitResult<App, O>;
+    : App;
 
 /** Per-field operators from the shared query-spec grammar. */
 export interface FieldOps<V> {
@@ -148,62 +143,34 @@ export type OrderDirection = 'ASC' | 'DESC';
 /** Order spec keyed by camelCase field names, e.g. `{ createdAt: 'DESC' }`. */
 export type OrderBy<App> = { [K in keyof App]?: OrderDirection };
 
-/**
- * What a call reads. `select` and `omit` are alternatives, not layers, and
- * stating both is refused at the call rather than silently resolved.
- */
-export interface Projection<
-  App,
-  S extends SelectShape<App> | undefined,
-  O extends OmitShape<App> | undefined
-> {
-  select?: S;
-  omit?: O;
-}
-
-export interface FindManyArgs<
-  App,
-  S extends SelectShape<App> | undefined,
-  O extends OmitShape<App> | undefined
-> extends Projection<App, S, O> {
+export interface FindManyArgs<App, S extends SelectShape<App> | undefined> {
   where?: Where<App>;
+  select?: S;
   orderBy?: OrderBy<App> | OrderBy<App>[];
   limit?: number;
   offset?: number;
 }
 
-export interface FindFirstArgs<
-  App,
-  S extends SelectShape<App> | undefined,
-  O extends OmitShape<App> | undefined
-> extends Projection<App, S, O> {
+export interface FindFirstArgs<App, S extends SelectShape<App> | undefined> {
   where?: Where<App>;
+  select?: S;
   orderBy?: OrderBy<App> | OrderBy<App>[];
 }
 
-export interface CreateArgs<
-  App,
-  S extends SelectShape<App> | undefined,
-  O extends OmitShape<App> | undefined
-> extends Projection<App, S, O> {
+export interface CreateArgs<App, S extends SelectShape<App> | undefined> {
   data: Data<App>;
+  select?: S;
 }
 
-export interface UpdateArgs<
-  App,
-  S extends SelectShape<App> | undefined,
-  O extends OmitShape<App> | undefined
-> extends Projection<App, S, O> {
+export interface UpdateArgs<App, S extends SelectShape<App> | undefined> {
   where: Where<App>;
   data: Data<App>;
+  select?: S;
 }
 
-export interface DeleteArgs<
-  App,
-  S extends SelectShape<App> | undefined,
-  O extends OmitShape<App> | undefined
-> extends Projection<App, S, O> {
+export interface DeleteArgs<App, S extends SelectShape<App> | undefined> {
   where: Where<App>;
+  select?: S;
 }
 
 /** Thrown by `findFirstOrThrow` / `updateOrThrow` when no row matches. */
@@ -230,11 +197,10 @@ export class TableClient<App> {
     private readonly db: Queryable
   ) {}
 
-  async findMany<
-    S extends SelectShape<App> | undefined = undefined,
-    O extends OmitShape<App> | undefined = undefined
-  >(args: FindManyArgs<App, S, O> = {}): Promise<SelectResult<App, S, O>[]> {
-    const fields = this.selectedFields(args);
+  async findMany<S extends SelectShape<App> | undefined = undefined>(
+    args: FindManyArgs<App, S> = {}
+  ): Promise<SelectResult<App, S>[]> {
+    const fields = this.selectedFields(args.select);
     const query = this.baseQuery().select(fields.map(field => this.column(field)));
     const predicate = this.predicate(args.where);
     if (predicate) query.where(predicate);
@@ -246,18 +212,16 @@ export class TableClient<App> {
     return rows.map(row => this.decodeRow(row, fields));
   }
 
-  async findFirst<
-    S extends SelectShape<App> | undefined = undefined,
-    O extends OmitShape<App> | undefined = undefined
-  >(args: FindFirstArgs<App, S, O> = {}): Promise<SelectResult<App, S, O> | null> {
-    const rows = await this.findMany<S, O>({ ...args, limit: 1 });
+  async findFirst<S extends SelectShape<App> | undefined = undefined>(
+    args: FindFirstArgs<App, S> = {}
+  ): Promise<SelectResult<App, S> | null> {
+    const rows = await this.findMany({ ...args, limit: 1 });
     return rows.length > 0 ? rows[0] : null;
   }
 
-  async findFirstOrThrow<
-    S extends SelectShape<App> | undefined = undefined,
-    O extends OmitShape<App> | undefined = undefined
-  >(args: FindFirstArgs<App, S, O> = {}): Promise<SelectResult<App, S, O>> {
+  async findFirstOrThrow<S extends SelectShape<App> | undefined = undefined>(
+    args: FindFirstArgs<App, S> = {}
+  ): Promise<SelectResult<App, S>> {
     const row = await this.findFirst(args);
     if (row === null) throw new RowNotFoundError(this.spec.table, 'findFirstOrThrow');
     return row;
@@ -273,11 +237,10 @@ export class TableClient<App> {
     return Number(row.count);
   }
 
-  async create<
-    S extends SelectShape<App> | undefined = undefined,
-    O extends OmitShape<App> | undefined = undefined
-  >(args: CreateArgs<App, S, O>): Promise<SelectResult<App, S, O>> {
-    const fields = this.selectedFields(args);
+  async create<S extends SelectShape<App> | undefined = undefined>(
+    args: CreateArgs<App, S>
+  ): Promise<SelectResult<App, S>> {
+    const fields = this.selectedFields(args.select);
     const query = this.baseQuery()
       .insert(this.encodeData(args.data))
       .returning(fields.map(field => this.column(field)));
@@ -286,11 +249,10 @@ export class TableClient<App> {
     return this.decodeRow(rows[0], fields);
   }
 
-  async update<
-    S extends SelectShape<App> | undefined = undefined,
-    O extends OmitShape<App> | undefined = undefined
-  >(args: UpdateArgs<App, S, O>): Promise<SelectResult<App, S, O>[]> {
-    const fields = this.selectedFields(args);
+  async update<S extends SelectShape<App> | undefined = undefined>(
+    args: UpdateArgs<App, S>
+  ): Promise<SelectResult<App, S>[]> {
+    const fields = this.selectedFields(args.select);
     const query = this.baseQuery()
       .update(this.encodeData(args.data))
       .where(this.required(args.where, 'update'))
@@ -300,20 +262,18 @@ export class TableClient<App> {
     return rows.map(row => this.decodeRow(row, fields));
   }
 
-  async updateOrThrow<
-    S extends SelectShape<App> | undefined = undefined,
-    O extends OmitShape<App> | undefined = undefined
-  >(args: UpdateArgs<App, S, O>): Promise<SelectResult<App, S, O>> {
+  async updateOrThrow<S extends SelectShape<App> | undefined = undefined>(
+    args: UpdateArgs<App, S>
+  ): Promise<SelectResult<App, S>> {
     const rows = await this.update(args);
     if (rows.length === 0) throw new RowNotFoundError(this.spec.table, 'updateOrThrow');
     return rows[0];
   }
 
-  async delete<
-    S extends SelectShape<App> | undefined = undefined,
-    O extends OmitShape<App> | undefined = undefined
-  >(args: DeleteArgs<App, S, O>): Promise<SelectResult<App, S, O>[]> {
-    const fields = this.selectedFields(args);
+  async delete<S extends SelectShape<App> | undefined = undefined>(
+    args: DeleteArgs<App, S>
+  ): Promise<SelectResult<App, S>[]> {
+    const fields = this.selectedFields(args.select);
     const query = this.baseQuery()
       .delete()
       .where(this.required(args.where, 'delete'))
@@ -336,34 +296,26 @@ export class TableClient<App> {
     return this.spec.columnByField[field] ?? field;
   }
 
-  private selectedFields(args: {
-    select?: SelectShape<App>;
-    omit?: OmitShape<App>;
-  }): (keyof App & string)[] {
+  private selectedFields(select: SelectShape<App> | undefined): (keyof App & string)[] {
     const all = Object.keys(this.spec.columnByField) as (keyof App & string)[];
-    if (args.select && args.omit) {
-      throw new Error(
-        `${this.spec.table}: state either 'select' or 'omit' — a projection already says what it reads.`
-      );
-    }
-    if (args.select) {
-      const picked = all.filter(field => args.select![field] === true);
-      if (picked.length > 0) return picked;
-    }
-    if (args.omit) return all.filter(field => args.omit![field] !== true);
-    return all;
+    if (!select) return all;
+    const picked = all.filter(field => select[field] === true);
+    if (picked.length > 0) return picked;
+    // Nothing picked: the select either excludes fields or says nothing at all,
+    // and both read what is left.
+    return all.filter(field => select[field] !== false);
   }
 
-  private decodeRow<S extends SelectShape<App> | undefined, O extends OmitShape<App> | undefined>(
+  private decodeRow<S extends SelectShape<App> | undefined>(
     row: unknown,
     fields: (keyof App & string)[]
-  ): SelectResult<App, S, O> {
+  ): SelectResult<App, S> {
     const raw = row as Record<string, unknown>;
     const decoded: Record<string, unknown> = {};
     for (const field of fields) {
       decoded[field] = this.spec.fields[field](raw[this.column(field)]);
     }
-    return decoded as SelectResult<App, S, O>;
+    return decoded as SelectResult<App, S>;
   }
 
   /**

--- a/postgres/pg-codegen/__fixtures__/generated/client.ts
+++ b/postgres/pg-codegen/__fixtures__/generated/client.ts
@@ -34,39 +34,44 @@ export interface TableSpec<App> {
 }
 
 /**
- * Select shape — same as the GraphQL ORM, stated either way round:
- *
- * - `{ id: true, name: true }` reads those fields and nothing else;
- * - `{ databaseId: false }` reads every field except that one, for the field a
- *   record has in general but this binding's table does not (a scope's copy of
- *   a table without the scope key column) or that a caller must not carry (a
- *   secret's id, row bookkeeping).
- *
- * Naming a field `true` is a projection and wins outright: the excluded ones
- * are simply not in it.
+ * `select: { id: true, name: true }` — read those fields and nothing else.
+ * Same shape and same inference as the GraphQL ORM's select.
  */
 export type SelectShape<App> = { [K in keyof App]?: boolean };
+
+/**
+ * `omit: { databaseId: true }` — read the record except those fields, for the
+ * field a record has in general but this binding's table does not (a scope's
+ * copy of a table without the scope key column) or that a caller must not
+ * carry (a secret's id, row bookkeeping). Prisma's `omit`, and the reason it
+ * exists there too: naming everything else is not the same statement.
+ *
+ * Mutually exclusive with `select` — a projection already says what it reads.
+ */
+export type OmitShape<App> = { [K in keyof App]?: boolean };
 
 type TrueKeys<App, S> = {
   [K in keyof S]-?: S[K] extends true ? K & keyof App : never;
 }[keyof S];
 
-type FalseKeys<App, S> = {
-  [K in keyof S]-?: S[K] extends false ? K & keyof App : never;
-}[keyof S];
+/** The record minus what `omit` names, which is the record when it names none. */
+type OmitResult<App, O> = O extends OmitShape<App>
+  ? [TrueKeys<App, O>] extends [never]
+    ? App
+    : Omit<App, TrueKeys<App, O>>
+  : App;
 
-/**
- * Rows narrow to what the select states: the picked fields, else the record
- * minus the excluded ones. No `select` returns the full record.
- */
-export type SelectResult<App, S extends SelectShape<App> | undefined> =
+/** Rows narrow to what the args state: `select` picks, `omit` subtracts. */
+export type SelectResult<
+  App,
+  S extends SelectShape<App> | undefined,
+  O extends OmitShape<App> | undefined = undefined
+> =
   S extends SelectShape<App>
     ? [TrueKeys<App, S>] extends [never]
-      ? [FalseKeys<App, S>] extends [never]
-        ? App
-        : Omit<App, FalseKeys<App, S>>
+      ? OmitResult<App, O>
       : Pick<App, TrueKeys<App, S>>
-    : App;
+    : OmitResult<App, O>;
 
 /** Per-field operators from the shared query-spec grammar. */
 export interface FieldOps<V> {
@@ -143,34 +148,62 @@ export type OrderDirection = 'ASC' | 'DESC';
 /** Order spec keyed by camelCase field names, e.g. `{ createdAt: 'DESC' }`. */
 export type OrderBy<App> = { [K in keyof App]?: OrderDirection };
 
-export interface FindManyArgs<App, S extends SelectShape<App> | undefined> {
-  where?: Where<App>;
+/**
+ * What a call reads. `select` and `omit` are alternatives, not layers, and
+ * stating both is refused at the call rather than silently resolved.
+ */
+export interface Projection<
+  App,
+  S extends SelectShape<App> | undefined,
+  O extends OmitShape<App> | undefined
+> {
   select?: S;
+  omit?: O;
+}
+
+export interface FindManyArgs<
+  App,
+  S extends SelectShape<App> | undefined,
+  O extends OmitShape<App> | undefined
+> extends Projection<App, S, O> {
+  where?: Where<App>;
   orderBy?: OrderBy<App> | OrderBy<App>[];
   limit?: number;
   offset?: number;
 }
 
-export interface FindFirstArgs<App, S extends SelectShape<App> | undefined> {
+export interface FindFirstArgs<
+  App,
+  S extends SelectShape<App> | undefined,
+  O extends OmitShape<App> | undefined
+> extends Projection<App, S, O> {
   where?: Where<App>;
-  select?: S;
   orderBy?: OrderBy<App> | OrderBy<App>[];
 }
 
-export interface CreateArgs<App, S extends SelectShape<App> | undefined> {
+export interface CreateArgs<
+  App,
+  S extends SelectShape<App> | undefined,
+  O extends OmitShape<App> | undefined
+> extends Projection<App, S, O> {
   data: Data<App>;
-  select?: S;
 }
 
-export interface UpdateArgs<App, S extends SelectShape<App> | undefined> {
+export interface UpdateArgs<
+  App,
+  S extends SelectShape<App> | undefined,
+  O extends OmitShape<App> | undefined
+> extends Projection<App, S, O> {
   where: Where<App>;
   data: Data<App>;
-  select?: S;
 }
 
-export interface DeleteArgs<App, S extends SelectShape<App> | undefined> {
+export interface DeleteArgs<
+  App,
+  S extends SelectShape<App> | undefined,
+  O extends OmitShape<App> | undefined
+> extends Projection<App, S, O> {
   where: Where<App>;
-  select?: S;
 }
 
 /** Thrown by `findFirstOrThrow` / `updateOrThrow` when no row matches. */
@@ -197,10 +230,11 @@ export class TableClient<App> {
     private readonly db: Queryable
   ) {}
 
-  async findMany<S extends SelectShape<App> | undefined = undefined>(
-    args: FindManyArgs<App, S> = {}
-  ): Promise<SelectResult<App, S>[]> {
-    const fields = this.selectedFields(args.select);
+  async findMany<
+    S extends SelectShape<App> | undefined = undefined,
+    O extends OmitShape<App> | undefined = undefined
+  >(args: FindManyArgs<App, S, O> = {}): Promise<SelectResult<App, S, O>[]> {
+    const fields = this.selectedFields(args);
     const query = this.baseQuery().select(fields.map(field => this.column(field)));
     const predicate = this.predicate(args.where);
     if (predicate) query.where(predicate);
@@ -212,16 +246,18 @@ export class TableClient<App> {
     return rows.map(row => this.decodeRow(row, fields));
   }
 
-  async findFirst<S extends SelectShape<App> | undefined = undefined>(
-    args: FindFirstArgs<App, S> = {}
-  ): Promise<SelectResult<App, S> | null> {
-    const rows = await this.findMany({ ...args, limit: 1 });
+  async findFirst<
+    S extends SelectShape<App> | undefined = undefined,
+    O extends OmitShape<App> | undefined = undefined
+  >(args: FindFirstArgs<App, S, O> = {}): Promise<SelectResult<App, S, O> | null> {
+    const rows = await this.findMany<S, O>({ ...args, limit: 1 });
     return rows.length > 0 ? rows[0] : null;
   }
 
-  async findFirstOrThrow<S extends SelectShape<App> | undefined = undefined>(
-    args: FindFirstArgs<App, S> = {}
-  ): Promise<SelectResult<App, S>> {
+  async findFirstOrThrow<
+    S extends SelectShape<App> | undefined = undefined,
+    O extends OmitShape<App> | undefined = undefined
+  >(args: FindFirstArgs<App, S, O> = {}): Promise<SelectResult<App, S, O>> {
     const row = await this.findFirst(args);
     if (row === null) throw new RowNotFoundError(this.spec.table, 'findFirstOrThrow');
     return row;
@@ -237,10 +273,11 @@ export class TableClient<App> {
     return Number(row.count);
   }
 
-  async create<S extends SelectShape<App> | undefined = undefined>(
-    args: CreateArgs<App, S>
-  ): Promise<SelectResult<App, S>> {
-    const fields = this.selectedFields(args.select);
+  async create<
+    S extends SelectShape<App> | undefined = undefined,
+    O extends OmitShape<App> | undefined = undefined
+  >(args: CreateArgs<App, S, O>): Promise<SelectResult<App, S, O>> {
+    const fields = this.selectedFields(args);
     const query = this.baseQuery()
       .insert(this.encodeData(args.data))
       .returning(fields.map(field => this.column(field)));
@@ -249,10 +286,11 @@ export class TableClient<App> {
     return this.decodeRow(rows[0], fields);
   }
 
-  async update<S extends SelectShape<App> | undefined = undefined>(
-    args: UpdateArgs<App, S>
-  ): Promise<SelectResult<App, S>[]> {
-    const fields = this.selectedFields(args.select);
+  async update<
+    S extends SelectShape<App> | undefined = undefined,
+    O extends OmitShape<App> | undefined = undefined
+  >(args: UpdateArgs<App, S, O>): Promise<SelectResult<App, S, O>[]> {
+    const fields = this.selectedFields(args);
     const query = this.baseQuery()
       .update(this.encodeData(args.data))
       .where(this.required(args.where, 'update'))
@@ -262,18 +300,20 @@ export class TableClient<App> {
     return rows.map(row => this.decodeRow(row, fields));
   }
 
-  async updateOrThrow<S extends SelectShape<App> | undefined = undefined>(
-    args: UpdateArgs<App, S>
-  ): Promise<SelectResult<App, S>> {
+  async updateOrThrow<
+    S extends SelectShape<App> | undefined = undefined,
+    O extends OmitShape<App> | undefined = undefined
+  >(args: UpdateArgs<App, S, O>): Promise<SelectResult<App, S, O>> {
     const rows = await this.update(args);
     if (rows.length === 0) throw new RowNotFoundError(this.spec.table, 'updateOrThrow');
     return rows[0];
   }
 
-  async delete<S extends SelectShape<App> | undefined = undefined>(
-    args: DeleteArgs<App, S>
-  ): Promise<SelectResult<App, S>[]> {
-    const fields = this.selectedFields(args.select);
+  async delete<
+    S extends SelectShape<App> | undefined = undefined,
+    O extends OmitShape<App> | undefined = undefined
+  >(args: DeleteArgs<App, S, O>): Promise<SelectResult<App, S, O>[]> {
+    const fields = this.selectedFields(args);
     const query = this.baseQuery()
       .delete()
       .where(this.required(args.where, 'delete'))
@@ -296,26 +336,34 @@ export class TableClient<App> {
     return this.spec.columnByField[field] ?? field;
   }
 
-  private selectedFields(select: SelectShape<App> | undefined): (keyof App & string)[] {
+  private selectedFields(args: {
+    select?: SelectShape<App>;
+    omit?: OmitShape<App>;
+  }): (keyof App & string)[] {
     const all = Object.keys(this.spec.columnByField) as (keyof App & string)[];
-    if (!select) return all;
-    const picked = all.filter(field => select[field] === true);
-    if (picked.length > 0) return picked;
-    // Nothing picked: the select either excludes fields or says nothing at all,
-    // and both read what is left.
-    return all.filter(field => select[field] !== false);
+    if (args.select && args.omit) {
+      throw new Error(
+        `${this.spec.table}: state either 'select' or 'omit' — a projection already says what it reads.`
+      );
+    }
+    if (args.select) {
+      const picked = all.filter(field => args.select![field] === true);
+      if (picked.length > 0) return picked;
+    }
+    if (args.omit) return all.filter(field => args.omit![field] !== true);
+    return all;
   }
 
-  private decodeRow<S extends SelectShape<App> | undefined>(
+  private decodeRow<S extends SelectShape<App> | undefined, O extends OmitShape<App> | undefined>(
     row: unknown,
     fields: (keyof App & string)[]
-  ): SelectResult<App, S> {
+  ): SelectResult<App, S, O> {
     const raw = row as Record<string, unknown>;
     const decoded: Record<string, unknown> = {};
     for (const field of fields) {
       decoded[field] = this.spec.fields[field](raw[this.column(field)]);
     }
-    return decoded as SelectResult<App, S>;
+    return decoded as SelectResult<App, S, O>;
   }
 
   /**

--- a/postgres/pg-codegen/__tests__/client.test.ts
+++ b/postgres/pg-codegen/__tests__/client.test.ts
@@ -84,31 +84,29 @@ it('treats bare values as equalTo and null as isNull', async () => {
   expect(noEmail.map(u => u.username)).toEqual(['mallory']);
 });
 
-it('omits a field the binding must not read, and keeps the rest', async () => {
+it('excludes a field the binding must not read, and keeps the rest', async () => {
   const created = await db.users.create({
     data: { username: 'nadia', email: 'nadia@example.com' },
     // A column this caller must not carry — the same shape a scope's copy of a
     // table without the scope key column needs.
-    omit: { email: true }
+    select: { email: false }
   });
   expect(created).toEqual({ id: created.id, username: 'nadia', createdAt: created.createdAt });
 
   const found = await db.users.findFirstOrThrow({
     where: { id: created.id },
-    omit: { email: true, createdAt: true }
+    select: { email: false, createdAt: false }
   });
   expect(found).toEqual({ id: created.id, username: 'nadia' });
-  // @ts-expect-error an omitted field is absent from the result type, not just the row
+  // @ts-expect-error an excluded field is absent from the result type, not just the row
   const _absent: unknown = found.email;
 
-  // Stating both is a contradiction, not a layering — refused, never resolved.
-  await expect(
-    db.users.findFirstOrThrow({
-      where: { id: created.id },
-      select: { username: true },
-      omit: { email: true }
-    })
-  ).rejects.toThrow(/either 'select' or 'omit'/);
+  // A field named `true` is a projection: the exclusions are simply not in it.
+  const projected = await db.users.findFirstOrThrow({
+    where: { id: created.id },
+    select: { username: true, email: false }
+  });
+  expect(projected).toEqual({ username: 'nadia' });
 });
 
 it('combines and/or/not filters', async () => {

--- a/postgres/pg-codegen/__tests__/client.test.ts
+++ b/postgres/pg-codegen/__tests__/client.test.ts
@@ -84,29 +84,31 @@ it('treats bare values as equalTo and null as isNull', async () => {
   expect(noEmail.map(u => u.username)).toEqual(['mallory']);
 });
 
-it('excludes a field the binding must not read, and keeps the rest', async () => {
+it('omits a field the binding must not read, and keeps the rest', async () => {
   const created = await db.users.create({
     data: { username: 'nadia', email: 'nadia@example.com' },
     // A column this caller must not carry — the same shape a scope's copy of a
     // table without the scope key column needs.
-    select: { email: false }
+    omit: { email: true }
   });
   expect(created).toEqual({ id: created.id, username: 'nadia', createdAt: created.createdAt });
 
   const found = await db.users.findFirstOrThrow({
     where: { id: created.id },
-    select: { email: false, createdAt: false }
+    omit: { email: true, createdAt: true }
   });
   expect(found).toEqual({ id: created.id, username: 'nadia' });
-  // @ts-expect-error an excluded field is absent from the result type, not just the row
-  found.email;
+  // @ts-expect-error an omitted field is absent from the result type, not just the row
+  const _absent: unknown = found.email;
 
-  // A field named `true` is a projection: the exclusions are simply not in it.
-  const projected = await db.users.findFirstOrThrow({
-    where: { id: created.id },
-    select: { username: true, email: false }
-  });
-  expect(projected).toEqual({ username: 'nadia' });
+  // Stating both is a contradiction, not a layering — refused, never resolved.
+  await expect(
+    db.users.findFirstOrThrow({
+      where: { id: created.id },
+      select: { username: true },
+      omit: { email: true }
+    })
+  ).rejects.toThrow(/either 'select' or 'omit'/);
 });
 
 it('combines and/or/not filters', async () => {

--- a/postgres/pg-codegen/__tests__/client.test.ts
+++ b/postgres/pg-codegen/__tests__/client.test.ts
@@ -84,6 +84,31 @@ it('treats bare values as equalTo and null as isNull', async () => {
   expect(noEmail.map(u => u.username)).toEqual(['mallory']);
 });
 
+it('excludes a field the binding must not read, and keeps the rest', async () => {
+  const created = await db.users.create({
+    data: { username: 'nadia', email: 'nadia@example.com' },
+    // A column this caller must not carry — the same shape a scope's copy of a
+    // table without the scope key column needs.
+    select: { email: false }
+  });
+  expect(created).toEqual({ id: created.id, username: 'nadia', createdAt: created.createdAt });
+
+  const found = await db.users.findFirstOrThrow({
+    where: { id: created.id },
+    select: { email: false, createdAt: false }
+  });
+  expect(found).toEqual({ id: created.id, username: 'nadia' });
+  // @ts-expect-error an excluded field is absent from the result type, not just the row
+  found.email;
+
+  // A field named `true` is a projection: the exclusions are simply not in it.
+  const projected = await db.users.findFirstOrThrow({
+    where: { id: created.id },
+    select: { username: true, email: false }
+  });
+  expect(projected).toEqual({ username: 'nadia' });
+});
+
 it('combines and/or/not filters', async () => {
   await db.users.create({ data: { username: 'frank' } });
   await db.users.create({ data: { username: 'grace' } });

--- a/postgres/pg-codegen/src/emit/templates/client.ts
+++ b/postgres/pg-codegen/src/emit/templates/client.ts
@@ -33,18 +33,38 @@ export interface TableSpec<App> {
   jsonFields?: readonly string[];
 }
 
-/** Select shape: `{ id: true, name: true }` — same as the GraphQL ORM. */
+/**
+ * Select shape — same as the GraphQL ORM, stated either way round:
+ *
+ * - `{ id: true, name: true }` reads those fields and nothing else;
+ * - `{ databaseId: false }` reads every field except that one, for the field a
+ *   record has in general but this binding's table does not (a scope's copy of
+ *   a table without the scope key column) or that a caller must not carry (a
+ *   secret's id, row bookkeeping).
+ *
+ * Naming a field `true` is a projection and wins outright: the excluded ones
+ * are simply not in it.
+ */
 export type SelectShape<App> = { [K in keyof App]?: boolean };
 
 type TrueKeys<App, S> = {
   [K in keyof S]-?: S[K] extends true ? K & keyof App : never;
 }[keyof S];
 
-/** Rows narrow to the selected fields; no `select` returns the full record. */
+type FalseKeys<App, S> = {
+  [K in keyof S]-?: S[K] extends false ? K & keyof App : never;
+}[keyof S];
+
+/**
+ * Rows narrow to what the select states: the picked fields, else the record
+ * minus the excluded ones. No `select` returns the full record.
+ */
 export type SelectResult<App, S extends SelectShape<App> | undefined> =
   S extends SelectShape<App>
     ? [TrueKeys<App, S>] extends [never]
-      ? App
+      ? [FalseKeys<App, S>] extends [never]
+        ? App
+        : Omit<App, FalseKeys<App, S>>
       : Pick<App, TrueKeys<App, S>>
     : App;
 
@@ -280,7 +300,10 @@ export class TableClient<App> {
     const all = Object.keys(this.spec.columnByField) as (keyof App & string)[];
     if (!select) return all;
     const picked = all.filter(field => select[field] === true);
-    return picked.length > 0 ? picked : all;
+    if (picked.length > 0) return picked;
+    // Nothing picked: the select either excludes fields or says nothing at all,
+    // and both read what is left.
+    return all.filter(field => select[field] !== false);
   }
 
   private decodeRow<S extends SelectShape<App> | undefined>(

--- a/postgres/pg-codegen/src/emit/templates/client.ts
+++ b/postgres/pg-codegen/src/emit/templates/client.ts
@@ -34,44 +34,39 @@ export interface TableSpec<App> {
 }
 
 /**
- * `select: { id: true, name: true }` — read those fields and nothing else.
- * Same shape and same inference as the GraphQL ORM's select.
+ * Select shape — same as the GraphQL ORM, stated either way round:
+ *
+ * - `{ id: true, name: true }` reads those fields and nothing else;
+ * - `{ databaseId: false }` reads every field except that one, for the field a
+ *   record has in general but this binding's table does not (a scope's copy of
+ *   a table without the scope key column) or that a caller must not carry (a
+ *   secret's id, row bookkeeping).
+ *
+ * Naming a field `true` is a projection and wins outright: the excluded ones
+ * are simply not in it.
  */
 export type SelectShape<App> = { [K in keyof App]?: boolean };
-
-/**
- * `omit: { databaseId: true }` — read the record except those fields, for the
- * field a record has in general but this binding's table does not (a scope's
- * copy of a table without the scope key column) or that a caller must not
- * carry (a secret's id, row bookkeeping). Prisma's `omit`, and the reason it
- * exists there too: naming everything else is not the same statement.
- *
- * Mutually exclusive with `select` — a projection already says what it reads.
- */
-export type OmitShape<App> = { [K in keyof App]?: boolean };
 
 type TrueKeys<App, S> = {
   [K in keyof S]-?: S[K] extends true ? K & keyof App : never;
 }[keyof S];
 
-/** The record minus what `omit` names, which is the record when it names none. */
-type OmitResult<App, O> = O extends OmitShape<App>
-  ? [TrueKeys<App, O>] extends [never]
-    ? App
-    : Omit<App, TrueKeys<App, O>>
-  : App;
+type FalseKeys<App, S> = {
+  [K in keyof S]-?: S[K] extends false ? K & keyof App : never;
+}[keyof S];
 
-/** Rows narrow to what the args state: `select` picks, `omit` subtracts. */
-export type SelectResult<
-  App,
-  S extends SelectShape<App> | undefined,
-  O extends OmitShape<App> | undefined = undefined
-> =
+/**
+ * Rows narrow to what the select states: the picked fields, else the record
+ * minus the excluded ones. No `select` returns the full record.
+ */
+export type SelectResult<App, S extends SelectShape<App> | undefined> =
   S extends SelectShape<App>
     ? [TrueKeys<App, S>] extends [never]
-      ? OmitResult<App, O>
+      ? [FalseKeys<App, S>] extends [never]
+        ? App
+        : Omit<App, FalseKeys<App, S>>
       : Pick<App, TrueKeys<App, S>>
-    : OmitResult<App, O>;
+    : App;
 
 /** Per-field operators from the shared query-spec grammar. */
 export interface FieldOps<V> {
@@ -148,62 +143,34 @@ export type OrderDirection = 'ASC' | 'DESC';
 /** Order spec keyed by camelCase field names, e.g. `{ createdAt: 'DESC' }`. */
 export type OrderBy<App> = { [K in keyof App]?: OrderDirection };
 
-/**
- * What a call reads. `select` and `omit` are alternatives, not layers, and
- * stating both is refused at the call rather than silently resolved.
- */
-export interface Projection<
-  App,
-  S extends SelectShape<App> | undefined,
-  O extends OmitShape<App> | undefined
-> {
-  select?: S;
-  omit?: O;
-}
-
-export interface FindManyArgs<
-  App,
-  S extends SelectShape<App> | undefined,
-  O extends OmitShape<App> | undefined
-> extends Projection<App, S, O> {
+export interface FindManyArgs<App, S extends SelectShape<App> | undefined> {
   where?: Where<App>;
+  select?: S;
   orderBy?: OrderBy<App> | OrderBy<App>[];
   limit?: number;
   offset?: number;
 }
 
-export interface FindFirstArgs<
-  App,
-  S extends SelectShape<App> | undefined,
-  O extends OmitShape<App> | undefined
-> extends Projection<App, S, O> {
+export interface FindFirstArgs<App, S extends SelectShape<App> | undefined> {
   where?: Where<App>;
+  select?: S;
   orderBy?: OrderBy<App> | OrderBy<App>[];
 }
 
-export interface CreateArgs<
-  App,
-  S extends SelectShape<App> | undefined,
-  O extends OmitShape<App> | undefined
-> extends Projection<App, S, O> {
+export interface CreateArgs<App, S extends SelectShape<App> | undefined> {
   data: Data<App>;
+  select?: S;
 }
 
-export interface UpdateArgs<
-  App,
-  S extends SelectShape<App> | undefined,
-  O extends OmitShape<App> | undefined
-> extends Projection<App, S, O> {
+export interface UpdateArgs<App, S extends SelectShape<App> | undefined> {
   where: Where<App>;
   data: Data<App>;
+  select?: S;
 }
 
-export interface DeleteArgs<
-  App,
-  S extends SelectShape<App> | undefined,
-  O extends OmitShape<App> | undefined
-> extends Projection<App, S, O> {
+export interface DeleteArgs<App, S extends SelectShape<App> | undefined> {
   where: Where<App>;
+  select?: S;
 }
 
 /** Thrown by `findFirstOrThrow` / `updateOrThrow` when no row matches. */
@@ -230,11 +197,10 @@ export class TableClient<App> {
     private readonly db: Queryable
   ) {}
 
-  async findMany<
-    S extends SelectShape<App> | undefined = undefined,
-    O extends OmitShape<App> | undefined = undefined
-  >(args: FindManyArgs<App, S, O> = {}): Promise<SelectResult<App, S, O>[]> {
-    const fields = this.selectedFields(args);
+  async findMany<S extends SelectShape<App> | undefined = undefined>(
+    args: FindManyArgs<App, S> = {}
+  ): Promise<SelectResult<App, S>[]> {
+    const fields = this.selectedFields(args.select);
     const query = this.baseQuery().select(fields.map(field => this.column(field)));
     const predicate = this.predicate(args.where);
     if (predicate) query.where(predicate);
@@ -246,18 +212,16 @@ export class TableClient<App> {
     return rows.map(row => this.decodeRow(row, fields));
   }
 
-  async findFirst<
-    S extends SelectShape<App> | undefined = undefined,
-    O extends OmitShape<App> | undefined = undefined
-  >(args: FindFirstArgs<App, S, O> = {}): Promise<SelectResult<App, S, O> | null> {
-    const rows = await this.findMany<S, O>({ ...args, limit: 1 });
+  async findFirst<S extends SelectShape<App> | undefined = undefined>(
+    args: FindFirstArgs<App, S> = {}
+  ): Promise<SelectResult<App, S> | null> {
+    const rows = await this.findMany({ ...args, limit: 1 });
     return rows.length > 0 ? rows[0] : null;
   }
 
-  async findFirstOrThrow<
-    S extends SelectShape<App> | undefined = undefined,
-    O extends OmitShape<App> | undefined = undefined
-  >(args: FindFirstArgs<App, S, O> = {}): Promise<SelectResult<App, S, O>> {
+  async findFirstOrThrow<S extends SelectShape<App> | undefined = undefined>(
+    args: FindFirstArgs<App, S> = {}
+  ): Promise<SelectResult<App, S>> {
     const row = await this.findFirst(args);
     if (row === null) throw new RowNotFoundError(this.spec.table, 'findFirstOrThrow');
     return row;
@@ -273,11 +237,10 @@ export class TableClient<App> {
     return Number(row.count);
   }
 
-  async create<
-    S extends SelectShape<App> | undefined = undefined,
-    O extends OmitShape<App> | undefined = undefined
-  >(args: CreateArgs<App, S, O>): Promise<SelectResult<App, S, O>> {
-    const fields = this.selectedFields(args);
+  async create<S extends SelectShape<App> | undefined = undefined>(
+    args: CreateArgs<App, S>
+  ): Promise<SelectResult<App, S>> {
+    const fields = this.selectedFields(args.select);
     const query = this.baseQuery()
       .insert(this.encodeData(args.data))
       .returning(fields.map(field => this.column(field)));
@@ -286,11 +249,10 @@ export class TableClient<App> {
     return this.decodeRow(rows[0], fields);
   }
 
-  async update<
-    S extends SelectShape<App> | undefined = undefined,
-    O extends OmitShape<App> | undefined = undefined
-  >(args: UpdateArgs<App, S, O>): Promise<SelectResult<App, S, O>[]> {
-    const fields = this.selectedFields(args);
+  async update<S extends SelectShape<App> | undefined = undefined>(
+    args: UpdateArgs<App, S>
+  ): Promise<SelectResult<App, S>[]> {
+    const fields = this.selectedFields(args.select);
     const query = this.baseQuery()
       .update(this.encodeData(args.data))
       .where(this.required(args.where, 'update'))
@@ -300,20 +262,18 @@ export class TableClient<App> {
     return rows.map(row => this.decodeRow(row, fields));
   }
 
-  async updateOrThrow<
-    S extends SelectShape<App> | undefined = undefined,
-    O extends OmitShape<App> | undefined = undefined
-  >(args: UpdateArgs<App, S, O>): Promise<SelectResult<App, S, O>> {
+  async updateOrThrow<S extends SelectShape<App> | undefined = undefined>(
+    args: UpdateArgs<App, S>
+  ): Promise<SelectResult<App, S>> {
     const rows = await this.update(args);
     if (rows.length === 0) throw new RowNotFoundError(this.spec.table, 'updateOrThrow');
     return rows[0];
   }
 
-  async delete<
-    S extends SelectShape<App> | undefined = undefined,
-    O extends OmitShape<App> | undefined = undefined
-  >(args: DeleteArgs<App, S, O>): Promise<SelectResult<App, S, O>[]> {
-    const fields = this.selectedFields(args);
+  async delete<S extends SelectShape<App> | undefined = undefined>(
+    args: DeleteArgs<App, S>
+  ): Promise<SelectResult<App, S>[]> {
+    const fields = this.selectedFields(args.select);
     const query = this.baseQuery()
       .delete()
       .where(this.required(args.where, 'delete'))
@@ -336,34 +296,26 @@ export class TableClient<App> {
     return this.spec.columnByField[field] ?? field;
   }
 
-  private selectedFields(args: {
-    select?: SelectShape<App>;
-    omit?: OmitShape<App>;
-  }): (keyof App & string)[] {
+  private selectedFields(select: SelectShape<App> | undefined): (keyof App & string)[] {
     const all = Object.keys(this.spec.columnByField) as (keyof App & string)[];
-    if (args.select && args.omit) {
-      throw new Error(
-        `${this.spec.table}: state either 'select' or 'omit' — a projection already says what it reads.`
-      );
-    }
-    if (args.select) {
-      const picked = all.filter(field => args.select![field] === true);
-      if (picked.length > 0) return picked;
-    }
-    if (args.omit) return all.filter(field => args.omit![field] !== true);
-    return all;
+    if (!select) return all;
+    const picked = all.filter(field => select[field] === true);
+    if (picked.length > 0) return picked;
+    // Nothing picked: the select either excludes fields or says nothing at all,
+    // and both read what is left.
+    return all.filter(field => select[field] !== false);
   }
 
-  private decodeRow<S extends SelectShape<App> | undefined, O extends OmitShape<App> | undefined>(
+  private decodeRow<S extends SelectShape<App> | undefined>(
     row: unknown,
     fields: (keyof App & string)[]
-  ): SelectResult<App, S, O> {
+  ): SelectResult<App, S> {
     const raw = row as Record<string, unknown>;
     const decoded: Record<string, unknown> = {};
     for (const field of fields) {
       decoded[field] = this.spec.fields[field](raw[this.column(field)]);
     }
-    return decoded as SelectResult<App, S, O>;
+    return decoded as SelectResult<App, S>;
   }
 
   /**

--- a/postgres/pg-codegen/src/emit/templates/client.ts
+++ b/postgres/pg-codegen/src/emit/templates/client.ts
@@ -34,39 +34,44 @@ export interface TableSpec<App> {
 }
 
 /**
- * Select shape — same as the GraphQL ORM, stated either way round:
- *
- * - `{ id: true, name: true }` reads those fields and nothing else;
- * - `{ databaseId: false }` reads every field except that one, for the field a
- *   record has in general but this binding's table does not (a scope's copy of
- *   a table without the scope key column) or that a caller must not carry (a
- *   secret's id, row bookkeeping).
- *
- * Naming a field `true` is a projection and wins outright: the excluded ones
- * are simply not in it.
+ * `select: { id: true, name: true }` — read those fields and nothing else.
+ * Same shape and same inference as the GraphQL ORM's select.
  */
 export type SelectShape<App> = { [K in keyof App]?: boolean };
+
+/**
+ * `omit: { databaseId: true }` — read the record except those fields, for the
+ * field a record has in general but this binding's table does not (a scope's
+ * copy of a table without the scope key column) or that a caller must not
+ * carry (a secret's id, row bookkeeping). Prisma's `omit`, and the reason it
+ * exists there too: naming everything else is not the same statement.
+ *
+ * Mutually exclusive with `select` — a projection already says what it reads.
+ */
+export type OmitShape<App> = { [K in keyof App]?: boolean };
 
 type TrueKeys<App, S> = {
   [K in keyof S]-?: S[K] extends true ? K & keyof App : never;
 }[keyof S];
 
-type FalseKeys<App, S> = {
-  [K in keyof S]-?: S[K] extends false ? K & keyof App : never;
-}[keyof S];
+/** The record minus what `omit` names, which is the record when it names none. */
+type OmitResult<App, O> = O extends OmitShape<App>
+  ? [TrueKeys<App, O>] extends [never]
+    ? App
+    : Omit<App, TrueKeys<App, O>>
+  : App;
 
-/**
- * Rows narrow to what the select states: the picked fields, else the record
- * minus the excluded ones. No `select` returns the full record.
- */
-export type SelectResult<App, S extends SelectShape<App> | undefined> =
+/** Rows narrow to what the args state: `select` picks, `omit` subtracts. */
+export type SelectResult<
+  App,
+  S extends SelectShape<App> | undefined,
+  O extends OmitShape<App> | undefined = undefined
+> =
   S extends SelectShape<App>
     ? [TrueKeys<App, S>] extends [never]
-      ? [FalseKeys<App, S>] extends [never]
-        ? App
-        : Omit<App, FalseKeys<App, S>>
+      ? OmitResult<App, O>
       : Pick<App, TrueKeys<App, S>>
-    : App;
+    : OmitResult<App, O>;
 
 /** Per-field operators from the shared query-spec grammar. */
 export interface FieldOps<V> {
@@ -143,34 +148,62 @@ export type OrderDirection = 'ASC' | 'DESC';
 /** Order spec keyed by camelCase field names, e.g. `{ createdAt: 'DESC' }`. */
 export type OrderBy<App> = { [K in keyof App]?: OrderDirection };
 
-export interface FindManyArgs<App, S extends SelectShape<App> | undefined> {
-  where?: Where<App>;
+/**
+ * What a call reads. `select` and `omit` are alternatives, not layers, and
+ * stating both is refused at the call rather than silently resolved.
+ */
+export interface Projection<
+  App,
+  S extends SelectShape<App> | undefined,
+  O extends OmitShape<App> | undefined
+> {
   select?: S;
+  omit?: O;
+}
+
+export interface FindManyArgs<
+  App,
+  S extends SelectShape<App> | undefined,
+  O extends OmitShape<App> | undefined
+> extends Projection<App, S, O> {
+  where?: Where<App>;
   orderBy?: OrderBy<App> | OrderBy<App>[];
   limit?: number;
   offset?: number;
 }
 
-export interface FindFirstArgs<App, S extends SelectShape<App> | undefined> {
+export interface FindFirstArgs<
+  App,
+  S extends SelectShape<App> | undefined,
+  O extends OmitShape<App> | undefined
+> extends Projection<App, S, O> {
   where?: Where<App>;
-  select?: S;
   orderBy?: OrderBy<App> | OrderBy<App>[];
 }
 
-export interface CreateArgs<App, S extends SelectShape<App> | undefined> {
+export interface CreateArgs<
+  App,
+  S extends SelectShape<App> | undefined,
+  O extends OmitShape<App> | undefined
+> extends Projection<App, S, O> {
   data: Data<App>;
-  select?: S;
 }
 
-export interface UpdateArgs<App, S extends SelectShape<App> | undefined> {
+export interface UpdateArgs<
+  App,
+  S extends SelectShape<App> | undefined,
+  O extends OmitShape<App> | undefined
+> extends Projection<App, S, O> {
   where: Where<App>;
   data: Data<App>;
-  select?: S;
 }
 
-export interface DeleteArgs<App, S extends SelectShape<App> | undefined> {
+export interface DeleteArgs<
+  App,
+  S extends SelectShape<App> | undefined,
+  O extends OmitShape<App> | undefined
+> extends Projection<App, S, O> {
   where: Where<App>;
-  select?: S;
 }
 
 /** Thrown by `findFirstOrThrow` / `updateOrThrow` when no row matches. */
@@ -197,10 +230,11 @@ export class TableClient<App> {
     private readonly db: Queryable
   ) {}
 
-  async findMany<S extends SelectShape<App> | undefined = undefined>(
-    args: FindManyArgs<App, S> = {}
-  ): Promise<SelectResult<App, S>[]> {
-    const fields = this.selectedFields(args.select);
+  async findMany<
+    S extends SelectShape<App> | undefined = undefined,
+    O extends OmitShape<App> | undefined = undefined
+  >(args: FindManyArgs<App, S, O> = {}): Promise<SelectResult<App, S, O>[]> {
+    const fields = this.selectedFields(args);
     const query = this.baseQuery().select(fields.map(field => this.column(field)));
     const predicate = this.predicate(args.where);
     if (predicate) query.where(predicate);
@@ -212,16 +246,18 @@ export class TableClient<App> {
     return rows.map(row => this.decodeRow(row, fields));
   }
 
-  async findFirst<S extends SelectShape<App> | undefined = undefined>(
-    args: FindFirstArgs<App, S> = {}
-  ): Promise<SelectResult<App, S> | null> {
-    const rows = await this.findMany({ ...args, limit: 1 });
+  async findFirst<
+    S extends SelectShape<App> | undefined = undefined,
+    O extends OmitShape<App> | undefined = undefined
+  >(args: FindFirstArgs<App, S, O> = {}): Promise<SelectResult<App, S, O> | null> {
+    const rows = await this.findMany<S, O>({ ...args, limit: 1 });
     return rows.length > 0 ? rows[0] : null;
   }
 
-  async findFirstOrThrow<S extends SelectShape<App> | undefined = undefined>(
-    args: FindFirstArgs<App, S> = {}
-  ): Promise<SelectResult<App, S>> {
+  async findFirstOrThrow<
+    S extends SelectShape<App> | undefined = undefined,
+    O extends OmitShape<App> | undefined = undefined
+  >(args: FindFirstArgs<App, S, O> = {}): Promise<SelectResult<App, S, O>> {
     const row = await this.findFirst(args);
     if (row === null) throw new RowNotFoundError(this.spec.table, 'findFirstOrThrow');
     return row;
@@ -237,10 +273,11 @@ export class TableClient<App> {
     return Number(row.count);
   }
 
-  async create<S extends SelectShape<App> | undefined = undefined>(
-    args: CreateArgs<App, S>
-  ): Promise<SelectResult<App, S>> {
-    const fields = this.selectedFields(args.select);
+  async create<
+    S extends SelectShape<App> | undefined = undefined,
+    O extends OmitShape<App> | undefined = undefined
+  >(args: CreateArgs<App, S, O>): Promise<SelectResult<App, S, O>> {
+    const fields = this.selectedFields(args);
     const query = this.baseQuery()
       .insert(this.encodeData(args.data))
       .returning(fields.map(field => this.column(field)));
@@ -249,10 +286,11 @@ export class TableClient<App> {
     return this.decodeRow(rows[0], fields);
   }
 
-  async update<S extends SelectShape<App> | undefined = undefined>(
-    args: UpdateArgs<App, S>
-  ): Promise<SelectResult<App, S>[]> {
-    const fields = this.selectedFields(args.select);
+  async update<
+    S extends SelectShape<App> | undefined = undefined,
+    O extends OmitShape<App> | undefined = undefined
+  >(args: UpdateArgs<App, S, O>): Promise<SelectResult<App, S, O>[]> {
+    const fields = this.selectedFields(args);
     const query = this.baseQuery()
       .update(this.encodeData(args.data))
       .where(this.required(args.where, 'update'))
@@ -262,18 +300,20 @@ export class TableClient<App> {
     return rows.map(row => this.decodeRow(row, fields));
   }
 
-  async updateOrThrow<S extends SelectShape<App> | undefined = undefined>(
-    args: UpdateArgs<App, S>
-  ): Promise<SelectResult<App, S>> {
+  async updateOrThrow<
+    S extends SelectShape<App> | undefined = undefined,
+    O extends OmitShape<App> | undefined = undefined
+  >(args: UpdateArgs<App, S, O>): Promise<SelectResult<App, S, O>> {
     const rows = await this.update(args);
     if (rows.length === 0) throw new RowNotFoundError(this.spec.table, 'updateOrThrow');
     return rows[0];
   }
 
-  async delete<S extends SelectShape<App> | undefined = undefined>(
-    args: DeleteArgs<App, S>
-  ): Promise<SelectResult<App, S>[]> {
-    const fields = this.selectedFields(args.select);
+  async delete<
+    S extends SelectShape<App> | undefined = undefined,
+    O extends OmitShape<App> | undefined = undefined
+  >(args: DeleteArgs<App, S, O>): Promise<SelectResult<App, S, O>[]> {
+    const fields = this.selectedFields(args);
     const query = this.baseQuery()
       .delete()
       .where(this.required(args.where, 'delete'))
@@ -296,26 +336,34 @@ export class TableClient<App> {
     return this.spec.columnByField[field] ?? field;
   }
 
-  private selectedFields(select: SelectShape<App> | undefined): (keyof App & string)[] {
+  private selectedFields(args: {
+    select?: SelectShape<App>;
+    omit?: OmitShape<App>;
+  }): (keyof App & string)[] {
     const all = Object.keys(this.spec.columnByField) as (keyof App & string)[];
-    if (!select) return all;
-    const picked = all.filter(field => select[field] === true);
-    if (picked.length > 0) return picked;
-    // Nothing picked: the select either excludes fields or says nothing at all,
-    // and both read what is left.
-    return all.filter(field => select[field] !== false);
+    if (args.select && args.omit) {
+      throw new Error(
+        `${this.spec.table}: state either 'select' or 'omit' — a projection already says what it reads.`
+      );
+    }
+    if (args.select) {
+      const picked = all.filter(field => args.select![field] === true);
+      if (picked.length > 0) return picked;
+    }
+    if (args.omit) return all.filter(field => args.omit![field] !== true);
+    return all;
   }
 
-  private decodeRow<S extends SelectShape<App> | undefined>(
+  private decodeRow<S extends SelectShape<App> | undefined, O extends OmitShape<App> | undefined>(
     row: unknown,
     fields: (keyof App & string)[]
-  ): SelectResult<App, S> {
+  ): SelectResult<App, S, O> {
     const raw = row as Record<string, unknown>;
     const decoded: Record<string, unknown> = {};
     for (const field of fields) {
       decoded[field] = this.spec.fields[field](raw[this.column(field)]);
     }
-    return decoded as SelectResult<App, S>;
+    return decoded as SelectResult<App, S, O>;
   }
 
   /**


### PR DESCRIPTION
## Summary

A binding that must read *all but a few* columns previously had to re-list every column it wanted. `select` now carries both directions, the way our GraphQL ORM's `InferSelectResult` already does — no second projection key:

```ts
// no select at all → the whole generated row
await routing.emailIdentities.findFirst({ where: { isActive: true } });

// exclusions → Omit<EmailIdentities, 'databaseId' | 'isActive' | …>
await routing.emailIdentities.findFirst({
  where: { isActive: true },
  select: { databaseId: false, isActive: false, createdAt: false, updatedAt: false }
});

// inclusions → Pick<EmailIdentities, 'id' | 'model'>
await routing.emailIdentities.findFirst({ select: { id: true, model: true } });
```

Type side:

```ts
SelectResult<App, S> =
  TrueKeys<S> extends never
    ? FalseKeys<S> extends never ? App : Omit<App, FalseKeys<S>>
    : Pick<App, TrueKeys<S>>;
```

So an excluded field is absent from the *type*, not just from the row, and reading it fails to compile. An explicit inclusion wins: stating `{ username: true, email: false }` reads only `username`, since the exclusion is already implied by what the projection leaves out.

Same narrowing applies to a mutation's `RETURNING` (`create`/`update`/`delete`), so a write can strip a column it must not carry back.


Link to Devin session: https://app.devin.ai/sessions/b1fb8d90ec0a4cd1bd95e3c77c6f6680
Requested by: @pyramation