### PR TITLE
Enforce per-request protection bounds from database/api settings

### DIFF
--- a/graphql/server/src/middleware/__tests__/request-protection.test.ts
+++ b/graphql/server/src/middleware/__tests__/request-protection.test.ts
@@ -1,0 +1,129 @@
+import type { RequestProtection } from '@constructive-io/express-context';
+import { DEFAULT_REQUEST_PROTECTION } from '@constructive-io/express-context';
+import type { NextFunction, Request, Response } from 'express';
+
+import { createRequestProtectionMiddleware } from '../request-protection';
+
+interface Captured {
+  status?: number;
+  body?: any;
+}
+
+const fakeRes = (captured: Captured): Response =>
+  ({
+    status(code: number) {
+      captured.status = code;
+      return this;
+    },
+    json(body: unknown) {
+      captured.body = body;
+      return this;
+    }
+  }) as unknown as Response;
+
+const fakeReq = (
+  headers: Record<string, string>,
+  useModule?: jest.Mock
+): Request =>
+  ({
+    get: (name: string) => headers[name.toLowerCase()],
+    constructive: useModule ? { useModule } : undefined
+  }) as unknown as Request;
+
+const run = async (req: Request) => {
+  const captured: Captured = {};
+  const next = jest.fn() as unknown as NextFunction;
+  await createRequestProtectionMiddleware()(req, fakeRes(captured), next);
+  return { captured, next: next as unknown as jest.Mock };
+};
+
+const protection = (overrides: Partial<RequestProtection>): RequestProtection => ({
+  ...DEFAULT_REQUEST_PROTECTION,
+  ...overrides
+});
+
+describe('createRequestProtectionMiddleware', () => {
+  it('attaches the tenant-resolved bounds to the request', async () => {
+    const resolved = protection({ statementTimeoutMs: 3_000 });
+    const req = fakeReq({}, jest.fn().mockResolvedValue(resolved));
+
+    const { next } = await run(req);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.requestProtection).toBe(resolved);
+  });
+
+  it('falls back to the platform defaults when the database has no settings row', async () => {
+    const req = fakeReq({}, jest.fn().mockResolvedValue(undefined));
+
+    await run(req);
+
+    expect(req.requestProtection).toEqual(DEFAULT_REQUEST_PROTECTION);
+  });
+
+  it('falls back to the platform defaults rather than opening the gate on a lookup failure', async () => {
+    const req = fakeReq({}, jest.fn().mockRejectedValue(new Error('routing pool down')));
+
+    const { next } = await run(req);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.requestProtection).toEqual(DEFAULT_REQUEST_PROTECTION);
+  });
+
+  it('still bounds a request that arrived without a resolved context', async () => {
+    const req = fakeReq({});
+
+    await run(req);
+
+    expect(req.requestProtection).toEqual(DEFAULT_REQUEST_PROTECTION);
+  });
+
+  it('rejects a body larger than the tenant allows', async () => {
+    const req = fakeReq(
+      { 'content-length': '5000', 'content-type': 'application/json' },
+      jest.fn().mockResolvedValue(protection({ maxRequestBytes: 2_000 }))
+    );
+
+    const { captured, next } = await run(req);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(captured.status).toBe(200);
+    expect(captured.body.errors[0].extensions).toMatchObject({
+      code: 'REQUEST_TOO_LARGE',
+      context: { bytes: 5000, limit: 2000 }
+    });
+  });
+
+  it('accepts a body at the limit', async () => {
+    const req = fakeReq(
+      { 'content-length': '2000', 'content-type': 'application/json' },
+      jest.fn().mockResolvedValue(protection({ maxRequestBytes: 2_000 }))
+    );
+
+    const { next } = await run(req);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('exempts multipart uploads, whose bodies are files bounded by the upload limits', async () => {
+    const req = fakeReq(
+      {
+        'content-length': '50000000',
+        'content-type': 'multipart/form-data; boundary=----x'
+      },
+      jest.fn().mockResolvedValue(protection({ maxRequestBytes: 2_000 }))
+    );
+
+    const { next } = await run(req);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('does not reject a request that declared no length', async () => {
+    const req = fakeReq({}, jest.fn().mockResolvedValue(protection({ maxRequestBytes: 2_000 })));
+
+    const { next } = await run(req);
+
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/graphql/server/src/middleware/__tests__/request-protection.test.ts
+++ b/graphql/server/src/middleware/__tests__/request-protection.test.ts
@@ -61,13 +61,16 @@ describe('createRequestProtectionMiddleware', () => {
     expect(req.requestProtection).toEqual(DEFAULT_REQUEST_PROTECTION);
   });
 
-  it('falls back to the platform defaults rather than opening the gate on a lookup failure', async () => {
-    const req = fakeReq({}, jest.fn().mockRejectedValue(new Error('routing pool down')));
+  it('fails the request when the bounds cannot be looked up', async () => {
+    // Serving on defaults would hide a broken routing plane behind numbers
+    // nobody chose, so the failure is surfaced instead.
+    const failure = new Error('routing pool down');
+    const req = fakeReq({}, jest.fn().mockRejectedValue(failure));
 
     const { next } = await run(req);
 
-    expect(next).toHaveBeenCalled();
-    expect(req.requestProtection).toEqual(DEFAULT_REQUEST_PROTECTION);
+    expect(next).toHaveBeenCalledWith(failure);
+    expect(req.requestProtection).toBeUndefined();
   });
 
   it('still bounds a request that arrived without a resolved context', async () => {

--- a/graphql/server/src/middleware/graphile.ts
+++ b/graphql/server/src/middleware/graphile.ts
@@ -4,6 +4,7 @@ import crypto from 'node:crypto';
 
 import { classify, type ErrorContext, errors, parse } from '@constructive-io/errors';
 import type { ComputeConfig } from '@constructive-io/express-context';
+import { DEFAULT_REQUEST_PROTECTION, protectionPgSettings } from '@constructive-io/express-context';
 import type { ConstructiveOptions } from '@constructive-io/graphql-types';
 import { getNodeEnv } from '@pgpmjs/env';
 import { Logger } from '@pgpmjs/logger';
@@ -20,6 +21,7 @@ import { isGraphqlObservabilityEnabled } from '../diagnostics/observability';
 import { HandlerCreationError } from '../errors/api-errors';
 import { respondWithGraphQLError } from '../errors/graphql-response';
 import { AuthCookiePlugin } from '../plugins/auth-cookie-plugin';
+import { RequestProtectionPlugin } from '../plugins/request-protection-plugin';
 import type { DatabaseSettings } from '../types';
 import { observeGraphileBuild } from './observability/graphile-build-stats';
 
@@ -173,6 +175,7 @@ const buildPreset = (
     extends: [createConstructivePreset(databaseSettings)],
     plugins: [
       AuthCookiePlugin,
+      RequestProtectionPlugin,
       // Only registered when the compute module is provisioned for this
       // database — all schema/table names come from the constructive
       // metaschema (express-context compute module loader); the plugin has
@@ -213,6 +216,12 @@ const buildPreset = (
         const req = (requestContext as { expressv4?: { req?: Request } })?.expressv4?.req;
         const context: Record<string, string> = {};
 
+        // Timeouts travel with the transaction as GUCs, so they bound the work
+        // this request can do inside PostgreSQL whatever the plan turns out to
+        // be. Resolved per request (not baked into the cached preset) so a
+        // tenant lowering a timeout takes effect on the next request.
+        const timeouts = protectionPgSettings(req?.requestProtection ?? DEFAULT_REQUEST_PROTECTION);
+
         if (req) {
           if (req.databaseId) {
             context['jwt.claims.database_id'] = req.databaseId;
@@ -239,6 +248,7 @@ const buildPreset = (
 
           if (req.token?.user_id) {
             const pgSettings: Record<string, string> = {
+              ...timeouts,
               role: roleName,
               'jwt.claims.token_id': req.token.id,
               'jwt.claims.user_id': req.token.user_id,
@@ -283,6 +293,7 @@ const buildPreset = (
           const headerActorId = req.get('X-Actor-Id');
           if (req.api?.isPublic === false && headerActorId) {
             const pgSettings: Record<string, string> = {
+              ...timeouts,
               role: roleName,
               'jwt.claims.user_id': headerActorId,
               'jwt.claims.principal_id': headerActorId,
@@ -304,6 +315,7 @@ const buildPreset = (
         }
 
         const anonSettings: Record<string, string> = {
+          ...timeouts,
           role: anonRole,
           ...context
         };

--- a/graphql/server/src/middleware/request-protection.ts
+++ b/graphql/server/src/middleware/request-protection.ts
@@ -1,0 +1,76 @@
+import './types'; // for Request type
+
+import { errors } from '@constructive-io/errors';
+import type { RequestProtection } from '@constructive-io/express-context';
+import { DEFAULT_REQUEST_PROTECTION } from '@constructive-io/express-context';
+import { Logger } from '@pgpmjs/logger';
+import type { NextFunction, Request, RequestHandler, Response } from 'express';
+
+import { respondWithGraphQLError } from '../errors/graphql-response';
+
+const log = new Logger('request-protection');
+
+/**
+ * Resolve the bounds this request runs under and attach them to it.
+ *
+ * The values come from the tenant's own `database_settings`/`api_settings`
+ * (clamped by the platform), read through the cached loader, so the cost is one
+ * routing-plane query per database/API per TTL window. A database with no
+ * settings row — or a request that arrived before the context middleware could
+ * resolve one — still gets the platform defaults, never "unlimited".
+ */
+const resolveProtection = async (req: Request): Promise<RequestProtection> => {
+  const resolved = await req.constructive?.useModule('requestProtection');
+  return resolved ?? DEFAULT_REQUEST_PROTECTION;
+};
+
+/**
+ * Multipart requests carry file bodies, which are streamed by the upload
+ * plugin and bounded by the upload limits rather than by the GraphQL request
+ * size: applying a JSON-sized cap to them would reject every upload.
+ */
+const isMultipart = (req: Request): boolean =>
+  (req.get('content-type') ?? '').toLowerCase().startsWith('multipart/form-data');
+
+/**
+ * Express middleware that resolves request protection and enforces the one
+ * bound that has to be checked before the body is read.
+ *
+ * The document bounds (depth, cost, page size, introspection) are enforced by
+ * `RequestProtectionPlugin` inside grafast, which is where the parsed document
+ * and coerced variables exist; this middleware exists so the resolved values
+ * are on the request by the time either that plugin or the pgSettings builder
+ * asks for them.
+ *
+ * Mount after the context middleware and before the GraphQL handler.
+ */
+export const createRequestProtectionMiddleware = (): RequestHandler => {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    let protection: RequestProtection;
+    try {
+      protection = await resolveProtection(req);
+    } catch (e: any) {
+      // A settings lookup failure must not open the gate: fall back to the
+      // platform defaults and say so, rather than serving the request unbounded.
+      log.warn(`Failed to resolve request protection, using platform defaults: ${e?.message ?? e}`);
+      protection = DEFAULT_REQUEST_PROTECTION;
+    }
+
+    req.requestProtection = protection;
+
+    const declaredLength = Number(req.get('content-length') ?? '');
+    if (
+      Number.isFinite(declaredLength) &&
+      declaredLength > protection.maxRequestBytes &&
+      !isMultipart(req)
+    ) {
+      respondWithGraphQLError(
+        res,
+        errors.REQUEST_TOO_LARGE({ bytes: declaredLength, limit: protection.maxRequestBytes })
+      );
+      return;
+    }
+
+    next();
+  };
+};

--- a/graphql/server/src/middleware/request-protection.ts
+++ b/graphql/server/src/middleware/request-protection.ts
@@ -3,12 +3,9 @@ import './types'; // for Request type
 import { errors } from '@constructive-io/errors';
 import type { RequestProtection } from '@constructive-io/express-context';
 import { DEFAULT_REQUEST_PROTECTION } from '@constructive-io/express-context';
-import { Logger } from '@pgpmjs/logger';
 import type { NextFunction, Request, RequestHandler, Response } from 'express';
 
 import { respondWithGraphQLError } from '../errors/graphql-response';
-
-const log = new Logger('request-protection');
 
 /**
  * Resolve the bounds this request runs under and attach them to it.
@@ -46,14 +43,15 @@ const isMultipart = (req: Request): boolean =>
  */
 export const createRequestProtectionMiddleware = (): RequestHandler => {
   return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    // A lookup failure is neither "unlimited" nor "the defaults": the request
+    // has no known bounds, so it is handed to the error handler rather than
+    // served under numbers nobody chose.
     let protection: RequestProtection;
     try {
       protection = await resolveProtection(req);
-    } catch (e: any) {
-      // A settings lookup failure must not open the gate: fall back to the
-      // platform defaults and say so, rather than serving the request unbounded.
-      log.warn(`Failed to resolve request protection, using platform defaults: ${e?.message ?? e}`);
-      protection = DEFAULT_REQUEST_PROTECTION;
+    } catch (e) {
+      next(e);
+      return;
     }
 
     req.requestProtection = protection;

--- a/graphql/server/src/middleware/types.ts
+++ b/graphql/server/src/middleware/types.ts
@@ -1,3 +1,5 @@
+import type { RequestProtection } from '@constructive-io/express-context';
+
 import type { ApiStructure } from '../types';
 
 export type ConstructiveAPIToken = {
@@ -21,6 +23,12 @@ declare global {
       token?: ConstructiveAPIToken;
       /** Device token from constructive_device_token cookie for trusted device tracking */
       deviceToken?: string;
+      /**
+       * Per-request protection bounds, resolved from the tenant's
+       * database/API settings and clamped by the platform. Set by
+       * `createRequestProtectionMiddleware`.
+       */
+      requestProtection?: RequestProtection;
     }
   }
 }

--- a/graphql/server/src/plugins/request-protection-plugin.ts
+++ b/graphql/server/src/plugins/request-protection-plugin.ts
@@ -1,0 +1,59 @@
+import '../middleware/types'; // for Request type
+
+import { DEFAULT_REQUEST_PROTECTION } from '@constructive-io/express-context';
+import type { Request } from 'express';
+import type { GraphileConfig } from 'graphile-config';
+
+import { enforceDocumentProtection } from '../protection/document-gate';
+
+/**
+ * Get the Express request from a grafserv request context.
+ */
+const getExpressRequest = (
+  requestContext: Partial<Grafast.RequestContext> | undefined
+): Request | undefined => (requestContext as { expressv4?: { req?: Request } })?.expressv4?.req;
+
+/**
+ * RequestProtectionPlugin — applies a tenant's document bounds to every
+ * operation.
+ *
+ * The check runs in `prepareArgs` rather than `parseAndValidate` for one
+ * reason: `parseAndValidate` sees no request, so it could only enforce the
+ * bounds baked into the schema's preset at build time — and a Graphile
+ * instance is cached per API for as long as the schema is valid, so a tenant
+ * lowering a limit would not take effect until the cache turned over.
+ * `prepareArgs` carries both the request (hence the freshly resolved settings)
+ * and the coerced variables, which is also what makes `first: $n` enforceable.
+ */
+export const RequestProtectionPlugin: GraphileConfig.Plugin = {
+  name: 'RequestProtectionPlugin',
+  version: '0.0.0',
+  description:
+    'Enforces per-request query depth, cost, page size and introspection bounds resolved from database_settings/api_settings.',
+
+  grafast: {
+    middleware: {
+      prepareArgs(next, event) {
+        const { args } = event;
+        const req = getExpressRequest(args.requestContext);
+
+        // No resolved settings means the protection middleware did not run for
+        // this request (an embedded/test harness mounting grafserv directly);
+        // the platform defaults still apply rather than nothing at all.
+        const protection = req?.requestProtection ?? DEFAULT_REQUEST_PROTECTION;
+
+        if (args.document && args.schema) {
+          enforceDocumentProtection(
+            args.schema,
+            args.document,
+            args.variableValues,
+            protection,
+            args.operationName
+          );
+        }
+
+        return next();
+      }
+    }
+  }
+};

--- a/graphql/server/src/protection/__tests__/document-gate.test.ts
+++ b/graphql/server/src/protection/__tests__/document-gate.test.ts
@@ -1,0 +1,211 @@
+import type { RequestProtection } from '@constructive-io/express-context';
+import { DEFAULT_REQUEST_PROTECTION } from '@constructive-io/express-context';
+import { buildSchema, parse } from 'graphql';
+
+import { enforceDocumentProtection } from '../document-gate';
+
+/**
+ * A miniature Graphile-shaped schema: two connections (one nested inside the
+ * other) so cost multiplies, plus a self-referencing field so depth can be
+ * driven arbitrarily deep.
+ */
+const schema = buildSchema(/* GraphQL */ `
+  type PageInfo {
+    hasNextPage: Boolean!
+  }
+
+  type Post {
+    id: ID!
+    title: String
+    author: User
+  }
+
+  type PostsConnection {
+    nodes: [Post]
+    pageInfo: PageInfo!
+    totalCount: Int
+  }
+
+  type User {
+    id: ID!
+    name: String
+    manager: User
+    posts(first: Int, last: Int): PostsConnection
+  }
+
+  type UsersConnection {
+    nodes: [User]
+    pageInfo: PageInfo!
+  }
+
+  type Query {
+    users(first: Int, last: Int): UsersConnection
+    user(id: ID!): User
+  }
+`);
+
+const protection = (overrides: Partial<RequestProtection> = {}): RequestProtection => ({
+  ...DEFAULT_REQUEST_PROTECTION,
+  ...overrides
+});
+
+const enforce = (
+  source: string,
+  overrides: Partial<RequestProtection> = {},
+  variableValues: Record<string, unknown> = {}
+) =>
+  enforceDocumentProtection(schema, parse(source), variableValues, protection(overrides));
+
+const codeOf = (fn: () => unknown): string | undefined => {
+  try {
+    fn();
+    return undefined;
+  } catch (e: any) {
+    return e.code;
+  }
+};
+
+describe('depth', () => {
+  it('accepts an operation at the limit', () => {
+    const analysis = enforce('{ user(id: "1") { manager { name } } }', { maxQueryDepth: 3 });
+    expect(analysis.depth).toBe(3);
+  });
+
+  it('rejects an operation past the limit', () => {
+    expect(
+      codeOf(() => enforce('{ user(id: "1") { manager { manager { name } } } }', { maxQueryDepth: 3 }))
+    ).toBe('QUERY_TOO_DEEP');
+  });
+
+  it('counts depth through a fragment spread, which is where a query can hide it', () => {
+    const source = `
+      { user(id: "1") { ...deep } }
+      fragment deep on User { manager { manager { name } } }
+    `;
+    expect(codeOf(() => enforce(source, { maxQueryDepth: 3 }))).toBe('QUERY_TOO_DEEP');
+    expect(enforce(source, { maxQueryDepth: 4 }).depth).toBe(4);
+  });
+
+  it('does not charge an inline fragment as a level of its own', () => {
+    expect(enforce('{ user(id: "1") { ... on User { name } } }').depth).toBe(2);
+  });
+
+  it('does not hang on a cyclic fragment', () => {
+    const source = `
+      { user(id: "1") { ...a } }
+      fragment a on User { manager { ...a } }
+    `;
+    // Cyclic documents are rejected by GraphQL validation; the walk only has to
+    // terminate rather than diagnose them.
+    expect(() => enforce(source, { maxQueryDepth: 50 })).not.toThrow();
+  });
+});
+
+describe('page size', () => {
+  it('rejects a literal first above the limit', () => {
+    expect(codeOf(() => enforce('{ users(first: 500) { nodes { id } } }', { maxPageSize: 100 }))).toBe(
+      'PAGE_SIZE_TOO_LARGE'
+    );
+  });
+
+  it('rejects a last above the limit too', () => {
+    expect(codeOf(() => enforce('{ users(last: 500) { nodes { id } } }', { maxPageSize: 100 }))).toBe(
+      'PAGE_SIZE_TOO_LARGE'
+    );
+  });
+
+  it('rejects a page size passed through a variable', () => {
+    expect(
+      codeOf(() =>
+        enforce(
+          'query ($n: Int) { users(first: $n) { nodes { id } } }',
+          { maxPageSize: 100 },
+          { n: 500 }
+        )
+      )
+    ).toBe('PAGE_SIZE_TOO_LARGE');
+  });
+
+  it('accepts a page size at the limit', () => {
+    expect(() => enforce('{ users(first: 100) { nodes { id } } }', { maxPageSize: 100 })).not.toThrow();
+  });
+});
+
+describe('cost', () => {
+  it('charges a connection its page size', () => {
+    expect(enforce('{ users(first: 100) { nodes { id } } }').cost).toBe(100);
+  });
+
+  it('multiplies a nested connection by the one above it', () => {
+    expect(
+      enforce('{ users(first: 100) { nodes { posts(first: 50) { nodes { id } } } } }').cost
+    ).toBe(100 + 100 * 50);
+  });
+
+  it('does not charge plain fields, so a wide flat selection stays cheap', () => {
+    expect(enforce('{ user(id: "1") { id name manager { id name } } }').cost).toBe(0);
+  });
+
+  it('rejects an operation whose nesting exceeds the cost limit', () => {
+    expect(
+      codeOf(() =>
+        enforce('{ users(first: 1000) { nodes { posts(first: 1000) { nodes { id } } } } }', {
+          maxPageSize: 1_000,
+          maxQueryCost: 100_000
+        })
+      )
+    ).toBe('QUERY_TOO_COSTLY');
+  });
+
+  it('charges an unpaged connection an assumed page size rather than nothing', () => {
+    expect(enforce('{ users { nodes { id } } }').cost).toBe(100);
+  });
+});
+
+describe('introspection', () => {
+  it('rejects __schema when the tenant has introspection off', () => {
+    expect(codeOf(() => enforce('{ __schema { queryType { name } } }'))).toBe(
+      'INTROSPECTION_DISABLED'
+    );
+  });
+
+  it('rejects __type as well', () => {
+    expect(codeOf(() => enforce('{ __type(name: "User") { name } }'))).toBe(
+      'INTROSPECTION_DISABLED'
+    );
+  });
+
+  it('allows introspection when the tenant enabled it', () => {
+    expect(() =>
+      enforce('{ __schema { queryType { name } } }', { enableIntrospection: true })
+    ).not.toThrow();
+  });
+
+  it('never blocks __typename, which is not introspection of the schema', () => {
+    expect(() => enforce('{ user(id: "1") { __typename name } }')).not.toThrow();
+  });
+});
+
+describe('operation selection', () => {
+  it('measures the named operation the request will run, not the first in the document', () => {
+    const document = parse(`
+      query cheap { user(id: "1") { name } }
+      query deep { user(id: "1") { manager { manager { name } } } }
+    `);
+
+    expect(() =>
+      enforceDocumentProtection(schema, document, {}, protection({ maxQueryDepth: 3 }), 'cheap')
+    ).not.toThrow();
+    expect(() =>
+      enforceDocumentProtection(schema, document, {}, protection({ maxQueryDepth: 3 }), 'deep')
+    ).toThrow();
+  });
+
+  it('measures nothing when the document has no operation', () => {
+    const document = parse('fragment orphan on User { name }');
+    expect(enforceDocumentProtection(schema, document, {}, protection())).toEqual({
+      depth: 0,
+      cost: 0
+    });
+  });
+});

--- a/graphql/server/src/protection/__tests__/document-gate.test.ts
+++ b/graphql/server/src/protection/__tests__/document-gate.test.ts
@@ -61,7 +61,9 @@ const codeOf = (fn: () => unknown): string | undefined => {
     fn();
     return undefined;
   } catch (e: any) {
-    return e.code;
+    // The gate rejects with grafast's SafeError, which carries the registered
+    // code in `extensions` so grafserv can surface it to the client.
+    return e.extensions?.code;
   }
 };
 
@@ -164,25 +166,25 @@ describe('cost', () => {
 
 describe('introspection', () => {
   it('rejects __schema when the tenant has introspection off', () => {
-    expect(codeOf(() => enforce('{ __schema { queryType { name } } }'))).toBe(
-      'INTROSPECTION_DISABLED'
-    );
+    expect(
+      codeOf(() => enforce('{ __schema { queryType { name } } }', { enableIntrospection: false }))
+    ).toBe('INTROSPECTION_DISABLED');
   });
 
   it('rejects __type as well', () => {
-    expect(codeOf(() => enforce('{ __type(name: "User") { name } }'))).toBe(
-      'INTROSPECTION_DISABLED'
-    );
+    expect(
+      codeOf(() => enforce('{ __type(name: "User") { name } }', { enableIntrospection: false }))
+    ).toBe('INTROSPECTION_DISABLED');
   });
 
-  it('allows introspection when the tenant enabled it', () => {
-    expect(() =>
-      enforce('{ __schema { queryType { name } } }', { enableIntrospection: true })
-    ).not.toThrow();
+  it('allows introspection when the tenant has not turned it off', () => {
+    expect(() => enforce('{ __schema { queryType { name } } }')).not.toThrow();
   });
 
   it('never blocks __typename, which is not introspection of the schema', () => {
-    expect(() => enforce('{ user(id: "1") { __typename name } }')).not.toThrow();
+    expect(() =>
+      enforce('{ user(id: "1") { __typename name } }', { enableIntrospection: false })
+    ).not.toThrow();
   });
 });
 

--- a/graphql/server/src/protection/document-gate.ts
+++ b/graphql/server/src/protection/document-gate.ts
@@ -1,0 +1,223 @@
+/**
+ * Document gate — depth, cost, page size and introspection limits.
+ *
+ * A statement timeout stops a slow query; it does not stop a cheap-looking one
+ * that asks for a million rows across nested connections, because that request
+ * spends its budget in output size and memory rather than in a single statement.
+ * These bounds are therefore checked against the *document*, before any plan is
+ * executed.
+ *
+ * Cost is measured as the number of rows the operation can pull: a connection
+ * contributes its page size multiplied by the page sizes of every connection
+ * above it, so `users(first: 100) { posts(first: 100) }` costs 100 + 10,000
+ * rather than the 4 fields it looks like. A connection with no `first`/`last`
+ * is charged `ASSUMED_PAGE_SIZE`, since it is unbounded in principle.
+ *
+ * The walk is manual rather than `visitWithTypeInfo` because fragment spreads
+ * have to be followed (a document can hide its depth entirely inside
+ * fragments) and the visitor does not follow them.
+ */
+
+import { errors } from '@constructive-io/errors';
+import { ASSUMED_PAGE_SIZE, type RequestProtection } from '@constructive-io/express-context';
+import type {
+  DocumentNode,
+  FragmentDefinitionNode,
+  GraphQLNamedType,
+  GraphQLSchema,
+  OperationDefinitionNode,
+  SelectionSetNode
+} from 'graphql';
+import { getNamedType, isObjectType, Kind, typeFromAST } from 'graphql';
+
+/** Arguments a connection field uses to size its page. */
+const PAGE_SIZE_ARGS = ['first', 'last'] as const;
+
+/** A connection is any object type that carries Relay's `pageInfo`. */
+const isConnectionType = (type: GraphQLNamedType | null | undefined): boolean =>
+  Boolean(type && isObjectType(type) && 'pageInfo' in type.getFields());
+
+interface Walk {
+  schema: GraphQLSchema;
+  fragments: Record<string, FragmentDefinitionNode>;
+  variableValues: Record<string, unknown>;
+  protection: RequestProtection;
+  /** Fragment names on the current path, so a cyclic document cannot hang the walk. */
+  activeFragments: Set<string>;
+  maxDepth: number;
+  cost: number;
+}
+
+/**
+ * Resolve a `first`/`last` argument to a number, whether it arrived as a
+ * literal or through a variable. Returns null when the field does not page.
+ */
+const requestedPageSize = (
+  args: readonly { readonly name: { readonly value: string }; readonly value: unknown }[] | undefined,
+  variableValues: Record<string, unknown>
+): number | null => {
+  if (!args) return null;
+  let size: number | null = null;
+  for (const arg of args) {
+    if (!(PAGE_SIZE_ARGS as readonly string[]).includes(arg.name.value)) continue;
+    const value = arg.value as { kind: string; value?: string; name?: { value: string } };
+    const resolved =
+      value.kind === Kind.INT
+        ? Number(value.value)
+        : value.kind === Kind.VARIABLE
+          ? Number(variableValues[value.name!.value])
+          : null;
+    if (resolved !== null && Number.isFinite(resolved)) {
+      size = size === null ? resolved : Math.max(size, resolved);
+    }
+  }
+  return size;
+};
+
+/**
+ * Walk one selection set, accumulating depth and cost.
+ *
+ * @param parentType - the type the selections are read from, or null when the
+ *   schema cannot resolve it (an invalid document; validation reports that, so
+ *   the walk only stops charging cost rather than raising its own error)
+ * @param depth - nesting level of these selections
+ * @param multiplier - rows the enclosing connections can return
+ */
+function walkSelectionSet(
+  walk: Walk,
+  selectionSet: SelectionSetNode,
+  parentType: GraphQLNamedType | null,
+  depth: number,
+  multiplier: number
+): void {
+  if (depth > walk.maxDepth) walk.maxDepth = depth;
+  if (depth > walk.protection.maxQueryDepth) {
+    throw errors.QUERY_TOO_DEEP({ depth, limit: walk.protection.maxQueryDepth });
+  }
+
+  for (const selection of selectionSet.selections) {
+    if (selection.kind === Kind.FIELD) {
+      if (selection.name.value === '__schema' || selection.name.value === '__type') {
+        if (!walk.protection.enableIntrospection) {
+          throw errors.INTROSPECTION_DISABLED();
+        }
+      }
+
+      const field =
+        parentType && isObjectType(parentType)
+          ? parentType.getFields()[selection.name.value]
+          : undefined;
+      const fieldType = field ? getNamedType(field.type) : null;
+
+      const pageSize = requestedPageSize(selection.arguments, walk.variableValues);
+      if (pageSize !== null && pageSize > walk.protection.maxPageSize) {
+        throw errors.PAGE_SIZE_TOO_LARGE({
+          requested: pageSize,
+          limit: walk.protection.maxPageSize
+        });
+      }
+
+      // A connection charges rows; every other field is free, so a wide but
+      // flat selection is not penalized for being wide.
+      let childMultiplier = multiplier;
+      if (isConnectionType(fieldType)) {
+        childMultiplier = multiplier * (pageSize ?? ASSUMED_PAGE_SIZE);
+        walk.cost += childMultiplier;
+        if (walk.cost > walk.protection.maxQueryCost) {
+          throw errors.QUERY_TOO_COSTLY({
+            cost: walk.cost,
+            limit: walk.protection.maxQueryCost
+          });
+        }
+      }
+
+      if (selection.selectionSet) {
+        walkSelectionSet(walk, selection.selectionSet, fieldType, depth + 1, childMultiplier);
+      }
+      continue;
+    }
+
+    if (selection.kind === Kind.INLINE_FRAGMENT) {
+      const onType = selection.typeCondition
+        ? (typeFromAST(walk.schema, selection.typeCondition) as GraphQLNamedType | undefined)
+        : parentType;
+      // An inline fragment is not a level of nesting of its own.
+      walkSelectionSet(walk, selection.selectionSet, onType ?? null, depth, multiplier);
+      continue;
+    }
+
+    if (selection.kind === Kind.FRAGMENT_SPREAD) {
+      const name = selection.name.value;
+      // A document may spread the same fragment in sibling positions; only a
+      // cycle (a fragment reachable from itself) is refused, and the GraphQL
+      // validation rules already reject those with a proper error.
+      if (walk.activeFragments.has(name)) continue;
+      const fragment = walk.fragments[name];
+      if (!fragment) continue;
+
+      const onType = typeFromAST(walk.schema, fragment.typeCondition) as
+        | GraphQLNamedType
+        | undefined;
+      walk.activeFragments.add(name);
+      try {
+        walkSelectionSet(walk, fragment.selectionSet, onType ?? null, depth, multiplier);
+      } finally {
+        walk.activeFragments.delete(name);
+      }
+    }
+  }
+}
+
+export interface DocumentAnalysis {
+  /** Deepest field nesting in the operation. */
+  depth: number;
+  /** Rows the operation can pull across all of its connections. */
+  cost: number;
+}
+
+/**
+ * Enforce the document-level bounds for one operation.
+ *
+ * Throws the matching public error on the first bound exceeded; returns what it
+ * measured otherwise, so a caller can log or expose it.
+ */
+export function enforceDocumentProtection(
+  schema: GraphQLSchema,
+  document: DocumentNode,
+  variableValues: Record<string, unknown> | null | undefined,
+  protection: RequestProtection,
+  operationName?: string | null
+): DocumentAnalysis {
+  const fragments: Record<string, FragmentDefinitionNode> = {};
+  const operations: OperationDefinitionNode[] = [];
+  for (const definition of document.definitions) {
+    if (definition.kind === Kind.FRAGMENT_DEFINITION) fragments[definition.name.value] = definition;
+    else if (definition.kind === Kind.OPERATION_DEFINITION) operations.push(definition);
+  }
+
+  const operation = operationName
+    ? operations.find((op) => op.name?.value === operationName)
+    : operations[0];
+  if (!operation) return { depth: 0, cost: 0 };
+
+  const rootType =
+    operation.operation === 'query'
+      ? schema.getQueryType()
+      : operation.operation === 'mutation'
+        ? schema.getMutationType()
+        : schema.getSubscriptionType();
+
+  const walk: Walk = {
+    schema,
+    fragments,
+    variableValues: variableValues ?? {},
+    protection,
+    activeFragments: new Set(),
+    maxDepth: 0,
+    cost: 0
+  };
+
+  walkSelectionSet(walk, operation.selectionSet, rootType ?? null, 1, 1);
+
+  return { depth: walk.maxDepth, cost: walk.cost };
+}

--- a/graphql/server/src/protection/document-gate.ts
+++ b/graphql/server/src/protection/document-gate.ts
@@ -18,8 +18,10 @@
  * fragments) and the visitor does not follow them.
  */
 
+import type { ConstructiveError } from '@constructive-io/errors';
 import { errors } from '@constructive-io/errors';
 import { ASSUMED_PAGE_SIZE, type RequestProtection } from '@constructive-io/express-context';
+import { SafeError } from 'grafast';
 import type {
   DocumentNode,
   FragmentDefinitionNode,
@@ -29,6 +31,22 @@ import type {
   SelectionSetNode
 } from 'graphql';
 import { getNamedType, isObjectType, Kind, typeFromAST } from 'graphql';
+
+/**
+ * Reject the request with an error the client can act on.
+ *
+ * The gate runs inside grafast's `prepareArgs`, before execution, where a
+ * plain throw is reported as an unknown handler failure: HTTP 500 with the
+ * `extensions` dropped. `SafeError` is grafserv's contract for "this message
+ * and these extensions are meant for the client", so the registered code,
+ * class and HTTP status survive the trip.
+ */
+const reject = (error: ConstructiveError): never => {
+  throw new SafeError(error.message, {
+    ...error.toExtensions(),
+    statusCode: error.http
+  });
+};
 
 /** Arguments a connection field uses to size its page. */
 const PAGE_SIZE_ARGS = ['first', 'last'] as const;
@@ -92,14 +110,14 @@ function walkSelectionSet(
 ): void {
   if (depth > walk.maxDepth) walk.maxDepth = depth;
   if (depth > walk.protection.maxQueryDepth) {
-    throw errors.QUERY_TOO_DEEP({ depth, limit: walk.protection.maxQueryDepth });
+    reject(errors.QUERY_TOO_DEEP({ depth, limit: walk.protection.maxQueryDepth }));
   }
 
   for (const selection of selectionSet.selections) {
     if (selection.kind === Kind.FIELD) {
       if (selection.name.value === '__schema' || selection.name.value === '__type') {
         if (!walk.protection.enableIntrospection) {
-          throw errors.INTROSPECTION_DISABLED();
+          reject(errors.INTROSPECTION_DISABLED());
         }
       }
 
@@ -111,10 +129,12 @@ function walkSelectionSet(
 
       const pageSize = requestedPageSize(selection.arguments, walk.variableValues);
       if (pageSize !== null && pageSize > walk.protection.maxPageSize) {
-        throw errors.PAGE_SIZE_TOO_LARGE({
-          requested: pageSize,
-          limit: walk.protection.maxPageSize
-        });
+        reject(
+          errors.PAGE_SIZE_TOO_LARGE({
+            requested: pageSize,
+            limit: walk.protection.maxPageSize
+          })
+        );
       }
 
       // A connection charges rows; every other field is free, so a wide but
@@ -124,10 +144,12 @@ function walkSelectionSet(
         childMultiplier = multiplier * (pageSize ?? ASSUMED_PAGE_SIZE);
         walk.cost += childMultiplier;
         if (walk.cost > walk.protection.maxQueryCost) {
-          throw errors.QUERY_TOO_COSTLY({
-            cost: walk.cost,
-            limit: walk.protection.maxQueryCost
-          });
+          reject(
+            errors.QUERY_TOO_COSTLY({
+              cost: walk.cost,
+              limit: walk.protection.maxQueryCost
+            })
+          );
         }
       }
 

--- a/graphql/server/src/server.ts
+++ b/graphql/server/src/server.ts
@@ -41,6 +41,7 @@ import { createDebugDatabaseMiddleware } from './middleware/observability/debug-
 import { debugMemory } from './middleware/observability/debug-memory';
 import { localObservabilityOnly } from './middleware/observability/guard';
 import { createRequestLogger } from './middleware/observability/request-logger';
+import { createRequestProtectionMiddleware } from './middleware/request-protection';
 import { getRoutingSchema } from './middleware/routing';
 
 const log = new Logger('server');
@@ -168,6 +169,9 @@ class Server {
       loaders: createDefaultRegistry(),
       routingSchema: getRoutingSchema(effectiveOpts)
     }));
+    // Resolve the tenant's protection bounds before anything can spend budget
+    // on the request (and before the GraphQL handler reads them for pgSettings).
+    app.use(createRequestProtectionMiddleware());
     app.use(createCaptchaMiddleware());
 
     // CSRF protection for cookie-authenticated requests

--- a/packages/errors/src/registry.ts
+++ b/packages/errors/src/registry.ts
@@ -296,6 +296,47 @@ export const registry = {
   }),
 
   // ===========================================================================
+  // Request protection (public, dynamic) — raised by the GraphQL runtime when a
+  // request exceeds the bounds resolved from database_settings/api_settings.
+  // Each carries the limit that was in force so a client can adapt rather than
+  // guess.
+  // ===========================================================================
+  QUERY_TOO_DEEP: defineError<{ depth?: number; limit?: number }>({
+    code: 'QUERY_TOO_DEEP',
+    class: 'public',
+    http: 400,
+    message: 'The query is nested too deeply. Please request fewer nested levels.',
+    positional: ['depth', 'limit']
+  }),
+  QUERY_TOO_COSTLY: defineError<{ cost?: number; limit?: number }>({
+    code: 'QUERY_TOO_COSTLY',
+    class: 'public',
+    http: 400,
+    message: 'The query is too expensive. Please request fewer records or fewer nested lists.',
+    positional: ['cost', 'limit']
+  }),
+  PAGE_SIZE_TOO_LARGE: defineError<{ requested?: number; limit?: number }>({
+    code: 'PAGE_SIZE_TOO_LARGE',
+    class: 'public',
+    http: 400,
+    message: 'The requested page size is too large. Please request fewer records per page.',
+    positional: ['requested', 'limit']
+  }),
+  REQUEST_TOO_LARGE: defineError<{ bytes?: number; limit?: number }>({
+    code: 'REQUEST_TOO_LARGE',
+    class: 'public',
+    http: 413,
+    message: 'The request body is too large.',
+    positional: ['bytes', 'limit']
+  }),
+  INTROSPECTION_DISABLED: defineError({
+    code: 'INTROSPECTION_DISABLED',
+    class: 'public',
+    http: 403,
+    message: 'Schema introspection is disabled for this API.'
+  }),
+
+  // ===========================================================================
   // Client / transport (public) — synthesized client-side by the GraphQL client
   // for network, timeout, and HTTP-level failures (no DB/server origin).
   // ===========================================================================

--- a/packages/express-context/__tests__/request-protection.test.ts
+++ b/packages/express-context/__tests__/request-protection.test.ts
@@ -1,0 +1,192 @@
+import type { Pool } from 'pg';
+
+import { requestProtectionLoader } from '../src/loaders/request-protection';
+import type { LoaderContext } from '../src/loaders/types';
+import {
+  DEFAULT_REQUEST_PROTECTION,
+  PROTECTION_BOUNDS,
+  protectionPgSettings,
+  resolveRequestProtection
+} from '../src/request-protection';
+
+describe('resolveRequestProtection', () => {
+  it('falls back to the platform default when neither scope has a preference', () => {
+    const resolved = resolveRequestProtection(null, null);
+    expect(resolved).toEqual(DEFAULT_REQUEST_PROTECTION);
+    expect(resolved.statementTimeoutMs).toBe(PROTECTION_BOUNDS.statementTimeoutMs.default);
+  });
+
+  it('inherits a database setting when the API expresses nothing', () => {
+    const resolved = resolveRequestProtection({ statementTimeoutMs: 5_000 }, {});
+    expect(resolved.statementTimeoutMs).toBe(5_000);
+  });
+
+  it('lets an API override lower a database setting', () => {
+    const resolved = resolveRequestProtection(
+      { statementTimeoutMs: 20_000 },
+      { statementTimeoutMs: 2_000 }
+    );
+    expect(resolved.statementTimeoutMs).toBe(2_000);
+  });
+
+  it('refuses to let an API override raise a database setting', () => {
+    const resolved = resolveRequestProtection(
+      { statementTimeoutMs: 5_000 },
+      { statementTimeoutMs: 90_000 }
+    );
+    expect(resolved.statementTimeoutMs).toBe(5_000);
+  });
+
+  it('clamps a value written above the platform ceiling', () => {
+    const resolved = resolveRequestProtection({ statementTimeoutMs: 999_999_999 }, null);
+    expect(resolved.statementTimeoutMs).toBe(PROTECTION_BOUNDS.statementTimeoutMs.max);
+  });
+
+  it('clamps a value written below the floor, so a tenant cannot brick its own API', () => {
+    const resolved = resolveRequestProtection({ statementTimeoutMs: 0 }, null);
+    expect(resolved.statementTimeoutMs).toBe(PROTECTION_BOUNDS.statementTimeoutMs.floor);
+  });
+
+  it('treats null as "no preference" rather than as zero', () => {
+    const resolved = resolveRequestProtection(
+      { maxQueryDepth: null, maxPageSize: 10 },
+      { maxQueryDepth: null, maxPageSize: null }
+    );
+    expect(resolved.maxQueryDepth).toBe(PROTECTION_BOUNDS.maxQueryDepth.default);
+    expect(resolved.maxPageSize).toBe(10);
+  });
+
+  it('keeps introspection off by default and lets either scope turn it on', () => {
+    expect(resolveRequestProtection(null, null).enableIntrospection).toBe(false);
+    expect(resolveRequestProtection({ enableIntrospection: true }, {}).enableIntrospection).toBe(
+      true
+    );
+    // Unlike the numeric bounds, an API may re-enable introspection for itself.
+    expect(
+      resolveRequestProtection({ enableIntrospection: false }, { enableIntrospection: true })
+        .enableIntrospection
+    ).toBe(true);
+    expect(
+      resolveRequestProtection({ enableIntrospection: true }, { enableIntrospection: false })
+        .enableIntrospection
+    ).toBe(false);
+  });
+
+  it('resolves every bound, so a new column cannot silently arrive unresolved', () => {
+    const resolved = resolveRequestProtection(null, null);
+    for (const key of Object.keys(PROTECTION_BOUNDS)) {
+      expect(typeof (resolved as unknown as Record<string, unknown>)[key]).toBe('number');
+    }
+  });
+});
+
+describe('protectionPgSettings', () => {
+  it('emits the three timeout GUCs as millisecond integers', () => {
+    expect(
+      protectionPgSettings({
+        ...DEFAULT_REQUEST_PROTECTION,
+        statementTimeoutMs: 7_000,
+        idleInTransactionTimeoutMs: 8_000,
+        lockTimeoutMs: 900
+      })
+    ).toEqual({
+      statement_timeout: '7000',
+      idle_in_transaction_session_timeout: '8000',
+      lock_timeout: '900'
+    });
+  });
+
+  it('carries no other setting, so it can be merged into any pgSettings', () => {
+    expect(Object.keys(protectionPgSettings(DEFAULT_REQUEST_PROTECTION))).toHaveLength(3);
+  });
+});
+
+// ─── Loader ─────────────────────────────────────────────────────────────────
+
+interface Call {
+  text: string;
+  values?: unknown[];
+}
+
+const fakePool = (rows: unknown[][]) => {
+  const calls: Call[] = [];
+  let i = 0;
+  const pool = {
+    query: jest.fn(async (text: string, values?: unknown[]) => {
+      calls.push({ text, values });
+      return { rows: rows[i++] ?? [] };
+    })
+  } as unknown as Pool;
+  return { pool, calls };
+};
+
+const ctx = (routingPool: Pool, databaseId = 'db-1', apiId?: string): LoaderContext =>
+  ({
+    routingPool,
+    tenantPool: {} as Pool,
+    databaseId,
+    apiId,
+    dbname: 'tenant'
+  }) as LoaderContext;
+
+describe('requestProtectionLoader', () => {
+  beforeEach(() => {
+    requestProtectionLoader.invalidate();
+  });
+
+  it('binds the database and API it was asked about', async () => {
+    const { pool, calls } = fakePool([[{ db_statement_timeout_ms: '5000' }]]);
+
+    await requestProtectionLoader.resolve(ctx(pool, 'db-a', 'api-a'));
+
+    expect(calls[0].values).toEqual(['db-a', 'api-a']);
+    expect(calls[0].text).toMatch(/api_settings/);
+  });
+
+  it('reads a bigint back as a number rather than a string', async () => {
+    // node-postgres returns bigint as a string; an unparsed value would sail
+    // through the clamp as NaN and land on the default.
+    const { pool } = fakePool([[{ db_statement_timeout_ms: '4000', db_lock_timeout_ms: '250' }]]);
+
+    const resolved = await requestProtectionLoader.resolve(ctx(pool));
+
+    expect(resolved?.statementTimeoutMs).toBe(4_000);
+    expect(resolved?.lockTimeoutMs).toBe(250);
+  });
+
+  it('applies the API override as a lower-only bound', async () => {
+    const { pool } = fakePool([
+      [
+        {
+          db_statement_timeout_ms: '20000',
+          api_statement_timeout_ms: '3000',
+          db_max_page_size: 200,
+          api_max_page_size: 900
+        }
+      ]
+    ]);
+
+    const resolved = await requestProtectionLoader.resolve(ctx(pool, 'db-a', 'api-a'));
+
+    expect(resolved?.statementTimeoutMs).toBe(3_000);
+    expect(resolved?.maxPageSize).toBe(200);
+  });
+
+  it('keeps two APIs on one database apart in the cache', async () => {
+    const { pool } = fakePool([
+      [{ db_statement_timeout_ms: '20000', api_statement_timeout_ms: '3000' }],
+      [{ db_statement_timeout_ms: '20000', api_statement_timeout_ms: '9000' }]
+    ]);
+
+    const first = await requestProtectionLoader.resolve(ctx(pool, 'db-a', 'api-1'));
+    const second = await requestProtectionLoader.resolve(ctx(pool, 'db-a', 'api-2'));
+
+    expect(first?.statementTimeoutMs).toBe(3_000);
+    expect(second?.statementTimeoutMs).toBe(9_000);
+  });
+
+  it('returns nothing when the database has no settings row, so the caller uses the defaults', async () => {
+    const { pool } = fakePool([[]]);
+    expect(await requestProtectionLoader.resolve(ctx(pool))).toBeUndefined();
+  });
+});

--- a/packages/express-context/__tests__/request-protection.test.ts
+++ b/packages/express-context/__tests__/request-protection.test.ts
@@ -1,6 +1,9 @@
 import type { Pool } from 'pg';
 
-import { requestProtectionLoader } from '../src/loaders/request-protection';
+import {
+  forgetProtectionColumns,
+  requestProtectionLoader
+} from '../src/loaders/request-protection';
 import type { LoaderContext } from '../src/loaders/types';
 import {
   DEFAULT_REQUEST_PROTECTION,
@@ -56,18 +59,20 @@ describe('resolveRequestProtection', () => {
     expect(resolved.maxPageSize).toBe(10);
   });
 
-  it('keeps introspection off by default and lets either scope turn it on', () => {
-    expect(resolveRequestProtection(null, null).enableIntrospection).toBe(false);
-    expect(resolveRequestProtection({ enableIntrospection: true }, {}).enableIntrospection).toBe(
-      true
+  it('leaves introspection on until metadata takes it away, and never puts it back', () => {
+    // A database that has expressed no preference — a routing plane older than
+    // the column — keeps the introspection its clients already rely on.
+    expect(resolveRequestProtection(null, null).enableIntrospection).toBe(true);
+    expect(resolveRequestProtection({ enableIntrospection: false }, {}).enableIntrospection).toBe(
+      false
     );
-    // Unlike the numeric bounds, an API may re-enable introspection for itself.
-    expect(
-      resolveRequestProtection({ enableIntrospection: false }, { enableIntrospection: true })
-        .enableIntrospection
-    ).toBe(true);
+    // Lower-only: an API may switch it off for itself, never back on.
     expect(
       resolveRequestProtection({ enableIntrospection: true }, { enableIntrospection: false })
+        .enableIntrospection
+    ).toBe(false);
+    expect(
+      resolveRequestProtection({ enableIntrospection: false }, { enableIntrospection: true })
         .enableIntrospection
     ).toBe(false);
   });
@@ -108,17 +113,47 @@ interface Call {
   values?: unknown[];
 }
 
-const fakePool = (rows: unknown[][]) => {
+/**
+ * A routing pool that answers the column probe with a fully-migrated plane
+ * (unless `columns` says otherwise) and then the settings rows in order.
+ */
+const fakePool = (rows: unknown[][], columns?: { database: string[]; api: string[] }) => {
   const calls: Call[] = [];
   let i = 0;
+  const probeRows = columns
+    ? [
+      ...columns.database.map((c) => ({ table_name: 'database_settings', column_name: c })),
+      ...columns.api.map((c) => ({ table_name: 'api_settings', column_name: c }))
+    ]
+    : ALL_PROTECTION_COLUMNS.flatMap((c) => [
+      { table_name: 'database_settings', column_name: c },
+      { table_name: 'api_settings', column_name: c }
+    ]);
+
   const pool = {
     query: jest.fn(async (text: string, values?: unknown[]) => {
+      if (text.includes('information_schema.columns')) return { rows: probeRows };
       calls.push({ text, values });
       return { rows: rows[i++] ?? [] };
     })
   } as unknown as Pool;
   return { pool, calls };
 };
+
+const ALL_PROTECTION_COLUMNS = [
+  'statement_timeout_ms',
+  'idle_in_transaction_timeout_ms',
+  'lock_timeout_ms',
+  'max_concurrent_requests',
+  'max_queue_wait_ms',
+  'rate_limit_rpm',
+  'rate_limit_burst',
+  'max_query_depth',
+  'max_query_cost',
+  'max_page_size',
+  'max_request_bytes',
+  'enable_introspection'
+];
 
 const ctx = (routingPool: Pool, databaseId = 'db-1', apiId?: string): LoaderContext =>
   ({
@@ -188,5 +223,22 @@ describe('requestProtectionLoader', () => {
   it('returns nothing when the database has no settings row, so the caller uses the defaults', async () => {
     const { pool } = fakePool([[]]);
     expect(await requestProtectionLoader.resolve(ctx(pool))).toBeUndefined();
+  });
+
+  it('selects only the columns a routing plane actually has', async () => {
+    // A plane published before these columns existed must resolve to the
+    // platform defaults, not fail every request with `column … does not exist`.
+    const { pool, calls } = fakePool([[{ db_statement_timeout_ms: '5000' }]], {
+      database: ['statement_timeout_ms'],
+      api: []
+    });
+
+    const resolved = await requestProtectionLoader.resolve(ctx(pool, 'db-old'));
+
+    expect(calls[0].text).not.toMatch(/idle_in_transaction_timeout_ms/);
+    expect(calls[0].text).not.toMatch(/aps\./);
+    expect(resolved?.statementTimeoutMs).toBe(5_000);
+    expect(resolved?.lockTimeoutMs).toBe(PROTECTION_BOUNDS.lockTimeoutMs.default);
+    forgetProtectionColumns(pool);
   });
 });

--- a/packages/express-context/src/index.ts
+++ b/packages/express-context/src/index.ts
@@ -71,6 +71,22 @@ export { buildPgSettings } from './pg-settings';
 // withPgClient helper
 export { withPgClient } from './pg-client';
 
+// Request protection (platform bounds + resolver)
+export type {
+  NumericProtectionKey,
+  ProtectionBound,
+  RequestProtection,
+  RequestProtectionInput,
+} from './request-protection';
+export {
+  ASSUMED_PAGE_SIZE,
+  DEFAULT_REQUEST_PROTECTION,
+  INTROSPECTION_BOUND,
+  PROTECTION_BOUNDS,
+  protectionPgSettings,
+  resolveRequestProtection,
+} from './request-protection';
+
 // Request ID middleware
 export { requestIdMiddleware } from './request-id';
 
@@ -100,6 +116,7 @@ export {
   inferenceLogLoader,
   llmLoader,
   pubkeyLoader,
+  requestProtectionLoader,
   requireDatabaseId,
   requireIdentityProvider,
   rlsLoader,

--- a/packages/express-context/src/loaders/index.ts
+++ b/packages/express-context/src/loaders/index.ts
@@ -9,6 +9,7 @@
  *   - rlsModule       (routing-plane rls_settings)
  *   - corsOrigins     (routing-plane cors_settings)
  *   - databaseSettings(routing-plane database_settings)
+ *   - requestProtection (routing-plane database_settings/api_settings bounds)
  *   - pubkeyChallengeSettings (routing-plane pubkey_settings)
  *   - webauthnSettings(routing-plane webauthn_settings)
  *   - authSettings    (metaschema_modules_public.sessions_module → tenant DB)
@@ -54,6 +55,7 @@ export { identityProvidersLoader, requireIdentityProvider } from './identity-pro
 export { inferenceLogLoader } from './inference-log';
 export { llmLoader } from './llm';
 export { pubkeyLoader } from './pubkey';
+export { requestProtectionLoader } from './request-protection';
 export { rlsLoader } from './rls';
 export { webauthnLoader } from './webauthn';
 
@@ -71,6 +73,7 @@ import { inferenceLogLoader } from './inference-log';
 import { llmLoader } from './llm';
 import { pubkeyLoader } from './pubkey';
 import { createLoaderRegistry } from './registry';
+import { requestProtectionLoader } from './request-protection';
 import { rlsLoader } from './rls';
 import { webauthnLoader } from './webauthn';
 
@@ -88,5 +91,6 @@ export function createDefaultRegistry() {
   registry.register(agentChatLoader);
   registry.register(llmLoader);
   registry.register(computeLoader);
+  registry.register(requestProtectionLoader);
   return registry;
 }

--- a/packages/express-context/src/loaders/request-protection.ts
+++ b/packages/express-context/src/loaders/request-protection.ts
@@ -1,0 +1,104 @@
+/**
+ * Request Protection Loader
+ *
+ * Reads the per-database bounds and the per-API overrides raw, then resolves
+ * them through the platform's own defaults and ceilings.
+ *
+ * Unlike the feature-flag loader next door this cannot `COALESCE` in SQL: an
+ * API override is lower-only, so the two scopes are combined with `LEAST` and
+ * then clamped in code, where the platform constants live.
+ */
+
+import type { RequestProtection, RequestProtectionInput } from '../request-protection';
+import { resolveRequestProtection } from '../request-protection';
+import { createModuleLoader } from './create-loader';
+import type { LoaderContext, ModuleLoader } from './types';
+import { routingSchemaOf } from './types';
+
+// ─── SQL ────────────────────────────────────────────────────────────────────
+
+const PROTECTION_COLUMNS = [
+  'statement_timeout_ms',
+  'idle_in_transaction_timeout_ms',
+  'lock_timeout_ms',
+  'max_concurrent_requests',
+  'max_queue_wait_ms',
+  'rate_limit_rpm',
+  'rate_limit_burst',
+  'max_query_depth',
+  'max_query_cost',
+  'max_page_size',
+  'max_request_bytes',
+  'enable_introspection'
+] as const;
+
+type ProtectionColumn = (typeof PROTECTION_COLUMNS)[number];
+
+const requestProtectionSql = (schema: string): string => {
+  const select = PROTECTION_COLUMNS.flatMap((column) => [
+    `ds.${column} AS db_${column}`,
+    `aps.${column} AS api_${column}`
+  ]).join(',\n    ');
+
+  return `
+  SELECT
+    ${select}
+  FROM "${schema}".database_settings ds
+  LEFT JOIN "${schema}".api_settings aps ON ds.database_id = aps.database_id AND aps.api_id = $2
+  WHERE ds.database_id = $1
+  LIMIT 1
+`;
+};
+
+// ─── Row Types ──────────────────────────────────────────────────────────────
+
+type RequestProtectionRow = Record<`db_${ProtectionColumn}` | `api_${ProtectionColumn}`, unknown>;
+
+/**
+ * `bigint` columns arrive as strings from node-postgres (pg returns int8 as
+ * text to avoid the 2^53 cliff), so every numeric bound is normalized here
+ * rather than trusted to already be a number.
+ */
+const num = (value: unknown): number | null => {
+  if (value === null || value === undefined) return null;
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const bool = (value: unknown): boolean | null =>
+  value === null || value === undefined ? null : Boolean(value);
+
+const scopeOf = (row: RequestProtectionRow, prefix: 'db' | 'api'): RequestProtectionInput => ({
+  statementTimeoutMs: num(row[`${prefix}_statement_timeout_ms`]),
+  idleInTransactionTimeoutMs: num(row[`${prefix}_idle_in_transaction_timeout_ms`]),
+  lockTimeoutMs: num(row[`${prefix}_lock_timeout_ms`]),
+  maxConcurrentRequests: num(row[`${prefix}_max_concurrent_requests`]),
+  maxQueueWaitMs: num(row[`${prefix}_max_queue_wait_ms`]),
+  rateLimitRpm: num(row[`${prefix}_rate_limit_rpm`]),
+  rateLimitBurst: num(row[`${prefix}_rate_limit_burst`]),
+  maxQueryDepth: num(row[`${prefix}_max_query_depth`]),
+  maxQueryCost: num(row[`${prefix}_max_query_cost`]),
+  maxPageSize: num(row[`${prefix}_max_page_size`]),
+  maxRequestBytes: num(row[`${prefix}_max_request_bytes`]),
+  enableIntrospection: bool(row[`${prefix}_enable_introspection`])
+});
+
+// ─── Loader ─────────────────────────────────────────────────────────────────
+
+export const requestProtectionLoader: ModuleLoader<RequestProtection> =
+  createModuleLoader<RequestProtection>({
+    name: 'requestProtection',
+    ttlMs: 5 * 60_000,
+    async resolve(ctx: LoaderContext) {
+      const { routingPool, databaseId, apiId } = ctx;
+
+      const result = await routingPool.query<RequestProtectionRow>(
+        requestProtectionSql(routingSchemaOf(ctx)),
+        [databaseId, apiId ?? null]
+      );
+      const row = result.rows[0];
+      if (!row) return undefined;
+
+      return resolveRequestProtection(scopeOf(row, 'db'), scopeOf(row, 'api'));
+    }
+  });

--- a/packages/express-context/src/loaders/request-protection.ts
+++ b/packages/express-context/src/loaders/request-protection.ts
@@ -7,7 +7,15 @@
  * Unlike the feature-flag loader next door this cannot `COALESCE` in SQL: an
  * API override is lower-only, so the two scopes are combined with `LEAST` and
  * then clamped in code, where the platform constants live.
+ *
+ * The columns are also selected by feature detection rather than by name
+ * alone. A serving cluster runs routing planes of several ages — the plane is
+ * a published package a tenant upgrades on its own schedule — and a plane that
+ * predates these columns must resolve to the platform defaults, not fail every
+ * request against it with `column ds.… does not exist`.
  */
+
+import type { Pool } from 'pg';
 
 import type { RequestProtection, RequestProtectionInput } from '../request-protection';
 import { resolveRequestProtection } from '../request-protection';
@@ -34,25 +42,94 @@ const PROTECTION_COLUMNS = [
 
 type ProtectionColumn = (typeof PROTECTION_COLUMNS)[number];
 
-const requestProtectionSql = (schema: string): string => {
+/** Which of the protection columns a given routing plane actually carries. */
+interface AvailableColumns {
+  database: Set<string>;
+  api: Set<string>;
+}
+
+const availableColumnsSql = `
+  SELECT table_name, column_name
+  FROM information_schema.columns
+  WHERE table_schema = $1
+    AND table_name IN ('database_settings', 'api_settings')
+    AND column_name = ANY($2::text[])
+`;
+
+const requestProtectionSql = (schema: string, columns: AvailableColumns): string => {
   const select = PROTECTION_COLUMNS.flatMap((column) => [
-    `ds.${column} AS db_${column}`,
-    `aps.${column} AS api_${column}`
-  ]).join(',\n    ');
+    columns.database.has(column) ? `ds.${column} AS db_${column}` : null,
+    columns.api.has(column) ? `aps.${column} AS api_${column}` : null
+  ])
+    .filter((expr): expr is string => expr !== null)
+    .join(',\n    ');
+
+  // The join is dropped when the plane carries no API-scope column, so a plane
+  // without an `api_settings` table at all is still readable.
+  const join = columns.api.size
+    ? `\n  LEFT JOIN "${schema}".api_settings aps ON ds.database_id = aps.database_id AND aps.api_id = $2`
+    : '';
 
   return `
   SELECT
-    ${select}
-  FROM "${schema}".database_settings ds
-  LEFT JOIN "${schema}".api_settings aps ON ds.database_id = aps.database_id AND aps.api_id = $2
+    ds.database_id${select ? `,\n    ${select}` : ''}
+  FROM "${schema}".database_settings ds${join}
   WHERE ds.database_id = $1
   LIMIT 1
 `;
 };
 
+/**
+ * The routing plane's shape changes only when it is redeployed, so it is read
+ * once per pool+schema. Keyed by the pool object so a test pool and a serving
+ * pool never share an answer.
+ */
+const columnCache = new WeakMap<Pool, Map<string, Promise<AvailableColumns>>>();
+
+const availableColumns = (pool: Pool, schema: string): Promise<AvailableColumns> => {
+  let bySchema = columnCache.get(pool);
+  if (!bySchema) {
+    bySchema = new Map();
+    columnCache.set(pool, bySchema);
+  }
+
+  const cached = bySchema.get(schema);
+  if (cached) return cached;
+
+  const pending = pool
+    .query<{ table_name: string; column_name: string }>(availableColumnsSql, [
+      schema,
+      [...PROTECTION_COLUMNS]
+    ])
+    .then((result) => {
+      const columns: AvailableColumns = { database: new Set(), api: new Set() };
+      for (const { table_name, column_name } of result.rows) {
+        if (table_name === 'database_settings') columns.database.add(column_name);
+        else columns.api.add(column_name);
+      }
+      return columns;
+    })
+    .catch((e) => {
+      // A failed probe is not an answer: drop it so the next request retries
+      // rather than caching "this plane has no protection columns" forever.
+      bySchema.delete(schema);
+      throw e;
+    });
+
+  bySchema.set(schema, pending);
+  return pending;
+};
+
+/** Test seam: forget what a pool's routing plane looked like. */
+export const forgetProtectionColumns = (pool: Pool): void => {
+  columnCache.delete(pool);
+};
+
 // ─── Row Types ──────────────────────────────────────────────────────────────
 
-type RequestProtectionRow = Record<`db_${ProtectionColumn}` | `api_${ProtectionColumn}`, unknown>;
+type RequestProtectionRow = Partial<
+  Record<`db_${ProtectionColumn}` | `api_${ProtectionColumn}`, unknown>
+>;
 
 /**
  * `bigint` columns arrive as strings from node-postgres (pg returns int8 as
@@ -91,10 +168,13 @@ export const requestProtectionLoader: ModuleLoader<RequestProtection> =
     ttlMs: 5 * 60_000,
     async resolve(ctx: LoaderContext) {
       const { routingPool, databaseId, apiId } = ctx;
+      const schema = routingSchemaOf(ctx);
+      const columns = await availableColumns(routingPool, schema);
 
+      const params: unknown[] = columns.api.size ? [databaseId, apiId ?? null] : [databaseId];
       const result = await routingPool.query<RequestProtectionRow>(
-        requestProtectionSql(routingSchemaOf(ctx)),
-        [databaseId, apiId ?? null]
+        requestProtectionSql(schema, columns),
+        params
       );
       const row = result.rows[0];
       if (!row) return undefined;

--- a/packages/express-context/src/request-protection.ts
+++ b/packages/express-context/src/request-protection.ts
@@ -93,11 +93,18 @@ export const PROTECTION_BOUNDS: Record<NumericProtectionKey, ProtectionBound> = 
 export const ASSUMED_PAGE_SIZE = 100;
 
 /**
- * Introspection is off unless a tenant turns it on, and `PLATFORM_ALLOWS`
- * is the kill switch that keeps it off cluster-wide regardless.
+ * Introspection stays on until metadata says otherwise, and `platformAllows`
+ * is the kill switch that takes it away cluster-wide regardless.
+ *
+ * The platform default is permissive here where the metadata default is not
+ * (`database_settings.enable_introspection` is `NOT NULL DEFAULT false`) on
+ * purpose: this value applies to a database that has expressed *no*
+ * preference — typically one whose routing plane predates the column — and
+ * silently disabling introspection for it would break GraphiQL and codegen for
+ * every tenant the moment this code deployed, without anyone opting in.
  */
 export const INTROSPECTION_BOUND = {
-  default: false,
+  default: true,
   platformAllows: true
 };
 
@@ -162,11 +169,15 @@ export function resolveRequestProtection(
     resolved[name] = clamp(preferred ?? bound.default, bound);
   }
 
-  // An API override may switch introspection either way within its database;
-  // the platform switch can only ever take it away.
-  const requested = api?.enableIntrospection ?? database?.enableIntrospection ?? INTROSPECTION_BOUND.default;
+  // Lower-only applies to the flag too: an API may switch introspection off
+  // for itself, never back on for a database that turned it off, and the
+  // platform switch can only ever take it away.
+  const enableIntrospection =
+    (database?.enableIntrospection ?? INTROSPECTION_BOUND.default) &&
+    (api?.enableIntrospection ?? true) &&
+    INTROSPECTION_BOUND.platformAllows;
 
-  return { ...resolved, enableIntrospection: requested && INTROSPECTION_BOUND.platformAllows };
+  return { ...resolved, enableIntrospection };
 }
 
 /**

--- a/packages/express-context/src/request-protection.ts
+++ b/packages/express-context/src/request-protection.ts
@@ -1,0 +1,182 @@
+/**
+ * request-protection — platform bounds for the per-request protection settings.
+ *
+ * `database_settings` / `api_settings` carry a tenant's *preferences*; this
+ * module owns the numbers the platform will actually honour. The platform
+ * default and the hard ceiling are code constants rather than rows, so a
+ * tenant can never widen a bound by writing metadata: a setting is only ever
+ * read as a request to be *stricter* than the platform is.
+ *
+ *   effective = clamp(LEAST(api_override, database_setting) ?? default, floor, max)
+ *
+ * `LEAST` (not `COALESCE`) is what makes an API override lower-only: an API
+ * that asks for a 60s statement timeout under a database that says 10s gets
+ * 10s. The floor exists so a tenant cannot write a value that makes its own
+ * API unusable (a 0ms statement timeout), and the ceiling so it cannot raise
+ * one past what the shared cluster will absorb.
+ */
+
+// ─── Resolved shape ─────────────────────────────────────────────────────────
+
+/** Every request-protection bound, resolved to a value the runtime enforces. */
+export interface RequestProtection {
+  /** `statement_timeout` for the request's transaction. */
+  statementTimeoutMs: number;
+  /** `idle_in_transaction_session_timeout` for the request's transaction. */
+  idleInTransactionTimeoutMs: number;
+  /** `lock_timeout` for the request's transaction. */
+  lockTimeoutMs: number;
+  /** In-flight requests allowed per tenant (not yet enforced). */
+  maxConcurrentRequests: number;
+  /** How long a request may wait for a concurrency slot (not yet enforced). */
+  maxQueueWaitMs: number;
+  /** Sustained request rate per tenant (not yet enforced). */
+  rateLimitRpm: number;
+  /** Burst allowance above `rateLimitRpm` (not yet enforced). */
+  rateLimitBurst: number;
+  /** Deepest selection set accepted in an operation. */
+  maxQueryDepth: number;
+  /** Largest static cost accepted in an operation. */
+  maxQueryCost: number;
+  /** Largest `first`/`last` accepted on a connection. */
+  maxPageSize: number;
+  /** Largest request body accepted. */
+  maxRequestBytes: number;
+  /** Whether the schema answers introspection queries. */
+  enableIntrospection: boolean;
+}
+
+/** The numeric bounds — every field of {@link RequestProtection} but the flag. */
+export type NumericProtectionKey = Exclude<keyof RequestProtection, 'enableIntrospection'>;
+
+/** What the platform grants, and the window a tenant may move inside. */
+export interface ProtectionBound {
+  /** Applied when neither scope expresses a preference. */
+  default: number;
+  /** Lowest value a tenant can make effective — below this its API breaks. */
+  floor: number;
+  /** Highest value the platform honours, whatever metadata says. */
+  max: number;
+}
+
+// ─── Platform bounds ────────────────────────────────────────────────────────
+
+/**
+ * The platform's own numbers. Deliberately constants: a ceiling stored next to
+ * the value it caps is a ceiling a tenant can edit.
+ */
+export const PROTECTION_BOUNDS: Record<NumericProtectionKey, ProtectionBound> = {
+  statementTimeoutMs: { default: 30_000, floor: 1_000, max: 120_000 },
+  idleInTransactionTimeoutMs: { default: 60_000, floor: 1_000, max: 300_000 },
+  lockTimeoutMs: { default: 5_000, floor: 100, max: 60_000 },
+  maxConcurrentRequests: { default: 50, floor: 1, max: 500 },
+  maxQueueWaitMs: { default: 5_000, floor: 0, max: 60_000 },
+  rateLimitRpm: { default: 600, floor: 1, max: 60_000 },
+  rateLimitBurst: { default: 60, floor: 1, max: 10_000 },
+  maxQueryDepth: { default: 12, floor: 1, max: 50 },
+  // Cost is measured in rows a document can pull (see ASSUMED_PAGE_SIZE), so
+  // the default has to leave room for the nesting Graphile encourages while
+  // still refusing the millions-of-rows shapes.
+  maxQueryCost: { default: 1_000_000, floor: 100, max: 100_000_000 },
+  maxPageSize: { default: 1_000, floor: 1, max: 10_000 },
+  maxRequestBytes: { default: 1_000_000, floor: 1_024, max: 10_000_000 }
+};
+
+/**
+ * What a connection with no `first`/`last` is charged.
+ *
+ * Such a field is unbounded in principle, so charging it the tenant's
+ * `maxPageSize` would make a large ceiling self-defeating: raising the page
+ * size a client *may* ask for would shrink the query it can write. A fixed
+ * estimate keeps the two bounds independent.
+ */
+export const ASSUMED_PAGE_SIZE = 100;
+
+/**
+ * Introspection is off unless a tenant turns it on, and `PLATFORM_ALLOWS`
+ * is the kill switch that keeps it off cluster-wide regardless.
+ */
+export const INTROSPECTION_BOUND = {
+  default: false,
+  platformAllows: true
+};
+
+/** What a database with no settings row gets. */
+export const DEFAULT_REQUEST_PROTECTION: RequestProtection = resolveDefaults();
+
+function resolveDefaults(): RequestProtection {
+  const numeric = Object.fromEntries(
+    Object.entries(PROTECTION_BOUNDS).map(([key, bound]) => [key, bound.default])
+  ) as Record<NumericProtectionKey, number>;
+  return { ...numeric, enableIntrospection: INTROSPECTION_BOUND.default };
+}
+
+// ─── Raw metadata shape ─────────────────────────────────────────────────────
+
+/**
+ * One scope's stored preferences. Every field is nullable — `null` is "no
+ * preference at this scope", which is why the resolver never treats a missing
+ * value as a zero.
+ */
+export interface RequestProtectionInput {
+  statementTimeoutMs?: number | null;
+  idleInTransactionTimeoutMs?: number | null;
+  lockTimeoutMs?: number | null;
+  maxConcurrentRequests?: number | null;
+  maxQueueWaitMs?: number | null;
+  rateLimitRpm?: number | null;
+  rateLimitBurst?: number | null;
+  maxQueryDepth?: number | null;
+  maxQueryCost?: number | null;
+  maxPageSize?: number | null;
+  maxRequestBytes?: number | null;
+  enableIntrospection?: boolean | null;
+}
+
+// ─── Resolution ─────────────────────────────────────────────────────────────
+
+const clamp = (value: number, bound: ProtectionBound): number =>
+  Math.min(Math.max(value, bound.floor), bound.max);
+
+/** The stricter of two preferences, ignoring the scopes that expressed none. */
+const strictest = (a: number | null | undefined, b: number | null | undefined): number | null => {
+  const values = [a, b].filter((v): v is number => typeof v === 'number' && Number.isFinite(v));
+  return values.length > 0 ? Math.min(...values) : null;
+};
+
+/**
+ * Resolve the bounds a request runs under.
+ *
+ * @param database - the `database_settings` row for the tenant, if any
+ * @param api - the `api_settings` overrides for the API the request arrived on
+ */
+export function resolveRequestProtection(
+  database?: RequestProtectionInput | null,
+  api?: RequestProtectionInput | null
+): RequestProtection {
+  const resolved = {} as Record<NumericProtectionKey, number>;
+  for (const [name, bound] of Object.entries(PROTECTION_BOUNDS) as Array<
+    [NumericProtectionKey, ProtectionBound]
+  >) {
+    const preferred = strictest(database?.[name], api?.[name]);
+    resolved[name] = clamp(preferred ?? bound.default, bound);
+  }
+
+  // An API override may switch introspection either way within its database;
+  // the platform switch can only ever take it away.
+  const requested = api?.enableIntrospection ?? database?.enableIntrospection ?? INTROSPECTION_BOUND.default;
+
+  return { ...resolved, enableIntrospection: requested && INTROSPECTION_BOUND.platformAllows };
+}
+
+/**
+ * The timeout GUCs as `SET LOCAL` pairs, for merging into a request's
+ * pgSettings. PostgreSQL reads a bare integer for all three as milliseconds.
+ */
+export function protectionPgSettings(protection: RequestProtection): Record<string, string> {
+  return {
+    statement_timeout: String(protection.statementTimeoutMs),
+    idle_in_transaction_session_timeout: String(protection.idleInTransactionTimeoutMs),
+    lock_timeout: String(protection.lockTimeoutMs)
+  };
+}

--- a/packages/express-context/src/types.ts
+++ b/packages/express-context/src/types.ts
@@ -10,6 +10,7 @@
 import type { Pool, PoolClient } from 'pg';
 
 import type { BillingClient } from './billing-client';
+import type { RequestProtection } from './request-protection';
 
 // ─── API Structure ──────────────────────────────────────────────────────────
 
@@ -249,6 +250,7 @@ export interface BuiltinModuleMap {
   agentChat: AgentChatConfig;
   llm: LlmConfig;
   compute: ComputeConfig;
+  requestProtection: RequestProtection;
 }
 
 // ─── Constructive Context ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The 11 request-protection columns added to `database_settings`/`api_settings` in constructive-db were metadata nothing read. This makes them load-bearing: the platform's defaults/ceilings live in code, metadata may only ever *lower* a bound, and the resolved values ride the request as pg GUCs plus a pre-execution GraphQL gate.

```
effective(x) = clamp(LEAST(api_override, database_setting) ?? platform_default, floor, platform_max)
```

- timeouts (`statement_timeout`, `idle_in_transaction_session_timeout`, `lock_timeout`) merge into the per-request `pgSettings`
- depth / cost / page size / introspection are checked in a grafast `prepareArgs` middleware, **not** baked into the preset: the Graphile handler is cached per `svc_key`, so anything captured at construction time would keep serving a stale tenant's bounds. Cost is charged as rows a document can pull — a connection contributes `pageSize × (page sizes above it)`, so `users(first: 100) { posts(first: 100) }` costs 100 + 10,000 rather than looking like 4 fields.
- request body bytes are checked from `Content-Length` before the body is read (multipart exempt: those are files bounded by the upload limits).

Two decisions worth calling out:

**The loader selects columns by feature detection, not by name.** A routing plane is a published package a tenant upgrades on its own schedule, so a plane predating these columns would otherwise fail *every* request with `column ds.idle_in_transaction_timeout_ms does not exist`. `information_schema.columns` is probed once per pool+schema and the SELECT (and the `api_settings` join) is built from what is actually there; absent columns simply read as "no preference".

**Introspection's platform default is `true` while the metadata default is `false`.** The platform value only applies when a database has expressed *no* preference; defaulting it off there would silently kill GraphiQL and codegen for every existing tenant the moment this deployed, with nobody opting in. Once a tenant's plane carries `enable_introspection`, its `false` wins — and lower-only applies to the flag too (an API may switch it off for itself, never back on).

A settings lookup failure is passed to `next(err)` rather than falling back to defaults: serving under numbers nobody chose is how a broken routing plane stays invisible.

Rejections throw grafast's `SafeError` carrying the registered `extensions` (`QUERY_TOO_DEEP`, `QUERY_TOO_COSTLY`, `PAGE_SIZE_TOO_LARGE`, `REQUEST_TOO_LARGE`, `INTROSPECTION_DISABLED`) — a plain throw inside `prepareArgs` reaches the client as a bare 500 with the extensions dropped.

`maxConcurrentRequests`, `maxQueueWaitMs`, `rateLimitRpm` and `rateLimitBurst` are resolved but not enforced: enforcement needs state shared across server processes plus the caps/limits ceilings a tenant must not be able to raise.

Note the pg-side values only take effect once `@constructive-db/routing` is republished with the new columns and the pin here is bumped; until then every database resolves to the platform defaults, by design.


Link to Devin session: https://app.devin.ai/sessions/fd9f9aa438b24c75b2861f1a9ffc0e3c
Open in Devin Desktop: https://app.devin.ai/desktop/session/fd9f9aa438b24c75b2861f1a9ffc0e3c?variant=devin
Requested by: @pyramation