### PR TITLE
feat(bucket-provisioner): name a bucket from its own identity, and allow no browser origin

### DIFF
--- a/packages/bucket-provisioner/README.md
+++ b/packages/bucket-provisioner/README.md
@@ -152,7 +152,7 @@ The main class that orchestrates bucket creation and configuration.
 | `connection.accessKeyId` | `string` | AWS access key ID |
 | `connection.secretAccessKey` | `string` | AWS secret access key |
 | `connection.forcePathStyle` | `boolean?` | Force path-style URLs (auto-detected per provider) |
-| `allowedOrigins` | `string[]` | Domains allowed for CORS (e.g., `['https://app.example.com']`) |
+| `allowedOrigins` | `string[]?` | Domains allowed for CORS (e.g., `['https://app.example.com']`). Empty or omitted means no browser origin may reach these buckets, and they are provisioned with no CORS rule set at all. |
 
 #### `provisioner.provision(options): Promise<ProvisionResult>`
 
@@ -161,7 +161,7 @@ Creates and configures a bucket. Steps:
 1. Creates the bucket (or verifies it exists)
 2. Configures Block Public Access
 3. Applies bucket policy (public-read or none)
-4. Sets CORS rules for presigned URL uploads
+4. Sets CORS rules for presigned URL uploads (skipped when no origins are allowed)
 5. Optionally enables versioning
 6. Adds lifecycle rules for temp buckets
 
@@ -172,6 +172,7 @@ Creates and configures a bucket. Steps:
 | `region` | `string?` | Override region for this bucket |
 | `versioning` | `boolean?` | Enable S3 versioning (default: `false`) |
 | `publicUrlPrefix` | `string?` | CDN/public URL for public buckets |
+| `allowedOrigins` | `string[]?` | Per-bucket CORS origins, overriding the constructor's |
 
 #### `provisioner.inspect(bucketName, accessType): Promise<ProvisionResult>`
 
@@ -184,6 +185,21 @@ Returns the underlying `@aws-sdk/client-s3` S3Client for advanced operations.
 #### `provisioner.bucketExists(bucketName): Promise<boolean>`
 
 Checks if a bucket exists and is accessible.
+
+### Naming
+
+#### `physicalBucketName({ scope, databaseId, bucketKey })`
+
+The physical name a platform-provisioned bucket gets from its own identity:
+`{scope}-{database label}-{bucketKey}-{digest}`. Takes no prefix — a bucket
+belongs to one database at one scope, and there is no global bucket namespace to
+prefix into. Each readable component has its own budget, so a long scope cannot
+crowd out the database label, and the digest covers the untruncated identity.
+
+#### `mintPhysicalBucketName(prefix, databaseId, bucketKey)`
+
+The prefixed policy — `{prefix}-{bucketKey}-{digest}` — for a deployment that
+names its own bucket namespace.
 
 ### Policy Builders
 

--- a/packages/bucket-provisioner/__tests__/naming.test.ts
+++ b/packages/bucket-provisioner/__tests__/naming.test.ts
@@ -1,4 +1,4 @@
-import { mintPhysicalBucketName } from '../src/naming';
+import { mintPhysicalBucketName, physicalBucketName } from '../src/naming';
 
 const PREFIX = 'test-bucket';
 const DATABASE_ID = '80a2eaaf-f77e-4bfe-8506-df929ef1b8d9';
