### PR TITLE
fix: a malformed graphql request is answered as bad input, not a server failure

### DIFF
--- a/graphql/server/src/middleware/__tests__/mask-error.test.ts
+++ b/graphql/server/src/middleware/__tests__/mask-error.test.ts
@@ -1,0 +1,117 @@
+import {
+  execute,
+  GraphQLError,
+  GraphQLInputObjectType,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+  parse,
+  validate,
+} from 'graphql';
+
+import { maskError } from '../mask-error';
+
+const ResetPasswordInput = new GraphQLInputObjectType({
+  name: 'ResetPasswordInput',
+  fields: {
+    roleId: { type: new GraphQLNonNull(GraphQLString) },
+    newPassword: { type: new GraphQLNonNull(GraphQLString) },
+  },
+});
+
+const schema = new GraphQLSchema({
+  query: new GraphQLObjectType({
+    name: 'Query',
+    fields: { ok: { type: GraphQLString, resolve: () => 'ok' } },
+  }),
+  mutation: new GraphQLObjectType({
+    name: 'Mutation',
+    fields: {
+      resetPassword: {
+        type: GraphQLString,
+        args: { input: { type: new GraphQLNonNull(ResetPasswordInput) } },
+        resolve: () => 'true',
+      },
+      brokenField: {
+        type: GraphQLString,
+        resolve: () => {
+          throw new Error('relation "internal_secrets" does not exist');
+        },
+      },
+    },
+  }),
+});
+
+/** The errors a request produces, as the client would receive them. */
+const run = async (query: string, variables?: Record<string, unknown>) => {
+  const document = parse(query);
+  const invalid = validate(schema, document);
+  const raised: readonly GraphQLError[] = invalid.length
+    ? invalid
+    : ((await execute({ schema, document, variableValues: variables })).errors ?? []);
+
+  expect(raised.length).toBeGreaterThan(0);
+  return raised.map(
+    (error) => maskError(error) as { message: string; extensions?: Record<string, unknown> }
+  );
+};
+
+describe('maskError', () => {
+  const nodeEnv = process.env.NODE_ENV;
+
+  beforeAll(() => {
+    process.env.NODE_ENV = 'production';
+  });
+
+  afterAll(() => {
+    process.env.NODE_ENV = nodeEnv;
+  });
+
+  it('surfaces an input field the schema does not define', async () => {
+    const [result] = await run('mutation($i: ResetPasswordInput!){ resetPassword(input: $i) }', {
+      i: { userId: 'role-1', roleId: 'role-1', newPassword: 'secret' },
+    });
+
+    expect(result.message).toContain('Field "userId" is not defined by type "ResetPasswordInput"');
+    expect(result.extensions?.code).toBe('BAD_USER_INPUT');
+    expect(result.extensions?.errorId).toBeUndefined();
+  });
+
+  it('surfaces a required input field the request left out', async () => {
+    const [result] = await run('mutation($i: ResetPasswordInput!){ resetPassword(input: $i) }', {
+      i: { roleId: 'role-1' },
+    });
+
+    expect(result.message).toContain('Field "newPassword" of required type "String!" was not provided');
+    expect(result.extensions?.code).toBe('BAD_USER_INPUT');
+  });
+
+  it('surfaces a selection the schema cannot answer', async () => {
+    const [result] = await run(
+      'mutation{ resetPassword(input: {roleId: "r", newPassword: "p"}){ id } }'
+    );
+
+    expect(result.message).toContain('must not have a selection');
+    expect(result.extensions?.code).toBe('BAD_USER_INPUT');
+  });
+
+  it('keeps a code the GraphQL layer supplied for itself', () => {
+    const error = new GraphQLError('PersistedQueryNotFound', {
+      extensions: { code: 'PERSISTED_QUERY_NOT_FOUND' },
+    });
+
+    const result = maskError(error) as { message: string; extensions?: Record<string, unknown> };
+
+    expect(result.message).toBe('PersistedQueryNotFound');
+    expect(result.extensions?.code).toBe('PERSISTED_QUERY_NOT_FOUND');
+  });
+
+  it('masks an unrecognized error raised while resolving a field', async () => {
+    const [result] = await run('mutation{ brokenField }');
+
+    expect(result.message).toMatch(/^An unexpected error occurred\. Reference: [0-9a-f]{16}$/);
+    expect(result.extensions?.code).toBe('INTERNAL_SERVER_ERROR');
+    expect(result.extensions?.errorId).toEqual(expect.any(String));
+  });
+});

--- a/graphql/server/src/middleware/graphile.ts
+++ b/graphql/server/src/middleware/graphile.ts
@@ -1,14 +1,11 @@
 import './types'; // for Request type
 
