### PR TITLE
feat(pg-codegen): generate an upsert that states its conflict target

### DIFF
--- a/postgres/pg-codegen/README.md
+++ b/postgres/pg-codegen/README.md
@@ -57,6 +57,7 @@ One `create<Schema>Db(db, options?)` factory per schema, one client per table:
 | `findFirstOrThrow(args?)` | `SelectResult`, else `RowNotFoundError` |
 | `count(where?)` | `number` |
 | `create({ data, select? })` | the inserted row |
+| `upsert({ conflict, create, update?, select? })` | the inserted or reconciled row, else `null` |
 | `update({ where, data, select? })` | the updated rows |
 | `updateOrThrow({ where, data, select? })` | one updated row, else `RowNotFoundError` |
 | `delete({ where, select? })` | the deleted rows |
@@ -88,6 +89,23 @@ await db.resources.update({
 ```
 
 An expression is deparsed in place — never bound as a value, never serialized as one.
+
+### Upsert
+
+`upsert` states the unique fields it conflicts on, the row to insert, and what to set when one already exists:
+
+```ts
+import { fn } from '@constructive-io/query-builder';
+
+await db.appConfigs.upsert({
+  conflict: ['namespaceId', 'name'],
+  create: { name, value, namespaceId },
+  update: { value, updatedAt: fn('now') }
+});
+// INSERT INTO … ON CONFLICT (namespace_id, name) DO UPDATE SET value = $1, updated_at = now() RETURNING …
+```
+
+Stating no `update` leaves a conflicting row as it is (`ON CONFLICT DO NOTHING`), and then there is no row to return — the result is `null`. An empty `conflict` throws, since it names no unique constraint.
 
 ### Selections type the result
 

--- a/postgres/pg-codegen/__fixtures__/generated/client.ts
+++ b/postgres/pg-codegen/__fixtures__/generated/client.ts
@@ -171,6 +171,28 @@ export interface CreateArgs<App, S extends SelectShape<App> | undefined> {
   select?: S;
 }
 
+/**
+ * An upsert states the unique columns it conflicts on, the row to insert, and
+ * what to set when one already exists. No `update` means an existing row is
+ * left as it is (`ON CONFLICT DO NOTHING`), and then there may be no row to
+ * return.
+ *
+ * ```ts
+ * await db.appConfigs.upsert({
+ *   conflict: ['namespaceId', 'name'],
+ *   create: { name, value, namespaceId },
+ *   update: { value, updatedAt: fn('now') }
+ * });
+ * ```
+ */
+export interface UpsertArgs<App, S extends SelectShape<App> | undefined> {
+  /** The unique fields to conflict on, named as generated fields. */
+  conflict: readonly (keyof App & string)[];
+  create: Data<App>;
+  update?: Data<App>;
+  select?: S;
+}
+
 export interface UpdateArgs<App, S extends SelectShape<App> | undefined> {
   where: Where<App>;
   data: Data<App>;
@@ -256,6 +278,35 @@ export class TableClient<App> {
     const { text, values } = query.build();
     const { rows } = await this.db.query(text, values);
     return this.decodeRow(rows[0], fields);
+  }
+
+  /**
+   * Insert a row, or reconcile the one the conflict target already matches.
+   * Returns the resulting row, or null when a conflicting row was left as it
+   * is by an upsert that states no `update`.
+   */
+  async upsert<S extends SelectShape<App> | undefined = undefined>(
+    args: UpsertArgs<App, S>
+  ): Promise<SelectResult<App, S> | null> {
+    if (args.conflict.length === 0) {
+      throw new Error(
+        `${this.spec.table}.upsert: refusing an empty conflict target, which names no unique constraint`
+      );
+    }
+    const fields = this.selectedFields(args.select);
+    const columns = args.conflict.map(field => this.column(field));
+    const updateColumns = args.update ? this.encodeData(args.update) : {};
+    const query = this.baseQuery()
+      .insert(this.encodeData(args.create))
+      .onConflict(
+        Object.keys(updateColumns).length > 0
+          ? { columns, action: 'update', updateColumns }
+          : { columns, action: 'nothing' }
+      )
+      .returning(fields.map(field => this.column(field)));
+    const { text, values } = query.build();
+    const { rows } = await this.db.query(text, values);
+    return rows.length > 0 ? this.decodeRow(rows[0], fields) : null;
   }
 
   async update<S extends SelectShape<App> | undefined = undefined>(

--- a/postgres/pg-codegen/__fixtures__/generated/client.ts
+++ b/postgres/pg-codegen/__fixtures__/generated/client.ts
@@ -186,8 +186,12 @@ export interface CreateArgs<App, S extends SelectShape<App> | undefined> {
  * ```
  */
 export interface UpsertArgs<App, S extends SelectShape<App> | undefined> {
-  /** The unique fields to conflict on, named as generated fields. */
-  conflict: readonly (keyof App & string)[];
+  /**
+   * The unique fields to conflict on. Generated fields autocomplete and map to
+   * their columns; a runtime-configured column (a scope key this binding's
+   * table carries) is named as the column it is.
+   */
+  conflict: readonly (keyof App & string)[] | readonly string[];
   create: Data<App>;
   update?: Data<App>;
   select?: S;

--- a/postgres/pg-codegen/__tests__/client.test.ts
+++ b/postgres/pg-codegen/__tests__/client.test.ts
@@ -149,6 +149,47 @@ it('writes a value derived from the column it sets', async () => {
   expect(bumped).toEqual({ lastEventSeq: '1', status: 'succeeded' });
 });
 
+it('inserts a row, or reconciles the one the conflict target matches', async () => {
+  const inserted = await db.users.upsert({
+    conflict: ['username'],
+    create: { username: 'mo', email: 'mo@example.com' },
+    update: { email: 'mo@example.com' },
+    select: { id: true, email: true }
+  });
+  expect(inserted?.email).toBe('mo@example.com');
+
+  const reconciled = await db.users.upsert({
+    conflict: ['username'],
+    create: { username: 'mo', email: 'ignored@example.com' },
+    update: { email: 'mo@corp.example' },
+    select: { id: true, email: true }
+  });
+  expect(reconciled).toEqual({ id: inserted?.id, email: 'mo@corp.example' });
+  expect(await db.users.count({ username: 'mo' })).toBe(1);
+});
+
+it('leaves a conflicting row as it is when an upsert states no update', async () => {
+  const first = await db.users.upsert({
+    conflict: ['username'],
+    create: { username: 'nia', email: 'nia@example.com' }
+  });
+  expect(first?.email).toBe('nia@example.com');
+
+  // DO NOTHING skipped the row, so there is none to return.
+  expect(
+    await db.users.upsert({ conflict: ['username'], create: { username: 'nia', email: 'other@example.com' } })
+  ).toBeNull();
+  expect((await db.users.findFirstOrThrow({ where: { username: 'nia' } })).email).toBe(
+    'nia@example.com'
+  );
+});
+
+it('refuses an upsert that names no conflict target', async () => {
+  await expect(db.users.upsert({ conflict: [], create: { username: 'omar' } })).rejects.toThrow(
+    /refusing an empty conflict target/
+  );
+});
+
 it('deletes rows and reports what was removed', async () => {
   await db.users.create({ data: { username: 'ivan' } });
   const removed = await db.users.delete({ where: { username: 'ivan' }, select: { username: true } });

--- a/postgres/pg-codegen/src/emit/templates/client.ts
+++ b/postgres/pg-codegen/src/emit/templates/client.ts
@@ -171,6 +171,28 @@ export interface CreateArgs<App, S extends SelectShape<App> | undefined> {
   select?: S;
 }
 
+/**
+ * An upsert states the unique columns it conflicts on, the row to insert, and
+ * what to set when one already exists. No `update` means an existing row is
+ * left as it is (`ON CONFLICT DO NOTHING`), and then there may be no row to
+ * return.
+ *
+ * ```ts
+ * await db.appConfigs.upsert({
+ *   conflict: ['namespaceId', 'name'],
+ *   create: { name, value, namespaceId },
+ *   update: { value, updatedAt: fn('now') }
+ * });
+ * ```
+ */
+export interface UpsertArgs<App, S extends SelectShape<App> | undefined> {
+  /** The unique fields to conflict on, named as generated fields. */
+  conflict: readonly (keyof App & string)[];
+  create: Data<App>;
+  update?: Data<App>;
+  select?: S;
+}
+
 export interface UpdateArgs<App, S extends SelectShape<App> | undefined> {
   where: Where<App>;
   data: Data<App>;
@@ -256,6 +278,35 @@ export class TableClient<App> {
     const { text, values } = query.build();
     const { rows } = await this.db.query(text, values);
     return this.decodeRow(rows[0], fields);
+  }
+
+  /**
+   * Insert a row, or reconcile the one the conflict target already matches.
+   * Returns the resulting row, or null when a conflicting row was left as it
+   * is by an upsert that states no `update`.
+   */
+  async upsert<S extends SelectShape<App> | undefined = undefined>(
+    args: UpsertArgs<App, S>
+  ): Promise<SelectResult<App, S> | null> {
+    if (args.conflict.length === 0) {
+      throw new Error(
+        `${this.spec.table}.upsert: refusing an empty conflict target, which names no unique constraint`
+      );
+    }
+    const fields = this.selectedFields(args.select);
+    const columns = args.conflict.map(field => this.column(field));
+    const updateColumns = args.update ? this.encodeData(args.update) : {};
+    const query = this.baseQuery()
+      .insert(this.encodeData(args.create))
+      .onConflict(
+        Object.keys(updateColumns).length > 0
+          ? { columns, action: 'update', updateColumns }
+          : { columns, action: 'nothing' }
+      )
+      .returning(fields.map(field => this.column(field)));
+    const { text, values } = query.build();
+    const { rows } = await this.db.query(text, values);
+    return rows.length > 0 ? this.decodeRow(rows[0], fields) : null;
   }
 
   async update<S extends SelectShape<App> | undefined = undefined>(

--- a/postgres/pg-codegen/src/emit/templates/client.ts
+++ b/postgres/pg-codegen/src/emit/templates/client.ts
@@ -186,8 +186,12 @@ export interface CreateArgs<App, S extends SelectShape<App> | undefined> {
  * ```
  */
 export interface UpsertArgs<App, S extends SelectShape<App> | undefined> {
-  /** The unique fields to conflict on, named as generated fields. */
-  conflict: readonly (keyof App & string)[];
+  /**
+   * The unique fields to conflict on. Generated fields autocomplete and map to
+   * their columns; a runtime-configured column (a scope key this binding's
+   * table carries) is named as the column it is.
+   */
+  conflict: readonly (keyof App & string)[] | readonly string[];
   create: Data<App>;
   update?: Data<App>;
   select?: S;


### PR DESCRIPTION
## Summary

A config-style write — insert the row, or reconcile the one that already exists — had no generated method, so every such call site dropped back to a raw `INSERT … ON CONFLICT` with physical column names hand-written into the SQL. The `fun` CLI alone has several. `upsert` closes that gap:

```ts
await db.appConfigs.upsert({
  conflict: ['namespaceId', 'name'],          // generated fields, mapped to columns
  create: { name, value, namespaceId },
  update: { value, updatedAt: fn('now') }
});
// INSERT INTO … ON CONFLICT (namespace_id, name) DO UPDATE SET value = $1, updated_at = now() RETURNING …
```

Semantics worth stating:

- No `update` → `ON CONFLICT DO NOTHING`, so a conflicting row is left as it is and there is no returned row: the result is `null`.
- An empty `conflict` throws — it names no unique constraint, and Postgres would take the statement as a plain insert.
- `create`/`update` are the same `Data<App>` as the other writes, so an expression value (`fn('now')`, `add(col('n'), 1)`) passes through un-serialized, and `select` types the returned row exactly as elsewhere.


Link to Devin session: https://app.devin.ai/sessions/b1fb8d90ec0a4cd1bd95e3c77c6f6680
Requested by: @pyramation