### PR TITLE
feat(express-context): bounded counter + batch flusher, RefusalRecorder, GraphQL refusal emitters (#1950 phase 2)

### DIFF
--- a/graphql/server/src/diagnostics/debug-memory-snapshot.ts
+++ b/graphql/server/src/diagnostics/debug-memory-snapshot.ts
@@ -6,6 +6,7 @@ import { getCacheStats } from 'graphile-cache';
 
 import { getInFlightCount, getInFlightKeys } from '../middleware/graphile';
 import { getGraphileBuildStats } from '../middleware/observability/graphile-build-stats';
+import { getRefusalRecorderStats } from '../refusals/recorder';
 
 const toMB = (bytes: number): string => `${(bytes / 1024 / 1024).toFixed(1)} MB`;
 
@@ -55,6 +56,8 @@ export interface DebugMemorySnapshot {
     keys: string[];
   };
   graphileBuilds: ReturnType<typeof getGraphileBuildStats>;
+  /** In-memory refusal counter + flusher state; null when no recorder is installed. */
+  refusals: ReturnType<typeof getRefusalRecorderStats>;
   uptimeMinutes: number;
   timestamp: string;
 }
@@ -119,6 +122,7 @@ export const getDebugMemorySnapshot = (): DebugMemorySnapshot => {
       keys: getInFlightKeys(),
     },
     graphileBuilds: getGraphileBuildStats(),
+    refusals: getRefusalRecorderStats(),
     uptimeMinutes: process.uptime() / 60,
     timestamp: new Date().toISOString(),
   };

--- a/graphql/server/src/middleware/__tests__/admission-control.test.ts
+++ b/graphql/server/src/middleware/__tests__/admission-control.test.ts
@@ -1,8 +1,9 @@
 import type { RequestProtection } from '@constructive-io/express-context';
-import { DEFAULT_REQUEST_PROTECTION } from '@constructive-io/express-context';
+import { DEFAULT_REQUEST_PROTECTION, RefusalRecorder } from '@constructive-io/express-context';
 import { EventEmitter } from 'events';
 import type { NextFunction, Request, Response } from 'express';
 
+import { installRefusalRecorder } from '../../refusals/recorder';
 import { createAdmissionControlMiddleware } from '../admission-control';
 
 const protection = (overrides: Partial<RequestProtection>): RequestProtection => ({
@@ -289,6 +290,96 @@ describe('createAdmissionControlMiddleware', () => {
       const fourth = send(middleware, fakeReq({ protection: bounds, ip: '10.0.0.4' }));
       await fourth.done;
       expect(fourth.res.captured.status).toBe(429);
+    });
+  });
+
+  describe('refusal recording', () => {
+    let sink: jest.Mock;
+    let recorder: RefusalRecorder;
+
+    beforeEach(() => {
+      sink = jest.fn(async (): Promise<void> => undefined);
+      recorder = new RefusalRecorder({ sink, intervalMs: 60_000, jitterMs: 0 });
+      installRefusalRecorder(recorder);
+    });
+
+    afterEach(() => {
+      installRefusalRecorder(null);
+    });
+
+    it('counts a rate-limit refusal keyed by tenant, route and anonymised source', async () => {
+      const middleware = createAdmissionControlMiddleware({ trustedProxyHops: 0 });
+      const bounds = protection({ rateLimitRpm: 1, rateLimitBurst: 1 });
+      for (let i = 0; i < 2; i++) {
+        const admitted = send(middleware, fakeReq({ protection: bounds, ip: '203.0.113.7' }));
+        await admitted.done;
+        admitted.res.emit('finish');
+      }
+
+      const refused = send(middleware, fakeReq({ protection: bounds, ip: '203.0.113.7' }));
+      await refused.done;
+      expect(refused.res.captured.status).toBe(429);
+
+      await recorder.flush();
+      expect(sink).toHaveBeenCalledTimes(1);
+      expect(sink.mock.calls[0][0]).toEqual([
+        expect.objectContaining({
+          database_id: 'db-1',
+          lane: 'graphql',
+          reason: 'rate_limited',
+          route_key: 'POST /graphql',
+          source_bucket: '203.0.113.0/24',
+          count: 1
+        })
+      ]);
+    });
+
+    it('distinguishes an immediate concurrency refusal from a queue timeout', async () => {
+      const middleware = createAdmissionControlMiddleware({ trustedProxyHops: 0 });
+      const immediate = protection({ maxConcurrentRequests: 1, maxQueueWaitMs: 0 });
+      const held = send(middleware, fakeReq({ protection: immediate, ip: '10.0.0.1' }));
+      await held.done;
+      const refused = send(middleware, fakeReq({ protection: immediate, ip: '10.0.0.2' }));
+      await refused.done;
+      expect(refused.res.captured.status).toBe(429);
+
+      const waits = protection({ maxConcurrentRequests: 1, maxQueueWaitMs: 20 });
+      const timedOut = send(middleware, fakeReq({ protection: waits, ip: '10.0.0.3' }));
+      await timedOut.done;
+      expect(timedOut.res.captured.status).toBe(429);
+      held.res.emit('finish');
+
+      await recorder.flush();
+      const reasons = sink.mock.calls[0][0].map((r: { reason: string }) => r.reason).sort();
+      expect(reasons).toEqual(['concurrency_saturated', 'queue_timeout']);
+    });
+
+    it('still refuses when the recorder is broken', async () => {
+      installRefusalRecorder({
+        record: () => {
+          throw new Error('recorder exploded');
+        }
+      } as unknown as RefusalRecorder);
+      const middleware = createAdmissionControlMiddleware({ trustedProxyHops: 0 });
+      const bounds = protection({ rateLimitRpm: 1, rateLimitBurst: 1 });
+      for (let i = 0; i < 2; i++) {
+        const admitted = send(middleware, fakeReq({ protection: bounds }));
+        await admitted.done;
+        admitted.res.emit('finish');
+      }
+
+      const refused = send(middleware, fakeReq({ protection: bounds }));
+      await refused.done;
+      expect(refused.res.captured.status).toBe(429);
+      expect(refused.res.captured.body.errors[0].extensions.code).toBe('RATE_LIMITED');
+    });
+
+    it('does not record admitted requests', async () => {
+      const middleware = createAdmissionControlMiddleware({ trustedProxyHops: 0 });
+      const { done, res } = send(middleware, fakeReq());
+      await done;
+      res.emit('finish');
+      expect(recorder.stats().keys).toBe(0);
     });
   });
 });

--- a/graphql/server/src/middleware/admission-control.ts
+++ b/graphql/server/src/middleware/admission-control.ts
@@ -13,6 +13,7 @@ import { Logger } from '@pgpmjs/logger';
 import type { NextFunction, Request, RequestHandler, Response } from 'express';
 
 import { respondWithGraphQLError } from '../errors/graphql-response';
+import { recordRefusal } from '../refusals/recorder';
 
 const log = new Logger('admission');
 
