### PR TITLE
feat(agentic-server): carry invocation/job/attempt/run linkage into InferenceEntry

### DIFF
--- a/agentic/agentic-server/__tests__/gateway.test.ts
+++ b/agentic/agentic-server/__tests__/gateway.test.ts
@@ -142,6 +142,56 @@ describe('POST /v1/chat/completions', () => {
     });
   });
 
+  it('forwards task-correlation headers into the sink entry so tokens join to the task', async () => {
+    await fetch(`http://localhost:${agenticPort}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Database-Id': 'db-link-1',
+        'X-Entity-Id': 'entity-link-1',
+        'X-Actor-Id': 'actor-link-1',
+        'X-Invocation-Id': '0190a5f0-0000-7000-8000-000000000001',
+        'X-Job-Id': '4242',
+        'X-Attempt': '2',
+        'X-Run-Id': '0190a5f0-0000-7000-8000-000000000002'
+      },
+      body: JSON.stringify({ model: 'llama3', messages: [{ role: 'user', content: 'linked' }] })
+    });
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(sinkEntries).toHaveLength(1);
+    expect(sinkEntries[0]).toMatchObject({
+      databaseId: 'db-link-1',
+      entityId: 'entity-link-1',
+      actorId: 'actor-link-1',
+      invocationId: '0190a5f0-0000-7000-8000-000000000001',
+      jobId: '4242',
+      attempt: 2,
+      runId: '0190a5f0-0000-7000-8000-000000000002'
+    });
+  });
+
+  it('leaves linkage undefined when no correlation headers arrive and drops a malformed X-Attempt', async () => {
+    await fetch(`http://localhost:${agenticPort}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Database-Id': 'db-unlinked-1',
+        'X-Attempt': 'two'
+      },
+      body: JSON.stringify({ model: 'llama3', messages: [{ role: 'user', content: 'unlinked' }] })
+    });
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(sinkEntries).toHaveLength(1);
+    expect(sinkEntries[0].invocationId).toBeUndefined();
+    expect(sinkEntries[0].jobId).toBeUndefined();
+    expect(sinkEntries[0].attempt).toBeUndefined();
+    expect(sinkEntries[0].runId).toBeUndefined();
+  });
+
   it('flattens content parts into the single string ollama accepts', async () => {
     // pi and every other harness send `content` as parts; ollama's chat api takes
     // only a string, so the gateway is where the dialects meet.
@@ -270,6 +320,26 @@ describe('header security (isPublic)', () => {
 
     expect(res.status).toBe(400);
     expect(llmRequests).toHaveLength(0);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(publicSinkEntries).toHaveLength(0);
+  });
+
+  it('strips task-correlation headers too, so an external client cannot pin usage onto a task', async () => {
+    publicSinkEntries.length = 0;
+    const res = await fetch(`http://localhost:${publicPort}/v1/usage`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Database-Id': 'SHOULD-BE-STRIPPED',
+        'X-Invocation-Id': 'SHOULD-BE-STRIPPED',
+        'X-Job-Id': '1',
+        'X-Attempt': '1',
+        'X-Run-Id': 'SHOULD-BE-STRIPPED'
+      },
+      body: JSON.stringify({ model: 'm', total_tokens: 1 })
+    });
+
+    expect(res.status).toBe(400);
     await new Promise((r) => setTimeout(r, 50));
     expect(publicSinkEntries).toHaveLength(0);
   });

