### PR TITLE
feat(safegres): action runs the workspace CLI and finds reports from the config

### DIFF
--- a/packages/safegres/README.md
+++ b/packages/safegres/README.md
@@ -437,10 +437,13 @@ job summary, annotations and a sticky PR comment:
 ```yaml
       - uses: constructive-io/constructive/packages/safegres@main
         with:
-          out: safegres-reports
           comment: true          # sticky PR comment (needs pull-requests: write)
           upload-sarif: true     # code scanning (needs security-events: write)
 ```
+
+Auditing a pgpm workspace (`source.pgpm`) adds `version: local`, which runs the repo's own safegres
+rather than installing one: that path deploys through `pgsql-test`, an optional peer only the
+workspace has.
 
 On a pull request it also measures the delta for you: it picks the base branch's most recent run
 that *is* a sane comparison — succeeded, younger than 48 hours, and audited a commit in this

--- a/packages/safegres/__tests__/action.test.ts
+++ b/packages/safegres/__tests__/action.test.ts
@@ -35,6 +35,26 @@ describe('action.yml', () => {
     expect(action).toContain('perf?.score?.value');
   });
 
+  it('runs the CLI the install step resolved, not a bare global binary', () => {
+    // `version: local` exists because a pgpm-workspace audit deploys through
+    // pgsql-test, an optional peer that only the workspace has; a step that
+    // calls plain `safegres` would work everywhere except there.
+    const invocations = action.match(/^ *\S.*"\$\{args\[@\]\}"/gm) ?? [];
+    expect(invocations).toHaveLength(2);
+    for (const line of invocations) expect(line).toContain('steps.install.outputs.bin');
+    expect(action).toContain('bin=npx --no-install safegres');
+  });
+
+  it('finds the reports through the resolved directory, not the `out` input', () => {
+    // The documented shape puts the directory in the config (`outputs.dir`) and
+    // passes no `out`, so anything reading a written file off `inputs.out`
+    // silently points at the working directory for exactly those callers.
+    expect(action).toContain('print-config');
+    expect(action).toContain('outputs?.dir');
+    expect(action).toContain('sarif_file: ${{ inputs.working-directory }}/${{ steps.audit.outputs.out-dir }}');
+    expect(action).not.toMatch(/inputs\.out \}\}\/safegres\./);
+  });
+
   it('never appends an argument with a bare test, which `set -e` would abort on', () => {
     expect(action).not.toMatch(/^\s*\[[^\]]*\]\s*&&\s*args\+=/m);
   });

--- a/packages/safegres/action.yml
+++ b/packages/safegres/action.yml
@@ -13,7 +13,12 @@ branding:
 # bite, and which artifacts leave the runner.
 inputs:
   version:
-    description: 'npm version of the safegres CLI to install (dist-tag or exact version).'
+    description: >-
+      npm version of the safegres CLI to install (dist-tag or exact version), or
+      `local` to run the one already in the working directory's node_modules.
+      A pgpm-workspace audit (`source.pgpm`) needs `local`: that path deploys
+      through the optional peer `pgsql-test`, which a globally installed CLI
+      cannot resolve, and the repo already pins the two together.
     required: false
     default: 'latest'
   config:
@@ -122,6 +127,9 @@ outputs:
   report:
     description: 'Path to the JSON report, when the run wrote one.'
     value: ${{ steps.audit.outputs.report }}
+  out-dir:
+    description: 'Directory the reports were written to, from `out` or the config.'
+    value: ${{ steps.audit.outputs.out-dir }}
   baseline-run-id:
     description: 'Run the delta was measured against, when `compare: auto` found one.'
     value: ${{ steps.baseline.outputs.compare-run-id }}
@@ -136,8 +144,15 @@ runs:
   using: composite
   steps:
     - name: Install safegres
+      id: install
       shell: bash
