### PR TITLE
fix(server): a resolved API row with no served role is a visible failure, not a substituted default

### DIFF
--- a/graphql/server/src/middleware/__tests__/api.test.ts
+++ b/graphql/server/src/middleware/__tests__/api.test.ts
@@ -115,3 +115,74 @@ describe('api middleware routing priority', () => {
     ]));
   });
 });
+
+describe('missing served role on an X-Api-Name row', () => {
+  beforeEach(() => {
+    svcCache.clear();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    svcCache.clear();
+  });
+
+  const poolWithApiRow = (row: Record<string, unknown>): void => {
+    const query = jest.fn(async (_sql: string, params: unknown[]) => {
+      if (Array.isArray(params[0])) {
+        return { rows: (params[0] as string[]).map((schema_name) => ({ schema_name })) };
+      }
+      if (params[0] === 'db-123' && params[1] === 'customer-api') {
+        return {
+          rows: [{
+            api_id: 'api-123',
+            database_id: 'db-123',
+            dbname: 'tenant_db',
+            role_name: 'authenticated',
+            anon_role: 'anonymous',
+            is_public: false,
+            schemas: ['api_public'],
+            ...row
+          }]
+        };
+      }
+      return { rows: [] };
+    });
+    mockGetPgPool.mockReturnValue({ query } as unknown as Pool);
+  };
+
+  const request = () => createRequest({
+    host: 'admin.localhost',
+    'X-Database-Id': 'db-123',
+    'X-Api-Name': 'customer-api'
+  });
+
+  it.each([
+    ['role_name', null],
+    ['role_name', ''],
+    ['role_name', '   '],
+    ['role_name', undefined],
+    ['anon_role', null],
+    ['anon_role', ''],
+    ['anon_role', '   '],
+    ['anon_role', undefined]
+  ])('throws MISSING_API_ROLE when %s is %p instead of inventing a role, and caches nothing', async (column, value) => {
+    poolWithApiRow({ [column]: value });
+
+    await expect(getApiConfig(createPrivateOptions(), request())).rejects.toMatchObject({
+      code: 'MISSING_API_ROLE',
+      column,
+      apiId: 'api-123',
+      message: expect.stringContaining(column)
+    });
+    expect(svcCache.has('api:db-123:customer-api')).toBe(false);
+  });
+
+  it('passes the row roles through verbatim when both are present', async () => {
+    poolWithApiRow({ role_name: 'administrator', anon_role: 'administrator' });
+
+    const result = await getApiConfig(createPrivateOptions(), request());
+
+    expect(result).toMatchObject({ roleName: 'administrator', anonRole: 'administrator' });
+    expect(svcCache.get('api:db-123:customer-api')).toBe(result);
+  });
+});

