### PR TITLE
feat(pg-codegen)!: camelCase generated metadata/decoders, README rewritten around the client

### DIFF
--- a/postgres/pg-codegen/README.md
+++ b/postgres/pg-codegen/README.md
@@ -12,9 +12,113 @@
    <a href="https://www.npmjs.com/package/pg-codegen"><img height="20" src="https://img.shields.io/github/package-json/v/constructive-io/constructive?filename=postgres%2Fpg-codegen%2Fpackage.json"/></a>
 </p>
 
-Type-safe TypeScript from a live PostgreSQL schema: application and row types, runtime decoders, serializers, column metadata and enum unions — one tree-shakable module per table.
+A Prisma-like, fully typed database client generated from your live PostgreSQL schema — plus the types, decoders and serializers it is built on.
 
-> A database row arrives as `unknown`. `pg-codegen` is what turns it into a value TypeScript can trust, without a hand-written `as string` in sight.
+> No hand-written row mappers, no `row.created_at as string`, no column lists at the call site. Point it at a database and query.
+
+## 🚀 Quick start
+
+```bash
+npm install pg-codegen
+pg-codegen --schema app_public --out src/generated
+```
+
+```ts
+import { Pool } from 'pg';
+import { createAppPublicDb } from './generated/app_public/db';
+
+const db = createAppPublicDb(new Pool());
+
+// full row, decoded and camelCase — no select needed
+const user = await db.users.findFirst({ where: { email: 'nadia@example.com' } });
+
+// narrow it inline; the result type follows
+const names = await db.users.findMany({
+  where: { isActive: true, createdAt: { greaterThan: since } },
+  select: { id: true, username: true },
+  orderBy: { createdAt: 'DESC' },
+  limit: 20
+});
+
+const created = await db.users.create({ data: { username: 'nadia', email: 'nadia@example.com' } });
+await db.users.updateOrThrow({ where: { id: created.id }, data: { isActive: false } });
+```
+
+Connection settings come from the standard PG environment (`PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, `PGDATABASE`) via `pg-env`.
+
+## 🧭 The client
+
+One `create<Schema>Db(db, options?)` factory per schema, one client per table:
+
+| Method | Returns |
+|---|---|
+| `findMany(args?)` | `SelectResult[]` |
+| `findFirst(args?)` | `SelectResult \| null` |
+| `findFirstOrThrow(args?)` | `SelectResult`, else `RowNotFoundError` |
+| `count(where?)` | `number` |
+| `create({ data, select? })` | the inserted row |
+| `update({ where, data, select? })` | the updated rows |
+| `updateOrThrow({ where, data, select? })` | one updated row, else `RowNotFoundError` |
+| `delete({ where, select? })` | the deleted rows |
+| `$with(db)` | the same clients bound to another connection |
+
+`where` / `select` / `orderBy` are keyed by camelCase field names and mapped to physical columns for you. `where` speaks the same query-spec grammar as the GraphQL side — `equalTo`, `notEqualTo`, `in`, `notIn`, `lessThan`, `greaterThanOrEqualTo`, `like`, `likeInsensitive`, `startsWith`, `includes`, `isNull`, … — and a bare value means `equalTo` (`null` means `isNull`):
+
+```ts
+await db.posts.findMany({ where: { authorId, status: { in: ['draft', 'review'] }, publishedAt: null } });
+await db.posts.findMany({ where: { or: [{ authorId }, { editorId: authorId }], not: { status: 'archived' } } });
+```
+
+`and` / `or` / `not` nest the same shape.
+
+`update` and `delete` **require** a `where`: an empty filter throws rather than rewriting the table. Reads accept one and read the table unfiltered.
+
+Writes are encoded from the generated column metadata (json/jsonb columns stringified, `Date` → ISO), and every returned row comes back through the generated per-column decoders, so a value that does not match its column's type raises `CoerceError` instead of flowing on as a lie.
+
+### Selections type the result
+
+`select` is the only projection, stated either way round, and the return type follows it with nothing to annotate:
+
+```ts
+await db.emailIdentities.findFirst({ where: { id } });
+// EmailIdentities | null — every column
+
+await db.emailIdentities.findFirst({ select: { id: true, slug: true } });
+// Pick<EmailIdentities, 'id' | 'slug'> | null
+
+await db.emailIdentities.findFirst({ select: { databaseId: false } });
+// Omit<EmailIdentities, 'databaseId'> | null
+```
+
+Excluding is what a caller reaches for when a field must not be carried — a secret's id, row bookkeeping — or when this binding's table genuinely lacks it: an excluded field is absent from the type, so reading it does not compile. Naming any field `true` is a projection and wins outright; the excluded ones are simply not in it.
+
+### Transactions
+
+`$with` rebinds every table client to another connection, so a transaction is the same code against a different handle:
+
+```ts
+const client = await pool.connect();
+try {
+  await client.query('BEGIN');
+  const tx = db.$with(client);
+  const run = await tx.agentRuns.create({ data: { threadId, status: 'running' } });
+  await tx.agentEvents.create({ data: { runId: run.id, seq: 1 } });
+  await client.query('COMMIT');
+} finally {
+  client.release();
+}
+```
+
+### Tables provisioned under a different name
+
+The schema and physical table names are runtime arguments, so one generated client serves a per-tenant or per-scope deployment of the same tables:
+
+```ts
+const routing = createRoutingPublicDb(pool, {
+  schema: tenant.schema,
+  tables: { emailIdentities: 'platform_email_identities' }
+});
+```
 
 ## ✨ What it generates
 
@@ -24,25 +128,47 @@ For every table, view, materialized view and partitioned table in the schemas yo
 |---|---|
 | `AgentRuns` | application shape, camelCase |
 | `AgentRunsRow` | database row shape, snake_case |
-| `AGENT_RUNS_TABLE` | `schema`, `name`, `qualifiedName`, `columns`, `primaryKey`, `columnByField` |
-| `AGENT_RUNS_FIELDS` | one decoder per column, for projections |
+| `agentRunsTable` | `schema`, `name`, `qualifiedName`, `columns`, `primaryKey`, `columnByField` |
+| `agentRunsFields` | one decoder per column, for projections |
 | `decodeAgentRuns` | decode an untrusted camelCase envelope (a wire payload, a parsed body) |
 | `decodeAgentRunsRow` | decode an untrusted database row |
 | `agentRunsFromRow` | row → application shape |
 | `decodeAgentRunsFromRow` | both, composed |
 | `serializeAgentRuns` | `Partial<AgentRuns>` → `Partial<AgentRunsRow>` for INSERT/UPDATE |
 
-Plus an `enums.ts` per schema: a literal union, a `readonly` value list and `as*`/`require*` checkers for every PostgreSQL enum a column references.
+Plus, per schema, a `db.ts` (the client above), an `enums.ts` — a literal union, a `readonly` value list and `as*`/`require*` checkers for every PostgreSQL enum a column references — and barrels; and one shared `client.ts` runtime at the root.
 
 Every decoder is backed by [`@constructive-io/coerce`](../../packages/coerce): a NOT NULL column throws `CoerceError` naming the offending column, a nullable column answers `null`, and the text forms `pg` returns for `int8`/`numeric` are parsed rather than passed through as strings. Nothing is silently coerced across types, so a malformed row cannot become a default value.
 
-## 🛠️ Install
+## 🔧 Below the client
 
-```bash
-npm install pg-codegen
+The client covers single-table reads and writes. For a join, a function call, or SQL the builder does not model, keep the query and decode its columns — `agentRunsFields` takes an overridable label so the error names the alias the query actually used:
+
+```ts
+import { agentRunsFields } from '@my/db-types/codegen_test/agent-runs';
+import { threadsFields } from '@my/db-types/codegen_test/threads';
+
+const { rows } = await db.query(`
+  SELECT r.id, r.status, t.title AS thread_title
+  FROM agent_runs r JOIN threads t ON t.id = r.thread_id
+`);
+
+const summaries = rows.map(row => ({
+  id: agentRunsFields.id(row.id),
+  status: agentRunsFields.status(row.status),
+  threadTitle: threadsFields.title(row.thread_title, 'run_summary.thread_title')
+}));
 ```
 
-## 🚀 Usage
+A whole row from a `SELECT *`-shaped query decodes in one call, and each table is its own module so a bundle carries only what it touches:
+
+```ts
+import { decodeAgentRunsFromRow } from '@my/db-types/codegen_test/agent-runs';
+
+const run = decodeAgentRunsFromRow(rows[0]); // AgentRuns, or CoerceError naming the column
+```
+
+## 📟 CLI
 
 ```bash
 pg-codegen --schema app_public --out src/generated
@@ -52,9 +178,9 @@ pg-codegen --schema app_public --out src/generated --check
 
 `--check` re-introspects and compares against the committed output, exiting non-zero on drift — run it in CI so generated types cannot go stale against a migration.
 
-Connection settings come from the standard PG environment (`PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, `PGDATABASE`) via `pg-env`.
+## 🧩 Programmatic use
 
