### PR TITLE
feat(server): refuse non-servable roles on resolved API rows before SET ROLE

### DIFF
--- a/graphql/server/src/middleware/__tests__/api.test.ts
+++ b/graphql/server/src/middleware/__tests__/api.test.ts
@@ -77,8 +77,8 @@ describe('api middleware routing priority', () => {
             api_id: 'api-123',
             database_id: 'db-123',
             dbname: 'tenant_db',
-            role_name: 'api_role',
-            anon_role: 'api_anon',
+            role_name: 'authenticated',
+            anon_role: 'anonymous',
             is_public: false,
             schemas: ['api_public']
           }]
@@ -103,8 +103,8 @@ describe('api middleware routing priority', () => {
     expect(result).toMatchObject({
       apiId: 'api-123',
       dbname: 'tenant_db',
-      anonRole: 'api_anon',
-      roleName: 'api_role',
+      anonRole: 'anonymous',
+      roleName: 'authenticated',
       schema: ['api_public'],
       databaseId: 'db-123',
       isPublic: false
@@ -115,3 +115,81 @@ describe('api middleware routing priority', () => {
     ]));
   });
 });
+
+describe('servable-role door check (X-Api-Name lookup)', () => {
+  beforeEach(() => {
+    svcCache.clear();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    svcCache.clear();
+  });
+
+  const poolWithApiRow = (row: Record<string, unknown>) => {
+    const query = jest.fn(async (_sql: string, params: unknown[]) => {
+      if (Array.isArray(params[0])) {
+        return { rows: (params[0] as string[]).map((schema_name) => ({ schema_name })) };
+      }
+      if (params[0] === 'db-123' && params[1] === 'customer-api') {
+        return {
+          rows: [{
+            api_id: 'api-123',
+            database_id: 'db-123',
+            dbname: 'tenant_db',
+            is_public: false,
+            schemas: ['api_public'],
+            ...row
+          }]
+        };
+      }
+      return { rows: [] };
+    });
+    mockGetPgPool.mockReturnValue({ query } as unknown as Pool);
+    return query;
+  };
+
+  const request = () => createRequest({
+    host: 'admin.localhost',
+    'X-Database-Id': 'db-123',
+    'X-Api-Name': 'customer-api'
+  });
+
+  it.each([
+    ['role_name', 'administrator'],
+    ['anon_role', 'administrator'],
+    ['role_name', 'postgres'],
+    ['anon_role', 'authenticated_client'],
+    ['role_name', 'anon'],
+    ['anon_role', null],
+    ['role_name', undefined]
+  ])('refuses a row whose %s is %p and caches nothing', async (column, role) => {
+    poolWithApiRow({ role_name: 'authenticated', anon_role: 'anonymous', [column]: role });
+
+    await expect(getApiConfig(createPrivateOptions(), request())).rejects.toMatchObject({
+      code: 'NON_SERVABLE_ROLE',
+      column,
+      message: expect.stringContaining(column)
+    });
+    expect(svcCache.has('api:db-123:customer-api')).toBe(false);
+  });
+
+  it('serves a row whose roles are both servable', async () => {
+    poolWithApiRow({ role_name: 'authenticated', anon_role: 'anonymous' });
+
+    const result = await getApiConfig(createPrivateOptions(), request());
+
+    expect(result).toMatchObject({ roleName: 'authenticated', anonRole: 'anonymous' });
+    expect(svcCache.get('api:db-123:customer-api')).toBe(result);
+  });
+
+  it('never invents a role when the row leaves one blank', async () => {
+    poolWithApiRow({ role_name: 'authenticated', anon_role: null });
+
+    await expect(getApiConfig(createPrivateOptions(), request())).rejects.toMatchObject({
+      code: 'NON_SERVABLE_ROLE',
+      role: null
+    });
+  });
+});
+

