### PR TITLE
chore(fixtures): bump the @constructive-db fixture modules to the same-scope FK release

### DIFF
--- a/.agents/skills/constructive-monorepo-setup/SKILL.md
+++ b/.agents/skills/constructive-monorepo-setup/SKILL.md
@@ -22,7 +22,7 @@ pgpm docker start --image docker.io/constructiveio/postgres-plus:18 --recreate
 eval "$(pgpm env)"
 
 # 4. Bootstrap admin users for testing
-pgpm admin-users bootstrap --yes
+pgpm admin-users bootstrap --client --yes
 pgpm admin-users add --test --yes
 
 # 5. Build the monorepo

--- a/.agents/skills/constructive-setup/SKILL.md
+++ b/.agents/skills/constructive-setup/SKILL.md
@@ -29,7 +29,7 @@ pgpm docker start --image docker.io/constructiveio/postgres-plus:18 --recreate
 eval "$(pgpm env)"
 
 # 3. Bootstrap database users
-pgpm admin-users bootstrap --yes
+pgpm admin-users bootstrap --client --yes
 pgpm admin-users add --test --yes
 
 # 4. Build the monorepo
@@ -70,7 +70,7 @@ For environment variable details, see the **pgpm** skill: [references/env.md](..
 Create the required PostgreSQL roles for Constructive's security model:
 
 ```bash
-pgpm admin-users bootstrap --yes
+pgpm admin-users bootstrap --client --yes
 pgpm admin-users add --test --yes
 ```
 

--- a/.agents/skills/constructive-setup/references/local-dev-setup.md
+++ b/.agents/skills/constructive-setup/references/local-dev-setup.md
@@ -13,7 +13,7 @@ Quick-start for running the Constructive GraphQL server locally with Docker Post
 ```bash
 pgpm docker start --image docker.io/constructiveio/postgres-plus:18 --recreate
 eval "$(pgpm env)"
-pgpm admin-users bootstrap --yes
+pgpm admin-users bootstrap --client --yes
 pgpm admin-users add --test --yes
 ```
 

--- a/.agents/skills/constructive-setup/references/local-env.md
+++ b/.agents/skills/constructive-setup/references/local-env.md
@@ -44,7 +44,7 @@ Sets `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, and `PGDATABASE` for the local 
 ### 4. Bootstrap database users
 
 ```bash
-pgpm admin-users bootstrap --yes
+pgpm admin-users bootstrap --client --yes
 pgpm admin-users add --test --yes
 ```
 

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -306,7 +306,7 @@ jobs:
 
       - name: Seed app_user
         run: |
-          pnpm --filter pgpm exec node dist/index.js admin-users bootstrap --yes
+          pnpm --filter pgpm exec node dist/index.js admin-users bootstrap --client --yes
           pnpm --filter pgpm exec node dist/index.js admin-users add --test --yes
 
       - name: Install pgpm fixture modules
@@ -426,7 +426,7 @@ jobs:
 
       - name: Seed app_user
         run: |
-          pnpm --filter pgpm exec node dist/index.js admin-users bootstrap --yes
+          pnpm --filter pgpm exec node dist/index.js admin-users bootstrap --client --yes
           pnpm --filter pgpm exec node dist/index.js admin-users add --test --yes
 
       - name: Install pgpm fixture modules
@@ -510,7 +510,7 @@ jobs:
 
       - name: Seed app_user
         run: |
-          pnpm --filter pgpm exec node dist/index.js admin-users bootstrap --yes
+          pnpm --filter pgpm exec node dist/index.js admin-users bootstrap --client --yes
           pnpm --filter pgpm exec node dist/index.js admin-users add --test --yes
 
       - name: Install Ollama

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -29,7 +29,7 @@ pnpm build
 Seed the `app_user` roles used by tests:
 
 ```sh
-pnpm --filter pgpm exec node dist/index.js admin-users bootstrap --yes
+pnpm --filter pgpm exec node dist/index.js admin-users bootstrap --client --yes
 pnpm --filter pgpm exec node dist/index.js admin-users add --test --yes
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ssh:
 	docker exec -it postgres /bin/bash
 
 roles:
-	pnpm --filter pgpm exec node dist/index.js admin-users bootstrap --yes
+	pnpm --filter pgpm exec node dist/index.js admin-users bootstrap --client --yes
 	pnpm --filter pgpm exec node dist/index.js admin-users add --test --yes
 
 install:

--- a/pgpm.json
+++ b/pgpm.json
@@ -3,10 +3,10 @@
     "testing/*"
   ],
   "dependencies": {
-    "@constructive-db/apps": "5.1.0",
-    "@constructive-db/catalog": "5.1.0",
-    "@constructive-db/routing": "6.1.0",
-    "@constructive-db/routing-platform": "5.1.0",
+    "@constructive-db/apps": "7.0.0",
+    "@constructive-db/catalog": "6.0.0",
+    "@constructive-db/routing": "8.0.0",
+    "@constructive-db/routing-platform": "7.0.0",
     "@pgpm/database-jobs": "0.41.0",
     "@pgpm/function-resolution": "0.41.0",
     "@pgpm/jwt-claims": "0.41.0",


### PR DESCRIPTION
## Summary

Moves the root `pgpm.json` fixture pins onto the just-published output of the constructive-db same-scope foreign key fix (constructive-io/constructive-platform#21):

```diff
-  "@constructive-db/apps": "5.1.0",
-  "@constructive-db/catalog": "5.1.0",
-  "@constructive-db/routing": "6.1.0",
-  "@constructive-db/routing-platform": "5.1.0",
+  "@constructive-db/apps": "7.0.0",
+  "@constructive-db/catalog": "6.0.0",
+  "@constructive-db/routing": "8.0.0",
+  "@constructive-db/routing-platform": "7.0.0",
```

**No test or fixture changes are needed for the FK change itself.** The majors are breaking at the SQL level — `routes.target_*`, `sites.bucket_id`, `app_components.component_*` and friends now reference the same-scope source tables instead of the shared `catalog_private.*` projection — but `__fixtures__/seed/scoped/test-data.sql` already seeds each routing/apps source row alongside its catalog twin under the same id (and inserts the `apps_public` rows after `routing_public.{apis,domains}`), so every constraint is satisfied under either shape and `resolve_route()` reads the same compiled bindings.

**One real break, in the bootstrap and not the tests:** the new majors are the first to grant to `authenticated_client` (`routing/…/rls_settings/grants`, `routing-platform/…/grants/usage`) — `npm pack` of 6.1.0/5.1.0 contains zero references to it. That role is opt-in (`admin-users bootstrap --client`), so with a plain `bootstrap --yes` every `seed.pgpm` deploy died at `role "authenticated_client" does not exist` and took the whole `integration-graphql` and `pg-graphql` lanes with it. Added `--client` to the three CI bootstrap steps and to the local instructions that mirror them (`Makefile`, `DEVELOPMENT.md`, the two setup skills) — matching what constructive-platform's own `AGENTS.md` already requires of anyone deploying these modules.

Verified against the new modules with `pgpm install -W --force`: `graphql/server-test` 11/11 suites, 156 tests (including `scoped-routing`, `fn-routes`, `express-context`, `upload`) and `graphile/graphile-function-bindings` 2/2 suites, 22 tests.

Note that `pgpm install -W @constructive-db/apps@latest` does not move an already-installed module — it re-resolved the existing `5.1.0` pin and left `pgpm.json` untouched, so that one line was edited by hand and then verified by a forced reinstall (`default_version = '7.0.0'`).


Link to Devin session: https://app.devin.ai/sessions/d1f8e59e2aeb44bcb6dbeb0edd1145c6
Requested by: @pyramation