-Programmatically — for a schema whose physical name is per-tenant, say, where you want to rewrite it to a stable alias before emitting:
+For a schema whose physical name is per-tenant, say, where you want to rewrite it to a stable alias before emitting:
 
 ```ts
 import { Client } from 'pg';
@@ -70,53 +196,6 @@ for (const schema of ir.schemas) {
 await writeFileTree(outDir, emitFileTree(ir));
 ```
 
-## 📟 Example output
-
-```ts
-// generated/codegen_test/agent-runs.ts
-export interface AgentRuns {
-  id: string;
-  threadId: string;
-  status: RunStatus;
-  tags: string[];
-  retrySeconds: number[] | null;
-  lastEventSeq: number;
-  finishedAt: string | null;
-}
-
-export const decodeAgentRunsFromRow = (value: unknown, label = 'codegen_test.agent_runs'): AgentRuns =>
-  agentRunsFromRow(decodeAgentRunsRow(value, label));
-```
-
-Consume per table, so a bundle carries only the tables it touches:
-
-```ts
-import { decodeAgentRunsFromRow } from '@my/db-types/codegen_test/agent-runs';
-
-const { rows } = await db.query('SELECT * FROM agent_runs WHERE id = $1', [id]);
-const run = decodeAgentRunsFromRow(rows[0]); // AgentRuns, or CoerceError naming the column
-```
-
-### Projections
-
-A joined or partial SELECT is not a whole row, so a record decoder would reject it. Decode it column by column instead — `FIELDS` takes an overridable label so the error names the alias the query actually used:
-
-```ts
-import { AGENT_RUNS_FIELDS } from '@my/db-types/codegen_test/agent-runs';
-import { THREADS_FIELDS } from '@my/db-types/codegen_test/threads';
-
-const { rows } = await db.query(`
-  SELECT r.id, r.status, t.title AS thread_title
-  FROM agent_runs r JOIN threads t ON t.id = r.thread_id
-`);
-
-const summaries = rows.map(row => ({
-  id: AGENT_RUNS_FIELDS.id(row.id),
-  status: AGENT_RUNS_FIELDS.status(row.status),
-  threadTitle: THREADS_FIELDS.title(row.thread_title, 'run_summary.thread_title')
-}));
-```
-
 ## 🧱 How it works
 
 ```
@@ -125,4 +204,4 @@ PostgreSQL → introspectron → IR (ir.ts) → emitters (emit/*) → file tree
 
 `buildIr` normalizes an introspection result into the shape every emitter consumes: columns with a resolved scalar, nullability, defaults, primary keys, and the enums they reference. Domains are unwrapped to their base type, arrays carry their element scalar, and a type with no mapping degrades to `unknown` rather than to `any` — the generator never claims to know a shape it does not.
 
-Emission is Babel AST rather than string templates, so output is stable enough to snapshot and to diff in `--check`.
+Emission is Babel AST rather than string templates, so output is stable enough to snapshot and to diff in `--check`. The client runtime is the one exception: `emit/templates/client.ts` is real, typechecked, tested source that is copied into the output, so the runtime every generated client shares is not assembled from AST.

--- a/postgres/pg-codegen/__fixtures__/generated/client.ts
+++ b/postgres/pg-codegen/__fixtures__/generated/client.ts
@@ -18,7 +18,7 @@ export interface Queryable {
   query(text: string, values?: unknown[]): Promise<{ rows: unknown[]; rowCount?: number | null }>;
 }
 
-/** One generated decoder per field, as emitted in the `<TABLE>_FIELDS` constant. */
+/** One generated decoder per field, as emitted in the `<table>Fields` constant. */
 export type FieldDecoders<App> = {
   [K in keyof App]: (value: unknown, label?: string) => App[K];
 };

--- a/postgres/pg-codegen/__fixtures__/generated/codegen_test/active-users.ts
+++ b/postgres/pg-codegen/__fixtures__/generated/codegen_test/active-users.ts
@@ -14,7 +14,7 @@ export interface ActiveUsersRow {
   username: string | null;
 }
 /** Column metadata for `codegen_test.active_users`. */
-export const ACTIVE_USERS_TABLE = {
+export const activeUsersTable = {
   schema: 'codegen_test',
   name: 'active_users',
   qualifiedName: 'codegen_test.active_users',
@@ -33,9 +33,9 @@ export const ACTIVE_USERS_TABLE = {
  * lenient and answers `null`.
  *
  * ```ts