--- a/agentic/agentic-server/src/index.ts
+++ b/agentic/agentic-server/src/index.ts
@@ -28,6 +28,7 @@ export type { AgenticServerStartOptions } from './server';
 export { createAgenticServer } from './server';
 export type {
   AgenticServerOptions,
+  InferenceAttribution,
   InferenceEntry,
   InferenceSink,
   ProviderConfig,

--- a/agentic/agentic-server/src/router.ts
+++ b/agentic/agentic-server/src/router.ts
@@ -21,7 +21,7 @@ import {
   transformEmbedRequest,
   transformEmbedResponse
 } from './transforms';
-import type { AgenticServerOptions, ResolvedProvider } from './types';
+import type { AgenticServerOptions, InferenceAttribution, ResolvedProvider } from './types';
 
 const log = new Logger('agentic-server');
 
@@ -62,6 +62,26 @@ function upstreamErrorMessage(
     : `${provider.type} provider error ${status}`;
 }
 
+/**
+ * Who the call is for and which task it is a cost of. Identity comes from the
+ * caller's identity headers; task linkage from the correlation headers the
+ * runtimes forward (`X-Invocation-Id`, `X-Job-Id`, `X-Attempt`, `X-Run-Id`).
+ * `X-Attempt` must be a non-negative integer or it is dropped.
+ */
+export const readAttribution = (req: any): InferenceAttribution => {
+  const rawAttempt = req.get('X-Attempt');
+  const attempt = typeof rawAttempt === 'string' && /^\d+$/.test(rawAttempt) ? Number(rawAttempt) : undefined;
+  return {
+    databaseId: req.get('X-Database-Id'),
+    entityId: req.get('X-Entity-Id'),
+    actorId: req.get('X-Actor-Id'),
+    invocationId: req.get('X-Invocation-Id'),
+    jobId: req.get('X-Job-Id'),
+    attempt,
+    runId: req.get('X-Run-Id')
+  };
+};
+
 export const createRouter = (options: AgenticServerOptions): Router => {
   const router = Router();
   // Metering is backend-agnostic: the caller injects an InferenceSink. When
@@ -75,8 +95,8 @@ export const createRouter = (options: AgenticServerOptions): Router => {
       res.status(400).json({ error: { message: 'X-Database-Id is required' } });
       return;
     }
-    const entityId = req.get('X-Entity-Id');
-    const actorId = req.get('X-Actor-Id');
+    const attribution = readAttribution(req);
+    const { entityId } = attribution;
     const requestProvider = req.get('X-LLM-Provider');
     const startTime = process.hrtime.bigint();
 
@@ -134,7 +154,7 @@ export const createRouter = (options: AgenticServerOptions): Router => {
 
         if (sink) {
           sink.logInference({
-            databaseId, entityId, actorId,
+            ...attribution,
             model: String(req.body?.model || body.model || ''),
             provider: provider.type,
             service: 'chat',
@@ -167,7 +187,7 @@ export const createRouter = (options: AgenticServerOptions): Router => {
 
         if (sink) {
           sink.logInference({
-            databaseId, entityId, actorId,
+            ...attribution,
             model: String(req.body?.model || body.model || ''),
             provider: provider.type,
             service: 'chat',
@@ -196,7 +216,7 @@ export const createRouter = (options: AgenticServerOptions): Router => {
 
       if (sink) {
         sink.logInference({
-          databaseId, entityId, actorId,
+          ...attribution,
           model: String(req.body?.model || body.model || ''),
           provider: provider.type,
           service: 'chat',
@@ -217,7 +237,7 @@ export const createRouter = (options: AgenticServerOptions): Router => {
 
       if (sink) {
         sink.logInference({
-          databaseId, entityId, actorId,
+          ...attribution,
           model: String(req.body?.model || ''),
           provider: provider.type,
           service: 'chat',
@@ -249,8 +269,8 @@ export const createRouter = (options: AgenticServerOptions): Router => {
       res.status(400).json({ error: { message: 'X-Database-Id is required' } });
       return;
     }
-    const entityId = req.get('X-Entity-Id');
-    const actorId = req.get('X-Actor-Id');
+    const attribution = readAttribution(req);
+    const { entityId } = attribution;
     const requestProvider = req.get('X-LLM-Provider');
     const startTime = process.hrtime.bigint();
 
@@ -277,7 +297,7 @@ export const createRouter = (options: AgenticServerOptions): Router => {
 
         if (sink) {
           sink.logInference({
-            databaseId, entityId, actorId,
+            ...attribution,
             model: String(req.body?.model || body.model || ''),
             provider: provider.type,
             service: 'embed',
@@ -302,7 +322,7 @@ export const createRouter = (options: AgenticServerOptions): Router => {
 
       if (sink) {
         sink.logInference({
-          databaseId, entityId, actorId,
+          ...attribution,
           model: String(req.body?.model || body.model || ''),
           provider: provider.type,
           service: 'embed',
@@ -323,7 +343,7 @@ export const createRouter = (options: AgenticServerOptions): Router => {
 
       if (sink) {
         sink.logInference({
-          databaseId, entityId, actorId,
+          ...attribution,
           model: String(req.body?.model || ''),
           provider: provider.type,
           service: 'embed',
@@ -348,8 +368,7 @@ export const createRouter = (options: AgenticServerOptions): Router => {
       res.status(400).json({ error: { message: 'X-Database-Id is required' } });
       return;
     }
-    const entityId = req.get('X-Entity-Id');
-    const actorId = req.get('X-Actor-Id');
+    const attribution = readAttribution(req);
 
     const {
       model,
@@ -372,9 +391,7 @@ export const createRouter = (options: AgenticServerOptions): Router => {
 
     if (sink) {
       sink.logInference({
-        databaseId,
-        entityId,
-        actorId,
+        ...attribution,
         model: String(model),
         provider: String(reportedProvider || 'unknown'),
         service: (service === 'embed' ? 'embed' : 'chat') as 'chat' | 'embed',

--- a/agentic/agentic-server/src/server.ts
+++ b/agentic/agentic-server/src/server.ts
@@ -7,11 +7,18 @@ export interface AgenticServerStartOptions extends AgenticServerOptions {
   port?: number;
 }
 
-/** Identity headers trusted only when isPublic === false (private network). */
+/** Identity + task-correlation headers trusted only when isPublic === false
+ *  (private network). The correlation headers say which invocation/job/attempt/
+ *  run a model call is a cost of; an external client must not be able to pin
+ *  its usage onto someone else's task. */
 const IDENTITY_HEADERS = [
   'x-database-id',
   'x-entity-id',
-  'x-actor-id'
+  'x-actor-id',
+  'x-invocation-id',
+  'x-job-id',
+  'x-attempt',
+  'x-run-id'
 ] as const;
 
 /**

--- a/agentic/agentic-server/src/types.ts
+++ b/agentic/agentic-server/src/types.ts
@@ -24,6 +24,8 @@ export interface AgenticServerOptions {
    *  When false (default), the server is deployed behind a private network
    *  (Docker network, K8s service mesh) and trusts identity headers directly:
    *    X-Database-Id, X-Entity-Id, X-Actor-Id
+   *  and the task-correlation headers
+   *    X-Invocation-Id, X-Job-Id, X-Attempt, X-Run-Id
    *  When true, identity headers are stripped from incoming requests
    *  (external clients cannot set tenant context). */
   isPublic?: boolean;
@@ -51,10 +53,24 @@ export interface InferenceSink {
   logInference(entry: InferenceEntry): void;
 }
 
+/** The identity + task-linkage slice of an InferenceEntry, read from headers. */
+export type InferenceAttribution = Pick<
+  InferenceEntry,
+  'databaseId' | 'entityId' | 'actorId' | 'invocationId' | 'jobId' | 'attempt' | 'runId'
+>;
+
 export interface InferenceEntry {
   databaseId: string;
   entityId?: string;
   actorId?: string;
+  /** Task linkage — the invocation / job / attempt / agent run this call is a
+   *  cost of. Inference is COGS attributed to the task the customer was
+   *  charged for; it is never a customer meter of its own. Absent when the
+   *  call was served outside an invocation. */
+  invocationId?: string;
+  jobId?: string;
+  attempt?: number;
+  runId?: string;
   model: string;
   provider: string;
   service: 'chat' | 'embed';

--- a/agentic/metering/__tests__/gateway.test.ts
+++ b/agentic/metering/__tests__/gateway.test.ts
@@ -1,13 +1,18 @@
 import {
   ACTOR_ID_HEADER,
+  ATTEMPT_HEADER,
   buildIdentityHeaders,
   completionsBaseUrl,
   DATABASE_ID_HEADER,
   ENTITY_ID_HEADER,
   GATEWAY_API,
+  INVOCATION_ID_HEADER,
+  JOB_ID_HEADER,
   normalizeGatewayUrl,
   resolveMeteredGateway,
-  resolveMeteredModel} from '../src';
+  resolveMeteredModel,
+  RUN_ID_HEADER
+} from '../src';
 
 const models = [{ id: 'anthropic/claude-sonnet-4', contextWindow: 200000, maxTokens: 8192 }];
 
@@ -36,6 +41,33 @@ describe('buildIdentityHeaders', () => {
 
   it('rejects a missing databaseId up front', () => {
     expect(() => buildIdentityHeaders({ databaseId: '   ' })).toThrow(/databaseId is required/);
+  });
+
+  it('carries the task the run is a cost of: invocation, job, attempt, run', () => {
+    expect(
+      buildIdentityHeaders({
+        databaseId: 'db-1',
+        invocationId: 'inv-1',
+        jobId: '4242',
+        attempt: 0,
+        runId: 'run-1'
+      })
+    ).toEqual({
+      [DATABASE_ID_HEADER]: 'db-1',
+      [INVOCATION_ID_HEADER]: 'inv-1',
+      [JOB_ID_HEADER]: '4242',
+      [ATTEMPT_HEADER]: '0',
+      [RUN_ID_HEADER]: 'run-1'
+    });
+  });
+
+  it('refuses malformed task linkage rather than sending something the gateway drops', () => {
+    expect(() => buildIdentityHeaders({ databaseId: 'db-1', jobId: 'job-1' })).toThrow(/jobId must be decimal digits/);
+    expect(() => buildIdentityHeaders({ databaseId: 'db-1', attempt: -1 })).toThrow(/attempt must be a non-negative integer/);
+    expect(() => buildIdentityHeaders({ databaseId: 'db-1', attempt: 1.5 })).toThrow(/attempt must be a non-negative integer/);
+    expect(buildIdentityHeaders({ databaseId: 'db-1', invocationId: ' ', jobId: '', runId: '' })).toEqual({
+      [DATABASE_ID_HEADER]: 'db-1'
+    });
   });
 });
 

--- a/agentic/metering/src/identity.ts
+++ b/agentic/metering/src/identity.ts
@@ -1,10 +1,12 @@
 /**
- * Who a metered request belongs to.
+ * Who a metered request belongs to, and which task it is a cost of.
  *
- * These are exactly the headers `agentic-server` reads (`X-Database-Id`,
- * `X-Entity-Id`, `X-Actor-Id`) — the same identity lane the platform's own
- * clients use — so a pi session lands in `inference_log` beside every other
- * metered call rather than in a parallel accounting scheme.
+ * These are exactly the headers `agentic-server` reads — identity
+ * (`X-Database-Id`, `X-Entity-Id`, `X-Actor-Id`) plus task correlation
+ * (`X-Invocation-Id`, `X-Job-Id`, `X-Attempt`, `X-Run-Id`) — the same lane the
+ * platform's own clients use, so a pi session lands in `inference_log` beside
+ * every other metered call rather than in a parallel accounting scheme, and its
+ * tokens join the invocation the customer was actually charged for.
  *
  * Headers are only trustworthy where the gateway is not reachable by the
  * untrusted party: in-cluster, or behind an authenticated ingress that pins the
@@ -19,6 +21,14 @@ export interface MeteredIdentity {
   entityId?: string;
   /** The actor on whose behalf the run executes. */
   actorId?: string;
+  /** Invocation the run is executing, when the platform dispatched it. */
+  invocationId?: string;
+  /** Queue job id for that invocation; decimal digits only. */
+  jobId?: string;
+  /** Attempt number of that job; a non-negative integer. */
+  attempt?: number;
+  /** The agent run itself. */
+  runId?: string;
   /**
    * Bearer token for the gateway's ingress — run-scoped, not an account token.
    * Sent as `Authorization: Bearer <token>`.
@@ -29,6 +39,10 @@ export interface MeteredIdentity {
 export const DATABASE_ID_HEADER = 'X-Database-Id';
 export const ENTITY_ID_HEADER = 'X-Entity-Id';
 export const ACTOR_ID_HEADER = 'X-Actor-Id';
+export const INVOCATION_ID_HEADER = 'X-Invocation-Id';
+export const JOB_ID_HEADER = 'X-Job-Id';
+export const ATTEMPT_HEADER = 'X-Attempt';
+export const RUN_ID_HEADER = 'X-Run-Id';
 
 /**
  * Build the identity headers for a metered request.
@@ -46,6 +60,21 @@ export function buildIdentityHeaders(identity: MeteredIdentity): Record<string, 
   if (entityId) headers[ENTITY_ID_HEADER] = entityId;
   const actorId = identity.actorId?.trim();
   if (actorId) headers[ACTOR_ID_HEADER] = actorId;
+  const invocationId = identity.invocationId?.trim();
+  if (invocationId) headers[INVOCATION_ID_HEADER] = invocationId;
+  const jobId = identity.jobId?.trim();
+  if (jobId) {
+    if (!/^\d+$/.test(jobId)) throw new Error(`metered model: identity.jobId must be decimal digits, got "${jobId}"`);
+    headers[JOB_ID_HEADER] = jobId;
+  }
+  if (identity.attempt !== undefined) {
+    if (!Number.isInteger(identity.attempt) || identity.attempt < 0) {
+      throw new Error(`metered model: identity.attempt must be a non-negative integer, got ${identity.attempt}`);
+    }
+    headers[ATTEMPT_HEADER] = String(identity.attempt);
+  }
+  const runId = identity.runId?.trim();
+  if (runId) headers[RUN_ID_HEADER] = runId;
   const runToken = identity.runToken?.trim();
   if (runToken) headers.Authorization = `Bearer ${runToken}`;
   return headers;

--- a/agentic/metering/src/index.ts
+++ b/agentic/metering/src/index.ts
@@ -23,10 +23,14 @@ export {
 } from './gateway';
 export {
   ACTOR_ID_HEADER,
+  ATTEMPT_HEADER,
   buildIdentityHeaders,
   DATABASE_ID_HEADER,
   ENTITY_ID_HEADER,
-  type MeteredIdentity
+  INVOCATION_ID_HEADER,
+  JOB_ID_HEADER,
+  type MeteredIdentity,
+  RUN_ID_HEADER
 } from './identity';
 export {
   httpUsageSink,

--- a/agentic/pi/__tests__/embed/lanes.test.ts
+++ b/agentic/pi/__tests__/embed/lanes.test.ts
@@ -61,6 +61,30 @@ describe('composeRun', () => {
     expect(run.lanes.meteredModel!.selectedModel).toBe('gpt-5');
   });
 
+  it('books metered calls against the run: X-Run-Id rides on the gateway headers', () => {
+    const run = composeRun({
+      runId: 'run-42',
+      metering: { mode: 'gateway', gatewayUrl, identity: { ...identity, invocationId: 'inv-1', jobId: '7', attempt: 1 }, models }
+    });
+
+    expect(run.lanes.meteredModel!.config.headers).toMatchObject({
+      'X-Run-Id': 'run-42',
+      'X-Invocation-Id': 'inv-1',
+      'X-Job-Id': '7',
+      'X-Attempt': '1',
+      'X-Entity-Id': 'ent-1'
+    });
+  });
+
+  it('lets a host pin the run id on the identity explicitly', () => {
+    const run = composeRun({
+      runId: 'run-42',
+      metering: { mode: 'gateway', gatewayUrl, identity: { ...identity, runId: 'run-pinned' }, models }
+    });
+
+    expect(run.lanes.meteredModel!.config.headers['X-Run-Id']).toBe('run-pinned');
+  });
+
   it('picks the self-report lane for a run on the host’s own provider key', () => {
     const run = composeRun({
       runId: 'run-1',

--- a/agentic/pi/src/embed/lanes.ts
+++ b/agentic/pi/src/embed/lanes.ts
@@ -81,14 +81,22 @@ export function composeRun(options: ComposeRunOptions): ComposedRun {
     extensions.push(lanes.log.extension);
   }
 
+  // The run id rides on the metering identity so the gateway can book every
+  // model call against this run (`X-Run-Id`); a host may still pin it explicitly.
   const metering = options.metering;
   if (metering?.mode === 'gateway') {
-    const { mode: _mode, ...meteredOptions } = metering;
-    lanes.meteredModel = createMeteredModelExtension(meteredOptions);
+    const { mode: _mode, identity, ...meteredOptions } = metering;
+    lanes.meteredModel = createMeteredModelExtension({
+      ...meteredOptions,
+      identity: { runId: options.runId, ...identity }
+    });
     extensions.push(lanes.meteredModel.extension);
   } else if (metering?.mode === 'self-report') {
-    const { mode: _mode, ...reportOptions } = metering;
-    lanes.usageReport = createUsageReportExtension(reportOptions);
+    const { mode: _mode, identity, ...reportOptions } = metering;
+    lanes.usageReport = createUsageReportExtension({
+      ...reportOptions,
+      identity: { runId: options.runId, ...identity }
+    });
     extensions.push(lanes.usageReport.extension);
   }
 


### PR DESCRIPTION
## Summary

Companion to constructive-db Phase 3 of the billing plan (constructive-planning#1985): inference is COGS attributed to the task the customer paid for, never a customer meter of its own. For that join to exist, both ends of the gateway have to carry *which task* each model call belongs to.

**Gateway (`agentic-server`)**
- `InferenceEntry` gains `invocationId?`, `jobId?`, `attempt?`, `runId?`; new `InferenceAttribution = Pick<InferenceEntry, 'databaseId'|'entityId'|'actorId'|…linkage>` exported.
- `readAttribution(req)` reads `X-Database-Id / X-Entity-Id / X-Actor-Id / X-Invocation-Id / X-Job-Id / X-Attempt / X-Run-Id` once per request; every `sink.logInference({...})` call (chat ok/error/stream, embed ok/error, `/v1/usage`) spreads it, so no sink path can drop linkage. `X-Attempt` must be `^\d+$` or is dropped.
- Trust boundary: the four correlation headers join `IDENTITY_HEADERS`, so a public (`isPublic: true`) server strips them exactly like identity — an external client cannot pin its usage onto someone else's invocation.

**Client (`@agentic-kit/metering` + `@agentic-kit/pi`)** — the producer side the reviewer flagged as inert
- `MeteredIdentity` gains the same four optional fields; `buildIdentityHeaders` emits them (throws up front on a non-digit `jobId` or non-integer/negative `attempt`, same posture as the existing `databaseId` check). Both the gateway lane and the self-report lane (`reporter.ts`) go through this one function.
- `composeRun` threads its `runId` into the metering identity: `identity: { runId: options.runId, ...identity }` — so every pi run now sends `X-Run-Id`, while a host may still pin it explicitly. Hosts that dispatch from a platform invocation pass `invocationId`/`jobId`/`attempt` on the identity.

Wire format is unchanged for callers that don't send the headers (all fields optional). The constructive-db runtimes send `X-Invocation-Id`/`X-Job-Id`/`X-Attempt` from the job frame.

Tests: agentic-server gateway 22/22, metering 38/38, pi 62/62 — linkage forwarded end to end, malformed/absent linkage stays undefined or is refused client-side, public strip.


Link to Devin session: https://app.devin.ai/sessions/bc06c04115054722b1913a1bcfd99256
Open in Devin Desktop: https://app.devin.ai/desktop/session/bc06c04115054722b1913a1bcfd99256?variant=devin
Requested by: @pyramation