### PR TITLE
feat(storage): record uploaded files through the generated recorder

### DIFF
--- a/graphile/graphile-presigned-url-plugin/__tests__/managed-upload.test.ts
+++ b/graphile/graphile-presigned-url-plugin/__tests__/managed-upload.test.ts
@@ -64,6 +64,7 @@ function storageModuleRow(overrides: Record<string, unknown> = {}): Record<strin
     buckets_table: 'app_buckets',
     files_schema: 'storage_public',
     files_table: 'app_files',
+    private_schema: 'storage_private',
     endpoint: null,
     public_url_prefix: 'https://cdn.example.com',
     provider: 'minio',
@@ -76,6 +77,7 @@ function storageModuleRow(overrides: Record<string, unknown> = {}): Record<strin
     max_bulk_files: null,
     max_bulk_total_size: null,
     has_path_shares: false,
+    has_versioning: false,
     entity_schema: null,
     entity_table: null,
     ...overrides,
@@ -125,6 +127,8 @@ function storageConfig(): StorageModuleConfig {
     scope: 'app',
     bucketsQualifiedName: 'storage_public.app_buckets',
     filesQualifiedName: 'storage_public.app_files',
+    filesTableName: 'app_files',
+    recorderQualifiedName: 'storage_private.app_files_record_file',
     defaultMaxFileSize: 1000,
     hasPathShares: false,
     allowedOrigins: null,
@@ -487,7 +491,7 @@ describe('finalizeStagedUpload', () => {
     const db = fakeDb([
       SET_CONFIG,
       { match: /SELECT id, key, mime_type/, rows: () => [] },
-      { match: /INSERT INTO storage_public\.app_files/, rows: () => [{ id: FILE_ID }] },
+      { match: /SELECT id FROM storage_private\.app_files_record_file/, rows: () => [{ id: FILE_ID }] },
     ]);
 
     const { projection, deduplicated } = await finalizeStagedUpload({
@@ -505,8 +509,14 @@ describe('finalizeStagedUpload', () => {
       url: `https://cdn.example.com/${staged.contentHash}`,
     });
 
-    const insert = db.queries.find((q) => /INSERT/.test(q.text));
-    expect(insert?.values).toEqual([BUCKET_ID, staged.contentHash, staged.contentHash, 'image/png', 16, 'hero.png', true]);
+    const recorder = db.queries.find((q) => /record_file/.test(q.text));
+    expect(recorder?.text).toContain('bucket_id :=');
+    expect(recorder?.text).toContain('upload :=');
+    expect(recorder?.text).not.toContain('owner_id');
+    expect(recorder?.text).not.toContain('is_public');
+    expect(recorder?.values).toEqual([
+      BUCKET_ID, staged.contentHash, staged.contentHash, 'image/png', 16, 'hero.png', null,
+    ]);
     // Copy to the content key, then drop the staged object.
     expect(s3.client.send).toHaveBeenCalledTimes(2);
   });
@@ -575,7 +585,7 @@ describe('finalizeStagedUpload', () => {
           SET_CONFIG,
           { match: /SELECT id, key, mime_type/, rows: () => [existingRow(status)] },
           { match: /DELETE FROM storage_public\.app_files/, rows: () => [] },
-          { match: /INSERT INTO storage_public\.app_files/, rows: () => [{ id: NEW_FILE_ID }] },
+          { match: /SELECT id FROM storage_private\.app_files_record_file/, rows: () => [{ id: NEW_FILE_ID }] },
         ]);
 
         const { projection, deduplicated } = await finalizeStagedUpload({
@@ -622,7 +632,7 @@ describe('finalizeStagedUpload', () => {
     const db = fakeDb([
       SET_CONFIG,
       { match: /SELECT id, key, mime_type/, rows: () => [] },
-      { match: /INSERT INTO storage_public\.app_files/, rows: () => { throw new Error('insert boom'); } },
+      { match: /SELECT id FROM storage_private\.app_files_record_file/, rows: () => { throw new Error('insert boom'); } },
     ]);
 
     await expect(
@@ -632,6 +642,29 @@ describe('finalizeStagedUpload', () => {
     // Copy + delete promoted + delete staged: bytes no row names are bytes GC
     // can never reach, so they do not outlive the failed call.
     expect(s3.client.send).toHaveBeenCalledTimes(3);
+  });
+
+  it('fails loudly when the storage module has no generated recorder', async () => {
+    const { finalizeStagedUpload } = await import('../src/managed-upload');
+    const db = fakeDb([
+      SET_CONFIG,
+      { match: /SELECT id, key, mime_type/, rows: () => [] },
+    ]);
+
+    await expect(
+      finalizeStagedUpload({
+        target: {
+          ...target,
+          storageConfig: { ...storageConfig(), recorderQualifiedName: null },
+        },
+        withPgClient: db.withPgClient,
+        pgSettings: null,
+        staged,
+      }),
+    ).rejects.toThrow(
+      `STORAGE_RECORDER_MISSING: storage module ${APP_MODULE_ID} (app_files)`,
+    );
+    expect(db.queries.some((q) => /INSERT INTO/.test(q.text))).toBe(false);
   });
 
   it('rejects bytes the bucket does not allow before writing anything', async () => {

--- a/graphile/graphile-presigned-url-plugin/__tests__/storage-file-recorder.test.ts
+++ b/graphile/graphile-presigned-url-plugin/__tests__/storage-file-recorder.test.ts
@@ -103,21 +103,33 @@ describe('recordManagedFile', () => {
     });
   });
 
-  it('does not pass optional arguments unsupported by the module', async () => {
-    const query = jest.fn().mockResolvedValue({ rows: [{ id: 'file-id' }] });
+  it('fails loudly when a version chain is requested on a non-versioned module', async () => {
+    const query = jest.fn();
 
-    await recordManagedFile(
-      { query },
-      storageConfig(),
-      {
-        ...input(),
-        previousVersionId: '44444444-4444-4444-4444-444444444444',
-        path: 'assets',
-      },
+    await expect(
+      recordManagedFile(
+        { query },
+        storageConfig(),
+        {
+          ...input(),
+          previousVersionId: '44444444-4444-4444-4444-444444444444',
+        },
+      ),
+    ).rejects.toThrow(
+      'STORAGE_VERSIONING_UNSUPPORTED: storage module 11111111-1111-1111-1111-111111111111 (app_files)',
     );
+    expect(query).not.toHaveBeenCalled();
+  });
 
-    expect(query.mock.calls[0][0].text).not.toContain('previous_version_id');
-    expect(query.mock.calls[0][0].text).not.toContain('path :=');
+  it('fails loudly when a path is requested on a module without path shares', async () => {
+    const query = jest.fn();
+
+    await expect(
+      recordManagedFile({ query }, storageConfig(), { ...input(), path: 'assets' }),
+    ).rejects.toThrow(
+      'STORAGE_PATH_SHARES_UNSUPPORTED: storage module 11111111-1111-1111-1111-111111111111 (app_files)',
+    );
+    expect(query).not.toHaveBeenCalled();
   });
 
   it('fails before writing when no recorder is exposed', async () => {

--- a/graphile/graphile-presigned-url-plugin/__tests__/storage-file-recorder.test.ts
+++ b/graphile/graphile-presigned-url-plugin/__tests__/storage-file-recorder.test.ts
@@ -1,0 +1,133 @@
+import { recordManagedFile } from '../src/storage-file-recorder';
+import type { StorageModuleConfig } from '../src/types';
+
+function storageConfig(
+  overrides: Partial<StorageModuleConfig> = {},
+): StorageModuleConfig {
+  return {
+    id: '11111111-1111-1111-1111-111111111111',
+    bucketsQualifiedName: 'storage_public.app_buckets',
+    filesQualifiedName: 'storage_public.app_files',
+    schemaName: 'storage_public',
+    bucketsTableName: 'app_buckets',
+    filesTableName: 'app_files',
+    recorderQualifiedName: 'storage_private.app_files_record_file',
+    scope: 'app',
+    entityTableId: null,
+    entityQualifiedName: null,
+    endpoint: null,
+    publicUrlPrefix: null,
+    provider: 'minio',
+    allowedOrigins: null,
+    uploadUrlExpirySeconds: 900,
+    downloadUrlExpirySeconds: 3600,
+    defaultMaxFileSize: 1000,
+    maxFilenameLength: 1024,
+    cacheTtlSeconds: 300,
+    hasPathShares: false,
+    hasVersioning: false,
+    hasConfirmUpload: false,
+    maxBulkFiles: 100,
+    maxBulkTotalSize: 1000,
+    ...overrides,
+  };
+}
+
+function input() {
+  return {
+    bucketId: '22222222-2222-2222-2222-222222222222',
+    key: 'assets/logo.png',
+    contentHash: 'a'.repeat(64),
+    mimeType: 'image/png',
+    size: 16,
+    filename: 'logo.png',
+  };
+}
+
+describe('recordManagedFile', () => {
+  it('calls the generated recorder with only base object facts', async () => {
+    const query = jest.fn().mockResolvedValue({
+      rows: [{ id: '33333333-3333-3333-3333-333333333333' }],
+    });
+
+    await expect(recordManagedFile({ query }, storageConfig(), input())).resolves.toBe(
+      '33333333-3333-3333-3333-333333333333',
+    );
+
+    expect(query).toHaveBeenCalledWith({
+      text: expect.stringContaining(
+        'SELECT id FROM storage_private.app_files_record_file(bucket_id := $1::uuid, key := $2::text',
+      ),
+      values: [
+        input().bucketId,
+        input().key,
+        input().contentHash,
+        input().mimeType,
+        input().size,
+        input().filename,
+        null,
+      ],
+    });
+    expect(query.mock.calls[0][0].text).not.toContain('owner_id');
+    expect(query.mock.calls[0][0].text).not.toContain('is_public');
+  });
+
+  it('appends supported version and path arguments by name', async () => {
+    const query = jest.fn().mockResolvedValue({ rows: [{ id: 'file-id' }] });
+
+    await recordManagedFile(
+      { query },
+      storageConfig({ hasVersioning: true, hasPathShares: true }),
+      {
+        ...input(),
+        previousVersionId: '44444444-4444-4444-4444-444444444444',
+        path: 'assets',
+      },
+    );
+
+    expect(query.mock.calls[0][0]).toEqual({
+      text: expect.stringMatching(
+        /previous_version_id := \$8::uuid, path := \$9::text/,
+      ),
+      values: [
+        input().bucketId,
+        input().key,
+        input().contentHash,
+        input().mimeType,
+        input().size,
+        input().filename,
+        null,
+        '44444444-4444-4444-4444-444444444444',
+        'assets',
+      ],
+    });
+  });
+
+  it('does not pass optional arguments unsupported by the module', async () => {
+    const query = jest.fn().mockResolvedValue({ rows: [{ id: 'file-id' }] });
+
+    await recordManagedFile(
+      { query },
+      storageConfig(),
+      {
+        ...input(),
+        previousVersionId: '44444444-4444-4444-4444-444444444444',
+        path: 'assets',
+      },
+    );
+
+    expect(query.mock.calls[0][0].text).not.toContain('previous_version_id');
+    expect(query.mock.calls[0][0].text).not.toContain('path :=');
+  });
+
+  it('fails before writing when no recorder is exposed', async () => {
+    const query = jest.fn();
+
+    await expect(
+      recordManagedFile({ query }, storageConfig({ recorderQualifiedName: null }), input()),
+    ).rejects.toThrow(
+      'STORAGE_RECORDER_MISSING: storage module 11111111-1111-1111-1111-111111111111 (app_files)',
+    );
+    expect(query).not.toHaveBeenCalled();
+  });
+});

--- a/graphile/graphile-presigned-url-plugin/src/managed-upload.ts
+++ b/graphile/graphile-presigned-url-plugin/src/managed-upload.ts
@@ -26,6 +26,7 @@ import { type FileRefFieldBinding, getFileRefFieldBinding } from './file-ref-reg
 import { provisionAndRecordPhysicalBucket, resolveS3ForDatabase } from './physical-bucket';
 import { type WithPgClient, withRequestPgClient } from './request-pg-client';
 import { copyS3Object, deleteS3Object } from './s3-signer';
+import { recordManagedFile } from './storage-file-recorder';
 import { getBucketConfig, loadAllStorageModules } from './storage-module-cache';
 import type { BucketConfig, FileProjection, PresignedUrlPluginOptions, S3Config, StorageModuleConfig } from './types';
 
@@ -371,22 +372,14 @@ export async function finalizeStagedUpload(args: {
   let fileId: string;
   try {
     fileId = await withRequestPgClient(withPgClient, pgSettings, async (pgClient) => {
-      const result = await pgClient.query({
-        text: `INSERT INTO ${storageConfig.filesQualifiedName}
-             (bucket_id, key, content_hash, mime_type, size, filename, is_public)
-             VALUES ($1, $2, $3, $4, $5, $6, $7)
-             RETURNING id`,
-        values: [
-          bucket.id,
-          finalKey,
-          staged.contentHash,
-          staged.contentType,
-          staged.size,
-          staged.filename ?? null,
-          bucket.is_public,
-        ],
+      return recordManagedFile(pgClient, storageConfig, {
+        bucketId: bucket.id,
+        key: finalKey,
+        contentHash: staged.contentHash,
+        mimeType: staged.contentType,
+        size: staged.size,
+        filename: staged.filename,
       });
-      return (result.rows[0] as { id: string }).id;
     });
   } catch (err) {
     // No row names either key, so both are unreachable to GC. Dropping the

--- a/graphile/graphile-presigned-url-plugin/src/plugin.ts
+++ b/graphile/graphile-presigned-url-plugin/src/plugin.ts
@@ -34,6 +34,7 @@ import { buildFileProjection, type FileProjection } from './managed-upload';
 import { provisionAndRecordPhysicalBucket, resolveS3ForDatabase } from './physical-bucket';
 import { withRequestPgClient } from './request-pg-client';
 import { deleteS3Object,generatePresignedPutUrl } from './s3-signer';
+import { recordManagedFile } from './storage-file-recorder';
 import { getBucketConfig, loadAllStorageModules, resolveStorageConfigFromCodec, storedPhysicalName } from './storage-module-cache';
 import type { BucketConfig,PresignedUrlPluginOptions, S3Config, StorageModuleConfig } from './types';
 
@@ -767,35 +768,16 @@ async function processSingleFile(
   // Auto-derive ltree path from custom key directory (only when has_path_shares)
   const derivedPath = isCustomKey && storageConfig.hasPathShares ? derivePathFromKey(s3Key) : null;
 
-  // Create file record. An entity-keyed plane (the module records an entity
-  // table) carries owner_id on its rows; app- and database-scope planes do not.
-  const hasOwnerColumn = storageConfig.entityTableId !== null;
-  const columns = ['bucket_id', 'key', 'content_hash', 'mime_type', 'size', 'filename', 'is_public'];
-  const values: any[] = [bucket.id, s3Key, contentHash, contentType, size, filename || null, bucket.is_public];
-
-  if (hasOwnerColumn) {
-    columns.push('owner_id');
-    values.push(bucket.owner_id);
-  }
-  if (previousVersionId) {
-    columns.push('previous_version_id');
-    values.push(previousVersionId);
-  }
-  if (derivedPath) {
-    columns.push('path');
-    values.push(derivedPath);
-  }
-
-  const placeholders = values.map((_: any, i: number) => `$${i + 1}`).join(', ');
-  const fileResult = await txClient.query({
-    text: `INSERT INTO ${storageConfig.filesQualifiedName}
-           (${columns.join(', ')})
-           VALUES (${placeholders})
-           RETURNING id`,
-    values,
+  const fileId = await recordManagedFile(txClient, storageConfig, {
+    bucketId: bucket.id,
+    key: s3Key,
+    contentHash,
+    mimeType: contentType,
+    size,
+    filename: filename || null,
+    previousVersionId,
+    path: derivedPath,
   });
-
-  const fileId = fileResult.rows[0].id;
 
   // Generate presigned PUT URL
   const uploadUrl = await generatePresignedPutUrl(

--- a/graphile/graphile-presigned-url-plugin/src/storage-file-recorder.ts
+++ b/graphile/graphile-presigned-url-plugin/src/storage-file-recorder.ts
@@ -1,0 +1,66 @@
+import type { StorageModuleConfig } from './types';
+
+interface RecordManagedFileInput {
+  bucketId: string;
+  key: string;
+  contentHash: string;
+  mimeType: string;
+  size: number;
+  filename: string | null | undefined;
+  previousVersionId?: string | null;
+  path?: string | null;
+}
+
+/**
+ * Record a managed file through the storage plane's generated recorder.
+ *
+ * The recorder owns the files-table insert so bucket inheritance and claims
+ * attribution run at the database boundary. Optional arguments are only named
+ * when the generated function supports them and the caller has a value.
+ */
+export async function recordManagedFile(
+  pgClient: { query: (opts: { text: string; values: unknown[] }) => Promise<{ rows: unknown[] }> },
+  storageConfig: StorageModuleConfig,
+  input: RecordManagedFileInput,
+): Promise<string> {
+  if (!storageConfig.recorderQualifiedName) {
+    throw new Error(
+      `STORAGE_RECORDER_MISSING: storage module ${storageConfig.id} (${storageConfig.filesTableName}) ` +
+      `must expose ${storageConfig.filesTableName}_record_file in its private schema`,
+    );
+  }
+
+  const args = [
+    'bucket_id := $1::uuid',
+    'key := $2::text',
+    'content_hash := $3::text',
+    'mime_type := $4::text',
+    'size := $5::bigint',
+    'filename := $6::text',
+    'upload := $7::jsonb',
+  ];
+  const values: unknown[] = [
+    input.bucketId,
+    input.key,
+    input.contentHash,
+    input.mimeType,
+    input.size,
+    input.filename ?? null,
+    null,
+  ];
+
+  if (storageConfig.hasVersioning && input.previousVersionId) {
+    args.push(`previous_version_id := $${values.length + 1}::uuid`);
+    values.push(input.previousVersionId);
+  }
+  if (storageConfig.hasPathShares && input.path) {
+    args.push(`path := $${values.length + 1}::text`);
+    values.push(input.path);
+  }
+
+  const result = await pgClient.query({
+    text: `SELECT id FROM ${storageConfig.recorderQualifiedName}(${args.join(', ')})`,
+    values,
+  });
+  return (result.rows[0] as { id: string }).id;
+}

--- a/graphile/graphile-presigned-url-plugin/src/storage-file-recorder.ts
+++ b/graphile/graphile-presigned-url-plugin/src/storage-file-recorder.ts
@@ -29,6 +29,18 @@ export async function recordManagedFile(
       `must expose ${storageConfig.filesTableName}_record_file in its private schema`,
     );
   }
+  if (input.previousVersionId != null && !storageConfig.hasVersioning) {
+    throw new Error(
+      `STORAGE_VERSIONING_UNSUPPORTED: storage module ${storageConfig.id} (${storageConfig.filesTableName}) ` +
+      'does not support previous_version_id',
+    );
+  }
+  if (input.path != null && !storageConfig.hasPathShares) {
+    throw new Error(
+      `STORAGE_PATH_SHARES_UNSUPPORTED: storage module ${storageConfig.id} (${storageConfig.filesTableName}) ` +
+      'does not support path',
+    );
+  }
 
   const args = [
     'bucket_id := $1::uuid',
@@ -49,11 +61,11 @@ export async function recordManagedFile(
     null,
   ];
 
-  if (storageConfig.hasVersioning && input.previousVersionId) {
+  if (storageConfig.hasVersioning && input.previousVersionId != null) {
     args.push(`previous_version_id := $${values.length + 1}::uuid`);
     values.push(input.previousVersionId);
   }
-  if (storageConfig.hasPathShares && input.path) {
+  if (storageConfig.hasPathShares && input.path != null) {
     args.push(`path := $${values.length + 1}::text`);
     values.push(input.path);
   }

--- a/graphile/graphile-presigned-url-plugin/src/storage-module-cache.ts
+++ b/graphile/graphile-presigned-url-plugin/src/storage-module-cache.ts
@@ -48,6 +48,7 @@ const ALL_STORAGE_MODULES_QUERY = `
     bt.name AS buckets_table,
     fs.schema_name AS files_schema,
     ft.name AS files_table,
+    ps.schema_name AS private_schema,
     sm.endpoint,
     sm.public_url_prefix,
     sm.provider,
@@ -60,6 +61,7 @@ const ALL_STORAGE_MODULES_QUERY = `
     sm.max_bulk_files,
     sm.max_bulk_total_size,
     sm.has_path_shares,
+    sm.has_versioning,
     sm.has_confirm_upload,
     es.schema_name AS entity_schema,
     et.name AS entity_table
@@ -68,6 +70,7 @@ const ALL_STORAGE_MODULES_QUERY = `
   JOIN metaschema_public.schema bs ON bs.id = bt.schema_id
   JOIN metaschema_public.table ft ON ft.id = sm.files_table_id
   JOIN metaschema_public.schema fs ON fs.id = ft.schema_id
+  LEFT JOIN metaschema_public.schema ps ON ps.id = sm.private_schema_id
   LEFT JOIN metaschema_public.table et ON et.id = sm.entity_table_id
   LEFT JOIN metaschema_public.schema es ON es.id = et.schema_id
   WHERE sm.database_id = $1
@@ -81,6 +84,7 @@ interface StorageModuleRow {
   buckets_table: string;
   files_schema: string;
   files_table: string;
+  private_schema: string | null;
   endpoint: string | null;
   public_url_prefix: string | null;
   provider: string | null;
@@ -93,6 +97,7 @@ interface StorageModuleRow {
   max_bulk_files: number | null;
   max_bulk_total_size: number | null;
   has_path_shares: boolean;
+  has_versioning: boolean;
   has_confirm_upload: boolean;
   entity_schema: string | null;
   entity_table: string | null;
@@ -107,6 +112,9 @@ function buildConfig(row: StorageModuleRow): StorageModuleConfig {
     id: row.id,
     bucketsQualifiedName: QuoteUtils.quoteQualifiedIdentifier(row.buckets_schema, row.buckets_table),
     filesQualifiedName: QuoteUtils.quoteQualifiedIdentifier(row.files_schema, row.files_table),
+    recorderQualifiedName: row.private_schema
+      ? QuoteUtils.quoteQualifiedIdentifier(row.private_schema, `${row.files_table}_record_file`)
+      : null,
     schemaName: row.buckets_schema,
     bucketsTableName: row.buckets_table,
     filesTableName: row.files_table,
@@ -125,6 +133,7 @@ function buildConfig(row: StorageModuleRow): StorageModuleConfig {
     maxFilenameLength: row.max_filename_length ?? DEFAULT_MAX_FILENAME_LENGTH,
     cacheTtlSeconds,
     hasPathShares: row.has_path_shares ?? false,
+    hasVersioning: row.has_versioning ?? false,
     hasConfirmUpload: row.has_confirm_upload ?? false,
     maxBulkFiles: row.max_bulk_files ?? DEFAULT_MAX_BULK_FILES,
     maxBulkTotalSize: row.max_bulk_total_size ?? DEFAULT_MAX_BULK_TOTAL_SIZE,

--- a/graphile/graphile-presigned-url-plugin/src/types.ts
+++ b/graphile/graphile-presigned-url-plugin/src/types.ts
@@ -37,6 +37,8 @@ export interface StorageModuleConfig {
   bucketsTableName: string;
   /** Files table name */
   filesTableName: string;
+  /** Qualified generated managed-file recorder, or null when unavailable */
+  recorderQualifiedName: string | null;
 
   // --- Scope identity ---
 
@@ -78,6 +80,8 @@ export interface StorageModuleConfig {
    * without it every row is treated as live, because there is nothing to read.
    */
   hasConfirmUpload: boolean;
+  /** Whether the files table carries the versioning chain. */
+  hasVersioning: boolean;
 
   // --- Bulk upload limits ---
 

--- a/graphile/graphile-settings/__tests__/upload-resolver.test.ts
+++ b/graphile/graphile-settings/__tests__/upload-resolver.test.ts
@@ -31,6 +31,7 @@ function storageModuleRow(): Record<string, unknown> {
     buckets_table: 'app_buckets',
     files_schema: 'storage_public',
     files_table: 'app_files',
+    private_schema: 'storage_private',
     endpoint: null,
     public_url_prefix: 'https://cdn.example.com',
     provider: 'minio',
@@ -43,6 +44,8 @@ function storageModuleRow(): Record<string, unknown> {
     max_bulk_files: null,
     max_bulk_total_size: null,
     has_path_shares: false,
+    has_versioning: false,
+    has_confirm_upload: false,
     entity_schema: null,
     entity_table: null,
   };
@@ -88,7 +91,7 @@ function fakeContext(opts: { isPublic?: boolean; existingFile?: boolean; failIns
         : [],
     },
     {
-      match: /INSERT INTO storage_public\.app_files/,
+      match: /app_files_record_file/,
       rows: () => {
         if (opts.failInsert) throw new Error('insert boom');
         return [{ id: FILE_ID }];
@@ -232,8 +235,9 @@ describe('multipart upload resolver', () => {
     expect(call.bucket).toBe('myapp-default-public-db');
     expect(call.key).toMatch(/^\.staging\//);
 
-    const insert = queries.find((q) => /INSERT INTO storage_public\.app_files/.test(q.text));
-    expect(insert).toBeDefined();
+    const recorder = queries.find((q) => /app_files_record_file/.test(q.text));
+    expect(recorder).toBeDefined();
+    expect(recorder?.text).not.toContain('INSERT INTO');
   });
 
   it('deduplicates against an existing row rather than inserting a second one', async () => {

--- a/graphql/server-test/__fixtures__/seed/db-scope-storage/schema.sql
+++ b/graphql/server-test/__fixtures__/seed/db-scope-storage/schema.sql
@@ -8,13 +8,16 @@
 -- upload mutation on this schema.
 
 CREATE SCHEMA IF NOT EXISTS "tess-storage-public";
+CREATE SCHEMA IF NOT EXISTS "tess-storage-private";
 
 GRANT USAGE ON SCHEMA "tess-storage-public" TO administrator, authenticated, anonymous;
+GRANT USAGE ON SCHEMA "tess-storage-private" TO administrator, authenticated, anonymous;
 
 CREATE TABLE "tess-storage-public".buckets (
   id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
   key text NOT NULL,
   type text NOT NULL DEFAULT 'private',
+  owner_id uuid,
   is_public boolean NOT NULL DEFAULT false,
   allowed_mime_types text[] NULL,
   max_file_size bigint NULL,
@@ -48,3 +51,52 @@ COMMENT ON TABLE "tess-storage-public".files IS E'@storageFiles\nStorage files t
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON "tess-storage-public".buckets TO administrator, authenticated, anonymous;
 GRANT SELECT, INSERT, UPDATE, DELETE ON "tess-storage-public".files TO administrator, authenticated, anonymous;
+
+CREATE FUNCTION "tess-storage-private".files_record_file(
+  bucket_id uuid,
+  key text,
+  content_hash text,
+  mime_type text,
+  size bigint,
+  filename text,
+  upload jsonb,
+  status text DEFAULT 'requested',
+  previous_version_id uuid DEFAULT NULL
+) RETURNS "tess-storage-public".files
+LANGUAGE plpgsql
+SECURITY INVOKER
+VOLATILE
+AS $function$
+DECLARE
+  v_row "tess-storage-public".files;
+BEGIN
+  INSERT INTO "tess-storage-public".files (
+    bucket_id,
+    key,
+    content_hash,
+    mime_type,
+    size,
+    filename,
+    owner_id,
+    is_public,
+    previous_version_id
+  )
+  SELECT
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    $6,
+    b.owner_id,
+    b.is_public,
+    $9
+  FROM "tess-storage-public".buckets b
+  WHERE b.id = $1
+  RETURNING * INTO v_row;
+  RETURN v_row;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION "tess-storage-private".files_record_file(uuid, text, text, text, bigint, text, jsonb, text, uuid)
+  TO administrator, authenticated, anonymous;

--- a/graphql/server-test/__fixtures__/seed/db-scope-storage/schema.sql
+++ b/graphql/server-test/__fixtures__/seed/db-scope-storage/schema.sql
@@ -17,7 +17,6 @@ CREATE TABLE "tess-storage-public".buckets (
   id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
   key text NOT NULL,
   type text NOT NULL DEFAULT 'private',
-  owner_id uuid,
   is_public boolean NOT NULL DEFAULT false,
   allowed_mime_types text[] NULL,
   max_file_size bigint NULL,
@@ -77,7 +76,6 @@ BEGIN
     mime_type,
     size,
     filename,
-    owner_id,
     is_public,
     previous_version_id
   )
@@ -88,7 +86,6 @@ BEGIN
     $4,
     $5,
     $6,
-    b.owner_id,
     b.is_public,
     $9
   FROM "tess-storage-public".buckets b

--- a/graphql/server-test/__fixtures__/seed/db-scope-storage/test-data.sql
+++ b/graphql/server-test/__fixtures__/seed/db-scope-storage/test-data.sql
@@ -70,7 +70,8 @@ INSERT INTO metaschema_modules_public.storage_module (
   provider,
   allowed_origins,
   scope,
-  private_schema_id
+  private_schema_id,
+  has_versioning
 )
 VALUES (
   'ce556000-0000-4000-8000-000000000001',
@@ -83,7 +84,8 @@ VALUES (
   'minio',
   ARRAY['*'],
   'database',
-  'ce552000-0000-4000-8000-000000000002'
+  'ce552000-0000-4000-8000-000000000002',
+  true
 ) ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO "tess-storage-public".buckets (id, key, type, is_public)

--- a/graphql/server-test/__fixtures__/seed/db-scope-storage/test-data.sql
+++ b/graphql/server-test/__fixtures__/seed/db-scope-storage/test-data.sql
@@ -24,6 +24,16 @@ VALUES (
   true
 ) ON CONFLICT (id) DO NOTHING;
 
+INSERT INTO metaschema_public.schema (id, database_id, name, schema_name, description, is_public)
+VALUES (
+  'ce552000-0000-4000-8000-000000000002',
+  'ce551000-0000-4000-8000-000000000001',
+  'private',
+  'tess-storage-private',
+  NULL,
+  false
+) ON CONFLICT (id) DO NOTHING;
+
 INSERT INTO metaschema_public.table (id, database_id, schema_id, name, description)
 VALUES
   ('ce553000-0000-4000-8000-000000000001', 'ce551000-0000-4000-8000-000000000001', 'ce552000-0000-4000-8000-000000000001', 'buckets', NULL),
@@ -59,7 +69,8 @@ INSERT INTO metaschema_modules_public.storage_module (
   public_url_prefix,
   provider,
   allowed_origins,
-  scope
+  scope,
+  private_schema_id
 )
 VALUES (
   'ce556000-0000-4000-8000-000000000001',
@@ -71,7 +82,8 @@ VALUES (
   NULL,  -- use global CDN_PUBLIC_URL_PREFIX
   'minio',
   ARRAY['*'],
-  'database'
+  'database',
+  'ce552000-0000-4000-8000-000000000002'
 ) ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO "tess-storage-public".buckets (id, key, type, is_public)

--- a/graphql/server-test/__fixtures__/seed/simple-seed-storage/schema.sql
+++ b/graphql/server-test/__fixtures__/seed/simple-seed-storage/schema.sql
@@ -10,12 +10,15 @@ CREATE FUNCTION _test_create_storage_schema(schema_name text) RETURNS void
 LANGUAGE plpgsql AS $$
 BEGIN
   EXECUTE format('CREATE SCHEMA IF NOT EXISTS %I', schema_name);
+  EXECUTE format('CREATE SCHEMA IF NOT EXISTS %I', schema_name || '-private');
 
   EXECUTE format('GRANT USAGE ON SCHEMA %I TO administrator, authenticated, anonymous', schema_name);
+  EXECUTE format('GRANT USAGE ON SCHEMA %I TO administrator, authenticated, anonymous', schema_name || '-private');
 
   EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON TABLES TO administrator', schema_name);
   EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT USAGE ON SEQUENCES TO administrator, authenticated', schema_name);
   EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON FUNCTIONS TO administrator, authenticated, anonymous', schema_name);
+  EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA %I GRANT ALL ON FUNCTIONS TO administrator, authenticated, anonymous', schema_name || '-private');
 
   -- Buckets table
   EXECUTE format(
@@ -23,6 +26,7 @@ BEGIN
        id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
        key text NOT NULL,
        type text NOT NULL DEFAULT ''private'',
+       owner_id uuid,
        is_public boolean NOT NULL DEFAULT false,
        allowed_mime_types text[] NULL,
        max_file_size bigint NULL,
@@ -63,6 +67,58 @@ BEGIN
   -- Grant CRUD to all roles
   EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON %I.app_buckets TO administrator, authenticated, anonymous', schema_name);
   EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON %I.app_files TO administrator, authenticated, anonymous', schema_name);
+
+  EXECUTE format($sql$
+    CREATE FUNCTION %I.app_files_record_file(
+      bucket_id uuid,
+      key text,
+      content_hash text,
+      mime_type text,
+      size bigint,
+      filename text,
+      upload jsonb,
+      status text DEFAULT 'requested',
+      previous_version_id uuid DEFAULT NULL
+    ) RETURNS %I.app_files
+    LANGUAGE plpgsql
+    SECURITY INVOKER
+    VOLATILE
+    AS $function$
+    DECLARE
+      v_row %I.app_files;
+    BEGIN
+      INSERT INTO %I.app_files (
+        bucket_id,
+        key,
+        content_hash,
+        mime_type,
+        size,
+        filename,
+        owner_id,
+        is_public,
+        previous_version_id
+      )
+      SELECT
+        $1,
+        $2,
+        $3,
+        $4,
+        $5,
+        $6,
+        b.owner_id,
+        b.is_public,
+        $9
+      FROM %I.app_buckets b
+      WHERE b.id = $1
+      RETURNING * INTO v_row;
+      RETURN v_row;
+    END;
+    $function$;
+  $sql$, schema_name || '-private', schema_name, schema_name, schema_name, schema_name);
+
+  EXECUTE format(
+    'GRANT EXECUTE ON FUNCTION %I.app_files_record_file(uuid, text, text, text, bigint, text, jsonb, text, uuid) TO administrator, authenticated, anonymous',
+    schema_name || '-private');
 END;
 $$;
 

--- a/graphql/server-test/__fixtures__/seed/simple-seed-storage/schema.sql
+++ b/graphql/server-test/__fixtures__/seed/simple-seed-storage/schema.sql
@@ -26,7 +26,6 @@ BEGIN
        id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
        key text NOT NULL,
        type text NOT NULL DEFAULT ''private'',
-       owner_id uuid,
        is_public boolean NOT NULL DEFAULT false,
        allowed_mime_types text[] NULL,
        max_file_size bigint NULL,
@@ -94,7 +93,6 @@ BEGIN
         mime_type,
         size,
         filename,
-        owner_id,
         is_public,
         previous_version_id
       )
@@ -105,7 +103,6 @@ BEGIN
         $4,
         $5,
         $6,
-        b.owner_id,
         b.is_public,
         $9
       FROM %I.app_buckets b

--- a/graphql/server-test/__fixtures__/seed/simple-seed-storage/test-data.sql
+++ b/graphql/server-test/__fixtures__/seed/simple-seed-storage/test-data.sql
@@ -19,7 +19,8 @@ VALUES (
 -- Schema entries
 INSERT INTO metaschema_public.schema (id, database_id, name, schema_name, description, is_public)
 VALUES
-  ('6dbae92a-5450-401b-1ed5-d69e7754940d', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', 'public', 'simple-storage-public', NULL, true)
+  ('6dbae92a-5450-401b-1ed5-d69e7754940d', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', 'public', 'simple-storage-public', NULL, true),
+  ('6dbae92a-5450-401b-1ed5-d69e7754940e', '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9', 'private', 'simple-storage-public-private', NULL, false)
 ON CONFLICT (id) DO NOTHING;
 
 -- Table entries for storage tables
@@ -71,7 +72,8 @@ INSERT INTO metaschema_modules_public.storage_module (
   public_url_prefix,
   provider,
   allowed_origins,
-  scope
+  scope,
+  private_schema_id
 )
 VALUES (
   'c0000001-0000-0000-0000-000000000001',
@@ -83,7 +85,8 @@ VALUES (
   NULL,  -- use global CDN_PUBLIC_URL_PREFIX
   'minio',
   ARRAY['*'],
-  'app'
+  'app',
+  '6dbae92a-5450-401b-1ed5-d69e7754940e'
 ) ON CONFLICT (id) DO NOTHING;
 
 -- =====================================================
@@ -120,7 +123,8 @@ VALUES (
 
 INSERT INTO metaschema_public.schema (id, database_id, name, schema_name, description, is_public)
 VALUES
-  ('a2a2a2a2-b3b3-4c4c-d5d5-e6e6e6e6e6e6', 'a1a1a1a1-b2b2-4c3c-d4d4-e5e5e5e5e5e5', 'public', 'bob-storage-public', NULL, true)
+  ('a2a2a2a2-b3b3-4c4c-d5d5-e6e6e6e6e6e6', 'a1a1a1a1-b2b2-4c3c-d4d4-e5e5e5e5e5e5', 'public', 'bob-storage-public', NULL, true),
+  ('a2a2a2a2-b3b3-4c4c-d5d5-e6e6e6e6e6f', 'a1a1a1a1-b2b2-4c3c-d4d4-e5e5e5e5e5e5', 'private', 'bob-storage-public-private', NULL, false)
 ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO metaschema_public.table (id, database_id, schema_id, name, description)
@@ -165,7 +169,8 @@ INSERT INTO metaschema_modules_public.storage_module (
   public_url_prefix,
   provider,
   allowed_origins,
-  scope
+  scope,
+  private_schema_id
 )
 VALUES (
   'c1c1c1c1-0000-0000-0000-000000000001',
@@ -177,7 +182,8 @@ VALUES (
   NULL,
   'minio',
   ARRAY['*'],
-  'app'
+  'app',
+  'a2a2a2a2-b3b3-4c4c-d5d5-e6e6e6e6e6f'
 ) ON CONFLICT (id) DO NOTHING;
 
 -- =====================================================
@@ -252,7 +258,8 @@ VALUES (
 
 INSERT INTO metaschema_public.schema (id, database_id, name, schema_name, description, is_public)
 VALUES
-  ('fa22fa22-a3a3-4b4b-c5c5-d6d6d6d6d6d6', 'fa11fa11-a2a2-4b3b-c4c4-d5d5d5d5d5d5', 'public', 'mallory-storage-public', NULL, true)
+  ('fa22fa22-a3a3-4b4b-c5c5-d6d6d6d6d6d6', 'fa11fa11-a2a2-4b3b-c4c4-d5d5d5d5d5d5', 'public', 'mallory-storage-public', NULL, true),
+  ('fa22fa22-a3a3-4b4b-c5c5-d6d6d6d6d6d7', 'fa11fa11-a2a2-4b3b-c4c4-d5d5d5d5d5d5', 'private', 'mallory-storage-public-private', NULL, false)
 ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO metaschema_public.table (id, database_id, schema_id, name, description)
@@ -289,7 +296,8 @@ INSERT INTO metaschema_modules_public.storage_module (
   public_url_prefix,
   provider,
   allowed_origins,
-  scope
+  scope,
+  private_schema_id
 )
 VALUES (
   'fa66fa66-0000-0000-0000-000000000001',
@@ -301,7 +309,8 @@ VALUES (
   NULL,
   'minio',
   ARRAY['*'],
-  'app'
+  'app',
+  'fa22fa22-a3a3-4b4b-c5c5-d6d6d6d6d6d7'
 ) ON CONFLICT (id) DO NOTHING;
 
 -- =====================================================

--- a/graphql/server-test/__fixtures__/seed/simple-seed-storage/test-data.sql
+++ b/graphql/server-test/__fixtures__/seed/simple-seed-storage/test-data.sql
@@ -73,7 +73,8 @@ INSERT INTO metaschema_modules_public.storage_module (
   provider,
   allowed_origins,
   scope,
-  private_schema_id
+  private_schema_id,
+  has_versioning
 )
 VALUES (
   'c0000001-0000-0000-0000-000000000001',
@@ -86,7 +87,8 @@ VALUES (
   'minio',
   ARRAY['*'],
   'app',
-  '6dbae92a-5450-401b-1ed5-d69e7754940e'
+  '6dbae92a-5450-401b-1ed5-d69e7754940e',
+  true
 ) ON CONFLICT (id) DO NOTHING;
 
 -- =====================================================
@@ -124,7 +126,7 @@ VALUES (
 INSERT INTO metaschema_public.schema (id, database_id, name, schema_name, description, is_public)
 VALUES
   ('a2a2a2a2-b3b3-4c4c-d5d5-e6e6e6e6e6e6', 'a1a1a1a1-b2b2-4c3c-d4d4-e5e5e5e5e5e5', 'public', 'bob-storage-public', NULL, true),
-  ('a2a2a2a2-b3b3-4c4c-d5d5-e6e6e6e6e6f', 'a1a1a1a1-b2b2-4c3c-d4d4-e5e5e5e5e5e5', 'private', 'bob-storage-public-private', NULL, false)
+  ('a2a2a2a2-b3b3-4c4c-d5d5-e6e6e6e6e6f0', 'a1a1a1a1-b2b2-4c3c-d4d4-e5e5e5e5e5e5', 'private', 'bob-storage-public-private', NULL, false)
 ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO metaschema_public.table (id, database_id, schema_id, name, description)
@@ -170,7 +172,8 @@ INSERT INTO metaschema_modules_public.storage_module (
   provider,
   allowed_origins,
   scope,
-  private_schema_id
+  private_schema_id,
+  has_versioning
 )
 VALUES (
   'c1c1c1c1-0000-0000-0000-000000000001',
@@ -183,7 +186,8 @@ VALUES (
   'minio',
   ARRAY['*'],
   'app',
-  'a2a2a2a2-b3b3-4c4c-d5d5-e6e6e6e6e6f'
+  'a2a2a2a2-b3b3-4c4c-d5d5-e6e6e6e6e6f0',
+  true
 ) ON CONFLICT (id) DO NOTHING;
 
 -- =====================================================
@@ -297,7 +301,8 @@ INSERT INTO metaschema_modules_public.storage_module (
   provider,
   allowed_origins,
   scope,
-  private_schema_id
+  private_schema_id,
+  has_versioning
 )
 VALUES (
   'fa66fa66-0000-0000-0000-000000000001',
@@ -310,7 +315,8 @@ VALUES (
   'minio',
   ARRAY['*'],
   'app',
-  'fa22fa22-a3a3-4b4b-c5c5-d6d6d6d6d6d7'
+  'fa22fa22-a3a3-4b4b-c5c5-d6d6d6d6d6d7',
+  true
 ) ON CONFLICT (id) DO NOTHING;
 
 -- =====================================================


### PR DESCRIPTION
## Summary

The upload plugin was the last place still hand-writing an INSERT into a storage `files` table, so it was also the last place with its own opinion about who a file belongs to. Both upload lanes now go through the storage plane's generated recorder (`<private_schema>.<files>_record_file`, shipped by constructive-db #3510/#3513), which means the database decides ownership and visibility and the plugin decides nothing:

```diff
-const columns = ['bucket_id','key','content_hash','mime_type','size','filename','is_public'];
-if (storageConfig.entityTableId !== null) { columns.push('owner_id'); values.push(bucket.owner_id); }
-if (previousVersionId) { ... }  if (derivedPath) { ... }
-INSERT INTO <files> (…) VALUES (…) RETURNING id
+const fileId = await recordManagedFile(txClient, storageConfig, { bucketId, key, contentHash, … });
+//   -> SELECT id FROM <priv>.<files>_record_file(bucket_id := $1::uuid, key := $2::text, …)
```

`is_public` and `owner_id` are gone from the caller entirely: the generated files table has a `BEFORE INSERT` inheritance trigger that copies them (plus the scope key) from the bucket, so passing them was a second source for a fact the database already owns.

There is deliberately **no direct-insert fallback**. A tagged storage plane that exposes no recorder fails with `STORAGE_RECORDER_MISSING` naming the module, rather than silently taking a second creation path that would work fine and therefore never get fixed.

Two related capability mismatches now also fail loudly instead of silently. `plugin.ts` computes a `previousVersionId` for *any* custom-key plane, independent of the module's `has_versioning` — so gating the recorder argument on `has_versioning` would have dropped the version chain while still returning that `previousVersionId` to the client. `STORAGE_VERSIONING_UNSUPPORTED` / `STORAGE_PATH_SHARES_UNSUPPORTED` are raised before any query instead.

Everything the callers legitimately own is untouched: content-hash and custom-key dedup, custom-key versioning, stale `requested`-row deletion (lifecycle cleanup, still a direct DELETE), the staged S3 copy/promotion and its cleanup on failure, presigned PUT generation, and the returned projection.

### Resolving the recorder

`storage-module-cache.ts` resolves it from the module row, joining `private_schema_id` → `metaschema_public.schema.schema_name` for the **physical** schema name — the `private_schema_name` column holds the logical name (`storage_private`) while the schema is prefixed (`constructive_storage_private`), so it is not usable here. `has_versioning` is selected for the same reason `has_path_shares` already was.

### Fixtures

The two hand-authored storage planes in `graphql/server-test/__fixtures__` are tagged storage planes exercising real uploads, so they now supply their own `SECURITY INVOKER` recorder in a private schema and register that schema as the module's `private_schema_id` — the part that makes a hand-rolled plane well-formed rather than half-declared. Their table shape is unchanged (no `owner_id` on buckets: that attribute is what the registry uses to classify a plane as entity-keyed).


Link to Devin session: https://app.devin.ai/sessions/967dd6f667004819ae392597f090a3cd
Open in Devin Desktop: https://app.devin.ai/desktop/session/967dd6f667004819ae392597f090a3cd?variant=devin
Requested by: @pyramation