-import crypto from 'node:crypto';
-
-import { classify, type ErrorContext, errors, parse } from '@constructive-io/errors';
+import { errors } from '@constructive-io/errors';
 import type { ComputeConfig } from '@constructive-io/express-context';
 import type { ConstructiveOptions } from '@constructive-io/graphql-types';
 import { getNodeEnv } from '@pgpmjs/env';
 import { Logger } from '@pgpmjs/logger';
 import type { NextFunction, Request, RequestHandler, Response } from 'express';
-import type { GraphQLError, GraphQLFormattedError } from 'grafast/graphql';
 import { createGraphileInstance, graphileCache,type GraphileCacheEntry } from 'graphile-cache';
 import type { GraphileConfig } from 'graphile-config';
 import { createFunctionBindingsPlugin } from 'graphile-function-bindings';
@@ -21,99 +18,10 @@ import { HandlerCreationError } from '../errors/api-errors';
 import { respondWithGraphQLError } from '../errors/graphql-response';
 import { AuthCookiePlugin } from '../plugins/auth-cookie-plugin';
 import type { DatabaseSettings } from '../types';
+import { maskError } from './mask-error';
 import { observeGraphileBuild } from './observability/graphile-build-stats';
 
-const maskErrorLog = new Logger('graphile:maskError');
-
 const isDev = (): boolean => getNodeEnv() === 'development';
-
-/**
- * GraphQL framework protocol codes. These originate in the GraphQL/grafast
- * transport layer (not in constructive-db), so they are not Constructive domain
- * codes in the `@constructive-io/errors` registry. They are always safe to
- * surface — they carry no sensitive detail. Everything else (auth, account,
- * resource, constraint, and every constructive-db code) is classified by the
- * registry, which is the single source of truth for public vs. internal.
- */
-const GRAPHQL_PROTOCOL_CODES = new Set([
-  'GRAPHQL_VALIDATION_FAILED',
-  'GRAPHQL_PARSE_FAILED',
-  'PERSISTED_QUERY_NOT_FOUND',
-  'PERSISTED_QUERY_NOT_SUPPORTED'
-]);
-
-/** A code is safe to surface when the registry classifies it public, or it is a
- * GraphQL framework protocol code. */
-const isPublicCode = (code: string | null | undefined): boolean =>
-  Boolean(code) && (classify(code) === 'public' || GRAPHQL_PROTOCOL_CODES.has(code as string));
-
-/**
- * Normalize any GraphQL/database error into a canonical Constructive shape.
- *
- * Database errors surface through Grafast without a populated `extensions.code`
- * (the semantic code lives in the message, and any SQLSTATE/DETAIL lives on the
- * underlying pg error at `originalError`). We parse `originalError` first so we
- * can recover the structured code, then fall back to the GraphQL error itself.
- */
-const normalizeError = (
-  error: GraphQLError,
-): { code: string | null; context: ErrorContext; class: 'public' | 'internal' } => {
-  const original = (error as { originalError?: unknown }).originalError;
-  const fromOriginal = original ? parse(original) : null;
-  const parsed = fromOriginal?.code ? fromOriginal : parse(error);
-  return { code: parsed.code, context: parsed.context, class: parsed.class };
-};
-
-/**
- * Production-aware error handling backed by `@constructive-io/errors`.
- *
- * 1. Enrich `extensions.code`/`class`/`context` from the parsed error so clients
- *    always receive a machine-readable code (fixing the gap where database
- *    errors reached clients as a bare message with empty `extensions`).
- * 2. Surface public (registered/allowlisted) errors as-is.
- * 3. In development, pass everything through (enriched) for debugging.
- * 4. In production, mask internal/unknown errors behind a reference ID and log
- *    the original.
- */
-const maskError = (error: GraphQLError): GraphQLError | GraphQLFormattedError => {
-  const { code, context, class: errorClass } = normalizeError(error);
-
-  // Lift the structured code onto extensions for every recognized error so
-  // clients always receive a machine-readable code (`extensions` is read-only
-  // on GraphQLError, so we build a formatted error rather than mutating it).
-  const extensions: Record<string, unknown> = { ...error.extensions };
-  if (code) {
-    extensions.code = code;
-    extensions.class = errorClass;
-    if (Object.keys(context).length > 0) {
-      extensions.context = context;
-    }
-  }
-
-  const effectiveCode = code ?? (error.extensions?.code as string | undefined);
-  if (isPublicCode(effectiveCode) || getNodeEnv() === 'development') {
-    // Note: grafserv strips originalError and internal extensions before
-    // serializing to the client, so returning the enriched error is safe.
-    return {
-      message: error.message,
-      ...(error.locations ? { locations: error.locations } : {}),
-      ...(error.path ? { path: error.path } : {}),
-      extensions,
-    } as GraphQLFormattedError;
-  }
-
-  // Mask internal/unknown errors with a reference ID.
-  const errorId = crypto.randomBytes(8).toString('hex');
-  maskErrorLog.error(`[masked-error:${errorId}]`, error);
-
-  return {
-    message: `An unexpected error occurred. Reference: ${errorId}`,
-    extensions: {
-      code: 'INTERNAL_SERVER_ERROR',
-      errorId
-    }
-  } as GraphQLFormattedError;
-};
 
 // =============================================================================
 // Single-Flight Pattern: In-Flight Tracking

