### PR TITLE
Pin the published platform plane that carries request protection

### DIFF
--- a/pgpm.json
+++ b/pgpm.json
@@ -3,16 +3,16 @@
     "testing/*"
   ],
   "dependencies": {
-    "@constructive-db/apps": "7.0.0",
-    "@constructive-db/catalog": "6.0.0",
-    "@constructive-db/routing": "8.0.0",
-    "@constructive-db/routing-platform": "7.0.0",
-    "@pgpm/database-jobs": "0.41.0",
-    "@pgpm/function-resolution": "0.41.0",
-    "@pgpm/jwt-claims": "0.41.0",
-    "@pgpm/metaschema-modules": "0.41.0",
-    "@pgpm/metaschema-schema": "0.41.0",
-    "@pgpm/stamps": "0.41.0",
-    "@pgpm/uuid": "0.41.0"
+    "@constructive-db/apps": "7.1.0",
+    "@constructive-db/catalog": "6.1.0",
+    "@constructive-db/routing": "8.1.0",
+    "@constructive-db/routing-platform": "7.1.0",
+    "@pgpm/database-jobs": "0.44.0",
+    "@pgpm/function-resolution": "0.44.0",
+    "@pgpm/jwt-claims": "0.44.0",
+    "@pgpm/metaschema-modules": "0.44.0",
+    "@pgpm/metaschema-schema": "0.44.0",
+    "@pgpm/stamps": "0.44.0",
+    "@pgpm/uuid": "0.44.0"
   }
 }

--- a/pgpm.json
+++ b/pgpm.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@constructive-db/apps": "7.1.0",
     "@constructive-db/catalog": "6.1.0",
-    "@constructive-db/routing": "8.1.0",
+    "@constructive-db/routing": "8.2.0",
     "@constructive-db/routing-platform": "7.1.0",
     "@pgpm/database-jobs": "0.44.0",
     "@pgpm/function-resolution": "0.44.0",


### PR DESCRIPTION
## Summary

The request-protection runtime (#1790) reads 11 columns off `routing_public.database_settings` / `api_settings`, but the plane pinned here (`@constructive-db/routing@8.0.0`) doesn't have them — the loader feature-detects the columns and every database silently resolves to the platform defaults. Those columns are now published in `8.1.0`, so this bumps the pin and the rest of the platform plane it deploys with.

```diff
-"@constructive-db/apps": "7.0.0",  "catalog": "6.0.0",  "routing": "8.0.0",  "routing-platform": "7.0.0"
+"@constructive-db/apps": "7.1.0",  "catalog": "6.1.0",  "routing": "8.1.0",  "routing-platform": "7.1.0"
-"@pgpm/*": "0.41.0"
+"@pgpm/*": "0.44.0"
```

The `@pgpm/*` bump is not cosmetic and not separable: the generated `catalog`/`routing` output at these versions calls `jwt_private.require_database_id()`, which only exists from `@pgpm/jwt-claims@0.44.0` — deploying the new plane against 0.41.0 fails at deploy time.

No code changes: `requestProtection`'s column probe now finds all 11 columns, so tenant-configured bounds start winning over the compatibility defaults.


Link to Devin session: https://app.devin.ai/sessions/fd9f9aa438b24c75b2861f1a9ffc0e3c
Open in Devin Desktop: https://app.devin.ai/desktop/session/fd9f9aa438b24c75b2861f1a9ffc0e3c?variant=devin
Requested by: @pyramation