### PR TITLE
Add a reusable Graphile performance harness

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -109,7 +109,7 @@ jobs:
           - batch: packages-core
             packages: 'packages/url-domains packages/coerce packages/csrf packages/oauth packages/12factor-env packages/orm packages/express-context packages/errors packages/llm-env packages/node-type-registry packages/query-spec packages/server-utils packages/site-deploy examples/site-deploy-ssg postgres/pg-cache postgres/pg-env'
           - batch: packages-services
-            packages: 'packages/postmaster packages/smtppostmaster packages/csv-to-pg packages/cli postgres/pgsql-client postgres/pg-ast'
+            packages: 'packages/postmaster packages/smtppostmaster packages/csv-to-pg packages/cli packages/perf-harness postgres/pgsql-client postgres/pg-ast'
           - batch: graphql
             packages: 'graphql/query graphql/codegen'
           - batch: graphile-unit

--- a/packages/perf-harness/README.md
+++ b/packages/perf-harness/README.md
@@ -1,0 +1,82 @@
+# Graphile performance harness
+
+Reusable infrastructure for measuring Graphile schema builds in fresh Node
+processes. The core accepts any list of serializable benchmark cases; it does not
+interpret case names or optimization-specific configuration.
+
+Each measurement receives a new PID, starts Node with `--expose-gc`, runs a
+deterministic GC sequence, records build time and memory metrics, validates a
+runtime query, and reports a schema hash. Cases can opt into schema equivalence
+groups and provide their own lifecycle validation through the worker result.
+
+## Running locally
+
+Build the package, then invoke its local CLI script from the workspace root:
+
+```sh
+pnpm --filter @constructive-io/perf-harness build
+pnpm --filter @constructive-io/perf-harness cperf prepare \
+  --database-url 'postgresql:///benchmark' \
+  --schema cperf_example --tables 4
+```
+
+Use an existing local benchmark database. The equivalent direct CLI entry is
+`node packages/perf-harness/dist/cli.js`; pass `run` with the suite's `--cases`
+and `--worker` arguments to execute measurements.
+
+`makage` assembles the package in `dist`, where `index.js` is the CommonJS library
+entry, `esm/index.js` is the ESM library entry for bundlers, and `cli.js` is the
+`cperf` executable. The package manifest's entry paths are relative to that
+artifact directory. The private workspace package uses the local `cperf` script
+above. Importing either library entry does not start the CLI.
+
+`pnpm --filter @constructive-io/perf-harness test` rebuilds the package before
+running unit tests and smoke tests against the generated library and CLI entries.
+
+## Extending the harness
+
+Define a suite and provide a dedicated worker entry point:
+
+```ts
+const suite = {
+  name: 'example',
+  cases: [
+    {
+      name: 'baseline',
+      workerConfig: { schemas: ['cperf_example'] },
+      expectedSchemaGroup: 'example-schema',
+    },
+  ],
+};
+
+await runBenchmarkSuite(suite, options, workerPath);
+```
+
+`workerConfig` must be JSON-serializable. Logic is implemented in the worker
+entry rather than serializing functions across process boundaries.
+
+Each worker has a five-minute wall-clock deadline, including startup, database
+access, validation, and cleanup. Set `options.workerTimeoutMs` or pass
+`--worker-timeout-ms` to `cperf run` to override it with a positive integer
+(maximum 2,147,483,647 ms). The effective deadline is recorded in `report.config`;
+it does not change the build-only `buildMs` measurement.
+
+A timed-out worker is killed and must finish closing before the next case starts.
+Its failure is recorded even if it already printed a successful result. If its
+process and stdio cannot be confirmed closed within another five seconds, the
+suite stops scheduling cases and writes a failed report containing the completed
+runs. Earlier successful samples may remain in summaries, but the report's
+validation fails. The CLI exits nonzero for either kind of failure.
+
+The package includes `stock-worker.js` as a minimal upstream Graphile baseline.
+It emits one result after releasing its Graphile service. A measurement or release
+failure fails the run; if both fail, the error report retains both diagnostics in
+that order.
+The top-level commands require `--database-url`; the runner forwards it and the
+opaque case configuration to each short-lived worker as CLI arguments. Database
+credentials are redacted from worker failures and JSON reports. This harness is
+intended for local development on a trusted machine because command arguments
+may be visible to other local processes.
+
+The PostgreSQL fixture command only creates a previously absent schema whose
+name starts with `cperf_`; it never drops or replaces schemas.

--- a/packages/perf-harness/__tests__/entrypoints.test.ts
+++ b/packages/perf-harness/__tests__/entrypoints.test.ts
@@ -1,0 +1,116 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import type { BenchmarkReport } from '../src/types';
+
+describe('built package entry points', () => {
+  const packageRoot = resolve(__dirname, '..');
+  const artifactRoot = resolve(packageRoot, 'dist');
+  let manifest: { main: string; module: string; bin: { cperf: string } };
+
+  beforeAll(async () => {
+    manifest = JSON.parse(
+      await readFile(resolve(artifactRoot, 'package.json'), 'utf8')
+    );
+  });
+
+  const node = (args: string[], input?: string) =>
+    spawnSync(process.execPath, args, {
+      cwd: packageRoot,
+      encoding: 'utf8',
+      input,
+      timeout: 15_000,
+    });
+
+  test('imports the CommonJS library without running the CLI', () => {
+    const entry = resolve(artifactRoot, manifest.main);
+    const result = node([
+      '--eval',
+      `const assert = require('node:assert/strict');
+       const library = require(${JSON.stringify(entry)});
+       assert.equal(typeof library.runBenchmarkSuite, 'function');
+       assert.equal(typeof library.prepareFixture, 'function');`,
+    ]);
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toBe('');
+  });
+
+  test('imports the emitted ESM library without CommonJS globals or CLI startup', () => {
+    const entry = pathToFileURL(resolve(artifactRoot, manifest.module)).href;
+    const result = node(
+      [
+        '--no-warnings',
+        '--experimental-loader',
+        pathToFileURL(resolve(__dirname, 'fixtures/esm-loader.mjs')).href,
+        '--input-type=module',
+      ],
+      `import assert from 'node:assert/strict';
+       import * as library from ${JSON.stringify(entry)};
+       assert.equal(typeof require, 'undefined');
+       assert.equal(typeof module, 'undefined');
+       assert.equal(typeof library.runBenchmarkSuite, 'function');
+       assert.equal(typeof library.prepareFixture, 'function');`
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('');
+  });
+
+  test('runs a benchmark through the built manifest bin and writes its report', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'cperf-entry-'));
+    const output = resolve(directory, 'report.json');
+    const databaseUrl = 'postgres://secret@example.test/database';
+    const cases = [
+      { name: 'baseline', workerConfig: { value: 1, schemaHash: 'same' } },
+    ];
+    try {
+      const result = node([
+        resolve(artifactRoot, manifest.bin.cperf),
+        'run',
+        '--database-url',
+        databaseUrl,
+        '--worker',
+        resolve(__dirname, 'fixtures/fake-worker.js'),
+        '--cases',
+        Buffer.from(JSON.stringify(cases)).toString('base64url'),
+        '--repetitions',
+        '1',
+        '--worker-timeout-ms',
+        '5000',
+        '--output',
+        output,
+      ]);
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      const report: BenchmarkReport = JSON.parse(
+        await readFile(output, 'utf8')
+      );
+      expect(report.validation.allRunsSucceeded).toBe(true);
+      expect(report.validation.freshProcessPerRun).toBe(true);
+      expect(report.summaries.baseline.sampleCount).toBe(1);
+      expect(JSON.stringify(report)).not.toContain(databaseUrl);
+      expect(result.stdout + result.stderr).not.toContain(databaseUrl);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test('reports CLI argument errors with a nonzero exit', () => {
+    const result = node([
+      resolve(artifactRoot, manifest.bin.cperf),
+      'prepare',
+      '--schema',
+      'cperf_example',
+    ]);
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('--database-url is required');
+  });
+});

--- a/packages/perf-harness/__tests__/fixture.test.ts
+++ b/packages/perf-harness/__tests__/fixture.test.ts
@@ -1,0 +1,233 @@
+import { Pool } from 'pg';
+
+import {
+  prepareFixture,
+  validateFixtureSchema,
+  validateFixtureTableCount,
+} from '../src/fixture';
+
+jest.mock('pg', () => ({
+  Pool: jest.fn(),
+}));
+
+type MockClient = {
+  query: jest.Mock;
+  release: jest.Mock;
+};
+
+type MockPool = {
+  connect: jest.Mock;
+  end: jest.Mock;
+};
+
+const fixtureOptions = {
+  databaseUrl: 'postgres://fixture-test',
+  schema: 'cperf_fixture_test',
+  tables: 1,
+};
+
+const queryResult = (text: string) => {
+  if (text.includes('pg_namespace')) {
+    return { rows: [{ exists: false }] };
+  }
+  if (text.includes('current_database')) {
+    return { rows: [{ database: 'fixture_db', server_version: '16' }] };
+  }
+  return { rows: [] };
+};
+
+const createMocks = (): { client: MockClient; pool: MockPool } => {
+  const client: MockClient = {
+    query: jest.fn(async (text: string) => queryResult(text)),
+    release: jest.fn(),
+  };
+  const pool: MockPool = {
+    connect: jest.fn().mockResolvedValue(client),
+    end: jest.fn().mockResolvedValue(undefined),
+  };
+  (Pool as unknown as jest.Mock).mockImplementation(() => pool);
+  return { client, pool };
+};
+
+const rejected = async (promise: Promise<unknown>): Promise<unknown> => {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error('expected prepareFixture to reject');
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('fixture safety', () => {
+  test('only accepts narrowly scoped benchmark schema names', () => {
+    expect(validateFixtureSchema('cperf_example_1')).toBe('cperf_example_1');
+    expect(() => validateFixtureSchema('public')).toThrow(
+      'must start with cperf_'
+    );
+    expect(() =>
+      validateFixtureSchema('cperf_example; drop schema public')
+    ).toThrow('must start with cperf_');
+  });
+
+  test('bounds generated fixture size', () => {
+    expect(validateFixtureTableCount(64)).toBe(64);
+    expect(() => validateFixtureTableCount(0)).toThrow('between 1 and 500');
+    expect(() => validateFixtureTableCount(501)).toThrow('between 1 and 500');
+  });
+});
+
+describe('fixture resource lifecycle', () => {
+  test('ends the pool when connecting fails without releasing a client', async () => {
+    const { client, pool } = createMocks();
+    const connectError = new Error('connect failed');
+    pool.connect.mockRejectedValue(connectError);
+
+    await expect(prepareFixture(fixtureOptions)).rejects.toBe(connectError);
+
+    expect(client.release).not.toHaveBeenCalled();
+    expect(pool.end).toHaveBeenCalledTimes(1);
+  });
+
+  test('retains a falsy connection failure when ending the pool also fails', async () => {
+    const { client, pool } = createMocks();
+    const endError = new Error('end failed');
+    pool.connect.mockRejectedValue(undefined);
+    pool.end.mockRejectedValue(endError);
+
+    const error = await rejected(prepareFixture(fixtureOptions));
+
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors).toEqual([undefined, endError]);
+    expect(
+      (error as AggregateError & { cause: unknown }).cause
+    ).toBeUndefined();
+    expect(client.release).not.toHaveBeenCalled();
+    expect(pool.end).toHaveBeenCalledTimes(1);
+  });
+
+  test('commits and releases the client before ending the pool on success', async () => {
+    const { client, pool } = createMocks();
+
+    await expect(prepareFixture(fixtureOptions)).resolves.toEqual(
+      expect.objectContaining({
+        database: 'fixture_db',
+        tableCount: 2,
+        functionCount: 1,
+      })
+    );
+
+    expect(client.query).toHaveBeenCalledWith('commit');
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(pool.end).toHaveBeenCalledTimes(1);
+    expect(client.release.mock.invocationCallOrder[0]).toBeLessThan(
+      pool.end.mock.invocationCallOrder[0]
+    );
+  });
+
+  test('rolls back, releases, and ends resources after a SQL failure', async () => {
+    const { client, pool } = createMocks();
+    const queryError = new Error('create schema failed');
+    client.query.mockImplementation(async (text: string) => {
+      if (text.includes('create schema')) {
+        throw queryError;
+      }
+      return queryResult(text);
+    });
+
+    await expect(prepareFixture(fixtureOptions)).rejects.toBe(queryError);
+
+    expect(client.query).toHaveBeenCalledWith('rollback');
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(pool.end).toHaveBeenCalledTimes(1);
+  });
+
+  test('retains a rollback failure with the original SQL failure', async () => {
+    const { client, pool } = createMocks();
+    const queryError = new Error('create schema failed');
+    const rollbackError = new Error('rollback failed');
+    client.query.mockImplementation(async (text: string) => {
+      if (text.includes('create schema')) {
+        throw queryError;
+      }
+      if (text === 'rollback') {
+        throw rollbackError;
+      }
+      return queryResult(text);
+    });
+
+    const error = await rejected(prepareFixture(fixtureOptions));
+
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors).toEqual([
+      queryError,
+      rollbackError,
+    ]);
+    expect((error as AggregateError & { cause: unknown }).cause).toBe(
+      queryError
+    );
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(pool.end).toHaveBeenCalledTimes(1);
+  });
+
+  test('still ends the pool when releasing the client fails', async () => {
+    const { client, pool } = createMocks();
+    const releaseError = new Error('release failed');
+    client.release.mockImplementation(() => {
+      throw releaseError;
+    });
+
+    await expect(prepareFixture(fixtureOptions)).rejects.toBe(releaseError);
+
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(pool.end).toHaveBeenCalledTimes(1);
+  });
+
+  test('surfaces a pool end failure after releasing the client', async () => {
+    const { client, pool } = createMocks();
+    const endError = new Error('end failed');
+    pool.end.mockRejectedValue(endError);
+
+    await expect(prepareFixture(fixtureOptions)).rejects.toBe(endError);
+
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(pool.end).toHaveBeenCalledTimes(1);
+  });
+
+  test('orders the primary and cleanup failures and preserves the primary cause', async () => {
+    const { client, pool } = createMocks();
+    const queryError = new Error('create schema failed');
+    const rollbackError = new Error('rollback failed');
+    const releaseError = new Error('release failed');
+    const endError = new Error('end failed');
+    client.query.mockImplementation(async (text: string) => {
+      if (text.includes('create schema')) {
+        throw queryError;
+      }
+      if (text === 'rollback') {
+        throw rollbackError;
+      }
+      return queryResult(text);
+    });
+    client.release.mockImplementation(() => {
+      throw releaseError;
+    });
+    pool.end.mockRejectedValue(endError);
+
+    const error = await rejected(prepareFixture(fixtureOptions));
+
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors).toEqual([
+      queryError,
+      rollbackError,
+      releaseError,
+      endError,
+    ]);
+    expect((error as AggregateError & { cause: unknown }).cause).toBe(
+      queryError
+    );
+  });
+});