--- a/graphql/server/src/middleware/__tests__/routing.test.ts
+++ b/graphql/server/src/middleware/__tests__/routing.test.ts
@@ -36,8 +36,8 @@ const matchedRoute = (overrides: Partial<ResolvedRoute> = {}): ResolvedRoute => 
     api_id: 'api-1',
     database_id: 'db-1',
     dbname: 'tenant_db',
-    role_name: 'api_role',
-    anon_role: 'api_anon',
+    role_name: 'authenticated',
+    anon_role: 'anonymous',
     is_public: true,
     schemas: ['app_public']
   },
@@ -106,8 +106,8 @@ describe('routeToApiStructure', () => {
         apiId: 'api-1',
         databaseId: 'db-1',
         dbname: 'tenant_db',
-        roleName: 'api_role',
-        anonRole: 'api_anon',
+        roleName: 'authenticated',
+        anonRole: 'anonymous',
         schema: ['app_public'],
         isPublic: true
       })
@@ -120,6 +120,22 @@ describe('routeToApiStructure', () => {
 
   it('returns null when resolved_config lacks api essentials', () => {
     expect(routeToApiStructure(matchedRoute({ resolved_config: {} }), opts)).toBeNull();
+  });
+
+  it('carries the row roles through verbatim — no fallback role is invented', () => {
+    const structure = routeToApiStructure(
+      matchedRoute({
+        resolved_config: {
+          api_id: 'api-1',
+          database_id: 'db-1',
+          dbname: 'tenant_db',
+          is_public: true,
+          schemas: ['app_public']
+        }
+      }),
+      opts
+    );
+    expect(structure).toEqual(expect.objectContaining({ roleName: undefined, anonRole: undefined }));
   });
 });
 
@@ -194,8 +210,8 @@ describe('getApiConfig with scoped routing enabled', () => {
       resolved_config: {
         api_id: 'api-1',
         dbname: 'tenant_db',
-        role_name: 'api_role',
-        anon_role: 'api_anon',
+        role_name: 'authenticated',
+        anon_role: 'anonymous',
         is_public: true,
         schemas: ['app_public']
       }
@@ -210,5 +226,43 @@ describe('getApiConfig with scoped routing enabled', () => {
     await expect(
       getApiConfig(createOptions(), createRequest({ host: 'api.example.com' }))
     ).rejects.toMatchObject({ code: 'NO_DATABASE_ID' });
+  });
+
+  it.each([
+    ['role_name', 'administrator'],
+    ['anon_role', 'administrator'],
+    ['role_name', 'authenticated_client'],
+    ['anon_role', 'anon'],
+    ['anon_role', undefined]
+  ])('refuses to serve a route whose %s is %p (NON_SERVABLE_ROLE, nothing cached)', async (column, role) => {
+    const route = matchedRoute({
+      resolved_config: {
+        api_id: 'api-1',
+        database_id: 'db-1',
+        dbname: 'tenant_db',
+        role_name: 'authenticated',
+        anon_role: 'anonymous',
+        is_public: true,
+        schemas: ['app_public'],
+        [column]: role
+      }
+    });
+    const query = jest.fn(async (sql: string, params: unknown[]) => {
+      if (sql.includes('information_schema.schemata')) return schemaValidationRows(params);
+      if (sql.includes('resolve_route')) return { rows: [route] };
+      throw new Error(`unexpected query: ${sql}`);
+    });
+    mockGetPgPool.mockReturnValue(createPool(query) as never);
+
+    const req = createRequest({ host: 'api.example.com' });
+    await expect(getApiConfig(createOptions(), req)).rejects.toMatchObject({
+      code: 'NON_SERVABLE_ROLE',
+      column
+    });
+    expect(svcCache.has(req.svc_key as string)).toBe(false);
+    // Nothing past the resolver ran: no module settings were loaded for a refused row.
+    expect(query.mock.calls.every(([sql]) =>
+      String(sql).includes('information_schema.schemata') || String(sql).includes('resolve_route')
+    )).toBe(true);
   });
 });