-      run: npm install -g safegres@${{ inputs.version }}
+      run: |
+        if [ "${{ inputs.version }}" = "local" ]; then
+          echo 'bin=npx --no-install safegres' >> "$GITHUB_OUTPUT"
+        else
+          npm install -g "safegres@${{ inputs.version }}"
+          echo 'bin=safegres' >> "$GITHUB_OUTPUT"
+        fi
 
     # Which report the delta is measured against — validated and logged, because
     # the usual `gh run list --limit 1` hands the audit whatever row the API
@@ -154,7 +169,7 @@ runs:
         add() { if [ -n "$2" ]; then args+=("$1" "$2"); fi; }
         add --workflow "${{ inputs.compare-workflow }}"
         add --artifact "${{ inputs.compare-artifact }}"
-        safegres "${args[@]}"
+        ${{ steps.install.outputs.bin }} "${args[@]}"
 
     - name: Audit
       id: audit
@@ -185,6 +200,8 @@ runs:
           add --compare       "${{ inputs.compare }}"
           add --compare-ref   "${{ inputs.compare-ref }}"
         fi
+        config=()
+        if [ -n "${{ inputs.config }}" ]; then config=(--config "${{ inputs.config }}"); fi
         if [ "${{ inputs.report-only }}" = "true" ]; then args+=(--report-only); fi
         if [ "${{ inputs.comment }}" = "true" ]; then args+=(--github-comment); fi
         # Unquoted on purpose: this is the verbatim-arguments escape hatch.
@@ -192,11 +209,26 @@ runs:
         # The gate's exit code is the job's, but the outputs below are worth
         # having on a failing run too — that is when someone reads them.
         status=0