--- a/packages/perf-harness/__tests__/fixtures/esm-loader.mjs
+++ b/packages/perf-harness/__tests__/fixtures/esm-loader.mjs
@@ -1,0 +1,27 @@
+import { readFile } from 'node:fs/promises';
+import { extname } from 'node:path';
+
+const esmRoot = new URL('../../dist/esm/', import.meta.url).href;
+
+// Exercise the real emitted module graph using the extension resolution and
+// module format a bundler applies to this package's `module` entry.
+export const resolve = async (specifier, context, nextResolve) => {
+  if (context.parentURL?.startsWith(esmRoot) && specifier.startsWith('.')) {
+    const target = new URL(specifier, context.parentURL);
+    if (target.href.startsWith(esmRoot) && !extname(target.pathname)) {
+      specifier = `${target.href}.js`;
+    }
+  }
+  return nextResolve(specifier, context);
+};
+
+export const load = async (url, context, nextLoad) => {
+  if (url.startsWith(esmRoot)) {
+    return {
+      format: 'module',
+      source: await readFile(new URL(url), 'utf8'),
+      shortCircuit: true,
+    };
+  }
+  return nextLoad(url, context);
+};

--- a/packages/perf-harness/__tests__/fixtures/fake-worker.js
+++ b/packages/perf-harness/__tests__/fixtures/fake-worker.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const valueFor = (name) => {
+  const flag = `--${name}`;
+  const index = process.argv.indexOf(flag);
+  if (index < 0 || !process.argv[index + 1]) {
+    throw new Error(`${flag} is required`);
+  }
+  return process.argv[index + 1];
+};
+
+const databaseUrl = valueFor('database-url');
+const envelope = JSON.parse(
+  Buffer.from(valueFor('worker-config'), 'base64url').toString('utf8')
+);
+if (envelope.workerConfig.pidFile) {
+  require('node:fs').writeFileSync(
+    envelope.workerConfig.pidFile,
+    String(process.pid)
+  );
+}
+const value = envelope.workerConfig.value;
+const memory = {
+  rss: value,
+  heapTotal: value,
+  heapUsed: value,
+  external: value,
+  arrayBuffers: value,
+};
+const result = {
+  status: 'ok',
+  pid: process.pid,
+  caseName: envelope.caseName,
+  buildMs: value,
+  schemaHash: envelope.workerConfig.schemaHash,
+  schemaTypeCount: 10,
+  runtimeVerified: true,
+  caseValidation: { passed: true, errors: [] },
+  memory: {
+    baseline: memory,
+    afterBuild: memory,
+    delta: memory,
+    processPeakRss: value,
+  },
+};
+if (envelope.workerConfig.mode !== 'hang') {
+  process.stdout.write(`CPERF_RESULT ${JSON.stringify(result)}\n`);
+}
+if (['hang', 'result-then-hang'].includes(envelope.workerConfig.mode)) {
+  process.stderr.write(`connecting to ${databaseUrl}\n`);
+  setInterval(() => undefined, 1_000);
+}