@@ -109,10 +110,12 @@ export const createAdmissionControlMiddleware = (
     const databaseId = req.databaseId ?? UNKNOWN_DATABASE;
 
     // ─── Per-caller rate ────────────────────────────────────────────────────
-    const ip = clientIpFrom(req, resolveHops(req, options.trustedProxyHops));
+    const hops = resolveHops(req, options.trustedProxyHops);
+    const ip = clientIpFrom(req, hops);
     const rateKey = `${databaseId}\u0000${ip}\u0000${routeOf(req)}`;
     if (!rate.admit(rateKey, protection.rateLimitRpm, protection.rateLimitBurst)) {
       log.warn(`[admission] rate limit: database=${databaseId} ip=${ip} route=${routeOf(req)}`);
+      recordRefusal(req, 'rate_limited', { sourceIp: ip });
       respondWithGraphQLError(res, errors.RATE_LIMITED(), {
         status: 429,
         headers: { 'Retry-After': retryAfterSeconds(rate.retryAfterMs(rateKey)) }
@@ -137,6 +140,9 @@ export const createAdmissionControlMiddleware = (
         `[admission] concurrency refused: database=${databaseId} ` +
           `limit=${protection.maxConcurrentRequests} reason=${lease.refusal} waited=${lease.queuedMs}ms`
       );
+      recordRefusal(req, lease.refusal === 'queue_timeout' ? 'queue_timeout' : 'concurrency_saturated', {
+        sourceIp: ip
+      });
       respondWithGraphQLError(
         res,
         errors.CONCURRENCY_LIMIT_REACHED({

--- a/graphql/server/src/middleware/request-protection.ts
+++ b/graphql/server/src/middleware/request-protection.ts
@@ -6,6 +6,7 @@ import { DEFAULT_REQUEST_PROTECTION } from '@constructive-io/express-context';
 import type { NextFunction, Request, RequestHandler, Response } from 'express';
 
 import { respondWithGraphQLError } from '../errors/graphql-response';
+import { recordRefusal } from '../refusals/recorder';
 
 /**
  * Resolve the bounds this request runs under and attach them to it.
@@ -62,6 +63,7 @@ export const createRequestProtectionMiddleware = (): RequestHandler => {
       declaredLength > protection.maxRequestBytes &&
       !isMultipart(req)
     ) {
+      recordRefusal(req, 'request_too_large');
       respondWithGraphQLError(
         res,
         errors.REQUEST_TOO_LARGE({ bytes: declaredLength, limit: protection.maxRequestBytes })

--- a/graphql/server/src/plugins/__tests__/request-protection-plugin.test.ts
+++ b/graphql/server/src/plugins/__tests__/request-protection-plugin.test.ts
@@ -1,0 +1,20 @@
+import { SafeError } from 'grafast';
+
+import { documentRefusalReason } from '../request-protection-plugin';
+
+describe('documentRefusalReason', () => {
+  it.each([
+    ['QUERY_TOO_DEEP', 'query_too_deep'],
+    ['QUERY_TOO_COSTLY', 'query_too_costly'],
+    ['PAGE_SIZE_TOO_LARGE', 'page_size_too_large']
+  ])('maps %s to the %s refusal', (code, reason) => {
+    expect(documentRefusalReason(new SafeError('refused', { code, statusCode: 400 }))).toBe(reason);
+  });
+
+  it('ignores errors that are not document-protection refusals', () => {
+    expect(documentRefusalReason(new SafeError('other', { code: 'FORBIDDEN' }))).toBeUndefined();
+    expect(documentRefusalReason(new SafeError('no code'))).toBeUndefined();
+    expect(documentRefusalReason(new Error('plain'))).toBeUndefined();
+    expect(documentRefusalReason('string')).toBeUndefined();
+  });
+});

--- a/graphql/server/src/plugins/request-protection-plugin.ts
+++ b/graphql/server/src/plugins/request-protection-plugin.ts
@@ -1,10 +1,27 @@
 import '../middleware/types'; // for Request type
 
+import type { RefusalReason } from '@constructive-io/express-context';
 import { DEFAULT_REQUEST_PROTECTION } from '@constructive-io/express-context';
 import type { Request } from 'express';
+import { SafeError } from 'grafast';
 import type { GraphileConfig } from 'graphile-config';
 
 import { enforceDocumentProtection } from '../protection/document-gate';
+import { recordRefusal } from '../refusals/recorder';
+
+/** The document-gate error codes, as the refusal taxonomy names them. */
+const DOCUMENT_REFUSALS: Record<string, RefusalReason> = {
+  QUERY_TOO_DEEP: 'query_too_deep',
+  QUERY_TOO_COSTLY: 'query_too_costly',
+  PAGE_SIZE_TOO_LARGE: 'page_size_too_large'
+};
+
+/** The refusal a gate rejection counts as, or undefined for any other error. */
+export const documentRefusalReason = (err: unknown): RefusalReason | undefined => {
+  if (!(err instanceof SafeError)) return undefined;
+  const code = (err.extensions as { code?: unknown } | undefined)?.code;
+  return typeof code === 'string' ? DOCUMENT_REFUSALS[code] : undefined;
+};
 
 /**
  * Get the Express request from a grafserv request context.
@@ -43,13 +60,21 @@ export const RequestProtectionPlugin: GraphileConfig.Plugin = {
         const protection = req?.requestProtection ?? DEFAULT_REQUEST_PROTECTION;
 
         if (args.document && args.schema) {
-          enforceDocumentProtection(
-            args.schema,
-            args.document,
-            args.variableValues,
-            protection,
-            args.operationName
-          );
+          try {
+            enforceDocumentProtection(
+              args.schema,
+              args.document,
+              args.variableValues,
+              protection,
+              args.operationName
+            );
+          } catch (err) {
+            // The rejection is still the client's `SafeError`; it is counted on
+            // the way out, keyed by the tenant the request resolved.
+            const reason = documentRefusalReason(err);
+            if (reason && req) recordRefusal(req, reason);
+            throw err;
+          }
         }
 
         return next();

--- a/graphql/server/src/refusals/recorder.ts
+++ b/graphql/server/src/refusals/recorder.ts
@@ -1,0 +1,188 @@
+import '../middleware/types'; // for Request type
+
+import type { Refusal, RefusalReason, RefusalRecorderStats } from '@constructive-io/express-context';
+import {
+  clientIpFrom,
+  createRecordRefusalsSink,
+  RefusalRecorder,
+  trustedProxyHops
+} from '@constructive-io/express-context';
+import type { ConstructiveOptions } from '@constructive-io/graphql-types';
+import { Logger } from '@pgpmjs/logger';
+import type { Request } from 'express';
+import type { Pool } from 'pg';
+import { getPgPool } from 'pg-cache';
+
+const log = new Logger('refusals');
+
+/**
+ * refusals/recorder — the GraphQL lane's `RefusalRecorder`.
+ *
+ * One recorder per process, installed by the server at startup and read by
+ * every refusal site through `recordRefusal`. Emitters never see the recorder,
+ * the pool or a promise: `recordRefusal` is a synchronous counter bump that
+ * cannot fail the response being written around it. A harness that mounts a
+ * middleware without a server has no recorder installed and the call is a
+ * no-op.
+ *
+ * ## Flush identity
+ *
+ * A flush runs outside any tenant request, so it establishes its own identity
+ * at the top of its transaction: the `platform-bootstrap` service principal
+ * (`jwt.claims.user_id` / `principal_id`) attributed to the platform database
+ * (`jwt.claims.database_id`, `entity_id`, `entity_type`). Those are the claims
+ * every other unattended platform write carries; resolving them is the
+ * claim-establishment step at the entry point, not a lookup inside the
+ * function being called — `record_refusals` raises if the claims are missing.
+ * Resolution is cached after the first success; a failure is reported by the
+ * recorder as a failed flush (loud, every interval) and retried next time.
+ *
+ * @module refusals/recorder
+ */
+
+/** The principal an unattended platform write acts as. */
+export const PLATFORM_BOOTSTRAP_PRINCIPAL = 'platform-bootstrap';
+
+let installed: RefusalRecorder | null = null;
+
+/** Make `recorder` the process's recorder. Returns the previous one, if any. */
+export const installRefusalRecorder = (recorder: RefusalRecorder | null): RefusalRecorder | null => {
+  const previous = installed;
+  installed = recorder;
+  return previous;
+};
+
+export const getRefusalRecorder = (): RefusalRecorder | null => installed;
+
+export const getRefusalRecorderStats = (): RefusalRecorderStats | null => installed?.stats() ?? null;
+
+/** The route half of a refusal key — the same shape admission control keys on. */
+export const routeKeyOf = (req: Request): string =>
+  `${req.method} ${req.baseUrl ?? ''}${req.path ?? req.url ?? ''}`;
+
+/**
+ * How far back through `X-Forwarded-For` to believe; mirrors admission
+ * control's resolution so the refusal source is the same address the limiter
+ * keyed on.
+ */
+const resolveHops = (req: Request, configured?: number): number => {
+  if (typeof configured === 'number') return configured;
+  const fromEnv = trustedProxyHops();
+  if (fromEnv > 0) return fromEnv;
+  return req.app?.get('trust proxy') ? 1 : 0;
+};
+
+export interface RecordRefusalOptions {
+  /** Overrides the address the refusal is attributed to. */
+  sourceIp?: string | null;
+  /** See `AdmissionControlOptions.trustedProxyHops`. */
+  trustedProxyHops?: number;
+  /** Overrides `req.databaseId`. */
+  databaseId?: string | null;
+}
+
+/**
+ * Count one GraphQL-lane refusal. Synchronous; never throws; does nothing
+ * when no recorder is installed.
+ */
+export const recordRefusal = (req: Request, reason: RefusalReason, opts: RecordRefusalOptions = {}): void => {
+  const recorder = installed;
+  if (!recorder) return;
+  const refusal: Refusal = {
+    databaseId: opts.databaseId !== undefined ? opts.databaseId : req.databaseId ?? null,
+    lane: 'graphql',
+    reason,
+    routeKey: routeKeyOf(req),
+    sourceIp:
+      opts.sourceIp !== undefined
+        ? opts.sourceIp
+        : clientIpFrom(req, resolveHops(req, opts.trustedProxyHops))
+  };
+  try {
+    recorder.record(refusal);
+  } catch (err) {
+    // The refusal response is already being written; a broken recorder is
+    // reported here and via the recorder's own stats, never to the client.
+    log.error(`refusal not recorded reason=${reason}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+};
+
+interface PlatformFlushIdentity {
+  databaseId: string;
+  actorId: string;
+  principalId: string;
+}
+
+/**
+ * Resolve the claims a flush runs under: the platform database and the
+ * `platform-bootstrap` service principal's user row. Throws — with the row
+ * that was missing named — rather than returning a partial identity.
+ */
+export const resolvePlatformFlushIdentity = async (
+  pool: Pool,
+  principalName = PLATFORM_BOOTSTRAP_PRINCIPAL
+): Promise<PlatformFlushIdentity> => {
+  const database = await pool.query<{ id: string }>(
+    `SELECT id FROM metaschema_public.database WHERE platform IS TRUE`
+  );
+  if (database.rowCount !== 1) {
+    throw new Error(
+      `refusals: expected exactly one platform database (metaschema_public.database.platform), found ${database.rowCount}`
+    );
+  }
+  const principal = await pool.query<{ user_id: string; bypass_step_up: boolean }>(
+    `SELECT user_id, bypass_step_up FROM constructive_auth_public.principals WHERE name = $1`,
+    [principalName]
+  );
+  if (principal.rowCount !== 1) {
+    throw new Error(`refusals: no service principal named '${principalName}'`);
+  }
+  if (principal.rows[0].bypass_step_up !== true) {
+    throw new Error(`refusals: principal '${principalName}' is not a service principal (no bypass_step_up)`);
+  }
+  return {
+    databaseId: database.rows[0].id,
+    actorId: principal.rows[0].user_id,
+    principalId: principal.rows[0].user_id
+  };
+};
+
+export const platformFlushClaims = (identity: PlatformFlushIdentity): Record<string, string> => ({
+  'jwt.claims.database_id': identity.databaseId,
+  'jwt.claims.user_id': identity.actorId,
+  'jwt.claims.principal_id': identity.principalId,
+  'jwt.claims.entity_id': identity.databaseId,
+  'jwt.claims.entity_type': 'database'
+});
+
+export interface PlatformRefusalRecorderOptions {
+  intervalMs?: number;
+  jitterMs?: number;
+  maxKeys?: number;
+  principalName?: string;
+}
+
+/**
+ * The recorder the server runs: counts in memory, flushes into
+ * `constructive_limits_private.record_refusals` on the platform pool under the
+ * platform flush identity. Not started; the caller owns start/stop.
+ */
+export const createPlatformRefusalRecorder = (
+  opts: ConstructiveOptions,
+  recorderOpts: PlatformRefusalRecorderOptions = {}
+): RefusalRecorder => {
+  const pool = getPgPool(opts.pg);
+  let cached: Record<string, string> | null = null;
+  const claims = async (): Promise<Record<string, string>> => {
+    if (cached) return cached;
+    cached = platformFlushClaims(await resolvePlatformFlushIdentity(pool, recorderOpts.principalName));
+    log.info(`[refusals] flushing as '${recorderOpts.principalName ?? PLATFORM_BOOTSTRAP_PRINCIPAL}'`);
+    return cached;
+  };
+  return new RefusalRecorder({
+    sink: createRecordRefusalsSink({ pool, claims }),
+    intervalMs: recorderOpts.intervalMs,
+    jitterMs: recorderOpts.jitterMs,
+    maxKeys: recorderOpts.maxKeys
+  });
+};

--- a/graphql/server/src/refusals/recorder.ts
+++ b/graphql/server/src/refusals/recorder.ts
@@ -30,8 +30,10 @@ const log = new Logger('refusals');
  * A flush runs outside any tenant request, so it establishes its own identity
  * at the top of its transaction: the `platform-bootstrap` service principal
  * (`jwt.claims.user_id` / `principal_id`) attributed to the platform database
- * (`jwt.claims.database_id`, `entity_id`, `entity_type`). Those are the claims
- * every other unattended platform write carries; resolving them is the
+ * (`jwt.claims.database_id`, `entity_id`, `entity_type`) as the platform
+ * `system` role type (`jwt.claims.role_type`), which the generated writer's
+ * guard and RESTRICTIVE insert policy require. Those are the claims every
+ * other unattended platform write carries; resolving them is the
  * claim-establishment step at the entry point, not a lookup inside the
  * function being called — `record_refusals` raises if the claims are missing.
  * Resolution is cached after the first success; a failure is reported by the
@@ -152,7 +154,8 @@ export const platformFlushClaims = (identity: PlatformFlushIdentity): Record<str
   'jwt.claims.user_id': identity.actorId,
   'jwt.claims.principal_id': identity.principalId,
   'jwt.claims.entity_id': identity.databaseId,
-  'jwt.claims.entity_type': 'database'
+  'jwt.claims.entity_type': 'database',
+  'jwt.claims.role_type': 'system'
 });
 
 export interface PlatformRefusalRecorderOptions {
@@ -164,7 +167,7 @@ export interface PlatformRefusalRecorderOptions {
 
 /**
  * The recorder the server runs: counts in memory, flushes into
- * `constructive_limits_private.record_refusals` on the platform pool under the
+ * `constructive_usage_private.record_refusals` on the platform pool under the
  * platform flush identity. Not started; the caller owns start/stop.
  */
 export const createPlatformRefusalRecorder = (

--- a/graphql/server/src/server.ts
+++ b/graphql/server/src/server.ts
@@ -1,4 +1,5 @@
 import { createCsrfMiddleware } from '@constructive-io/csrf';
+import type { RefusalRecorder } from '@constructive-io/express-context';
 import { createContextMiddleware, createDefaultRegistry, requestIdMiddleware } from '@constructive-io/express-context';
 import { getEnvOptions } from '@constructive-io/graphql-env';
 import type { ConstructiveOptions } from '@constructive-io/graphql-types';
@@ -44,6 +45,7 @@ import { localObservabilityOnly } from './middleware/observability/guard';
 import { createRequestLogger } from './middleware/observability/request-logger';
 import { createRequestProtectionMiddleware } from './middleware/request-protection';
 import { getRoutingSchema } from './middleware/routing';
+import { createPlatformRefusalRecorder, installRefusalRecorder } from './refusals/recorder';
 
 const log = new Logger('server');
 
@@ -84,6 +86,7 @@ class Server {
   private closed = false;
   private httpServer: HttpServer | null = null;
   private debugSampler: DebugSamplerHandle | null = null;
+  private refusalRecorder: RefusalRecorder | null = null;
 
   constructor(opts: ConstructiveOptions) {
     this.opts = getEnvOptions(opts);
@@ -227,6 +230,12 @@ class Server {
 
     this.app = app;
     this.debugSampler = observabilityEnabled ? startDebugSampler(effectiveOpts) : null;
+
+    // Refusals are counted in memory by the middleware above and flushed to
+    // the platform table on a timer; the request path never touches the pool.
+    this.refusalRecorder = createPlatformRefusalRecorder(effectiveOpts);
+    installRefusalRecorder(this.refusalRecorder);
+    this.refusalRecorder.start();
   }
 
   listen(): HttpServer {
@@ -352,6 +361,11 @@ class Server {
     this.closed = true;
     this.shuttingDown = true;
     await this.removeEventListener();
+    if (this.refusalRecorder) {
+      installRefusalRecorder(null);
+      await this.refusalRecorder.stop();
+      this.refusalRecorder = null;
+    }
     if (this.debugSampler) {
       await this.debugSampler.stop();
       this.debugSampler = null;

--- a/packages/express-context/__tests__/refusals.test.ts
+++ b/packages/express-context/__tests__/refusals.test.ts
@@ -1,0 +1,288 @@
+import type { RefusalKey, RefusalRow } from '../src/refusals';
+import {
+  createRecordRefusalsSink,
+  OVERFLOW_ROUTE,
+  OVERFLOW_SOURCE,
+  REFUSAL_REASONS,
+  refusalKeyOf,
+  refusalOverflowKey,
+  RefusalRecorder,
+  refusalRows,
+  sourceBucket,
+  UNKNOWN_SOURCE
+} from '../src/refusals';
+
+// ─── Source anonymisation ───────────────────────────────────────────────────
+
+describe('sourceBucket', () => {
+  it('truncates IPv4 to a /24', () => {
+    expect(sourceBucket('203.0.113.77')).toBe('203.0.113.0/24');
+    expect(sourceBucket('10.1.2.3')).toBe('10.1.2.0/24');
+  });
+
+  it('truncates IPv6 to a /48', () => {
+    expect(sourceBucket('2001:db8:abcd:1234:5678:9abc:def0:1')).toBe('2001:db8:abcd::/48');
+    expect(sourceBucket('2001:0db8::1')).toBe('2001:db8:0::/48');
+    expect(sourceBucket('::1')).toBe('0:0:0::/48');
+    expect(sourceBucket('fe80::1%eth0')).toBe('fe80:0:0::/48');
+    expect(sourceBucket('[2001:db8::2]')).toBe('2001:db8:0::/48');
+  });
+
+  it('unwraps IPv4-mapped IPv6 to the IPv4 /24', () => {
+    expect(sourceBucket('::ffff:192.0.2.9')).toBe('192.0.2.0/24');
+  });
+
+  it('never returns the raw address', () => {
+    for (const ip of ['203.0.113.77', '2001:db8::1', '::ffff:192.0.2.9']) {
+      expect(sourceBucket(ip)).not.toBe(ip);
+      expect(sourceBucket(ip)).not.toContain(ip);
+    }
+  });
+
+  it('is unknown for anything unparseable', () => {
+    for (const ip of [null, undefined, '', 'unknown', '999.1.1.1', 'not-an-ip', '1:::2', '[::1', 'gggg::1']) {
+      expect(sourceBucket(ip)).toBe(UNKNOWN_SOURCE);
+    }
+  });
+});
+
+// ─── Keys / rows ────────────────────────────────────────────────────────────
+
+const key = (over: Partial<RefusalKey> = {}): RefusalKey => ({
+  minuteBucket: Date.UTC(2026, 8, 3, 0, 15),
+  databaseId: 'db-1',
+  lane: 'graphql',
+  reason: 'rate_limited',
+  routeKey: 'POST /graphql',
+  sourceBucket: '203.0.113.0/24',
+  ...over
+});
+
+describe('refusal keys', () => {
+  it('serialises every field, with null database distinct from a value', () => {
+    expect(refusalKeyOf(key())).toBe(refusalKeyOf(key()));
+    expect(refusalKeyOf(key({ databaseId: null }))).not.toBe(refusalKeyOf(key()));
+    expect(refusalKeyOf(key({ sourceBucket: '198.51.100.0/24' }))).not.toBe(refusalKeyOf(key()));
+    expect(refusalKeyOf(key({ reason: 'queue_timeout' }))).not.toBe(refusalKeyOf(key()));
+  });
+
+  it('overflow collapses route and source and keeps tenant, lane, reason, minute', () => {
+    expect(refusalOverflowKey(key())).toEqual(
+      key({ routeKey: OVERFLOW_ROUTE, sourceBucket: OVERFLOW_SOURCE })
+    );
+  });
+
+  it('shapes rows for record_refusals(jsonb)', () => {
+    const rows = refusalRows([
+      { key: key(), count: 4, firstAt: Date.UTC(2026, 8, 3, 0, 15, 2), lastAt: Date.UTC(2026, 8, 3, 0, 15, 40) }
+    ]);
+    expect(rows).toEqual<RefusalRow[]>([
+      {
+        minute_bucket: '2026-09-03T00:15:00.000Z',
+        database_id: 'db-1',
+        lane: 'graphql',
+        reason: 'rate_limited',
+        route_key: 'POST /graphql',
+        source_bucket: '203.0.113.0/24',
+        count: 4,
+        first_seen_at: '2026-09-03T00:15:02.000Z',
+        last_seen_at: '2026-09-03T00:15:40.000Z'
+      }
+    ]);
+  });
+
+  it('the taxonomy is the documented one', () => {
+    expect([...REFUSAL_REASONS].sort()).toEqual(
+      [
+        'rate_limited',
+        'concurrency_saturated',
+        'queue_timeout',
+        'request_too_large',
+        'query_too_deep',
+        'query_too_costly',
+        'page_size_too_large',
+        'anonymous_not_callable',
+        'route_rate_limited'
+      ].sort()
+    );
+  });
+});
+
+// ─── RefusalRecorder ────────────────────────────────────────────────────────
+
+describe('RefusalRecorder', () => {
+  const at = Date.UTC(2026, 8, 3, 0, 15, 30);
+
+  it('record() is synchronous and aggregates by minute/tenant/reason/route/source', async () => {
+    const sink = jest.fn(async (_rows: RefusalRow[]): Promise<void> => undefined);
+    const recorder = new RefusalRecorder({ sink, intervalMs: 60_000, jitterMs: 0 });
+
+    const result = recorder.record({
+      databaseId: 'db-1',
+      lane: 'graphql',
+      reason: 'rate_limited',
+      routeKey: 'POST /graphql',
+      sourceIp: '203.0.113.7',
+      at
+    });
+    expect(result).toBeUndefined();
+    recorder.record({
+      databaseId: 'db-1',
+      lane: 'graphql',
+      reason: 'rate_limited',
+      routeKey: 'POST /graphql',
+      sourceIp: '203.0.113.200',
+      at: at + 10_000
+    });
+    recorder.record({
+      databaseId: null,
+      lane: 'graphql',
+      reason: 'request_too_large',
+      routeKey: 'POST /graphql',
+      sourceIp: undefined,
+      at
+    });
+    expect(recorder.stats().keys).toBe(2);
+
+    await recorder.flush();
+    expect(sink).toHaveBeenCalledTimes(1);
+    const rows: RefusalRow[] = sink.mock.calls[0][0];
+    expect(rows).toHaveLength(2);
+    expect(rows).toContainEqual(
+      expect.objectContaining({
+        minute_bucket: '2026-09-03T00:15:00.000Z',
+        database_id: 'db-1',
+        reason: 'rate_limited',
+        source_bucket: '203.0.113.0/24',
+        count: 2,
+        first_seen_at: '2026-09-03T00:15:30.000Z',
+        last_seen_at: '2026-09-03T00:15:40.000Z'
+      })
+    );
+    expect(rows).toContainEqual(
+      expect.objectContaining({ database_id: null, reason: 'request_too_large', source_bucket: UNKNOWN_SOURCE, count: 1 })
+    );
+    expect(recorder.stats().keys).toBe(0);
+  });
+
+  it('a flood of distinct sources folds into an overflow row per tenant/reason', async () => {
+    const sink = jest.fn(async (_rows: RefusalRow[]): Promise<void> => undefined);
+    const recorder = new RefusalRecorder({ sink, intervalMs: 60_000, jitterMs: 0, maxKeys: 100 });
+    for (let i = 0; i < 10_000; i++) {
+      recorder.record({
+        databaseId: 'db-1',
+        lane: 'graphql',
+        reason: 'rate_limited',
+        routeKey: 'POST /graphql',
+        sourceIp: `10.${(i >> 8) & 255}.${i & 255}.1`,
+        at
+      });
+    }
+    expect(recorder.stats().keys).toBe(101);
+    expect(recorder.stats().overflowed).toBe(9_900);
+
+    await recorder.flush();
+    const rows: RefusalRow[] = sink.mock.calls[0][0];
+    expect(rows).toHaveLength(101);
+    const overflow = rows.find((r) => r.source_bucket === OVERFLOW_SOURCE);
+    expect(overflow).toMatchObject({ database_id: 'db-1', reason: 'rate_limited', route_key: OVERFLOW_ROUTE, count: 9_900 });
+    expect(rows.reduce((sum, r) => sum + r.count, 0)).toBe(10_000);
+  });
+
+  it('a broken sink is reported, the batch dropped, and record() keeps working', async () => {
+    const sink = jest.fn(async () => {
+      throw new Error('record_refusals: no identity');
+    });
+    const onError = jest.fn();
+    const recorder = new RefusalRecorder({ sink, intervalMs: 60_000, jitterMs: 0, onError });
+    const refusal = {
+      databaseId: 'db-1',
+      lane: 'graphql' as const,
+      reason: 'concurrency_saturated' as const,
+      routeKey: 'POST /graphql',
+      sourceIp: '203.0.113.7',
+      at
+    };
+
+    recorder.record(refusal);
+    await expect(recorder.flush()).resolves.toBeUndefined();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(recorder.stats().flusher).toMatchObject({ consecutiveFailures: 1, droppedEntries: 1 });
+
+    expect(() => recorder.record(refusal)).not.toThrow();
+    expect(recorder.stats().keys).toBe(1);
+    await recorder.flush();
+    expect(onError).toHaveBeenCalledTimes(2);
+  });
+
+  it('start()/stop() flush on shutdown', async () => {
+    const sink = jest.fn(async (_rows: RefusalRow[]): Promise<void> => undefined);
+    const recorder = new RefusalRecorder({ sink, intervalMs: 60_000, jitterMs: 0 });
+    recorder.start();
+    recorder.record({ databaseId: 'db-1', lane: 'sync', reason: 'route_rate_limited', routeKey: 'rb-1', sourceIp: null, at });
+    await recorder.stop();
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(recorder.stats().flusher.running).toBe(false);
+  });
+});
+
+// ─── record_refusals sink ───────────────────────────────────────────────────
+
+describe('createRecordRefusalsSink', () => {
+  const fakePool = () => {
+    const queries: { text: string; values?: unknown[] }[] = [];
+    const client = {
+      query: jest.fn(async (text: string, values?: unknown[]) => {
+        queries.push({ text, values });
+        return { rows: [{ recorded: 1 }], rowCount: 1 };
+      }),
+      release: jest.fn()
+    };
+    const pool = { connect: jest.fn(async () => client) };
+    return { pool, client, queries };
+  };
+
+  it('writes one record_refusals call per batch inside a transaction carrying the claims', async () => {
+    const { pool, client, queries } = fakePool();
+    const claims = jest.fn(async () => ({
+      'jwt.claims.user_id': 'u-platform',
+      'jwt.claims.database_id': 'db-platform'
+    }));
+    const sink = createRecordRefusalsSink({ pool: pool as any, claims });
+    const rows = refusalRows([{ key: key(), count: 2, firstAt: 1, lastAt: 2 }]);
+
+    await sink(rows);
+
+    const texts = queries.map((q) => q.text);
+    expect(texts[0]).toBe('BEGIN');
+    expect(texts.slice(1, 3)).toEqual(['SELECT set_config($1, $2, true)', 'SELECT set_config($1, $2, true)']);
+    expect(queries[1].values).toEqual(['jwt.claims.user_id', 'u-platform']);
+    expect(queries[2].values).toEqual(['jwt.claims.database_id', 'db-platform']);
+    expect(texts[3]).toBe('SELECT "constructive_limits_private"."record_refusals"($1::jsonb) AS recorded');
+    expect(JSON.parse(queries[3].values![0] as string)).toEqual(rows);
+    expect(texts[4]).toBe('COMMIT');
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing for an empty batch and rejects a bad function name', async () => {
+    const { pool, claims } = { ...fakePool(), claims: jest.fn(async () => ({})) };
+    await createRecordRefusalsSink({ pool: pool as any, claims })([]);
+    expect(pool.connect).not.toHaveBeenCalled();
+    expect(claims).not.toHaveBeenCalled();
+    expect(() =>
+      createRecordRefusalsSink({ pool: pool as any, claims, functionName: 'x; drop table y' })
+    ).toThrow(/invalid function name/);
+  });
+
+  it('propagates a failed write so the flusher can report it', async () => {
+    const { pool, client } = fakePool();
+    client.query.mockImplementation(async (text: string) => {
+      if (text.startsWith('SELECT "')) throw new Error('claim missing');
+      return { rows: [], rowCount: 0 };
+    });
+    const sink = createRecordRefusalsSink({ pool: pool as any, claims: async () => ({}) });
+    await expect(sink(refusalRows([{ key: key(), count: 1, firstAt: 1, lastAt: 1 }]))).rejects.toThrow('claim missing');
+    expect(client.query).toHaveBeenCalledWith('ROLLBACK');
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/express-context/__tests__/refusals.test.ts
+++ b/packages/express-context/__tests__/refusals.test.ts
@@ -258,7 +258,7 @@ describe('createRecordRefusalsSink', () => {
     expect(texts.slice(1, 3)).toEqual(['SELECT set_config($1, $2, true)', 'SELECT set_config($1, $2, true)']);
     expect(queries[1].values).toEqual(['jwt.claims.user_id', 'u-platform']);
     expect(queries[2].values).toEqual(['jwt.claims.database_id', 'db-platform']);
-    expect(texts[3]).toBe('SELECT "constructive_limits_private"."record_refusals"($1::jsonb) AS recorded');
+    expect(texts[3]).toBe('SELECT "constructive_usage_private"."record_refusals"($1::jsonb) AS recorded');
     expect(JSON.parse(queries[3].values![0] as string)).toEqual(rows);
     expect(texts[4]).toBe('COMMIT');
     expect(client.release).toHaveBeenCalledTimes(1);

--- a/packages/express-context/__tests__/usage-counter.test.ts
+++ b/packages/express-context/__tests__/usage-counter.test.ts
@@ -1,0 +1,230 @@
+import type { CounterEntry } from '../src/usage-counter';
+import { BoundedCounter, CounterFlusher } from '../src/usage-counter';
+
+interface Key {
+  tenant: string;
+  source: string;
+}
+
+const keyOf = (k: Key): string => `${k.tenant}|${k.source}`;
+const overflowKey = (k: Key): Key => ({ tenant: k.tenant, source: 'overflow' });
+
+const counterOf = (maxKeys: number) => new BoundedCounter<Key>({ maxKeys, keyOf, overflowKey });
+
+const flushTick = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+// ─── BoundedCounter ─────────────────────────────────────────────────────────
+
+describe('BoundedCounter', () => {
+  it('aggregates increments that serialise to the same key', () => {
+    const counter = counterOf(10);
+    counter.increment({ tenant: 'a', source: '1' }, 1, 1_000);
+    counter.increment({ tenant: 'a', source: '1' }, 2, 3_000);
+    counter.increment({ tenant: 'a', source: '1' }, 1, 2_000);
+
+    expect(counter.size).toBe(1);
+    expect(counter.drain()).toEqual([
+      { key: { tenant: 'a', source: '1' }, count: 4, firstAt: 1_000, lastAt: 3_000 }
+    ]);
+  });
+
+  it('drain starts a fresh window', () => {
+    const counter = counterOf(10);
+    counter.increment({ tenant: 'a', source: '1' });
+    expect(counter.drain()).toHaveLength(1);
+    expect(counter.size).toBe(0);
+    expect(counter.drain()).toEqual([]);
+  });
+
+  it('folds new keys into the overflow key once full, keeping the attribution', () => {
+    const counter = counterOf(2);
+    counter.increment({ tenant: 'a', source: '1' });
+    counter.increment({ tenant: 'a', source: '2' });
+    counter.increment({ tenant: 'a', source: '3' });
+    counter.increment({ tenant: 'b', source: '4' }, 5);
+    // A key already present keeps its own entry.
+    counter.increment({ tenant: 'a', source: '1' });
+
+    const drained = counter.drain();
+    expect(drained).toHaveLength(4);
+    expect(drained).toContainEqual(expect.objectContaining({ key: { tenant: 'a', source: '1' }, count: 2 }));
+    expect(drained).toContainEqual(expect.objectContaining({ key: { tenant: 'a', source: 'overflow' }, count: 1 }));
+    expect(drained).toContainEqual(expect.objectContaining({ key: { tenant: 'b', source: 'overflow' }, count: 5 }));
+  });
+
+  it('reports how many increments overflowed and resets on drain', () => {
+    const counter = counterOf(1);
+    counter.increment({ tenant: 'a', source: '1' });
+    counter.increment({ tenant: 'a', source: '2' }, 3);
+    expect(counter.overflowed).toBe(3);
+    counter.drain();
+    expect(counter.overflowed).toBe(0);
+  });
+
+  it('stays bounded under 10,000 distinct keys', () => {
+    const counter = counterOf(2_000);
+    const start = process.hrtime.bigint();
+    for (let i = 0; i < 10_000; i++) {
+      counter.increment({ tenant: `t${i % 7}`, source: `s${i}` });
+    }
+    const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6;
+
+    // 2,000 real keys plus at most one overflow key per tenant.
+    expect(counter.size).toBeLessThanOrEqual(2_000 + 7);
+    expect(counter.overflowed).toBe(8_000);
+    const total = counter.drain().reduce((sum, e) => sum + e.count, 0);
+    expect(total).toBe(10_000);
+    // Well under a millisecond per increment even on a slow CI box.
+    expect(elapsedMs).toBeLessThan(2_000);
+  });
+
+  it('rejects a non-positive bound at construction', () => {
+    expect(() => counterOf(0)).toThrow(/maxKeys/);
+  });
+});
+
+// ─── CounterFlusher ─────────────────────────────────────────────────────────
+
+describe('CounterFlusher', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  const flusherOf = (
+    counter: BoundedCounter<Key>,
+    sink: (entries: CounterEntry<Key>[]) => Promise<void>,
+    onError: (err: unknown, dropped: CounterEntry<Key>[]) => void = () => undefined
+  ) => new CounterFlusher(counter, sink, { intervalMs: 1_000, jitterMs: 0, onError });
+
+  it('drains into the sink on the interval', async () => {
+    const counter = counterOf(10);
+    const sink = jest.fn(async (_entries: CounterEntry<Key>[]): Promise<void> => undefined);
+    const flusher = flusherOf(counter, sink);
+    flusher.start();
+
+    counter.increment({ tenant: 'a', source: '1' }, 2);
+    jest.advanceTimersByTime(999);
+    expect(sink).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(1);
+    await flushTick();
+
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(sink.mock.calls[0][0]).toEqual([expect.objectContaining({ count: 2 })]);
+    expect(counter.size).toBe(0);
+    expect(flusher.stats().lastFlushAt).not.toBeNull();
+    await flusher.stop();
+  });
+
+  it('skips the sink when nothing was counted', async () => {
+    const counter = counterOf(10);
+    const sink = jest.fn(async (_entries: CounterEntry<Key>[]): Promise<void> => undefined);
+    const flusher = flusherOf(counter, sink);
+    flusher.start();
+    jest.advanceTimersByTime(3_000);
+    await flushTick();
+    expect(sink).not.toHaveBeenCalled();
+    await flusher.stop();
+  });
+
+  it('reports a failed flush with the dropped batch and keeps counting', async () => {
+    const counter = counterOf(10);
+    const sink = jest.fn(async () => {
+      throw new Error('platform db down');
+    });
+    const onError = jest.fn();
+    const flusher = flusherOf(counter, sink, onError);
+    flusher.start();
+
+    counter.increment({ tenant: 'a', source: '1' }, 3);
+    jest.advanceTimersByTime(1_000);
+    await flushTick();
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    const [err, dropped] = onError.mock.calls[0];
+    expect((err as Error).message).toBe('platform db down');
+    expect(dropped).toEqual([expect.objectContaining({ count: 3 })]);
+    // Dropped, not re-queued: a broken sink must not grow the counter.
+    expect(counter.size).toBe(0);
+    expect(flusher.stats()).toMatchObject({
+      consecutiveFailures: 1,
+      droppedEntries: 1,
+      lastError: 'platform db down'
+    });
+
+    // Every failure is reported — no "log once then go quiet".
+    counter.increment({ tenant: 'a', source: '1' });
+    jest.advanceTimersByTime(1_000);
+    await flushTick();
+    expect(onError).toHaveBeenCalledTimes(2);
+    expect(flusher.stats().consecutiveFailures).toBe(2);
+
+    await flusher.stop();
+  });
+
+  it('a throwing onError does not stop the loop', async () => {
+    const counter = counterOf(10);
+    const sink = jest.fn(async () => {
+      throw new Error('nope');
+    });
+    const flusher = flusherOf(counter, sink, () => {
+      throw new Error('reporter broke too');
+    });
+    flusher.start();
+    counter.increment({ tenant: 'a', source: '1' });
+    jest.advanceTimersByTime(1_000);
+    await flushTick();
+    counter.increment({ tenant: 'a', source: '1' });
+    jest.advanceTimersByTime(1_000);
+    await flushTick();
+    expect(sink).toHaveBeenCalledTimes(2);
+    await flusher.stop();
+  });
+
+  it('stop() flushes what is pending and disarms the timer', async () => {
+    const counter = counterOf(10);
+    const sink = jest.fn(async (_entries: CounterEntry<Key>[]): Promise<void> => undefined);
+    const flusher = flusherOf(counter, sink);
+    flusher.start();
+    counter.increment({ tenant: 'a', source: '1' });
+
+    await flusher.stop();
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(flusher.stats().running).toBe(false);
+
+    counter.increment({ tenant: 'a', source: '2' });
+    jest.advanceTimersByTime(10_000);
+    await flushTick();
+    expect(sink).toHaveBeenCalledTimes(1);
+  });
+
+  it('serialises overlapping flushes', async () => {
+    const counter = counterOf(10);
+    let release: () => void = () => undefined;
+    const order: number[] = [];
+    const sink = jest.fn(async (entries: CounterEntry<Key>[]) => {
+      order.push(entries[0].count);
+      if (order.length === 1) await new Promise<void>((resolve) => (release = resolve));
+    });
+    const flusher = flusherOf(counter, sink);
+
+    counter.increment({ tenant: 'a', source: '1' }, 1);
+    const first = flusher.flush();
+    await flushTick();
+    counter.increment({ tenant: 'a', source: '1' }, 2);
+    const second = flusher.flush();
+    await flushTick();
+    expect(sink).toHaveBeenCalledTimes(1);
+
+    release();
+    await Promise.all([first, second]);
+    expect(order).toEqual([1, 2]);
+  });
+
+  it('rejects a non-positive interval at construction', () => {
+    expect(() =>
+      new CounterFlusher(counterOf(1), async () => undefined, { intervalMs: 0, jitterMs: 0, onError: () => undefined })
+    ).toThrow(/intervalMs/);
+  });
+});

--- a/packages/express-context/src/index.ts
+++ b/packages/express-context/src/index.ts
@@ -91,6 +91,42 @@ export {
 export type { AdmissionLease, AdmissionRefusal, AdmissionRequest } from './admission';
 export { clientIpFrom, ConcurrencyLimiter, RateWindow, trustedProxyHops } from './admission';
 
+// Shared in-memory counter + batch flush (refusal observability, page/request metering)
+export type {
+  RecordRefusalsSinkOptions,
+  Refusal,
+  RefusalKey,
+  RefusalLane,
+  RefusalReason,
+  RefusalRecorderOptions,
+  RefusalRecorderStats,
+  RefusalRow,
+  RefusalSink
+} from './refusals';
+export {
+  createRecordRefusalsSink,
+  DEFAULT_REFUSAL_FLUSH_INTERVAL_MS,
+  DEFAULT_REFUSAL_FLUSH_JITTER_MS,
+  DEFAULT_REFUSAL_MAX_KEYS,
+  OVERFLOW_ROUTE,
+  OVERFLOW_SOURCE,
+  REFUSAL_REASONS,
+  refusalKeyOf,
+  refusalOverflowKey,
+  RefusalRecorder,
+  refusalRows,
+  sourceBucket,
+  UNKNOWN_SOURCE
+} from './refusals';
+export type {
+  BoundedCounterOptions,
+  CounterEntry,
+  CounterFlusherOptions,
+  CounterFlusherStats,
+  CounterSink
+} from './usage-counter';
+export { BoundedCounter, CounterFlusher } from './usage-counter';
+
 // Request ID middleware
 export { requestIdMiddleware } from './request-id';
 

--- a/packages/express-context/src/refusals.ts
+++ b/packages/express-context/src/refusals.ts
@@ -1,0 +1,338 @@
+/**
+ * refusals — the refusal-observability instantiation of `usage-counter`.
+ *
+ * Every refusal the platform issues (a 429 from admission control, a 413 for an
+ * oversized body, a document-gate rejection, a gateway's route or IP window)
+ * is one `RefusalRecorder.record(...)` call at the point the response is
+ * written. That call is an in-memory increment and nothing else — no promise,
+ * no pool, no allocation beyond the key — so a flood costs a counter bump and
+ * refusing traffic keeps working when the recorder's store is down.
+ *
+ * Counts are keyed by `(minute, database, lane, reason, route, source /24)`,
+ * which is exactly the set of questions the platform table answers: which
+ * tenant, why, on which route, from which network, since when. Raw addresses
+ * are never part of the key; `sourceBucket` truncates to a /24 (v4) or /48
+ * (v6) before anything is counted.
+ *
+ * The flush writes the drained batch as one `record_refusals(jsonb)` call —
+ * one statement per window regardless of how many keys it holds.
+ *
+ * @module refusals
+ */
+
+import { Logger } from '@pgpmjs/logger';
+import type { Pool, PoolClient } from 'pg';
+import { withPgClient } from 'pg-query-context';
+
+import type { CounterEntry, CounterFlusherStats } from './usage-counter';
+import { BoundedCounter, CounterFlusher } from './usage-counter';
+
+const log = new Logger('refusals');
+
+/** Which platform surface refused the request. */
+export type RefusalLane = 'graphql' | 'sync' | 'static';
+
+/**
+ * Why a request was refused. Text in the table rather than an enum, so a new
+ * reason is a code change and not a migration; this union is the one list.
+ */
+export type RefusalReason =
+  | 'rate_limited'
+  | 'concurrency_saturated'
+  | 'queue_timeout'
+  | 'request_too_large'
+  | 'query_too_deep'
+  | 'query_too_costly'
+  | 'page_size_too_large'
+  | 'anonymous_not_callable'
+  | 'route_rate_limited';
+
+export const REFUSAL_REASONS: readonly RefusalReason[] = [
+  'rate_limited',
+  'concurrency_saturated',
+  'queue_timeout',
+  'request_too_large',
+  'query_too_deep',
+  'query_too_costly',
+  'page_size_too_large',
+  'anonymous_not_callable',
+  'route_rate_limited'
+];
+
+/** One refused request, as the emitter sees it. */
+export interface Refusal {
+  /** The tenant refused, or null when the request never resolved one. */
+  databaseId: string | null;
+  lane: RefusalLane;
+  reason: RefusalReason;
+  /** `"POST /graphql"`, a route binding id, `host+path` — what the lane keys on. */
+  routeKey: string;
+  /** The client address as the lane resolved it. Bucketed before it is counted. */
+  sourceIp: string | null | undefined;
+  /** Epoch ms; defaults to now. */
+  at?: number;
+}
+
+/** The aggregation key — one `refusal_log` row per distinct value per window. */
+export interface RefusalKey {
+  /** Epoch ms, truncated to the minute. */
+  minuteBucket: number;
+  databaseId: string | null;
+  lane: RefusalLane;
+  reason: RefusalReason;
+  routeKey: string;
+  sourceBucket: string;
+}
+
+/** `source_bucket` when the lane could not resolve an address. */
+export const UNKNOWN_SOURCE = 'unknown';
+/** `source_bucket` / `route_key` of the fold-down entry once the counter is full. */
+export const OVERFLOW_SOURCE = 'overflow';
+export const OVERFLOW_ROUTE = '*';
+
+/** A row as `constructive_limits_private.record_refusals(jsonb)` reads it. */
+export interface RefusalRow {
+  minute_bucket: string;
+  database_id: string | null;
+  lane: RefusalLane;
+  reason: RefusalReason;
+  route_key: string;
+  source_bucket: string;
+  count: number;
+  first_seen_at: string;
+  last_seen_at: string;
+}
+
+export type RefusalSink = (rows: RefusalRow[]) => Promise<void>;
+
+const MINUTE_MS = 60_000;
+
+const IPV4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
+
+/**
+ * Reduce a client address to a network prefix: `/24` for IPv4, `/48` for IPv6.
+ * Enough to tell "one network hammering an anonymous route" from "the tenant's
+ * own users"; not enough to be a person. Anything unparseable is `unknown`.
+ */
+export const sourceBucket = (ip: string | null | undefined): string => {
+  if (!ip) return UNKNOWN_SOURCE;
+  let addr = ip.trim();
+  if (addr.startsWith('[')) {
+    const end = addr.indexOf(']');
+    if (end === -1) return UNKNOWN_SOURCE;
+    addr = addr.slice(1, end);
+  }
+  const zone = addr.indexOf('%');
+  if (zone !== -1) addr = addr.slice(0, zone);
+  if (addr.toLowerCase().startsWith('::ffff:')) {
+    const mapped = addr.slice('::ffff:'.length);
+    if (IPV4.test(mapped)) addr = mapped;
+  }
+
+  const v4 = IPV4.exec(addr);
+  if (v4) {
+    const octets = v4.slice(1, 5).map(Number);
+    if (octets.some((o) => o > 255)) return UNKNOWN_SOURCE;
+    return `${octets[0]}.${octets[1]}.${octets[2]}.0/24`;
+  }
+
+  const groups = expandIpv6(addr);
+  if (!groups) return UNKNOWN_SOURCE;
+  return `${groups[0]}:${groups[1]}:${groups[2]}::/48`;
+};
+
+/** The eight hextets of an IPv6 address, or null when it does not parse. */
+const expandIpv6 = (addr: string): string[] | null => {
+  if (!/^[0-9a-fA-F:]+$/.test(addr) || addr.indexOf(':::') !== -1) return null;
+  const halves = addr.split('::');
+  if (halves.length > 2) return null;
+  const head = halves[0] ? halves[0].split(':') : [];
+  const tail = halves.length === 2 && halves[1] ? halves[1].split(':') : [];
+  const missing = 8 - head.length - tail.length;
+  if (halves.length === 2 ? missing < 1 : missing !== 0) return null;
+  const groups = [...head, ...Array<string>(missing).fill('0'), ...tail];
+  if (groups.some((g) => g.length === 0 || g.length > 4)) return null;
+  return groups.map((g) => parseInt(g, 16).toString(16));
+};
+
+const minuteOf = (at: number): number => Math.floor(at / MINUTE_MS) * MINUTE_MS;
+
+export const refusalKeyOf = (key: RefusalKey): string =>
+  `${key.minuteBucket}\u0000${key.databaseId ?? ''}\u0000${key.lane}\u0000${key.reason}\u0000${key.routeKey}\u0000${key.sourceBucket}`;
+
+/**
+ * Where a key folds to once the counter is full: same minute, tenant, lane and
+ * reason; route and source collapsed. A source-spraying flood therefore costs
+ * `maxKeys` entries plus one per `(database, lane, reason)`, the tenant/reason
+ * attribution is never lost, and the presence of an `overflow` row is itself
+ * the signal that a spray happened.
+ */
+export const refusalOverflowKey = (key: RefusalKey): RefusalKey => ({
+  ...key,
+  routeKey: OVERFLOW_ROUTE,
+  sourceBucket: OVERFLOW_SOURCE
+});
+
+/** Shape a drained batch for `record_refusals(jsonb)`. */
+export const refusalRows = (entries: CounterEntry<RefusalKey>[]): RefusalRow[] =>
+  entries.map(({ key, count, firstAt, lastAt }) => ({
+    minute_bucket: new Date(key.minuteBucket).toISOString(),
+    database_id: key.databaseId,
+    lane: key.lane,
+    reason: key.reason,
+    route_key: key.routeKey,
+    source_bucket: key.sourceBucket,
+    count,
+    first_seen_at: new Date(firstAt).toISOString(),
+    last_seen_at: new Date(lastAt).toISOString()
+  }));
+
+export interface RefusalRecorderOptions {
+  /** Where a drained batch goes. See `createRecordRefusalsSink`. */
+  sink: RefusalSink;
+  /** Base flush interval. Default 10 s. */
+  intervalMs?: number;
+  /** Jitter added to each interval. Default 2 s. */
+  jitterMs?: number;
+  /** Distinct keys held per window before folding. Default 2,000. */
+  maxKeys?: number;
+  /**
+   * Failure reporter. Defaults to an error log naming the SQL error and how
+   * many refusals were dropped; every failed flush is reported.
+   */
+  onError?: (err: unknown, dropped: CounterEntry<RefusalKey>[]) => void;
+}
+
+export const DEFAULT_REFUSAL_FLUSH_INTERVAL_MS = 10_000;
+export const DEFAULT_REFUSAL_FLUSH_JITTER_MS = 2_000;
+export const DEFAULT_REFUSAL_MAX_KEYS = 2_000;
+
+const defaultOnError = (err: unknown, dropped: CounterEntry<RefusalKey>[]): void => {
+  const refusals = dropped.reduce((sum, e) => sum + e.count, 0);
+  const message = err instanceof Error ? err.message : String(err);
+  log.error(
+    `[refusals] flush failed; dropped ${refusals} refusals across ${dropped.length} keys: ${message}`
+  );
+};
+
+export interface RefusalRecorderStats {
+  keys: number;
+  overflowed: number;
+  recordFailures: number;
+  flusher: CounterFlusherStats;
+}
+
+/**
+ * `BoundedCounter<RefusalKey>` + `CounterFlusher` + a `record_refusals` sink.
+ * Construct one per process, `start()` it, `record()` from every refusal site,
+ * `stop()` on shutdown.
+ */
+export class RefusalRecorder {
+  private readonly counter: BoundedCounter<RefusalKey>;
+  private readonly flusher: CounterFlusher<RefusalKey>;
+  private recordFailures = 0;
+
+  constructor(opts: RefusalRecorderOptions) {
+    this.counter = new BoundedCounter<RefusalKey>({
+      maxKeys: opts.maxKeys ?? DEFAULT_REFUSAL_MAX_KEYS,
+      keyOf: refusalKeyOf,
+      overflowKey: refusalOverflowKey
+    });
+    this.flusher = new CounterFlusher<RefusalKey>(
+      this.counter,
+      (entries) => opts.sink(refusalRows(entries)),
+      {
+        intervalMs: opts.intervalMs ?? DEFAULT_REFUSAL_FLUSH_INTERVAL_MS,
+        jitterMs: opts.jitterMs ?? DEFAULT_REFUSAL_FLUSH_JITTER_MS,
+        onError: opts.onError ?? defaultOnError
+      }
+    );
+  }
+
+  /**
+   * Count one refusal. Synchronous and never throws: the request that is
+   * being refused must finish being refused whatever state the recorder is in.
+   */
+  record(refusal: Refusal): void {
+    try {
+      const at = refusal.at ?? Date.now();
+      this.counter.increment(
+        {
+          minuteBucket: minuteOf(at),
+          databaseId: refusal.databaseId,
+          lane: refusal.lane,
+          reason: refusal.reason,
+          routeKey: refusal.routeKey,
+          sourceBucket: sourceBucket(refusal.sourceIp)
+        },
+        1,
+        at
+      );
+    } catch (err) {
+      this.recordFailures += 1;
+      const message = err instanceof Error ? err.message : String(err);
+      log.error(`[refusals] record failed (refusal still served): ${message}`);
+    }
+  }
+
+  start(): void {
+    this.flusher.start();
+  }
+
+  /** Final flush, then stop. */
+  stop(): Promise<void> {
+    return this.flusher.stop();
+  }
+
+  /** Drain and write now; a sink failure is reported, never thrown. */
+  flush(): Promise<void> {
+    return this.flusher.flush();
+  }
+
+  stats(): RefusalRecorderStats {
+    return {
+      keys: this.counter.size,
+      overflowed: this.counter.overflowed,
+      recordFailures: this.recordFailures,
+      flusher: this.flusher.stats()
+    };
+  }
+}
+
+export interface RecordRefusalsSinkOptions {
+  /** The platform database's pool. */
+  pool: Pool;
+  /**
+   * The transaction-local claims the flush runs under, resolved by the caller
+   * (a service principal plus the platform database id). The function raises
+   * if `jwt.claims.user_id` is absent, so a resolver that returns nothing
+   * useful fails loudly at the first flush rather than writing unattributed.
+   */
+  claims: () => Promise<Record<string, string>>;
+  /** Default `constructive_limits_private.record_refusals`. */
+  functionName?: string;
+}
+
+const FUNCTION_NAME = /^[a-z_][a-z0-9_]*\.[a-z_][a-z0-9_]*$/;
+
+/**
+ * A sink that writes a batch as one `record_refusals(jsonb)` call inside a
+ * transaction carrying the caller's claims. Claims are resolved per flush so a
+ * pool that was unreachable at startup does not leave the recorder wedged.
+ */
+export const createRecordRefusalsSink = (opts: RecordRefusalsSinkOptions): RefusalSink => {
+  const fn = opts.functionName ?? 'constructive_limits_private.record_refusals';
+  if (!FUNCTION_NAME.test(fn)) {
+    throw new Error(`createRecordRefusalsSink: invalid function name ${JSON.stringify(fn)}`);
+  }
+  const [schema, name] = fn.split('.');
+  const sql = `SELECT "${schema}"."${name}"($1::jsonb) AS recorded`;
+
+  return async (rows) => {
+    if (rows.length === 0) return;
+    const claims = await opts.claims();
+    await withPgClient(opts.pool, claims, async (client: PoolClient) => {
+      await client.query(sql, [JSON.stringify(rows)]);
+    });
+  };
+};

--- a/packages/express-context/src/refusals.ts
+++ b/packages/express-context/src/refusals.ts
@@ -90,7 +90,7 @@ export const UNKNOWN_SOURCE = 'unknown';
 export const OVERFLOW_SOURCE = 'overflow';
 export const OVERFLOW_ROUTE = '*';
 
-/** A row as `constructive_limits_private.record_refusals(jsonb)` reads it. */
+/** A row as `constructive_usage_private.record_refusals(jsonb)` reads it. */
 export interface RefusalRow {
   minute_bucket: string;
   database_id: string | null;
@@ -309,7 +309,7 @@ export interface RecordRefusalsSinkOptions {
    * useful fails loudly at the first flush rather than writing unattributed.
    */
   claims: () => Promise<Record<string, string>>;
-  /** Default `constructive_limits_private.record_refusals`. */
+  /** Default `constructive_usage_private.record_refusals`. */
   functionName?: string;
 }
 
@@ -321,7 +321,7 @@ const FUNCTION_NAME = /^[a-z_][a-z0-9_]*\.[a-z_][a-z0-9_]*$/;
  * pool that was unreachable at startup does not leave the recorder wedged.
  */
 export const createRecordRefusalsSink = (opts: RecordRefusalsSinkOptions): RefusalSink => {
-  const fn = opts.functionName ?? 'constructive_limits_private.record_refusals';
+  const fn = opts.functionName ?? 'constructive_usage_private.record_refusals';
   if (!FUNCTION_NAME.test(fn)) {
     throw new Error(`createRecordRefusalsSink: invalid function name ${JSON.stringify(fn)}`);
   }

--- a/packages/express-context/src/usage-counter.ts
+++ b/packages/express-context/src/usage-counter.ts
@@ -1,0 +1,254 @@
+/**
+ * usage-counter — the shared in-memory count + batch-flush mechanism.
+ *
+ * Two classes, neither of which knows what is being counted:
+ *
+ *   - `BoundedCounter<K>` is the map. Consumers pass the key type, how a key
+ *     serialises (`keyOf`) and where a key folds to once the map is full
+ *     (`overflowKey`). `increment` is O(1), synchronous and never throws, so a
+ *     request path can call it while refusing traffic without ever waiting on,
+ *     or being affected by, whatever eventually stores the counts.
+ *   - `CounterFlusher<K>` is the loop. It drains the counter on a jittered
+ *     interval, hands the batch to a `sink`, and owns the failure policy: a
+ *     batch the sink cannot write is reported through `onError` *and dropped*.
+ *     Re-queuing under a broken sink is how a bounded counter becomes an
+ *     unbounded one, and the counter is already accumulating the next window.
+ *
+ * Refusal observability instantiates these with a refusal key and a sink that
+ * calls `constructive_limits_private.record_refusals` (see `refusals.ts`); the
+ * page/request metering lane instantiates the same two classes with its own
+ * `K`, `keyOf`, `overflowKey`, bound, interval and sink. The seam is the
+ * constructor arguments — nothing in this file is specific to either.
+ *
+ * Counters live in process memory only. A crash loses at most one interval's
+ * worth of counts; `stop()` flushes on graceful shutdown. That is deliberate:
+ * the alternative is a durable write per event, which is the thing counting in
+ * memory exists to avoid.
+ *
+ * @module usage-counter
+ */
+
+export interface CounterEntry<K> {
+  key: K;
+  /** Sum of every `by` since this entry was created (or last drained). */
+  count: number;
+  /** Earliest `at` folded into this entry. */
+  firstAt: number;
+  /** Latest `at` folded into this entry. */
+  lastAt: number;
+}
+
+export interface BoundedCounterOptions<K> {
+  /**
+   * Distinct keys the counter will hold between drains. Past this, a *new* key
+   * is replaced by `overflowKey(key)` before it is counted; keys already
+   * present keep incrementing. Overflow keys are always admitted, so the true
+   * ceiling is `maxKeys` plus the number of distinct overflow keys the
+   * consumer's `overflowKey` can produce — keep that small.
+   */
+  maxKeys: number;
+  /** Serialise a key. Two keys with the same string share one entry. */
+  keyOf: (key: K) => string;
+  /**
+   * Where a key folds to once the map is full. Should collapse the
+   * high-cardinality parts of the key (a source address, a route) while
+   * keeping the attribution the consumer cannot afford to lose.
+   */
+  overflowKey: (key: K) => K;
+}
+
+export class BoundedCounter<K> {
+  private readonly entries = new Map<string, CounterEntry<K>>();
+  private overflowedSinceDrain = 0;
+  private readonly maxKeys: number;
+  private readonly keyOf: (key: K) => string;
+  private readonly overflowKey: (key: K) => K;
+
+  constructor(opts: BoundedCounterOptions<K>) {
+    if (!Number.isInteger(opts.maxKeys) || opts.maxKeys < 1) {
+      throw new Error(`BoundedCounter: maxKeys must be a positive integer, got ${opts.maxKeys}`);
+    }
+    this.maxKeys = opts.maxKeys;
+    this.keyOf = opts.keyOf;
+    this.overflowKey = opts.overflowKey;
+  }
+
+  /** Distinct keys currently held. */
+  get size(): number {
+    return this.entries.size;
+  }
+
+  /** Increments folded into an overflow key since the last drain. */
+  get overflowed(): number {
+    return this.overflowedSinceDrain;
+  }
+
+  /**
+   * Add `by` to `key`. Synchronous, O(1), never throws for a well-formed
+   * `keyOf`/`overflowKey`; the caller's request path must not depend on it in
+   * any other way.
+   */
+  increment(key: K, by = 1, at: number = Date.now()): void {
+    let id = this.keyOf(key);
+    let entry = this.entries.get(id);
+    if (!entry && this.entries.size >= this.maxKeys) {
+      key = this.overflowKey(key);
+      id = this.keyOf(key);
+      entry = this.entries.get(id);
+      this.overflowedSinceDrain += by;
+    }
+    if (!entry) {
+      this.entries.set(id, { key, count: by, firstAt: at, lastAt: at });
+      return;
+    }
+    entry.count += by;
+    if (at < entry.firstAt) entry.firstAt = at;
+    if (at > entry.lastAt) entry.lastAt = at;
+  }
+
+  /**
+   * Return every entry and start a fresh window. The returned array is the
+   * only reference to those entries, so a slow sink never contends with the
+   * hot path.
+   */
+  drain(): CounterEntry<K>[] {
+    const drained = Array.from(this.entries.values());
+    this.entries.clear();
+    this.overflowedSinceDrain = 0;
+    return drained;
+  }
+}
+
+export type CounterSink<K> = (entries: CounterEntry<K>[]) => Promise<void>;
+
+export interface CounterFlusherOptions<K> {
+  /** Base time between flushes. */
+  intervalMs: number;
+  /**
+   * Uniform random offset added to each interval so replicas started together
+   * do not hit the store on the same tick.
+   */
+  jitterMs: number;
+  /**
+   * Called for every failed flush with the batch that was dropped. Every
+   * failure is reported — there is no "log once then go quiet" — and the
+   * request path is not involved, so making this loud is free.
+   */
+  onError: (err: unknown, dropped: CounterEntry<K>[]) => void;
+}
+
+export interface CounterFlusherStats {
+  /** Epoch ms of the last flush attempt that returned without error, or null. */
+  lastFlushAt: number | null;
+  /** Epoch ms of the last failed flush, or null. */
+  lastErrorAt: number | null;
+  /** Message of the last failed flush, or null. */
+  lastError: string | null;
+  /** Failed flushes since the last success. */
+  consecutiveFailures: number;
+  /** Entries handed to `onError` over the flusher's lifetime. */
+  droppedEntries: number;
+  /** Whether the timer is armed. */
+  running: boolean;
+}
+
+export class CounterFlusher<K> {
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private inFlight: Promise<void> | null = null;
+  private running = false;
+  private lastFlushAt: number | null = null;
+  private lastErrorAt: number | null = null;
+  private lastError: string | null = null;
+  private consecutiveFailures = 0;
+  private droppedEntries = 0;
+
+  constructor(
+    private readonly counter: BoundedCounter<K>,
+    private readonly sink: CounterSink<K>,
+    private readonly opts: CounterFlusherOptions<K>
+  ) {
+    if (!(opts.intervalMs > 0)) {
+      throw new Error(`CounterFlusher: intervalMs must be positive, got ${opts.intervalMs}`);
+    }
+    if (!(opts.jitterMs >= 0)) {
+      throw new Error(`CounterFlusher: jitterMs must be non-negative, got ${opts.jitterMs}`);
+    }
+  }
+
+  /** Arm the timer. Idempotent. The timer is unref'd so it never pins the process. */
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    this.arm();
+  }
+
+  /** Disarm the timer and flush whatever is pending. Idempotent. */
+  async stop(): Promise<void> {
+    this.running = false;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    await this.flush();
+  }
+
+  /**
+   * Drain and write now. Never rejects: a sink failure goes to `onError`. If a
+   * flush is already in flight the call waits for it and then runs its own, so
+   * two overlapping timers cannot send batches out of order.
+   */
+  async flush(): Promise<void> {
+    if (this.inFlight) await this.inFlight;
+    const run = this.flushOnce();
+    this.inFlight = run;
+    try {
+      await run;
+    } finally {
+      if (this.inFlight === run) this.inFlight = null;
+    }
+  }
+
+  stats(): CounterFlusherStats {
+    return {
+      lastFlushAt: this.lastFlushAt,
+      lastErrorAt: this.lastErrorAt,
+      lastError: this.lastError,
+      consecutiveFailures: this.consecutiveFailures,
+      droppedEntries: this.droppedEntries,
+      running: this.running
+    };
+  }
+
+  private arm(): void {
+    const delay = this.opts.intervalMs + Math.floor(Math.random() * (this.opts.jitterMs + 1));
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      void this.flush().finally(() => {
+        if (this.running) this.arm();
+      });
+    }, delay);
+    this.timer.unref?.();
+  }
+
+  private async flushOnce(): Promise<void> {
+    const entries = this.counter.drain();
+    if (entries.length === 0) return;
+    try {
+      await this.sink(entries);
+      this.lastFlushAt = Date.now();
+      this.consecutiveFailures = 0;
+    } catch (err) {
+      this.lastErrorAt = Date.now();
+      this.lastError = err instanceof Error ? err.message : String(err);
+      this.consecutiveFailures += 1;
+      this.droppedEntries += entries.length;
+      // The batch is gone whether or not onError itself misbehaves; a
+      // reporter that throws must not turn one lost window into a stuck loop.
+      try {
+        this.opts.onError(err, entries);
+      } catch {
+        // Fire-and-forget by design: the failure is already recorded in stats().
+      }
+    }
+  }
+}

--- a/packages/express-context/src/usage-counter.ts
+++ b/packages/express-context/src/usage-counter.ts
@@ -15,7 +15,7 @@
  *     unbounded one, and the counter is already accumulating the next window.
  *
  * Refusal observability instantiates these with a refusal key and a sink that
- * calls `constructive_limits_private.record_refusals` (see `refusals.ts`); the
+ * calls `constructive_usage_private.record_refusals` (see `refusals.ts`); the
  * page/request metering lane instantiates the same two classes with its own
  * `K`, `keyOf`, `overflowKey`, bound, interval and sink. The seam is the
  * constructor arguments — nothing in this file is specific to either.


### PR DESCRIPTION

## Summary

Phase 2 of constructive-planning#1950 (epic #1951), the `constructive` half. Design: https://github.com/constructive-io/constructive-planning/issues/1950#issuecomment-5518446307. SQL side (generated `refusal_log_module`: `constructive_usage_public.platform_refusal_logs` / `platform_refusal_usage_summaries`, `constructive_usage_private.record_refusals` + rollup) and the sync/static gateway emitters are constructive-io/constructive-db#3647, which carries this package via `pnpm patch` of 0.26.2 until it is published — publish after this merges, then the patch is dropped.

**The shared mechanism** — `packages/express-context/src/usage-counter.ts`, next to `RateWindow`/`ConcurrencyLimiter`. This is the seam #1947 (metering) instantiates with its own key type; nothing in it knows about refusals.

```ts
class BoundedCounter<K> {
  constructor({ maxKeys, keyOf: (k: K) => string, overflowKey: (k: K) => K });
  increment(key: K, by = 1, at = Date.now()): void; // sync, O(1), no I/O; past maxKeys folds into overflowKey(key)
  drain(): CounterEntry<K>[];                        // { key, count, firstAt, lastAt }
  size; overflowed;
}
class CounterFlusher<K> {
  constructor(counter, sink: (entries) => Promise<void>, { intervalMs, jitterMs, onError(err, dropped) });
  start(); stop(): Promise<void> /* final flush */; flush(); stats();
}
```

Failure semantics: a sink failure is reported to `onError` **every time** with the dropped batch, then dropped (never re-queued — a broken sink must not grow memory). Process death loses at most one interval of counts (default 10s ± 2s jitter). Timer is `unref`'d.

**The refusal instantiation** — `packages/express-context/src/refusals.ts`:

- `RefusalKey = { minuteBucket, databaseId|null, lane, reason, routeKey, sourceBucket }`, taxonomy `rate_limited | concurrency_saturated | queue_timeout | request_too_large | query_too_deep | query_too_costly | page_size_too_large | anonymous_not_callable | route_rate_limited`, lanes `graphql | sync | static`.
- `sourceBucket(ip)`: IPv4 → `/24`, IPv6 → `/48`, IPv4-mapped unwrapped, anything else → `unknown`. Raw IPs are never persisted.
- Overflow (> `maxKeys`, default 2000) folds to `{ …, routeKey: '*', sourceBucket: 'overflow' }` — tenant/reason/minute attribution survives a flood of distinct sources.
- `createRecordRefusalsSink({ pool, claims })` → one `BEGIN; set_config(jwt.claims.*, true)…; SELECT constructive_usage_private.record_refusals($1::jsonb); COMMIT` per batch via `pg-query-context.withPgClient`.
- `RefusalRecorder.record()` is sync and swallows nothing except its own counting error (logged); flushes propagate to the flusher's `onError`.

**GraphQL emitters** (`graphql/server`):

- `refusals/recorder.ts`: process-wide installed recorder; `recordRefusal(req, reason)` is a no-op when nothing is installed (unit harnesses). Flush identity = `platform-bootstrap` principal on the platform database, resolved once from `metaschema_public.database WHERE platform` + `constructive_auth_public.principals`, set as `jwt.claims.{user_id,principal_id,database_id,entity_id,entity_type}` plus `jwt.claims.role_type='system'` (the generated writer's guard and RESTRICTIVE `AuthzSystemOnly` insert policy require it) at the top of the flush transaction — never passed to the SQL function. A failed resolution is a failed (loud) flush, retried next interval.
- `admission-control.ts`: `rate_limited`, `concurrency_saturated` (`queue_full`), `queue_timeout`.
- `request-protection.ts`: `request_too_large`.
- `request-protection-plugin.ts`: wraps `enforceDocumentProtection`, maps `SafeError` codes `QUERY_TOO_DEEP|QUERY_TOO_COSTLY|PAGE_SIZE_TOO_LARGE` → refusal, rethrows unchanged. `document-gate.ts` and `middleware/api.ts` untouched (#1949 owns the latter).
- `server.ts`: create/install/start on construction, `stop()` (final flush) in `close()`. Stats on `/debug/memory` as `refusals`.

Introspection is not a refusal today (the gate has no introspection rule), so nothing is emitted for it.

## Tests

- `express-context`: `usage-counter.test.ts` (aggregation, overflow, 10k-key bound, interval flush, failure→drop→report every time, throwing `onError`, stop flushes, serialised flushes), `refusals.test.ts` (anonymisation incl. never-raw, key/row shaping, taxonomy, flood→overflow row, broken sink keeps `record()` working, sink SQL/claims/rollback).
- `graphql/server`: admission-control records rate/concurrency/timeout with the expected row, still 429s with a throwing recorder, records nothing on admit; `documentRefusalReason` mapping.

`pnpm lint` (0 errors), `pnpm --filter '@constructive-io/graphql-server...' build`, `express-context` 99/99, `graphql/server` 197/197.




Link to Devin session: https://app.devin.ai/sessions/e174c7806d97414baab4e5bda18e0529
Open in Devin Desktop: https://app.devin.ai/desktop/session/e174c7806d97414baab4e5bda18e0529?variant=devin
Requested by: @pyramation