--- a/graphql/server/src/middleware/__tests__/routing.test.ts
+++ b/graphql/server/src/middleware/__tests__/routing.test.ts
@@ -121,6 +121,24 @@ describe('routeToApiStructure', () => {
   it('returns null when resolved_config lacks api essentials', () => {
     expect(routeToApiStructure(matchedRoute({ resolved_config: {} }), opts)).toBeNull();
   });
+
+  it.each([
+    ['role_name', null],
+    ['role_name', ''],
+    ['role_name', '   '],
+    ['role_name', undefined],
+    ['anon_role', null],
+    ['anon_role', ''],
+    ['anon_role', '   '],
+    ['anon_role', undefined]
+  ])('throws MISSING_API_ROLE when %s is %p instead of inventing a role', (column, value) => {
+    const route = matchedRoute({
+      resolved_config: { ...(matchedRoute().resolved_config as Record<string, unknown>), [column]: value }
+    });
+    expect(() => routeToApiStructure(route, opts)).toThrow(
+      expect.objectContaining({ code: 'MISSING_API_ROLE', column, apiId: 'api-1' })
+    );
+  });
 });
 
 describe('getApiConfig with scoped routing enabled', () => {

--- a/graphql/server/src/middleware/api.ts
+++ b/graphql/server/src/middleware/api.ts
@@ -15,7 +15,7 @@ import { getPgPool } from 'pg-cache';
 import errorPage50x from '../errors/50x';
 import errorPage404Message from '../errors/404-message';
 import { ApiConfigResult, ApiError, ApiOptions, ApiStructure, AuthSettings, DatabaseSettings, PubkeyChallengeSettings, RlsModule, WebauthnSettings } from '../types';
-import { getRoutingSchema, isValidSchemaName, resolveRoute, routeToApiStructure } from './routing';
+import { getRoutingSchema, isValidSchemaName, requireApiRole, resolveRoute, routeToApiStructure } from './routing';
 
 const log = new Logger('api');
 
@@ -236,8 +236,8 @@ export const getSvcKey = (opts: ApiOptions, req: Request): string => {
 const toApiStructure = (row: ApiRow, opts: ApiOptions, settings: ResolvedModuleSettings = {}): ApiStructure => ({
   apiId: row.api_id,
   dbname: row.dbname || opts.pg?.database || '',
-  anonRole: row.anon_role || 'anon',
-  roleName: row.role_name || 'authenticated',
+  anonRole: requireApiRole('anon_role', row.anon_role, row.api_id),
+  roleName: requireApiRole('role_name', row.role_name, row.api_id),
   schema: row.schemas || [],
   rlsModule: settings.rlsModule,
   domains: [],
@@ -499,6 +499,12 @@ export const createApiMiddleware = (opts: ApiOptions) => {
 
       if (err.code === 'NO_VALID_SCHEMAS') {
         res.status(404).send(errorPage404Message(err.message));
+        return;
+      }
+
+      if (err.code === 'MISSING_API_ROLE') {
+        log.error('[api-middleware] resolved API row has no served role:', err.message);
+        res.status(500).send(errorPage50x);
         return;
       }
 

--- a/graphql/server/src/middleware/routing.ts
+++ b/graphql/server/src/middleware/routing.ts
@@ -19,6 +19,28 @@ const log = new Logger('routing');
 // Contract (constructive-db docs/architecture/scoped-domain-routing.md):
 // a single row is always returned; no match → route_binding_id IS NULL.
 
+/**
+ * The role an API row names is the role the server will SET ROLE to; a row
+ * that leaves one blank is a broken surface, not a request for a default.
+ * Throws (code MISSING_API_ROLE) rather than substituting a role.
+ */
+export const requireApiRole = (
+  column: 'role_name' | 'anon_role',
+  value: string | null | undefined,
+  apiId: string | undefined
+): string => {
+  if (typeof value !== 'string' || value.trim() === '') {
+    const error = new Error(
+      `API ${apiId ?? '<unknown>'} has no ${column}; a served role is required and there is no default.`
+    ) as Error & { code?: string; column?: string; apiId?: string };
+    error.code = 'MISSING_API_ROLE';
+    error.column = column;
+    error.apiId = apiId;
+    throw error;
+  }
+  return value;
+};
+
 /** Row shape returned by <schema>.resolve_route() — frozen DB↔server contract. */
 export interface ResolvedRoute {
   route_binding_id: string | null;
@@ -126,13 +148,15 @@ export const routeToApiStructure = (
     return null;
   }
 
+  const apiId = config.api_id ?? route.target_source_id ?? undefined;
+
   return {
-    apiId: config.api_id ?? route.target_source_id ?? undefined,
+    apiId,
     // Scoped APIs leave dbname NULL when their schemas live in the serving
     // database; fall back to the server's own database in that case.
     dbname: config.dbname || opts.pg?.database || '',
-    anonRole: config.anon_role || 'anon',
-    roleName: config.role_name || 'authenticated',
+    anonRole: requireApiRole('anon_role', config.anon_role, apiId),
+    roleName: requireApiRole('role_name', config.role_name, apiId),
     schema: config.schemas,
     domains: [],
     databaseId: config.database_id,


### PR DESCRIPTION
## Summary

Follow-up to constructive-io/constructive-planning#1949 (the kept half of the closed #1801). The two API resolution paths quietly invented a role when the routing row left one blank:

```diff
-  anonRole: row.anon_role || 'anon',
-  roleName: row.role_name || 'authenticated',
+  anonRole: requireApiRole('anon_role', row.anon_role, row.api_id),
+  roleName: requireApiRole('role_name', row.role_name, row.api_id),
```

`'anon'` is not even a role that exists, so the fallback turned a broken row into a request-time `SET ROLE` failure with no pointer back to the row. `requireApiRole` (in `routing.ts`, shared by `toApiStructure` for the `X-Api-Name` lookup and `routeToApiStructure` for scoped host routing) throws `MISSING_API_ROLE` (with `column` and `apiId`) on NULL / undefined / blank; the middleware maps it to a 500 like `NO_DATABASE_ID`, and nothing is cached.

This is deliberately **not** a policy check: any non-blank role passes through verbatim (covered by a test that serves `administrator`/`administrator`). Who may put a privileged role on a row is enforced in the database — constructive-db PR for #1949.

Tests: both columns × {null, '', '   ', undefined} on both resolution paths.


Link to Devin session: https://app.devin.ai/sessions/aaf98a35fd294acc94565f8171665f0f
Open in Devin Desktop: https://app.devin.ai/desktop/session/aaf98a35fd294acc94565f8171665f0f?variant=devin
Requested by: @pyramation