### PR TITLE
feat(pgpm): `pgpm env` keeps already-set PG* vars; pgpm skill accepts a developer's own Postgres

### DIFF
--- a/.agents/skills/pgpm/SKILL.md
+++ b/.agents/skills/pgpm/SKILL.md
@@ -30,9 +30,13 @@ Use this skill when:
 # 1. Install pgpm
 npm install -g pgpm
 
-# 2. Start a local PostgreSQL container
+# 2. Get a PostgreSQL to work against.
+#    Already running one (e.g. `pg_isready -h localhost -p 5432` answers)? Use it:
+#    export PGHOST/PGPORT/PGUSER/PGPASSWORD for a superuser and skip this step.
+#    Do not stop the developer's server or start Docker on top of it.
+#    Otherwise, start the pgpm container and load its connection vars:
 pgpm docker start
-eval "$(pgpm env)"
+eval "$(pgpm env)"   # keeps any PG* you already exported; --reset overwrites
 
 # 3. Create a workspace
 pgpm init workspace
@@ -152,7 +156,7 @@ pgpm handles extension creation during deploy. Declare extensions in your `.cont
 ## Essential Development Workflow
 
 ```bash
-# Start PostgreSQL and load environment
+# Start PostgreSQL and load environment (skip both if PG* already point at your own server)
 pgpm docker start
 eval "$(pgpm env)"
 
@@ -331,13 +335,15 @@ In `noTty` mode, `inquirerer` uses defaults where available and throws with the 
 
 | Issue | Quick Fix |
 |-------|-----------|
-| Can't connect to database | `pgpm docker start && eval "$(pgpm env)"` |
+| Can't connect to database | `pg_isready -h $PGHOST -p $PGPORT`; if nothing is listening, `pgpm docker start && eval "$(pgpm env)"` |
 | `PGHOST` not set | `eval "$(pgpm env)"` — must use `eval`, not run in subshell |
+| Developer already runs Postgres on 5432 | Use it: `export PGHOST=localhost PGPORT=5432 PGUSER=<superuser> PGPASSWORD=...` then `pgpm admin-users bootstrap --yes`. No Docker needed |
 | Transaction aborted in tests | Use `db.beforeEach()` / `db.afterEach()` savepoint pattern |
 | Tests interfere with each other | Ensure every test file has `beforeEach`/`afterEach` hooks |
 | Module not found during deploy | Verify `.control` file exists and workspace structure is correct |
 | Dependency not found | Check `.control` `requires` uses control names, not npm names |
-| Port 5432 already in use | `lsof -i :5432` then stop conflicting process |
+| Port 5432 already in use | If it's a Postgres, use it (row above) — never stop a developer's server. Want the pgpm container anyway? `pgpm docker start --port 5433` and `export PGPORT=5433` |
+| `pnpm install` fails with `ERR_PNPM_IGNORED_BUILDS` | Add the package to `pnpm-policy.yaml` (`allowBuilds` with a reason, or `false`) and `pnpm run policy`. Don't run `pnpm approve-builds` |
 | `Invalid line format` in pgpm.plan | Dependencies `[...]` must come right after change name, before timestamp |
 | `CREATE OR REPLACE` error | Remove `OR REPLACE` — pgpm is deterministic |
 | Container won't start | `pgpm docker start --recreate` for a fresh container |

--- a/.agents/skills/pgpm/references/docker.md
+++ b/.agents/skills/pgpm/references/docker.md
@@ -14,6 +14,12 @@ Use this skill when:
 
 ## Quick Start
 
