### PR TITLE
fix(graphql-server): surface CSRF rejections as JSON

### DIFF
--- a/graphql/server-test/__tests__/server.integration.test.ts
+++ b/graphql/server-test/__tests__/server.integration.test.ts
@@ -464,6 +464,129 @@ describe('Error paths', () => {
   });
 });
 
+describe('Cookie-authenticated GraphQL CSRF flow', () => {
+  let request: supertest.Agent;
+  let teardown: () => Promise<void>;
+
+  const host = 'app.test.constructive.io';
+  const query = { query: '{ __typename }' };
+
+  const getCsrfCookie = async () => {
+    const res = await request.get('/graphql').set('Host', host);
+    const setCookie = res.headers['set-cookie'];
+    const cookies = Array.isArray(setCookie) ? setCookie : [setCookie];
+    const csrfCookie = cookies
+      .filter((cookie): cookie is string => typeof cookie === 'string')
+      .map((cookie) => cookie.split(';')[0])
+      .find((cookie) => cookie.startsWith('csrf_token='));
+
+    expect(csrfCookie).toBeDefined();
+    return csrfCookie!;
+  };
+
+  const postWithSession = async (csrfCookie?: string, csrfToken?: string) => {
+    const cookies = [
+      csrfCookie,
+      'constructive_session=test-session'
+    ].filter((cookie): cookie is string => Boolean(cookie));
+    let req = request
+      .post('/graphql')
+      .set('Host', host)
+      .set('Cookie', cookies.join('; '));
+
+    if (csrfToken) {
+      req = req.set('X-CSRF-Token', csrfToken);
+    }
+
+    return req.send(query);
+  };
+
+  beforeAll(async () => {
+    ({ request, teardown } = await getConnections(
+      {
+        schemas,
+        authRole: 'anonymous',
+        server: {
+          useRouting: true,
+          api: {
+            isPublic: true,
+            metaSchemas: scopedMetaSchemas
+          }
+        }
+      },
+      seedAdaptersFor('simple-seed-scoped')
+    ));
+    teardowns.push(teardown);
+  });
+
+  it('allows the documented token, session cookie, and header flow', async () => {
+    const csrfCookie = await getCsrfCookie();
+    const csrfToken = csrfCookie.slice('csrf_token='.length);
+
+    const res = await postWithSession(csrfCookie, csrfToken);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ data: { __typename: 'Query' } });
+  });
+
+  it('returns a JSON CSRF error when the submitted token is missing', async () => {
+    const csrfCookie = await getCsrfCookie();
+
+    const res = await postWithSession(csrfCookie);
+
+    expect(res.status).toBe(403);
+    expect(res.headers['content-type']).toMatch(/^application\/json/);
+    expect(res.body).toEqual({
+      error: {
+        code: 'CSRF_TOKEN_INVALID',
+        message: 'CSRF token validation failed',
+        requestId: expect.any(String)
+      }
+    });
+  });
+
+  it('returns a JSON CSRF error when the CSRF cookie is missing', async () => {
+    const res = await postWithSession();
+
+    expect(res.status).toBe(403);
+    expect(res.headers['content-type']).toMatch(/^application\/json/);
+    expect(res.body).toEqual({
+      error: {
+        code: 'CSRF_TOKEN_MISSING',
+        message: 'CSRF token missing from cookie',
+        requestId: expect.any(String)
+      }
+    });
+  });
+
+  it('returns the same JSON CSRF error when the submitted token is wrong', async () => {
+    const csrfCookie = await getCsrfCookie();
+
+    const res = await postWithSession(csrfCookie, 'wrong-token');
+
+    expect(res.status).toBe(403);
+    expect(res.headers['content-type']).toMatch(/^application\/json/);
+    expect(res.body).toEqual({
+      error: {
+        code: 'CSRF_TOKEN_INVALID',
+        message: 'CSRF token validation failed',
+        requestId: expect.any(String)
+      }
+    });
+  });
+
+  it('keeps genuinely unknown routes on the HTML 404 path', async () => {
+    const res = await request
+      .get('/this-route-does-not-exist')
+      .set('Host', host);
+
+    expect(res.status).toBe(404);
+    expect(res.headers['content-type']).toMatch(/^text\/html/);
+    expect(res.text).toContain('<title>Not Found</title>');
+    expect(res.text).toContain('The requested page was not found');
+  });
+});
+
 afterAll(async () => {
   for (const teardown of teardowns) {
     await teardown();

--- a/graphql/server/src/middleware/error-handler.ts
+++ b/graphql/server/src/middleware/error-handler.ts
@@ -14,7 +14,9 @@ const isDevelopment = (): boolean => getNodeEnv() === 'development';
 
 const wantsJson = (req: Request): boolean => {
   const accept = req.get('Accept') || '';
-  return accept.includes('application/json') || accept.includes('application/graphql-response+json');
+  return accept.includes('application/json')
+    || accept.includes('application/graphql-response+json')
+    || Boolean(req.is('json'));
 };
 
 const sanitizeMessage = (error: Error): string => {


### PR DESCRIPTION
## Summary

GraphQL JSON requests without an explicit `Accept` header were misclassified as HTML clients by `wantsJson`. CSRF middleware correctly raised a typed error and the centralized handler preserved status 403, but `sendResponse` rendered every non-5xx HTML error with the Not Found page.

This changes content negotiation to also recognize a JSON request `Content-Type`, preserving the existing structured CSRF response for API clients while leaving genuine browser/HTML 404s unchanged.

Closes #1681.

### Before / after transcript

Requests below omit `Accept`, matching the reported flow. Tokens and request IDs are redacted.

| Scenario | Before on `main` | After |
|---|---|---|
| session + CSRF cookie + matching `X-CSRF-Token` | `200 application/graphql-response+json` `{"data":{"__typename":"Query"}}` | unchanged |
| missing `X-CSRF-Token` | `403 text/html` Not Found page | `403 application/json` `{"error":{"code":"CSRF_TOKEN_INVALID","message":"CSRF token validation failed","requestId":"…"}}` |
| session cookie only / missing CSRF cookie | `403 text/html` Not Found page | `403 application/json` `{"error":{"code":"CSRF_TOKEN_MISSING","message":"CSRF token missing from cookie","requestId":"…"}}` |
| wrong `X-CSRF-Token` | `403 text/html` Not Found page | `403 application/json` `{"error":{"code":"CSRF_TOKEN_INVALID","message":"CSRF token validation failed","requestId":"…"}}` |
| unknown route | `404 text/html` `<title>Not Found</title>` / `The requested page was not found` | unchanged |

The JSON error never includes the expected token value.

Edge transcript:

| Case | Status | Content-Type | ACAO | Body |
|---|---:|---|---|---|
| `GET /graphql` token issuance | 405 | `application/json` | absent | `{"errors":[{"message":"Method not supported, please use POST","extensions":{}}]}`; sets `csrf_token=<redacted>` |
| wrong Origin + session cookie only | 403 | `application/json` | absent | `CSRF_TOKEN_MISSING` after the fix; previously the same 403 rendered the Not Found HTML page |
| wrong Origin + valid CSRF cookie/header | 200 | `application/graphql-response+json` | absent | `{"data":{"__typename":"Query"}}` (unchanged) |

### Root cause and regression proof

The issue was not CSRF middleware ordering or 404 fallthrough: the error reached `errorHandler`, was categorized as 403, then the Accept-only `wantsJson` check selected the HTML branch and its generic 4xx renderer. Recognizing the JSON request content type fixes the representation at that content-negotiation boundary.

The new five-case E2E block uses the existing `@constructive-io/graphql-server-test` HTTP harness. Against unmodified production code on `main`, the happy flow and genuine 404 passed, while all three CSRF rejection tests failed specifically because they received `text/html` instead of JSON (`3 failed, 2 passed`). With this change, all five pass.

Validation:

- `graphql/server`: 13 suites, 143 tests passed
- `graphql/server-test/server.integration.test.ts`: 39 tests passed
- `graphql/server-test/scoped-routing.integration.test.ts`: 7 tests passed
- affected-package lint: no errors
- affected-package builds: passed
- PR CI: 20 passed, 0 failed, 1 skipped

### Deliberately left alone

- The local fixtures have no auth module, so the E2E synthesizes the session cookie; `csrfProtect` only checks cookie presence, so it exercises the same CSRF branch, but a real sign-in/`Set-Cookie` leg was not locally available.
- The CSRF cookie currently emits `Max-Age=86` because of a pre-existing unit mismatch.
- A wrong-Origin request with a valid double-submit pair succeeds server-side but receives no `Access-Control-Allow-Origin`; adding server-side Origin validation is separate from this error-surfacing fix.
- `GET /graphql` returns 405 while setting the token cookie, and CSRF 403s are logged as `unexpected_error`; both are pre-existing and outside this focused fix.

Link to Devin session: https://app.devin.ai/sessions/311a44c399bc4b10b4eafa163d9660ba
Requested by: @pyramation