--- a/graphql/server/src/middleware/mask-error.ts
+++ b/graphql/server/src/middleware/mask-error.ts
@@ -1,0 +1,133 @@
+import crypto from 'node:crypto';
+
+import { classify, type ErrorContext, parse } from '@constructive-io/errors';
+import { getNodeEnv } from '@pgpmjs/env';
+import { Logger } from '@pgpmjs/logger';
+import { type GraphQLError, type GraphQLFormattedError } from 'graphql';
+
+const maskErrorLog = new Logger('graphile:maskError');
+
+/**
+ * GraphQL framework protocol codes. These originate in the GraphQL/grafast
+ * transport layer (not in constructive-db), so they are not Constructive domain
+ * codes in the `@constructive-io/errors` registry. They are always safe to
+ * surface — they carry no sensitive detail. Everything else (auth, account,
+ * resource, constraint, and every constructive-db code) is classified by the
+ * registry, which is the single source of truth for public vs. internal.
+ */
+const GRAPHQL_PROTOCOL_CODES = new Set([
+  'GRAPHQL_VALIDATION_FAILED',
+  'GRAPHQL_PARSE_FAILED',
+  'PERSISTED_QUERY_NOT_FOUND',
+  'PERSISTED_QUERY_NOT_SUPPORTED'
+]);
+
+/** A code is safe to surface when the registry classifies it public, or it is a
+ * GraphQL framework protocol code. */
+const isPublicCode = (code: string | null | undefined): boolean =>
+  Boolean(code) && (classify(code) === 'public' || GRAPHQL_PROTOCOL_CODES.has(code as string));
+
+/**
+ * An error the GraphQL layer raised about the *request*, before any resolver
+ * ran: an unknown input field, a value of the wrong type, a missing required
+ * variable. graphql-js reports variable coercion without an `extensions.code`
+ * (unlike parse/validation, which carry `GRAPHQL_PARSE_FAILED` /
+ * `GRAPHQL_VALIDATION_FAILED`), so code-based classification alone reads it as
+ * unknown and masks it — telling a client its own malformed query was a server
+ * failure, with a reference id pointing at nothing.
+ *
+ * A request error is answered before a field is resolved, so it carries no
+ * response `path` — every execution error has one. Coercion wraps the inner
+ * complaint about the value, so `originalError` may be set, but only ever to
+ * another GraphQL-layer error: anything a resolver or the database threw arrives
+ * as a foreign error (a pg error, an `Error`) and is masked as before. The wrap
+ * is recognized by name rather than by `instanceof`, because the error is raised
+ * by whichever copy of graphql-js grafast resolved, not by this package's.
+ */
+const isGraphQLLayerError = (value: unknown): boolean =>
+  value == null ||
+  ((value as Error).name === 'GraphQLError' &&
+    isGraphQLLayerError((value as GraphQLError).originalError));
+
+const isRequestError = (error: GraphQLError): boolean =>
+  error.path == null && isGraphQLLayerError((error as { originalError?: unknown }).originalError);
+
+/** The code a surfaced request error carries when graphql-js supplied none. */
+const BAD_USER_INPUT = 'BAD_USER_INPUT';
+
+/**
+ * Normalize any GraphQL/database error into a canonical Constructive shape.
+ *
+ * Database errors surface through Grafast without a populated `extensions.code`
+ * (the semantic code lives in the message, and any SQLSTATE/DETAIL lives on the
+ * underlying pg error at `originalError`). We parse `originalError` first so we
+ * can recover the structured code, then fall back to the GraphQL error itself.
+ */
+const normalizeError = (
+  error: GraphQLError,
+): { code: string | null; context: ErrorContext; class: 'public' | 'internal' } => {
+  const original = (error as { originalError?: unknown }).originalError;
+  const fromOriginal = original ? parse(original) : null;
+  const parsed = fromOriginal?.code ? fromOriginal : parse(error);
+  return { code: parsed.code, context: parsed.context, class: parsed.class };
+};
+
+/**
+ * Production-aware error handling backed by `@constructive-io/errors`.
+ *
+ * 1. Enrich `extensions.code`/`class`/`context` from the parsed error so clients
+ *    always receive a machine-readable code (fixing the gap where database
+ *    errors reached clients as a bare message with empty `extensions`).
+ * 2. Surface public (registered/allowlisted) errors as-is.
+ * 3. In development, pass everything through (enriched) for debugging.
+ * 4. In production, mask internal/unknown errors behind a reference ID and log
+ *    the original.
+ */
+export const maskError = (error: GraphQLError): GraphQLError | GraphQLFormattedError => {
+  const { code, context, class: errorClass } = normalizeError(error);
+
+  // Lift the structured code onto extensions for every recognized error so
+  // clients always receive a machine-readable code (`extensions` is read-only
+  // on GraphQLError, so we build a formatted error rather than mutating it).
+  const extensions: Record<string, unknown> = { ...error.extensions };
+  if (code) {
+    extensions.code = code;
+    extensions.class = errorClass;
+    if (Object.keys(context).length > 0) {
+      extensions.context = context;
+    }
+  }
+
+  const effectiveCode = code ?? (error.extensions?.code as string | undefined);
+  if (!effectiveCode && isRequestError(error)) {
+    extensions.code = BAD_USER_INPUT;
+    return {
+      message: error.message,
+      ...(error.locations ? { locations: error.locations } : {}),
+      extensions,
+    } as GraphQLFormattedError;
+  }
+
+  if (isPublicCode(effectiveCode) || getNodeEnv() === 'development') {
+    // Note: grafserv strips originalError and internal extensions before
+    // serializing to the client, so returning the enriched error is safe.
+    return {
+      message: error.message,
+      ...(error.locations ? { locations: error.locations } : {}),
+      ...(error.path ? { path: error.path } : {}),
+      extensions,
+    } as GraphQLFormattedError;
+  }
+
+  // Mask internal/unknown errors with a reference ID.
+  const errorId = crypto.randomBytes(8).toString('hex');
+  maskErrorLog.error(`[masked-error:${errorId}]`, error);
+
+  return {
+    message: `An unexpected error occurred. Reference: ${errorId}`,
+    extensions: {
+      code: 'INTERNAL_SERVER_ERROR',
+      errorId
+    }
+  } as GraphQLFormattedError;
+};


