### PR TITLE
feat(storage): pair storage planes through registry FK relations, not table names

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -113,7 +113,7 @@ jobs:
           - batch: graphql
             packages: 'graphql/query graphql/codegen'
           - batch: graphile-unit
-            packages: 'graphile/graphile-plugin-utils graphile/graphile-realtime-subscriptions graphile/graphile-sql-expression-validator graphile/graphile-upload-plugin'
+            packages: 'graphile/graphile-plugin-utils graphile/graphile-realtime-subscriptions graphile/graphile-sql-expression-validator graphile/graphile-upload-plugin graphile/graphile-storage-registry'
           - batch: agentic
             packages: 'agentic/protocol agentic/agentic-kit agentic/agent agentic/harness agentic/chat agentic/cli agentic/db-tools agentic/pi agentic/react agentic/agentic-server agentic/anthropic agentic/openai agentic/ollama agentic/run-log agentic/metering'
           - batch: pgpm-unit

--- a/graphile/graphile-bucket-provisioner-plugin/__tests__/plugin.test.ts
+++ b/graphile/graphile-bucket-provisioner-plugin/__tests__/plugin.test.ts
@@ -103,12 +103,16 @@ function createMockPgClient(overrides: Record<string, any> = {}) {
     'metaschema_modules_public.storage_module': {
       rows: [{
         id: 'sm-uuid-456',
+        scope: 'app',
+        entity_table_id: null,
         buckets_schema: 'app_public',
         buckets_table: 'buckets',
         endpoint: null,
         public_url_prefix: null,
         provider: null,
         allowed_origins: null,
+        entity_schema: null,
+        entity_table: null,
       }],
     },
     app_public: {
@@ -527,11 +531,15 @@ describe('createBucketProvisionerPlugin', () => {
         'metaschema_modules_public.storage_module': {
           rows: [{
             id: 'sm-uuid-456',
+            scope: 'app',
+            entity_table_id: null,
             buckets_schema: 'app_public',
             buckets_table: 'buckets',
             endpoint: 'http://custom-minio:9000',
             public_url_prefix: 'https://cdn.example.com',
             provider: 'minio',
+            entity_schema: null,
+            entity_table: null,
           }],
         },
       });
@@ -584,11 +592,15 @@ describe('createBucketProvisionerPlugin', () => {
         'metaschema_modules_public.storage_module': {
           rows: [{
             id: 'sm-uuid-456',
+            scope: 'app',
+            entity_table_id: null,
             buckets_schema: 'app_public',
             buckets_table: 'buckets',
             endpoint: null,
             public_url_prefix: 'https://cdn.example.com',
             provider: null,
+            entity_schema: null,
+            entity_table: null,
           }],
         },
       });
@@ -726,7 +738,10 @@ describe('createBucketProvisionerPlugin', () => {
           pgCodec: {
             name: 'Bucket',
             attributes: { key: {} },
-            extensions: { tags: { storageBuckets: true } },
+            extensions: {
+              tags: { storageBuckets: true },
+              pg: { schemaName: 'app_public', name: 'buckets' },
+            },
           },
         },
       };
@@ -747,7 +762,10 @@ describe('createBucketProvisionerPlugin', () => {
           pgCodec: {
             name: 'Bucket',
             attributes: { key: {}, type: {}, allowed_origins: {} },
-            extensions: { tags: { storageBuckets: true } },
+            extensions: {
+              tags: { storageBuckets: true },
+              pg: { schemaName: 'app_public', name: 'buckets' },
+            },
           },
         },
       };
@@ -770,7 +788,10 @@ describe('createBucketProvisionerPlugin', () => {
           pgCodec: {
             name: 'Bucket',
             attributes: { key: {}, type: {} },
-            extensions: { tags: { storageBuckets: true } },
+            extensions: {
+              tags: { storageBuckets: true },
+              pg: { schemaName: 'app_public', name: 'buckets' },
+            },
           },
         },
       };
@@ -795,7 +816,10 @@ describe('createBucketProvisionerPlugin', () => {
           pgCodec: {
             name: 'Bucket',
             attributes: { key: {}, type: {} },
-            extensions: { tags: { storageBuckets: true } },
+            extensions: {
+              tags: { storageBuckets: true },
+              pg: { schemaName: 'app_public', name: 'buckets' },
+            },
           },
         },
       };
@@ -840,7 +864,10 @@ describe('createBucketProvisionerPlugin', () => {
           pgCodec: {
             name: 'Bucket',
             attributes: { key: {}, type: {} },
-            extensions: { tags: { storageBuckets: true } },
+            extensions: {
+              tags: { storageBuckets: true },
+              pg: { schemaName: 'app_public', name: 'buckets' },
+            },
           },
         },
       };
@@ -883,7 +910,10 @@ describe('createBucketProvisionerPlugin', () => {
           pgCodec: {
             name: 'Bucket',
             attributes: { key: {}, type: {} },
-            extensions: { tags: { storageBuckets: true } },
+            extensions: {
+              tags: { storageBuckets: true },
+              pg: { schemaName: 'app_public', name: 'buckets' },
+            },
           },
         },
       };
@@ -916,7 +946,10 @@ describe('createBucketProvisionerPlugin', () => {
           pgCodec: {
             name: 'Bucket',
             attributes: { key: {}, type: {} },
-            extensions: { tags: { storageBuckets: true } },
+            extensions: {
+              tags: { storageBuckets: true },
+              pg: { schemaName: 'app_public', name: 'buckets' },
+            },
           },
         },
       };
@@ -945,7 +978,10 @@ describe('createBucketProvisionerPlugin', () => {
           pgCodec: {
             name: 'Bucket',
             attributes: { key: {}, type: {} },
-            extensions: { tags: { storageBuckets: true } },
+            extensions: {
+              tags: { storageBuckets: true },
+              pg: { schemaName: 'app_public', name: 'buckets' },
+            },
           },
         },
       };
@@ -967,7 +1003,10 @@ describe('createBucketProvisionerPlugin', () => {
           pgCodec: {
             name: 'Bucket',
             attributes: { key: {}, type: {}, allowed_origins: {} },
-            extensions: { tags: { storageBuckets: true } },
+            extensions: {
+              tags: { storageBuckets: true },
+              pg: { schemaName: 'app_public', name: 'buckets' },
+            },
           },
         },
       };
@@ -999,7 +1038,10 @@ describe('createBucketProvisionerPlugin', () => {
           pgCodec: {
             name: 'Bucket',
             attributes: { key: {}, type: {}, allowed_origins: {} },
-            extensions: { tags: { storageBuckets: true } },
+            extensions: {
+              tags: { storageBuckets: true },
+              pg: { schemaName: 'app_public', name: 'buckets' },
+            },
           },
         },
       };
@@ -1052,7 +1094,10 @@ describe('createBucketProvisionerPlugin', () => {
           pgCodec: {
             name: 'Bucket',
             attributes: { key: {}, type: {}, allowed_origins: {} },
-            extensions: { tags: { storageBuckets: true } },
+            extensions: {
+              tags: { storageBuckets: true },
+              pg: { schemaName: 'app_public', name: 'buckets' },
+            },
           },
         },
       };
@@ -1125,12 +1170,16 @@ describe('CORS resolution hierarchy', () => {
       'metaschema_modules_public.storage_module': {
         rows: [{
           id: 'sm-uuid-456',
+          scope: 'app',
+          entity_table_id: null,
           buckets_schema: 'app_public',
           buckets_table: 'buckets',
           endpoint: null,
           public_url_prefix: null,
           provider: null,
           allowed_origins: ['https://db-default.example.com'],
+          entity_schema: null,
+          entity_table: null,
         }],
       },
     });
@@ -1182,12 +1231,16 @@ describe('CORS resolution hierarchy', () => {
       'metaschema_modules_public.storage_module': {
         rows: [{
           id: 'sm-uuid-456',
+          scope: 'app',
+          entity_table_id: null,
           buckets_schema: 'app_public',
           buckets_table: 'buckets',
           endpoint: null,
           public_url_prefix: null,
           provider: null,
           allowed_origins: ['https://db-default.example.com'],
+          entity_schema: null,
+          entity_table: null,
         }],
       },
     });
@@ -1241,12 +1294,16 @@ describe('CORS resolution hierarchy', () => {
       'metaschema_modules_public.storage_module': {
         rows: [{
           id: 'sm-uuid-456',
+          scope: 'app',
+          entity_table_id: null,
           buckets_schema: 'app_public',
           buckets_table: 'buckets',
           endpoint: null,
           public_url_prefix: null,
           provider: null,
           allowed_origins: null,
+          entity_schema: null,
+          entity_table: null,
         }],
       },
     });

--- a/graphile/graphile-bucket-provisioner-plugin/src/plugin.ts
+++ b/graphile/graphile-bucket-provisioner-plugin/src/plugin.ts
@@ -50,9 +50,12 @@ const log = new Logger('graphile-bucket-provisioner:plugin');
 // --- Storage module queries ---
 
 /**
- * Resolve the app-level storage module (scope = 'app').
+ * Resolve the storage module whose buckets table is the one being addressed.
+ *
+ * The buckets table's identity (schema + table, from the codec being mutated or
+ * the module row) is the fact that names the plane — never a scope literal.
  */
-const APP_STORAGE_MODULE_QUERY = `
+const STORAGE_MODULE_BY_BUCKETS_TABLE_QUERY = `
   SELECT
     sm.id,
     sm.scope,
@@ -67,12 +70,13 @@ const APP_STORAGE_MODULE_QUERY = `
   JOIN metaschema_public.table bt ON bt.id = sm.buckets_table_id
   JOIN metaschema_public.schema bs ON bs.id = bt.schema_id
   WHERE sm.database_id = $1
-    AND sm.scope = 'app'
-  LIMIT 1
+    AND bs.schema_name = $2
+    AND bt.name = $3
 `;
 
 /**
- * Resolve ALL storage modules for a database (for ownerId-based resolution).
+ * Resolve ALL storage modules for a database (for bucket-key and ownerId-based
+ * resolution in the explicit provisionBucket mutation).
  */
 const ALL_STORAGE_MODULES_QUERY = `
   SELECT
@@ -126,39 +130,115 @@ function runQuery(
 }
 
 /**
- * Resolve the storage module for a given scope.
- * If ownerId is provided, probes entity tables to find the matching module.
- * Otherwise, returns the app-level module.
+ * Resolve the storage module whose buckets table is the one being addressed.
+ *
+ * This is the resolution the auto-provision/CORS hooks use: the codec being
+ * mutated names its table, and the table names its module. A `@storageBuckets`
+ * table with no module row (or with several) is a provisioning bug and throws.
  */
-async function resolveStorageModule(
+async function resolveStorageModuleByBucketsTable(
   pgClient: any,
   databaseId: string,
-  ownerId?: string,
-): Promise<StorageModuleRow | null> {
-  if (!ownerId) {
-    // App-level resolution
-    const result = await runQuery(pgClient, APP_STORAGE_MODULE_QUERY, [databaseId]);
-    return (result.rows[0] as StorageModuleRow) ?? null;
+  schemaName: string,
+  tableName: string,
+): Promise<StorageModuleRow> {
+  const result = await runQuery(pgClient, STORAGE_MODULE_BY_BUCKETS_TABLE_QUERY, [
+    databaseId,
+    schemaName,
+    tableName,
+  ]);
+  const rows = result.rows as StorageModuleRow[];
+  if (rows.length === 0) {
+    throw new Error(
+      `STORAGE_MODULE_NOT_FOUND: no storage module in database ${databaseId} records ` +
+      `${schemaName}.${tableName} as its buckets table`,
+    );
   }
+  if (rows.length > 1) {
+    throw new Error(
+      `STORAGE_MODULE_AMBIGUOUS: ${rows.length} storage modules in database ${databaseId} record ` +
+      `${schemaName}.${tableName} as their buckets table`,
+    );
+  }
+  return rows[0];
+}
 
-  // Entity-scoped: load all modules and probe entity tables
+/**
+ * The explicit provisionBucket mutation's resolution: find the plane that
+ * actually holds the named bucket row.
+ *
+ * With an ownerId, the owning entity row names the plane (probed through each
+ * entity-keyed module's recorded entity table). Without one, every
+ * non-entity-keyed plane's buckets table is probed for the key under RLS —
+ * exactly one plane may hold it; several is ambiguous and throws rather than
+ * silently picking.
+ */
+async function resolveBucketByKey(
+  pgClient: any,
+  databaseId: string,
+  bucketKey: string,
+  ownerId?: string,
+): Promise<{ storageModule: StorageModuleRow; bucket: BucketRow } | null> {
   const result = await runQuery(pgClient, ALL_STORAGE_MODULES_QUERY, [databaseId]);
   const modules = result.rows as StorageModuleRow[];
-  const entityModules = modules.filter((m) => m.entity_schema && m.entity_table);
 
-  for (const mod of entityModules) {
-    const entityTable = QuoteUtils.quoteQualifiedIdentifier(mod.entity_schema!, mod.entity_table!);
-    const probe = await runQuery(
-      pgClient,
-      `SELECT 1 FROM ${entityTable} WHERE id = $1 LIMIT 1`,
-      [ownerId],
+  if (modules.length === 0) {
+    throw new Error(
+      `STORAGE_MODULE_NOT_PROVISIONED: database ${databaseId} has no storage modules`,
     );
-    if (probe.rows.length > 0) {
-      return mod;
+  }
+
+  if (ownerId) {
+    const entityModules = modules.filter((m) => m.entity_table_id !== null && m.entity_schema && m.entity_table);
+    for (const mod of entityModules) {
+      const entityTable = QuoteUtils.quoteQualifiedIdentifier(mod.entity_schema!, mod.entity_table!);
+      const probe = await runQuery(
+        pgClient,
+        `SELECT 1 FROM ${entityTable} WHERE id = $1 LIMIT 1`,
+        [ownerId],
+      );
+      if (probe.rows.length === 0) continue;
+
+      const bucketsTable = QuoteUtils.quoteQualifiedIdentifier(mod.buckets_schema, mod.buckets_table);
+      const bucketResult = await runQuery(
+        pgClient,
+        `SELECT id, key, type, is_public, allowed_origins, physical_name
+         FROM ${bucketsTable}
+         WHERE key = $1 AND owner_id = $2
+         LIMIT 1`,
+        [bucketKey, ownerId],
+      );
+      if (bucketResult.rows.length === 0) return null;
+      return { storageModule: mod, bucket: bucketResult.rows[0] as BucketRow };
+    }
+    return null;
+  }
+
+  const matches: { storageModule: StorageModuleRow; bucket: BucketRow }[] = [];
+  for (const mod of modules.filter((m) => m.entity_table_id === null)) {
+    const bucketsTable = QuoteUtils.quoteQualifiedIdentifier(mod.buckets_schema, mod.buckets_table);
+    const bucketResult = await runQuery(
+      pgClient,
+      `SELECT id, key, type, is_public, allowed_origins, physical_name
+       FROM ${bucketsTable}
+       WHERE key = $1
+       LIMIT 1`,
+      [bucketKey],
+    );
+    if (bucketResult.rows.length > 0) {
+      matches.push({ storageModule: mod, bucket: bucketResult.rows[0] as BucketRow });
     }
   }
 
-  return null;
+  if (matches.length === 0) return null;
+  if (matches.length > 1) {
+    const scopes = matches.map((m) => `'${m.storageModule.scope}'`).join(', ');
+    throw new Error(
+      `BUCKET_KEY_AMBIGUOUS: bucket key "${bucketKey}" exists in ${matches.length} storage planes ` +
+      `(scopes ${scopes}); provide an ownerId or use a plane-unique key`,
+    );
+  }
+  return matches[0];
 }
 
 interface BucketRow {
@@ -299,7 +379,7 @@ function buildProvisioner(
  * auto-provisioning hook.
  */
 async function provisionBucketForRow(
-  pgClient: any,
+  storageModule: StorageModuleRow,
   databaseId: string,
   bucketKey: string,
   bucketType: string,
@@ -308,9 +388,6 @@ async function provisionBucketForRow(
   s3BucketName: string,
 ): Promise<ProvisionResult> {
   const accessType = bucketType as 'public' | 'private' | 'temp';
-
-  // Read storage module config to check for endpoint/provider/CORS overrides
-  const storageModule = await resolveStorageModule(pgClient, databaseId);
 
   // Resolve CORS origins using the 3-tier hierarchy
   const effectiveOrigins = resolveAllowedOrigins(
@@ -346,7 +423,7 @@ async function provisionBucketForRow(
  * Update CORS on an existing S3 bucket when allowed_origins changes.
  */
 async function updateBucketCors(
-  pgClient: any,
+  storageModule: StorageModuleRow,
   databaseId: string,
   bucketKey: string,
   bucketType: string,
@@ -355,8 +432,6 @@ async function updateBucketCors(
   s3BucketName: string,
 ): Promise<void> {
   const accessType = bucketType as 'public' | 'private' | 'temp';
-
-  const storageModule = await resolveStorageModule(pgClient, databaseId);
 
   const effectiveOrigins = resolveAllowedOrigins(
     bucketAllowedOrigins,
@@ -468,38 +543,14 @@ export function createBucketProvisionerPlugin(
                 throw new Error('DATABASE_NOT_FOUND');
               }
 
-              // Resolve storage module (app-level or entity-scoped via ownerId)
-              const storageModule = await resolveStorageModule(pgClient, databaseId, ownerId);
-              if (!storageModule) {
-                throw new Error(
-                  ownerId
-                    ? 'STORAGE_MODULE_NOT_FOUND_FOR_OWNER: no storage module found for the given ownerId'
-                    : 'STORAGE_MODULE_NOT_PROVISIONED',
-                );
-              }
-
-              // Look up the bucket row (RLS enforced via pgSettings)
-              const hasOwner = ownerId && storageModule.scope !== 'app';
-              const bucketsTable = QuoteUtils.quoteQualifiedIdentifier(storageModule.buckets_schema, storageModule.buckets_table);
-              const bucketResult = await runQuery(
-                pgClient,
-                hasOwner
-                  ? `SELECT id, key, type, is_public, allowed_origins, physical_name
-                     FROM ${bucketsTable}
-                     WHERE key = $1 AND owner_id = $2
-                     LIMIT 1`
-                  : `SELECT id, key, type, is_public, allowed_origins, physical_name
-                     FROM ${bucketsTable}
-                     WHERE key = $1
-                     LIMIT 1`,
-                hasOwner ? [bucketKey, ownerId] : [bucketKey],
-              );
-
-              if (bucketResult.rows.length === 0) {
+              // Resolve the plane that actually holds the named bucket row
+              // (RLS enforced via pgSettings) — never a guessed scope.
+              const resolution = await resolveBucketByKey(pgClient, databaseId, bucketKey, ownerId);
+              if (!resolution) {
                 throw new Error('BUCKET_NOT_FOUND');
               }
-
-              const bucket = bucketResult.rows[0] as BucketRow;
+              const { storageModule, bucket } = resolution;
+              const bucketsTable = QuoteUtils.quoteQualifiedIdentifier(storageModule.buckets_schema, storageModule.buckets_table);
 
               // First provision mints a name; afterwards the stored coordinate
               // is authoritative and the naming hook is never consulted again.
@@ -510,7 +561,7 @@ export function createBucketProvisionerPlugin(
 
               try {
                 const result = await provisionBucketForRow(
-                  pgClient,
+                  storageModule,
                   databaseId,
                   bucket.key,
                   bucket.type,
@@ -604,6 +655,11 @@ export function createBucketProvisionerPlugin(
 
           log.debug(`Wrapping mutation "${fieldName}" for ${isCreate ? 'auto-provisioning' : 'CORS update'} (codec: ${pgCodec.name})`);
 
+          // The codec being mutated names the buckets table — the hook always
+          // operates on the plane that table belongs to, never a guessed scope.
+          const codecSchemaName = pgCodec.extensions?.pg?.schemaName as string | undefined;
+          const codecTableName = pgCodec.extensions?.pg?.name as string | undefined;
+
           const defaultResolver = (obj: any) => obj[fieldName];
           const { resolve: oldResolve = defaultResolver, ...rest } = field;
 
@@ -637,6 +693,12 @@ export function createBucketProvisionerPlugin(
                     return result;
                   }
 
+                  if (!codecSchemaName || !codecTableName) {
+                    throw new Error(
+                      `Auto-provision failed for "${fieldName}": codec ${pgCodec.name} carries no pg schema/table identity`,
+                    );
+                  }
+
                   await withPgClient(pgSettings, async (pgClient: any) => {
                     const databaseId = await resolveDatabaseId(pgClient);
                     if (!databaseId) {
@@ -644,9 +706,15 @@ export function createBucketProvisionerPlugin(
                       return;
                     }
 
+                    // The mutated table names its module — the plane being written
+                    // is the plane that gets provisioned.
+                    const storageModule = await resolveStorageModuleByBucketsTable(
+                      pgClient, databaseId, codecSchemaName, codecTableName,
+                    );
+
                     // Newly-created row has no stored coordinate yet — mint on first provision.
                     const result = await provisionBucketForRow(
-                      pgClient,
+                      storageModule,
                       databaseId,
                       bucketInput.key,
                       bucketInput.type,
@@ -656,17 +724,17 @@ export function createBucketProvisionerPlugin(
                     );
 
                     // Record the provisioned name on the just-created row.
-                    const storageModule = await resolveStorageModule(pgClient, databaseId);
-                    if (storageModule) {
-                      const bucketsTable = QuoteUtils.quoteQualifiedIdentifier(storageModule.buckets_schema, storageModule.buckets_table);
-                      const idResult = await runQuery(
-                        pgClient,
-                        `SELECT id FROM ${bucketsTable} WHERE key = $1 LIMIT 1`,
-                        [bucketInput.key],
-                      );
-                      const bucketId = idResult.rows[0]?.id;
-                      if (bucketId) await recordPhysicalName(withPgClient, bucketsTable, bucketId, result.bucketName);
-                    }
+                    const bucketsTable = QuoteUtils.quoteQualifiedIdentifier(storageModule.buckets_schema, storageModule.buckets_table);
+                    const ownerId = bucketInput.ownerId ?? bucketInput.owner_id ?? null;
+                    const idResult = await runQuery(
+                      pgClient,
+                      ownerId
+                        ? `SELECT id FROM ${bucketsTable} WHERE key = $1 AND owner_id = $2 LIMIT 1`
+                        : `SELECT id FROM ${bucketsTable} WHERE key = $1 LIMIT 1`,
+                      ownerId ? [bucketInput.key, ownerId] : [bucketInput.key],
+                    );
+                    const bucketId = idResult.rows[0]?.id;
+                    if (bucketId) await recordPhysicalName(withPgClient, bucketsTable, bucketId, result.bucketName);
                   });
                 } else {
                   // --- UPDATE: re-apply CORS if allowed_origins is in the patch ---
@@ -678,6 +746,12 @@ export function createBucketProvisionerPlugin(
                     return result;
                   }
 
+                  if (!codecSchemaName || !codecTableName) {
+                    throw new Error(
+                      `CORS update failed for "${fieldName}": codec ${pgCodec.name} carries no pg schema/table identity`,
+                    );
+                  }
+
                   await withPgClient(pgSettings, async (pgClient: any) => {
                     const databaseId = await resolveDatabaseId(pgClient);
                     if (!databaseId) {
@@ -685,12 +759,11 @@ export function createBucketProvisionerPlugin(
                       return;
                     }
 
-                    // Read the storage module config (app-level; auto-hook doesn't have ownerId context)
-                    const storageModule = await resolveStorageModule(pgClient, databaseId);
-                    if (!storageModule) {
-                      log.warn('CORS update skipped: storage module not provisioned');
-                      return;
-                    }
+                    // The mutated table names its module — CORS applies to the
+                    // plane whose row was updated.
+                    const storageModule = await resolveStorageModuleByBucketsTable(
+                      pgClient, databaseId, codecSchemaName, codecTableName,
+                    );
 
                     // We need the bucket key — it may come from input or patch
                     // For updates, PostGraphile uses nodeId or the row's PK, so
@@ -728,7 +801,7 @@ export function createBucketProvisionerPlugin(
                     const recorded = storedPhysicalName(bucket);
 
                     await updateBucketCors(
-                      pgClient,
+                      storageModule,
                       databaseId,
                       bucket.key,
                       bucket.type,

--- a/graphile/graphile-presigned-url-plugin/package.json
+++ b/graphile/graphile-presigned-url-plugin/package.json
@@ -44,6 +44,7 @@
     "@aws-sdk/s3-request-presigner": "^3.1052.0",
     "@pgpmjs/logger": "workspace:^",
     "@pgsql/quotes": "^18.2.4",
+    "graphile-storage-registry": "workspace:^",
     "lru-cache": "^11.2.7",
     "mime-bytes": "workspace:^"
   },

--- a/graphile/graphile-presigned-url-plugin/src/index.ts
+++ b/graphile/graphile-presigned-url-plugin/src/index.ts
@@ -52,7 +52,7 @@ export { createPresignedUrlPlugin,PresignedUrlPlugin } from './plugin';
 export { PresignedUrlPreset } from './preset';
 export { type WithPgClient, withRequestPgClient } from './request-pg-client';
 export { copyS3Object, deleteS3Object, generatePresignedGetUrl, generatePresignedPutUrl, headObject, readObjectPrefix } from './s3-signer';
-export { clearBucketCache, clearStorageModuleCache, getBucketConfig, getStorageModuleConfig, getStorageModuleConfigForOwner, isS3BucketProvisioned, loadAllStorageModules, markS3BucketProvisioned,resolveStorageConfigFromCodec, resolveStorageModuleByFileId } from './storage-module-cache';
+export { clearBucketCache, clearStorageModuleCache, getBucketConfig, isS3BucketProvisioned, loadAllStorageModules, markS3BucketProvisioned,resolveStorageConfigFromCodec, resolveStorageModuleByFileId } from './storage-module-cache';
 export type {
   BucketConfig,
   BucketNameResolver,

--- a/graphile/graphile-presigned-url-plugin/src/managed-upload.ts
+++ b/graphile/graphile-presigned-url-plugin/src/managed-upload.ts
@@ -142,8 +142,8 @@ export async function resolveManagedUploadTarget(args: {
     );
   }
 
-  if (storageConfig.scope !== 'app') {
-    // An entity-scoped module resolves its bucket per owning row, and a
+  if (storageConfig.entityTableId !== null) {
+    // An entity-keyed module resolves its bucket per owning row, and a
     // multipart column write does not carry one. Refuse rather than write a
     // tenant's file into whichever bucket happened to resolve.
     throw new Error(

--- a/graphile/graphile-presigned-url-plugin/src/plugin.ts
+++ b/graphile/graphile-presigned-url-plugin/src/plugin.ts
@@ -7,6 +7,8 @@
  *    on root Mutation for each @storageFiles/@storageBuckets pair. These combine
  *    bucket resolution + file INSERT + presigned URL generation in one step.
  *    E.g., `uploadAppFile(input: { bucketKey: "public", contentHash: "...", ... })`
+ *    Pairs are discovered from the registry's FK relations (see
+ *    graphile-storage-registry) — table naming carries no meaning here.
  *
  * 2. Delete middleware — wraps `delete*` mutations on `@storageFiles`-tagged tables
  *    with S3 object cleanup (sync + async GC fallback via AFTER DELETE trigger).
@@ -22,6 +24,7 @@ import 'graphile-build';
 import { Logger } from '@pgpmjs/logger';
 import { access, context as grafastContext, lambda, object } from 'grafast';
 import type { GraphileConfig } from 'graphile-config';
+import { discoverStoragePlanes, uploadSurfaceNames } from 'graphile-storage-registry';
 import { checkTypeAgreement } from 'mime-bytes';
 
 import { validateCustomKey } from './custom-key';
@@ -143,49 +146,30 @@ export function createPresignedUrlPlugin(
             log.warn('No JSON scalar in this schema; upload payloads will omit the `file` projection');
           }
 
-          const bucketCodecs = Object.values((build.input as any).pgRegistry.pgCodecs).filter(
-            (codec: any) => codec.attributes && (codec.extensions as any)?.tags?.storageBuckets,
-          );
+          // Each @storageFiles table is paired with its @storageBuckets table
+          // through the registry's actual FK relation; a tagged table that cannot
+          // be paired is a provisioning bug and throws at schema build.
+          const planes = discoverStoragePlanes((build.input as any).pgRegistry as any);
 
-          if (bucketCodecs.length === 0) return fields;
+          if (planes.length === 0) return fields;
 
           const newFields: Record<string, any> = {};
 
           // --- File upload mutations (uploadAppFile, uploadDataRoomFile, etc.) ---
-          const fileCodecs = Object.values((build.input as any).pgRegistry.pgCodecs).filter(
-            (codec: any) => codec.attributes && (codec.extensions as any)?.tags?.storageFiles,
-          );
+          for (const plane of planes) {
+            const filesCodec = plane.filesCodec as any;
+            const matchingBucketCodec = plane.bucketsCodec as any;
+            const names = uploadSurfaceNames(build.inflection as any, plane.filesCodec);
+            const { filesTypeName, uploadMutation: mutationName } = names;
 
-          for (const filesCodec of fileCodecs as any[]) {
-            const filesTypeName = (build.inflection as any).tableType(filesCodec);
-
-            // Find the matching bucket codec by table name prefix.
-            // Schema-name matching is ambiguous when multiple storage modules share
-            // the same PG schema (e.g. app_files + data_room_files both in storage_public).
-            // Instead, derive the prefix from the raw SQL table name:
-            //   "data_room_files" → prefix "data_room" → matches "data_room_buckets"
-            //   "app_files"       → prefix "app"       → matches "app_buckets"
-            const filesRawName = filesCodec.extensions?.pg?.name as string | undefined;
-            const filesPrefix = filesRawName?.replace(/_files$/, '');
-            const matchingBucketCodec = (bucketCodecs as any[]).find((bc: any) => {
-              const bucketRawName = bc.extensions?.pg?.name as string | undefined;
-              const bucketPrefix = bucketRawName?.replace(/_buckets$/, '');
-              return bucketPrefix === filesPrefix;
-            });
-            if (!matchingBucketCodec) {
-              log.debug(`Skipping upload mutation for ${filesCodec.name}: no matching bucket codec with prefix "${filesPrefix}"`);
-              continue;
-            }
-
-            const hasOwnerId = !!matchingBucketCodec.attributes.owner_id;
-            const mutationName = `upload${filesTypeName}`;
+            const hasOwnerId = plane.hasOwnerId;
 
             const ownerIdGqlType = hasOwnerId
               ? (build as any).getGraphQLTypeByPgCodec(matchingBucketCodec.attributes.owner_id.codec, 'input')
               : null;
 
             const InputType = new GraphQLInputObjectType({
-              name: `Upload${filesTypeName}Input`,
+              name: names.uploadInputType,
               fields: {
                 bucketKey: { type: GraphQLString, description: 'Bucket key (e.g., "public", "private"). Omit to use the database\'s default bucket for the requested access.' },
                 isPublic: { type: GraphQLBoolean, description: 'Which default bucket to resolve when bucketKey is omitted: the public one (true) or the private one (default false). Ignored when bucketKey is given.' },
@@ -201,7 +185,7 @@ export function createPresignedUrlPlugin(
             });
 
             const PayloadType = new GraphQLObjectType({
-              name: `Upload${filesTypeName}Payload`,
+              name: names.uploadPayloadType,
               fields: {
                 uploadUrl: { type: GraphQLString, description: 'Presigned PUT URL (null if deduplicated)' },
                 fileId: { type: new GraphQLNonNull(GraphQLString), description: 'The file ID (UUID)' },
@@ -311,7 +295,7 @@ export function createPresignedUrlPlugin(
 
             // --- Bulk file upload mutation ---
             const BulkFileInputType = new GraphQLInputObjectType({
-              name: `Upload${filesTypeName}BulkFileInput`,
+              name: names.bulkUploadFileInputType,
               fields: {
                 contentHash: { type: new GraphQLNonNull(GraphQLString), description: 'SHA-256 content hash (hex-encoded, 64 chars)' },
                 contentType: { type: new GraphQLNonNull(GraphQLString), description: 'MIME type of the file' },
@@ -322,7 +306,7 @@ export function createPresignedUrlPlugin(
             });
 
             const BulkFilePayloadType = new GraphQLObjectType({
-              name: `Upload${filesTypeName}BulkFilePayload`,
+              name: names.bulkUploadFilePayloadType,
               fields: {
                 uploadUrl: { type: GraphQLString },
                 fileId: { type: new GraphQLNonNull(GraphQLString) },
@@ -335,7 +319,7 @@ export function createPresignedUrlPlugin(
             });
 
             const BulkInputType = new GraphQLInputObjectType({
-              name: `Upload${filesTypeName}BulkInput`,
+              name: names.bulkUploadInputType,
               fields: {
                 bucketKey: { type: GraphQLString, description: 'Bucket key (e.g., "public", "private"). Omit to use the database\'s default bucket for the requested access.' },
                 isPublic: { type: GraphQLBoolean, description: 'Which default bucket to resolve when bucketKey is omitted. Ignored when bucketKey is given.' },
@@ -347,13 +331,13 @@ export function createPresignedUrlPlugin(
             });
 
             const BulkPayloadType = new GraphQLObjectType({
-              name: `Upload${filesTypeName}BulkPayload`,
+              name: names.bulkUploadPayloadType,
               fields: {
                 files: { type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(BulkFilePayloadType))) },
               },
             });
 
-            const bulkMutationName = `upload${filesTypeName}s`;
+            const bulkMutationName = names.bulkUploadMutation;
             log.debug(`Adding bulk file upload mutation "${bulkMutationName}" for ${filesTypeName}`);
 
             newFields[bulkMutationName] = context.fieldWithHooks(
@@ -783,8 +767,9 @@ async function processSingleFile(
   // Auto-derive ltree path from custom key directory (only when has_path_shares)
   const derivedPath = isCustomKey && storageConfig.hasPathShares ? derivePathFromKey(s3Key) : null;
 
-  // Create file record
-  const hasOwnerColumn = storageConfig.scope !== 'app';
+  // Create file record. An entity-keyed plane (the module records an entity
+  // table) carries owner_id on its rows; app- and database-scope planes do not.
+  const hasOwnerColumn = storageConfig.entityTableId !== null;
   const columns = ['bucket_id', 'key', 'content_hash', 'mime_type', 'size', 'filename', 'is_public'];
   const values: any[] = [bucket.id, s3Key, contentHash, contentType, size, filename || null, bucket.is_public];
 

--- a/graphile/graphile-presigned-url-plugin/src/storage-module-cache.ts
+++ b/graphile/graphile-presigned-url-plugin/src/storage-module-cache.ts
@@ -35,52 +35,9 @@ const storageModuleCache = new LRUCache<string, StorageModuleConfig>({
 });
 
 /**
- * SQL query to resolve the app-level storage module config for a database.
- *
- * Joins storage_module → table → schema to get fully-qualified table names.
- * Filters to app-level (scope = 'app') by default.
- *
- * Requires the multi-scope schema (scope column on storage_module).
- */
-const APP_STORAGE_MODULE_QUERY = `
-  SELECT
-    sm.id,
-    sm.scope,
-    sm.entity_table_id,
-    bs.schema_name AS buckets_schema,
-    bt.name AS buckets_table,
-    fs.schema_name AS files_schema,
-    ft.name AS files_table,
-    sm.endpoint,
-    sm.public_url_prefix,
-    sm.provider,
-    sm.allowed_origins,
-    sm.upload_url_expiry_seconds,
-    sm.download_url_expiry_seconds,
-    sm.default_max_file_size,
-    sm.max_filename_length,
-    sm.cache_ttl_seconds,
-    sm.max_bulk_files,
-    sm.max_bulk_total_size,
-    sm.has_path_shares,
-    sm.has_confirm_upload,
-    NULL AS entity_schema,
-    NULL AS entity_table
-  FROM metaschema_modules_public.storage_module sm
-  JOIN metaschema_public.table bt ON bt.id = sm.buckets_table_id
-  JOIN metaschema_public.schema bs ON bs.id = bt.schema_id
-  JOIN metaschema_public.table ft ON ft.id = sm.files_table_id
-  JOIN metaschema_public.schema fs ON fs.id = ft.schema_id
-  WHERE sm.database_id = $1
-    AND sm.scope = 'app'
-  LIMIT 1
-`;
-
-/**
- * SQL query to resolve ALL storage modules for a database (app-level + entity-scoped).
- *
- * Returns all storage modules with their entity table names for ownerId resolution.
- * Requires the multi-scope schema.
+ * SQL query to resolve ALL storage modules for a database, whatever their
+ * scope. Returns each module with its entity table names so callers can
+ * classify entity-keyed planes and resolve owners.
  */
 const ALL_STORAGE_MODULES_QUERY = `
   SELECT
@@ -175,116 +132,6 @@ function buildConfig(row: StorageModuleRow): StorageModuleConfig {
 }
 
 /**
- * Resolve the app-level storage module config for a database, using the LRU cache.
- *
- * This is the default path when no ownerId is provided. It returns the
- * storage module with scope = 'app' (app-level / database-wide).
- *
- * @param pgClient - A pg client from the Graphile context (withPgClient or pgClient)
- * @param databaseId - The metaschema database UUID
- * @returns StorageModuleConfig or null if no storage module is provisioned
- */
-export async function getStorageModuleConfig(
-  pgClient: { query: (opts: { text: string; values?: unknown[] }) => Promise<{ rows: unknown[] }> },
-  databaseId: string,
-): Promise<StorageModuleConfig | null> {
-  const cacheKey = `storage:${databaseId}:app`;
-  const cached = storageModuleCache.get(cacheKey);
-  if (cached) {
-    return cached;
-  }
-
-  log.debug(`Cache miss for app-level storage in database ${databaseId}, querying metaschema...`);
-
-  const result = await pgClient.query({ text: APP_STORAGE_MODULE_QUERY, values: [databaseId] });
-
-  if (result.rows.length === 0) {
-    log.warn(`No app-level storage module found for database ${databaseId}`);
-    return null;
-  }
-
-  const config = buildConfig(result.rows[0] as StorageModuleRow);
-  storageModuleCache.set(cacheKey, config);
-  log.debug(`Cached app-level storage config for database ${databaseId}: ${config.bucketsQualifiedName}`);
-
-  return config;
-}
-
-/**
- * Resolve the storage module config for a specific owner entity.
- *
- * When ownerId is provided, this function:
- * 1. Loads ALL storage modules for the database (cached)
- * 2. Finds which entity-scoped module contains the ownerId in its entity table
- * 3. Returns that module's config
- *
- * This is the core of Option C — the ownerId tells us which scope to use.
- *
- * @param pgClient - A pg client from the Graphile context
- * @param databaseId - The metaschema database UUID
- * @param ownerId - The entity instance UUID (e.g., a data room ID, team ID)
- * @returns StorageModuleConfig or null if no matching module found
- */
-export async function getStorageModuleConfigForOwner(
-  pgClient: { query: (opts: { text: string; values?: unknown[] }) => Promise<{ rows: unknown[] }> },
-  databaseId: string,
-  ownerId: string,
-): Promise<StorageModuleConfig | null> {
-  // Check if we already have a cached mapping for this ownerId
-  const ownerCacheKey = `storage:${databaseId}:owner:${ownerId}`;
-  const cachedOwner = storageModuleCache.get(ownerCacheKey);
-  if (cachedOwner) {
-    return cachedOwner;
-  }
-
-  // Load all storage modules for this database
-  const allModulesCacheKey = `storage:${databaseId}:all`;
-  let allConfigs: StorageModuleConfig[];
-  const cachedAll = storageModuleCache.get(allModulesCacheKey);
-  if (cachedAll) {
-    // We stored a sentinel; re-derive from individual caches
-    // Actually, let's just query fresh — this is the cache-miss path
-    allConfigs = [];
-  } else {
-    allConfigs = [];
-  }
-
-  if (allConfigs.length === 0) {
-    log.debug(`Loading all storage modules for database ${databaseId} to resolve ownerId ${ownerId}`);
-    const result = await pgClient.query({ text: ALL_STORAGE_MODULES_QUERY, values: [databaseId] });
-    allConfigs = (result.rows as StorageModuleRow[]).map(buildConfig);
-
-    // Cache each individual config by its scope
-    for (const config of allConfigs) {
-      const key = `storage:${databaseId}:scope:${config.scope}`;
-      storageModuleCache.set(key, config);
-    }
-  }
-
-  // Find entity-scoped modules and probe their entity tables for the ownerId
-  const entityModules = allConfigs.filter((c) => c.entityQualifiedName !== null);
-
-  for (const mod of entityModules) {
-    const probeResult = await pgClient.query({
-      text: `SELECT 1 FROM ${mod.entityQualifiedName} WHERE id = $1 LIMIT 1`,
-      values: [ownerId],
-    });
-    if (probeResult.rows.length > 0) {
-      // Found the matching module — cache the ownerId→module mapping
-      storageModuleCache.set(ownerCacheKey, mod);
-      log.debug(
-        `Resolved ownerId ${ownerId} to storage module ${mod.id} ` +
-        `(scope=${mod.scope}, table=${mod.bucketsQualifiedName})`,
-      );
-      return mod;
-    }
-  }
-
-  log.warn(`No entity-scoped storage module found for ownerId ${ownerId} in database ${databaseId}`);
-  return null;
-}
-
-/**
  * Resolve the storage module that owns a specific file by probing all file tables.
  *
  * Since UUIDs are globally unique, exactly one table will contain the file.
@@ -343,12 +190,6 @@ export async function loadAllStorageModules(
   log.debug(`Loading all storage modules for database ${databaseId}`);
   const result = await pgClient.query({ text: ALL_STORAGE_MODULES_QUERY, values: [databaseId] });
   const configs = (result.rows as StorageModuleRow[]).map(buildConfig);
-
-  // Cache each individual config by its scope
-  for (const config of configs) {
-    const key = `storage:${databaseId}:scope:${config.scope}`;
-    storageModuleCache.set(key, config);
-  }
 
   // Store the full list under a sentinel key (only if non-empty to avoid caching failed lookups)
   if (configs.length > 0) {
@@ -446,9 +287,9 @@ export async function getBucketConfig(
 
   log.debug(`Bucket cache miss for ${databaseId}:${bucketKey}${ownerId ? ` (owner=${ownerId})` : ''}, querying DB...`);
 
-  // Entity-scoped buckets use (owner_id, key) composite lookup;
-  // app-level buckets just use key.
-  const isEntityScoped = storageConfig.scope !== 'app';
+  // Entity-keyed planes (the module records an entity table) use the
+  // (owner_id, key) composite lookup; app- and database-scope planes just use key.
+  const isEntityScoped = storageConfig.entityTableId !== null;
   const hasOwner = ownerId && isEntityScoped;
   const result = await pgClient.query({
     text: hasOwner

--- a/graphile/graphile-storage-registry/README.md
+++ b/graphile/graphile-storage-registry/README.md
@@ -1,0 +1,34 @@
+# graphile-storage-registry
+
+Registry-derived storage plane discovery for PostGraphile v5.
+
+A storage plane is a `@storageFiles` table and the `@storageBuckets` table it
+writes into. This package pairs them through their **actual foreign-key
+relations** in the Graphile registry (`pgRegistry.pgRelations`) — never through
+table names — and derives the canonical upload surface names from the schema's
+own inflection, so no physical name is ever load-bearing.
+
+## Usage
+
+```ts
+import { discoverStoragePlanes, uploadSurfaceNames } from 'graphile-storage-registry';
+
+const planes = discoverStoragePlanes(build.input.pgRegistry);
+for (const plane of planes) {
+  const names = uploadSurfaceNames(build.inflection, plane.filesCodec);
+  // names.uploadMutation === 'uploadAppFile', names.bulkUploadMutation === 'uploadAppFiles', …
+}
+```
+
+`discoverStoragePlanes` throws at schema build when a tagged storage table
+cannot be paired:
+
+- `STORAGE_PLANE_UNPAIRED` — a `@storageFiles` table with no FK to a
+  `@storageBuckets` table, or a `@storageBuckets` table referenced by no files
+  table.
+- `STORAGE_PLANE_AMBIGUOUS` — a files table with FKs to more than one buckets
+  table.
+
+A plane is entity-keyed when its buckets table carries an `owner_id` attribute
+(`plane.hasOwnerId`) — a registry fact, never inferred from the plane's scope
+name.

--- a/graphile/graphile-storage-registry/__tests__/pairing.test.ts
+++ b/graphile/graphile-storage-registry/__tests__/pairing.test.ts
@@ -1,0 +1,200 @@
+import {
+  discoverStoragePlanes,
+  pairStoragePlane,
+  type StorageCodec,
+  type StoragePgRegistry,
+  uploadSurfaceNames,
+} from '../src';
+
+function codec(
+  name: string,
+  opts: {
+    schemaName?: string;
+    tableName?: string;
+    tags?: Record<string, unknown>;
+    attributes?: Record<string, unknown>;
+  } = {},
+): StorageCodec {
+  return {
+    name,
+    attributes: opts.attributes ?? { id: {} },
+    extensions: {
+      pg: { schemaName: opts.schemaName ?? 'storage_public', name: opts.tableName ?? name },
+      tags: opts.tags ?? {},
+    },
+  };
+}
+
+/**
+ * Build a registry the way graphile-build-pg does: a forward relation entry on
+ * the FK-holding codec (isReferencee absent/false), and a mirrored backward
+ * entry on the referenced codec (isReferencee: true).
+ */
+function registry(
+  codecs: StorageCodec[],
+  fks: { from: StorageCodec; to: StorageCodec; relationName: string; attributes?: string[] }[],
+): StoragePgRegistry {
+  const pgCodecs: Record<string, StorageCodec> = {};
+  for (const c of codecs) pgCodecs[c.name] = c;
+
+  const pgRelations: StoragePgRegistry['pgRelations'] = {};
+  for (const c of codecs) pgRelations[c.name] = {};
+
+  for (const fk of fks) {
+    const attrs = fk.attributes ?? ['bucket_id'];
+    pgRelations[fk.from.name][fk.relationName] = {
+      localAttributes: attrs,
+      remoteAttributes: ['id'],
+      remoteResource: { codec: fk.to },
+    };
+    pgRelations[fk.to.name][`${fk.from.name}ByTheir${attrs.join('And')}`] = {
+      isReferencee: true,
+      localAttributes: ['id'],
+      remoteAttributes: attrs,
+      remoteResource: { codec: fk.from },
+    };
+  }
+
+  return { pgCodecs, pgRelations };
+}
+
+describe('pairStoragePlane', () => {
+  it('pairs a prefixed files table with its buckets table through the FK', () => {
+    const buckets = codec('appBuckets', { tableName: 'app_buckets', tags: { storageBuckets: true } });
+    const files = codec('appFiles', { tableName: 'app_files', tags: { storageFiles: true } });
+    const reg = registry([buckets, files], [{ from: files, to: buckets, relationName: 'appBucketsByMyBucketId' }]);
+
+    const pair = pairStoragePlane(files, reg);
+    expect(pair.bucketsCodec).toBe(buckets);
+    expect(pair.relationName).toBe('appBucketsByMyBucketId');
+    expect(pair.fkAttributes).toEqual(['bucket_id']);
+    expect(pair.hasOwnerId).toBe(false);
+  });
+
+  it('pairs an unprefixed (database-scope) files table — naming carries no meaning', () => {
+    const buckets = codec('buckets', { tags: { storageBuckets: true } });
+    const files = codec('files', { tags: { storageFiles: true } });
+    const reg = registry([buckets, files], [{ from: files, to: buckets, relationName: 'bucketsByMyBucketId' }]);
+
+    const pair = pairStoragePlane(files, reg);
+    expect(pair.bucketsCodec).toBe(buckets);
+  });
+
+  it('detects an entity-keyed plane from the buckets table owner_id attribute', () => {
+    const buckets = codec('dataRoomBuckets', {
+      tableName: 'data_room_buckets',
+      tags: { storageBuckets: true },
+      attributes: { id: {}, owner_id: {} },
+    });
+    const files = codec('dataRoomFiles', { tableName: 'data_room_files', tags: { storageFiles: true } });
+    const reg = registry([buckets, files], [{ from: files, to: buckets, relationName: 'dataRoomBucketsByMyBucketId' }]);
+
+    expect(pairStoragePlane(files, reg).hasOwnerId).toBe(true);
+  });
+
+  it('ignores backward (referencee) relations and FKs to untagged tables', () => {
+    const buckets = codec('buckets', { tags: { storageBuckets: true } });
+    const files = codec('files', { tags: { storageFiles: true } });
+    const shares = codec('shares');
+    const reg = registry(
+      [buckets, files, shares],
+      [
+        { from: files, to: buckets, relationName: 'bucketsByMyBucketId' },
+        { from: shares, to: files, relationName: 'filesByMyFileId', attributes: ['file_id'] },
+        { from: files, to: shares, relationName: 'sharesByMyShareId', attributes: ['share_id'] },
+      ],
+    );
+
+    const pair = pairStoragePlane(files, reg);
+    expect(pair.bucketsCodec).toBe(buckets);
+    expect(pair.fkAttributes).toEqual(['bucket_id']);
+  });
+
+  it('throws STORAGE_PLANE_UNPAIRED when the files table has no FK to a buckets table', () => {
+    const buckets = codec('buckets', { tags: { storageBuckets: true } });
+    const files = codec('files', { tags: { storageFiles: true } });
+    const reg = registry([buckets, files], []);
+
+    expect(() => pairStoragePlane(files, reg)).toThrow(/STORAGE_PLANE_UNPAIRED/);
+    expect(() => pairStoragePlane(files, reg)).toThrow(/storage_public\.files/);
+  });
+
+  it('throws STORAGE_PLANE_AMBIGUOUS when the files table references two buckets tables', () => {
+    const bucketsA = codec('buckets', { tags: { storageBuckets: true } });
+    const bucketsB = codec('otherBuckets', { tableName: 'other_buckets', tags: { storageBuckets: true } });
+    const files = codec('files', { tags: { storageFiles: true } });
+    const reg = registry(
+      [bucketsA, bucketsB, files],
+      [
+        { from: files, to: bucketsA, relationName: 'bucketsByMyBucketId' },
+        { from: files, to: bucketsB, relationName: 'otherBucketsByMyOtherBucketId', attributes: ['other_bucket_id'] },
+      ],
+    );
+
+    expect(() => pairStoragePlane(files, reg)).toThrow(/STORAGE_PLANE_AMBIGUOUS/);
+  });
+});
+
+describe('discoverStoragePlanes', () => {
+  it('discovers every plane, including multiple planes in one schema', () => {
+    const appBuckets = codec('appBuckets', { tableName: 'app_buckets', tags: { storageBuckets: true } });
+    const appFiles = codec('appFiles', { tableName: 'app_files', tags: { storageFiles: true } });
+    const dbBuckets = codec('buckets', { tags: { storageBuckets: true } });
+    const dbFiles = codec('files', { tags: { storageFiles: true } });
+    const reg = registry(
+      [appBuckets, appFiles, dbBuckets, dbFiles],
+      [
+        { from: appFiles, to: appBuckets, relationName: 'appBucketsByMyBucketId' },
+        { from: dbFiles, to: dbBuckets, relationName: 'bucketsByMyBucketId' },
+      ],
+    );
+
+    const pairs = discoverStoragePlanes(reg);
+    expect(pairs).toHaveLength(2);
+    expect(pairs.map((p) => [p.filesCodec.name, p.bucketsCodec.name])).toEqual([
+      ['appFiles', 'appBuckets'],
+      ['files', 'buckets'],
+    ]);
+  });
+
+  it('returns [] for a registry with no tagged storage tables', () => {
+    const plain = codec('users');
+    expect(discoverStoragePlanes(registry([plain], []))).toEqual([]);
+  });
+
+  it('throws when a tagged buckets table is referenced by no files table', () => {
+    const buckets = codec('buckets', { tags: { storageBuckets: true } });
+    expect(() => discoverStoragePlanes(registry([buckets], []))).toThrow(/STORAGE_PLANE_UNPAIRED/);
+  });
+
+  it('throws (via pairing) when a tagged files table cannot be paired', () => {
+    const buckets = codec('buckets', { tags: { storageBuckets: true } });
+    const files = codec('files', { tags: { storageFiles: true } });
+    const orphanFiles = codec('orphanFiles', { tableName: 'orphan_files', tags: { storageFiles: true } });
+    const reg = registry(
+      [buckets, files, orphanFiles],
+      [{ from: files, to: buckets, relationName: 'bucketsByMyBucketId' }],
+    );
+
+    expect(() => discoverStoragePlanes(reg)).toThrow(/STORAGE_PLANE_UNPAIRED/);
+  });
+});
+
+describe('uploadSurfaceNames', () => {
+  it('derives every upload surface name from the inflected type name', () => {
+    const files = codec('appFiles', { tableName: 'app_files', tags: { storageFiles: true } });
+    const inflection = { tableType: (c: StorageCodec) => (c.name === 'appFiles' ? 'AppFile' : c.name) };
+
+    expect(uploadSurfaceNames(inflection, files)).toEqual({
+      filesTypeName: 'AppFile',
+      uploadMutation: 'uploadAppFile',
+      uploadInputType: 'UploadAppFileInput',
+      uploadPayloadType: 'UploadAppFilePayload',
+      bulkUploadMutation: 'uploadAppFiles',
+      bulkUploadInputType: 'UploadAppFileBulkInput',
+      bulkUploadPayloadType: 'UploadAppFileBulkPayload',
+      bulkUploadFileInputType: 'UploadAppFileBulkFileInput',
+      bulkUploadFilePayloadType: 'UploadAppFileBulkFilePayload',
+    });
+  });
+});

--- a/graphile/graphile-storage-registry/jest.config.js
+++ b/graphile/graphile-storage-registry/jest.config.js
@@ -1,0 +1,19 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testTimeout: 60000,
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        babelConfig: false,
+        tsconfig: 'tsconfig.json'
+      }
+    ]
+  },
+  transformIgnorePatterns: [`/node_modules/*`],
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  modulePathIgnorePatterns: ['dist/*']
+};

