### PR TITLE
feat(run-log): registered entry types, durable gate decisions, and span projection

### DIFF
--- a/agentic/run-log/README.md
+++ b/agentic/run-log/README.md
@@ -77,10 +77,24 @@ for await (const batch of follow(store, 'run-1', { waitForChange })) {
 | --- | --- |
 | `projectParts` | the renderable transcript — a tool call and its later result collapse into one part, so no renderer correlates messages itself |
 | `projectUsage` | tokens and cost, per `provider/model` and per run, including nested tool usage and compaction calls |
-| `projectToolState` | what is running, and what is waiting on a human (approvals ride in the log as pi `custom` messages, so a surface that reconnects hours later still sees a pending request) |
+| `projectToolState` | what is running, what is waiting on a human, and how the gate settled each call (approvals and gate decisions ride in the log as pi `custom` messages, so a surface that reconnects hours later still sees a pending request) |
+| `projectSpans` | how long each step took, and inside what — tool spans (call → result), model spans, approval spans (request → answer) with parents, for a timeline |
 | `projectSession` | a pi session file — the resume path, cloud → local included |
 
-All four are pure and total: the same records always produce the same output, whichever host wrote them, which is the property the tests assert as *placement invariance*.
+All of them are pure and total: the same records always produce the same output, whichever host wrote them, which is the property the tests assert as *placement invariance*.
+
+A span duration derived from a *pair of writes* is a bound, not a measurement — the gap between a tool call and its result includes the wait for a human — so every span says which it is (`timing: 'bounded' | 'measured'`) and a tool span carries its approval wait separately. An interval that never closed stays `open` with no duration, because a run still in flight must not look like one that finished.
+
+## Entry types
+
+New event kinds are namespaced pi `custom` messages, not new tables: the log stores entries verbatim, so a type is only a `customType` string plus a validator. `constructiveEntryTypes()` is the registry of the ones this platform writes — approval requests and answers, and `constructive.gate.decision` — each pairing a details type with a runtime assertion, a label, and a visibility:
+
+| Visibility | Meaning |
+| --- | --- |
+| `surface` | part of the conversation the model sees — an approval question and its answer |
+| `log-only` | audit and trace data, never fed back to the model — a gate decision, which the model already learned of through the blocked call's error |
+
+An unregistered type is `log-only`: a trace view showing an unknown row is right, a prompt built from one is not.
 
 Unreadable input fails loudly. A corrupt record, a mixed-version log, or a session whose header is not first throws rather than degrading into an empty transcript — a run that silently renders as blank is worse than one that reports it cannot be read. An *unknown* entry type is different: it is carried through as an `unknown` part, so a log written by a newer pi still renders.
 

--- a/agentic/run-log/__tests__/entry-types.test.ts
+++ b/agentic/run-log/__tests__/entry-types.test.ts
@@ -1,0 +1,81 @@
+import {
+  APPROVAL_REQUEST_TYPE,
+  APPROVAL_RESOLUTION_TYPE,
+  constructiveEntryTypes,
+  EntryTypeRegistry,
+  GATE_DECISION_TYPE
+} from '../src';
+
+describe('EntryTypeRegistry', () => {
+  const definition = {
+    customType: 'acme.thing.happened',
+    visibility: 'log-only' as const,
+    label: 'Thing happened',
+    assertDetails: (value: unknown) => value as { thing: string }
+  };
+
+  it('registers, finds and lists types in registration order', () => {
+    const registry = new EntryTypeRegistry().register(definition);
+
+    expect(registry.has('acme.thing.happened')).toBe(true);
+    expect(registry.get('acme.thing.happened')?.label).toBe('Thing happened');
+    expect(registry.list().map((entry) => entry.customType)).toEqual(['acme.thing.happened']);
+  });
+
+  it('refuses to register the same type twice', () => {
+    const registry = new EntryTypeRegistry().register(definition);
+
+    expect(() => registry.register(definition)).toThrow(/already registered/);
+  });
+
+  it('treats an unregistered type as log-only', () => {
+    // A renderer showing an unknown row in the trace is right; one feeding it to
+    // a model would not be.
+    expect(new EntryTypeRegistry().visibilityOf('acme.unknown')).toBe('log-only');
+  });
+
+  it('hands out an independent registry so one host cannot surprise another', () => {
+    constructiveEntryTypes().register(definition);
+
+    expect(constructiveEntryTypes().has('acme.thing.happened')).toBe(false);
+  });
+});
+
+describe('constructiveEntryTypes', () => {
+  const registry = constructiveEntryTypes();
+
+  it('knows the types Constructive writes', () => {
+    expect(registry.list().map((entry) => entry.customType)).toEqual([
+      APPROVAL_REQUEST_TYPE,
+      APPROVAL_RESOLUTION_TYPE,
+      GATE_DECISION_TYPE
+    ]);
+  });
+
+  it('puts approvals on the surface and gate decisions in the log only', () => {
+    // The agent is blocked on an approval, so it belongs to the conversation; a
+    // denial already reached the model through the blocked call's error.
+    expect(registry.visibilityOf(APPROVAL_REQUEST_TYPE)).toBe('surface');
+    expect(registry.visibilityOf(APPROVAL_RESOLUTION_TYPE)).toBe('surface');
+    expect(registry.visibilityOf(GATE_DECISION_TYPE)).toBe('log-only');
+  });
+
+  it('narrows details through the registered guard', () => {
+    const gate = registry.get(GATE_DECISION_TYPE)!;
+
+    expect(
+      gate.assertDetails({ toolCallId: 'call-1', toolName: 'bash', verdict: 'deny', decision: 'deny' })
+    ).toMatchObject({ toolCallId: 'call-1', decision: 'deny' });
+    expect(() => gate.assertDetails({ toolName: 'bash', decision: 'deny' })).toThrow(/toolCallId/);
+    expect(() => gate.assertDetails({ toolCallId: 'call-1', decision: 'maybe' })).toThrow(/allow.*deny/);
+  });
+
+  it('rejects an approval resolution that decides nothing', () => {
+    const resolution = registry.get(APPROVAL_RESOLUTION_TYPE)!;
+
+    expect(resolution.assertDetails({ toolCallId: 'call-1', decision: 'approved' })).toMatchObject({
+      decision: 'approved'
+    });
+    expect(() => resolution.assertDetails({ toolCallId: 'call-1' })).toThrow(/approved.*rejected/);
+  });
+});

--- a/agentic/run-log/__tests__/spans.test.ts
+++ b/agentic/run-log/__tests__/spans.test.ts
@@ -1,0 +1,188 @@
+import {
+  approvalRequestMessage,
+  approvalResolutionMessage,
+  gateDecisionMessage,
+  type ModelSpan,
+  projectSpans,
+  type RunEventRecord,
+  type Span,
+  type ToolSpan,
+  wrapEntry
+} from '../src';
+import type { PiSessionEntry } from '../src/pi-entry';
+import {
+  assistantText,
+  assistantToolCall,
+  custom,
+  futureEntry,
+  header,
+  resetIds,
+  toolResult,
+  userMessage
+} from './fixtures';
+
+beforeEach(resetIds);
+
+/** Fixtures timestamp entry `n` at `00:00:0n`, so a gap of one is 1000ms. */
+const recordsOf = (...entries: PiSessionEntry[]): RunEventRecord[] =>
+  entries.map((entry, i) =>
+    wrapEntry({ runId: 'run-1', seq: i + 1, entry, recordedAt: `2026-01-01T00:00:0${String(i)}.000Z` })
+  );
+
+const byId = (spans: readonly Span[], id: string): Span => {
+  const span = spans.find((candidate) => candidate.id === id);
+  if (!span) throw new Error(`no span ${id} in ${spans.map((s) => s.id).join(', ')}`);
+  return span;
+};
+
+describe('projectSpans', () => {
+  it('brackets a tool call with its result and parents it to the model turn', () => {
+    const { spans } = projectSpans(
+      recordsOf(
+        userMessage('add a test', 1),
+        assistantToolCall({ id: 'call-1', name: 'write_file', arguments: { path: 'a.ts' } }, 2),
+        toolResult({ toolCallId: 'call-1', toolName: 'write_file', text: 'wrote a.ts' }, 5)
+      )
+    );
+
+    const model = spans.find((span): span is ModelSpan => span.kind === 'model');
+    const tool = byId(spans, 'tool:call-1') as ToolSpan;
+
+    expect(model).toMatchObject({ model: 'claude-sonnet-4-5', provider: 'anthropic', status: 'ok' });
+    // The turn is bracketed by the previous entry and its own: 00:00:01 → 00:00:02.
+    expect(model).toMatchObject({ durationMs: 1000, timing: 'bounded' });
+    expect(tool).toMatchObject({
+      kind: 'tool',
+      parentId: model!.id,
+      name: 'write_file',
+      arguments: { path: 'a.ts' },
+      status: 'ok',
+      output: 'wrote a.ts',
+      // 00:00:02 → 00:00:05.
+      durationMs: 3000,
+      timing: 'bounded',
+      startSeq: 2,
+      endSeq: 3
+    });
+  });
+
+  it('leaves an unsettled tool call open rather than closing it at the last record', () => {
+    const { spans } = projectSpans(
+      recordsOf(userMessage('go', 1), assistantToolCall({ id: 'call-1', name: 'bash' }, 2))
+    );
+
+    expect(byId(spans, 'tool:call-1')).toMatchObject({ status: 'open' });
+    expect(byId(spans, 'tool:call-1').durationMs).toBeUndefined();
+    expect(byId(spans, 'tool:call-1').endedAt).toBeUndefined();
+  });
+
+  it('measures the approval wait separately from the tool it blocked', () => {
+    const { spans } = projectSpans(
+      recordsOf(
+        assistantToolCall({ id: 'call-1', name: 'deploy' }, 1),
+        custom(approvalRequestMessage({ toolCallId: 'call-1', prompt: 'deploy to prod?' }), 2),
+        custom(approvalResolutionMessage({ toolCallId: 'call-1', decision: 'approved', actorId: 'user-1' }), 6),
+        toolResult({ toolCallId: 'call-1', toolName: 'deploy', text: 'deployed' }, 9)
+      )
+    );
+
+    const approval = byId(spans, 'approval:call-1');
+    expect(approval).toMatchObject({
+      kind: 'approval',
+      parentId: 'tool:call-1',
+      prompt: 'deploy to prod?',
+      decision: 'approved',
+      actorId: 'user-1',
+      status: 'ok',
+      // A request and its answer are exactly the interval a human held the run.
+      timing: 'measured',
+      durationMs: 4000
+    });
+    expect(byId(spans, 'tool:call-1')).toMatchObject({
+      status: 'ok',
+      durationMs: 8000,
+      approvalWaitMs: 4000
+    });
+  });
+
+  it('marks a rejected approval denied', () => {
+    const { spans } = projectSpans(
+      recordsOf(
+        assistantToolCall({ id: 'call-1', name: 'deploy' }, 1),
+        custom(approvalRequestMessage({ toolCallId: 'call-1', prompt: 'ok?' }), 2),
+        custom(approvalResolutionMessage({ toolCallId: 'call-1', decision: 'rejected', reason: 'not today' }), 3)
+      )
+    );
+
+    expect(byId(spans, 'approval:call-1')).toMatchObject({ status: 'denied', decision: 'rejected' });
+  });
+
+  it('closes a gate-denied tool call, which no tool result ever will', () => {
+    const { spans } = projectSpans(
+      recordsOf(
+        assistantToolCall({ id: 'call-1', name: 'bash' }, 1),
+        custom(
+          gateDecisionMessage({
+            toolCallId: 'call-1',
+            toolName: 'bash',
+            verdict: 'deny',
+            decision: 'deny',
+            reason: 'bash is not permitted in this run'
+          }),
+          4
+        )
+      )
+    );
+
+    expect(byId(spans, 'tool:call-1')).toMatchObject({
+      status: 'denied',
+      gateDecision: 'deny',
+      gateReason: 'bash is not permitted in this run',
+      durationMs: 3000,
+      endSeq: 2
+    });
+  });
+
+  it('keeps an allowed gate decision from settling the call', () => {
+    const { spans } = projectSpans(
+      recordsOf(
+        assistantToolCall({ id: 'call-1', name: 'bash' }, 1),
+        custom(gateDecisionMessage({ toolCallId: 'call-1', toolName: 'bash', verdict: 'allow', decision: 'allow' }), 2)
+      )
+    );
+
+    expect(byId(spans, 'tool:call-1')).toMatchObject({ status: 'open', gateDecision: 'allow' });
+  });
+
+  it('carries the response id a metered inference row can be joined on', () => {
+    const { spans } = projectSpans(
+      recordsOf(assistantText('done', 2, { responseId: 'resp-42', stopReason: 'stop' }))
+    );
+
+    expect(spans[0]).toMatchObject({ kind: 'model', responseId: 'resp-42', stopReason: 'stop' });
+  });
+
+  it('marks an errored turn without inventing a status for the run', () => {
+    const { spans } = projectSpans(
+      recordsOf(assistantText('', 2, { stopReason: 'error', errorMessage: 'overloaded' }))
+    );
+
+    expect(spans[0]).toMatchObject({ status: 'error', errorMessage: 'overloaded' });
+  });
+
+  it('ignores entry types it has never seen', () => {
+    const { spans } = projectSpans(recordsOf(header(), userMessage('go', 1), futureEntry(2)));
+
+    expect(spans).toEqual([]);
+  });
+
+  it('is pure: the same records always project the same spans', () => {
+    const records = recordsOf(
+      userMessage('go', 1),
+      assistantToolCall({ id: 'call-1', name: 'bash' }, 2),
+      toolResult({ toolCallId: 'call-1', toolName: 'bash', text: 'ok' }, 3)
+    );
+
+    expect(projectSpans(records)).toEqual(projectSpans(records));
+  });
+});

--- a/agentic/run-log/src/entry-types.ts
+++ b/agentic/run-log/src/entry-types.ts
@@ -1,0 +1,129 @@
+/**
+ * The entry-type registry: the one place that says what a `custom` entry in a
+ * run log means.
+ *
+ * pi's session format is extensible through `custom` messages, and Constructive
+ * uses that seam rather than new tables — an approval, a gate decision, a future
+ * command are all entries in the same append-only log, so a new kind of event
+ * costs a registration here and no schema change at all.
+ *
+ * Two things are registered per type. A `details` guard, because the payload
+ * arrives from a database column or an HTTP body and a projector must not read
+ * it untyped. And a *visibility*: whether the entry is part of what the model
+ * sees (`surface`) or a record only humans and tooling read (`log-only`). pi
+ * decides what to replay from the entries it wrote itself, so the flag does not
+ * steer the agent loop; it tells a renderer which rows belong to the
+ * conversation and which belong to the trace, and it documents intent for the
+ * writer.
+ */
+
+import {
+  APPROVAL_REQUEST_TYPE,
+  APPROVAL_RESOLUTION_TYPE,
+  assertApprovalRequestDetails,
+  assertApprovalResolutionDetails,
+  assertGateDecisionDetails,
+  GATE_DECISION_TYPE
+} from './projectors/tool-state';
+
+/**
+ * Whether an entry contributes to the conversation the model sees.
+ *
+ * - `surface`: the entry is (or becomes) part of the model's context — an
+ *   approval prompt the agent must react to, for instance.
+ * - `log-only`: durable, replayable, projected into traces and audits, but
+ *   never part of what the model reads. A gate decision is the archetype: the
+ *   model already learned of a denial through the blocked tool call's error.
+ */
+export type EntryVisibility = 'surface' | 'log-only';
+
+/** What the registry knows about one `customType`. */
+export interface EntryTypeDefinition<TDetails = unknown> {
+  /** The namespaced discriminator, e.g. `constructive.gate.decision`. */
+  customType: string;
+  visibility: EntryVisibility;
+  /** Short human label — a renderer's fallback row title. */
+  label: string;
+  /**
+   * Narrow the entry's `details`. Throws rather than returning null: a payload
+   * that cannot be read is a corrupted entry, never an empty one.
+   */
+  assertDetails: (value: unknown) => TDetails;
+}
+
+/**
+ * A registry of `custom` entry types.
+ *
+ * Registration is by value rather than by module side effect so a host can hold
+ * its own registry (a test, a downstream package adding its own vocabulary)
+ * without mutating everyone else's.
+ */
+export class EntryTypeRegistry {
+  private readonly types = new Map<string, EntryTypeDefinition<unknown>>();
+
+  constructor(definitions: readonly EntryTypeDefinition<never>[] = []) {
+    for (const definition of definitions) this.register(definition);
+  }
+
+  /** Register a type. Re-registering the same `customType` is a programming error. */
+  register<TDetails>(definition: EntryTypeDefinition<TDetails>): this {
+    if (this.types.has(definition.customType)) {
+      throw new Error(`entry type ${definition.customType} is already registered`);
+    }
+    this.types.set(definition.customType, definition as EntryTypeDefinition<unknown>);
+    return this;
+  }
+
+  /** The definition for a `customType`, or undefined when nothing claims it. */
+  get(customType: string): EntryTypeDefinition<unknown> | undefined {
+    return this.types.get(customType);
+  }
+
+  has(customType: string): boolean {
+    return this.types.has(customType);
+  }
+
+  /** Every registered type, in registration order. */
+  list(): readonly EntryTypeDefinition<unknown>[] {
+    return Array.from(this.types.values());
+  }
+
+  /**
+   * The visibility of a `customType`. An unregistered type is `log-only`: a
+   * renderer showing an unknown row in the trace is right, and one feeding it
+   * to a model would not be.
+   */
+  visibilityOf(customType: string): EntryVisibility {
+    return this.types.get(customType)?.visibility ?? 'log-only';
+  }
+}
+
+/**
+ * The types Constructive itself writes.
+ *
+ * A host that adds its own vocabulary registers onto a copy
+ * (`constructiveEntryTypes()`) rather than mutating a shared singleton, so one
+ * package's registration cannot surprise another's projector.
+ */
+export const constructiveEntryTypes = (): EntryTypeRegistry =>
+  new EntryTypeRegistry()
+    .register({
+      customType: APPROVAL_REQUEST_TYPE,
+      // The agent is blocked on this one, and a reconnecting surface must be
+      // able to see it — it belongs to the conversation.
+      visibility: 'surface',
+      label: 'Approval requested',
+      assertDetails: assertApprovalRequestDetails
+    })
+    .register({
+      customType: APPROVAL_RESOLUTION_TYPE,
+      visibility: 'surface',
+      label: 'Approval answered',
+      assertDetails: assertApprovalResolutionDetails
+    })
+    .register({
+      customType: GATE_DECISION_TYPE,
+      visibility: 'log-only',
+      label: 'Gate decision',
+      assertDetails: (value: unknown) => assertGateDecisionDetails(value)
+    });

--- a/agentic/run-log/src/index.ts
+++ b/agentic/run-log/src/index.ts
@@ -8,6 +8,12 @@
  */
 
 export {
+  constructiveEntryTypes,
+  type EntryTypeDefinition,
+  EntryTypeRegistry,
+  type EntryVisibility
+} from './entry-types';
+export {
   follow,
   type FollowOptions,
   readAll
@@ -64,6 +70,18 @@ export {
   type SessionProjectionOptions
 } from './projectors/session';
 export {
+  type ApprovalSpan,
+  type ModelSpan,
+  projectSpans,
+  type Span,
+  type SpanBase,
+  type SpanKind,
+  type SpanProjection,
+  type SpanStatus,
+  type SpanTiming,
+  type ToolSpan
+} from './projectors/spans';
+export {
   APPROVAL_REQUEST_TYPE,
   APPROVAL_RESOLUTION_TYPE,
   type ApprovalRequestInput,
@@ -71,6 +89,13 @@ export {
   type ApprovalResolutionInput,
   approvalResolutionMessage,
   type ApprovalState,
+  assertApprovalRequestDetails,
+  assertApprovalResolutionDetails,
+  assertGateDecisionDetails,
+  GATE_DECISION_TYPE,
+  type GateDecisionDetails,
+  gateDecisionMessage,
+  type GateDecisionState,
   projectToolState,
   type ToolCallState,
   type ToolCallStatus,

--- a/agentic/run-log/src/projectors/spans.ts
+++ b/agentic/run-log/src/projectors/spans.ts
@@ -1,0 +1,256 @@
+/**
+ * Span projection: run log records → timed intervals with parents.
+ *
+ * The log answers *what* happened and the parts projection answers *in what
+ * order*, but a trace view asks "how long did this take, and inside what" —
+ * questions pi's entries only answer in pairs. Every entry is timestamped, so a
+ * tool call and its result, or an approval request and its answer, bracket an
+ * interval; nothing new has to be stored to know it.
+ *
+ * Two honesty rules shape the output. A duration derived from a *pair of writes*
+ * is a bound, not a measurement — the gap between a tool call and its result
+ * includes the wait for a human — so every span says which it is via `timing`,
+ * and a tool span carries its approval wait separately so a renderer can show
+ * "blocked on you" apart from "running". And an interval that never closed stays
+ * `open` with no duration rather than being closed at the last record: a run
+ * still in flight must not look like one that finished.
+ */
+
+import {
+  contentText,
+  isAssistantMessage,
+  isPiMessageEntry,
+  isToolResultMessage,
+  type PiUsage,
+  toolCalls
+} from '../pi-entry';
+import type { RunEventRecord } from '../record';
+import {
+  APPROVAL_REQUEST_TYPE,
+  APPROVAL_RESOLUTION_TYPE,
+  assertGateDecisionDetails,
+  GATE_DECISION_TYPE
+} from './tool-state';
+
+export type SpanKind = 'model' | 'tool' | 'approval';
+
+export type SpanStatus = 'open' | 'ok' | 'error' | 'denied';
+
+/**
+ * Whether the duration is the interval that was measured, or a bound that
+ * includes whatever else sat between the two writes.
+ */
+export type SpanTiming = 'measured' | 'bounded';
+
+export interface SpanBase {
+  /** Stable within a run — a renderer's key and a parent reference. */
+  id: string;
+  kind: SpanKind;
+  /** Row title: the tool name, the model, or the awaited tool. */
+  name: string;
+  parentId?: string;
+  startSeq: number;
+  /** Absent while the span is still open. */
+  endSeq?: number;
+  startedAt: string;
+  endedAt?: string;
+  durationMs?: number;
+  timing: SpanTiming;
+  status: SpanStatus;
+}
+
+export interface ModelSpan extends SpanBase {
+  kind: 'model';
+  model?: string;
+  provider?: string;
+  /** pi's provider response id — the join key to a metered inference row. */
+  responseId?: string;
+  stopReason?: string;
+  usage?: PiUsage;
+  errorMessage?: string;
+}
+
+export interface ToolSpan extends SpanBase {
+  kind: 'tool';
+  toolCallId: string;
+  arguments: Record<string, unknown>;
+  output?: string;
+  details?: unknown;
+  /** Of the total duration, how much was spent waiting on a human. */
+  approvalWaitMs?: number;
+  /** Set when the gate settled the call instead of an execution. */
+  gateDecision?: 'allow' | 'deny';
+  gateReason?: string;
+}
+
+export interface ApprovalSpan extends SpanBase {
+  kind: 'approval';
+  toolCallId: string;
+  prompt: string;
+  decision?: 'approved' | 'rejected';
+  actorId?: string;
+}
+
+export type Span = ModelSpan | ToolSpan | ApprovalSpan;
+
+export interface SpanProjection {
+  /** In start order — the order a timeline draws them. */
+  spans: Span[];
+}
+
+const ms = (from: string, to: string): number | undefined => {
+  const start = Date.parse(from);
+  const end = Date.parse(to);
+  if (Number.isNaN(start) || Number.isNaN(end)) return undefined;
+  return end - start;
+};
+
+const close = (span: Span, seq: number, at: string): void => {
+  span.endSeq = seq;
+  span.endedAt = at;
+  const duration = ms(span.startedAt, at);
+  if (duration !== undefined) span.durationMs = duration;
+};
+
+const detailsOf = (value: unknown): Record<string, unknown> =>
+  typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {};
+
+/**
+ * Project records into spans. Pure, and like the other projectors it ignores what
+ * it does not recognise — a log written by a newer pi still traces. A *registered*
+ * type that is malformed is another matter and throws: a gate decision naming no
+ * tool call is a writer bug, and a trace that quietly omitted a refusal would be
+ * worse than one that fails.
+ */
+export function projectSpans(records: readonly RunEventRecord[]): SpanProjection {
+  const spans: Span[] = [];
+  const tools = new Map<string, ToolSpan>();
+  const approvals = new Map<string, ApprovalSpan>();
+  /**
+   * The end of the previous entry, which is the earliest the next model call
+   * can have begun — pi logs a response, never a request.
+   */
+  let previousAt: string | undefined;
+
+  for (const { entry, seq } of records) {
+    const at = typeof entry.timestamp === 'string' ? entry.timestamp : undefined;
+    if (at === undefined) continue;
+    const previous = previousAt;
+    previousAt = at;
+
+    if (!isPiMessageEntry(entry)) continue;
+    const message = entry.message;
+
+    if (isAssistantMessage(message)) {
+      const span: ModelSpan = {
+        id: `model:${entry.id}`,
+        kind: 'model',
+        name: message.model ?? 'model',
+        // The turn began no earlier than the previous entry was written; with no
+        // previous entry the interval is unknown and the span is a point.
+        startedAt: previous ?? at,
+        startSeq: seq,
+        endSeq: seq,
+        endedAt: at,
+        timing: 'bounded',
+        status: message.stopReason === 'error' ? 'error' : 'ok',
+        ...(message.model ? { model: message.model } : {}),
+        ...(message.provider ? { provider: message.provider } : {}),
+        ...(typeof message.responseId === 'string' ? { responseId: message.responseId } : {}),
+        ...(message.stopReason ? { stopReason: message.stopReason } : {}),
+        ...(message.usage ? { usage: message.usage } : {}),
+        ...(message.errorMessage ? { errorMessage: message.errorMessage } : {})
+      };
+      const duration = ms(span.startedAt, at);
+      if (duration !== undefined) span.durationMs = duration;
+      spans.push(span);
+
+      for (const call of toolCalls(message)) {
+        const tool: ToolSpan = {
+          id: `tool:${call.id}`,
+          kind: 'tool',
+          name: call.name,
+          parentId: span.id,
+          toolCallId: call.id,
+          arguments: call.arguments ?? {},
+          startedAt: at,
+          startSeq: seq,
+          // A call and its result are two writes; anything between them —
+          // approval, queueing — is inside the interval.
+          timing: 'bounded',
+          status: 'open'
+        };
+        tools.set(call.id, tool);
+        spans.push(tool);
+      }
+      continue;
+    }
+
+    if (isToolResultMessage(message)) {
+      const tool = tools.get(message.toolCallId);
+      if (!tool) continue;
+      close(tool, seq, at);
+      tool.status = message.isError ? 'error' : 'ok';
+      tool.output = contentText(message.content);
+      if (message.details !== undefined) tool.details = message.details;
+      const approval = approvals.get(message.toolCallId);
+      if (approval?.durationMs !== undefined) tool.approvalWaitMs = approval.durationMs;
+      continue;
+    }
+
+    if (message.role !== 'custom') continue;
+    const info = detailsOf(message.details);
+    const toolCallId = typeof info.toolCallId === 'string' ? info.toolCallId : undefined;
+    if (toolCallId === undefined) continue;
+
+    if (message.customType === APPROVAL_REQUEST_TYPE) {
+      const tool = tools.get(toolCallId);
+      const approval: ApprovalSpan = {
+        id: `approval:${toolCallId}`,
+        kind: 'approval',
+        name: tool?.name ?? 'approval',
+        ...(tool ? { parentId: tool.id } : {}),
+        toolCallId,
+        prompt: contentText(message.content),
+        startedAt: at,
+        startSeq: seq,
+        // Request and answer are exactly the interval a human held the run.
+        timing: 'measured',
+        status: 'open'
+      };
+      approvals.set(toolCallId, approval);
+      spans.push(approval);
+      continue;
+    }
+
+    if (message.customType === APPROVAL_RESOLUTION_TYPE) {
+      const approval = approvals.get(toolCallId);
+      if (!approval) continue;
+      close(approval, seq, at);
+      const approved = info.decision === 'approved';
+      approval.decision = approved ? 'approved' : 'rejected';
+      approval.status = approved ? 'ok' : 'denied';
+      if (typeof info.actorId === 'string') approval.actorId = info.actorId;
+      const tool = tools.get(toolCallId);
+      if (tool && approval.durationMs !== undefined) tool.approvalWaitMs = approval.durationMs;
+      continue;
+    }
+
+    if (message.customType === GATE_DECISION_TYPE) {
+      // Throws on a malformed decision — see the note on this function.
+      const decision = assertGateDecisionDetails(message.details, seq);
+      const tool = tools.get(decision.toolCallId);
+      if (!tool) continue;
+      tool.gateDecision = decision.decision;
+      if (decision.reason !== undefined) tool.gateReason = decision.reason;
+      // A denied call is never executed, so this write is the only thing that
+      // will ever close its span.
+      if (decision.decision === 'deny' && tool.status === 'open') {
+        close(tool, seq, at);
+        tool.status = 'denied';
+      }
+    }
+  }
+
+  return { spans };
+}

--- a/agentic/run-log/src/projectors/tool-state.ts
+++ b/agentic/run-log/src/projectors/tool-state.ts
@@ -16,6 +16,14 @@ import type { RunEventRecord } from '../record';
 export const APPROVAL_REQUEST_TYPE = 'constructive.approval.request';
 /** `customType` of the human's answer to a request. */
 export const APPROVAL_RESOLUTION_TYPE = 'constructive.approval.resolution';
+/**
+ * `customType` of a settled gate decision.
+ *
+ * Unlike an approval, this is written for *every* decision including the ones
+ * no human saw: a policy rule that denies a tool call is otherwise invisible in
+ * the log, leaving "which tool calls did the gate block" unanswerable.
+ */
+export const GATE_DECISION_TYPE = 'constructive.gate.decision';
 
 export type ToolCallStatus = 'requested' | 'awaiting-approval' | 'rejected' | 'running' | 'completed' | 'failed';
 
@@ -40,8 +48,27 @@ export interface ApprovalState {
   actorId?: string;
 }
 
+/** A settled gate decision as it is carried in the log. */
+export interface GateDecisionDetails {
+  toolCallId: string;
+  toolName: string;
+  /** What the policy said: `allow`, `deny` or `ask`. */
+  verdict: string;
+  /** How the call was finally settled — `ask` resolves to one of these. */
+  decision: 'allow' | 'deny';
+  reason?: string;
+  actorId?: string;
+  decidedAt?: string;
+}
+
+export interface GateDecisionState extends GateDecisionDetails {
+  seq: number;
+}
+
 export interface ToolStateProjection {
   tools: Record<string, ToolCallState>;
+  /** Settled gate decisions in log order, keyed by tool call id. */
+  gateDecisions: Record<string, GateDecisionState>;
   /** In log order — the oldest unanswered request first. */
   pendingApprovals: ApprovalState[];
 }
@@ -53,12 +80,22 @@ interface ApprovalDetails {
   actorId?: unknown;
 }
 
-const details = (value: unknown): ApprovalDetails =>
-  typeof value === 'object' && value !== null ? (value as ApprovalDetails) : {};
+interface GateDetails extends ApprovalDetails {
+  toolName?: unknown;
+  verdict?: unknown;
+  decidedAt?: unknown;
+}
+
+/** Where a bad entry is, when the caller is projecting a log rather than validating one value. */
+const at = (seq?: number): string => (seq === undefined ? '' : ` at seq ${String(seq)}`);
+
+const details = (value: unknown): GateDetails =>
+  typeof value === 'object' && value !== null ? (value as GateDetails) : {};
 
 export function projectToolState(records: readonly RunEventRecord[]): ToolStateProjection {
   const tools: Record<string, ToolCallState> = {};
   const approvals = new Map<string, ApprovalState>();
+  const gateDecisions: Record<string, GateDecisionState> = {};
 
   for (const { entry, seq } of records) {
     if (!isPiMessageEntry(entry)) continue;
@@ -101,13 +138,7 @@ export function projectToolState(records: readonly RunEventRecord[]): ToolStateP
     if (message.role !== 'custom') continue;
 
     if (message.customType === APPROVAL_REQUEST_TYPE) {
-      const info = details(message.details);
-      const toolCallId = typeof info.toolCallId === 'string' ? info.toolCallId : null;
-      if (!toolCallId) {
-        throw new Error(
-          `approval request at seq ${String(seq)} carries no toolCallId; the run log cannot attribute it`
-        );
-      }
+      const { toolCallId } = assertApprovalRequestDetails(message.details, seq);
       const approval: ApprovalState = {
         toolCallId,
         requestedSeq: seq,
@@ -120,21 +151,16 @@ export function projectToolState(records: readonly RunEventRecord[]): ToolStateP
     }
 
     if (message.customType === APPROVAL_RESOLUTION_TYPE) {
-      const info = details(message.details);
-      const toolCallId = typeof info.toolCallId === 'string' ? info.toolCallId : null;
-      if (!toolCallId) {
-        throw new Error(
-          `approval resolution at seq ${String(seq)} carries no toolCallId; the run log cannot attribute it`
-        );
-      }
+      const info = assertApprovalResolutionDetails(message.details, seq);
+      const toolCallId = info.toolCallId;
       const approved = info.decision === 'approved';
       const existing = approvals.get(toolCallId);
       const approval: ApprovalState = {
         ...(existing ?? { toolCallId, requestedSeq: seq, prompt: '' }),
         resolvedSeq: seq,
-        decision: approved ? 'approved' : 'rejected',
-        ...(typeof info.reason === 'string' ? { reason: info.reason } : {}),
-        ...(typeof info.actorId === 'string' ? { actorId: info.actorId } : {})
+        decision: info.decision,
+        ...(info.reason === undefined ? {} : { reason: info.reason }),
+        ...(info.actorId === undefined ? {} : { actorId: info.actorId })
       };
       approvals.set(toolCallId, approval);
       const state = tools[toolCallId];
@@ -143,6 +169,23 @@ export function projectToolState(records: readonly RunEventRecord[]): ToolStateP
       } else if (state) {
         tools[toolCallId] = { ...state, approval };
       }
+      continue;
+    }
+
+    if (message.customType === GATE_DECISION_TYPE) {
+      const decision = assertGateDecisionDetails(message.details, seq);
+      gateDecisions[decision.toolCallId] = { ...decision, seq };
+      const state = tools[decision.toolCallId];
+      // A blocked call never produces a tool result, so the gate's `deny` is the
+      // only thing that will ever settle it.
+      if (state && decision.decision === 'deny' && state.settledSeq === undefined) {
+        tools[decision.toolCallId] = {
+          ...state,
+          status: 'rejected',
+          settledSeq: seq,
+          ...(decision.reason === undefined ? {} : { output: decision.reason })
+        };
+      }
     }
   }
 
@@ -150,7 +193,54 @@ export function projectToolState(records: readonly RunEventRecord[]): ToolStateP
     .filter((approval) => approval.resolvedSeq === undefined)
     .sort((a, b) => a.requestedSeq - b.requestedSeq);
 
-  return { tools, pendingApprovals };
+  return { tools, gateDecisions, pendingApprovals };
+}
+
+/** Narrow the `details` of a `constructive.gate.decision` entry. */
+export function assertGateDecisionDetails(value: unknown, seq?: number): GateDecisionDetails {
+  const info = details(value);
+  const toolCallId = typeof info.toolCallId === 'string' ? info.toolCallId : null;
+  if (!toolCallId) {
+    throw new TypeError(`gate decision${at(seq)} carries no toolCallId; the run log cannot attribute it`);
+  }
+  if (info.decision !== 'allow' && info.decision !== 'deny') {
+    throw new TypeError(`gate decision${at(seq)} must settle to "allow" or "deny"`);
+  }
+  return {
+    toolCallId,
+    toolName: typeof info.toolName === 'string' ? info.toolName : '',
+    verdict: typeof info.verdict === 'string' ? info.verdict : info.decision,
+    decision: info.decision,
+    ...(typeof info.reason === 'string' ? { reason: info.reason } : {}),
+    ...(typeof info.actorId === 'string' ? { actorId: info.actorId } : {}),
+    ...(typeof info.decidedAt === 'string' ? { decidedAt: info.decidedAt } : {})
+  };
+}
+
+/** Narrow the `details` of a `constructive.approval.request` entry. */
+export function assertApprovalRequestDetails(value: unknown, seq?: number): { toolCallId: string } {
+  const info = details(value);
+  if (typeof info.toolCallId !== 'string' || info.toolCallId.length === 0) {
+    throw new TypeError(`approval request${at(seq)} carries no toolCallId; the run log cannot attribute it`);
+  }
+  return { toolCallId: info.toolCallId };
+}
+
+/** Narrow the `details` of a `constructive.approval.resolution` entry. */
+export function assertApprovalResolutionDetails(value: unknown, seq?: number): ApprovalResolutionInput {
+  const info = details(value);
+  if (typeof info.toolCallId !== 'string' || info.toolCallId.length === 0) {
+    throw new TypeError(`approval resolution${at(seq)} carries no toolCallId; the run log cannot attribute it`);
+  }
+  if (info.decision !== 'approved' && info.decision !== 'rejected') {
+    throw new TypeError(`approval resolution${at(seq)} must decide "approved" or "rejected"`);
+  }
+  return {
+    toolCallId: info.toolCallId,
+    decision: info.decision,
+    ...(typeof info.reason === 'string' ? { reason: info.reason } : {}),
+    ...(typeof info.actorId === 'string' ? { actorId: info.actorId } : {})
+  };
 }
 
 /** The parts of an approval request an extension needs to write one. */
@@ -173,6 +263,26 @@ export const approvalRequestMessage = (input: ApprovalRequestInput) => ({
   content: input.prompt,
   display: true,
   details: { toolCallId: input.toolCallId },
+  timestamp: Date.now()
+});
+
+/** Build the pi `custom` message a settled gate decision is carried in. */
+export const gateDecisionMessage = (input: GateDecisionDetails) => ({
+  role: 'custom' as const,
+  customType: GATE_DECISION_TYPE,
+  content: `gate ${input.decision}: ${input.toolName}${input.reason ? ` — ${input.reason}` : ''}`,
+  // The model already learned of a denial through the blocked call's error; a
+  // second telling would only spend context.
+  display: false,
+  details: {
+    toolCallId: input.toolCallId,
+    toolName: input.toolName,
+    verdict: input.verdict,
+    decision: input.decision,
+    ...(input.reason ? { reason: input.reason } : {}),
+    ...(input.actorId ? { actorId: input.actorId } : {}),
+    ...(input.decidedAt ? { decidedAt: input.decidedAt } : {})
+  },
   timestamp: Date.now()
 });
 


### PR DESCRIPTION
## Summary

A trajectory view wants typed rows and timing. The log already holds everything both derive from — every entry is timestamped and stored verbatim — so this adds three read/write-time pieces in `@agentic-kit/run-log` and no schema.

**1. An entry-type registry.** New event kinds are namespaced pi `custom` messages, so a type is a `customType` string plus a validator — never a table. Each definition also declares a DSH-inspired visibility, which is the distinction a renderer and a prompt builder need and cannot derive:

```ts
type EntryVisibility = 'surface' | 'log-only';   // conversational vs. audit/trace
constructiveEntryTypes().visibilityOf(GATE_DECISION_TYPE)   // 'log-only'
constructiveEntryTypes().visibilityOf('acme.unknown')       // 'log-only' — unknown is not surfaced
```

**2. `constructive.gate.decision`.** An `ask` verdict is durable because a human answered it; a *policy* `deny` blocked the call, told the model why, and left nothing behind — "which calls did the gate refuse, and on whose authority" was unanswerable. The decision is now an entry, and `projectToolState` grew `gateDecisions` plus one settlement rule, since a blocked call never produces a tool result:

```ts
if (state && decision.decision === 'deny' && state.settledSeq === undefined)
  tools[id] = { ...state, status: 'rejected', settledSeq: seq, output: decision.reason };
```

It is `display: false` / `log-only`: the model already learned of the refusal through the blocked call's error, and telling it twice only spends context. The writer side (binding the gate's `onDecision` to the log) is the companion change in `constructive-db`.

**3. `projectSpans()`** — tool spans (call → result), model spans, approval spans (request → answer), with parents, status and usage. The honesty is in the types: a duration between two *writes* is a bound, not a measurement, so a span says which it is and a tool span carries its approval wait separately.

```ts
timing: 'measured'   // approval request → answer: exactly the interval a human held the run
timing: 'bounded'    // tool call → result: includes approval and queue wait
status: 'open'       // still in flight — no invented end, no invented duration
```

Unknown entry types are ignored as elsewhere, but a *registered* type that is malformed throws (`assertGateDecisionDetails`): a trace that quietly omitted a refusal is worse than one that fails. The approval branches of `projectToolState` now go through the same assertions, so the registry's validators and the projector cannot disagree.

Part of constructive-io/constructive-planning#1676; independent of the `agent_run` attribution work (#1672).


Link to Devin session: https://app.devin.ai/sessions/e18344c4a98243fbbad8b381a70ff245
Requested by: @pyramation