@@ -50,6 +50,81 @@ describe('mintPhysicalBucketName', () => {
 
   it('falls back to the digest alone when both components sanitize away', () => {
     const name = mintPhysicalBucketName('!!!', DATABASE_ID, '???');
+
+    expect(name).toMatch(/^[a-f0-9]{12}$/);
+  });
+});
+
+describe('physicalBucketName', () => {
+  const identity = {
+    scope: 'database',
+    databaseId: DATABASE_ID,
+    bucketKey: 'build-logs',
+  };
+
+  it('names the scope, the database and the key', () => {
+    expect(physicalBucketName(identity)).toMatch(
+      /^database-80a2eaaf-build-logs-[a-f0-9]{12}$/,
+    );
+  });
+
+  it('is stable for a given identity', () => {
+    expect(physicalBucketName(identity)).toBe(physicalBucketName(identity));
+  });
+
+  it('keeps the database label when the scope overruns its budget', () => {
+    const name = physicalBucketName({
+      ...identity,
+      scope: 'some-extremely-long-entity-scope-name',
+    });
+
+    expect(name).toContain('80a2eaaf');
+    expect(name).toContain('build-logs');
+    expect(name).toMatch(BUCKET_NAME);
+  });
+
+  it('separates scopes whose readable labels truncate to the same thing', () => {
+    const first = physicalBucketName({
+      ...identity,
+      scope: 'organization-alpha-tier',
+    });
+    const second = physicalBucketName({
+      ...identity,
+      scope: 'organization-beta-tier',
+    });
+
+    expect(first).not.toBe(second);
+  });
+
+  it('separates the same key across databases and across keys', () => {
+    expect(physicalBucketName(identity)).not.toBe(
+      physicalBucketName({
+        ...identity,
+        databaseId: '11111111-2222-3333-4444-555555555555',
+      }),
+    );
+    expect(physicalBucketName(identity)).not.toBe(
+      physicalBucketName({ ...identity, bucketKey: 'assets' }),
+    );
+  });
+
+  it('always returns a bounded S3 bucket name without edge hyphens', () => {
+    const name = physicalBucketName({
+      scope: 'Some Very.Long_Entity Scope',
+      databaseId: DATABASE_ID,
+      bucketKey: 'Marketing_Site/Assets — 2024'.repeat(5),
+    });
+
+    expect(name).toMatch(BUCKET_NAME);
+    expect(name).not.toMatch(/^-|-$/);
+  });
+
+  it('stays legal when every readable component sanitizes away', () => {
+    const name = physicalBucketName({
+      scope: '!!!',
+      databaseId: '???',
+      bucketKey: '***',
+    });
 
     expect(name).toMatch(/^[a-f0-9]{12}$/);
   });

--- a/packages/bucket-provisioner/__tests__/provisioner.test.ts
+++ b/packages/bucket-provisioner/__tests__/provisioner.test.ts
@@ -46,13 +46,13 @@ describe('BucketProvisioner constructor', () => {
     expect(provisioner).toBeInstanceOf(BucketProvisioner);
   });
 
-  it('throws on empty allowedOrigins', () => {
+  it('accepts no allowed origins, for buckets no browser reaches', () => {
     expect(
       () => new BucketProvisioner({ ...defaultOptions, allowedOrigins: [] }),
-    ).toThrow(ProvisionerError);
+    ).not.toThrow();
     expect(
-      () => new BucketProvisioner({ ...defaultOptions, allowedOrigins: [] }),
-    ).toThrow('allowedOrigins must contain at least one origin');
+      () => new BucketProvisioner({ connection: defaultOptions.connection }),
+    ).not.toThrow();
   });
 
   it('exposes S3Client via getClient()', () => {
@@ -118,6 +118,65 @@ describe('BucketProvisioner.provision — private bucket', () => {
       (call: any[]) => call[0].constructor.name === 'DeleteBucketPolicyCommand',
     );
     expect(deletePolicyCall).toBeDefined();
+  });
+});
+
+describe('BucketProvisioner.provision — no browser origins', () => {
+  it('writes no CORS rule set for a bucket nothing browses', async () => {
+    const provisioner = new BucketProvisioner({
+      connection: defaultOptions.connection,
+      allowedOrigins: [],
+    });
+    const result = await provisioner.provision({
+      bucketName: 'test-build-logs',
+      accessType: 'private',
+    });
+
+    expect(result.corsRules).toEqual([]);
+    const commandNames = mockSend.mock.calls.map(
+      (call: any[]) => call[0].constructor.name,
+    );
+    expect(commandNames).toEqual([
+      'CreateBucketCommand',
+      'PutPublicAccessBlockCommand',
+      'DeleteBucketPolicyCommand',
+    ]);
+  });
+
+  it('still applies the lifecycle rule a temp bucket needs', async () => {
+    const provisioner = new BucketProvisioner({
+      connection: defaultOptions.connection,
+    });
+    const result = await provisioner.provision({
+      bucketName: 'test-temp-unbrowsed',
+      accessType: 'temp',
+    });
+
+    expect(result.corsRules).toEqual([]);
+    expect(result.lifecycleRules).toHaveLength(1);
+    const commandNames = mockSend.mock.calls.map(
+      (call: any[]) => call[0].constructor.name,
+    );
+    expect(commandNames).toContain('PutBucketLifecycleConfigurationCommand');
+    expect(commandNames).not.toContain('PutBucketCorsCommand');
+  });
+
+  it('honours a per-bucket origin even when the default is empty', async () => {
+    const provisioner = new BucketProvisioner({
+      connection: defaultOptions.connection,
+      allowedOrigins: [],
+    });
+    const result = await provisioner.provision({
+      bucketName: 'test-browsed',
+      accessType: 'private',
+      allowedOrigins: ['https://app.example.com'],
+    });
+
+    expect(result.corsRules).toHaveLength(1);
+    const commandNames = mockSend.mock.calls.map(
+      (call: any[]) => call[0].constructor.name,
+    );
+    expect(commandNames).toContain('PutBucketCorsCommand');
   });
 });
 

--- a/packages/bucket-provisioner/src/index.ts
+++ b/packages/bucket-provisioner/src/index.ts
@@ -32,7 +32,8 @@ export type { BucketProvisionerOptions } from './provisioner';
 export { BucketProvisioner } from './provisioner';
 
 // Physical naming policy
-export { mintPhysicalBucketName } from './naming';
+export type { PhysicalBucketIdentity } from './naming';
+export { mintPhysicalBucketName, physicalBucketName } from './naming';
 
 // S3 client factory
 export { createS3Client } from './client';

--- a/packages/bucket-provisioner/src/naming.ts
+++ b/packages/bucket-provisioner/src/naming.ts
@@ -11,6 +11,37 @@ const PREFIX_BUDGET = 20;
 const BUCKET_KEY_BUDGET = 63 - IDENTITY_DIGEST_LENGTH - PREFIX_BUDGET - 3;
 
 /**
+ * Readable budgets for a name minted from a bucket's own identity.
+ *
+ * Each component gets its own budget rather than sharing one prefix budget, so
+ * a long scope cannot eat the database label (or the label the key) — every
+ * component keeps the room it was given, and the digest below covers whatever
+ * truncation drops.
+ */
+const SCOPE_BUDGET = 12;
+/**
+ * How many characters of the owning database's id the readable head carries:
+ * the first group of a UUID, enough to recognise a tenant in a bucket listing.
+ */
+const DATABASE_LABEL_LENGTH = 8;
+const IDENTITY_KEY_BUDGET =
+  MAX_BUCKET_NAME_LENGTH -
+  IDENTITY_DIGEST_LENGTH -
+  SCOPE_BUDGET -
+  DATABASE_LABEL_LENGTH -
+  3;
+
+/** What a physical bucket name is derived from: the bucket row's own identity. */
+export interface PhysicalBucketIdentity {
+  /** The scope the bucket row lives at (`platform`, `database`, an entity scope). */
+  scope: string;
+  /** The database that owns the bucket row. */
+  databaseId: string;
+  /** The bucket's logical key, as declared on the row. */
+  bucketKey: string;
+}
+
+/**
  * Reduce a component to the S3 bucket-name alphabet: lowercase, `[a-z0-9-]`,
  * with runs of separators collapsed and no leading or trailing hyphen.
  *
@@ -25,39 +56,89 @@ function sanitizeBucketNameComponent(value: string): string {
     .replace(/^-+|-+$/g, '');
 }
 
+/** A readable component: sanitized, truncated to its own budget, hyphen-free at the edges. */
+function readableComponent(value: string, budget: number): string {
+  return sanitizeBucketNameComponent(value).slice(0, budget).replace(/-+$/, '');
+}
+
 /**
- * The single physical-bucket naming policy:
- * `{prefix}-{bucketKey}-{digest}` (e.g. `myapp-public-3f9c1a2b7e04`).
+ * Assemble a bounded, S3-legal name from readable components and the untruncated
+ * identity they were derived from.
  *
- * Both the presigned-upload (lazy) path and the bucket-provisioner (eager) path
- * derive names from this one function, so a bucket's physical name is identical
- * regardless of which path mints it.
- *
- * The name is bounded and S3-legal by construction: the prefix and key are
- * sanitized to `[a-z0-9-]` and truncated to a readable budget, and the tail is
- * a digest of the *untruncated* identity — so two buckets whose keys agree only
- * past the truncation point, or the same key in two databases, still get distinct
- * names. Names remain stable for a given (prefix, databaseId, bucketKey) because
- * nothing here reads the clock or a counter; and an already-provisioned bucket
- * never consults this function at all, since `platform_buckets.physical_name` is
- * authoritative once recorded.
+ * The digest is taken over the identity rather than over what survived
+ * truncation, so two buckets whose components agree only past their budgets
+ * still get distinct names. Nothing here reads the clock or a counter, so a
+ * given identity always mints the same name.
  */
-export function mintPhysicalBucketName(prefix: string, databaseId: string, bucketKey: string): string {
-  const identity = `${prefix}/${databaseId}/${bucketKey}`;
-  const digest = createHash('sha256').update(identity).digest('hex').slice(0, IDENTITY_DIGEST_LENGTH);
+function assembleBucketName(
+  readable: readonly string[],
+  identity: string,
+  describeIdentity: string
+): string {
+  const digest = createHash('sha256')
+    .update(identity)
+    .digest('hex')
+    .slice(0, IDENTITY_DIGEST_LENGTH);
 
-  const safePrefix = sanitizeBucketNameComponent(prefix).slice(0, PREFIX_BUDGET).replace(/-+$/, '');
-  const safeKey = sanitizeBucketNameComponent(bucketKey).slice(0, BUCKET_KEY_BUDGET).replace(/-+$/, '');
-
-  const name = [safePrefix, safeKey, digest].filter((part) => part.length > 0).join('-');
+  const name = [...readable, digest].filter((part) => part.length > 0).join('-');
 
   // The digest alone already satisfies both bounds, so this is only reachable
-  // when both readable components sanitize away to nothing.
+  // when every readable component sanitizes away to nothing.
   if (name.length < MIN_BUCKET_NAME_LENGTH || name.length > MAX_BUCKET_NAME_LENGTH) {
     throw new Error(
-      `[bucket-provisioner] Cannot mint a legal S3 bucket name for key "${bucketKey}": got "${name}"`,
+      `[bucket-provisioner] Cannot mint a legal S3 bucket name for ${describeIdentity}: got "${name}"`,
     );
   }
 
   return name;
+}
+
+/**
+ * The physical name a bucket gets from its own identity:
+ * `{scope}-{database label}-{bucketKey}-{digest}`
+ * (e.g. `database-028752cb-buildlogs-3f9c1a2b7e04`).
+ *
+ * This is the policy for a platform-provisioned bucket, and it takes no prefix
+ * because there is no global bucket namespace to prefix into: a bucket belongs
+ * to one database at one scope, and that is what its name should say. Callers
+ * derive names from here rather than composing a prefix of their own, so the
+ * policy can change in one place — and an already-provisioned bucket never
+ * consults it at all, since the row's recorded `physical_name` is authoritative.
+ *
+ * The scope is part of the digested identity untruncated, so two scopes of one
+ * database that declare the same bucket key stay distinct even when their
+ * readable labels truncate to the same thing.
+ */
+export function physicalBucketName(identity: PhysicalBucketIdentity): string {
+  const { scope, databaseId, bucketKey } = identity;
+  return assembleBucketName(
+    [
+      readableComponent(scope, SCOPE_BUDGET),
+      readableComponent(databaseId, DATABASE_LABEL_LENGTH),
+      readableComponent(bucketKey, IDENTITY_KEY_BUDGET),
+    ],
+    `${scope}/${databaseId}/${bucketKey}`,
+    `key "${bucketKey}" at scope "${scope}"`,
+  );
+}
+
+/**
+ * The prefixed physical-bucket naming policy:
+ * `{prefix}-{bucketKey}-{digest}` (e.g. `myapp-public-3f9c1a2b7e04`).
+ *
+ * For a deployment that names its own bucket namespace — a single-app
+ * installation, or the presigned-upload (lazy) path meeting a bucket an app
+ * configured. A platform-provisioned bucket uses {@link physicalBucketName}
+ * instead, whose components come from the bucket row rather than from
+ * deployment config.
+ */
+export function mintPhysicalBucketName(prefix: string, databaseId: string, bucketKey: string): string {
+  return assembleBucketName(
+    [
+      readableComponent(prefix, PREFIX_BUDGET),
+      readableComponent(bucketKey, BUCKET_KEY_BUDGET),
+    ],
+    `${prefix}/${databaseId}/${bucketKey}`,
+    `key "${bucketKey}"`,
+  );
 }

--- a/packages/bucket-provisioner/src/provisioner.ts
+++ b/packages/bucket-provisioner/src/provisioner.ts
@@ -53,8 +53,13 @@ export interface BucketProvisionerOptions {
    * Default allowed origins for CORS rules.
    * These are the domains where your app runs (e.g., ["https://app.example.com"]).
    * Required for browser-based presigned URL uploads.
+   *
+   * Empty (or omitted) means no browser origin may reach these buckets — a
+   * build's log store, say, which only server-side code ever opens. Such a
+   * bucket is provisioned with no CORS rule set at all rather than with a
+   * fabricated origin.
    */
-  allowedOrigins: string[];
+  allowedOrigins?: string[];
 }
 
 /**
@@ -88,15 +93,8 @@ export class BucketProvisioner {
   private readonly allowedOrigins: string[];
 
   constructor(options: BucketProvisionerOptions) {
-    if (!options.allowedOrigins || options.allowedOrigins.length === 0) {
-      throw new ProvisionerError(
-        'INVALID_CONFIG',
-        'allowedOrigins must contain at least one origin for CORS configuration',
-      );
-    }
-
     this.config = options.connection;
-    this.allowedOrigins = options.allowedOrigins;
+    this.allowedOrigins = options.allowedOrigins ?? [];
     this.client = createS3Client(options.connection);
   }
 
@@ -142,12 +140,19 @@ export class BucketProvisioner {
       await this.deleteBucketPolicy(bucketName);
     }
 
-    // 4. Set CORS rules (per-bucket override takes precedence over default)
+    // 4. Set CORS rules (per-bucket override takes precedence over default).
+    // A bucket no browser origin may reach gets no rule set: cross-origin
+    // access is the bucket's own recorded data, and "none recorded" is a
+    // legitimate answer, not a missing setting to invent an origin for.
     const effectiveOrigins = options.allowedOrigins ?? this.allowedOrigins;
-    const corsRules = accessType === 'private'
-      ? buildPrivateCorsRules(effectiveOrigins)
-      : buildUploadCorsRules(effectiveOrigins);
-    await this.setCors(bucketName, corsRules);
+    const corsRules = effectiveOrigins.length === 0
+      ? []
+      : accessType === 'private'
+        ? buildPrivateCorsRules(effectiveOrigins)
+        : buildUploadCorsRules(effectiveOrigins);
+    if (corsRules.length > 0) {
+      await this.setCors(bucketName, corsRules);
+    }
 
     // 5. Versioning
     if (versioning) {


### PR DESCRIPTION
## Summary

Two gaps in `@constructive-io/bucket-provisioner` that a downstream consumer (constructive-db's reconciler, which provisions storage buckets eagerly from rows) could only work around by reimplementing the package:

**1. A bucket has an identity, not a prefix.** `mintPhysicalBucketName(prefix, databaseId, bucketKey)` assumes a deployment-wide bucket namespace to prefix into, and gives the whole prefix one 20-char budget:

```ts
const safePrefix = sanitizeBucketNameComponent(prefix).slice(0, PREFIX_BUDGET);
```

A caller with no such namespace has to smuggle its identity through the prefix (`` `${scope}-${databaseId.split('-')[0]}` ``), and then a long scope eats the budget before the database label appears — two databases at the same long scope produce the same readable text and differ only in the digest. New API, per-component budgets:

```ts
physicalBucketName({ scope, databaseId, bucketKey })
// -> database-028752cb-build-logs-3f9c1a2b7e04
```

The digest still covers the *untruncated* `${scope}/${databaseId}/${bucketKey}`, so truncation is cosmetic, never collapsing. `mintPhysicalBucketName` is unchanged for prefixed deployments (the presigned-url resolver) and now shares the assembly/validation helper.

**2. "No browser may reach this bucket" is a legal configuration.** The constructor refused it:

```ts
if (!options.allowedOrigins || options.allowedOrigins.length === 0)
  throw new ProvisionerError('INVALID_CONFIG', 'allowedOrigins must contain at least one origin…');
```

So a consumer provisioning buckets nothing in a browser touches (build logs, artifacts) had to pass a fake origin to get past the constructor and then hand-roll the create/BPA/policy/lifecycle sequence to keep the fake out of S3. `allowedOrigins` is now optional, and an empty effective list means *no CORS rule set is written at all* — every other step is unchanged:

```ts
const corsRules = effectiveOrigins.length === 0 ? [] : accessType === 'private' ? … : …;
if (corsRules.length > 0) await this.setCors(bucketName, corsRules);
```

Per-bucket `provision({ allowedOrigins })` still overrides an empty constructor default, so a bucket that *does* face a browser is configured normally.

No existing caller changes: every in-repo consumer passes a non-empty list and gets identical behavior.

## Testing

`packages/bucket-provisioner`: 129 tests pass, build and lint clean. New coverage for the per-component budgets (a long scope no longer crowds out the database label; scopes whose readable labels truncate identically still get distinct names) and for the empty-origin path (no `PutBucketCors` command is sent, `corsRules` is `[]`, temp lifecycle rules still applied, per-bucket origins still honored).


Link to Devin session: https://app.devin.ai/sessions/6953eeb0c1b041d09921b3618afbebd3
Open in Devin Desktop: https://app.devin.ai/desktop/session/6953eeb0c1b041d09921b3618afbebd3?variant=devin
Requested by: @pyramation