--- a/graphile/graphile-storage-registry/package.json
+++ b/graphile/graphile-storage-registry/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "graphile-storage-registry",
+  "version": "0.0.1",
+  "description": "Registry-derived storage plane discovery for PostGraphile v5 — pairs @storageFiles/@storageBuckets codecs through their actual foreign-key relations and derives the canonical upload surface names, so no table name is ever load-bearing",
+  "author": "Constructive <developers@constructive.io>",
+  "homepage": "https://github.com/constructive-io/constructive",
+  "license": "MIT",
+  "main": "index.js",
+  "module": "esm/index.js",
+  "types": "index.d.ts",
+  "scripts": {
+    "clean": "makage clean",
+    "prepack": "npm run build",
+    "build": "makage build",
+    "build:dev": "makage build --dev",
+    "lint": "eslint . --fix",
+    "test": "jest",
+    "test:watch": "jest --watch"
+  },
+  "publishConfig": {
+    "access": "public",
+    "directory": "dist"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/constructive-io/constructive"
+  },
+  "bugs": {
+    "url": "https://github.com/constructive-io/constructive/issues"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.11",
+    "makage": "^0.3.0"
+  },
+  "keywords": [
+    "postgraphile",
+    "graphile",
+    "constructive",
+    "storage",
+    "registry",
+    "plugin",
+    "postgres",
+    "graphql"
+  ]
+}

