### PR TITLE
fix(pgsql-test): fail the harness when seeding fails

### DIFF
--- a/pgpm/export/__tests__/export-parity.test.ts
+++ b/pgpm/export/__tests__/export-parity.test.ts
@@ -676,7 +676,7 @@ describe('export parity — SQL vs GraphQL (integration)', () => {
         }
 
         // Sanity: at least 105 deploy files were produced (one per sql_action)
-        const deployFiles = sqlPaths.filter(p => p.includes(EXTENSION_NAME) && p.includes('/deploy/'));
+        const deployFiles = sqlPaths.filter(p => p.startsWith(`${EXTENSION_NAME}/deploy/`));
         expect(deployFiles.length).toBe(TOTAL_ACTIONS);
 
         // Cleanup

--- a/postgres/pgsql-test/__tests__/postgres-test.seed-failures.test.ts
+++ b/postgres/pgsql-test/__tests__/postgres-test.seed-failures.test.ts
@@ -1,0 +1,26 @@
+process.env.LOG_SCOPE = 'pgsql-test';
+
+import { seed } from '../src';
+import { getConnections } from '../src/connect';
+
+jest.setTimeout(30000);
+
+it('fails the harness when a seed adapter throws', async () => {
+  await expect(
+    getConnections({}, [
+      seed.fn(async () => {
+        throw new Error('DELIBERATE_SEED_FAILURE');
+      })
+    ])
+  ).rejects.toThrow('DELIBERATE_SEED_FAILURE');
+});
+
+it('fails the harness when seed SQL is invalid', async () => {
+  await expect(
+    getConnections({}, [
+      seed.fn(async ({ pg }) => {
+        await pg.query('SELECT * FROM a_relation_that_does_not_exist');
+      })
+    ])
+  ).rejects.toThrow(/a_relation_that_does_not_exist/);
+});

--- a/postgres/pgsql-test/src/connect.ts
+++ b/postgres/pgsql-test/src/connect.ts
@@ -116,8 +116,14 @@ export const getConnections = async (
     } catch (error) {
       // Format the error with PostgreSQL extended fields for better debugging
       const formatted = formatPgError(error);
-      process.stderr.write(`[pgsql-test] Seed error (continuing):\n${formatted}\n`);
-      // continue without teardown to allow caller-managed lifecycle
+      process.stderr.write(`[pgsql-test] Seed failed:\n${formatted}\n`);
+      try {
+        await teardown();
+      } catch {
+        // Teardown of a database we are already abandoning: the seed error below
+        // is the actionable one, and hiding it behind a cleanup failure is worse.
+      }
+      throw new Error(`[pgsql-test] Seed failed:\n${formatted}`, { cause: error });
     }
   }
 


### PR DESCRIPTION
## Summary

`getConnections` caught every error from the seed phase, logged it to stderr, and handed the caller working clients on a half-built database:

```ts
} catch (error) {
  process.stderr.write(`[pgsql-test] Seed error (continuing):\n${formatted}\n`);
  // continue without teardown to allow caller-managed lifecycle
}
```

So a failed fixture deploy — the pgpm deploy that stands the schema up, or any `seed.fn`/`seed.sqlfile` — is not a setup failure but a *passing* setup, and the suite reports `relation "…" does not exist` in each test instead of the one error that caused it. Jest buries the stderr line above the first failure, which is how a single broken deploy reads as twenty unrelated mysteries.

Now the seed phase is fatal: stderr formatting is kept, the ephemeral database is torn down (its own failure deliberately swallowed with a comment, so it can't mask the seed error), and the original error is rethrown as the `cause`:

```ts
process.stderr.write(`[pgsql-test] Seed failed:\n${formatted}\n`);
try { await teardown(); } catch { /* abandoning this db anyway */ }
throw new Error(`[pgsql-test] Seed failed:\n${formatted}`, { cause: error });
```

Two tests cover it (a throwing adapter and invalid seed SQL). Measured before changing: no suite in this package, nor the db-heavy suites in `constructive-db` (metaschema, introspection, database-jobs, app provisioning), was riding on a swallowed seed failure — patched and unpatched runs are identical, and the rethrow was verified to actually fire with a deliberately-throwing adapter.


Link to Devin session: https://app.devin.ai/sessions/47477486a4fd45e684bd663b7007a629
Requested by: @pyramation