### PR TITLE
feat(safegres): let the PR comment carry the report, capped and deduplicated

### DIFF
--- a/packages/safegres/__tests__/github.test.ts
+++ b/packages/safegres/__tests__/github.test.ts
@@ -1,5 +1,6 @@
 import {
   COMMENT_MARKER,
+  COMMENT_MAX_CHARS,
   renderAnnotations,
   renderGithubComment,
   renderGithubSummary,
@@ -154,7 +155,89 @@ describe('renderGithubComment', () => {
     });
     expect(out).toContain('| `direct:app` | role | 3 |');
   });
+
+  it('names the ratchet verdict even when nothing is new', () => {
+    const report = perfReport(0);
+    expect(renderGithubComment(report)).toContain(
+      'Perf baseline: **0 new**, 2 accepted, 1 resolved.'
+    );
+  });
+
+  it('carries the report at summary detail, without per-finding tables', () => {
+    const out = renderGithubComment(perfReport(0), {
+      config: { comment: { sections: ['scores', 'delta', 'new-findings', 'report'] } }
+    });
+    expect(out).toContain('## Report');
+    expect(out).toContain('| 0 | 1 | 0 | 0 | 0 |');
+    // The report says this once — the comment does not repeat it above.
+    expect(occurrences(out, 'Perf baseline: **0 new**')).toBe(1);
+    expect(occurrences(out, 'Exposure (config)')).toBe(1);
+    expect(out).not.toContain('### Security findings');
+  });
+
+  it('adds the finding tables at normal detail', () => {
+    const out = renderGithubComment(makeReport(), {
+      config: { comment: { sections: ['report'], detail: 'normal' } }
+    });
+    expect(out).toContain('### Security findings');
+    expect(out).toContain('app_public.widgets');
+  });
+
+  it('degrades to summary detail rather than exceeding what GitHub accepts', () => {
+    // GitHub rejects a body over 64 KB outright, so a database with thousands
+    // of findings must lose the tables, not the comment.
+    const findings = Array.from({ length: 4000 }, (_, i) =>
+      finding({ table: `widgets_${i}`, message: `grants exist on a table with RLS disabled (${i})` })
+    );
+    const out = renderGithubComment(makeReport({ findings }), {
+      config: { comment: { sections: ['report'], detail: 'normal' } }
+    });
+    expect(out.length).toBeLessThanOrEqual(COMMENT_MAX_CHARS);
+    expect(out).not.toContain('### Security findings');
+    expect(out).toContain('| 0 | 4000 | 0 | 0 | 0 |');
+  });
+
+  it('points at the artifact when even the summary does not fit', () => {
+    const unaddressable = Array.from({ length: 4000 }, (_, i) => ({
+      schema: 'app_private',
+      table: `hidden_${i}`,
+      reason: 'no primary key'
+    }));
+    const report = makeReport();
+    report.exposure = { ...report.exposure!, unaddressable };
+    const out = renderGithubComment(report, {
+      config: { comment: { sections: ['report'] } }
+    });
+    expect(out.length).toBeLessThanOrEqual(COMMENT_MAX_CHARS);
+    expect(out).toContain('too large for a PR comment');
+  });
+
+  it('accepts `findings` as the old name for the report section', () => {
+    const out = renderGithubComment(makeReport(), {
+      config: { comment: { sections: ['findings'] } }
+    });
+    expect(out).toContain('## Report');
+  });
 });
