### PR TITLE
feat(run-log): read transcripts through a reader registry, pi as the first reader

### DIFF
--- a/agentic/run-log/__tests__/transcripts.test.ts
+++ b/agentic/run-log/__tests__/transcripts.test.ts
@@ -1,0 +1,253 @@
+/**
+ * The neutral transcript seam: a record names its format, a registered reader
+ * turns that format's entries into neutral events, and every projector reads
+ * the events. These tests use a format this package knows nothing about, so a
+ * regression that re-couples the read path to pi fails here.
+ */
+
+import {
+  assertRunEventRecord,
+  passthroughReader,
+  PI_TRANSCRIPT_FORMAT,
+  piTranscriptReader,
+  projectParts,
+  projectSession,
+  projectToolState,
+  projectUsage,
+  type RunEventRecord,
+  type TranscriptEntry,
+  type TranscriptEvent,
+  type TranscriptReader,
+  TranscriptReaderRegistry,
+  transcriptReaders,
+  wrapEntry
+} from '../src';
+import { assistantToolCall, header, resetIds, toolResult, usage } from './fixtures';
+
+beforeEach(resetIds);
+
+const HARNESS = 'harness-test';
+
+/** A transcript shaped nothing like pi's: one flat event per entry. */
+const harnessReader: TranscriptReader = {
+  format: HARNESS,
+  version: 2,
+  assertEntry: (value) => {
+    const entry = value as TranscriptEntry;
+    if (typeof entry?.type !== 'string') throw new TypeError('harness-test entry needs a type');
+    return entry;
+  },
+  toEvents: (entry): TranscriptEvent[] => {
+    const base = { entryId: entry.id as string };
+    switch (entry.type) {
+    case 'user/message':
+      return [{ kind: 'text', role: 'user', text: entry.text as string, ...base }];
+    case 'assistant/message':
+      return [
+        {
+          kind: 'model-response',
+          model: 'deepseek-chat',
+          provider: 'deepseek',
+          usage: { input: 10, output: 5, totalTokens: 15 },
+          ...base
+        },
+        {
+          kind: 'text',
+          role: 'assistant',
+          text: entry.text as string,
+          model: 'deepseek-chat',
+          provider: 'deepseek',
+          ...base
+        }
+      ];
+    case 'tool/call':
+      return [
+        {
+          kind: 'tool-call',
+          toolCallId: entry.callId as string,
+          name: entry.tool as string,
+          arguments: (entry.args ?? {}) as Record<string, unknown>,
+          ...base
+        }
+      ];
+    case 'tool/result':
+      return [
+        {
+          kind: 'tool-result',
+          toolCallId: entry.callId as string,
+          name: entry.tool as string,
+          output: entry.text as string,
+          failed: entry.error === true,
+          ...base
+        }
+      ];
+    default:
+      return [{ kind: 'unknown', entryType: entry.type, entry, ...base }];
+    }
+  }
+};
+
+const readers = new TranscriptReaderRegistry([piTranscriptReader, harnessReader]);
+
+let seq = 0;
+const record = (entry: TranscriptEntry, format = HARNESS): RunEventRecord =>
+  wrapEntry({ runId: 'run-1', seq: (seq += 1), entry, transcriptFormat: format, readers });
+
+beforeEach(() => {
+  seq = 0;
+});
+
+describe('the record wrapper', () => {
+  it('carries a format the package has never seen, validated by that reader', () => {
+    const entry: TranscriptEntry = { type: 'user/message', id: 'e1', text: 'hi' };
+    const wrapped = record(entry);
+
+    expect(wrapped.transcriptFormat).toBe(HARNESS);
+    // The reader's own version, not pi's.
+    expect(wrapped.transcriptVersion).toBe(2);
+    expect(wrapped.entry).toBe(entry);
+  });
+
+  it('validates with the reader named by the format, not with pi', () => {
+    // No id/parentId/timestamp: pi would reject this, harness-test does not.
+    expect(() => record({ type: 'user/message', text: 'hi' })).not.toThrow();
+    expect(() =>
+      wrapEntry({ runId: 'run-1', seq: 1, entry: { type: 'user/message' }, readers })
+    ).toThrow(/must carry a non-empty string `id`/);
+  });
+
+  it('fails loudly when nothing can read the format', () => {
+    expect(() =>
+      wrapEntry({ runId: 'run-1', seq: 1, entry: { type: 'x' }, transcriptFormat: 'dsh', readers })
+    ).toThrow(/no transcript reader registered for format "dsh"; this registry reads harness-test, pi/);
+
+    expect(() =>
+      assertRunEventRecord(
+        {
+          runId: 'run-1',
+          seq: 1,
+          recordedAt: '2026-01-01T00:00:00.000Z',
+          transcriptFormat: 'dsh',
+          transcriptVersion: 1,
+          entry: { type: 'x' }
+        },
+        readers
+      )
+    ).toThrow(/no transcript reader registered for format "dsh"/);
+  });
+
+  it('narrows an untrusted non-pi record', () => {
+    const parsed = assertRunEventRecord(JSON.parse(JSON.stringify(record({ type: 'user/message', id: 'e1', text: 'hi' }))), readers);
+    expect(parsed.transcriptFormat).toBe(HARNESS);
+    expect(parsed.entry).toEqual({ type: 'user/message', id: 'e1', text: 'hi' });
+  });
+});
+
+describe('projecting a non-pi transcript', () => {
+  const records = (): RunEventRecord[] => [
+    record({ type: 'user/message', id: 'e1', text: 'add a column' }),
+    record({ type: 'assistant/message', id: 'e2', text: 'on it' }),
+    record({ type: 'tool/call', id: 'e3', callId: 'c1', tool: 'create_field', args: { name: 'email' } }),
+    record({ type: 'tool/result', id: 'e4', callId: 'c1', tool: 'create_field', text: 'created' })
+  ];
+
+  it('renders parts without any harness-specific renderer', () => {
+    const { parts } = projectParts(records(), { readers });
+
+    expect(parts.map((part) => part.kind)).toEqual(['text', 'text', 'tool']);
+    expect(parts[0]).toMatchObject({ role: 'user', text: 'add a column' });
+    expect(parts[1]).toMatchObject({ role: 'assistant', text: 'on it', model: 'deepseek-chat' });
+    // The call and its result collapse into one part, exactly as for pi.
+    expect(parts[2]).toMatchObject({
+      kind: 'tool',
+      toolCallId: 'c1',
+      name: 'create_field',
+      arguments: { name: 'email' },
+      status: 'completed',
+      output: 'created',
+      settledSeq: 4
+    });
+  });
+
+  it('meters it under its own provider and model', () => {
+    const totals = projectUsage(records(), { readers });
+    expect(totals.totalTokens).toBe(15);
+    expect(totals.byModel['deepseek/deepseek-chat']).toMatchObject({
+      provider: 'deepseek',
+      model: 'deepseek-chat',
+      input: 10,
+      output: 5
+    });
+  });
+
+  it('tracks its tool calls', () => {
+    const { tools } = projectToolState(records(), { readers });
+    expect(tools.c1).toMatchObject({ name: 'create_field', status: 'completed', output: 'created' });
+  });
+
+  it('projects one log whose records changed format mid-run', () => {
+    const mixed: RunEventRecord[] = [
+      wrapEntry({ runId: 'run-1', seq: 1, entry: header(), transcriptFormat: PI_TRANSCRIPT_FORMAT, readers }),
+      wrapEntry({
+        runId: 'run-1',
+        seq: 2,
+        entry: assistantToolCall({ id: 'c0', name: 'list_tables' }, 2),
+        transcriptFormat: PI_TRANSCRIPT_FORMAT,
+        readers
+      }),
+      wrapEntry({
+        runId: 'run-1',
+        seq: 3,
+        entry: { type: 'user/message', id: 'e1', text: 'thanks' },
+        transcriptFormat: HARNESS,
+        readers
+      })
+    ];
+
+    const { parts, sessionId } = projectParts(mixed, { readers });
+    expect(sessionId).toBe('session-1');
+    expect(parts.map((part) => part.kind)).toEqual(['tool', 'text']);
+  });
+
+  it('refuses to re-emit a non-pi log as a pi session file', () => {
+    expect(() => projectSession(records())).toThrow(/pi/);
+  });
+});
+
+describe('a format with no reader yet', () => {
+  it('stores and renders as unknown parts, entry preserved', () => {
+    const registry = new TranscriptReaderRegistry([passthroughReader('dsh')]);
+    const entry: TranscriptEntry = { type: 'turn/start', id: 't1', turn: 4 };
+    const stored = wrapEntry({
+      runId: 'run-1',
+      seq: 1,
+      entry,
+      transcriptFormat: 'dsh',
+      readers: registry
+    });
+
+    const { parts } = projectParts([stored], { readers: registry });
+    expect(parts).toEqual([{ kind: 'unknown', entryType: 'turn/start', entry, seq: 1, entryId: 't1' }]);
+  });
+});
+
+describe('the pi reader', () => {
+  it('is the only format the default registry reads', () => {
+    expect(transcriptReaders.formats()).toEqual([PI_TRANSCRIPT_FORMAT]);
+    expect(transcriptReaders.has('dsh')).toBe(false);
+  });
+
+  it('means several things by one assistant message', () => {
+    const events = piTranscriptReader.toEvents(assistantToolCall({ id: 'c1', name: 'run_codegen' }, 2));
+    expect(events.map((event) => event.kind)).toEqual(['model-response', 'tool-call']);
+    expect(events[0]).toMatchObject({ kind: 'model-response', provider: 'anthropic', stopReason: 'toolUse' });
+    expect(events[1]).toMatchObject({ kind: 'tool-call', toolCallId: 'c1', name: 'run_codegen' });
+  });
+
+  it('carries tool result usage into the neutral event', () => {
+    const [event] = piTranscriptReader.toEvents(
+      toolResult({ toolCallId: 'c1', toolName: 'run_codegen', text: 'ok', usage: usage() })
+    );
+    expect(event).toMatchObject({ kind: 'tool-result', toolCallId: 'c1', failed: false, output: 'ok' });
+  });
+});