### PR DESCRIPTION
## Summary

`maskError` classified by error *code*, and graphql-js raises variable coercion errors with **no** `extensions.code` — unlike parse/validation, which carry `GRAPHQL_PARSE_FAILED` / `GRAPHQL_VALIDATION_FAILED`. So a client that sent an unknown input field got

```
An unexpected error occurred. Reference: 9fcabcb86c167e95
```

with a reference id pointing at a log line that says the client's own query was wrong. Every "reset password is broken" report in this shape was a caller typo the server refused to name.

A request error is now surfaced with its real message and `extensions.code = 'BAD_USER_INPUT'`. It is distinguished structurally, not by code:

```ts
const isRequestError = (error) =>
  error.path == null && isGraphQLLayerError(error.originalError);
```

- **no response `path`** — a request is answered before any field resolves; every execution error is located at a path.
- **`originalError`, if set, is itself a GraphQL-layer error** — coercion wraps the inner complaint about the value, so `originalError == null` alone was too strict (that was the first attempt, and it still masked coercion). Anything a resolver or the database threw arrives as a foreign error (a pg error, a plain `Error`) and is masked exactly as before. The wrap is matched by `name === 'GraphQLError'` rather than `instanceof`, because the error comes from whichever copy of graphql-js grafast resolved, not this package's.

Also moves `maskError` out of `graphile.ts` into its own `mask-error.ts` so it can be tested without standing up the middleware's workspace dependencies. No behavior change from the move.

Tests execute a real schema — parse, validate, coerce, resolve — rather than hand-constructing errors, since the whole bug was in what graphql-js actually populates: unknown input field, missing required field, invalid selection → `BAD_USER_INPUT`; a supplied protocol code stays public; a throwing resolver stays masked with a reference id.


Link to Devin session: https://app.devin.ai/sessions/6953eeb0c1b041d09921b3618afbebd3
Open in Devin Desktop: https://app.devin.ai/desktop/session/6953eeb0c1b041d09921b3618afbebd3?variant=devin
Requested by: @pyramation