--- a/graphile/graphile-storage-registry/src/index.ts
+++ b/graphile/graphile-storage-registry/src/index.ts
@@ -1,0 +1,10 @@
+export type { StorageInflection, UploadSurfaceNames } from './naming';
+export { uploadSurfaceNames } from './naming';
+export type {
+  StorageCodec,
+  StorageCodecAttributes,
+  StorageCodecRelation,
+  StoragePgRegistry,
+  StoragePlanePair,
+} from './pairing';
+export { discoverStoragePlanes, pairStoragePlane } from './pairing';

--- a/graphile/graphile-storage-registry/src/naming.ts
+++ b/graphile/graphile-storage-registry/src/naming.ts
@@ -1,0 +1,59 @@
+/**
+ * Canonical names of a storage plane's upload surface.
+ *
+ * The presigned-url plugin emits these fields and types; anything that reports
+ * or consumes the surface (the `_meta` storage section, dynamic clients) must
+ * derive the same names from the same inflection facts. This module is the one
+ * definition of that derivation, so the emitter and the reporters cannot
+ * disagree.
+ */
+
+import type { StorageCodec } from './pairing';
+
+/** The slice of `build.inflection` the naming derivation reads. */
+export interface StorageInflection {
+  tableType(codec: StorageCodec): string;
+}
+
+/** The GraphQL names of one plane's upload surface. */
+export interface UploadSurfaceNames {
+  /** GraphQL type name of the files table (e.g. `AppFile`). */
+  filesTypeName: string;
+  /** Single upload mutation field (e.g. `uploadAppFile`). */
+  uploadMutation: string;
+  /** Input type of the single upload mutation (e.g. `UploadAppFileInput`). */
+  uploadInputType: string;
+  /** Payload type of the single upload mutation (e.g. `UploadAppFilePayload`). */
+  uploadPayloadType: string;
+  /** Bulk upload mutation field (e.g. `uploadAppFiles`). */
+  bulkUploadMutation: string;
+  /** Input type of the bulk upload mutation (e.g. `UploadAppFileBulkInput`). */
+  bulkUploadInputType: string;
+  /** Payload type of the bulk upload mutation (e.g. `UploadAppFileBulkPayload`). */
+  bulkUploadPayloadType: string;
+  /** Per-file input type inside the bulk input (e.g. `UploadAppFileBulkFileInput`). */
+  bulkUploadFileInputType: string;
+  /** Per-file payload type inside the bulk payload (e.g. `UploadAppFileBulkFilePayload`). */
+  bulkUploadFilePayloadType: string;
+}
+
+/**
+ * Derive the upload surface names for a plane's files codec.
+ */
+export function uploadSurfaceNames(
+  inflection: StorageInflection,
+  filesCodec: StorageCodec,
+): UploadSurfaceNames {
+  const filesTypeName = inflection.tableType(filesCodec);
+  return {
+    filesTypeName,
+    uploadMutation: `upload${filesTypeName}`,
+    uploadInputType: `Upload${filesTypeName}Input`,
+    uploadPayloadType: `Upload${filesTypeName}Payload`,
+    bulkUploadMutation: `upload${filesTypeName}s`,
+    bulkUploadInputType: `Upload${filesTypeName}BulkInput`,
+    bulkUploadPayloadType: `Upload${filesTypeName}BulkPayload`,
+    bulkUploadFileInputType: `Upload${filesTypeName}BulkFileInput`,
+    bulkUploadFilePayloadType: `Upload${filesTypeName}BulkFilePayload`,
+  };
+}

