### PR TITLE
docs(agentic): drop the license and credits boilerplate from the agentic READMEs

### DIFF
--- a/agentic/cli/README.md
+++ b/agentic/cli/README.md
@@ -80,7 +80,3 @@ Env overrides for CI and headless use (these win over the stored session; read p
 ## Roadmap
 
 - Harness system-prompt section + templates/prompts materialization, shared with constructive-desktop via a common adapter package.
-
-## Credits
-
-The interactive session is powered by the excellent [pi coding agent](https://github.com/badlogic/pi-mono) — thank you! `agent` layers the Constructive harness (skill releases, overlays, backend tooling) on top.

--- a/agentic/db-tools/README.md
+++ b/agentic/db-tools/README.md
@@ -62,7 +62,3 @@ const result = await describeSchemaTool.execute({ database_name: 'my-app' }, { c
 | [`@agentic-kit/harness`](https://www.npmjs.com/package/@agentic-kit/harness) | the neutral contracts: `HarnessTool`, `HarnessAdapter`, the run gate |
 | [`@agentic-kit/pi`](https://www.npmjs.com/package/@agentic-kit/pi) | the pi adapter: binds these tools and attaches a run's lanes to a pi session |
 | [`@agentic-kit/cli`](https://www.npmjs.com/package/@agentic-kit/cli) | the `agent` CLI, which materializes the tools into a pi agent dir |
-
-## License
-
-SEE LICENSE IN LICENSE

--- a/agentic/pi/README.md
+++ b/agentic/pi/README.md
@@ -109,7 +109,3 @@ For local development, the cold path and the warm pool depend on the backend's j
 - [`@agentic-kit/run-log`](https://www.npmjs.com/package/@agentic-kit/run-log) — the append-only run log
 - [`@agentic-kit/cli`](https://www.npmjs.com/package/@agentic-kit/cli) — `agent`, a local secure-by-default coding agent
 - [`agentic-kit`](https://www.npmjs.com/package/agentic-kit) — the umbrella package
-
-## Credits
-
-Built on the excellent [pi coding agent](https://github.com/badlogic/pi-mono) by Mario Zechner.

--- a/agentic/run-log/README.md
+++ b/agentic/run-log/README.md
@@ -105,7 +105,3 @@ Unreadable input fails loudly. A corrupt record, a mixed-version log, or a sessi
 - [`@agentic-kit/harness`](../harness) — host-neutral gates, policy, and the harness adapter contract
 - [`@agentic-kit/metering`](../metering) — the metered gateway and usage reporting
 - [`agentic-server`](../agentic-server) — the metered inference gateway
-
-## License
-
-SEE LICENSE IN LICENSE


### PR DESCRIPTION
## Summary

Removes boilerplate I had added to four agentic package READMEs — the `## License / SEE LICENSE IN LICENSE` tail in `run-log` and `db-tools`, and the `## Credits` tail in `pi` and `cli`. The license already lives in `LICENSE` and `package.json`, and makage appends `FOOTER.md` (which carries the disclaimer and credits) to every published README at build time, so these sections were duplicating it in the source tree.

Docs-only; no other README content touched.


Link to Devin session: https://app.devin.ai/sessions/2d292e43fd2e4f34bb84605b5aa2a250
Requested by: @pyramation