+
+function occurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+/** A report whose perf ratchet ran, with `added` new findings. */
+function perfReport(added: number): Report {
+  const report = makeReport();
+  report.perf = {
+    score: computeScore([], undefined, { exposedTables: 10, exposureKnown: true }),
+    findings: [],
+    diff: {
+      added: Array.from({ length: added }, () => finding({ code: 'X1', dimension: 'perf' })),
+      accepted: [finding({ code: 'X1' }), finding({ code: 'X2' })],
+      removed: [finding({ code: 'X3' })]
+    }
+  } as never;
+  return report;
+}
 
 describe('renderAnnotations', () => {
   it('annotates only what failed a gate by default', () => {

--- a/packages/safegres/docs/reporting.md
+++ b/packages/safegres/docs/reporting.md
@@ -124,13 +124,32 @@ What appears is configuration, not code:
   "report": {
     "github": {
       "summary": ["security", "perf", "planes:direct:*"],  // which scores get a badge, in order
-      "comment": { "sticky": true, "sections": ["scores", "delta", "new-findings"] },
+      "comment": {
+        "sticky": true,
+        "sections": ["scores", "delta", "new-findings", "report"],
+        "detail": "summary"                                 // how much report the comment carries
+      },
       "annotations": "gate-failures",                       // "all" | "gate-failures" | "none"
       "badges": true                                        // false → 🟢🟡🔴 text, no images
     }
   }
 }
 ```
+
+The comment's sections, in the order they render: `scores` (badges, and the exposure line),
+`planes`, `delta` (the movement, or why there is no baseline), `new-findings` (the perf ratchet's
+verdict — `Perf baseline: N new, N accepted, N resolved` — and the new findings themselves) and
+`report`, the same markdown report the job summary carries. `findings` is the old name for
+`report`.
+
+`report` is off by default: a comment is read on the way past, and the full report is a click away
+in the job summary and the reports artifact. Turn it on to review an audit without leaving the PR —
+`comment.detail` then decides how much of it lands. Default `summary` is the report *minus* the
+per-finding tables (scores, exposure, counts, the delta, the ratchet verdict); `normal`/`verbose`
+add the tables. GitHub rejects a comment body over 64 KB outright, so a body that would not fit
+degrades a step at a time — `verbose` → `normal` → `summary` → a line pointing at the artifact —
+rather than failing to post. When `report` is on, the sections above it stop repeating what it
+already says (the exposure line, the delta, the ratchet verdict), so each fact appears once.
 
 GitHub Markdown has no text color, so a genuinely colored score has to be an image; `badges: false`
 falls back to emoji for air-gapped runners that cannot reach shields.io.

--- a/packages/safegres/schema/safegres.schema.json
+++ b/packages/safegres/schema/safegres.schema.json
@@ -1044,12 +1044,22 @@
                       "scores",
                       "delta",
                       "new-findings",
+                      "report",
                       "findings",
                       "planes"
                     ],
                     "description": "Section"
                   },
-                  "description": "Sections to include. Default scores, delta, new-findings."
+                  "description": "Sections to include. Default scores, delta, new-findings. `report` adds the markdown report (`findings` is its old name)."
+                },
+                "detail": {
+                  "type": "string",
+                  "enum": [
+                    "summary",
+                    "normal",
+                    "verbose"
+                  ],
+                  "description": "How much of the report the report section carries. Default summary."
                 }
               },
               "description": "Sticky PR comment"

--- a/packages/safegres/src/config/schema.ts
+++ b/packages/safegres/src/config/schema.ts
@@ -218,9 +218,15 @@ const FAIL_ON: Shape<FailOnConfig> = {
 const GITHUB_COMMENT: Shape<GithubCommentConfig> = {
   sticky: bool('Reuse one comment per PR instead of appending. Default true.'),
   sections: list(
-    'Sections to include. Default scores, delta, new-findings.',
-    str('Section', ['scores', 'delta', 'new-findings', 'findings', 'planes'])
-  )
+    'Sections to include. Default scores, delta, new-findings. `report` adds the '
+      + 'markdown report (`findings` is its old name).',
+    str('Section', ['scores', 'delta', 'new-findings', 'report', 'findings', 'planes'])
+  ),
+  detail: str('How much of the report the report section carries. Default summary.', [
+    'summary',
+    'normal',
+    'verbose'
+  ])
 };
 
 const GITHUB: Shape<GithubReportConfig> = {

--- a/packages/safegres/src/config/types.ts
+++ b/packages/safegres/src/config/types.ts
@@ -504,8 +504,23 @@ export interface GithubReportConfig {
 export interface GithubCommentConfig {
   /** Reuse one comment per PR instead of appending. Default `true`. */
   sticky?: boolean;
-  /** Sections to include. Default `['scores', 'delta', 'new-findings']`. */
-  sections?: Array<'scores' | 'delta' | 'new-findings' | 'findings' | 'planes'>;
+  /**
+   * Sections to include, in this order: `scores` (badges + exposure), `planes`,
+   * `delta`, `new-findings` (the perf ratchet verdict and what it caught), and
+   * `report` — the same markdown report the job summary carries, at `detail`.
+   * `findings` is the old name for `report`. Default
+   * `['scores', 'delta', 'new-findings']`; add `report` to review the audit
+   * without leaving the PR.
+   */
+  sections?: Array<'scores' | 'delta' | 'new-findings' | 'report' | 'findings' | 'planes'>;
+  /**
+   * How much of the report the `report` section carries. Default `summary` —
+   * scores, exposure, counts, the delta and the ratchet verdict, with no
+   * per-finding tables, because a comment is read on the way past and GitHub
+   * rejects a body over 64 KB. `normal`/`verbose` add the finding tables and
+   * degrade back to `summary` when the body would not fit.
+   */
+  detail?: 'summary' | 'normal' | 'verbose';
 }
 
 /**

--- a/packages/safegres/src/report/github.ts
+++ b/packages/safegres/src/report/github.ts
@@ -92,16 +92,52 @@ export function renderGithubSummary(report: Report, options: GithubRenderOptions
 }
 
 /**
- * The sticky PR comment: shorter than the summary by design. A comment is read
- * on the way past, so it carries the scores, the movement, and what is new —
- * the full finding tables live in the job summary and the SARIF alerts.
+ * GitHub rejects an issue comment body over 65536 characters, and a comment
+ * that fails to post is worse than a short one — so a comment carrying the
+ * report degrades (verbose → normal → summary → a pointer at the job summary)
+ * rather than being truncated at a byte boundary by the API.
+ */
+export const COMMENT_MAX_CHARS = 65536;
+
+/**
+ * The sticky PR comment: shorter than the summary by default. A comment is read
+ * on the way past, so out of the box it carries the scores, the movement, and
+ * what is new, with the full finding tables in the job summary and the SARIF
+ * alerts.
+ *
+ * `comment.sections` chooses what it says. `report` puts the whole markdown
+ * report in the comment at `comment.detail` (default `summary`: scores,
+ * exposure, counts, the delta and the ratchet verdict — no per-finding tables),
+ * which is the same render the job summary uses, so the two cannot disagree.
  */
 export function renderGithubComment(report: Report, options: GithubRenderOptions = {}): string {
+  const wanted = options.config?.comment?.detail ?? 'summary';
+  const chain: Array<'verbose' | 'normal' | 'summary'> =
+    wanted === 'verbose' ? ['verbose', 'normal', 'summary'] : wanted === 'normal' ? ['normal', 'summary'] : ['summary'];
+  for (const detail of chain) {
+    const body = commentBody(report, options, detail);
+    if (body.length <= COMMENT_MAX_CHARS) return body;
+  }
+  return commentBody(report, options, null);
+}
+
+/**
+ * One comment body. `detail` is the report section's detail, or null to drop
+ * the report and say where it went — which is how the size cap is honored.
+ */
+function commentBody(
+  report: Report,
+  options: GithubRenderOptions,
+  detail: 'summary' | 'normal' | 'verbose' | null
+): string {
   const config = options.config ?? {};
   const badges = config.badges !== false;
   const sections = new Set(config.comment?.sections ?? ['scores', 'delta', 'new-findings']);
   const selectors = config.summary ?? ['security', 'perf'];
   const view = selectView(report, { planes: planePatterns(selectors), ...options.view });
+  // `findings` is the old name for `report`; both mean "the markdown report".
+  const wantsReport = sections.has('report') || sections.has('findings');
+  const withReport = wantsReport && detail != null;
 
   const out: string[] = [COMMENT_MARKER, '## safegres', ''];
 
@@ -112,7 +148,8 @@ export function renderGithubComment(report: Report, options: GithubRenderOptions
         .join(' '),
       ''
     );
-    if (report.exposure) {
+    // Everything below is in the report too, so it is said once.
+    if (report.exposure && !withReport) {
       out.push(
         report.exposure.known
           ? `Exposure (${report.exposure.source}): **${report.exposure.exposedTables}/`
@@ -137,7 +174,10 @@ export function renderGithubComment(report: Report, options: GithubRenderOptions
     );
   }
 
-  if (sections.has('delta') && report.comparison) {
+  // The report renders the comparison (or the reason there is none) itself.
+  const wantsDelta = sections.has('delta') && !withReport;
+
+  if (wantsDelta && report.comparison) {
     const cmp = report.comparison;
     const since = describeBaseline(cmp.previous);
     if (cmp.unchanged) {
@@ -157,7 +197,7 @@ export function renderGithubComment(report: Report, options: GithubRenderOptions
       }
       out.push('');
     }
-  } else if (sections.has('delta') && report.comparisonSkipped) {
+  } else if (wantsDelta && report.comparisonSkipped) {
     out.push(
       `_No delta baseline: ${report.comparisonSkipped}. `
         + 'The absolute score and the perf baseline still gate this run._',
@@ -166,7 +206,18 @@ export function renderGithubComment(report: Report, options: GithubRenderOptions
   }
 
   if (sections.has('new-findings')) {
-    const added = report.perf?.diff?.added ?? [];
+    const diff = report.perf?.diff;
+    // The ratchet's verdict, even when it is "nothing new": a comment that only
+    // speaks up on new debt cannot be distinguished from one that never ran.
+    // The report carries this line itself, so it is not repeated under it.
+    if (diff && !withReport) {
+      out.push(
+        `Perf baseline: **${diff.added.length} new**, ${diff.accepted.length} accepted, `
+          + `${diff.removed.length} resolved.`,
+        ''
+      );
+    }
+    const added = diff?.added ?? [];
     if (added.length > 0) {
       out.push(
         `**${added.length} new performance finding${added.length === 1 ? '' : 's'} since the baseline**`,
@@ -177,8 +228,14 @@ export function renderGithubComment(report: Report, options: GithubRenderOptions
     }
   }
 
-  if (sections.has('findings')) {
-    out.push(renderMarkdown(report, { title: 'Findings', view: options.view }), '');
+  if (withReport) {
+    out.push(renderMarkdown(report, { title: 'Report', view: { detail, ...options.view } }), '');
+  } else if (wantsReport) {
+    out.push(
+      '_The report is too large for a PR comment — it is in the job summary and the '
+        + 'reports artifact._',
+      ''
+    );
   }
 
   return out.join('\n');


### PR DESCRIPTION
## Summary

The sticky PR comment could not carry the report. `sections: ['findings']` existed, but it rendered
`renderMarkdown(report, { view: options.view })` — no `detail` — so it pasted the *whole* report
(hundreds of KB on a database with thousands of findings) into a body GitHub rejects over 64 KB.
The ratchet's verdict was missing too: the comment spoke only when there was new perf debt, so
"0 new, 2 accepted, 1 resolved" and "the audit never ran" looked the same.

`comment.sections` now takes `report` (with `findings` kept as its old name) and
`comment.detail` decides how much of it lands, defaulting to `summary` — the same render the job
summary uses at `detail: summary`, i.e. scores, exposure, counts, the delta and the ratchet verdict
with no per-finding tables:

```jsonc
"comment": { "sections": ["scores", "delta", "new-findings", "report"], "detail": "summary" }
```

Two things make that safe to turn on:

```ts
// the body is capped, by losing detail rather than by being rejected
for (const detail of chain /* verbose -> normal -> summary */) {
  const body = commentBody(report, options, detail);
  if (body.length <= COMMENT_MAX_CHARS /* 65536 */) return body;
}
return commentBody(report, options, null); // "too large for a PR comment — job summary/artifact"
```

and each fact appears once: with `report` on, the sections above it drop what it already says (the
exposure line, the delta block, the ratchet line), so the comment reads as one document rather than
as a preamble followed by its own duplicate.

Independent of `report`, `new-findings` now always names the ratchet's verdict when a baseline diff
exists — `Perf baseline: **0 new**, 2 accepted, 1 resolved.` — which is the line the deleted
per-repo script in constructive-db used to emit and the one thing a reviewer wants from a run that
found nothing.

Config type, JSON schema (regenerated via `npm run schema`), `docs/reporting.md` and tests updated;
the size cap is tested by rendering a 4000-finding report at `detail: normal` and asserting the
result stays under the limit with the tables gone.

Nothing changes for a repo that does not set `comment.sections`: the default is still
`['scores', 'delta', 'new-findings']`.


Link to Devin session: https://app.devin.ai/sessions/82689f1e86b344cd9c75553b50c6a235
Open in Devin Desktop: https://app.devin.ai/desktop/session/82689f1e86b344cd9c75553b50c6a235?variant=devin
Requested by: @pyramation