- * id: ACTIVE_USERS_FIELDS.id(row.id),
+ * id: activeUsersFields.id(row.id),
  * ``` */
-export const ACTIVE_USERS_FIELDS = {
+export const activeUsersFields = {
   /** `id` (int4) */id: (value: unknown): number | null => asInteger(value),
   /** `username` (citext) */username: (value: unknown): string | null => asString(value)
 } as const;

--- a/postgres/pg-codegen/__fixtures__/generated/codegen_test/agent-runs.ts
+++ b/postgres/pg-codegen/__fixtures__/generated/codegen_test/agent-runs.ts
@@ -37,7 +37,7 @@ export interface AgentRunsRow {
   finished_at: string | null;
 }
 /** Column metadata for `codegen_test.agent_runs`. */
-export const AGENT_RUNS_TABLE = {
+export const agentRunsTable = {
   schema: 'codegen_test',
   name: 'agent_runs',
   qualifiedName: 'codegen_test.agent_runs',
@@ -65,9 +65,9 @@ export const AGENT_RUNS_TABLE = {
  * lenient and answers `null`.
  *
  * ```ts
- * id: AGENT_RUNS_FIELDS.id(row.id),
+ * id: agentRunsFields.id(row.id),
  * ``` */
-export const AGENT_RUNS_FIELDS = {
+export const agentRunsFields = {
   /** `id` (uuid) */id: (value: unknown, label = 'agent_runs.id'): string => requireUuid(value, label),
   /** `thread_id` (uuid) */threadId: (value: unknown, label = 'agent_runs.thread_id'): string => requireUuid(value, label),
   /** `status` (run_status) */status: (value: unknown, label = 'agent_runs.status'): RunStatus => requireRunStatus(value, label),

--- a/postgres/pg-codegen/__fixtures__/generated/codegen_test/db.ts
+++ b/postgres/pg-codegen/__fixtures__/generated/codegen_test/db.ts
@@ -5,13 +5,13 @@
 import { TableClient } from '../client';
 import type { Queryable } from '../client';
 import type { ActiveUsers } from './active-users';
-import { ACTIVE_USERS_FIELDS, ACTIVE_USERS_TABLE } from './active-users';
+import { activeUsersFields, activeUsersTable } from './active-users';
 import type { AgentRuns } from './agent-runs';
-import { AGENT_RUNS_FIELDS, AGENT_RUNS_TABLE } from './agent-runs';
+import { agentRunsFields, agentRunsTable } from './agent-runs';
 import type { Posts } from './posts';
-import { POSTS_FIELDS, POSTS_TABLE } from './posts';
+import { postsFields, postsTable } from './posts';
 import type { Users } from './users';
-import { USERS_FIELDS, USERS_TABLE } from './users';
+import { usersFields, usersTable } from './users';
 /** Runtime overrides for the physical schema and per-table names, for tables provisioned into per-tenant schemas. */
 export interface CodegenTestDbOptions {
   schema?: string;
@@ -33,29 +33,29 @@ export interface CodegenTestDb {
 /** One Prisma-like client per table over any pg Pool/Client, decoding rows into the generated CodegenTest application types. */
 export const createCodegenTestDb = (db: Queryable, options: CodegenTestDbOptions = {}): CodegenTestDb => ({
   activeUsers: new TableClient<ActiveUsers>({
-    schema: options?.schema ?? ACTIVE_USERS_TABLE.schema,
-    table: options?.tables?.activeUsers ?? ACTIVE_USERS_TABLE.name,
-    columnByField: ACTIVE_USERS_TABLE.columnByField,
-    fields: ACTIVE_USERS_FIELDS
+    schema: options?.schema ?? activeUsersTable.schema,
+    table: options?.tables?.activeUsers ?? activeUsersTable.name,
+    columnByField: activeUsersTable.columnByField,
+    fields: activeUsersFields
   }, db),
   agentRuns: new TableClient<AgentRuns>({
-    schema: options?.schema ?? AGENT_RUNS_TABLE.schema,
-    table: options?.tables?.agentRuns ?? AGENT_RUNS_TABLE.name,
-    columnByField: AGENT_RUNS_TABLE.columnByField,
-    fields: AGENT_RUNS_FIELDS,
+    schema: options?.schema ?? agentRunsTable.schema,
+    table: options?.tables?.agentRuns ?? agentRunsTable.name,
+    columnByField: agentRunsTable.columnByField,
+    fields: agentRunsFields,
     jsonFields: ['metadata', 'settings']
   }, db),
   posts: new TableClient<Posts>({
-    schema: options?.schema ?? POSTS_TABLE.schema,
-    table: options?.tables?.posts ?? POSTS_TABLE.name,
-    columnByField: POSTS_TABLE.columnByField,
-    fields: POSTS_FIELDS
+    schema: options?.schema ?? postsTable.schema,
+    table: options?.tables?.posts ?? postsTable.name,
+    columnByField: postsTable.columnByField,
+    fields: postsFields
   }, db),
   users: new TableClient<Users>({
-    schema: options?.schema ?? USERS_TABLE.schema,
-    table: options?.tables?.users ?? USERS_TABLE.name,
-    columnByField: USERS_TABLE.columnByField,
-    fields: USERS_FIELDS
+    schema: options?.schema ?? usersTable.schema,
+    table: options?.tables?.users ?? usersTable.name,
+    columnByField: usersTable.columnByField,
+    fields: usersFields
   }, db),
   $with: (next: Queryable) => createCodegenTestDb(next, options)
 });

--- a/postgres/pg-codegen/__fixtures__/generated/codegen_test/posts.ts
+++ b/postgres/pg-codegen/__fixtures__/generated/codegen_test/posts.ts
@@ -22,7 +22,7 @@ export interface PostsRow {
   published_at: string | null;
 }
 /** Column metadata for `codegen_test.posts`. */
-export const POSTS_TABLE = {
+export const postsTable = {
   schema: 'codegen_test',
   name: 'posts',
   qualifiedName: 'codegen_test.posts',
@@ -45,9 +45,9 @@ export const POSTS_TABLE = {
  * lenient and answers `null`.
  *
  * ```ts
