### PR TITLE
fix(uploads): report why a presigned upload failed instead of an empty reason

### DIFF
--- a/graphile/graphile-presigned-url-plugin/__tests__/s3-failure.test.ts
+++ b/graphile/graphile-presigned-url-plugin/__tests__/s3-failure.test.ts
@@ -1,0 +1,148 @@
+/**
+ * The presigned lane's diagnosis of a failed S3 call.
+ *
+ * The case that motivated this: a server whose CDN_ENDPOINT is unset signs
+ * against the library default (its own loopback), and the transport failure
+ * arrives as an `AggregateError` with an empty `message` — so reporting
+ * `err.message` gave the client a blank reason. These assert that the reason is
+ * never blank, that it names the coordinates, and that the original error stays
+ * reachable as `cause`.
+ */
+
+import { provisionAndRecordPhysicalBucket } from '../src/physical-bucket';
+import { describeS3Failure, s3FailureError } from '../src/s3-failure';
+import { generatePresignedPutUrl } from '../src/s3-signer';
+import { clearStorageModuleCache } from '../src/storage-module-cache';
+import type { BucketConfig, PresignedUrlPluginOptions, StorageModuleConfig } from '../src/types';
+
+/** An unreachable endpoint, as undici surfaces it: no message of its own. */
+function connectionRefused(): AggregateError {
+  const inner: any = new Error('connect ECONNREFUSED 127.0.0.1:9000');
+  inner.name = 'Error';
+  inner.code = 'ECONNREFUSED';
+  const aggregate = new AggregateError([inner], '');
+  return aggregate;
+}
+
+describe('describeS3Failure', () => {
+  it('reads through an AggregateError with an empty message to its causes', () => {
+    const described = describeS3Failure(connectionRefused());
+
+    expect(described).toContain('AggregateError');
+    expect(described).toContain('ECONNREFUSED 127.0.0.1:9000');
+  });
+
+  it('reads through a cause chain', () => {
+    const described = describeS3Failure(
+      new Error('', { cause: new Error('socket hang up') }),
+    );
+
+    expect(described).toContain('socket hang up');
+  });
+
+  it('keeps an S3 service error name and status', () => {
+    const err: any = new Error('Access Denied');
+    err.name = 'AccessDenied';
+    err.$metadata = { httpStatusCode: 403 };
+
+    expect(describeS3Failure(err)).toBe('AccessDenied: Access Denied HTTP 403');
+  });
+
+  it('never describes a failure as nothing', () => {
+    expect(describeS3Failure(new Error(''))).toBe('unknown error');
+    expect(describeS3Failure(undefined)).toBe('unknown error');
+    expect(describeS3Failure('boom')).toBe('boom');
+  });
+
+  it('stops walking a self-referential cause chain', () => {
+    const err: any = new Error('');
+    err.cause = err;
+
+    expect(() => describeS3Failure(err)).not.toThrow();
+  });
+});
+
+describe('s3FailureError', () => {
+  it('names the operation, the coordinates and the underlying reason', () => {
+    const cause = connectionRefused();
+
+    const err = s3FailureError(
+      'PRESIGN_PUT_FAILED',
+      { endpoint: 'http://localhost:9000', bucket: 'app-public-abc', key: 'deadbeef' },
+      cause,
+    );
+
+    expect(err.message).toContain('PRESIGN_PUT_FAILED');
+    expect(err.message).toContain('endpoint=http://localhost:9000');
+    expect(err.message).toContain('bucket=app-public-abc');
+    expect(err.message).toContain('key=deadbeef');
+    expect(err.message).toContain('ECONNREFUSED');
+    expect(err.cause).toBe(cause);
+  });
+
+  it('omits coordinates it was not given', () => {
+    const err = s3FailureError('PRESIGN_PUT_FAILED', { endpoint: undefined, bucket: 'b' }, new Error('nope'));
+
+    expect(err.message).not.toContain('endpoint=');
+    expect(err.message).toContain('bucket=b');
+  });
+});
+
+describe('the upload lane', () => {
+  it('reports a signing failure with its cause instead of an empty reason', async () => {
+    const cause = connectionRefused();
+    const client: any = {
+      // What @aws-sdk/s3-request-presigner reaches for while signing.
+      config: {
+        credentials: () => Promise.reject(cause),
+        region: () => Promise.resolve('us-east-1'),
+      },
+      send: jest.fn(),
+      middlewareStack: {
+        clone: (): any => ({ add: (): void => undefined, resolve: (): void => undefined }),
+      },
+    };
+
+    await expect(
+      generatePresignedPutUrl(
+        { client, bucket: 'app-public-abc', endpoint: 'http://localhost:9000' },
+        'deadbeef',
+        'image/png',
+        12,
+      ),
+    ).rejects.toThrow(/PRESIGN_PUT_FAILED.*endpoint=http:\/\/localhost:9000/s);
+  });
+
+  it('reports an unreachable object store when provisioning a bucket, naming the endpoint', async () => {
+    clearStorageModuleCache();
+    const cause = connectionRefused();
+    const options: PresignedUrlPluginOptions = {
+      s3: { client: {} as any, bucket: 'connection-default', endpoint: 'http://localhost:9000' },
+      resolveBucketName: () => 'app-public-abc',
+      ensureBucketProvisioned: () => Promise.reject(cause),
+    };
+    const withPgClient = jest.fn();
+
+    let thrown: any;
+    try {
+      await provisionAndRecordPhysicalBucket(
+        options,
+        withPgClient as any,
+        { bucketsQualifiedName: 'app_public.buckets' } as StorageModuleConfig,
+        '00000000-0000-0000-0000-0000000000db',
+        { id: 'bucket-1', key: 'public', type: 'public', physical_name: null } as BucketConfig,
+        null,
+      );
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown?.message).toContain('BUCKET_PROVISION_FAILED');
+    expect(thrown?.message).toContain('endpoint=http://localhost:9000');
+    expect(thrown?.message).toContain('bucket=app-public-abc');
+    expect(thrown?.message).toContain('ECONNREFUSED');
+    expect(thrown?.cause).toBe(cause);
+    // A failed provision must not record a physical name.
+    expect(withPgClient).not.toHaveBeenCalled();
+  });
+});