--- a/packages/perf-harness/__tests__/process.test.ts
+++ b/packages/perf-harness/__tests__/process.test.ts
@@ -1,0 +1,280 @@
+import childProcess from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { PassThrough } from 'node:stream';
+
+import {
+  DEFAULT_WORKER_TIMEOUT_MS,
+  parseWorkerProcessArgs,
+  runWorkerProcess,
+  validateWorkerTimeoutMs,
+  WorkerCleanupError,
+} from '../src/process';
+
+describe('worker CLI protocol', () => {
+  const encodedConfig = Buffer.from(
+    JSON.stringify({ caseName: 'baseline', workerConfig: { value: 1 } })
+  ).toString('base64url');
+
+  test('parses the database URL and worker envelope from CLI arguments', () => {
+    expect(
+      parseWorkerProcessArgs([
+        '--database-url',
+        'postgres:///benchmark',
+        '--worker-config',
+        encodedConfig,
+      ])
+    ).toEqual({
+      databaseUrl: 'postgres:///benchmark',
+      envelope: { caseName: 'baseline', workerConfig: { value: 1 } },
+    });
+  });
+
+  test('rejects missing, duplicate, and unsupported worker arguments', () => {
+    expect(() =>
+      parseWorkerProcessArgs(['--worker-config', encodedConfig])
+    ).toThrow('--database-url is required');
+    expect(() =>
+      parseWorkerProcessArgs(['--database-url', 'postgres:///benchmark'])
+    ).toThrow('--worker-config is required');
+    expect(() =>
+      parseWorkerProcessArgs([
+        '--database-url',
+        'postgres:///one',
+        '--database-url',
+        'postgres:///two',
+        '--worker-config',
+        encodedConfig,
+      ])
+    ).toThrow('--database-url may only be specified once');
+    expect(() =>
+      parseWorkerProcessArgs([
+        '--database-url',
+        'postgres:///benchmark',
+        '--worker-config',
+        encodedConfig,
+        '--unexpected',
+        'value',
+      ])
+    ).toThrow("unsupported worker argument '--unexpected'");
+  });
+});
+
+describe('fresh worker process', () => {
+  test('uses distinct PIDs and does not expose the database URL', async () => {
+    const worker = resolve(__dirname, 'fixtures/fake-worker.js');
+    const definition = {
+      name: 'baseline',
+      workerConfig: { value: 1, schemaHash: 'same' },
+    };
+    const databaseUrl = 'postgres://secret@example.test/database';
+    const first = await runWorkerProcess(worker, databaseUrl, definition);
+    const second = await runWorkerProcess(worker, databaseUrl, definition);
+    expect(first.pid).not.toBe(process.pid);
+    expect(second.pid).not.toBe(process.pid);
+    expect(first.pid).not.toBe(second.pid);
+    expect(JSON.stringify([first.result, second.result])).not.toContain(
+      databaseUrl
+    );
+  });
+
+  test.each(['hang', 'result-then-hang'])(
+    'reaps a %s worker before rejecting and redacts its diagnostics',
+    async (mode) => {
+      const directory = await mkdtemp(resolve(tmpdir(), 'cperf-timeout-'));
+      const pidFile = resolve(directory, 'worker.pid');
+      const spawn = jest.spyOn(childProcess, 'spawn');
+      const databaseUrl = 'postgres://secret@example.test/database';
+      const running = runWorkerProcess(
+        resolve(__dirname, 'fixtures/fake-worker.js'),
+        databaseUrl,
+        { name: mode, workerConfig: { mode, pidFile, value: 1 } },
+        2_000
+      );
+      const child = spawn.mock.results[0].value as childProcess.ChildProcess;
+      let closed = false;
+      child.once('close', () => {
+        closed = true;
+      });
+      // Keep a regression in timeout handling from orphaning the test child.
+      const watchdog = setTimeout(() => child.kill('SIGKILL'), 5_000);
+      try {
+        const error = await running.catch((failure: Error) => failure);
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toContain('timed out after 2000ms');
+        expect((error as Error).stack).not.toContain(databaseUrl);
+        expect(closed).toBe(true);
+        expect(Number(await readFile(pidFile, 'utf8'))).toBe(child.pid);
+      } finally {
+        clearTimeout(watchdog);
+        spawn.mockRestore();
+        await rm(directory, { recursive: true, force: true });
+      }
+    },
+    10_000
+  );
+});
+
+describe('worker deadline lifecycle', () => {
+  const definition = { name: 'baseline', workerConfig: {} };
+  const databaseUrl = 'postgres://secret@example.test/database';
+  let child: EventEmitter & {
+    pid: number | undefined;
+    stdout: PassThrough;
+    stderr: PassThrough;
+    kill: jest.Mock;
+    unref: jest.Mock;
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    child = Object.assign(new EventEmitter(), {
+      pid: 12345,
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      kill: jest.fn(() => true),
+      unref: jest.fn(),
+    });
+    jest
+      .spyOn(childProcess, 'spawn')
+      .mockReturnValue(
+        child as unknown as ReturnType<typeof childProcess.spawn>
+      );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  const writeSuccess = (): void => {
+    child.stdout.write(
+      `CPERF_RESULT ${JSON.stringify({
+        status: 'ok',
+        pid: child.pid,
+        caseName: definition.name,
+      })}\n`
+    );
+  };
+
+  test('clears its deadline on normal close', async () => {
+    const running = runWorkerProcess('worker.js', databaseUrl, definition, 100);
+    writeSuccess();
+    jest.advanceTimersByTime(99);
+    child.emit('close', 0, null);
+    await expect(running).resolves.toMatchObject({ pid: child.pid });
+    jest.advanceTimersByTime(10_000);
+    expect(child.kill).not.toHaveBeenCalled();
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  test('keeps a timeout latched until close, even after a success result', async () => {
+    const running = runWorkerProcess('worker.js', databaseUrl, definition, 100);
+    writeSuccess();
+    let settled = false;
+    const observed = running.catch((error: Error) => {
+      settled = true;
+      return error;
+    });
+    jest.advanceTimersByTime(100);
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    child.emit('close', 0, null);
+    expect(((await observed) as Error).message).toContain('timed out');
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  test('rejects spawn failure without waiting for the deadline', async () => {
+    child.pid = undefined;
+    const running = runWorkerProcess('worker.js', databaseUrl, definition, 100);
+    child.emit('error', new Error(`cannot spawn ${databaseUrl}`));
+    await expect(running).rejects.toThrow('could not start');
+    expect(child.kill).not.toHaveBeenCalled();
+    expect(jest.getTimerCount()).toBe(0);
+    expect(() => child.emit('error', new Error('late error'))).not.toThrow();
+  });
+
+  test('redacts synchronous spawn failures', async () => {
+    jest.mocked(childProcess.spawn).mockImplementationOnce(() => {
+      throw new Error(databaseUrl);
+    });
+    const error = await runWorkerProcess(
+      'worker.js',
+      databaseUrl,
+      definition
+    ).catch((failure: Error) => failure);
+    expect((error as Error).message).toContain('could not start');
+    expect((error as Error).stack).not.toContain(databaseUrl);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  test('reaps a worker after a post-spawn error before rejecting', async () => {
+    const running = runWorkerProcess('worker.js', databaseUrl, definition, 100);
+    let settled = false;
+    const observed = running.catch((error: Error) => {
+      settled = true;
+      return error;
+    });
+    child.emit('error', new Error(`stream failed: ${databaseUrl}`));
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    child.emit('close', 1, null);
+    expect(((await observed) as Error).message).not.toContain(databaseUrl);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  test.each(['false', 'throw', 'no-close'])(
+    'bounds cleanup when kill produces %s and tolerates late events',
+    async (outcome) => {
+      if (outcome === 'false') child.kill.mockReturnValue(false);
+      if (outcome === 'throw')
+        child.kill.mockImplementation(() => {
+          throw new Error(`cannot kill ${databaseUrl}`);
+        });
+      const running = runWorkerProcess(
+        'worker.js',
+        databaseUrl,
+        definition,
+        100
+      );
+      const observed = running.catch((error: Error) => error);
+      child.stderr.write(databaseUrl);
+      jest.advanceTimersByTime(100);
+      expect(child.stdout.destroyed).toBe(false);
+      jest.advanceTimersByTime(5_000);
+      const error = (await observed) as Error;
+      expect(error).toBeInstanceOf(WorkerCleanupError);
+      expect(error.message).toContain('cleanup was not confirmed');
+      expect(error.stack).not.toContain(databaseUrl);
+      expect(child.stdout.destroyed).toBe(true);
+      expect(child.stderr.destroyed).toBe(true);
+      expect(child.unref).toHaveBeenCalledTimes(1);
+      expect(() => {
+        child.emit('close', 0, null);
+        child.emit('error', new Error('late child error'));
+        child.stdout.emit('error', new Error('late stream error'));
+      }).not.toThrow();
+      jest.runAllTicks();
+      expect(jest.getTimerCount()).toBe(0);
+    }
+  );
+
+  test.each([0, -1, 1.5, NaN, Infinity, 2_147_483_648, null])(
+    'rejects invalid timeout %s before spawning',
+    async (timeout) => {
+      await expect(
+        runWorkerProcess('worker.js', databaseUrl, definition, timeout)
+      ).rejects.toThrow('workerTimeoutMs');
+      expect(childProcess.spawn).not.toHaveBeenCalled();
+      expect(jest.getTimerCount()).toBe(0);
+    }
+  );
+
+  test('normalizes the default timeout', () => {
+    expect(validateWorkerTimeoutMs()).toBe(DEFAULT_WORKER_TIMEOUT_MS);
+  });
+});

--- a/packages/perf-harness/__tests__/report.test.ts
+++ b/packages/perf-harness/__tests__/report.test.ts
@@ -1,0 +1,78 @@
+import {
+  compareCases,
+  summarizeCase,
+  validateSchemaGroups,
+} from '../src/report';
+import type { BenchmarkRun, SuccessfulWorkerResult } from '../src/types';
+
+const result = (caseName: string, value: number): SuccessfulWorkerResult => ({
+  status: 'ok',
+  pid: value,
+  caseName,
+  buildMs: value,
+  schemaHash: 'same',
+  schemaTypeCount: 10,
+  runtimeVerified: true,
+  caseValidation: { passed: true, errors: [] },
+  memory: {
+    baseline: {
+      rss: 10,
+      heapTotal: 10,
+      heapUsed: 10,
+      external: 10,
+      arrayBuffers: 10,
+    },
+    afterBuild: {
+      rss: value,
+      heapTotal: value,
+      heapUsed: value,
+      external: value,
+      arrayBuffers: value,
+    },
+    delta: {
+      rss: value - 10,
+      heapTotal: value - 10,
+      heapUsed: value - 10,
+      external: value - 10,
+      arrayBuffers: value - 10,
+    },
+    processPeakRss: value,
+  },
+});
+
+describe('generic reports', () => {
+  test('summarizes arbitrary cases and compares medians', () => {
+    const runs: BenchmarkRun[] = [10, 30, 20].map((value, index) => ({
+      repetition: index + 1,
+      position: 1,
+      caseName: 'base',
+      result: result('base', value),
+    }));
+    runs.push(
+      ...[5, 15, 10].map((value, index) => ({
+        repetition: index + 1,
+        position: 2,
+        caseName: 'candidate',
+        result: result('candidate', value),
+      }))
+    );
+    const base = summarizeCase(runs, 'base')!;
+    const candidate = summarizeCase(runs, 'candidate')!;
+    expect(
+      compareCases('base', 'candidate', base, candidate).buildMs.percentChange
+    ).toBe(-50);
+    expect(
+      validateSchemaGroups(
+        [
+          { name: 'base', workerConfig: null, expectedSchemaGroup: 'schema' },
+          {
+            name: 'candidate',
+            workerConfig: null,
+            expectedSchemaGroup: 'schema',
+          },
+        ],
+        runs
+      )
+    ).toEqual({ equivalent: true, hashes: { schema: 'same' }, errors: [] });
+  });
+});

--- a/packages/perf-harness/__tests__/run.test.ts
+++ b/packages/perf-harness/__tests__/run.test.ts
@@ -1,0 +1,218 @@
+import childProcess from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+
+import * as workerProcess from '../src/process';
+import { cliMain, runBenchmarkSuite } from '../src/run';
+import type { BenchmarkReport } from '../src/types';
+
+describe('generic suite runner', () => {
+  test('redacts errors returned by custom workers before recording them', async () => {
+    const databaseUrl = 'postgres://secret@example.test/database';
+    const run = jest
+      .spyOn(workerProcess, 'runWorkerProcess')
+      .mockResolvedValue({
+        pid: 12345,
+        result: {
+          status: 'error',
+          pid: 12345,
+          caseName: 'broken',
+          error: `could not connect to ${databaseUrl}; retrying ${databaseUrl}`,
+        },
+      });
+    try {
+      const report = await runBenchmarkSuite(
+        {
+          name: 'custom-worker-error',
+          cases: [{ name: 'broken', workerConfig: {} }],
+        },
+        { databaseUrl, repetitions: 1, seed: 1, order: null },
+        'custom-worker.js'
+      );
+      expect(report.runs[0].result).toMatchObject({
+        status: 'error',
+        error:
+          'could not connect to <redacted database URL>; retrying <redacted database URL>',
+      });
+      expect(report.validation.allRunsSucceeded).toBe(false);
+      expect(report.summaries).toEqual({});
+      expect(JSON.stringify(report)).not.toContain(databaseUrl);
+    } finally {
+      run.mockRestore();
+    }
+  });
+
+  test('requires the database URL as an explicit CLI argument', async () => {
+    await expect(
+      cliMain(['prepare', '--schema', 'cperf_explicit_cli'])
+    ).rejects.toThrow('--database-url is required');
+  });
+
+  test('validates fresh processes and schema groups without fixed case names', async () => {
+    const report = await runBenchmarkSuite(
+      {
+        name: 'test-suite',
+        cases: ['alpha', 'beta', 'gamma'].map((name, index) => ({
+          name,
+          workerConfig: { value: index + 1, schemaHash: 'same' },
+          expectedSchemaGroup: 'schema',
+        })),
+      },
+      {
+        databaseUrl: 'postgres:///not-used-by-fake-worker',
+        repetitions: 1,
+        seed: 1,
+        order: ['alpha', 'beta', 'gamma'],
+      },
+      resolve(__dirname, 'fixtures/fake-worker.js')
+    );
+    expect(report.validation).toEqual(
+      expect.objectContaining({
+        allRunsSucceeded: true,
+        freshProcessPerRun: true,
+        caseValidationPassed: true,
+        schemaGroupsEquivalent: true,
+        schemaGroups: { schema: 'same' },
+        errors: [],
+      })
+    );
+    expect(new Set(report.runs.map((run) => run.result.pid)).size).toBe(3);
+    expect(report.config.workerTimeoutMs).toBe(
+      workerProcess.DEFAULT_WORKER_TIMEOUT_MS
+    );
+    expect(JSON.stringify(report)).not.toContain('postgres:///');
+  });
+});
+
+describe('suite timeout reporting', () => {
+  const worker = resolve(__dirname, 'fixtures/fake-worker.js');
+  const options = {
+    databaseUrl: 'postgres://secret@example.test/database',
+    repetitions: 1,
+    seed: 1,
+    order: ['hung', 'healthy'],
+    workerTimeoutMs: 2_000,
+  };
+  const suite = {
+    name: 'timeout-suite',
+    cases: [
+      { name: 'hung', workerConfig: { mode: 'hang', value: 1 } },
+      { name: 'healthy', workerConfig: { value: 2, schemaHash: 'same' } },
+    ],
+  };
+  let watchdog: ReturnType<typeof setTimeout>;
+  let originalExitCode: typeof process.exitCode;
+
+  beforeEach(() => {
+    originalExitCode = process.exitCode;
+    const spawn = jest.spyOn(childProcess, 'spawn');
+    watchdog = setTimeout(() => {
+      for (const result of spawn.mock.results) {
+        if (result.type === 'return') result.value.kill('SIGKILL');
+      }
+    }, 5_000);
+  });
+
+  afterEach(() => {
+    clearTimeout(watchdog);
+    process.exitCode = originalExitCode;
+    jest.restoreAllMocks();
+  });
+
+  test('continues after a reaped timeout and excludes it from successful samples', async () => {
+    const report = await runBenchmarkSuite(suite, options, worker);
+    expect(report.config.workerTimeoutMs).toBe(2_000);
+    expect(report.runs.map((run) => run.result.status)).toEqual([
+      'error',
+      'ok',
+    ]);
+    expect(report.validation.allRunsSucceeded).toBe(false);
+    expect(report.validation.errors.join('\n')).toContain(
+      'timed out after 2000ms'
+    );
+    expect(report.summaries.hung).toBeUndefined();
+    expect(report.summaries.healthy.sampleCount).toBe(1);
+    expect(JSON.stringify(report)).not.toContain(options.databaseUrl);
+  }, 10_000);
+
+  test('stops scheduling when cleanup cannot be confirmed, retaining a failed partial report', async () => {
+    const run = jest
+      .spyOn(workerProcess, 'runWorkerProcess')
+      .mockRejectedValue(
+        new workerProcess.WorkerCleanupError('cleanup was not confirmed', 12345)
+      );
+    const report = await runBenchmarkSuite(suite, options, worker);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(report.schedule).toHaveLength(2);
+    expect(report.runs).toHaveLength(1);
+    expect(report.runs[0].result).toMatchObject({
+      status: 'error',
+      pid: 12345,
+    });
+    expect(report.validation.allRunsSucceeded).toBe(false);
+    expect(report.validation.errors.join('\n')).toContain(
+      'cleanup was not confirmed'
+    );
+    expect(report.summaries).toEqual({});
+  });
+
+  test('validates suite timeout before spawning', async () => {
+    await expect(
+      runBenchmarkSuite(suite, { ...options, workerTimeoutMs: NaN }, worker)
+    ).rejects.toThrow('workerTimeoutMs');
+    expect(childProcess.spawn).not.toHaveBeenCalled();
+  });
+
+  const cliArgs = (): string[] => [
+    'run',
+    '--database-url',
+    options.databaseUrl,
+    '--cases',
+    Buffer.from(JSON.stringify(suite.cases)).toString('base64url'),
+    '--worker',
+    worker,
+    '--repetitions',
+    '1',
+    '--order',
+    'hung,healthy',
+  ];
+
+  test('writes the timeout report and sets a failing CLI exit code', async () => {
+    const directory = await mkdtemp(resolve(tmpdir(), 'cperf-report-'));
+    const output = resolve(directory, 'report.json');
+    jest.spyOn(process.stdout, 'write').mockReturnValue(true);
+    try {
+      await cliMain([
+        ...cliArgs(),
+        '--worker-timeout-ms',
+        '2000',
+        '--output',
+        output,
+      ]);
+      const report: BenchmarkReport = JSON.parse(
+        await readFile(output, 'utf8')
+      );
+      expect(report.config.workerTimeoutMs).toBe(2_000);
+      expect(report.runs.map((run) => run.result.status)).toEqual([
+        'error',
+        'ok',
+      ]);
+      expect(report.validation.allRunsSucceeded).toBe(false);
+      expect(process.exitCode).toBe(1);
+      expect(JSON.stringify(report)).not.toContain(options.databaseUrl);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  }, 10_000);
+
+  test.each(['0', '-1', '1.5', 'NaN', '2147483648'])(
+    'rejects invalid CLI timeout %s',
+    async (value) => {
+      await expect(
+        cliMain([...cliArgs(), '--worker-timeout-ms', value])
+      ).rejects.toThrow('worker-timeout-ms');
+      expect(childProcess.spawn).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/packages/perf-harness/__tests__/schedule.test.ts
+++ b/packages/perf-harness/__tests__/schedule.test.ts
@@ -1,0 +1,29 @@
+import { makeSchedule } from '../src/schedule';
+
+const cases = [
+  { name: 'a', workerConfig: null },
+  { name: 'b', workerConfig: null },
+  { name: 'c', workerConfig: null },
+];
+
+describe('generic benchmark scheduling', () => {
+  test('is deterministic and supports any case list', () => {
+    const first = makeSchedule(cases, 4, 1234);
+    expect(makeSchedule(cases, 4, 1234)).toEqual(first);
+    expect(makeSchedule(cases, 4, 4321)).not.toEqual(first);
+    for (let repetition = 1; repetition <= 4; repetition += 1) {
+      expect(
+        first
+          .filter((item) => item.repetition === repetition)
+          .map((item) => item.caseName)
+          .sort()
+      ).toEqual(['a', 'b', 'c']);
+    }
+  });
+
+  test('accepts an exact order containing each case once', () => {
+    expect(
+      makeSchedule(cases, 2, 1, ['c', 'a', 'b']).map((item) => item.caseName)
+    ).toEqual(['c', 'a', 'b', 'c', 'a', 'b']);
+  });
+});

--- a/packages/perf-harness/__tests__/stock-worker.test.ts
+++ b/packages/perf-harness/__tests__/stock-worker.test.ts
@@ -1,0 +1,269 @@
+import { makeSchema } from 'graphile-build';
+import { buildSchema, type GraphQLSchema } from 'graphql';
+import { makePgService } from 'postgraphile/adaptors/pg';
+
+import { WORKER_RESULT_PREFIX } from '../src/process';
+import { runStockWorker } from '../src/stock-worker';
+import type { WorkerResult } from '../src/types';
+
+jest.mock('graphile-build', () => ({
+  defaultPreset: {},
+  makeSchema: jest.fn(),
+}));
+
+jest.mock('graphile-build-pg', () => ({ defaultPreset: {} }));
+
+jest.mock('postgraphile/adaptors/pg', () => ({
+  makePgService: jest.fn(),
+}));
+
+const mockedMakeSchema = jest.mocked(makeSchema);
+const mockedMakePgService = jest.mocked(makePgService);
+
+const databaseUrl = 'postgres://secret@example.test/benchmark';
+const encodedConfig = (workerConfig: unknown): string =>
+  Buffer.from(JSON.stringify({ caseName: 'stock', workerConfig })).toString(
+    'base64url'
+  );
+const workerArgs = (workerConfig: unknown): string[] => [
+  '--database-url',
+  databaseUrl,
+  '--worker-config',
+  encodedConfig(workerConfig),
+];
+
+interface MockService {
+  release: jest.Mock<Promise<void>, []>;
+}
+
+const createService = (): MockService => ({
+  release: jest.fn().mockResolvedValue(undefined),
+});
+
+const readResult = (write: jest.Mock): WorkerResult => {
+  const output = write.mock.calls[0]?.[0];
+  expect(typeof output).toBe('string');
+  expect(write).toHaveBeenCalledTimes(1);
+  return JSON.parse(
+    (output as string).slice(WORKER_RESULT_PREFIX.length)
+  ) as WorkerResult;
+};
+
+describe('stock worker lifecycle', () => {
+  let originalExitCode: typeof process.exitCode;
+  let originalGcDescriptor: PropertyDescriptor | undefined;
+  let output: jest.Mock;
+  let service: MockService;
+
+  beforeEach(() => {
+    originalExitCode = process.exitCode;
+    originalGcDescriptor = Object.getOwnPropertyDescriptor(global, 'gc');
+    Object.defineProperty(global, 'gc', {
+      configurable: true,
+      value: jest.fn(),
+      writable: true,
+    });
+    output = jest
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true) as unknown as jest.Mock;
+    service = createService();
+    // Schema construction is mocked separately; this service stub owns only
+    // the external release hook exercised by these lifecycle tests.
+    mockedMakePgService.mockReturnValue(
+      service as unknown as ReturnType<typeof makePgService>
+    );
+    mockedMakeSchema.mockResolvedValue({
+      schema: buildSchema('type Query { stock: String }'),
+      resolvedPreset: {},
+    } as { schema: GraphQLSchema; resolvedPreset: never });
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+    if (originalGcDescriptor) {
+      Object.defineProperty(global, 'gc', originalGcDescriptor);
+    } else {
+      Reflect.deleteProperty(global, 'gc');
+    }
+  });
+
+  test('writes exactly once after deferred cleanup completes', async () => {
+    let finishRelease: (() => void) | undefined;
+    service.release.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRelease = resolve;
+        })
+    );
+
+    const running = runStockWorker(workerArgs({ schemas: ['public'] }));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(service.release).toHaveBeenCalledTimes(1);
+    expect(output).not.toHaveBeenCalled();
+    finishRelease?.();
+    await running;
+
+    expect(readResult(output)).toMatchObject({
+      status: 'ok',
+      caseName: 'stock',
+    });
+  });
+
+  test('reports one successful result after releasing the service', async () => {
+    await runStockWorker(workerArgs({ schemas: ['public'] }));
+
+    expect(service.release).toHaveBeenCalledTimes(1);
+    expect(readResult(output)).toMatchObject({
+      status: 'ok',
+      caseName: 'stock',
+      runtimeVerified: true,
+    });
+    expect(global.gc).toHaveBeenCalledTimes(6);
+  });
+
+  test('reports a release failure once', async () => {
+    service.release.mockRejectedValue(new Error('release failed'));
+
+    await runStockWorker(workerArgs({ schemas: ['public'] }));
+
+    expect(readResult(output)).toMatchObject({
+      status: 'error',
+      error: 'release failed',
+    });
+    expect(process.exitCode).toBe(1);
+  });
+
+  test('reports a measurement failure after cleanup', async () => {
+    mockedMakeSchema.mockRejectedValue(new Error('measurement failed'));
+
+    await runStockWorker(workerArgs({ schemas: ['public'] }));
+
+    expect(service.release).toHaveBeenCalledTimes(1);
+    expect(readResult(output)).toMatchObject({
+      status: 'error',
+      error: 'measurement failed',
+    });
+  });
+
+  test('keeps the primary diagnostic before a release failure', async () => {
+    mockedMakeSchema.mockRejectedValue(
+      new Error(`measurement failed: ${databaseUrl}`)
+    );
+    service.release.mockRejectedValue(
+      new Error(`release failed: ${databaseUrl}`)
+    );
+
+    await runStockWorker(workerArgs({ schemas: ['public'] }));
+
+    const result = readResult(output);
+    expect(result).toMatchObject({ status: 'error' });
+    expect((result as Extract<WorkerResult, { status: 'error' }>).error).toBe(
+      'measurement failed: <redacted database URL>; release failed: <redacted database URL>'
+    );
+    expect(JSON.stringify(result)).not.toContain(databaseUrl);
+  });
+
+  test.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['false', false],
+    ['zero', 0],
+    ['empty string', ''],
+  ])('preserves a %s thrown value', async (_name, failure) => {
+    mockedMakeSchema.mockImplementation(async () => {
+      throw failure;
+    });
+
+    await runStockWorker(workerArgs({ schemas: ['public'] }));
+
+    const result = readResult(output);
+    expect(result.status).toBe('error');
+    expect((result as Extract<WorkerResult, { status: 'error' }>).error).toBe(
+      String(failure)
+    );
+  });
+
+  test('does not call hostile object toString or leak it', async () => {
+    const hostile = {
+      get toString(): never {
+        throw new Error(databaseUrl);
+      },
+    };
+    mockedMakeSchema.mockImplementation(async () => {
+      throw hostile;
+    });
+
+    await expect(
+      runStockWorker(workerArgs({ schemas: ['public'] }))
+    ).resolves.toBeUndefined();
+
+    const result = readResult(output);
+    expect(result).toMatchObject({ status: 'error', error: 'unknown error' });
+    expect(JSON.stringify(result)).not.toContain(databaseUrl);
+  });
+
+  test('handles an Error with a throwing message getter', async () => {
+    const hostile = Object.create(Error.prototype) as Error;
+    Object.defineProperty(hostile, 'message', {
+      configurable: true,
+      get: () => {
+        throw new Error(databaseUrl);
+      },
+    });
+    mockedMakeSchema.mockImplementation(async () => {
+      throw hostile;
+    });
+
+    await runStockWorker(workerArgs({ schemas: ['public'] }));
+
+    expect(readResult(output)).toMatchObject({
+      status: 'error',
+      error: 'unknown error',
+    });
+    expect(output.mock.calls.join(' ')).not.toContain(databaseUrl);
+  });
+
+  test('preserves a falsy cleanup rejection', async () => {
+    service.release.mockRejectedValue(false);
+
+    await runStockWorker(workerArgs({ schemas: ['public'] }));
+
+    expect(readResult(output)).toMatchObject({
+      status: 'error',
+      error: 'false',
+    });
+  });
+
+  test('redacts the full database URL in both failure diagnostics', async () => {
+    mockedMakeSchema.mockRejectedValue(
+      new Error(`could not connect to ${databaseUrl}`)
+    );
+    service.release.mockRejectedValue(
+      new Error(`could not release ${databaseUrl}`)
+    );
+
+    await runStockWorker(workerArgs({ schemas: ['public'] }));
+
+    const result = readResult(output);
+    expect(result).toMatchObject({
+      status: 'error',
+      error:
+        'could not connect to <redacted database URL>; could not release <redacted database URL>',
+    });
+    expect(JSON.stringify(result)).not.toContain(databaseUrl);
+  });
+
+  test('validates config before allocating a service', async () => {
+    await runStockWorker(workerArgs({ schemas: [] }));
+
+    expect(mockedMakePgService).not.toHaveBeenCalled();
+    expect(output).toHaveBeenCalledTimes(1);
+    expect(readResult(output)).toMatchObject({
+      status: 'error',
+      error: 'stock worker requires a non-empty schemas array',
+    });
+  });
+});

--- a/packages/perf-harness/jest.config.js
+++ b/packages/perf-harness/jest.config.js
@@ -1,0 +1,12 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }],
+  },
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  modulePathIgnorePatterns: ['dist/*'],
+  testPathIgnorePatterns: ['/__tests__/fixtures/'],
+};

--- a/packages/perf-harness/package.json
+++ b/packages/perf-harness/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@constructive-io/perf-harness",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Reusable fresh-process Graphile performance harness",
+  "main": "index.js",
+  "module": "esm/index.js",
+  "types": "index.d.ts",
+  "bin": {
+    "cperf": "cli.js"
+  },
+  "scripts": {
+    "clean": "makage clean",
+    "build": "makage build",
+    "build:dev": "makage build --dev",
+    "cperf": "node dist/cli.js",
+    "lint": "eslint . --fix",
+    "test": "pnpm run build && jest"
+  },
+  "dependencies": {
+    "graphile-build": "5.1.1",
+    "graphile-build-pg": "5.1.3",
+    "graphile-config": "1.1.0",
+    "graphql": "16.13.0",
+    "pg": "^8.21.0",
+    "postgraphile": "5.1.4"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.11",
+    "@types/pg": "^8.20.4",
+    "makage": "^0.8.0"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "license": "MIT"
+}

--- a/packages/perf-harness/src/cli.ts
+++ b/packages/perf-harness/src/cli.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+import { cliMain } from './run';
+
+void cliMain().catch((error: unknown) => {
+  process.stderr.write(
+    `${error instanceof Error ? error.message : String(error)}\n`
+  );
+  process.exitCode = 1;
+});

--- a/packages/perf-harness/src/fixture.ts
+++ b/packages/perf-harness/src/fixture.ts
@@ -1,0 +1,158 @@
+import { Pool, type PoolClient } from 'pg';
+
+export const FIXTURE_VERSION = 1;
+
+export interface PrepareFixtureOptions {
+  databaseUrl: string;
+  schema: string;
+  tables: number;
+}
+
+export interface PreparedFixture {
+  fixtureVersion: number;
+  database: string;
+  serverVersion: string;
+  schema: string;
+  tableCount: number;
+  functionCount: number;
+}
+
+export const validateFixtureSchema = (schema: string): string => {
+  if (
+    !/^cperf_[a-z0-9_]*$/.test(schema) ||
+    schema.length > 63 ||
+    schema.includes('\0')
+  ) {
+    throw new Error(
+      'fixture schema must start with cperf_, use only lowercase letters, digits, and underscores, and fit PostgreSQL identifiers'
+    );
+  }
+  return schema;
+};
+
+export const validateFixtureTableCount = (tables: number): number => {
+  if (!Number.isSafeInteger(tables) || tables < 1 || tables > 500) {
+    throw new Error('fixture table count must be an integer between 1 and 500');
+  }
+  return tables;
+};
+
+const quoteIdentifier = (identifier: string): string =>
+  `"${identifier.replaceAll('"', '""')}"`;
+
+const throwFixtureErrors = (errors: unknown[]): never => {
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+  throw new AggregateError(errors, 'fixture preparation failed', {
+    cause: errors[0],
+  });
+};
+
+export const prepareFixture = async (
+  options: PrepareFixtureOptions
+): Promise<PreparedFixture> => {
+  const schema = validateFixtureSchema(options.schema);
+  const tables = validateFixtureTableCount(options.tables);
+  const quotedSchema = quoteIdentifier(schema);
+  const pool = new Pool({ connectionString: options.databaseUrl, max: 1 });
+  const errors: unknown[] = [];
+  let client: PoolClient | undefined;
+  let result: PreparedFixture | undefined;
+
+  try {
+    client = await pool.connect();
+    await client.query('begin');
+    const existing = await client.query<{ exists: boolean }>(
+      'select exists(select 1 from pg_catalog.pg_namespace where nspname = $1) as exists',
+      [schema]
+    );
+    if (existing.rows[0]?.exists) {
+      throw new Error(
+        `fixture schema '${schema}' already exists; this command never replaces schemas`
+      );
+    }
+    await client.query(`create schema ${quotedSchema}`);
+    await client.query(
+      `comment on schema ${quotedSchema} is 'cperf fixture version ${FIXTURE_VERSION}'`
+    );
+    await client.query(
+      `create type ${quotedSchema}."entity_status" as enum ('draft', 'active', 'archived')`
+    );
+    await client.query(`
+      create table ${quotedSchema}."account" (
+        id bigint generated always as identity primary key,
+        external_id uuid not null unique,
+        name text not null,
+        metadata jsonb not null default '{}'::jsonb,
+        created_at timestamptz not null default now()
+      )
+    `);
+    for (let index = 1; index <= tables; index += 1) {
+      const table = quoteIdentifier(`entity_${index}`);
+      const functionName = quoteIdentifier(`entity_${index}_by_account`);
+      const indexName = quoteIdentifier(`entity_${index}_account_created_idx`);
+      await client.query(`
+        create table ${quotedSchema}.${table} (
+          id bigint generated always as identity primary key,
+          account_id bigint not null references ${quotedSchema}."account"(id),
+          status ${quotedSchema}."entity_status" not null default 'draft',
+          title text not null,
+          tags text[] not null default array[]::text[],
+          metadata jsonb not null default '{}'::jsonb,
+          created_at timestamptz not null default now(),
+          unique (account_id, title)
+        );
+        create index ${indexName}
+          on ${quotedSchema}.${table} (account_id, created_at desc);
+        create function ${quotedSchema}.${functionName}(requested_account_id bigint)
+          returns setof ${quotedSchema}.${table}
+          language sql stable
+          as 'select * from ${quotedSchema}.${table} where account_id = requested_account_id';
+      `);
+    }
+    const identity = await client.query<{
+      database: string;
+      server_version: string;
+    }>(
+      "select current_database() as database, current_setting('server_version') as server_version"
+    );
+    await client.query('commit');
+    result = {
+      fixtureVersion: FIXTURE_VERSION,
+      database: identity.rows[0].database,
+      serverVersion: identity.rows[0].server_version,
+      schema,
+      tableCount: tables + 1,
+      functionCount: tables,
+    };
+  } catch (error) {
+    errors.push(error);
+    if (client) {
+      try {
+        await client.query('rollback');
+      } catch (rollbackError) {
+        errors.push(rollbackError);
+      }
+    }
+  } finally {
+    if (client) {
+      try {
+        await client.release();
+      } catch (releaseError) {
+        errors.push(releaseError);
+      }
+    }
+    try {
+      await pool.end();
+    } catch (endError) {
+      errors.push(endError);
+    }
+  }
+
+  if (errors.length > 0) {
+    throwFixtureErrors(errors);
+  }
+
+  return result as PreparedFixture;
+};

--- a/packages/perf-harness/src/index.ts
+++ b/packages/perf-harness/src/index.ts
@@ -1,0 +1,7 @@
+export * from './fixture';
+export * from './metrics';
+export * from './process';
+export * from './report';
+export * from './run';
+export * from './schedule';
+export * from './types';

--- a/packages/perf-harness/src/metrics.ts
+++ b/packages/perf-harness/src/metrics.ts
@@ -1,0 +1,79 @@
+import { performance } from 'node:perf_hooks';
+
+import type {
+  CaseValidation,
+  JsonValue,
+  MemorySnapshot,
+  SuccessfulWorkerResult,
+} from './types';
+
+export interface MeasuredCaseResult {
+  schemaHash: string;
+  schemaTypeCount: number;
+  runtimeVerified: true;
+  caseValidation?: CaseValidation;
+  metadata?: Record<string, JsonValue>;
+}
+
+const collectGarbage = (): void => {
+  if (typeof global.gc !== 'function') {
+    throw new Error('benchmark worker requires Node --expose-gc');
+  }
+  global.gc();
+  global.gc();
+  global.gc();
+};
+
+const memorySnapshot = (): MemorySnapshot => {
+  const memory = process.memoryUsage();
+  return {
+    rss: memory.rss,
+    heapTotal: memory.heapTotal,
+    heapUsed: memory.heapUsed,
+    external: memory.external,
+    arrayBuffers: memory.arrayBuffers,
+  };
+};
+
+const memoryDelta = (
+  baseline: MemorySnapshot,
+  afterBuild: MemorySnapshot
+): MemorySnapshot => ({
+  rss: afterBuild.rss - baseline.rss,
+  heapTotal: afterBuild.heapTotal - baseline.heapTotal,
+  heapUsed: afterBuild.heapUsed - baseline.heapUsed,
+  external: afterBuild.external - baseline.external,
+  arrayBuffers: afterBuild.arrayBuffers - baseline.arrayBuffers,
+});
+
+export const measureBenchmarkCase = async <Built>(
+  caseName: string,
+  build: () => Promise<Built>,
+  validate: (built: Built) => Promise<MeasuredCaseResult>
+): Promise<SuccessfulWorkerResult> => {
+  collectGarbage();
+  const baseline = memorySnapshot();
+  const startedAt = performance.now();
+  const built = await build();
+  const buildMs = performance.now() - startedAt;
+  const measured = await validate(built);
+  collectGarbage();
+  const afterBuild = memorySnapshot();
+  return {
+    status: 'ok',
+    pid: process.pid,
+    caseName,
+    buildMs,
+    schemaHash: measured.schemaHash,
+    schemaTypeCount: measured.schemaTypeCount,
+    runtimeVerified: measured.runtimeVerified,
+    caseValidation: measured.caseValidation ?? { passed: true, errors: [] },
+    ...(measured.metadata ? { metadata: measured.metadata } : {}),
+    memory: {
+      baseline,
+      afterBuild,
+      delta: memoryDelta(baseline, afterBuild),
+      processPeakRss: process.resourceUsage().maxRSS * 1024,
+    },
+  };
+};

--- a/packages/perf-harness/src/process.ts
+++ b/packages/perf-harness/src/process.ts
@@ -1,0 +1,313 @@
+import { spawn } from 'node:child_process';
+
+import type {
+  BenchmarkCaseDefinition,
+  WorkerConfigEnvelope,
+  WorkerResult,
+} from './types';
+
+export const WORKER_RESULT_PREFIX = 'CPERF_RESULT ';
+export const DATABASE_URL_ARGUMENT = 'database-url';
+export const WORKER_CONFIG_ARGUMENT = 'worker-config';
+export const DEFAULT_WORKER_TIMEOUT_MS = 300_000;
+export const MAX_WORKER_TIMEOUT_MS = 2_147_483_647;
+const WORKER_CLEANUP_TIMEOUT_MS = 5_000;
+
+export const validateWorkerTimeoutMs = (
+  value = DEFAULT_WORKER_TIMEOUT_MS
+): number => {
+  if (
+    !Number.isSafeInteger(value) ||
+    value < 1 ||
+    value > MAX_WORKER_TIMEOUT_MS
+  ) {
+    throw new Error(
+      `workerTimeoutMs must be an integer between 1 and ${MAX_WORKER_TIMEOUT_MS}`
+    );
+  }
+  return value;
+};
+
+/** The suite must stop: another measurement could overlap this worker. */
+export class WorkerCleanupError extends Error {
+  constructor(
+    message: string,
+    readonly pid: number | undefined
+  ) {
+    super(message);
+    this.name = 'WorkerCleanupError';
+  }
+}
+
+export interface ParsedValueArgs {
+  values: Map<string, string>;
+}
+
+export interface WorkerProcessArgs {
+  databaseUrl: string;
+  envelope: WorkerConfigEnvelope;
+}
+
+export interface SpawnedWorkerResult {
+  pid: number;
+  result: WorkerResult;
+}
+
+const lastLines = (value: string, count = 20): string =>
+  value.trim().split('\n').slice(-count).join('\n');
+
+export const redactSecret = (value: string, secret: string): string =>
+  secret ? value.replaceAll(secret, '<redacted database URL>') : value;
+
+export const parseValueArgs = (args: readonly string[]): ParsedValueArgs => {
+  const values = new Map<string, string>();
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (
+      !flag?.startsWith('--') ||
+      value === undefined ||
+      value.startsWith('--')
+    ) {
+      throw new Error(`expected --name value near '${flag ?? '<end>'}'`);
+    }
+    const name = flag.slice(2);
+    if (values.has(name))
+      throw new Error(`--${name} may only be specified once`);
+    values.set(name, value);
+  }
+  return { values };
+};
+
+export const parseWorkerProcessArgs = (
+  args: readonly string[]
+): WorkerProcessArgs => {
+  const parsed = parseValueArgs(args);
+  for (const name of parsed.values.keys()) {
+    if (name !== DATABASE_URL_ARGUMENT && name !== WORKER_CONFIG_ARGUMENT) {
+      throw new Error(`unsupported worker argument '--${name}'`);
+    }
+  }
+  const databaseUrl = parsed.values.get(DATABASE_URL_ARGUMENT);
+  if (!databaseUrl) throw new Error('--database-url is required');
+  return {
+    databaseUrl,
+    envelope: parseWorkerEnvelope(parsed.values.get(WORKER_CONFIG_ARGUMENT)),
+  };
+};
+
+export const runWorkerProcess = (
+  workerPath: string,
+  databaseUrl: string,
+  definition: BenchmarkCaseDefinition,
+  timeoutMs = DEFAULT_WORKER_TIMEOUT_MS
+): Promise<SpawnedWorkerResult> =>
+  new Promise((resolve, reject) => {
+    validateWorkerTimeoutMs(timeoutMs);
+    const config: WorkerConfigEnvelope = {
+      caseName: definition.name,
+      workerConfig: definition.workerConfig,
+    };
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(
+        process.execPath,
+        [
+          '--expose-gc',
+          workerPath,
+          `--${DATABASE_URL_ARGUMENT}`,
+          databaseUrl,
+          `--${WORKER_CONFIG_ARGUMENT}`,
+          Buffer.from(JSON.stringify(config)).toString('base64url'),
+        ],
+        {
+          env: {
+            ...process.env,
+            NODE_ENV: 'production',
+            GRAPHILE_ENV: 'production',
+          },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        }
+      );
+    } catch (error) {
+      reject(
+        new Error(
+          redactSecret(
+            `benchmark worker could not start: ${String(
+              error instanceof Error ? error.message : error
+            )}`,
+            databaseUrl
+          )
+        )
+      );
+      return;
+    }
+    const pid = child.pid;
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    let failure: string | undefined;
+    let deadline: ReturnType<typeof setTimeout> | undefined;
+    let cleanupDeadline: ReturnType<typeof setTimeout> | undefined;
+    const diagnostics: string[] = [];
+    const ignoreLateError = (): undefined => undefined;
+    const onStdout = (chunk: string): void => {
+      stdout += chunk;
+    };
+    const onStderr = (chunk: string): void => {
+      stderr += chunk;
+    };
+    const failureMessage = (reason: string): string =>
+      redactSecret(
+        `benchmark worker ${pid ?? 'unknown'} (${definition.name}) ${reason}` +
+          (diagnostics.length ? `\n${diagnostics.join('\n')}` : '') +
+          (stderr.trim() ? `\n${lastLines(stderr)}` : ''),
+        databaseUrl
+      );
+    const finish = (error?: Error, result?: SpawnedWorkerResult): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(deadline);
+      clearTimeout(cleanupDeadline);
+      child.removeListener('close', onClose);
+      child.removeListener('error', onError);
+      child.on('error', ignoreLateError);
+      child.stdout.removeListener('data', onStdout);
+      child.stderr.removeListener('data', onStderr);
+      for (const stream of [child.stdout, child.stderr]) {
+        stream.removeListener('error', onError);
+        stream.on('error', ignoreLateError);
+      }
+      if (error) reject(error);
+      else resolve(result!);
+    };
+    const terminate = (reason: string): void => {
+      if (settled || failure !== undefined) return;
+      failure = reason;
+      clearTimeout(deadline);
+      cleanupDeadline = setTimeout(() => {
+        finish(
+          new WorkerCleanupError(
+            failureMessage(
+              `${failure}; cleanup was not confirmed within ${WORKER_CLEANUP_TIMEOUT_MS}ms`
+            ),
+            pid
+          )
+        );
+        // The suite stops on this error. Release our handles even if the OS
+        // cannot reap the worker, so the CLI can write its failed report.
+        child.stdout.destroy();
+        child.stderr.destroy();
+        child.unref();
+      }, WORKER_CLEANUP_TIMEOUT_MS);
+      try {
+        if (!child.kill('SIGKILL'))
+          diagnostics.push('SIGKILL could not be sent');
+      } catch (error) {
+        diagnostics.push(
+          redactSecret(
+            `SIGKILL failed: ${String(error instanceof Error ? error.message : error)}`,
+            databaseUrl
+          )
+        );
+      }
+    };
+    const onError = (error: Error): void => {
+      if (settled) return;
+      const detail = redactSecret(error.message, databaseUrl);
+      if (typeof pid !== 'number') {
+        finish(new Error(failureMessage(`could not start: ${detail}`)));
+        return;
+      }
+      diagnostics.push(detail);
+      terminate('failed before its process and stdio closed');
+    };
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    const onClose = (code: number | null, signal: string | null): void => {
+      if (settled) return;
+      if (failure !== undefined) {
+        finish(new Error(failureMessage(failure)));
+        return;
+      }
+      const resultLine = stdout
+        .split('\n')
+        .reverse()
+        .find((line) => line.startsWith(WORKER_RESULT_PREFIX));
+      if (!resultLine) {
+        finish(
+          new Error(
+            redactSecret(
+              `benchmark worker ${pid ?? 'unknown'} exited without a result ` +
+                `(code=${String(code)}, signal=${String(signal)})` +
+                (stderr.trim() ? `\n${lastLines(stderr)}` : ''),
+              databaseUrl
+            )
+          )
+        );
+        return;
+      }
+      try {
+        const result = JSON.parse(
+          resultLine.slice(WORKER_RESULT_PREFIX.length)
+        ) as WorkerResult;
+        if (typeof pid !== 'number' || result.pid !== pid) {
+          throw new Error(
+            `worker PID mismatch: spawned ${String(pid)}, reported ${String(
+              result.pid
+            )}`
+          );
+        }
+        if (result.caseName !== definition.name) {
+          throw new Error(
+            `worker case mismatch: expected ${definition.name}, reported ${result.caseName}`
+          );
+        }
+        if (result.status === 'ok' && code !== 0) {
+          throw new Error(`successful worker exited with code ${String(code)}`);
+        }
+        finish(undefined, { pid, result });
+      } catch (error) {
+        finish(
+          new Error(
+            redactSecret(
+              `invalid result from benchmark worker ${String(pid)}: ${String(
+                error instanceof Error ? error.message : error
+              )}`,
+              databaseUrl
+            )
+          )
+        );
+      }
+    };
+    child.stdout.on('data', onStdout);
+    child.stderr.on('data', onStderr);
+    child.stdout.on('error', onError);
+    child.stderr.on('error', onError);
+    child.on('error', onError);
+    child.once('close', onClose);
+    deadline = setTimeout(() => {
+      terminate(`timed out after ${timeoutMs}ms`);
+    }, timeoutMs);
+  });
+
+export const parseWorkerEnvelope = (
+  encoded: string | undefined
+): WorkerConfigEnvelope => {
+  if (!encoded) throw new Error('--worker-config is required');
+  const parsed = JSON.parse(
+    Buffer.from(encoded, 'base64url').toString('utf8')
+  ) as Partial<WorkerConfigEnvelope>;
+  if (
+    typeof parsed.caseName !== 'string' ||
+    parsed.caseName.length === 0 ||
+    parsed.workerConfig === undefined
+  ) {
+    throw new Error('worker configuration envelope is invalid');
+  }
+  return parsed as WorkerConfigEnvelope;
+};
+
+export const writeWorkerResult = (result: WorkerResult): void => {
+  process.stdout.write(`${WORKER_RESULT_PREFIX}${JSON.stringify(result)}\n`);
+};

--- a/packages/perf-harness/src/report.ts
+++ b/packages/perf-harness/src/report.ts
@@ -1,0 +1,123 @@
+import type {
+  BenchmarkCaseDefinition,
+  BenchmarkRun,
+  CaseComparison,
+  CaseSummary,
+  MetricComparison,
+  MetricSummary,
+  SuccessfulWorkerResult,
+} from './types';
+
+const median = (values: readonly number[]): number => {
+  if (values.length === 0) throw new Error('cannot summarize zero values');
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[middle];
+};
+
+const metricSummary = (values: number[]): MetricSummary => ({
+  median: median(values),
+  min: Math.min(...values),
+  max: Math.max(...values),
+  samples: values,
+});
+
+const successfulResultsFor = (
+  runs: readonly BenchmarkRun[],
+  caseName: string
+): SuccessfulWorkerResult[] =>
+  runs
+    .filter((run) => run.caseName === caseName && run.result.status === 'ok')
+    .map((run) => run.result as SuccessfulWorkerResult);
+
+export const summarizeCase = (
+  runs: readonly BenchmarkRun[],
+  caseName: string
+): CaseSummary | undefined => {
+  const results = successfulResultsFor(runs, caseName);
+  if (results.length === 0) return undefined;
+  return {
+    sampleCount: results.length,
+    buildMs: metricSummary(results.map((result) => result.buildMs)),
+    heapUsedAfterBuild: metricSummary(
+      results.map((result) => result.memory.afterBuild.heapUsed)
+    ),
+    heapUsedDelta: metricSummary(
+      results.map((result) => result.memory.delta.heapUsed)
+    ),
+    rssAfterBuild: metricSummary(
+      results.map((result) => result.memory.afterBuild.rss)
+    ),
+    rssDelta: metricSummary(results.map((result) => result.memory.delta.rss)),
+    processPeakRss: metricSummary(
+      results.map((result) => result.memory.processPeakRss)
+    ),
+  };
+};
+
+const compareMetric = (
+  baseline: MetricSummary,
+  candidate: MetricSummary
+): MetricComparison => ({
+  baseline: baseline.median,
+  candidate: candidate.median,
+  difference: candidate.median - baseline.median,
+  percentChange:
+    baseline.median === 0
+      ? null
+      : ((candidate.median - baseline.median) / Math.abs(baseline.median)) *
+        100,
+});
+
+export const compareCases = (
+  baselineCase: string,
+  candidateCase: string,
+  baseline: CaseSummary,
+  candidate: CaseSummary
+): CaseComparison => ({
+  baselineCase,
+  candidateCase,
+  buildMs: compareMetric(baseline.buildMs, candidate.buildMs),
+  heapUsedAfterBuild: compareMetric(
+    baseline.heapUsedAfterBuild,
+    candidate.heapUsedAfterBuild
+  ),
+  heapUsedDelta: compareMetric(baseline.heapUsedDelta, candidate.heapUsedDelta),
+  rssAfterBuild: compareMetric(baseline.rssAfterBuild, candidate.rssAfterBuild),
+  rssDelta: compareMetric(baseline.rssDelta, candidate.rssDelta),
+  processPeakRss: compareMetric(
+    baseline.processPeakRss,
+    candidate.processPeakRss
+  ),
+});
+
+export const validateSchemaGroups = (
+  definitions: readonly BenchmarkCaseDefinition[],
+  runs: readonly BenchmarkRun[]
+): {
+  equivalent: boolean;
+  hashes: Record<string, string | null>;
+  errors: string[];
+} => {
+  const groups = new Map<string, Set<string>>();
+  for (const definition of definitions) {
+    if (!definition.expectedSchemaGroup) continue;
+    const hashes =
+      groups.get(definition.expectedSchemaGroup) ?? new Set<string>();
+    for (const result of successfulResultsFor(runs, definition.name)) {
+      hashes.add(result.schemaHash);
+    }
+    groups.set(definition.expectedSchemaGroup, hashes);
+  }
+  const output: Record<string, string | null> = {};
+  const errors: string[] = [];
+  for (const [group, hashes] of groups) {
+    output[group] = hashes.size === 1 ? [...hashes][0] : null;
+    if (hashes.size !== 1) {
+      errors.push(`schema group '${group}' did not produce one schema hash`);
+    }
+  }
+  return { equivalent: errors.length === 0, hashes: output, errors };
+};

--- a/packages/perf-harness/src/run.ts
+++ b/packages/perf-harness/src/run.ts
@@ -1,0 +1,271 @@
+import { mkdir, rename, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+import { prepareFixture } from './fixture';
+import {
+  DEFAULT_WORKER_TIMEOUT_MS,
+  MAX_WORKER_TIMEOUT_MS,
+  parseValueArgs,
+  redactSecret,
+  runWorkerProcess,
+  validateWorkerTimeoutMs,
+  WorkerCleanupError,
+} from './process';
+import { summarizeCase, validateSchemaGroups } from './report';
+import { makeSchedule, validateCaseDefinitions } from './schedule';
+import type {
+  BenchmarkCaseDefinition,
+  BenchmarkReport,
+  BenchmarkRun,
+  BenchmarkSuiteDefinition,
+} from './types';
+
+export interface RunSuiteOptions {
+  databaseUrl: string;
+  repetitions: number;
+  seed: number;
+  order: string[] | null;
+  output?: string;
+  workerTimeoutMs?: number;
+}
+
+export const runBenchmarkSuite = async (
+  suite: BenchmarkSuiteDefinition,
+  options: RunSuiteOptions,
+  workerPath: string
+): Promise<BenchmarkReport> => {
+  const workerTimeoutMs = validateWorkerTimeoutMs(options.workerTimeoutMs);
+  validateCaseDefinitions(suite.cases);
+  const byName = new Map(
+    suite.cases.map((definition) => [definition.name, definition])
+  );
+  const schedule = makeSchedule(
+    suite.cases,
+    options.repetitions,
+    options.seed,
+    options.order
+  );
+  const runs: BenchmarkRun[] = [];
+  for (const coordinate of schedule) {
+    const definition = byName.get(coordinate.caseName)!;
+    process.stderr.write(
+      `[${runs.length + 1}/${schedule.length}] repetition ${
+        coordinate.repetition
+      }, ${coordinate.caseName}\n`
+    );
+    try {
+      const spawned = await runWorkerProcess(
+        workerPath,
+        options.databaseUrl,
+        definition,
+        workerTimeoutMs
+      );
+      let result = spawned.result;
+      if (result.status === 'error') {
+        result = {
+          ...result,
+          error: redactSecret(result.error, options.databaseUrl),
+        };
+      }
+      runs.push({ ...coordinate, result });
+    } catch (error) {
+      runs.push({
+        ...coordinate,
+        result: {
+          status: 'error',
+          pid: error instanceof WorkerCleanupError ? (error.pid ?? -1) : -1,
+          caseName: coordinate.caseName,
+          error: redactSecret(
+            error instanceof Error ? error.message : String(error),
+            options.databaseUrl
+          ),
+        },
+      });
+      if (error instanceof WorkerCleanupError) break;
+    }
+  }
+  const successfulRuns = runs.filter((run) => run.result.status === 'ok');
+  const allRunsSucceeded = successfulRuns.length === schedule.length;
+  const pids = successfulRuns.map((run) => run.result.pid);
+  const freshProcessPerRun =
+    allRunsSucceeded &&
+    pids.every((pid) => pid > 0 && pid !== process.pid) &&
+    new Set(pids).size === pids.length;
+  const caseValidationPassed =
+    allRunsSucceeded &&
+    successfulRuns.every(
+      (run) => run.result.status === 'ok' && run.result.caseValidation.passed
+    );
+  const schemaGroups = validateSchemaGroups(suite.cases, runs);
+  const errors: string[] = [];
+  for (const run of runs) {
+    if (run.result.status === 'error') {
+      errors.push(
+        `${run.caseName} repetition ${run.repetition}: ${run.result.error}`
+      );
+    } else {
+      for (const error of run.result.caseValidation.errors) {
+        errors.push(`${run.caseName} repetition ${run.repetition}: ${error}`);
+      }
+    }
+  }
+  if (!freshProcessPerRun) {
+    errors.push('fresh-process validation did not pass for every run');
+  }
+  errors.push(...schemaGroups.errors);
+  const summaries: Record<
+    string,
+    NonNullable<ReturnType<typeof summarizeCase>>
+  > = {};
+  for (const definition of suite.cases) {
+    const summary = summarizeCase(runs, definition.name);
+    if (summary) summaries[definition.name] = summary;
+  }
+  return {
+    format: 'constructive-performance-suite/v1',
+    generatedAt: new Date().toISOString(),
+    node: process.version,
+    platform: process.platform,
+    architecture: process.arch,
+    suite,
+    config: {
+      repetitions: options.repetitions,
+      seed: options.seed,
+      order: options.order,
+      workerTimeoutMs,
+    },
+    schedule,
+    runs,
+    validation: {
+      allRunsSucceeded,
+      freshProcessPerRun,
+      caseValidationPassed,
+      schemaGroupsEquivalent: schemaGroups.equivalent,
+      schemaGroups: schemaGroups.hashes,
+      errors,
+    },
+    summaries,
+  };
+};
+
+export const writeJsonAtomically = async (
+  output: string,
+  value: unknown
+): Promise<string> => {
+  const absoluteOutput = resolve(output);
+  await mkdir(dirname(absoluteOutput), { recursive: true });
+  const temporary = `${absoluteOutput}.tmp-${process.pid}`;
+  await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, {
+    encoding: 'utf8',
+    mode: 0o600,
+  });
+  await rename(temporary, absoluteOutput);
+  return absoluteOutput;
+};
+
+const positiveInteger = (
+  value: string | undefined,
+  name: string,
+  defaultValue: number,
+  maximum: number
+): number => {
+  if (value === undefined) return defaultValue;
+  if (!/^\d+$/.test(value)) throw new Error(`--${name} must be an integer`);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > maximum) {
+    throw new Error(`--${name} must be between 1 and ${maximum}`);
+  }
+  return parsed;
+};
+
+const databaseUrl = (args: ReturnType<typeof parseValueArgs>): string => {
+  const value = args.values.get('database-url');
+  if (!value) throw new Error('--database-url is required');
+  return value;
+};
+
+const stringList = (value: string | undefined): string[] | null => {
+  if (value === undefined) return null;
+  const result = value.split(',');
+  if (
+    result.some((item) => item.length === 0 || item.trim() !== item) ||
+    new Set(result).size !== result.length
+  ) {
+    throw new Error('list values must be unique exact non-empty strings');
+  }
+  return result;
+};
+
+const parseCases = (encoded: string): BenchmarkCaseDefinition[] => {
+  const parsed = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8'));
+  if (!Array.isArray(parsed))
+    throw new Error('--cases must encode a JSON array');
+  return parsed as BenchmarkCaseDefinition[];
+};
+
+export const cliMain = async (args = process.argv.slice(2)): Promise<void> => {
+  const [command, ...rest] = args;
+  const parsed = parseValueArgs(rest);
+  if (command === 'prepare') {
+    const schema = parsed.values.get('schema');
+    if (!schema) throw new Error('--schema is required');
+    const result = await prepareFixture({
+      databaseUrl: databaseUrl(parsed),
+      schema,
+      tables: positiveInteger(parsed.values.get('tables'), 'tables', 64, 500),
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return;
+  }
+  if (command !== 'run') {
+    throw new Error('expected prepare or run command');
+  }
+  const cases = parsed.values.get('cases');
+  const worker = parsed.values.get('worker');
+  if (!cases || !worker) throw new Error('--cases and --worker are required');
+  const report = await runBenchmarkSuite(
+    {
+      name: parsed.values.get('suite') ?? 'benchmark-suite',
+      cases: parseCases(cases),
+    },
+    {
+      databaseUrl: databaseUrl(parsed),
+      repetitions: positiveInteger(
+        parsed.values.get('repetitions'),
+        'repetitions',
+        3,
+        50
+      ),
+      seed: positiveInteger(
+        parsed.values.get('seed'),
+        'seed',
+        20260813,
+        0xffffffff
+      ),
+      order: stringList(parsed.values.get('order')),
+      output: parsed.values.get('output'),
+      workerTimeoutMs: positiveInteger(
+        parsed.values.get('worker-timeout-ms'),
+        'worker-timeout-ms',
+        DEFAULT_WORKER_TIMEOUT_MS,
+        MAX_WORKER_TIMEOUT_MS
+      ),
+    },
+    resolve(worker)
+  );
+  const output = await writeJsonAtomically(
+    parsed.values.get('output') ?? 'performance-report.json',
+    report
+  );
+  process.stdout.write(
+    `${JSON.stringify({ output, validation: report.validation })}\n`
+  );
+  if (
+    !report.validation.allRunsSucceeded ||
+    !report.validation.freshProcessPerRun ||
+    !report.validation.caseValidationPassed ||
+    !report.validation.schemaGroupsEquivalent
+  ) {
+    process.exitCode = 1;
+  }
+};

--- a/packages/perf-harness/src/schedule.ts
+++ b/packages/perf-harness/src/schedule.ts
@@ -1,0 +1,77 @@
+import type { BenchmarkCaseDefinition, BenchmarkCoordinate } from './types';
+
+const seededRandom = (seed: number): (() => number) => {
+  let state = seed >>> 0;
+  return () => {
+    state += 0x6d2b79f5;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+const shuffledCaseNames = (
+  definitions: readonly BenchmarkCaseDefinition[],
+  seed: number,
+  repetition: number
+): string[] => {
+  const result = definitions.map(({ name }) => name);
+  const random = seededRandom((seed ^ Math.imul(repetition, 0x9e3779b1)) >>> 0);
+  for (let index = result.length - 1; index > 0; index -= 1) {
+    const swapIndex = Math.floor(random() * (index + 1));
+    [result[index], result[swapIndex]] = [result[swapIndex], result[index]];
+  }
+  return result;
+};
+
+export const validateCaseDefinitions = (
+  definitions: readonly BenchmarkCaseDefinition[]
+): void => {
+  if (definitions.length === 0) {
+    throw new Error('benchmark suite must contain at least one case');
+  }
+  const names = definitions.map(({ name }) => name);
+  if (
+    names.some(
+      (name) => name.length === 0 || name.trim() !== name || name.includes('\0')
+    ) ||
+    new Set(names).size !== names.length
+  ) {
+    throw new Error(
+      'benchmark case names must be unique exact non-empty strings'
+    );
+  }
+};
+
+export const makeSchedule = (
+  definitions: readonly BenchmarkCaseDefinition[],
+  repetitions: number,
+  seed: number,
+  exactOrder: readonly string[] | null = null
+): BenchmarkCoordinate[] => {
+  validateCaseDefinitions(definitions);
+  if (!Number.isSafeInteger(repetitions) || repetitions < 1) {
+    throw new Error('repetitions must be a positive safe integer');
+  }
+  const expectedNames = definitions.map(({ name }) => name).sort();
+  const schedule: BenchmarkCoordinate[] = [];
+  for (let repetition = 1; repetition <= repetitions; repetition += 1) {
+    const order = exactOrder
+      ? [...exactOrder]
+      : shuffledCaseNames(definitions, seed, repetition);
+    if (
+      order.length !== definitions.length ||
+      new Set(order).size !== definitions.length ||
+      [...order].sort().some((name, index) => name !== expectedNames[index])
+    ) {
+      throw new Error(
+        'exact order must contain each benchmark case exactly once'
+      );
+    }
+    order.forEach((caseName, index) => {
+      schedule.push({ repetition, position: index + 1, caseName });
+    });
+  }
+  return schedule;
+};

--- a/packages/perf-harness/src/stock-worker.ts
+++ b/packages/perf-harness/src/stock-worker.ts
@@ -1,0 +1,143 @@
+import { createHash } from 'node:crypto';
+
+import {
+  defaultPreset as graphileBuildPreset,
+  makeSchema,
+} from 'graphile-build';
+import { defaultPreset as graphileBuildPgPreset } from 'graphile-build-pg';
+import { execute, lexicographicSortSchema, parse, printSchema } from 'graphql';
+import { makePgService } from 'postgraphile/adaptors/pg';
+
+import { measureBenchmarkCase } from './metrics';
+import {
+  parseWorkerProcessArgs,
+  redactSecret,
+  writeWorkerResult,
+} from './process';
+import type { SuccessfulWorkerResult, WorkerResult } from './types';
+
+interface StockConfig {
+  schemas: string[];
+}
+
+const validateConfig = (value: unknown): StockConfig => {
+  const schemas = (value as Partial<StockConfig>)?.schemas;
+  if (
+    !Array.isArray(schemas) ||
+    schemas.length === 0 ||
+    schemas.some((schema) => typeof schema !== 'string' || schema.length === 0)
+  ) {
+    throw new Error('stock worker requires a non-empty schemas array');
+  }
+  return { schemas };
+};
+
+const failureToText = (failure: unknown): string => {
+  try {
+    if (failure instanceof Error) {
+      const message: unknown = failure.message;
+      return typeof message === 'string' ? message : 'unknown error';
+    }
+    if (
+      failure === null ||
+      (typeof failure !== 'object' && typeof failure !== 'function')
+    ) {
+      return String(failure);
+    }
+  } catch {
+    // A hostile proxy or Error.message getter must not prevent reporting.
+  }
+  return 'unknown error';
+};
+
+export const runStockWorker = async (
+  args: readonly string[] = process.argv.slice(2)
+): Promise<void> => {
+  let databaseUrl = '';
+  let caseName = 'unknown';
+  let service: ReturnType<typeof makePgService> | undefined;
+  let primaryCaptured = false;
+  let primaryFailure: unknown;
+  let cleanupCaptured = false;
+  let cleanupFailure: unknown;
+  let successfulResult: SuccessfulWorkerResult | undefined;
+
+  try {
+    const workerArgs = parseWorkerProcessArgs(args);
+    databaseUrl = workerArgs.databaseUrl;
+    const { envelope } = workerArgs;
+    caseName = envelope.caseName;
+    const config = validateConfig(envelope.workerConfig);
+    service = makePgService({
+      connectionString: databaseUrl,
+      schemas: config.schemas,
+      pubsub: false,
+    });
+    successfulResult = await measureBenchmarkCase(
+      caseName,
+      async () =>
+        makeSchema({
+          extends: [graphileBuildPreset, graphileBuildPgPreset],
+          pgServices: [service],
+        }),
+      async ({ schema }) => {
+        const execution = await execute({
+          schema,
+          document: parse('{ __typename }'),
+        });
+        if (
+          execution.errors?.length ||
+          execution.data?.__typename !== 'Query'
+        ) {
+          throw new Error('runtime verification query failed');
+        }
+        const schemaText = printSchema(lexicographicSortSchema(schema));
+        return {
+          schemaHash: createHash('sha256').update(schemaText).digest('hex'),
+          schemaTypeCount: Object.keys(schema.getTypeMap()).length,
+          runtimeVerified: true as const,
+        };
+      }
+    );
+  } catch (error) {
+    primaryCaptured = true;
+    primaryFailure = error;
+  }
+
+  if (service !== undefined && service !== null) {
+    try {
+      await service.release();
+    } catch (error) {
+      cleanupCaptured = true;
+      cleanupFailure = error;
+    }
+  }
+
+  let result: WorkerResult;
+  if (primaryCaptured || cleanupCaptured) {
+    const failures: string[] = [];
+    if (primaryCaptured) failures.push(failureToText(primaryFailure));
+    if (cleanupCaptured) failures.push(failureToText(cleanupFailure));
+    process.exitCode = 1;
+    result = {
+      status: 'error',
+      pid: process.pid,
+      caseName,
+      error: redactSecret(failures.join('; '), databaseUrl),
+    };
+  } else {
+    result = successfulResult as SuccessfulWorkerResult;
+  }
+
+  // Classification and cleanup are complete before this single terminal
+  // protocol write. A write failure must not enter another result path.
+  writeWorkerResult(result);
+};
+
+if (
+  typeof require !== 'undefined' &&
+  typeof module !== 'undefined' &&
+  require.main === module
+) {
+  void runStockWorker();
+}

--- a/packages/perf-harness/src/types.ts
+++ b/packages/perf-harness/src/types.ts
@@ -1,0 +1,130 @@
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue =
+  JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+export interface BenchmarkCaseDefinition {
+  name: string;
+  workerConfig: JsonValue;
+  expectedSchemaGroup?: string;
+}
+
+export interface BenchmarkSuiteDefinition {
+  name: string;
+  cases: BenchmarkCaseDefinition[];
+}
+
+export interface BenchmarkCoordinate {
+  repetition: number;
+  position: number;
+  caseName: string;
+}
+
+export interface WorkerConfigEnvelope {
+  caseName: string;
+  workerConfig: JsonValue;
+}
+
+export interface MemorySnapshot {
+  rss: number;
+  heapTotal: number;
+  heapUsed: number;
+  external: number;
+  arrayBuffers: number;
+}
+
+export interface CaseValidation {
+  passed: boolean;
+  errors: string[];
+}
+
+export interface SuccessfulWorkerResult {
+  status: 'ok';
+  pid: number;
+  caseName: string;
+  buildMs: number;
+  schemaHash: string;
+  schemaTypeCount: number;
+  runtimeVerified: true;
+  caseValidation: CaseValidation;
+  metadata?: Record<string, JsonValue>;
+  memory: {
+    baseline: MemorySnapshot;
+    afterBuild: MemorySnapshot;
+    delta: MemorySnapshot;
+    processPeakRss: number;
+  };
+}
+
+export interface FailedWorkerResult {
+  status: 'error';
+  pid: number;
+  caseName: string;
+  error: string;
+}
+
+export type WorkerResult = SuccessfulWorkerResult | FailedWorkerResult;
+
+export interface BenchmarkRun extends BenchmarkCoordinate {
+  result: WorkerResult;
+}
+
+export interface MetricSummary {
+  median: number;
+  min: number;
+  max: number;
+  samples: number[];
+}
+
+export interface CaseSummary {
+  sampleCount: number;
+  buildMs: MetricSummary;
+  heapUsedAfterBuild: MetricSummary;
+  heapUsedDelta: MetricSummary;
+  rssAfterBuild: MetricSummary;
+  rssDelta: MetricSummary;
+  processPeakRss: MetricSummary;
+}
+
+export interface MetricComparison {
+  baseline: number;
+  candidate: number;
+  difference: number;
+  percentChange: number | null;
+}
+
+export interface CaseComparison {
+  baselineCase: string;
+  candidateCase: string;
+  buildMs: MetricComparison;
+  heapUsedAfterBuild: MetricComparison;
+  heapUsedDelta: MetricComparison;
+  rssAfterBuild: MetricComparison;
+  rssDelta: MetricComparison;
+  processPeakRss: MetricComparison;
+}
+
+export interface BenchmarkReport {
+  format: 'constructive-performance-suite/v1';
+  generatedAt: string;
+  node: string;
+  platform: string;
+  architecture: string;
+  suite: BenchmarkSuiteDefinition;
+  config: {
+    repetitions: number;
+    seed: number;
+    order: string[] | null;
+    workerTimeoutMs: number;
+  };
+  schedule: BenchmarkCoordinate[];
+  runs: BenchmarkRun[];
+  validation: {
+    allRunsSucceeded: boolean;
+    freshProcessPerRun: boolean;
+    caseValidationPassed: boolean;
+    schemaGroupsEquivalent: boolean;
+    schemaGroups: Record<string, string | null>;
+    errors: string[];
+  };
+  summaries: Record<string, CaseSummary>;
+}

--- a/packages/perf-harness/tsconfig.esm.json
+++ b/packages/perf-harness/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/esm",
+    "module": "esnext",
+    "moduleResolution": "bundler"
+  }
+}

--- a/packages/perf-harness/tsconfig.json
+++ b/packages/perf-harness/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "moduleResolution": "nodenext",
+    "module": "nodenext",
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2711,6 +2711,37 @@ importers:
         version: 0.8.0
     publishDirectory: dist
 
+  packages/perf-harness:
+    dependencies:
+      graphile-build:
+        specifier: 5.1.1
+        version: 5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)
+      graphile-build-pg:
+        specifier: 5.1.3
+        version: 5.1.3(@dataplan/pg@1.1.1(@dataplan/json@1.0.1(grafast@1.1.2(graphql@16.13.0)))(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0))(grafast@1.1.2(graphql@16.13.0))(graphile-build@5.1.1(grafast@1.1.2(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0))(graphile-config@1.1.0)(graphql@16.13.0)(pg-sql2@5.0.1)(pg@8.21.0)(tamedevil@0.1.1)
+      graphile-config:
+        specifier: 1.1.0
+        version: 1.1.0
+      graphql:
+        specifier: 16.13.0
+        version: 16.13.0
+      pg:
+        specifier: ^8.21.0
+        version: 8.21.0
+      postgraphile:
+        specifier: 5.1.4
+        version: 5.1.4(f282a162d8bd20a217e08c60f5396af8)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.11
+        version: 22.19.19
+      '@types/pg':
+        specifier: ^8.20.4
+        version: 8.20.4
+      makage:
+        specifier: ^0.8.0
+        version: 0.8.0
+
   packages/postmaster:
     dependencies:
       12factor-env:


### PR DESCRIPTION
## Summary

Adds a reusable Graphile performance harness that runs each measurement in a fresh Node process, isolating build timing and memory samples between cases. Suites supply serializable case definitions and a dedicated worker entry for their build and validation logic. This consolidates #1716 and incorporates subsequent review fixes.

- Seeded scheduling and repetitions; build-only timing; memory snapshots, deltas, and peak RSS.
- Schema-group/hash validation, runtime query checks, per-case validation, and a minimal upstream Graphile baseline worker.
- Explicit database URL and worker-config CLI arguments; atomic JSON reports with database URL redaction, including custom-worker errors.
- Configurable worker deadline (five minutes by default). A timed-out worker is killed and confirmed closed before continuing; unconfirmed cleanup after another five seconds stops scheduling and produces a failed partial report.
- PostgreSQL fixture preparation that closes the pool on failure and preserves primary, rollback, release, and shutdown errors.
- The baseline worker emits one terminal result after releasing its service. Measurement and release failures both fail the run, preserving both redacted diagnostics when they occur together.
- Separate library and CLI entries: CJS/ESM library imports do not start the CLI; the built `cperf` executable and local workspace script run the command interface.
- The private package is included in the CI unit-test matrix; its tests build the package before exercising generated entries.

## Validation

- Frozen-lockfile install; CJS and ESM builds.
- 65 tests across 7 suites, covering worker timeouts, cleanup failures, library imports, and the built CLI.
- Local workspace CLI smoke test and type checks for the new tests.
- ESLint, Prettier check, and `git diff --check`.
- Full CI on `27f4dc7331e5`: [17/17 jobs passed](https://github.com/constructive-io/constructive/actions/runs/34105549807), including 65/65 perf-harness tests.