--- a/agentic/run-log/src/file-store.ts
+++ b/agentic/run-log/src/file-store.ts
@@ -29,7 +29,7 @@ import {
   type RunLogStore,
   START
 } from './store';
-import type { PiSessionEntry } from './transcripts/pi-entry';
+import type { TranscriptEntry } from './transcripts/entry';
 
 export interface FileRunLogStoreOptions {
   /** Absolute path of the log file. Parent directories are created. */
@@ -68,7 +68,7 @@ export class FileRunLogStore implements RunLogStore {
 
   async append(
     runId: string,
-    entries: readonly PiSessionEntry[],
+    entries: readonly TranscriptEntry[],
     options: AppendOptions = {}
   ): Promise<RunEventRecord[]> {
     const existing = this.load().filter((record) => record.runId === runId);

--- a/agentic/run-log/src/index.ts
+++ b/agentic/run-log/src/index.ts
@@ -20,6 +20,13 @@ export {
 } from './follow';
 export { type SessionEntrySource, SessionMirror, type SessionMirrorOptions } from './mirror';
 export {
+  type EventGroup,
+  type ProjectionOptions,
+  type SequencedEvent,
+  toEventGroups,
+  toEvents
+} from './projectors/events';
+export {
   type BashPart,
   type Conversation,
   type ConversationPart,
@@ -98,6 +105,25 @@ export {
   START
 } from './store';
 export {
+  assertTranscriptEntry,
+  type TranscriptEntry
+} from './transcripts/entry';
+export {
+  type BashEvent,
+  type CustomEvent,
+  type ModelResponseEvent,
+  type SessionStartEvent,
+  type SummaryEvent,
+  type TextEvent,
+  type ThinkingEvent,
+  type ToolCallEvent,
+  type ToolResultEvent,
+  type TranscriptEvent,
+  type TranscriptEventBase,
+  type TranscriptUsage,
+  type UnknownEvent
+} from './transcripts/event';
+export {
   assertTranscriptFormat,
   PI_TRANSCRIPT_FORMAT,
   SUPPORTED_PI_TRANSCRIPT_VERSION,
@@ -135,3 +161,10 @@ export {
   type PiUserMessage,
   toolCalls
 } from './transcripts/pi-entry';
+export { piEntryToEvents, piTranscriptReader } from './transcripts/pi-reader';
+export {
+  passthroughReader,
+  type TranscriptReader,
+  TranscriptReaderRegistry
+} from './transcripts/reader';
+export { defaultTranscriptReaders, transcriptReaders } from './transcripts/registry';

--- a/agentic/run-log/src/mirror.ts
+++ b/agentic/run-log/src/mirror.ts
@@ -20,8 +20,9 @@
 
 import type { RunEventRecord } from './record';
 import type { RunLogAppendStore } from './store';
-import type { TranscriptFormat } from './transcripts/format';
-import { assertPiSessionEntry, type PiSessionEntry } from './transcripts/pi-entry';
+import { type TranscriptEntry } from './transcripts/entry';
+import { PI_TRANSCRIPT_FORMAT, type TranscriptFormat } from './transcripts/format';
+import { transcriptReaders } from './transcripts/registry';
 
 /** The slice of a harness session manager the mirror needs. */
 export interface SessionEntrySource {
@@ -33,11 +34,11 @@ export interface SessionMirrorOptions {
   runId: string;
   store: RunLogAppendStore;
   /**
-   * Narrow each entry before it is appended. Defaults to the pi transcript
-   * reader, which is the only entry shape the record currently types; an adapter
-   * for another transcript supplies its own.
+   * Narrow each entry before it is appended. Defaults to the reader registered
+   * for `transcriptFormat`, so an adapter for another transcript gets its own
+   * validation by registering its reader.
    */
-  assertEntry?: (entry: unknown) => PiSessionEntry;
+  assertEntry?: (entry: unknown) => TranscriptEntry;
   /** Transcript format the entries are encoded in, e.g. `pi`. */
   transcriptFormat?: TranscriptFormat;
   /** Transcript format version the entries are produced under. */
@@ -47,7 +48,7 @@ export interface SessionMirrorOptions {
 export class SessionMirror {
   private readonly runId: string;
   private readonly store: RunLogAppendStore;
-  private readonly assertEntry: (entry: unknown) => PiSessionEntry;
+  private readonly assertEntry: (entry: unknown) => TranscriptEntry;
   private readonly transcriptFormat: TranscriptFormat | undefined;
   private readonly transcriptVersion: number | undefined;
 
@@ -60,7 +61,9 @@ export class SessionMirror {
   constructor(options: SessionMirrorOptions) {
     this.runId = options.runId;
     this.store = options.store;
-    this.assertEntry = options.assertEntry ?? assertPiSessionEntry;
+    this.assertEntry =
+      options.assertEntry ??
+      transcriptReaders.require(options.transcriptFormat ?? PI_TRANSCRIPT_FORMAT).assertEntry;
     this.transcriptFormat = options.transcriptFormat;
     this.transcriptVersion = options.transcriptVersion;
   }
@@ -95,7 +98,7 @@ export class SessionMirror {
       this.headerMirrored = false;
     }
 
-    const batch: PiSessionEntry[] = [];
+    const batch: TranscriptEntry[] = [];
     if (!this.headerMirrored && header !== null && header !== undefined) batch.push(this.assertEntry(header));
 
     const entries = source.getEntries();

--- a/agentic/run-log/src/projectors/events.ts
+++ b/agentic/run-log/src/projectors/events.ts
@@ -1,0 +1,54 @@
+/**
+ * The step every projector shares: records → neutral events, in log order.
+ *
+ * Each record names its own transcript format, so this is also where a mixed
+ * log stops being a special case: the reader is chosen per record, and a run
+ * that changed harness projects as one conversation.
+ */
+
+import type { RunEventRecord } from '../record';
+import type { TranscriptEvent } from '../transcripts/event';
+import type { TranscriptReaderRegistry } from '../transcripts/reader';
+import { transcriptReaders } from '../transcripts/registry';
+
+export interface ProjectionOptions {
+  /** Readers to interpret the records with. Defaults to the process registry. */
+  readers?: TranscriptReaderRegistry;
+}
+
+/** What one record meant, tagged with its position in the run. */
+export interface EventGroup {
+  seq: number;
+  events: TranscriptEvent[];
+}
+
+/** One event, tagged with the position of the record it came from. */
+export interface SequencedEvent {
+  seq: number;
+  event: TranscriptEvent;
+}
+
+/**
+ * Read every record with the reader its format names. Grouped by record because
+ * a span asks when the *previous entry* was written, which the flattened stream
+ * can no longer tell you.
+ */
+export function toEventGroups(
+  records: readonly RunEventRecord[],
+  options: ProjectionOptions = {}
+): EventGroup[] {
+  const readers = options.readers ?? transcriptReaders;
+  return records.map((record) => ({
+    seq: record.seq,
+    events: readers.require(record.transcriptFormat).toEvents(record.entry)
+  }));
+}
+
+export function toEvents(
+  records: readonly RunEventRecord[],
+  options: ProjectionOptions = {}
+): SequencedEvent[] {
+  return toEventGroups(records, options).flatMap(({ seq, events }) =>
+    events.map((event) => ({ seq, event }))
+  );
+}

--- a/agentic/run-log/src/projectors/parts.ts
+++ b/agentic/run-log/src/projectors/parts.ts
@@ -1,25 +1,18 @@
 /**
  * Renderable projection: run log records → an ordered list of parts a UI draws.
  *
- * This is the projection that replaces per-host transcript encodings. A tool
- * call and its later result collapse into one part, so a renderer never has to
- * correlate two messages itself, and an unknown entry type becomes an
- * `unknown` part rather than disappearing — a log written by a newer pi still
- * renders, minus the detail this version understands.
+ * This is the projection that replaces per-host transcript encodings. It reads
+ * neutral transcript events rather than any harness's entries, so a renderer
+ * draws a run without knowing which harness produced it. A tool call and its
+ * later result collapse into one part, so a renderer never has to correlate two
+ * messages itself, and an entry the format's reader does not understand becomes
+ * an `unknown` part rather than disappearing — a log written by a newer harness
+ * still renders, minus the detail this version understands.
  */
 
 import type { RunEventRecord } from '../record';
-import {
-  contentText,
-  isAssistantMessage,
-  isPiBranchSummaryEntry,
-  isPiCompactionEntry,
-  isPiMessageEntry,
-  isPiSessionHeader,
-  isToolResultMessage,
-  type PiSessionEntry,
-  toolCalls
-} from '../transcripts/pi-entry';
+import type { TranscriptEntry } from '../transcripts/entry';
+import { type ProjectionOptions, toEvents } from './events';
 
 export type ToolStatus = 'requested' | 'completed' | 'failed';
 
@@ -79,7 +72,7 @@ export interface SummaryPart extends PartBase {
 export interface UnknownPart extends PartBase {
   kind: 'unknown';
   entryType: string;
-  entry: PiSessionEntry;
+  entry: TranscriptEntry;
 }
 
 export type ConversationPart =
@@ -93,137 +86,120 @@ export type ConversationPart =
 
 export interface Conversation {
   parts: ConversationPart[];
-  /** From the session header, when the log carries one. */
+  /** From the transcript's opening entry, when the log carries one. */
   sessionId?: string;
   cwd?: string;
 }
 
 /**
  * Project records into a conversation. Pure and total: the same records always
- * produce the same parts, whichever host wrote them.
+ * produce the same parts, whichever harness wrote them.
  */
-export function projectParts(records: readonly RunEventRecord[]): Conversation {
+export function projectParts(
+  records: readonly RunEventRecord[],
+  options: ProjectionOptions = {}
+): Conversation {
   const parts: ConversationPart[] = [];
   const toolsByCallId = new Map<string, ToolPart>();
   let sessionId: string | undefined;
   let cwd: string | undefined;
 
-  for (const record of records) {
-    const { entry, seq } = record;
+  for (const { seq, event } of toEvents(records, options)) {
+    const base = { seq, ...(event.entryId === undefined ? {} : { entryId: event.entryId }) };
 
-    if (isPiSessionHeader(entry)) {
-      sessionId = entry.id;
-      if (typeof entry.cwd === 'string') cwd = entry.cwd;
-      continue;
+    switch (event.kind) {
+    case 'session-start':
+      if (event.sessionId !== undefined) sessionId = event.sessionId;
+      if (event.cwd !== undefined) cwd = event.cwd;
+      break;
+
+      // A model call is a trace and metering concern; its content arrives as the
+      // text and tool-call events that follow it.
+    case 'model-response':
+      break;
+
+    case 'text':
+      parts.push({
+        kind: 'text',
+        role: event.role,
+        text: event.text,
+        ...(event.model ? { model: event.model } : {}),
+        ...(event.provider ? { provider: event.provider } : {}),
+        ...base
+      });
+      break;
+
+    case 'thinking':
+      parts.push({ kind: 'thinking', text: event.text, ...base });
+      break;
+
+    case 'tool-call': {
+      const part: ToolPart = {
+        kind: 'tool',
+        toolCallId: event.toolCallId,
+        name: event.name,
+        arguments: event.arguments,
+        status: 'requested',
+        ...base
+      };
+      toolsByCallId.set(event.toolCallId, part);
+      parts.push(part);
+      break;
     }
 
-    if (isPiCompactionEntry(entry)) {
-      parts.push({ kind: 'summary', reason: 'compaction', summary: entry.summary, seq, entryId: entry.id });
-      continue;
-    }
-
-    if (isPiBranchSummaryEntry(entry)) {
-      parts.push({ kind: 'summary', reason: 'branch', summary: entry.summary, seq, entryId: entry.id });
-      continue;
-    }
-
-    if (!isPiMessageEntry(entry)) {
-      parts.push({ kind: 'unknown', entryType: entry.type, entry, seq, entryId: (entry as { id?: string }).id });
-      continue;
-    }
-
-    const message = entry.message;
-    const base = { seq, entryId: entry.id };
-
-    if (message.role === 'user') {
-      parts.push({ kind: 'text', role: 'user', text: contentText(message.content), ...base });
-      continue;
-    }
-
-    if (isAssistantMessage(message)) {
-      for (const block of Array.isArray(message.content) ? message.content : []) {
-        if (block.type === 'text' && block.text.length > 0) {
-          parts.push({
-            kind: 'text',
-            role: 'assistant',
-            text: block.text,
-            ...(message.model ? { model: message.model } : {}),
-            ...(message.provider ? { provider: message.provider } : {}),
-            ...base
-          });
-        } else if (block.type === 'thinking') {
-          parts.push({ kind: 'thinking', text: block.thinking, ...base });
-        }
-      }
-      for (const call of toolCalls(message)) {
-        const part: ToolPart = {
-          kind: 'tool',
-          toolCallId: call.id,
-          name: call.name,
-          arguments: call.arguments ?? {},
-          status: 'requested',
-          ...base
-        };
-        toolsByCallId.set(call.id, part);
-        parts.push(part);
-      }
-      continue;
-    }
-
-    if (isToolResultMessage(message)) {
-      const existing = toolsByCallId.get(message.toolCallId);
-      const output = contentText(message.content);
-      const status: ToolStatus = message.isError ? 'failed' : 'completed';
+    case 'tool-result': {
+      const existing = toolsByCallId.get(event.toolCallId);
+      const status: ToolStatus = event.failed ? 'failed' : 'completed';
       if (existing) {
         existing.status = status;
-        existing.output = output;
+        existing.output = event.output;
         existing.settledSeq = seq;
-        if (message.details !== undefined) existing.details = message.details;
+        if (event.details !== undefined) existing.details = event.details;
       } else {
         // A result whose call is not in this window (paged read, forked branch).
         parts.push({
           kind: 'tool',
-          toolCallId: message.toolCallId,
-          name: message.toolName,
+          toolCallId: event.toolCallId,
+          name: event.name,
           arguments: {},
           status,
-          output,
+          output: event.output,
           settledSeq: seq,
           ...base
         });
       }
-      continue;
+      break;
     }
 
-    if (message.role === 'bashExecution') {
+    case 'bash':
       parts.push({
         kind: 'bash',
-        command: message.command,
-        output: message.output,
-        ...(typeof message.exitCode === 'number' ? { exitCode: message.exitCode } : {}),
+        command: event.command,
+        output: event.output,
+        ...(event.exitCode === undefined ? {} : { exitCode: event.exitCode }),
         ...base
       });
-      continue;
-    }
+      break;
 
-    if (message.role === 'custom') {
+    case 'custom':
       parts.push({
         kind: 'custom',
-        customType: message.customType,
-        text: contentText(message.content),
-        display: message.display !== false,
-        ...(message.details !== undefined ? { details: message.details } : {}),
+        customType: event.customType,
+        text: event.text,
+        display: event.display,
+        ...(event.details === undefined ? {} : { details: event.details }),
         ...base
       });
-      continue;
-    }
+      break;
 
-    parts.push({
-      kind: 'summary',
-      reason: message.role === 'branchSummary' ? 'branch' : 'compaction',
-      summary: (message as { summary?: string }).summary ?? '',
-      ...base
-    });
+    case 'summary':
+      parts.push({ kind: 'summary', reason: event.reason, summary: event.summary, ...base });
+      break;
+
+    case 'unknown':
+      parts.push({ kind: 'unknown', entryType: event.entryType, entry: event.entry, ...base });
+      break;
+    }
   }
 
   return {

--- a/agentic/run-log/src/projectors/session.ts
+++ b/agentic/run-log/src/projectors/session.ts
@@ -8,6 +8,11 @@
  *
  * Returns a string rather than writing a file: the projection is pure, and the
  * node-side write lives in `@agentic-kit/run-log/file-store`.
+ *
+ * Unlike the other projectors this one is deliberately *not* neutral:
+ * re-emitting a transcript in its native encoding is per-format work, so a
+ * second harness ships its own session projection beside its reader rather than
+ * reusing this. The neutral half of "read a log" is `../transcripts/event`.
  */
 
 import { assertOrdered, type RunEventRecord } from '../record';
@@ -53,7 +58,8 @@ export function projectSession(
   }
   const transcriptVersion = records[0]?.transcriptVersion ?? SUPPORTED_PI_TRANSCRIPT_VERSION;
 
-  const entries = records.map((record) => record.entry);
+  // Safe: every record was just asserted to carry the pi transcript format.
+  const entries = records.map((record) => record.entry as PiSessionEntry);
   const headerIndex = entries.findIndex(isPiSessionHeader);
   if (headerIndex > 0) {
     throw new Error(

--- a/agentic/run-log/src/projectors/spans.ts
+++ b/agentic/run-log/src/projectors/spans.ts
@@ -3,7 +3,7 @@
  *
  * The log answers *what* happened and the parts projection answers *in what
  * order*, but a trace view asks "how long did this take, and inside what" —
- * questions pi's entries only answer in pairs. Every entry is timestamped, so a
+ * questions a transcript only answers in pairs. Every entry is timestamped, so a
  * tool call and its result, or an approval request and its answer, bracket an
  * interval; nothing new has to be stored to know it.
  *
@@ -17,14 +17,8 @@
  */
 
 import type { RunEventRecord } from '../record';
-import {
-  contentText,
-  isAssistantMessage,
-  isPiMessageEntry,
-  isToolResultMessage,
-  type PiUsage,
-  toolCalls
-} from '../transcripts/pi-entry';
+import type { TranscriptUsage } from '../transcripts/event';
+import { type ProjectionOptions, toEventGroups } from './events';
 import {
   APPROVAL_REQUEST_TYPE,
   APPROVAL_RESOLUTION_TYPE,
@@ -63,10 +57,10 @@ export interface ModelSpan extends SpanBase {
   kind: 'model';
   model?: string;
   provider?: string;
-  /** pi's provider response id — the join key to a metered inference row. */
+  /** The provider's response id — the join key to a metered inference row. */
   responseId?: string;
   stopReason?: string;
-  usage?: PiUsage;
+  usage?: TranscriptUsage;
   errorMessage?: string;
 }
 
@@ -115,64 +109,73 @@ const close = (span: Span, seq: number, at: string): void => {
 const detailsOf = (value: unknown): Record<string, unknown> =>
   typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {};
 
+const firstTimestamp = (events: readonly { at?: string }[]): string | undefined =>
+  events.find((event) => typeof event.at === 'string')?.at;
+
 /**
  * Project records into spans. Pure, and like the other projectors it ignores what
- * it does not recognise — a log written by a newer pi still traces. A *registered*
- * type that is malformed is another matter and throws: a gate decision naming no
- * tool call is a writer bug, and a trace that quietly omitted a refusal would be
- * worse than one that fails.
+ * it does not recognise — a log written by a newer harness still traces. A
+ * *registered* type that is malformed is another matter and throws: a gate
+ * decision naming no tool call is a writer bug, and a trace that quietly omitted
+ * a refusal would be worse than one that fails.
  */
-export function projectSpans(records: readonly RunEventRecord[]): SpanProjection {
+export function projectSpans(
+  records: readonly RunEventRecord[],
+  options: ProjectionOptions = {}
+): SpanProjection {
   const spans: Span[] = [];
   const tools = new Map<string, ToolSpan>();
   const approvals = new Map<string, ApprovalSpan>();
   /**
    * The end of the previous entry, which is the earliest the next model call
-   * can have begun — pi logs a response, never a request.
+   * can have begun — a transcript logs a response, never a request.
    */
   let previousAt: string | undefined;
 
-  for (const { entry, seq } of records) {
-    const at = typeof entry.timestamp === 'string' ? entry.timestamp : undefined;
+  for (const { events, seq } of toEventGroups(records, options)) {
+    const at = firstTimestamp(events);
     if (at === undefined) continue;
     const previous = previousAt;
     previousAt = at;
+    /** The model call the entry's tool calls belong to. */
+    let modelSpan: ModelSpan | undefined;
 
-    if (!isPiMessageEntry(entry)) continue;
-    const message = entry.message;
+    for (const event of events) {
+      if (event.kind === 'model-response') {
+        const span: ModelSpan = {
+          id: `model:${event.entryId ?? String(seq)}`,
+          kind: 'model',
+          name: event.model ?? 'model',
+          // The turn began no earlier than the previous entry was written; with
+          // no previous entry the interval is unknown and the span is a point.
+          startedAt: previous ?? at,
+          startSeq: seq,
+          endSeq: seq,
+          endedAt: at,
+          timing: 'bounded',
+          status: event.stopReason === 'error' ? 'error' : 'ok',
+          ...(event.model ? { model: event.model } : {}),
+          ...(event.provider ? { provider: event.provider } : {}),
+          ...(event.responseId ? { responseId: event.responseId } : {}),
+          ...(event.stopReason ? { stopReason: event.stopReason } : {}),
+          ...(event.usage ? { usage: event.usage } : {}),
+          ...(event.errorMessage ? { errorMessage: event.errorMessage } : {})
+        };
+        const duration = ms(span.startedAt, at);
+        if (duration !== undefined) span.durationMs = duration;
+        modelSpan = span;
+        spans.push(span);
+        continue;
+      }
 
-    if (isAssistantMessage(message)) {
-      const span: ModelSpan = {
-        id: `model:${entry.id}`,
-        kind: 'model',
-        name: message.model ?? 'model',
-        // The turn began no earlier than the previous entry was written; with no
-        // previous entry the interval is unknown and the span is a point.
-        startedAt: previous ?? at,
-        startSeq: seq,
-        endSeq: seq,
-        endedAt: at,
-        timing: 'bounded',
-        status: message.stopReason === 'error' ? 'error' : 'ok',
-        ...(message.model ? { model: message.model } : {}),
-        ...(message.provider ? { provider: message.provider } : {}),
-        ...(typeof message.responseId === 'string' ? { responseId: message.responseId } : {}),
-        ...(message.stopReason ? { stopReason: message.stopReason } : {}),
-        ...(message.usage ? { usage: message.usage } : {}),
-        ...(message.errorMessage ? { errorMessage: message.errorMessage } : {})
-      };
-      const duration = ms(span.startedAt, at);
-      if (duration !== undefined) span.durationMs = duration;
-      spans.push(span);
-
-      for (const call of toolCalls(message)) {
+      if (event.kind === 'tool-call') {
         const tool: ToolSpan = {
-          id: `tool:${call.id}`,
+          id: `tool:${event.toolCallId}`,
           kind: 'tool',
-          name: call.name,
-          parentId: span.id,
-          toolCallId: call.id,
-          arguments: call.arguments ?? {},
+          name: event.name,
+          ...(modelSpan ? { parentId: modelSpan.id } : {}),
+          toolCallId: event.toolCallId,
+          arguments: event.arguments,
           startedAt: at,
           startSeq: seq,
           // A call and its result are two writes; anything between them —
@@ -180,74 +183,74 @@ export function projectSpans(records: readonly RunEventRecord[]): SpanProjection
           timing: 'bounded',
           status: 'open'
         };
-        tools.set(call.id, tool);
+        tools.set(event.toolCallId, tool);
         spans.push(tool);
+        continue;
       }
-      continue;
-    }
 
-    if (isToolResultMessage(message)) {
-      const tool = tools.get(message.toolCallId);
-      if (!tool) continue;
-      close(tool, seq, at);
-      tool.status = message.isError ? 'error' : 'ok';
-      tool.output = contentText(message.content);
-      if (message.details !== undefined) tool.details = message.details;
-      const approval = approvals.get(message.toolCallId);
-      if (approval?.durationMs !== undefined) tool.approvalWaitMs = approval.durationMs;
-      continue;
-    }
-
-    if (message.role !== 'custom') continue;
-    const info = detailsOf(message.details);
-    const toolCallId = typeof info.toolCallId === 'string' ? info.toolCallId : undefined;
-    if (toolCallId === undefined) continue;
-
-    if (message.customType === APPROVAL_REQUEST_TYPE) {
-      const tool = tools.get(toolCallId);
-      const approval: ApprovalSpan = {
-        id: `approval:${toolCallId}`,
-        kind: 'approval',
-        name: tool?.name ?? 'approval',
-        ...(tool ? { parentId: tool.id } : {}),
-        toolCallId,
-        prompt: contentText(message.content),
-        startedAt: at,
-        startSeq: seq,
-        // Request and answer are exactly the interval a human held the run.
-        timing: 'measured',
-        status: 'open'
-      };
-      approvals.set(toolCallId, approval);
-      spans.push(approval);
-      continue;
-    }
-
-    if (message.customType === APPROVAL_RESOLUTION_TYPE) {
-      const approval = approvals.get(toolCallId);
-      if (!approval) continue;
-      close(approval, seq, at);
-      const approved = info.decision === 'approved';
-      approval.decision = approved ? 'approved' : 'rejected';
-      approval.status = approved ? 'ok' : 'denied';
-      if (typeof info.actorId === 'string') approval.actorId = info.actorId;
-      const tool = tools.get(toolCallId);
-      if (tool && approval.durationMs !== undefined) tool.approvalWaitMs = approval.durationMs;
-      continue;
-    }
-
-    if (message.customType === GATE_DECISION_TYPE) {
-      // Throws on a malformed decision — see the note on this function.
-      const decision = assertGateDecisionDetails(message.details, seq);
-      const tool = tools.get(decision.toolCallId);
-      if (!tool) continue;
-      tool.gateDecision = decision.decision;
-      if (decision.reason !== undefined) tool.gateReason = decision.reason;
-      // A denied call is never executed, so this write is the only thing that
-      // will ever close its span.
-      if (decision.decision === 'deny' && tool.status === 'open') {
+      if (event.kind === 'tool-result') {
+        const tool = tools.get(event.toolCallId);
+        if (!tool) continue;
         close(tool, seq, at);
-        tool.status = 'denied';
+        tool.status = event.failed ? 'error' : 'ok';
+        tool.output = event.output;
+        if (event.details !== undefined) tool.details = event.details;
+        const approval = approvals.get(event.toolCallId);
+        if (approval?.durationMs !== undefined) tool.approvalWaitMs = approval.durationMs;
+        continue;
+      }
+
+      if (event.kind !== 'custom') continue;
+      const info = detailsOf(event.details);
+      const toolCallId = typeof info.toolCallId === 'string' ? info.toolCallId : undefined;
+      if (toolCallId === undefined) continue;
+
+      if (event.customType === APPROVAL_REQUEST_TYPE) {
+        const tool = tools.get(toolCallId);
+        const approval: ApprovalSpan = {
+          id: `approval:${toolCallId}`,
+          kind: 'approval',
+          name: tool?.name ?? 'approval',
+          ...(tool ? { parentId: tool.id } : {}),
+          toolCallId,
+          prompt: event.text,
+          startedAt: at,
+          startSeq: seq,
+          // Request and answer are exactly the interval a human held the run.
+          timing: 'measured',
+          status: 'open'
+        };
+        approvals.set(toolCallId, approval);
+        spans.push(approval);
+        continue;
+      }
+
+      if (event.customType === APPROVAL_RESOLUTION_TYPE) {
+        const approval = approvals.get(toolCallId);
+        if (!approval) continue;
+        close(approval, seq, at);
+        const approved = info.decision === 'approved';
+        approval.decision = approved ? 'approved' : 'rejected';
+        approval.status = approved ? 'ok' : 'denied';
+        if (typeof info.actorId === 'string') approval.actorId = info.actorId;
+        const tool = tools.get(toolCallId);
+        if (tool && approval.durationMs !== undefined) tool.approvalWaitMs = approval.durationMs;
+        continue;
+      }
+
+      if (event.customType === GATE_DECISION_TYPE) {
+        // Throws on a malformed decision — see the note on this function.
+        const decision = assertGateDecisionDetails(event.details, seq);
+        const tool = tools.get(decision.toolCallId);
+        if (!tool) continue;
+        tool.gateDecision = decision.decision;
+        if (decision.reason !== undefined) tool.gateReason = decision.reason;
+        // A denied call is never executed, so this write is the only thing that
+        // will ever close its span.
+        if (decision.decision === 'deny' && tool.status === 'open') {
+          close(tool, seq, at);
+          tool.status = 'denied';
+        }
       }
     }
   }

--- a/agentic/run-log/src/projectors/tool-state.ts
+++ b/agentic/run-log/src/projectors/tool-state.ts
@@ -2,15 +2,15 @@
  * Tool and approval projection: run log records → the state a UI needs to know
  * what is running and what is waiting on a human.
  *
- * Approvals ride in the log as pi `custom` messages rather than a side channel,
- * because "the run is blocked on you" is part of the run's history: a surface
+ * Approvals ride in the log as transcript `custom` entries rather than a side
+ * channel, because "the run is blocked on you" is part of the run's history: a surface
  * that reconnects hours later must be able to see a pending request without
  * having been present when it was raised, and both placements then behave the
  * same — the cloud already treats the conversation as the approval UI.
  */
 
 import type { RunEventRecord } from '../record';
-import { contentText, isAssistantMessage, isPiMessageEntry, isToolResultMessage, toolCalls } from '../transcripts/pi-entry';
+import { type ProjectionOptions, toEvents } from './events';
 
 /** `customType` of an approval request written by the gate extension. */
 export const APPROVAL_REQUEST_TYPE = 'constructive.approval.request';
@@ -92,40 +92,38 @@ const at = (seq?: number): string => (seq === undefined ? '' : ` at seq ${String
 const details = (value: unknown): GateDetails =>
   typeof value === 'object' && value !== null ? (value as GateDetails) : {};
 
-export function projectToolState(records: readonly RunEventRecord[]): ToolStateProjection {
+export function projectToolState(
+  records: readonly RunEventRecord[],
+  options: ProjectionOptions = {}
+): ToolStateProjection {
   const tools: Record<string, ToolCallState> = {};
   const approvals = new Map<string, ApprovalState>();
   const gateDecisions: Record<string, GateDecisionState> = {};
 
-  for (const { entry, seq } of records) {
-    if (!isPiMessageEntry(entry)) continue;
-    const message = entry.message;
-
-    if (isAssistantMessage(message)) {
-      for (const call of toolCalls(message)) {
-        tools[call.id] = {
-          toolCallId: call.id,
-          name: call.name,
-          arguments: call.arguments ?? {},
-          status: 'requested',
-          requestedSeq: seq
-        };
-      }
+  for (const { seq, event } of toEvents(records, options)) {
+    if (event.kind === 'tool-call') {
+      tools[event.toolCallId] = {
+        toolCallId: event.toolCallId,
+        name: event.name,
+        arguments: event.arguments,
+        status: 'requested',
+        requestedSeq: seq
+      };
       continue;
     }
 
-    if (isToolResultMessage(message)) {
-      const state = tools[message.toolCallId];
+    if (event.kind === 'tool-result') {
+      const state = tools[event.toolCallId];
       const settled: Partial<ToolCallState> = {
-        status: message.isError ? 'failed' : 'completed',
+        status: event.failed ? 'failed' : 'completed',
         settledSeq: seq,
-        output: contentText(message.content)
+        output: event.output
       };
-      tools[message.toolCallId] = state
+      tools[event.toolCallId] = state
         ? { ...state, ...settled }
         : {
-          toolCallId: message.toolCallId,
-          name: message.toolName,
+          toolCallId: event.toolCallId,
+          name: event.name,
           arguments: {},
           requestedSeq: seq,
           status: settled.status as ToolCallStatus,
@@ -135,14 +133,14 @@ export function projectToolState(records: readonly RunEventRecord[]): ToolStateP
       continue;
     }
 
-    if (message.role !== 'custom') continue;
+    if (event.kind !== 'custom') continue;
 
-    if (message.customType === APPROVAL_REQUEST_TYPE) {
-      const { toolCallId } = assertApprovalRequestDetails(message.details, seq);
+    if (event.customType === APPROVAL_REQUEST_TYPE) {
+      const { toolCallId } = assertApprovalRequestDetails(event.details, seq);
       const approval: ApprovalState = {
         toolCallId,
         requestedSeq: seq,
-        prompt: contentText(message.content)
+        prompt: event.text
       };
       approvals.set(toolCallId, approval);
       const state = tools[toolCallId];
@@ -150,8 +148,8 @@ export function projectToolState(records: readonly RunEventRecord[]): ToolStateP
       continue;
     }
 
-    if (message.customType === APPROVAL_RESOLUTION_TYPE) {
-      const info = assertApprovalResolutionDetails(message.details, seq);
+    if (event.customType === APPROVAL_RESOLUTION_TYPE) {
+      const info = assertApprovalResolutionDetails(event.details, seq);
       const toolCallId = info.toolCallId;
       const approved = info.decision === 'approved';
       const existing = approvals.get(toolCallId);
@@ -172,8 +170,8 @@ export function projectToolState(records: readonly RunEventRecord[]): ToolStateP
       continue;
     }
 
-    if (message.customType === GATE_DECISION_TYPE) {
-      const decision = assertGateDecisionDetails(message.details, seq);
+    if (event.customType === GATE_DECISION_TYPE) {
+      const decision = assertGateDecisionDetails(event.details, seq);
       gateDecisions[decision.toolCallId] = { ...decision, seq };
       const state = tools[decision.toolCallId];
       // A blocked call never produces a tool result, so the gate's `deny` is the

--- a/agentic/run-log/src/projectors/usage.ts
+++ b/agentic/run-log/src/projectors/usage.ts
@@ -1,7 +1,7 @@
 /**
  * Usage projection: run log records → token and cost totals.
  *
- * Every usage-bearing pi entry counts, not just assistant messages: a tool that
+ * Every usage-bearing event counts, not just model responses: a tool that
  * performed nested LLM work reports `usage` on its result, and compaction and
  * branch summaries are model calls the run paid for. Missing any of those makes
  * a run look cheaper than it was, which is exactly the kind of drift metering
@@ -13,14 +13,8 @@
  */
 
 import type { RunEventRecord } from '../record';
-import {
-  isAssistantMessage,
-  isPiBranchSummaryEntry,
-  isPiCompactionEntry,
-  isPiMessageEntry,
-  isToolResultMessage,
-  type PiUsage
-} from '../transcripts/pi-entry';
+import type { TranscriptUsage } from '../transcripts/event';
+import { type ProjectionOptions, toEvents } from './events';
 
 export interface UsageTotals {
   input: number;
@@ -55,7 +49,7 @@ const empty = (): UsageTotals => ({
 
 const num = (value: unknown): number => (typeof value === 'number' && Number.isFinite(value) ? value : 0);
 
-function fold(target: UsageTotals, usage: PiUsage): void {
+function fold(target: UsageTotals, usage: TranscriptUsage): void {
   const input = num(usage.input);
   const output = num(usage.output);
   const cacheRead = num(usage.cacheRead);
@@ -75,10 +69,13 @@ function fold(target: UsageTotals, usage: PiUsage): void {
 export const modelKey = (provider: string, model: string): string => `${provider}/${model}`;
 
 /** Fold every usage-bearing entry in the records into run totals. */
-export function projectUsage(records: readonly RunEventRecord[]): RunUsage {
+export function projectUsage(
+  records: readonly RunEventRecord[],
+  options: ProjectionOptions = {}
+): RunUsage {
   const totals: RunUsage = { ...empty(), byModel: {} };
 
-  const add = (usage: PiUsage | undefined, provider = 'unknown', model = 'unknown'): void => {
+  const add = (usage: TranscriptUsage | undefined, provider = 'unknown', model = 'unknown'): void => {
     if (!usage) return;
     fold(totals, usage);
     const key = modelKey(provider, model);
@@ -90,22 +87,17 @@ export function projectUsage(records: readonly RunEventRecord[]): RunUsage {
   let lastProvider = 'unknown';
   let lastModel = 'unknown';
 
-  for (const { entry } of records) {
-    if (isPiMessageEntry(entry)) {
-      const message = entry.message;
-      if (isAssistantMessage(message)) {
-        lastProvider = message.provider ?? lastProvider;
-        lastModel = message.model ?? lastModel;
-        add(message.usage, message.provider ?? 'unknown', message.model ?? 'unknown');
-      } else if (isToolResultMessage(message)) {
-        // Nested model work inside a tool: attributed to the run's current model,
-        // which is the model that requested the tool.
-        add(message.usage, lastProvider, lastModel);
-      }
+  for (const { event } of toEvents(records, options)) {
+    if (event.kind === 'model-response') {
+      lastProvider = event.provider ?? lastProvider;
+      lastModel = event.model ?? lastModel;
+      add(event.usage, event.provider ?? 'unknown', event.model ?? 'unknown');
       continue;
     }
-    if (isPiCompactionEntry(entry) || isPiBranchSummaryEntry(entry)) {
-      add(entry.usage, lastProvider, lastModel);
+    // Nested model work inside a tool or a summary: attributed to the run's
+    // current model, which is the model that asked for it.
+    if (event.kind === 'tool-result' || event.kind === 'summary') {
+      add(event.usage, lastProvider, lastModel);
     }
   }
 

--- a/agentic/run-log/src/record.ts
+++ b/agentic/run-log/src/record.ts
@@ -9,12 +9,10 @@
  * that reader must migrate from.
  */
 
-import {
-  PI_TRANSCRIPT_FORMAT,
-  SUPPORTED_PI_TRANSCRIPT_VERSION,
-  type TranscriptFormat
-} from './transcripts/format';
-import { assertPiSessionEntry, type PiSessionEntry } from './transcripts/pi-entry';
+import { type TranscriptEntry } from './transcripts/entry';
+import { PI_TRANSCRIPT_FORMAT, type TranscriptFormat } from './transcripts/format';
+import type { TranscriptReaderRegistry } from './transcripts/reader';
+import { transcriptReaders } from './transcripts/registry';
 
 /** Version of the wrapper itself — bumped only if these fields change. */
 export const RUN_LOG_WRAPPER_VERSION = 1;
@@ -31,16 +29,18 @@ export interface RunEventRecord {
   /** That transcript's format version at write time. */
   transcriptVersion: number;
   /** The harness's session entry, byte-for-byte as it was produced. */
-  entry: PiSessionEntry;
+  entry: TranscriptEntry;
 }
 
 export interface WrapEntryOptions {
   runId: string;
   seq: number;
-  entry: PiSessionEntry;
+  entry: TranscriptEntry;
   recordedAt?: string;
   transcriptFormat?: TranscriptFormat;
   transcriptVersion?: number;
+  /** Readers used to validate the entry. Defaults to the process registry. */
+  readers?: TranscriptReaderRegistry;
 }
 
 export function wrapEntry(options: WrapEntryOptions): RunEventRecord {
@@ -48,13 +48,17 @@ export function wrapEntry(options: WrapEntryOptions): RunEventRecord {
   if (!Number.isInteger(options.seq) || options.seq < 1) {
     throw new TypeError(`run log seq must be a positive integer, received ${String(options.seq)}`);
   }
+  const format = options.transcriptFormat ?? PI_TRANSCRIPT_FORMAT;
+  const reader = (options.readers ?? transcriptReaders).require(format);
   return {
     runId: options.runId,
     seq: options.seq,
     recordedAt: options.recordedAt ?? new Date().toISOString(),
-    transcriptFormat: options.transcriptFormat ?? PI_TRANSCRIPT_FORMAT,
-    transcriptVersion: options.transcriptVersion ?? SUPPORTED_PI_TRANSCRIPT_VERSION,
-    entry: assertPiSessionEntry(options.entry)
+    transcriptFormat: format,
+    transcriptVersion: options.transcriptVersion ?? reader.version,
+    // The entry is validated by the format's own reader: what makes an entry
+    // well-formed is the transcript's rule, not the wrapper's.
+    entry: reader.assertEntry(options.entry)
   };
 }
 
@@ -63,7 +67,10 @@ export function wrapEntry(options: WrapEntryOptions): RunEventRecord {
  * unreadable — a log that cannot be parsed must fail loudly, never silently
  * render as an empty conversation.
  */
-export function assertRunEventRecord(value: unknown): RunEventRecord {
+export function assertRunEventRecord(
+  value: unknown,
+  readers: TranscriptReaderRegistry = transcriptReaders
+): RunEventRecord {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
     throw new TypeError(`run log record must be an object, received ${typeof value}`);
   }
@@ -93,20 +100,19 @@ export function assertRunEventRecord(value: unknown): RunEventRecord {
     recordedAt: record.recordedAt,
     transcriptFormat: record.transcriptFormat,
     transcriptVersion: record.transcriptVersion as number,
-    entry: assertPiSessionEntry(record.entry)
+    entry: readers.require(record.transcriptFormat).assertEntry(record.entry)
   };
 }
 
 /**
- * The de-duplication key for an append. pi entry ids are unique within a
+ * The de-duplication key for an append. Transcript entry ids are unique within a
  * session, so a retried append (a Job restart re-emitting its tail, a
  * reconnecting writer) is recognised rather than duplicated.
  */
-export function idempotencyKey(runId: string, entry: PiSessionEntry): string {
-  const id = typeof (entry as { id?: unknown }).id === 'string' ? (entry as { id: string }).id : null;
-  if (id) return `${runId}:${entry.type}:${id}`;
-  // Session headers carry no tree id; there is exactly one per session file.
-  return `${runId}:${entry.type}:${String((entry as { id?: string }).id ?? 'header')}`;
+export function idempotencyKey(runId: string, entry: TranscriptEntry): string {
+  // An opening entry may carry no id; there is exactly one per session.
+  const id = typeof entry.id === 'string' && entry.id.length > 0 ? entry.id : 'header';
+  return `${runId}:${entry.type}:${id}`;
 }
 
 /** Records must be contiguous and in order before anything projects them. */

--- a/agentic/run-log/src/store.ts
+++ b/agentic/run-log/src/store.ts
@@ -12,8 +12,8 @@ import {
   type RunEventRecord,
   wrapEntry
 } from './record';
+import type { TranscriptEntry } from './transcripts/entry';
 import type { TranscriptFormat } from './transcripts/format';
-import type { PiSessionEntry } from './transcripts/pi-entry';
 
 /** Read position: `afterSeq` is exclusive, so `0` means "from the start". */
 export interface RunLogCursor {
@@ -41,10 +41,10 @@ export interface AppendOptions {
 export interface RunLogAppendStore {
   /**
    * Append entries to a run, returning the records actually written. Entries
-   * already present (matched by pi entry id) are skipped, which makes an append
-   * safe to retry.
+   * already present (matched by transcript entry id) are skipped, which makes an
+   * append safe to retry.
    */
-  append(runId: string, entries: readonly PiSessionEntry[], options?: AppendOptions): Promise<RunEventRecord[]>;
+  append(runId: string, entries: readonly TranscriptEntry[], options?: AppendOptions): Promise<RunEventRecord[]>;
 }
 
 export interface RunLogReadStore {
@@ -60,7 +60,7 @@ export class MemoryRunLogStore implements RunLogStore {
 
   async append(
     runId: string,
-    entries: readonly PiSessionEntry[],
+    entries: readonly TranscriptEntry[],
     options: AppendOptions = {}
   ): Promise<RunEventRecord[]> {
     const records = this.runs.get(runId) ?? [];

--- a/agentic/run-log/src/transcripts/entry.ts
+++ b/agentic/run-log/src/transcripts/entry.ts
@@ -1,0 +1,32 @@
+/**
+ * A harness's own session entry, as the log stores it.
+ *
+ * The log is deliberately not a re-encoding of a harness's transcript — an
+ * entry is kept byte-for-byte so the run stays resumable in the harness that
+ * wrote it. All the wrapper knows structurally is that an entry is an object
+ * with a `type`; what that type *means* is the reader's business, selected by
+ * the record's `transcriptFormat`.
+ */
+
+export interface TranscriptEntry {
+  /** The format's own entry discriminator, e.g. pi's `message`. */
+  type: string;
+  [key: string]: unknown;
+}
+
+export const isEntryRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/**
+ * Narrow an untrusted value (a JSONB column, an HTTP body) to the structure
+ * every transcript shares. A format's own reader validates the rest.
+ */
+export function assertTranscriptEntry(value: unknown): TranscriptEntry {
+  if (!isEntryRecord(value)) {
+    throw new TypeError(`transcript entry must be an object, received ${typeof value}`);
+  }
+  if (typeof value.type !== 'string' || value.type.length === 0) {
+    throw new TypeError('transcript entry must carry a non-empty string `type`');
+  }
+  return value as TranscriptEntry;
+}

--- a/agentic/run-log/src/transcripts/event.ts
+++ b/agentic/run-log/src/transcripts/event.ts
@@ -1,0 +1,139 @@
+/**
+ * The neutral vocabulary every projector reads.
+ *
+ * A projector used to know pi's message shapes, which made "render a run" and
+ * "read pi" the same capability. An event is what a transcript entry *means* —
+ * a model answered, a tool was called, a human was asked — so a format is
+ * understood in exactly one place (its `TranscriptReader`) and rendering,
+ * tracing and usage folding stop caring which harness ran.
+ *
+ * Kept close to what the projectors need rather than to any one harness: pi's
+ * `message`/`toolResult`/`custom` entries and DeepSeek Harness's
+ * `assistant/message`, `tool/call`, `tool/result` events both land here without
+ * either format's naming surviving the trip.
+ */
+
+import type { TranscriptEntry } from './entry';
+
+/** Tokens and cost as a transcript reports them — all fields optional. */
+export interface TranscriptUsage {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  totalTokens?: number;
+  cost?: { total?: number; [key: string]: unknown };
+  [key: string]: unknown;
+}
+
+export interface TranscriptEventBase {
+  /** The entry's id in its own transcript, when the format gives entries ids. */
+  entryId?: string;
+  /** The entry's ISO timestamp, when it carries one. */
+  at?: string;
+}
+
+/** The transcript's opening entry: which session, and where it ran. */
+export interface SessionStartEvent extends TranscriptEventBase {
+  kind: 'session-start';
+  sessionId?: string;
+  cwd?: string;
+}
+
+export interface TextEvent extends TranscriptEventBase {
+  kind: 'text';
+  role: 'user' | 'assistant';
+  text: string;
+  model?: string;
+  provider?: string;
+}
+
+export interface ThinkingEvent extends TranscriptEventBase {
+  kind: 'thinking';
+  text: string;
+}
+
+/**
+ * A model finished answering. Separate from the text it produced because a
+ * trace and a usage total ask about the *call* — which model, what it cost, why
+ * it stopped — while a renderer asks about the content.
+ */
+export interface ModelResponseEvent extends TranscriptEventBase {
+  kind: 'model-response';
+  model?: string;
+  provider?: string;
+  /** The provider's response id — the join key to a metered inference row. */
+  responseId?: string;
+  stopReason?: string;
+  usage?: TranscriptUsage;
+  errorMessage?: string;
+}
+
+export interface ToolCallEvent extends TranscriptEventBase {
+  kind: 'tool-call';
+  toolCallId: string;
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+export interface ToolResultEvent extends TranscriptEventBase {
+  kind: 'tool-result';
+  toolCallId: string;
+  name: string;
+  output: string;
+  failed: boolean;
+  details?: unknown;
+  /** Nested model work the tool itself paid for. */
+  usage?: TranscriptUsage;
+}
+
+export interface BashEvent extends TranscriptEventBase {
+  kind: 'bash';
+  command: string;
+  output: string;
+  exitCode?: number;
+}
+
+/**
+ * A platform entry riding in the transcript — an approval request, a gate
+ * decision — discriminated by `customType` and interpreted by the entry-type
+ * registry rather than by a format's reader.
+ */
+export interface CustomEvent extends TranscriptEventBase {
+  kind: 'custom';
+  customType: string;
+  text: string;
+  /** Whether the entry is part of the conversation a human is shown. */
+  display: boolean;
+  details?: unknown;
+}
+
+export interface SummaryEvent extends TranscriptEventBase {
+  kind: 'summary';
+  reason: 'compaction' | 'branch';
+  summary: string;
+  usage?: TranscriptUsage;
+}
+
+/**
+ * An entry this reader does not understand. Carried rather than dropped: a log
+ * written by a newer harness still renders, minus the detail this version
+ * knows, and a projector never silently loses a row.
+ */
+export interface UnknownEvent extends TranscriptEventBase {
+  kind: 'unknown';
+  entryType: string;
+  entry: TranscriptEntry;
+}
+
+export type TranscriptEvent =
+  | SessionStartEvent
+  | TextEvent
+  | ThinkingEvent
+  | ModelResponseEvent
+  | ToolCallEvent
+  | ToolResultEvent
+  | BashEvent
+  | CustomEvent
+  | SummaryEvent
+  | UnknownEvent;

--- a/agentic/run-log/src/transcripts/pi-entry.ts
+++ b/agentic/run-log/src/transcripts/pi-entry.ts
@@ -17,6 +17,7 @@ export interface PiUsageCost {
   cacheRead?: number;
   cacheWrite?: number;
   total?: number;
+  [key: string]: unknown;
 }
 
 export interface PiUsage {

--- a/agentic/run-log/src/transcripts/pi-reader.ts
+++ b/agentic/run-log/src/transcripts/pi-reader.ts
@@ -1,0 +1,164 @@
+/**
+ * pi's transcript reader: pi session entries → neutral events.
+ *
+ * This is the only place in the package that knows pi's message shapes. It stays
+ * here rather than in `@agentic-kit/pi` on purpose — a reader must be
+ * browser-safe, because renderers project logs client-side, while the adapter
+ * package pulls pi's node SDK. The types it reads are structural (see
+ * `./pi-entry`), so nothing here imports pi either.
+ */
+
+import type { TranscriptEntry } from './entry';
+import type { TranscriptEvent } from './event';
+import { PI_TRANSCRIPT_FORMAT, SUPPORTED_PI_TRANSCRIPT_VERSION } from './format';
+import {
+  assertPiSessionEntry,
+  contentText,
+  isAssistantMessage,
+  isPiBranchSummaryEntry,
+  isPiCompactionEntry,
+  isPiMessageEntry,
+  isPiSessionHeader,
+  isToolResultMessage,
+  type PiSessionEntry,
+  toolCalls
+} from './pi-entry';
+import type { TranscriptReader } from './reader';
+
+/** What a single pi entry means, in order. */
+export function piEntryToEvents(entry: TranscriptEntry): TranscriptEvent[] {
+  const pi = entry as PiSessionEntry;
+  const base = {
+    ...(typeof pi.id === 'string' ? { entryId: pi.id } : {}),
+    ...(typeof pi.timestamp === 'string' ? { at: pi.timestamp } : {})
+  };
+
+  if (isPiSessionHeader(pi)) {
+    return [
+      {
+        kind: 'session-start',
+        ...base,
+        ...(typeof pi.id === 'string' ? { sessionId: pi.id } : {}),
+        ...(typeof pi.cwd === 'string' ? { cwd: pi.cwd } : {})
+      }
+    ];
+  }
+
+  if (isPiCompactionEntry(pi)) {
+    return [
+      { kind: 'summary', reason: 'compaction', summary: pi.summary, ...(pi.usage ? { usage: pi.usage } : {}), ...base }
+    ];
+  }
+
+  if (isPiBranchSummaryEntry(pi)) {
+    return [
+      { kind: 'summary', reason: 'branch', summary: pi.summary, ...(pi.usage ? { usage: pi.usage } : {}), ...base }
+    ];
+  }
+
+  if (!isPiMessageEntry(pi)) {
+    return [{ kind: 'unknown', entryType: pi.type, entry, ...base }];
+  }
+
+  const message = pi.message;
+
+  if (message.role === 'user') {
+    return [{ kind: 'text', role: 'user', text: contentText(message.content), ...base }];
+  }
+
+  if (isAssistantMessage(message)) {
+    const events: TranscriptEvent[] = [
+      {
+        kind: 'model-response',
+        ...(message.model ? { model: message.model } : {}),
+        ...(message.provider ? { provider: message.provider } : {}),
+        ...(typeof message.responseId === 'string' ? { responseId: message.responseId } : {}),
+        ...(message.stopReason ? { stopReason: message.stopReason } : {}),
+        ...(message.usage ? { usage: message.usage } : {}),
+        ...(message.errorMessage ? { errorMessage: message.errorMessage } : {}),
+        ...base
+      }
+    ];
+    for (const block of Array.isArray(message.content) ? message.content : []) {
+      if (block.type === 'text' && block.text.length > 0) {
+        events.push({
+          kind: 'text',
+          role: 'assistant',
+          text: block.text,
+          ...(message.model ? { model: message.model } : {}),
+          ...(message.provider ? { provider: message.provider } : {}),
+          ...base
+        });
+      } else if (block.type === 'thinking') {
+        events.push({ kind: 'thinking', text: block.thinking, ...base });
+      }
+    }
+    for (const call of toolCalls(message)) {
+      events.push({
+        kind: 'tool-call',
+        toolCallId: call.id,
+        name: call.name,
+        arguments: call.arguments ?? {},
+        ...base
+      });
+    }
+    return events;
+  }
+
+  if (isToolResultMessage(message)) {
+    return [
+      {
+        kind: 'tool-result',
+        toolCallId: message.toolCallId,
+        name: message.toolName,
+        output: contentText(message.content),
+        failed: message.isError === true,
+        ...(message.details === undefined ? {} : { details: message.details }),
+        ...(message.usage ? { usage: message.usage } : {}),
+        ...base
+      }
+    ];
+  }
+
+  if (message.role === 'bashExecution') {
+    return [
+      {
+        kind: 'bash',
+        command: message.command,
+        output: message.output,
+        ...(typeof message.exitCode === 'number' ? { exitCode: message.exitCode } : {}),
+        ...base
+      }
+    ];
+  }
+
+  if (message.role === 'custom') {
+    return [
+      {
+        kind: 'custom',
+        customType: message.customType,
+        text: contentText(message.content),
+        display: message.display !== false,
+        ...(message.details === undefined ? {} : { details: message.details }),
+        ...base
+      }
+    ];
+  }
+
+  return [
+    {
+      kind: 'summary',
+      reason: message.role === 'branchSummary' ? 'branch' : 'compaction',
+      summary: (message as { summary?: string }).summary ?? '',
+      ...base
+    }
+  ];
+}
+
+/** pi's session-file transcript (`@earendil-works/pi-coding-agent`). */
+export const piTranscriptReader: TranscriptReader = {
+  format: PI_TRANSCRIPT_FORMAT,
+  version: SUPPORTED_PI_TRANSCRIPT_VERSION,
+  assertEntry: assertPiSessionEntry,
+  toEvents: piEntryToEvents
+};

--- a/agentic/run-log/src/transcripts/reader.ts
+++ b/agentic/run-log/src/transcripts/reader.ts
@@ -1,0 +1,91 @@
+/**
+ * The transcript reader registry: one place per format that knows how to read
+ * it, looked up by the format a record was written under.
+ *
+ * A reader is registered *by value*, like an entry type, so a second harness
+ * ships its reader with its adapter and neither this package nor a renderer is
+ * released to support it. A record names its format, so a run that changed
+ * harness mid-flight still projects as one ordered log.
+ */
+
+import { assertTranscriptEntry, type TranscriptEntry } from './entry';
+import type { TranscriptEvent } from './event';
+import type { TranscriptFormat } from './format';
+
+export interface TranscriptReader {
+  format: TranscriptFormat;
+  /** The format version this reader projects without migration. */
+  version: number;
+  /** Narrow an untrusted entry of this format. Throws on anything unreadable. */
+  assertEntry: (value: unknown) => TranscriptEntry;
+  /**
+   * What the entry means, in order. One entry may mean several things — a pi
+   * assistant message is a model response plus its text plus its tool calls.
+   */
+  toEvents: (entry: TranscriptEntry) => TranscriptEvent[];
+}
+
+export class TranscriptReaderRegistry {
+  private readonly readers = new Map<TranscriptFormat, TranscriptReader>();
+
+  constructor(readers: readonly TranscriptReader[] = []) {
+    for (const reader of readers) this.register(reader);
+  }
+
+  register(reader: TranscriptReader): this {
+    this.readers.set(reader.format, reader);
+    return this;
+  }
+
+  get(format: TranscriptFormat): TranscriptReader | undefined {
+    return this.readers.get(format);
+  }
+
+  has(format: TranscriptFormat): boolean {
+    return this.readers.has(format);
+  }
+
+  formats(): TranscriptFormat[] {
+    return Array.from(this.readers.keys()).sort();
+  }
+
+  /**
+   * The reader for a format, or a loud failure. A log whose format nothing can
+   * read must not render as an empty conversation — the missing piece is an
+   * unregistered adapter, and saying so is the only useful outcome.
+   */
+  require(format: TranscriptFormat): TranscriptReader {
+    const reader = this.readers.get(format);
+    if (!reader) {
+      const known = this.formats();
+      throw new Error(
+        `no transcript reader registered for format "${format}"` +
+        (known.length === 0 ? '' : `; this registry reads ${known.join(', ')}`)
+      );
+    }
+    return reader;
+  }
+}
+
+/**
+ * A reader for a format whose entries the platform stores but cannot interpret.
+ *
+ * Every entry becomes an `unknown` event, which is enough to keep a log
+ * append-only, ordered and inspectable while its adapter is still being written.
+ */
+export function passthroughReader(format: TranscriptFormat, version = 1): TranscriptReader {
+  return {
+    format,
+    version,
+    assertEntry: assertTranscriptEntry,
+    toEvents: (entry) => [
+      {
+        kind: 'unknown',
+        entryType: entry.type,
+        entry,
+        ...(typeof entry.id === 'string' ? { entryId: entry.id } : {}),
+        ...(typeof entry.timestamp === 'string' ? { at: entry.timestamp } : {})
+      }
+    ]
+  };
+}

--- a/agentic/run-log/src/transcripts/registry.ts
+++ b/agentic/run-log/src/transcripts/registry.ts
@@ -1,0 +1,21 @@
+/**
+ * The registry the projectors use when a caller does not pass their own.
+ *
+ * pi is registered because it is the harness the platform ships; a host adding
+ * a second one either registers into its own registry or into this one at
+ * startup. Kept apart from `./reader` so the registry type does not depend on
+ * any format.
+ */
+
+import { piTranscriptReader } from './pi-reader';
+import { TranscriptReaderRegistry } from './reader';
+
+/** Readers registered out of the box. */
+export const defaultTranscriptReaders = (): TranscriptReaderRegistry =>
+  new TranscriptReaderRegistry([piTranscriptReader]);
+
+/**
+ * The process-wide registry. Mutable on purpose: a host registers its adapter's
+ * reader once at startup and every projector call then reads that format.
+ */
+export const transcriptReaders = defaultTranscriptReaders();


### PR DESCRIPTION
## Summary

The tool contract (#1759) unblocked the *write* side of a second harness; this unblocks the *read* side. Until now a run log could only ever hold pi: `RunEventRecord.entry` was literally `PiSessionEntry`, `wrapEntry`/`assertRunEventRecord` validated every entry with `assertPiSessionEntry` regardless of `transcriptFormat`, and all four read projectors walked pi's message shapes — so a DeepSeek run couldn't be stored, and nothing could render it.

A record now carries a neutral entry, and the format it names picks the code that reads it:

```ts
interface RunEventRecord { …, transcriptFormat: TranscriptFormat, entry: TranscriptEntry }  // was PiSessionEntry

interface TranscriptReader {
  format: TranscriptFormat;
  version: number;
  assertEntry(value: unknown): TranscriptEntry;   // the format's own validity rule
  toEvents(entry: TranscriptEntry): TranscriptEvent[];
}
```

`wrapEntry` and `assertRunEventRecord` validate through `readers.require(record.transcriptFormat)` rather than through pi, and the projectors read the neutral `TranscriptEvent` union (`session-start | text | thinking | model-response | tool-call | tool-result | bash | custom | summary | unknown`) instead of pi entries:

```diff
-for (const { entry } of records) {
-  if (isPiMessageEntry(entry) && isAssistantMessage(entry.message)) add(entry.message.usage, …)
+for (const { event } of toEvents(records, options)) {
+  if (event.kind === 'model-response') add(event.usage, …)
```

Three things worth knowing:

- **One entry can mean several things.** A reader returns a list, which is what lets pi's single assistant message stay one stored entry while spans/usage see a `model-response` and parts see the `text` and `tool-call`s under it. `toEventGroups` keeps that grouping so a tool span still gets its model span as `parentId`.
- **The pi reader lives in `run-log`, not in `@agentic-kit/pi`.** Readers must be browser-safe (renderers project logs client-side) and the pi structural types were already here; `@agentic-kit/pi` pulls pi's node SDK, so putting the reader there would drag the SDK into a renderer. Nothing in the read path imports pi.
- **`projectSession` stays deliberately pi-specific.** Re-emitting a transcript in its *native* encoding is per-format work, so it still asserts `PI_TRANSCRIPT_FORMAT` and refuses a non-pi log rather than emitting an unloadable session file; a second harness ships its own session projection beside its reader.

Unregistered formats fail loudly (`no transcript reader registered for format "dsh"; this registry reads pi`) instead of rendering an empty conversation, and `passthroughReader(format)` lets a format be stored and inspected as `unknown` parts while its adapter is still being written.

Public output contracts are unchanged: all 98 pre-existing run-log tests pass untouched, plus 13 new ones in `__tests__/transcripts.test.ts` that project a fabricated non-pi transcript (parts, usage, tool state, a log that changes format mid-run) so a regression that re-couples the read path to pi fails there. `pnpm build:dev`, `pnpm lint` and all 14 agentic packages' tests (525) pass locally.

No DB or schema change; `transcript_format` / `transcript_version` already carry this end to end from #3184.


Link to Devin session: https://app.devin.ai/sessions/2d292e43fd2e4f34bb84605b5aa2a250
Requested by: @pyramation