-        safegres "${args[@]}" "${extra[@]}" || status=$?
+        ${{ steps.install.outputs.bin }} "${args[@]}" "${extra[@]}" || status=$?
+
+        # Where the reports landed. `out` is the override; with a config-only
+        # job (the documented shape) the directory is `outputs.dir`, and asking
+        # the resolved config for it is the only way not to make every caller
+        # repeat the path in YAML just so the SARIF upload can find the file.
+        dir="${{ inputs.out }}"
+        if [ -z "$dir" ]; then
+          dir=$(${{ steps.install.outputs.bin }} print-config "${config[@]}" 2>/dev/null | node -e '
+            let s = "";
+            process.stdin.on("data", (d) => (s += d)).on("end", () => {
+              try { console.log(JSON.parse(s).config?.outputs?.dir ?? ""); } catch { console.log(""); }
+            });
+          ')
+        fi
+        echo "out-dir=$dir" >> "$GITHUB_OUTPUT"
 
         report=""
-        if [ -n "${{ inputs.out }}" ] && [ -f "${{ inputs.out }}/safegres.json" ]; then
-          report="${{ inputs.out }}/safegres.json"
+        if [ -n "$dir" ] && [ -f "$dir/safegres.json" ]; then
+          report="$dir/safegres.json"
         fi
         if [ -n "$report" ]; then
           node -e '
@@ -214,7 +246,7 @@ runs:
         exit $status
 
     - name: Upload SARIF
-      if: ${{ inputs.upload-sarif == 'true' && always() }}
+      if: ${{ inputs.upload-sarif == 'true' && always() && steps.audit.outputs.out-dir != '' }}
       uses: github/codeql-action/upload-sarif@v3
       with:
-        sarif_file: ${{ inputs.working-directory }}/${{ inputs.out }}/safegres.sarif
+        sarif_file: ${{ inputs.working-directory }}/${{ steps.audit.outputs.out-dir }}/safegres.sarif

--- a/packages/safegres/docs/reporting.md
+++ b/packages/safegres/docs/reporting.md
@@ -143,14 +143,14 @@ audit with `--github`, and optionally posts the comment and uploads the SARIF:
 ```yaml
 - uses: constructive-io/constructive/packages/safegres@main
   with:
-    out: safegres-reports
     comment: true
     upload-sarif: true
 ```
 
 Its inputs are deliberately only the things that differ *between jobs sharing one config* —
 `database`/`pgpm` (what to audit), `fail-on-grade` and `report-only` (whether the gates bite),
-`out`/`comment`/`upload-sarif` (what leaves the runner), the `compare*` inputs ([the
+`out`/`comment`/`upload-sarif` (what leaves the runner; `out` only when the config's `outputs.dir`
+is not where this job wants them), the `compare*` inputs ([the
 delta](#the-baseline-compare-auto)), plus
 `version`, `config`, `preset`, `working-directory` and an `args` escape hatch. Everything a run
 repeats belongs in the committed config file, so the common case passes nothing at all.
@@ -164,13 +164,23 @@ is worth reading:
 ```yaml
 - uses: constructive-io/constructive/packages/safegres@main
   id: audit
-  with: { out: safegres-reports, fail-on-grade: B }
+  with: { fail-on-grade: B }
 - if: always()
   run: echo "graded ${{ steps.audit.outputs.security-grade }}"
 ```
 
 Permissions are the caller's: `pull-requests: write` for `comment`, `security-events: write` for
 `upload-sarif`, `actions: read` for the default `compare: auto` baseline lookup.
+
+`version` installs the CLI globally (a dist-tag or an exact version), with one exception:
+`version: local` runs the safegres already in `working-directory`'s `node_modules`. A `source.pgpm`
+audit needs that — deploying the workspace goes through `pgsql-test`, an optional peer a global
+install does not resolve, and a repo auditing its own module already pins the pair in its lockfile.
+The rest of the run is identical.
+
+The SARIF upload and the `report`/`out-dir` outputs read the directory the reports were actually
+written to: `out` when it is given, otherwise the resolved config's `outputs.dir` (the action asks
+`safegres print-config`), so a config-only job does not have to repeat the path in YAML.
 
 ## What changed (`--compare`)
 


### PR DESCRIPTION
## Summary

Two things the action got wrong for the first repo to actually adopt it (constructive-db, `source.pgpm: application/app`):

**1. A globally installed CLI cannot audit a pgpm workspace.** `--pgpm` deploys through `pgsql-test`, an *optional peer*, which `npm i -g safegres` does not resolve:

```
--pgpm requires the optional peer dependency "pgsql-test" — install it (e.g. `npm i -D pgsql-test`) and retry
```

The repo doing the audit already pins both in its lockfile, so `version: local` runs that one instead:

```yaml
- run: |
    if [ "${{ inputs.version }}" = "local" ]; then echo 'bin=npx --no-install safegres' >> "$GITHUB_OUTPUT"
    else npm install -g "safegres@${{ inputs.version }}"; echo 'bin=safegres' >> "$GITHUB_OUTPUT"; fi
```

Both invocations (`baseline`, `audit`) now go through `steps.install.outputs.bin`; a test pins that so a third one cannot regress to a bare `safegres`.

**2. The SARIF upload read `inputs.out`, which the documented shape never sets.** The whole point is that the directory lives in the config (`outputs.dir`), so a config-only job uploaded `./safegres.sarif` — a path that does not exist — and exported an empty `report`. The action now resolves the directory it actually wrote to and exposes it:

```diff
-report="${{ inputs.out }}/safegres.json"
+dir="${{ inputs.out }}"
+[ -z "$dir" ] && dir=$(<bin> print-config [--config …] | node -e '… JSON.parse(s).config?.outputs?.dir …')
+echo "out-dir=$dir" >> "$GITHUB_OUTPUT"
-  sarif_file: …/${{ inputs.out }}/safegres.sarif
+  sarif_file: …/${{ steps.audit.outputs.out-dir }}/safegres.sarif
```

`out-dir` is a new output; the SARIF step is additionally gated on it being non-empty, so a crashed audit skips the upload rather than failing on a bogus path. Docs/README examples drop the now-redundant `out: safegres-reports`.

## Testing

`__tests__/action.test.ts` (5 tests, passing): the new case asserts the SARIF path and the report lookup go through the resolved directory, and that no `inputs.out`-derived file path survives.


Link to Devin session: https://app.devin.ai/sessions/82689f1e86b344cd9c75553b50c6a235
Open in Devin Desktop: https://app.devin.ai/desktop/session/82689f1e86b344cd9c75553b50c6a235?variant=devin
Requested by: @pyramation