--- a/graphile/graphile-presigned-url-plugin/src/index.ts
+++ b/graphile/graphile-presigned-url-plugin/src/index.ts
@@ -51,6 +51,7 @@ export { mintPhysicalBucketName, provisionAndRecordPhysicalBucket, resolveS3, re
 export { createPresignedUrlPlugin,PresignedUrlPlugin } from './plugin';
 export { PresignedUrlPreset } from './preset';
 export { type WithPgClient, withRequestPgClient } from './request-pg-client';
+export { describeS3Failure, s3FailureError } from './s3-failure';
 export { copyS3Object, deleteS3Object, generatePresignedGetUrl, generatePresignedPutUrl, headObject, readObjectPrefix } from './s3-signer';
 export { clearBucketCache, clearStorageModuleCache, getBucketConfig, isS3BucketProvisioned, loadAllStorageModules, markS3BucketProvisioned,resolveStorageConfigFromCodec, resolveStorageModuleByFileId } from './storage-module-cache';
 export type {

--- a/graphile/graphile-presigned-url-plugin/src/physical-bucket.ts
+++ b/graphile/graphile-presigned-url-plugin/src/physical-bucket.ts
@@ -12,6 +12,7 @@
 import { Logger } from '@pgpmjs/logger';
 
 import { type WithPgClient, withRequestPgClient } from './request-pg-client';
+import { s3FailureError } from './s3-failure';
 import { isS3BucketProvisioned, markS3BucketProvisioned } from './storage-module-cache';
 import type { BucketConfig, PresignedUrlPluginOptions, S3Config, StorageModuleConfig } from './types';
 
@@ -119,7 +120,18 @@ export async function provisionAndRecordPhysicalBucket(
 
   if (options.ensureBucketProvisioned && !isS3BucketProvisioned(s3BucketName)) {
     log.info(`Lazy-provisioning S3 bucket "${s3BucketName}" for database ${databaseId}`);
-    await options.ensureBucketProvisioned(s3BucketName, bucket.type, databaseId, allowedOrigins);
+    try {
+      await options.ensureBucketProvisioned(s3BucketName, bucket.type, databaseId, allowedOrigins);
+    } catch (err) {
+      // The first upload to a bucket is where an unreachable object store is
+      // discovered, and the transport's own message is routinely empty: name the
+      // endpoint it could not reach so the response says what is misconfigured.
+      throw s3FailureError(
+        'BUCKET_PROVISION_FAILED',
+        { endpoint: resolveS3(options).endpoint, bucket: s3BucketName, databaseId },
+        err,
+      );
+    }
     markS3BucketProvisioned(s3BucketName);
     log.info(`Lazy-provisioned S3 bucket "${s3BucketName}" successfully`);
   }

--- a/graphile/graphile-presigned-url-plugin/src/s3-failure.ts
+++ b/graphile/graphile-presigned-url-plugin/src/s3-failure.ts
@@ -1,0 +1,77 @@
+/**
+ * Turning an S3 transport failure into a reason a caller can act on.
+ *
+ * The AWS SDK routinely fails with an **empty** `message`: an unreachable
+ * endpoint arrives as an `AggregateError` whose own message is `''` and whose
+ * per-address `errors` hold the `ECONNREFUSED`, and a hung socket arrives as a
+ * bare wrapper around its `cause`. Anything that reports `err.message` verbatim
+ * therefore hands the client a blank reason — which is how a server signing
+ * against the wrong endpoint (a missing `CDN_ENDPOINT`, so the library default
+ * `http://localhost:9000`, i.e. the pod's own loopback) presents as an upload
+ * that fails with nothing to diagnose.
+ *
+ * So a failure is described by walking to where the words actually are, and
+ * re-thrown naming the coordinates it was talking to, with the original kept as
+ * `cause` for the server log.
+ */
+
+/** How far to walk `errors` / `cause` before the chain stops being informative. */
+const MAX_DEPTH = 4;
+
+interface ErrorLike {
+  name?: string;
+  message?: string;
+  errors?: unknown[];
+  cause?: unknown;
+  $metadata?: { httpStatusCode?: number };
+}
+
+/**
+ * Describe a thrown S3 error in one line, including the nested errors an
+ * `AggregateError` (or a `cause` chain) hides its actual reason in.
+ */
+export function describeS3Failure(err: unknown, depth = 0): string {
+  if (err === null || err === undefined) return 'unknown error';
+  if (typeof err !== 'object') return String(err);
+
+  const e = err as ErrorLike;
+  const name = typeof e.name === 'string' && e.name !== 'Error' ? e.name : '';
+  const message = typeof e.message === 'string' ? e.message : '';
+  const head = message.length > 0 ? [name, message].filter(Boolean).join(': ') : name;
+
+  const status = e.$metadata?.httpStatusCode ? `HTTP ${e.$metadata.httpStatusCode}` : '';
+
+  let detail = '';
+  if (depth < MAX_DEPTH) {
+    const nested = Array.isArray(e.errors) ? e.errors : e.cause !== undefined ? [e.cause] : [];
+    const described = nested
+      .map((inner) => describeS3Failure(inner, depth + 1))
+      .filter((text) => text.length > 0 && text !== 'unknown error');
+    if (described.length > 0) detail = `(${described.join('; ')})`;
+  }
+
+  const described = [head, status, detail].filter((part) => part.length > 0).join(' ');
+  return described.length > 0 ? described : 'unknown error';
+}
+
+/**
+ * Wrap a failed S3 call as an error whose message carries the operation, the
+ * coordinates it used, and the underlying reason — with the original as `cause`.
+ *
+ * `context` is rendered as `key=value` pairs in the order given; entries with no
+ * value are dropped, so a connection without an explicit endpoint (real AWS)
+ * does not print an empty one.
+ */
+export function s3FailureError(
+  operation: string,
+  context: Record<string, string | number | undefined | null>,
+  err: unknown,
+): Error {
+  const coordinates = Object.entries(context)
+    .filter(([, value]) => value !== undefined && value !== null && value !== '')
+    .map(([key, value]) => `${key}=${value}`)
+    .join(' ');
+
+  const prefix = coordinates.length > 0 ? `${operation}: ${coordinates}` : operation;
+  return new Error(`${prefix}: ${describeS3Failure(err)}`, { cause: err });
+}

--- a/graphile/graphile-presigned-url-plugin/src/s3-signer.ts
+++ b/graphile/graphile-presigned-url-plugin/src/s3-signer.ts
@@ -8,6 +8,7 @@ import {
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { Logger } from '@pgpmjs/logger';
 
+import { s3FailureError } from './s3-failure';
 import type { S3Config } from './types';
 
 const log = new Logger('graphile-presigned-url:s3');
@@ -40,7 +41,16 @@ export async function generatePresignedPutUrl(
     ContentLength: contentLength,
   });
 
-  const url = await getSignedUrl(s3Config.client as any, command, { expiresIn });
+  let url: string;
+  try {
+    url = await getSignedUrl(s3Config.client as any, command, { expiresIn });
+  } catch (err) {
+    throw s3FailureError(
+      'PRESIGN_PUT_FAILED',
+      { endpoint: s3Config.endpoint, bucket: s3Config.bucket, key, contentType },
+      err,
+    );
+  }
   log.debug(`Generated presigned PUT URL for key=${key}, contentType=${contentType}, expires=${expiresIn}s`);
   return url;
 }
@@ -74,7 +84,12 @@ export async function generatePresignedGetUrl(
   }
 
   const command = new GetObjectCommand(params as any);
-  const url = await getSignedUrl(s3Config.client as any, command, { expiresIn });
+  let url: string;
+  try {
+    url = await getSignedUrl(s3Config.client as any, command, { expiresIn });
+  } catch (err) {
+    throw s3FailureError('PRESIGN_GET_FAILED', { endpoint: s3Config.endpoint, bucket: s3Config.bucket, key }, err);
+  }
   log.debug(`Generated presigned GET URL for key=${key}, expires=${expiresIn}s`);
   return url;
 }


### PR DESCRIPTION
## Summary

The second half of constructive-planning#1880: a failing `uploadFiles` reported a blank reason, so a server signing against the wrong object store (unset `CDN_ENDPOINT` → the library default `http://localhost:9000`, i.e. the pod's own loopback) was undiagnosable from the response.

The reason was blank because the AWS SDK's transport failures usually have **no message of their own** — an unreachable endpoint arrives as an `AggregateError` whose `message` is `''` and whose `errors` hold the `ECONNREFUSED`, a hung socket as a bare wrapper around its `cause`. Anything reporting `err.message` verbatim reports nothing.

New `src/s3-failure.ts` walks to where the words actually are, and re-throws naming the coordinates the call used, keeping the original as `cause`:

```ts
describeS3Failure(new AggregateError([Error('connect ECONNREFUSED 127.0.0.1:9000')], ''))
// 'AggregateError (connect ECONNREFUSED 127.0.0.1:9000)'

s3FailureError('BUCKET_PROVISION_FAILED', { endpoint, bucket, databaseId }, err).message
// 'BUCKET_PROVISION_FAILED: endpoint=http://localhost:9000 bucket=app-public-abc databaseId=…: AggregateError (connect ECONNREFUSED 127.0.0.1:9000)'
```

It is used at the two S3 touches of the upload lane — presigning (`generatePresignedPutUrl` / `generatePresignedGetUrl`) and the first-upload bucket provision in `provisionAndRecordPhysicalBucket`, which is where an unreachable store is actually discovered. Absent coordinates are dropped, so a real-AWS connection with no explicit endpoint does not print an empty one, and the walk is depth-bounded so a self-referential `cause` cannot spin.

Nothing else changes: no new catches, no failure turned into a success, no `reason` invented where the lane throws today.


Link to Devin session: https://app.devin.ai/sessions/29c76906da794b24947b0784984be136
Requested by: @pyramation