### PR TITLE
docs(storage): document rustfs provider and add a rustfs compose profile

### DIFF
--- a/.agents/skills/pgpm/references/environment-configuration.md
+++ b/.agents/skills/pgpm/references/environment-configuration.md
@@ -128,12 +128,12 @@ const deployOptions = getDeploymentEnvOptions();
 
 | Variable | Description |
 |----------|-------------|
-| `BUCKET_PROVIDER` | Storage provider (s3, minio) |
+| `BUCKET_PROVIDER` | Storage provider (s3, minio, rustfs, gcs) — defaults to minio |
 | `BUCKET_NAME` | Bucket name |
 | `AWS_REGION` | AWS region |
 | `AWS_ACCESS_KEY_ID` | AWS access key |
 | `AWS_SECRET_ACCESS_KEY` | AWS secret key |
-| `MINIO_ENDPOINT` | MinIO endpoint URL |
+| `MINIO_ENDPOINT` | S3-compatible endpoint URL (MinIO or RustFS; both listen on 9000) |
 
 ### Jobs Configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,31 @@ services:
     networks:
       - constructive-net
 
+  # RustFS is an alternative to the `minio` service above: same S3 API on 9000
+  # and console on 9001, so the two cannot run together. Behind a profile:
+  # `docker compose up postgres` keeps MinIO, `docker compose --profile rustfs
+  # up postgres rustfs` swaps it in. Pair it with BUCKET_PROVIDER=rustfs.
+  rustfs:
+    container_name: rustfs
+    image: rustfs/rustfs:latest
+    profiles:
+      - rustfs
+    environment:
+      - RUSTFS_ACCESS_KEY=minioadmin
+      - RUSTFS_SECRET_KEY=minioadmin
+      - RUSTFS_ADDRESS=:9000
+      - RUSTFS_CONSOLE_ADDRESS=:9001
+      - RUSTFS_CONSOLE_ENABLE=true
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    expose:
+      - "9000"
+      - "9001"
+    command: /data
+    networks:
+      - constructive-net
+
 networks:
   constructive-net:
     name: constructive-net


### PR DESCRIPTION
## Summary

Follow-up to #1793, which added `'rustfs'` as an S3-compatible provider but left two consumer-facing surfaces MinIO-only.

- `BUCKET_PROVIDER` reference table still read `(s3, minio)`; now lists `rustfs`/`gcs` and notes the MinIO default. `MINIO_ENDPOINT`'s description is generalized since RustFS reuses the same var and port.
- The repo-root `docker-compose.yml` gained a `rustfs` service behind `profiles: [rustfs]`, mirroring the one added to constructive-db. It binds the same host ports as `minio` (9000/9001), so the profile makes them mutually exclusive: plain `docker compose up` is unchanged, and `docker compose --profile rustfs up postgres rustfs` swaps the backend (pair with `BUCKET_PROVIDER=rustfs`).

Verified by starting the profile locally: `GET localhost:9000/health` → 200.

No code changes: `BUCKET_PROVIDER` already flows into `cdn.provider` through `@pgpmjs/env`, so the `provider || 'minio'` fallbacks in `create-bucket.ts`, `s3-streamer`, and `upload-resolver` only apply when nothing is configured, and already accept `'rustfs'`.


Link to Devin session: https://app.devin.ai/sessions/27d60854a1024546b39137a175a2cad3
Open in Devin Desktop: https://app.devin.ai/desktop/session/27d60854a1024546b39137a175a2cad3?variant=devin
Requested by: @pyramation