- * id: POSTS_FIELDS.id(row.id),
+ * id: postsFields.id(row.id),
  * ``` */
-export const POSTS_FIELDS = {
+export const postsFields = {
   /** `id` (uuid) */id: (value: unknown, label = 'posts.id'): string => requireUuid(value, label),
   /** `user_id` (int4) */userId: (value: unknown, label = 'posts.user_id'): number => requireInteger(value, label),
   /** `title` (text) */title: (value: unknown, label = 'posts.title'): string => requireString(value, label),

--- a/postgres/pg-codegen/__fixtures__/generated/codegen_test/users.ts
+++ b/postgres/pg-codegen/__fixtures__/generated/codegen_test/users.ts
@@ -18,7 +18,7 @@ export interface UsersRow {
   created_at: string;
 }
 /** Column metadata for `codegen_test.users`. */
-export const USERS_TABLE = {
+export const usersTable = {
   schema: 'codegen_test',
   name: 'users',
   qualifiedName: 'codegen_test.users',
@@ -39,9 +39,9 @@ export const USERS_TABLE = {
  * lenient and answers `null`.
  *
  * ```ts
- * id: USERS_FIELDS.id(row.id),
+ * id: usersFields.id(row.id),
  * ``` */
-export const USERS_FIELDS = {
+export const usersFields = {
   /** `id` (int4) */id: (value: unknown, label = 'users.id'): number => requireInteger(value, label),
   /** `username` (citext) */username: (value: unknown, label = 'users.username'): string => requireString(value, label),
   /** `email` (email) */email: (value: unknown): string | null => asString(value),

--- a/postgres/pg-codegen/__tests__/__snapshots__/codegen.test.ts.snap
+++ b/postgres/pg-codegen/__tests__/__snapshots__/codegen.test.ts.snap
@@ -40,7 +40,7 @@ export interface AgentRunsRow {
   finished_at: string | null;
 }
 /** Column metadata for \`codegen_test.agent_runs\`. */
-export const AGENT_RUNS_TABLE = {
+export const agentRunsTable = {
   schema: 'codegen_test',
   name: 'agent_runs',
   qualifiedName: 'codegen_test.agent_runs',
@@ -68,9 +68,9 @@ export const AGENT_RUNS_TABLE = {
  * lenient and answers \`null\`.
  *
  * \`\`\`ts
- * id: AGENT_RUNS_FIELDS.id(row.id),
+ * id: agentRunsFields.id(row.id),
  * \`\`\` */
-export const AGENT_RUNS_FIELDS = {
+export const agentRunsFields = {
   /** \`id\` (uuid) */id: (value: unknown, label = 'agent_runs.id'): string => requireUuid(value, label),
   /** \`thread_id\` (uuid) */threadId: (value: unknown, label = 'agent_runs.thread_id'): string => requireUuid(value, label),
   /** \`status\` (run_status) */status: (value: unknown, label = 'agent_runs.status'): RunStatus => requireRunStatus(value, label),
@@ -197,7 +197,7 @@ export interface PostsRow {
   published_at: string | null;
 }
 /** Column metadata for \`codegen_test.posts\`. */
-export const POSTS_TABLE = {
+export const postsTable = {
   schema: 'codegen_test',
   name: 'posts',
   qualifiedName: 'codegen_test.posts',
@@ -220,9 +220,9 @@ export const POSTS_TABLE = {
  * lenient and answers \`null\`.
  *
  * \`\`\`ts
- * id: POSTS_FIELDS.id(row.id),
+ * id: postsFields.id(row.id),
  * \`\`\` */
-export const POSTS_FIELDS = {
+export const postsFields = {
   /** \`id\` (uuid) */id: (value: unknown, label = 'posts.id'): string => requireUuid(value, label),
   /** \`user_id\` (int4) */userId: (value: unknown, label = 'posts.user_id'): number => requireInteger(value, label),
   /** \`title\` (text) */title: (value: unknown, label = 'posts.title'): string => requireString(value, label),
@@ -314,13 +314,13 @@ exports[`generates the schema db factory 1`] = `
 import { TableClient } from '../client';
 import type { Queryable } from '../client';
 import type { ActiveUsers } from './active-users';