--- a/graphql/server/src/middleware/api.ts
+++ b/graphql/server/src/middleware/api.ts
@@ -16,6 +16,7 @@ import errorPage50x from '../errors/50x';
 import errorPage404Message from '../errors/404-message';
 import { ApiConfigResult, ApiError, ApiOptions, ApiStructure, AuthSettings, DatabaseSettings, PubkeyChallengeSettings, RlsModule, WebauthnSettings } from '../types';
 import { getRoutingSchema, isValidSchemaName, resolveRoute, routeToApiStructure } from './routing';
+import { assertServableRoles } from './servable-roles';
 
 const log = new Logger('api');
 
@@ -236,8 +237,8 @@ export const getSvcKey = (opts: ApiOptions, req: Request): string => {
 const toApiStructure = (row: ApiRow, opts: ApiOptions, settings: ResolvedModuleSettings = {}): ApiStructure => ({
   apiId: row.api_id,
   dbname: row.dbname || opts.pg?.database || '',
-  anonRole: row.anon_role || 'anon',
-  roleName: row.role_name || 'authenticated',
+  anonRole: row.anon_role,
+  roleName: row.role_name,
   schema: row.schemas || [],
   rlsModule: settings.rlsModule,
   domains: [],
@@ -331,6 +332,8 @@ const resolveApiNameHeader = async (ctx: ResolveContext): Promise<ApiStructure |
     return null;
   }
 
+  assertServableRoles(toApiStructure(row, opts), 'api-name-lookup');
+
   const loaderCtx = buildLoaderContext(pool, opts, row);
   const settings = await resolveModuleSettings(defaultRegistry, loaderCtx);
   log.debug(`[api-name-lookup] resolved schemas: [${row.schemas?.join(', ')}], rlsModule: ${settings.rlsModule ? 'found' : 'none'}, authSettings: ${settings.authSettings ? 'found' : 'none'}`);
@@ -361,6 +364,7 @@ const resolveScopedRoute = async (ctx: ResolveContext): Promise<ApiStructure | n
 
   const structure = routeToApiStructure(route, opts);
   if (!structure) return null;
+  assertServableRoles(structure, 'scoped-routing');
 
   log.debug(`[scoped-routing] resolved host=${host} → api=${structure.apiId} db=${structure.dbname}`);
 
@@ -499,6 +503,12 @@ export const createApiMiddleware = (opts: ApiOptions) => {
 
       if (err.code === 'NO_VALID_SCHEMAS') {
         res.status(404).send(errorPage404Message(err.message));
+        return;
+      }
+
+      if (err.code === 'NON_SERVABLE_ROLE') {
+        log.error('[api-middleware] non-servable role on resolved API, refusing to serve:', err.message);
+        res.status(500).send(errorPage50x);
         return;
       }
 

--- a/graphql/server/src/middleware/routing.ts
+++ b/graphql/server/src/middleware/routing.ts
@@ -131,8 +131,8 @@ export const routeToApiStructure = (
     // Scoped APIs leave dbname NULL when their schemas live in the serving
     // database; fall back to the server's own database in that case.
     dbname: config.dbname || opts.pg?.database || '',
-    anonRole: config.anon_role || 'anon',
-    roleName: config.role_name || 'authenticated',
+    anonRole: config.anon_role,
+    roleName: config.role_name,
     schema: config.schemas,
     domains: [],
     databaseId: config.database_id,

--- a/graphql/server/src/middleware/servable-roles.ts
+++ b/graphql/server/src/middleware/servable-roles.ts
@@ -1,0 +1,47 @@
+import { ApiStructure } from '../types';
+
+/**
+ * The roles served traffic may run as. No database connection is public; a
+ * request from the internet reaches PostgreSQL only through this process, which
+ * chooses the role. That choice is limited to these two — `administrator`, the
+ * provisioning owner, `authenticated_client` and everything else are internal.
+ *
+ * The routing plane enforces the same set with a CHECK on every `apis` table
+ * (`apis_role_name_servable` / `apis_anon_role_servable`); this is the
+ * server-side door check so a row that somehow says otherwise is refused before
+ * any `SET ROLE`, never served under a fallback role.
+ */
+export const SERVABLE_ROLES: ReadonlySet<string> = new Set(['anonymous', 'authenticated']);
+
+export const isServableRole = (role: unknown): role is string =>
+  typeof role === 'string' && SERVABLE_ROLES.has(role);
+
+export class NonServableRoleError extends Error {
+  readonly code = 'NON_SERVABLE_ROLE';
+
+  constructor(
+    readonly source: string,
+    readonly column: 'role_name' | 'anon_role',
+    readonly role: unknown
+  ) {
+    super(
+      `[${source}] refusing to serve: ${column} is ${
+        role === null || role === undefined ? String(role) : JSON.stringify(role)
+      }, not one of [${[...SERVABLE_ROLES].join(', ')}]`
+    );
+    this.name = 'NonServableRoleError';
+  }
+}
+
+/**
+ * Fail closed on a resolved API surface whose roles came from a row. Throws
+ * before the structure can be cached or handed to Graphile.
+ */
+export const assertServableRoles = (structure: ApiStructure, source: string): void => {
+  if (!isServableRole(structure.roleName)) {
+    throw new NonServableRoleError(source, 'role_name', structure.roleName);
+  }
+  if (!isServableRole(structure.anonRole)) {
+    throw new NonServableRoleError(source, 'anon_role', structure.anonRole);
+  }
+};


### PR DESCRIPTION
## Summary

Phase 1 (server half) of constructive-io/constructive-planning#1949 / epic #1951. Door check: the GraphQL server now refuses to run a request as anything other than `anonymous` or `authenticated`, even if a `routing_public.apis` row says otherwise. The DB half (CHECK constraints on `apis.role_name` / `apis.anon_role`) lands separately in constructive-db; this is defence in depth, not a substitute.

- New `middleware/servable-roles.ts`:
  ```ts
  export const SERVABLE_ROLES = new Set(['anonymous', 'authenticated']);
  export const assertServableRoles = (structure: ApiStructure, source: string) => void; // throws NonServableRoleError { code: 'NON_SERVABLE_ROLE', column, role }
  ```
- `api.ts#getApiConfig` calls `assertServableRoles` on every row-sourced structure (X-Api-Name lookup and scoped `resolve_route`) *before* module settings are loaded, before `svcCache.set`, and before anything reaches Graphile / `SET ROLE`. The middleware maps `NON_SERVABLE_ROLE` → HTTP 500 (`errorPage50x`) with an error log naming the column and value; the request is never served under a substitute role.
- Dead fallbacks removed in `toApiStructure` and `routeToApiStructure`:
  ```diff
  - anonRole: row.anon_role || 'anon',
  - roleName: row.role_name || 'authenticated',
  + anonRole: row.anon_role,
  + roleName: row.role_name,
  ```
  A blank/NULL role is now refused rather than invented (the DB constraint also forbids NULL for the same reason).
- `createAdminStructure` (internal, config-driven, not row-sourced) is intentionally untouched.

Tests: `api.test.ts` / `routing.test.ts` fixtures move from `api_role`/`api_anon` (never valid in production) to `authenticated`/`anonymous`; new cases cover `administrator`, the owner role, `authenticated_client`, `anon`, NULL and undefined on both columns and both resolution paths, assert `NON_SERVABLE_ROLE`, that nothing is cached, and that no module-settings query runs after refusal. Deleting the two `assertServableRoles` calls makes 13 tests fail.


Link to Devin session: https://app.devin.ai/sessions/aaf98a35fd294acc94565f8171665f0f
Open in Devin Desktop: https://app.devin.ai/desktop/session/aaf98a35fd294acc94565f8171665f0f?variant=devin
Requested by: @pyramation