+Docker is optional. If a PostgreSQL server is already running (check with
+`pg_isready -h localhost -p 5432`), export `PGHOST`/`PGPORT`/`PGUSER`/`PGPASSWORD` for a
+superuser and skip this reference entirely — do not stop that server to make room for
+the container. If you want both, start the container on another port (`--port 5433`)
+and `export PGPORT=5433`.
+
 ### Start PostgreSQL Container
 
 ```bash
@@ -115,7 +121,7 @@ If you see errors like "unrecognized parameter security_invoker", ensure you're 
 | Issue | Solution |
 |-------|----------|
 | "Docker is not installed" | Install Docker Desktop or Docker Engine |
-| "Port already in use" | Use `--port` to specify a different port, or stop the conflicting container |
+| "Port already in use" | If it's a running Postgres, use it (export PG*) instead of Docker; otherwise `--port 5433` + `export PGPORT=5433`. Never stop a developer's own server |
 | Container won't start | Check `docker logs postgres` for errors |
 | "Container already exists" | Use `--recreate` to remove and recreate |
 | Permission denied | Ensure Docker daemon is running and user has permissions |

--- a/.agents/skills/pgpm/references/env.md
+++ b/.agents/skills/pgpm/references/env.md
@@ -26,6 +26,21 @@ This sets the following environment variables:
 - `PGPASSWORD=password`
 - `PGDATABASE=postgres`
 
+These are the `pgpm docker start` defaults. Any of them that your shell has *already*
+set are kept (the output starts with a `# keeping PGUSER, PGPASSWORD ...` comment), so a
+developer pointing at their own PostgreSQL is not silently switched to the container's
+credentials. Use `pgpm env --reset` to overwrite them on purpose. `--supabase` always
+overwrites, since it is an explicit profile switch.
+
+### Using Your Own PostgreSQL
+
+If PostgreSQL is already running locally, `pgpm docker start` is unnecessary:
+
+```bash
+export PGHOST=localhost PGPORT=5432 PGUSER=postgres PGPASSWORD=yourpassword
+pgpm admin-users bootstrap --yes   # once
+```
+
 ### Run Command with Environment
 
 ```bash

--- a/.agents/skills/pgpm/references/troubleshooting.md
+++ b/.agents/skills/pgpm/references/troubleshooting.md
@@ -262,14 +262,33 @@ pgpm docker start
 port 5432 is already in use
 ```
 