-import { ACTIVE_USERS_FIELDS, ACTIVE_USERS_TABLE } from './active-users';
+import { activeUsersFields, activeUsersTable } from './active-users';
 import type { AgentRuns } from './agent-runs';
-import { AGENT_RUNS_FIELDS, AGENT_RUNS_TABLE } from './agent-runs';
+import { agentRunsFields, agentRunsTable } from './agent-runs';
 import type { Posts } from './posts';
-import { POSTS_FIELDS, POSTS_TABLE } from './posts';
+import { postsFields, postsTable } from './posts';
 import type { Users } from './users';
-import { USERS_FIELDS, USERS_TABLE } from './users';
+import { usersFields, usersTable } from './users';
 /** Runtime overrides for the physical schema and per-table names, for tables provisioned into per-tenant schemas. */
 export interface CodegenTestDbOptions {
   schema?: string;
@@ -342,29 +342,29 @@ export interface CodegenTestDb {
 /** One Prisma-like client per table over any pg Pool/Client, decoding rows into the generated CodegenTest application types. */
 export const createCodegenTestDb = (db: Queryable, options: CodegenTestDbOptions = {}): CodegenTestDb => ({
   activeUsers: new TableClient<ActiveUsers>({
-    schema: options?.schema ?? ACTIVE_USERS_TABLE.schema,
-    table: options?.tables?.activeUsers ?? ACTIVE_USERS_TABLE.name,
-    columnByField: ACTIVE_USERS_TABLE.columnByField,
-    fields: ACTIVE_USERS_FIELDS
+    schema: options?.schema ?? activeUsersTable.schema,
+    table: options?.tables?.activeUsers ?? activeUsersTable.name,
+    columnByField: activeUsersTable.columnByField,
+    fields: activeUsersFields
   }, db),
   agentRuns: new TableClient<AgentRuns>({
-    schema: options?.schema ?? AGENT_RUNS_TABLE.schema,
-    table: options?.tables?.agentRuns ?? AGENT_RUNS_TABLE.name,
-    columnByField: AGENT_RUNS_TABLE.columnByField,
-    fields: AGENT_RUNS_FIELDS,
+    schema: options?.schema ?? agentRunsTable.schema,
+    table: options?.tables?.agentRuns ?? agentRunsTable.name,
+    columnByField: agentRunsTable.columnByField,
+    fields: agentRunsFields,
     jsonFields: ['metadata', 'settings']
   }, db),
   posts: new TableClient<Posts>({
-    schema: options?.schema ?? POSTS_TABLE.schema,
-    table: options?.tables?.posts ?? POSTS_TABLE.name,
-    columnByField: POSTS_TABLE.columnByField,
-    fields: POSTS_FIELDS
+    schema: options?.schema ?? postsTable.schema,
+    table: options?.tables?.posts ?? postsTable.name,
+    columnByField: postsTable.columnByField,
+    fields: postsFields
   }, db),
   users: new TableClient<Users>({
-    schema: options?.schema ?? USERS_TABLE.schema,
-    table: options?.tables?.users ?? USERS_TABLE.name,
-    columnByField: USERS_TABLE.columnByField,
-    fields: USERS_FIELDS
+    schema: options?.schema ?? usersTable.schema,
+    table: options?.tables?.users ?? usersTable.name,
+    columnByField: usersTable.columnByField,
+    fields: usersFields
   }, db),
   $with: (next: Queryable) => createCodegenTestDb(next, options)
 });
@@ -392,7 +392,7 @@ export interface UsersRow {
   created_at: string;
 }
 /** Column metadata for \`codegen_test.users\`. */
-export const USERS_TABLE = {
+export const usersTable = {
   schema: 'codegen_test',
   name: 'users',
   qualifiedName: 'codegen_test.users',
@@ -413,9 +413,9 @@ export const USERS_TABLE = {
  * lenient and answers \`null\`.
  *
  * \`\`\`ts
- * id: USERS_FIELDS.id(row.id),
+ * id: usersFields.id(row.id),
  * \`\`\` */
-export const USERS_FIELDS = {
+export const usersFields = {
   /** \`id\` (int4) */id: (value: unknown, label = 'users.id'): number => requireInteger(value, label),
   /** \`username\` (citext) */username: (value: unknown, label = 'users.username'): string => requireString(value, label),
   /** \`email\` (email) */email: (value: unknown): string | null => asString(value),

--- a/postgres/pg-codegen/__tests__/decoders.test.ts
+++ b/postgres/pg-codegen/__tests__/decoders.test.ts
@@ -10,9 +10,9 @@ import type { PgTestClient } from 'pgsql-test/test-client';
 
 import type { AgentRuns } from '../__fixtures__/generated/codegen_test/agent-runs';
 import {
-  AGENT_RUNS_FIELDS,
-  AGENT_RUNS_TABLE,
+  agentRunsFields,
   agentRunsFromRow,
+  agentRunsTable,
   decodeAgentRuns,
   decodeAgentRunsFromRow,
   decodeAgentRunsRow,
@@ -146,47 +146,47 @@ describe('serializeAgentRuns', () => {
 
 describe('table metadata', () => {
   it('carries columns, primary key and the field mapping', () => {
-    expect(AGENT_RUNS_TABLE.qualifiedName).toBe('codegen_test.agent_runs');
-    expect(AGENT_RUNS_TABLE.primaryKey).toEqual(['id']);
-    expect(AGENT_RUNS_TABLE.columns).toContain('last_event_seq');
-    expect(AGENT_RUNS_TABLE.columnByField.lastEventSeq).toBe('last_event_seq');
+    expect(agentRunsTable.qualifiedName).toBe('codegen_test.agent_runs');
+    expect(agentRunsTable.primaryKey).toEqual(['id']);
+    expect(agentRunsTable.columns).toContain('last_event_seq');
+    expect(agentRunsTable.columnByField.lastEventSeq).toBe('last_event_seq');
   });
 });
 
 describe('per-column field decoders', () => {
   it('decodes one column of a projection a record decoder could not describe', () => {
     const joined = { run_id: RUN_ID, status: 'running', thread_name: 'main' };
-    expect(AGENT_RUNS_FIELDS.id(joined.run_id)).toBe(RUN_ID);
-    expect(AGENT_RUNS_FIELDS.status(joined.status)).toBe('running');
+    expect(agentRunsFields.id(joined.run_id)).toBe(RUN_ID);
+    expect(agentRunsFields.status(joined.status)).toBe('running');
   });
 
   it('parses the text forms pg returns, as the row decoder does', () => {
-    expect(AGENT_RUNS_FIELDS.lastEventSeq('9007199254740')).toBe(9007199254740);
-    expect(AGENT_RUNS_FIELDS.score('0.7500')).toBe(0.75);
+    expect(agentRunsFields.lastEventSeq('9007199254740')).toBe(9007199254740);
+    expect(agentRunsFields.score('0.7500')).toBe(0.75);
   });
 
   it('throws naming the column when a NOT NULL column is absent', () => {
-    expect(() => AGENT_RUNS_FIELDS.id(undefined)).toThrow(
+    expect(() => agentRunsFields.id(undefined)).toThrow(
       'agent_runs.id is required (expected a UUID)'
     );
-    expect(() => AGENT_RUNS_FIELDS.status('exploded')).toThrow(CoerceError);
+    expect(() => agentRunsFields.status('exploded')).toThrow(CoerceError);
   });
 
   it('takes an overridden label so a projection can name its own alias', () => {
-    expect(() => AGENT_RUNS_FIELDS.id(null, 'thread_run.run_id')).toThrow(
+    expect(() => agentRunsFields.id(null, 'thread_run.run_id')).toThrow(
       'thread_run.run_id is required (expected a UUID)'
     );
   });
 
   it('answers null for a nullable column rather than throwing', () => {
-    expect(AGENT_RUNS_FIELDS.finishedAt(null)).toBeNull();
-    expect(AGENT_RUNS_FIELDS.settings(undefined)).toBeNull();
+    expect(agentRunsFields.finishedAt(null)).toBeNull();
+    expect(agentRunsFields.settings(undefined)).toBeNull();
   });
 
   it('agrees with the row decoder on every column of a whole row', () => {
     const row: Record<string, unknown> = { ...decodeAgentRunsRow(validRow) };
-    for (const [field, column] of Object.entries(AGENT_RUNS_TABLE.columnByField)) {
-      const decode = AGENT_RUNS_FIELDS[field as keyof typeof AGENT_RUNS_FIELDS];
+    for (const [field, column] of Object.entries(agentRunsTable.columnByField)) {
+      const decode = agentRunsFields[field as keyof typeof agentRunsFields];
       expect(decode(validRow[column])).toEqual(row[column]);
     }
   });

--- a/postgres/pg-codegen/src/emit/client.ts
+++ b/postgres/pg-codegen/src/emit/client.ts
@@ -4,7 +4,7 @@
  * TableClient per table over the generated metadata and field decoders.
  */
 import * as fs from 'fs';
-import { toCamelCase, toConstantCase, toPascalCase } from 'inflekt';
+import { toCamelCase, toPascalCase } from 'inflekt';
 import * as path from 'path';
 
 import { IrSchema, IrTable } from '../ir';
@@ -48,10 +48,10 @@ export const emitSchemaDbModule = (schema: IrSchema): string => {
 
   for (const table of schema.tables) {
     const appType = toPascalCase(table.name);
-    const constant = toConstantCase(table.name);
+    const model = toCamelCase(table.name);
     const file = `./${tableFileName(table.name)}`;
     statements.push(typeImport([appType], file));
-    statements.push(namedImport([`${constant}_FIELDS`, `${constant}_TABLE`], file));
+    statements.push(namedImport([`${model}Fields`, `${model}Table`], file));
   }
 
   const tableNameProps = schema.tables.map(table => {
@@ -122,14 +122,14 @@ export const emitSchemaDbModule = (schema: IrSchema): string => {
   );
 
   const clientProperties: t.ObjectProperty[] = schema.tables.map(table => {
-    const constant = toConstantCase(table.name);
+    const model = toCamelCase(table.name);
     const spec = t.objectExpression([
       t.objectProperty(
         t.identifier('schema'),
         t.logicalExpression(
           '??',
           t.optionalMemberExpression(t.identifier('options'), t.identifier('schema'), false, true),
-          t.memberExpression(t.identifier(`${constant}_TABLE`), t.identifier('schema'))
+          t.memberExpression(t.identifier(`${model}Table`), t.identifier('schema'))
         )
       ),
       t.objectProperty(
@@ -142,14 +142,14 @@ export const emitSchemaDbModule = (schema: IrSchema): string => {
             false,
             true
           ),
-          t.memberExpression(t.identifier(`${constant}_TABLE`), t.identifier('name'))
+          t.memberExpression(t.identifier(`${model}Table`), t.identifier('name'))
         )
       ),
       t.objectProperty(
         t.identifier('columnByField'),
-        t.memberExpression(t.identifier(`${constant}_TABLE`), t.identifier('columnByField'))
+        t.memberExpression(t.identifier(`${model}Table`), t.identifier('columnByField'))
       ),
-      t.objectProperty(t.identifier('fields'), t.identifier(`${constant}_FIELDS`))
+      t.objectProperty(t.identifier('fields'), t.identifier(`${model}Fields`))
     ]);
     const jsonFields = table.columns.filter(column => column.scalar === 'json');
     if (jsonFields.length > 0) {

--- a/postgres/pg-codegen/src/emit/record.ts
+++ b/postgres/pg-codegen/src/emit/record.ts
@@ -3,7 +3,7 @@
  * snake_case row interface, coerce-backed decoders for both, row/application
  * converters, a serializer for writes, and typed table metadata.
  */
-import { toCamelCase, toConstantCase, toPascalCase } from 'inflekt';
+import { toCamelCase, toPascalCase } from 'inflekt';
 
 import { IrColumn, IrTable } from '../ir';
 import {
@@ -156,7 +156,7 @@ const decodeExpression = (
 };
 
 /**
- * `<TABLE>_FIELDS`: one decoder per column, for rows that are NOT a whole
+ * `<table>Fields`: one decoder per column, for rows that are NOT a whole
  * table row — a joined projection, an aliased column, a partial SELECT — where
  * a record decoder would reject the absent columns.
  *
@@ -237,8 +237,8 @@ export const emitRecordModule = (table: IrTable): string => {
   const usage: RecordModuleUsage = { coerceImports: new Set(), enumImports: new Set() };
   const pascal = toPascalCase(table.name);
   const rowTypeName = `${pascal}Row`;
-  const metadataName = `${toConstantCase(table.name)}_TABLE`;
-  const fieldsName = `${toConstantCase(table.name)}_FIELDS`;
+  const metadataName = `${toCamelCase(table.name)}Table`;
+  const fieldsName = `${toCamelCase(table.name)}Fields`;
   const qualified = `${table.schema}.${table.name}`;
 
   const statements: t.Statement[] = [];

--- a/postgres/pg-codegen/src/emit/templates/client.ts
+++ b/postgres/pg-codegen/src/emit/templates/client.ts
@@ -18,7 +18,7 @@ export interface Queryable {
   query(text: string, values?: unknown[]): Promise<{ rows: unknown[]; rowCount?: number | null }>;
 }
 
-/** One generated decoder per field, as emitted in the `<TABLE>_FIELDS` constant. */
+/** One generated decoder per field, as emitted in the `<table>Fields` constant. */
 export type FieldDecoders<App> = {
   [K in keyof App]: (value: unknown, label?: string) => App[K];
 };


### PR DESCRIPTION
## Summary

Two things, both cosmetic in effect but breaking in name.

**The per-table value exports lose their SCREAMING_CASE.** They are objects, not primitives, and the generated client already hides them, so the shouting bought nothing:

```diff
-export const AGENT_RUNS_TABLE = { schema, name, qualifiedName, columns, primaryKey, columnByField } as const;
-export const AGENT_RUNS_FIELDS = { id: …, threadId: … };
+export const agentRunsTable = { … } as const;
+export const agentRunsFields = { … };
```

A clean break — no aliases, no deprecation path. `db.ts` imports the new names, fixtures and snapshots are regenerated, and nothing else in this repo referenced the old ones.

**The README is rewritten around what the package actually is now.** It still described the decoder/serializer layer as the product and never mentioned the generated client, so a reader landed on `AGENT_RUNS_FIELDS.id(row.id)` as the headline API instead of `db.users.findFirst(...)`. It now leads with the client (method table, `where` grammar, `$with`, runtime schema/table binding), documents `select` typing the result — nothing → full row, `true` keys → `Pick`, `false` keys → `Omit` — and demotes the per-column decoders to the "below the client" section they belong in, for joins and raw SQL.


Link to Devin session: https://app.devin.ai/sessions/b1fb8d90ec0a4cd1bd95e3c77c6f6680
Requested by: @pyramation