--- a/graphile/graphile-storage-registry/src/pairing.ts
+++ b/graphile/graphile-storage-registry/src/pairing.ts
@@ -1,0 +1,159 @@
+/**
+ * Registry-derived storage plane discovery.
+ *
+ * A storage plane is a `@storageFiles` table and the `@storageBuckets` table it
+ * writes into. The pairing fact is the files table's foreign key to the buckets
+ * table — a relation the Graphile registry already carries — so it is read from
+ * `pgRegistry.pgRelations`, never derived from table names. Physical naming
+ * (`app_files`/`app_buckets` vs unprefixed `files`/`buckets`) is a rendering
+ * choice and carries no meaning here.
+ *
+ * A `@storageFiles` codec that cannot be paired through a real FK relation is a
+ * provisioning bug, and discovery throws at schema build rather than silently
+ * emitting a schema with no upload surface for that plane.
+ */
+
+/** The attributes shape shared by pg codecs. */
+export interface StorageCodecAttributes {
+  [attributeName: string]: unknown;
+}
+
+/**
+ * The slice of a Graphile pg codec that storage discovery reads. Structural on
+ * purpose: callers pass real codecs from `build.input.pgRegistry`, and this
+ * package stays free of graphile-build peer dependencies.
+ */
+export interface StorageCodec {
+  name: string;
+  attributes?: StorageCodecAttributes;
+  extensions?: {
+    pg?: { schemaName?: string; name?: string };
+    tags?: { storageFiles?: unknown; storageBuckets?: unknown; [tag: string]: unknown };
+  };
+}
+
+/** The slice of a registry relation entry that storage discovery reads. */
+export interface StorageCodecRelation {
+  isReferencee?: boolean;
+  localAttributes: readonly string[];
+  remoteAttributes: readonly string[];
+  remoteResource?: { codec?: StorageCodec };
+}
+
+/** The slice of `build.input.pgRegistry` that storage discovery reads. */
+export interface StoragePgRegistry {
+  pgCodecs: Record<string, StorageCodec>;
+  pgRelations: Record<string, Record<string, StorageCodecRelation>>;
+}
+
+/**
+ * A discovered storage plane: the files codec, the buckets codec its FK names,
+ * and the facts a plugin needs to shape the plane's GraphQL surface.
+ */
+export interface StoragePlanePair {
+  filesCodec: StorageCodec;
+  bucketsCodec: StorageCodec;
+  /** Registry name of the FK relation on the files codec (e.g. `bucketsByMyBucketId`). */
+  relationName: string;
+  /** FK attribute(s) on the files table referencing the buckets table (e.g. `['bucket_id']`). */
+  fkAttributes: string[];
+  /**
+   * Whether the plane is entity-keyed: the buckets table carries an `owner_id`
+   * attribute (a registry fact — never inferred from the plane's scope name).
+   */
+  hasOwnerId: boolean;
+}
+
+function hasTag(codec: StorageCodec, tag: 'storageFiles' | 'storageBuckets'): boolean {
+  return !!codec.attributes && !!codec.extensions?.tags?.[tag];
+}
+
+function codecSqlName(codec: StorageCodec): string {
+  const schema = codec.extensions?.pg?.schemaName;
+  const table = codec.extensions?.pg?.name ?? codec.name;
+  return schema ? `${schema}.${table}` : table;
+}
+
+/**
+ * Pair one `@storageFiles` codec with its `@storageBuckets` codec through the
+ * registry's FK relations.
+ *
+ * Reads the codec's forward relations (`isReferencee` false — the files table
+ * holds the FK) and keeps those whose remote codec is tagged `@storageBuckets`.
+ * Exactly one such relation must exist; zero or several is a malformed plane
+ * and throws.
+ */
+export function pairStoragePlane(
+  filesCodec: StorageCodec,
+  pgRegistry: StoragePgRegistry,
+): StoragePlanePair {
+  const relations = pgRegistry.pgRelations[filesCodec.name] ?? {};
+
+  const bucketRelations = Object.entries(relations).filter(
+    ([, relation]) =>
+      !relation.isReferencee &&
+      relation.remoteResource?.codec &&
+      hasTag(relation.remoteResource.codec, 'storageBuckets'),
+  );
+
+  if (bucketRelations.length === 0) {
+    throw new Error(
+      `STORAGE_PLANE_UNPAIRED: @storageFiles table ${codecSqlName(filesCodec)} has no ` +
+      `foreign key to a @storageBuckets table in the registry. A files table must ` +
+      `reference its buckets table; check the storage module's generated FK and the ` +
+      `@storageBuckets smart tag on the buckets table.`,
+    );
+  }
+
+  if (bucketRelations.length > 1) {
+    const targets = bucketRelations
+      .map(([, relation]) => codecSqlName(relation.remoteResource!.codec!))
+      .join(', ');
+    throw new Error(
+      `STORAGE_PLANE_AMBIGUOUS: @storageFiles table ${codecSqlName(filesCodec)} has ` +
+      `foreign keys to ${bucketRelations.length} @storageBuckets tables (${targets}); ` +
+      `a files table must reference exactly one buckets table.`,
+    );
+  }
+
+  const [relationName, relation] = bucketRelations[0];
+  const bucketsCodec = relation.remoteResource!.codec!;
+
+  return {
+    filesCodec,
+    bucketsCodec,
+    relationName,
+    fkAttributes: [...relation.localAttributes],
+    hasOwnerId: !!bucketsCodec.attributes?.owner_id,
+  };
+}
+
+/**
+ * Discover every storage plane in the registry.
+ *
+ * Pairs each `@storageFiles` codec through {@link pairStoragePlane}, then
+ * verifies no `@storageBuckets` codec was left unpaired — a buckets table with
+ * no files table referencing it is the same provisioning bug from the other
+ * side, and throws rather than being silently ignored.
+ */
+export function discoverStoragePlanes(pgRegistry: StoragePgRegistry): StoragePlanePair[] {
+  const codecs = Object.values(pgRegistry.pgCodecs);
+  const filesCodecs = codecs.filter((codec) => hasTag(codec, 'storageFiles'));
+  const bucketsCodecs = codecs.filter((codec) => hasTag(codec, 'storageBuckets'));
+
+  const pairs = filesCodecs.map((filesCodec) => pairStoragePlane(filesCodec, pgRegistry));
+
+  const pairedBuckets = new Set(pairs.map((pair) => pair.bucketsCodec));
+  const orphanBuckets = bucketsCodecs.filter((codec) => !pairedBuckets.has(codec));
+  if (orphanBuckets.length > 0) {
+    const names = orphanBuckets.map(codecSqlName).join(', ');
+    throw new Error(
+      `STORAGE_PLANE_UNPAIRED: @storageBuckets table(s) ${names} are referenced by no ` +
+      `@storageFiles table. Every buckets table must be the FK target of exactly one ` +
+      `files table; check the storage module's generated FK and the @storageFiles ` +
+      `smart tag on the files table.`,
+    );
+  }
+
+  return pairs;
+}

