### PR TITLE
feat(storage): add RustFS as an S3-compatible object store option

### DIFF
--- a/packages/bucket-provisioner/README.md
+++ b/packages/bucket-provisioner/README.md
@@ -146,7 +146,7 @@ The main class that orchestrates bucket creation and configuration.
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `connection.provider` | `'s3' \| 'minio' \| 'r2' \| 'gcs' \| 'spaces'` | Storage provider type |
+| `connection.provider` | `'s3' \| 'minio' \| 'rustfs' \| 'r2' \| 'gcs' \| 'spaces'` | Storage provider type |
 | `connection.region` | `string` | S3 region (e.g., `'us-east-1'`) |
 | `connection.endpoint` | `string?` | S3-compatible endpoint URL. Required for non-AWS providers. |
 | `connection.accessKeyId` | `string` | AWS access key ID |

--- a/packages/bucket-provisioner/__tests__/types.test.ts
+++ b/packages/bucket-provisioner/__tests__/types.test.ts
@@ -54,8 +54,8 @@ describe('ProvisionerError', () => {
 
 describe('Type definitions', () => {
   it('StorageProvider accepts valid values', () => {
-    const providers: StorageProvider[] = ['s3', 'minio', 'r2', 'gcs', 'spaces'];
-    expect(providers).toHaveLength(5);
+    const providers: StorageProvider[] = ['s3', 'minio', 'rustfs', 'r2', 'gcs', 'spaces'];
+    expect(providers).toHaveLength(6);
   });
 
   it('BucketAccessType accepts valid values', () => {

--- a/packages/bucket-provisioner/src/types.ts
+++ b/packages/bucket-provisioner/src/types.ts
@@ -13,14 +13,14 @@
  * Used to select provider-specific behavior (e.g., path-style URLs for MinIO,
  * jurisdiction headers for R2).
  */
-export type StorageProvider = 's3' | 'minio' | 'r2' | 'gcs' | 'spaces';
+export type StorageProvider = 's3' | 'minio' | 'rustfs' | 'r2' | 'gcs' | 'spaces';
 
 /**
  * Connection configuration for an S3-compatible storage backend.
  *
  * This is the input you provide to connect to your storage provider.
  * For AWS S3, only `region` and credentials are needed.
- * For MinIO/R2/etc., also provide `endpoint`.
+ * For MinIO/RustFS/R2/etc., also provide `endpoint`.
  */
 export interface StorageConnectionConfig {
   /** Storage provider type */

--- a/pgpm/cli/src/commands/docker.ts
+++ b/pgpm/cli/src/commands/docker.ts
@@ -26,6 +26,7 @@ PostgreSQL Options:
 
 Additional Services:
   --minio            Include MinIO S3-compatible object storage (API: 9000, Console: 9001)
+  --rustfs           Include RustFS S3-compatible object storage (API: 9000, Console: 9001)
   --ollama           Include Ollama LLM inference server (API: 11434)
   --gpu              Enable NVIDIA GPU passthrough for Ollama (requires NVIDIA Container Toolkit)
 
@@ -36,6 +37,7 @@ General Options:
 Examples:
   pgpm docker start                           Start PostgreSQL only
   pgpm docker start --minio                   Start PostgreSQL + MinIO
+  pgpm docker start --rustfs                  Start PostgreSQL + RustFS
   pgpm docker start --ollama                  Start PostgreSQL + Ollama (CPU)
   pgpm docker start --ollama --gpu            Start PostgreSQL + Ollama (NVIDIA GPU)
   pgpm docker start --port 5433               Start on custom port
@@ -44,6 +46,7 @@ Examples:
   pgpm docker start --recreate --minio        Recreate PostgreSQL + MinIO
   pgpm docker stop                            Stop PostgreSQL
   pgpm docker stop --minio                    Stop PostgreSQL + MinIO
+  pgpm docker stop --rustfs                   Stop PostgreSQL + RustFS
   pgpm docker stop --ollama                   Stop PostgreSQL + Ollama
   pgpm docker ls                              List services and status
 `;
@@ -92,6 +95,23 @@ const ADDITIONAL_SERVICES: Record<string, ServiceDefinition> = {
     },
     command: ['server', '/data', '--console-address', ':9001'],
     volumes: [{ name: 'minio-data', containerPath: '/data' }]
+  },
+  rustfs: {
+    name: 'rustfs',
+    image: 'rustfs/rustfs',
+    ports: [
+      { host: 9000, container: 9000 },
+      { host: 9001, container: 9001 }
+    ],
+    env: {
+      RUSTFS_ACCESS_KEY: 'minioadmin',
+      RUSTFS_SECRET_KEY: 'minioadmin',
+      RUSTFS_ADDRESS: ':9000',
+      RUSTFS_CONSOLE_ADDRESS: ':9001',
+      RUSTFS_CONSOLE_ENABLE: 'true'
+    },
+    command: ['/data'],
+    volumes: [{ name: 'rustfs-data', containerPath: '/data' }]
   },
   ollama: {
     name: 'ollama',
@@ -349,6 +369,20 @@ function resolveServiceFlags(args: Partial<Record<string, any>>): ServiceDefinit
   return services;
 }
 
+function findPortConflict(services: ServiceDefinition[]): string | null {
+  const owners = new Map<number, string>();
+  for (const service of services) {
+    for (const { host } of service.ports) {
+      const owner = owners.get(host);
+      if (owner) {
+        return `Services "${owner}" and "${service.name}" both bind host port ${host}. Start only one of them.`;
+      }
+      owners.set(host, service.name);
+    }
+  }
+  return null;
+}
+
 async function listServices(): Promise<void> {
   const dockerStatus = await getDockerStatus();
   const dockerAvailable = dockerStatus.binary && dockerStatus.daemon;
@@ -410,12 +444,18 @@ export default async (
   const includedServices = resolveServiceFlags(args);
 
   switch (subcommand) {
-  case 'start':
+  case 'start': {
+    const conflict = findPortConflict(includedServices);
+    if (conflict) {
+      await cliExitWithError(conflict);
+      return;
+    }
     await startContainer({ name, image, port, user, password, shmSize, recreate });
     for (const service of includedServices) {
       await startService(service, recreate, gpu);
     }
     break;
+  }
 
   case 'stop':
     await stopContainer(name);

--- a/pgpm/cli/src/commands/env.ts
+++ b/pgpm/cli/src/commands/env.ts
@@ -15,6 +15,7 @@ Database Profiles:
 
 Additional Services:
   --minio            Include MinIO/S3 environment variables
+  --rustfs           Include RustFS/S3 environment variables (same vars as --minio)
 
 Modes:
   No command         Print export statements for shell evaluation
@@ -24,11 +25,13 @@ Options:
   --help, -h         Show this help message
   --supabase         Use Supabase profile instead of default Postgres
   --minio            Include CDN_ENDPOINT, AWS_ACCESS_KEY, AWS_SECRET_KEY, AWS_REGION
+  --rustfs           Alias for --minio (RustFS serves the same S3 API on :9000)
 
 Examples:
   pgpm env                                    Print default Postgres env exports
   pgpm env --supabase                         Print Supabase env exports
   pgpm env --minio                            Print Postgres + MinIO env exports
+  pgpm env --rustfs                           Print Postgres + RustFS env exports
   pgpm env --supabase --minio                 Print Supabase + MinIO env exports
   eval "$(pgpm env)"                          Load default Postgres env into shell
   eval "$(pgpm env --minio)"                  Load Postgres + MinIO env into shell
@@ -49,21 +52,21 @@ const DEFAULT_PROFILE: PgConfig = {
   ...defaultPgConfig
 };
 
-interface MinioConfig {
+interface ObjectStoreConfig {
   endpoint: string;
   accessKey: string;
   secretKey: string;
   region: string;
 }
 
-const MINIO_PROFILE: MinioConfig = {
+const OBJECT_STORE_PROFILE: ObjectStoreConfig = {
   endpoint: 'http://localhost:9000',
   accessKey: 'minioadmin',
   secretKey: 'minioadmin',
   region: 'us-east-1',
 };
 
-function configToEnvVars(config: PgConfig, minio?: MinioConfig): Record<string, string> {
+function configToEnvVars(config: PgConfig, objectStore?: ObjectStoreConfig): Record<string, string> {
   const vars: Record<string, string> = {
     PGHOST: config.host,
     PGPORT: String(config.port),
@@ -72,26 +75,26 @@ function configToEnvVars(config: PgConfig, minio?: MinioConfig): Record<string, 
     PGDATABASE: config.database
   };
 
-  if (minio) {
-    vars.CDN_ENDPOINT = minio.endpoint;
-    vars.AWS_ACCESS_KEY = minio.accessKey;
-    vars.AWS_SECRET_KEY = minio.secretKey;
-    vars.AWS_REGION = minio.region;
+  if (objectStore) {
+    vars.CDN_ENDPOINT = objectStore.endpoint;
+    vars.AWS_ACCESS_KEY = objectStore.accessKey;
+    vars.AWS_SECRET_KEY = objectStore.secretKey;
+    vars.AWS_REGION = objectStore.region;
   }
 
   return vars;
 }
 
-function printExports(config: PgConfig, minio?: MinioConfig): void {
-  const envVars = configToEnvVars(config, minio);
+function printExports(config: PgConfig, objectStore?: ObjectStoreConfig): void {
+  const envVars = configToEnvVars(config, objectStore);
   for (const [key, value] of Object.entries(envVars)) {
     console.log(`export ${key}=${value}`);
   }
 }
 
-function executeCommand(config: PgConfig, command: string, args: string[], minio?: MinioConfig): Promise<number> {
+function executeCommand(config: PgConfig, command: string, args: string[], objectStore?: ObjectStoreConfig): Promise<number> {
   return new Promise((resolve, reject) => {
-    const envVars = configToEnvVars(config, minio);
+    const envVars = configToEnvVars(config, objectStore);
     const env = {
       ...process.env,
       ...envVars
@@ -123,11 +126,13 @@ export default async (
   }
 
   const useSupabase = argv.supabase === true || typeof argv.supabase === 'string';
-  const useMinio = argv.minio === true || typeof argv.minio === 'string';
+  const useObjectStore =
+    argv.minio === true || typeof argv.minio === 'string' ||
+    argv.rustfs === true || typeof argv.rustfs === 'string';
   const profile = useSupabase ? SUPABASE_PROFILE : DEFAULT_PROFILE;
-  const minioProfile = useMinio ? MINIO_PROFILE : undefined;
+  const objectStoreProfile = useObjectStore ? OBJECT_STORE_PROFILE : undefined;
 
-  const knownFlags = ['--supabase', '--minio'];
+  const knownFlags = ['--supabase', '--minio', '--rustfs'];
 
   const rawArgs = process.argv.slice(2);
   
@@ -148,14 +153,14 @@ export default async (
   }
 
   if (commandArgs.length === 0) {
-    printExports(profile, minioProfile);
+    printExports(profile, objectStoreProfile);
     return;
   }
 
   const [command, ...args] = commandArgs;
   
   try {
-    const exitCode = await executeCommand(profile, command, args, minioProfile);
+    const exitCode = await executeCommand(profile, command, args, objectStoreProfile);
     process.exit(exitCode);
   } catch (error) {
     if (error instanceof Error) {

--- a/pgpm/types/src/pgpm.ts
+++ b/pgpm/types/src/pgpm.ts
@@ -109,13 +109,13 @@ export interface ServerOptions {
 /**
  * Storage provider type for CDN/bucket operations
  */
-export type BucketProvider = 's3' | 'minio' | 'gcs';
+export type BucketProvider = 's3' | 'minio' | 'rustfs' | 'gcs';
 
 /**
  * CDN and file storage configuration
  */
 export interface CDNOptions {
-    /** Storage provider type (s3, minio, gcs). Defaults to 'minio' for local dev */
+    /** Storage provider type (s3, minio, rustfs, gcs). Defaults to 'minio' for local dev */
     provider?: BucketProvider;
     /** S3 bucket name for file storage */
     bucketName?: string;

--- a/uploads/s3-utils/README.md
+++ b/uploads/s3-utils/README.md
@@ -16,7 +16,7 @@ Unified S3 utilities for the Constructive ecosystem — client factory, file ope
 
 ## Features
 
-- **Multi-provider support** — AWS S3, MinIO, Cloudflare R2, Google Cloud Storage, DigitalOcean Spaces
+- **Multi-provider support** — AWS S3, MinIO, RustFS, Cloudflare R2, Google Cloud Storage, DigitalOcean Spaces
 - **Presigned URLs** — generate secure PUT and GET URLs with configurable expiry
 - **File operations** — streaming upload, download, existence checks, and metadata retrieval
 - **Bucket management** — create buckets with provider-appropriate policies and CORS
@@ -88,14 +88,14 @@ const client = createS3Client({
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `provider` | `'s3' \| 'minio' \| 'r2' \| 'gcs' \| 'spaces'` | yes | Storage provider |
+| `provider` | `'s3' \| 'minio' \| 'rustfs' \| 'r2' \| 'gcs' \| 'spaces'` | yes | Storage provider |
 | `region` | `string` | yes | S3 region (e.g. `"us-east-1"`) |
 | `endpoint` | `string` | non-AWS | Endpoint URL (required for all providers except `s3`) |
 | `accessKeyId` | `string` | yes | Access key ID |
 | `secretAccessKey` | `string` | yes | Secret access key |
 | `forcePathStyle` | `boolean` | no | Override path-style URL behavior |
 
-Path-style URLs are enabled automatically for `minio`, `r2`, and `gcs`. Virtual-hosted style is used for `s3` and `spaces`.
+Path-style URLs are enabled automatically for `minio`, `rustfs`, `r2`, and `gcs`. Virtual-hosted style is used for `s3` and `spaces`.
 
 Throws `S3ConfigError` on invalid configuration.
 
@@ -199,7 +199,7 @@ someReadable.pipe(pass);
 Creates a bucket with provider-appropriate policies and CORS configuration.
 
 - **MinIO**: read-only public access policy (list + get)
-- **S3/GCS**: full-access policy with CORS rules for browser uploads
+- **RustFS/S3/GCS**: full-access policy with CORS rules for browser uploads
 
 ```typescript
 const { success } = await createS3Bucket(client, 'my-bucket', {

--- a/uploads/s3-utils/__tests__/client.test.ts
+++ b/uploads/s3-utils/__tests__/client.test.ts
@@ -28,6 +28,15 @@ describe('createS3Client', () => {
     expect(client).toBeDefined();
   });
 
+  it('creates client for RustFS with endpoint', () => {
+    const client = createS3Client({
+      ...baseConfig,
+      provider: 'rustfs',
+      endpoint: 'http://rustfs:9000',
+    });
+    expect(client).toBeDefined();
+  });
+
   it('creates client for R2 with endpoint', () => {
     const client = createS3Client({
       ...baseConfig,

--- a/uploads/s3-utils/src/client.ts
+++ b/uploads/s3-utils/src/client.ts
@@ -7,6 +7,7 @@
  *
  * Handles provider-specific defaults:
  * - minio: forces path-style URLs, requires endpoint
+ * - rustfs: forces path-style URLs, requires endpoint
  * - r2: forces path-style URLs, requires endpoint
  * - gcs: forces path-style URLs, requires endpoint
  * - s3: virtual-hosted style (AWS default)
@@ -36,14 +37,14 @@ import { S3Client } from '@aws-sdk/client-s3';
  * Used to select provider-specific behavior (e.g., path-style URLs for MinIO,
  * jurisdiction headers for R2).
  */
-export type StorageProvider = 's3' | 'minio' | 'r2' | 'gcs' | 'spaces';
+export type StorageProvider = 's3' | 'minio' | 'rustfs' | 'r2' | 'gcs' | 'spaces';
 
 /**
  * Connection configuration for an S3-compatible storage backend.
  *
  * This is the input you provide to connect to your storage provider.
  * For AWS S3, only `region` and credentials are needed.
- * For MinIO/R2/etc., also provide `endpoint`.
+ * For MinIO/RustFS/R2/etc., also provide `endpoint`.
  */
 export interface StorageConnectionConfig {
   /** Storage provider type */
@@ -82,6 +83,7 @@ export class S3ConfigError extends Error {
  *
  * Provider-specific defaults:
  * - `minio`: forces path-style URLs (required by MinIO)
+ * - `rustfs`: forces path-style URLs
  * - `r2`: forces path-style URLs (required by Cloudflare R2)
  * - `s3`: uses virtual-hosted style (AWS default)
  * - `gcs`: forces path-style URLs (GCS S3-compatible API)
@@ -103,7 +105,7 @@ export function createS3Client(config: StorageConnectionConfig): S3Client {
   }
 
   // Providers that require path-style URLs
-  const pathStyleProviders = new Set(['minio', 'r2', 'gcs']);
+  const pathStyleProviders = new Set(['minio', 'rustfs', 'r2', 'gcs']);
   const forcePathStyle = config.forcePathStyle ?? pathStyleProviders.has(config.provider);
 
   // Non-AWS providers require an endpoint

--- a/uploads/s3-utils/src/policies.ts
+++ b/uploads/s3-utils/src/policies.ts
@@ -5,7 +5,7 @@ import {
   S3Client} from '@aws-sdk/client-s3';
 
 export interface CreateS3BucketOptions {
-  provider: 'minio' | 's3' | 'gcs';
+  provider: 'minio' | 'rustfs' | 's3' | 'gcs';
 }
 
 export async function createS3Bucket(


### PR DESCRIPTION
## Summary

Makes [RustFS](https://github.com/rustfs/rustfs) selectable alongside MinIO for local dev and provisioning. MinIO stays the default everywhere; this is purely additive. Part 1 of constructive-io/constructive-planning#1935 (the `constructive` half; `constructive-db`'s `fun up` follows separately).

No storage-layer redesign was needed — I ran `rustfs/rustfs:latest` locally and pointed the **unmodified** `BucketProvisioner` at it: CreateBucket, public bucket policy (anon GET 200), PublicAccessBlock, CORS, versioning, lifecycle and presigned PUT/GET all round-tripped. Four of those are silent no-ops on the MinIO image we use today, so RustFS is if anything a stricter test target.

What changed:

- `StorageProvider` gains `'rustfs'` (both the `s3-utils` union and the duplicate in `bucket-provisioner`), and `rustfs` joins the path-style set:
  ```ts
  const pathStyleProviders = new Set(['minio', 'rustfs', 'r2', 'gcs']);
  ```
  Endpoint-required validation already covers any non-`s3` provider, so nothing else in the client factory changes. `BucketProvider` in `@pgpmjs/types` gains it too.
- `pgpm docker start --rustfs` — a new entry in `ADDITIONAL_SERVICES`, which `resolveServiceFlags` picks up automatically, so `stop`/`ls` work with no further wiring. It differs from MinIO only in image, env prefix and argv:
  ```ts
  rustfs: { image: 'rustfs/rustfs', command: ['/data'],
            env: { RUSTFS_ACCESS_KEY, RUSTFS_SECRET_KEY, RUSTFS_ADDRESS: ':9000',
                   RUSTFS_CONSOLE_ADDRESS: ':9001', RUSTFS_CONSOLE_ENABLE: 'true' }, … }
  ```
  Since it binds the same 9000/9001 as MinIO, `start` now rejects flag combinations that collide on a host port (`findPortConflict`) instead of failing halfway through with a docker error.
- `pgpm env --rustfs` is an alias of `--minio` (same `CDN_ENDPOINT`/`AWS_*` values, same S3 API on :9000); the internal `MinioConfig`/`MINIO_PROFILE` are renamed to `ObjectStoreConfig`/`OBJECT_STORE_PROFILE` to match.
- `createS3Bucket`'s provider union accepts `'rustfs'`, which routes it through the standard (non-MinIO) policy + CORS branch — the branch RustFS accepted in testing.

Note: RustFS intentionally does not support ACL-based auth, and upstream describes lifecycle as still under test (config round-trips; I did not wait out an expiry).


Link to Devin session: https://app.devin.ai/sessions/27d60854a1024546b39137a175a2cad3
Open in Devin Desktop: https://app.devin.ai/desktop/session/27d60854a1024546b39137a175a2cad3?variant=devin
Requested by: @pyramation