-**Solution:**
-```bash
-# Find what's using the port
-lsof -i :5432
+**Solution:** first find out whether it is already a PostgreSQL server:
 
-# Either stop that process or use a different port
-# Edit docker-compose.yml to use different port
+```bash
+pg_isready -h localhost -p 5432
 ```
+
+If it answers, the developer runs their own Postgres — use it instead of Docker. Never
+stop or kill it to free the port. Ask for (or use) superuser credentials and skip
+`pgpm docker start`:
+
+```bash
+export PGHOST=localhost PGPORT=5432 PGUSER=postgres PGPASSWORD=yourpassword
+pgpm admin-users bootstrap --yes     # once: roles pgpm and pgsql-test expect
+```
+
+`eval "$(pgpm env)"` is safe here — it only fills in PG* variables that are not
+already set (pass `--reset` to overwrite on purpose).
+
+If you want the pgpm container *alongside* an existing server, move it and match the port:
+
+```bash
+pgpm docker start --port 5433
+export PGPORT=5433
+```
+
+Only if `lsof -i :5432` shows something that is not Postgres should you consider
+stopping that process.
 
 ### Volume Permission Issues
 
@@ -296,7 +315,7 @@ pgpm docker start
 | Transaction aborted | Use savepoint pattern |
 | Tests interfere | Check beforeEach/afterEach hooks |
 | Module not found | Verify workspace structure |
-| Port in use | `lsof -i :5432` then stop conflicting process |
+| Port in use | `pg_isready -h localhost -p 5432` — if it's Postgres, use it (export PG*); else `pgpm docker start --port 5433` + `PGPORT=5433` |
 
 ## Getting Help
 

--- a/pgpm/cli/__tests__/env.test.ts
+++ b/pgpm/cli/__tests__/env.test.ts
@@ -1,0 +1,54 @@
+import { PgConfig } from 'pg-env';
+
+import { resolveEnvVars } from '../src/commands/env';
+
+const profile: PgConfig = {
+  host: 'localhost',
+  port: 5432,
+  user: 'postgres',
+  password: 'password',
+  database: 'postgres'
+};
+
+describe('resolveEnvVars', () => {
+  it('emits the full profile when nothing is set', () => {
+    const { vars, kept } = resolveEnvVars(profile, {});
+    expect(vars).toEqual({
+      PGHOST: 'localhost',
+      PGPORT: '5432',
+      PGUSER: 'postgres',
+      PGPASSWORD: 'password',
+      PGDATABASE: 'postgres'
+    });
+    expect(kept).toEqual([]);
+  });
+
+  it('keeps PG* variables the shell already set and fills in the rest', () => {
+    const { vars, kept } = resolveEnvVars(profile, {
+      PGUSER: 'dan',
+      PGPASSWORD: 'secret',
+      PGPORT: '5433',
+      PGDATABASE: ''
+    });
+    expect(vars).toEqual({ PGHOST: 'localhost', PGDATABASE: 'postgres' });
+    expect(kept).toEqual(['PGPORT', 'PGUSER', 'PGPASSWORD']);
+  });
+
+  it('overwrites everything with --reset', () => {
+    const { vars, kept } = resolveEnvVars(profile, { PGUSER: 'dan' }, { reset: true });
+    expect(vars.PGUSER).toBe('postgres');
+    expect(kept).toEqual([]);
+  });
+
+  it('never keeps object-store variables', () => {
+    const objectStore = {
+      endpoint: 'http://localhost:9000',
+      accessKey: 'minioadmin',
+      secretKey: 'minioadmin',
+      region: 'us-east-1'
+    };
+    const { vars } = resolveEnvVars(profile, { AWS_REGION: 'eu-west-1' }, { objectStore });
+    expect(vars.AWS_REGION).toBe('us-east-1');
+    expect(vars.CDN_ENDPOINT).toBe('http://localhost:9000');
+  });
+});

--- a/pgpm/cli/src/commands/env.ts
+++ b/pgpm/cli/src/commands/env.ts
@@ -21,8 +21,14 @@ Modes:
   No command         Print export statements for shell evaluation
   With command       Execute command with environment variables applied
 
+Already running your own Postgres? PGHOST, PGPORT, PGUSER, PGPASSWORD and
+PGDATABASE that are already set in your shell are kept as-is; only the
+missing ones are filled in from the profile. Pass --reset to overwrite them
+(--supabase is an explicit profile switch and always overwrites).
+
 Options:
   --help, -h         Show this help message
+  --reset            Overwrite PG* variables that are already set
   --supabase         Use Supabase profile instead of default Postgres
   --minio            Include CDN_ENDPOINT, AWS_ACCESS_KEY, AWS_SECRET_KEY, AWS_REGION
   --rustfs           Alias for --minio (RustFS serves the same S3 API on :9000)
@@ -34,6 +40,7 @@ Examples:
   pgpm env --rustfs                           Print Postgres + RustFS env exports
   pgpm env --supabase --minio                 Print Supabase + MinIO env exports
   eval "$(pgpm env)"                          Load default Postgres env into shell
+  eval "$(pgpm env --reset)"                  Same, replacing any PG* already set
   eval "$(pgpm env --minio)"                  Load Postgres + MinIO env into shell
   eval "$(pgpm env --supabase --minio)"       Load Supabase + MinIO env into shell
   pgpm env pgpm deploy --database db1         Run command with default Postgres env
@@ -66,14 +73,41 @@ const OBJECT_STORE_PROFILE: ObjectStoreConfig = {
   region: 'us-east-1',
 };
 
-function configToEnvVars(config: PgConfig, objectStore?: ObjectStoreConfig): Record<string, string> {
-  const vars: Record<string, string> = {
+export interface EnvResolution {
+  /** Variables to export or pass to the child process. */
+  vars: Record<string, string>;
+  /** PG* variables left untouched because the caller's shell already set them. */
+  kept: string[];
+}
+
+export interface ResolveEnvOptions {
+  objectStore?: ObjectStoreConfig;
+  /** Overwrite PG* variables even when the environment already has them. */
+  reset?: boolean;
+}
+
+export function resolveEnvVars(
+  config: PgConfig,
+  existing: NodeJS.ProcessEnv,
+  { objectStore, reset = false }: ResolveEnvOptions = {}
+): EnvResolution {
+  const profileVars: Record<string, string> = {
     PGHOST: config.host,
     PGPORT: String(config.port),
     PGUSER: config.user,
     PGPASSWORD: config.password,
     PGDATABASE: config.database
   };
+
+  const vars: Record<string, string> = {};
+  const kept: string[] = [];
+  for (const [key, value] of Object.entries(profileVars)) {
+    if (!reset && existing[key]) {
+      kept.push(key);
+    } else {
+      vars[key] = value;
+    }
+  }
 
   if (objectStore) {
     vars.CDN_ENDPOINT = objectStore.endpoint;
@@ -82,22 +116,23 @@ function configToEnvVars(config: PgConfig, objectStore?: ObjectStoreConfig): Rec
     vars.AWS_REGION = objectStore.region;
   }
 
-  return vars;
+  return { vars, kept };
 }
 
-function printExports(config: PgConfig, objectStore?: ObjectStoreConfig): void {
-  const envVars = configToEnvVars(config, objectStore);
-  for (const [key, value] of Object.entries(envVars)) {
+function printExports({ vars, kept }: EnvResolution): void {
+  if (kept.length > 0) {
+    console.log(`# keeping ${kept.join(', ')} from your environment (pass --reset to overwrite)`);
+  }
+  for (const [key, value] of Object.entries(vars)) {
     console.log(`export ${key}=${value}`);
   }
 }
 