--- a/graphile/graphile-storage-registry/tsconfig.esm.json
+++ b/graphile/graphile-storage-registry/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/esm",
+    "module": "ESNext"
+  }
+}

--- a/graphile/graphile-storage-registry/tsconfig.json
+++ b/graphile/graphile-storage-registry/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "**/*.spec.*", "**/*.test.*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -984,6 +984,9 @@ importers:
       graphile-config:
         specifier: 1.1.0
         version: 1.1.0
+      graphile-storage-registry:
+        specifier: workspace:^
+        version: link:../graphile-storage-registry/dist
       graphile-utils:
         specifier: 5.0.3
         version: 5.0.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build-pg@5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(tamedevil@0.1.1)
@@ -1422,6 +1425,16 @@ importers:
       '@types/node':
         specifier: ^22.19.11
         version: 22.19.11
+      makage:
+        specifier: ^0.3.0
+        version: 0.3.0
+    publishDirectory: dist
+
+  graphile/graphile-storage-registry:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.11
+        version: 22.19.19
       makage:
         specifier: ^0.3.0
         version: 0.3.0


### PR DESCRIPTION
## Summary

Fixes the root cause behind database-scope storage planes having no GraphQL surface (constructive-io/constructive-planning#1779, PR 1 of 3): storage plane identity was derived from table-name syntax and a hardcoded scope, so any plane whose tables weren't named `<prefix>_files`/`<prefix>_buckets` — the unprefixed database-scope plane ships exactly that way — was silently skipped (`log.debug` + `continue`), and the bucket provisioner always resolved "the app plane" regardless of which buckets table was actually written.

Identity now comes from recorded facts, never names:

**New package `graphile-storage-registry`** — pairs each `@storageFiles` codec with its `@storageBuckets` codec through the registry's actual FK relation, and centralizes the upload surface naming so server and (later) `_meta`/clients derive the same names from the same fact:

```ts
discoverStoragePlanes(pgRegistry): StoragePlanePair[]
// filesCodec, bucketsCodec, relationName, fkAttributes, hasOwnerId
// throws STORAGE_PLANE_UNPAIRED   — tagged files table with no FK to a tagged buckets table
// throws STORAGE_PLANE_AMBIGUOUS  — FKs to more than one tagged buckets table
// also fails loudly on orphaned tagged buckets tables

uploadSurfaceNames(inflection, filesCodec)
// upload${T}, Upload${T}Input/Payload, upload${T}s, Upload${T}Bulk* — derived once, from inflection
```

**`graphile-presigned-url-plugin`**
- `plugin.ts`: the `_files`/`_buckets` suffix-stripping heuristic is gone; upload mutations are emitted for every registry-paired plane, so unprefixed (database-scope) planes get their `uploadFile` surface. Unpairable tagged tables now fail schema build instead of being silently skipped.
- `storage-module-cache.ts`: the `scope = 'app'` module query is deleted. Resolution loads all of a database's storage modules and matches the addressed codec by its recorded `schema_name` + `files/buckets` table facts. Entity classification is `entity_table_id !== null` — a non-app scope is *not* assumed to be an entity scope, so database-wide planes behave as ownerless storage (`managed-upload.ts`, owner-column decision in `processSingleFile`).

**`graphile-bucket-provisioner-plugin`**
- Auto-provision and CORS hooks resolve the module whose buckets table is being mutated (`resolveStorageModuleByBucketsTable(schema, table)` from the codec's pg identity), instead of defaulting every bucket to the app-level module. `physical_name` is recorded on the addressed plane's row.
- Explicit `provisionBucket` resolves the plane that actually holds the named bucket row (`resolveBucketByKey`): with `ownerId` through the entity-keyed modules' recorded entity tables; without it across all non-entity planes, throwing `BUCKET_KEY_AMBIGUOUS` when the same key exists in several planes rather than silently picking one. Empty module registry throws `STORAGE_MODULE_NOT_PROVISIONED`.

Registry relation orientation (`isReferencee` marks the reverse edge) matches the existing production consumer in `graphile-bulk-mutations/src/utils/relations.ts`.

Follow-ups (same plan): PR 2 expands `_meta` storage metadata + a runtime introspection-driven storage client; PR 3 removes the direct-S3/raw-SQL workaround from the constructive-db static-site e2e.


Link to Devin session: https://app.devin.ai/sessions/726e066d64e04f29bdbea669c09c6341
Requested by: @pyramation