-function executeCommand(config: PgConfig, command: string, args: string[], objectStore?: ObjectStoreConfig): Promise<number> {
+function executeCommand({ vars }: EnvResolution, command: string, args: string[]): Promise<number> {
   return new Promise((resolve, reject) => {
-    const envVars = configToEnvVars(config, objectStore);
     const env = {
       ...process.env,
-      ...envVars
+      ...vars
     };
 
     const child = spawn(command, args, {
@@ -129,10 +164,14 @@ export default async (
   const useObjectStore =
     argv.minio === true || typeof argv.minio === 'string' ||
     argv.rustfs === true || typeof argv.rustfs === 'string';
+  const reset = useSupabase || argv.reset === true || typeof argv.reset === 'string';
   const profile = useSupabase ? SUPABASE_PROFILE : DEFAULT_PROFILE;
-  const objectStoreProfile = useObjectStore ? OBJECT_STORE_PROFILE : undefined;
+  const resolution = resolveEnvVars(profile, process.env, {
+    objectStore: useObjectStore ? OBJECT_STORE_PROFILE : undefined,
+    reset
+  });
 
-  const knownFlags = ['--supabase', '--minio', '--rustfs'];
+  const knownFlags = ['--supabase', '--minio', '--rustfs', '--reset'];
 
   const rawArgs = process.argv.slice(2);
   
@@ -153,14 +192,14 @@ export default async (
   }
 
   if (commandArgs.length === 0) {
-    printExports(profile, objectStoreProfile);
+    printExports(resolution);
     return;
   }
 
   const [command, ...args] = commandArgs;
   
   try {
-    const exitCode = await executeCommand(profile, command, args, objectStoreProfile);
+    const exitCode = await executeCommand(resolution, command, args);
     process.exit(exitCode);
   } catch (error) {
     if (error instanceof Error) {


### PR DESCRIPTION
## Summary

Onboarding follow-up (constructive-io/constructive-planning#1970): a developer who already runs PostgreSQL on 5432 was told by the pgpm skill to `lsof -i :5432` and stop it, and `eval "$(pgpm env)"` silently replaced their credentials with the Docker defaults. Both are fixed here; the boilerplate side is constructive-io/pgpm-boilerplates#45.

**`pgpm env`** — PG* variables already present in the shell win; only the missing ones come from the profile, and the output says so:

```
$ PGUSER=dan PGPASSWORD=x pgpm env
# keeping PGUSER, PGPASSWORD from your environment (pass --reset to overwrite)
export PGHOST=localhost
export PGPORT=5432
export PGDATABASE=postgres
```

New `--reset` restores the old overwrite-everything behaviour; `--supabase` implies it (an explicit profile switch should switch). Same rule applies in exec mode (`pgpm env pnpm test`). The logic is pulled into an exported `resolveEnvVars(profile, existing, { objectStore, reset })` with unit tests; object-store vars (`CDN_ENDPOINT`, `AWS_*`) are always emitted as before.

**pgpm skill** (`.agents/skills/pgpm`, installed into every new workspace by `pgpm init`): Quick Start and the docker/env/troubleshooting references now say — check `pg_isready -h localhost -p 5432` first; if it answers, use that server with the developer's superuser credentials and `pgpm admin-users bootstrap --yes`, never stop it; want the container as well → `pgpm docker start --port 5433` + `export PGPORT=5433`. The "port in use → stop conflicting process" rows are gone. Added an `ERR_PNPM_IGNORED_BUILDS` → edit `pnpm-policy.yaml`, don't `pnpm approve-builds` row.

Verified: `pgpm/cli` jest (`__tests__/env.test.ts`), eslint, `tsc --noEmit`, and the built CLI output above.


Link to Devin session: https://app.devin.ai/sessions/1ef0d1c209f041afa29e0e4cc4b2cb29
Open in Devin Desktop: https://app.devin.ai/desktop/session/1ef0d1c209f041afa29e0e4cc4b2cb29?variant=devin
Requested by: @pyramation