### PR TITLE
feat(graphql): refuse requests to suspended databases via a standing loader

### DIFF
--- a/graphql/server/src/middleware/__tests__/standing.test.ts
+++ b/graphql/server/src/middleware/__tests__/standing.test.ts
@@ -1,0 +1,92 @@
+import type { DatabaseStanding } from '@constructive-io/express-context';
+import type { NextFunction, Request, Response } from 'express';
+
+import { createStandingMiddleware } from '../standing';
+
+interface Captured {
+  status?: number;
+  body?: any;
+}
+
+const fakeRes = (captured: Captured): Response =>
+  ({
+    set() {
+      return this;
+    },
+    status(code: number) {
+      captured.status = code;
+      return this;
+    },
+    json(body: unknown) {
+      captured.body = body;
+      return this;
+    }
+  }) as unknown as Response;
+
+const fakeReq = (useModule?: jest.Mock): Request =>
+  ({ constructive: useModule ? { useModule } : undefined }) as unknown as Request;
+
+const run = async (req: Request) => {
+  const captured: Captured = {};
+  const next = jest.fn() as unknown as NextFunction;
+  await createStandingMiddleware()(req, fakeRes(captured), next);
+  return { captured, next: next as unknown as jest.Mock };
+};
+
+const standing = (overrides: Partial<DatabaseStanding>): DatabaseStanding => ({
+  exists: true,
+  suspended: false,
+  suspendedAt: null,
+  reason: null,
+  ...overrides
+});
+
+describe('createStandingMiddleware', () => {
+  it('passes a database in good standing through', async () => {
+    const useModule = jest.fn().mockResolvedValue(standing({}));
+    const { next, captured } = await run(fakeReq(useModule));
+
+    expect(useModule).toHaveBeenCalledWith('standing');
+    expect(next).toHaveBeenCalledWith();
+    expect(captured.status).toBeUndefined();
+  });
+
+  it('refuses a suspended database with ACCESS_SUSPENDED and its reason', async () => {
+    const useModule = jest
+      .fn()
+      .mockResolvedValue(standing({ suspended: true, suspendedAt: new Date(), reason: 'billing' }));
+    const { next, captured } = await run(fakeReq(useModule));
+
+    expect(next).not.toHaveBeenCalled();
+    expect(captured.status).toBe(403);
+    expect(captured.body.errors[0].extensions.code).toBe('ACCESS_SUSPENDED');
+    expect(captured.body.errors[0].extensions.context).toEqual({ reason: 'billing' });
+  });
+
+  it('refuses a database the plane does not know', async () => {
+    const useModule = jest.fn().mockResolvedValue(standing({ exists: false }));
+    const { next, captured } = await run(fakeReq(useModule));
+
+    expect(next).not.toHaveBeenCalled();
+    expect(captured.status).toBe(403);
+    expect(captured.body.errors[0].extensions.code).toBe('ACCESS_SUSPENDED');
+  });
+
+  it('passes through when the plane has no standing module', async () => {
+    const { next } = await run(fakeReq(jest.fn().mockResolvedValue(undefined)));
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('passes through a request that never resolved a database', async () => {
+    const { next } = await run(fakeReq());
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('fails closed: a lookup failure goes to the error handler, not next()', async () => {
+    const failure = new Error('control plane unreachable');
+    const { next, captured } = await run(fakeReq(jest.fn().mockRejectedValue(failure)));
+
+    expect(next).toHaveBeenCalledWith(failure);
+    expect(captured.status).toBeUndefined();
+  });
+});

--- a/graphql/server/src/middleware/standing.ts
+++ b/graphql/server/src/middleware/standing.ts
@@ -1,0 +1,46 @@
+import './types'; // for Request type
+
+import { errors } from '@constructive-io/errors';
+import type { DatabaseStanding } from '@constructive-io/express-context';
+import type { NextFunction, Request, RequestHandler, Response } from 'express';
+
+import { respondWithGraphQLError } from '../errors/graphql-response';
+
+/**
+ * Express middleware that refuses requests pinned to a database that is not in
+ * good standing.
+ *
+ * The decision is the `standing` loader's (system-controlled
+ * `suspended_at`/`suspended_reason` on `metaschema_public.database`, cached for
+ * a few seconds), so an established client keeps being served for at most that
+ * window after a suspension. A database the plane does not know is refused the
+ * same way: a request pinned to it has nothing to run against. A lookup failure
+ * is handed to the error handler — "could not verify" is not "allowed".
+ *
+ * A request without a resolved database (no context, or a plane without
+ * `metaschema_public`) has nothing to be suspended and passes through.
+ *
+ * Mount after the context middleware and before the GraphQL handler.
+ */
+export const createStandingMiddleware = (): RequestHandler => {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    let standing: DatabaseStanding | undefined;
+    try {
+      standing = await req.constructive?.useModule('standing');
+    } catch (e) {
+      next(e);
+      return;
+    }
+
+    if (standing && (!standing.exists || standing.suspended)) {
+      respondWithGraphQLError(
+        res,
+        errors.ACCESS_SUSPENDED(standing.reason ? { reason: standing.reason } : {}),
+        { status: 403 }
+      );
+      return;
+    }
+
+    next();
+  };
+};

--- a/graphql/server/src/server.ts
+++ b/graphql/server/src/server.ts
@@ -45,6 +45,7 @@ import { localObservabilityOnly } from './middleware/observability/guard';
 import { createRequestLogger } from './middleware/observability/request-logger';
 import { createRequestProtectionMiddleware } from './middleware/request-protection';
 import { getRoutingSchema } from './middleware/routing';
+import { createStandingMiddleware } from './middleware/standing';
 import { createPlatformRefusalRecorder, installRefusalRecorder } from './refusals/recorder';
 
 const log = new Logger('server');
@@ -173,6 +174,9 @@ class Server {
       loaders: createDefaultRegistry(),
       routingSchema: getRoutingSchema(effectiveOpts)
     }));
+    // A suspended (or unknown) database is refused before anything is spent on
+    // the request; billing and platform admins set that state, the loader reads it.
+    app.use(createStandingMiddleware());
     // Resolve the tenant's protection bounds before anything can spend budget
     // on the request (and before the GraphQL handler reads them for pgSettings).
     app.use(createRequestProtectionMiddleware());

--- a/packages/express-context/__tests__/loaders/standing.test.ts
+++ b/packages/express-context/__tests__/loaders/standing.test.ts
@@ -1,0 +1,86 @@
+import type { Pool } from 'pg';
+
+import { DATABASE_STANDING_TTL_MS, standingLoader } from '../../src/loaders/standing';
+import type { LoaderContext } from '../../src/loaders/types';
+
+const fakePool = (rows: unknown[] | Error) => {
+  const query = jest.fn(async (_text: string, _values?: unknown[]) => {
+    if (rows instanceof Error) throw rows;
+    return { rows };
+  });
+  return { pool: { query } as unknown as Pool, query };
+};
+
+const ctx = (routingPool: Pool, databaseId = 'db-1'): LoaderContext => ({
+  routingPool,
+  tenantPool: {} as Pool,
+  databaseId,
+  dbname: 'tenant'
+});
+
+beforeEach(() => {
+  standingLoader.invalidate();
+});
+
+describe('standingLoader', () => {
+  it('reads the context database only, from the routing plane', async () => {
+    const { pool, query } = fakePool([{ suspended_at: null, suspended_reason: null }]);
+
+    const standing = await standingLoader.resolve(ctx(pool, 'db-a'));
+
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls[0][0]).toMatch(/FROM metaschema_public\.database/);
+    expect(query.mock.calls[0][1]).toEqual(['db-a']);
+    expect(standing).toEqual({ exists: true, suspended: false, suspendedAt: null, reason: null });
+  });
+
+  it('reports a suspended database with when and why', async () => {
+    const at = new Date('2026-01-02T03:04:05Z');
+    const { pool } = fakePool([{ suspended_at: at.toISOString(), suspended_reason: 'billing' }]);
+
+    const standing = await standingLoader.resolve(ctx(pool));
+
+    expect(standing).toEqual({ exists: true, suspended: true, suspendedAt: at, reason: 'billing' });
+  });
+
+  it('reports a database the plane does not know as not existing', async () => {
+    const { pool } = fakePool([]);
+
+    expect(await standingLoader.resolve(ctx(pool))).toEqual({
+      exists: false,
+      suspended: false,
+      suspendedAt: null,
+      reason: null
+    });
+  });
+
+  it('propagates a read failure rather than answering', async () => {
+    const { pool } = fakePool(new Error('control plane unreachable'));
+
+    await expect(standingLoader.resolve(ctx(pool))).rejects.toThrow('control plane unreachable');
+  });
+
+  it('serves repeat reads from cache and re-reads after invalidation', async () => {
+    const { pool, query } = fakePool([{ suspended_at: null, suspended_reason: null }]);
+
+    await standingLoader.resolve(ctx(pool));
+    await standingLoader.resolve(ctx(pool));
+    expect(query).toHaveBeenCalledTimes(1);
+
+    standingLoader.invalidate('db-1');
+    await standingLoader.resolve(ctx(pool));
+    expect(query).toHaveBeenCalledTimes(2);
+  });
+
+  it('bounds the stale window to a few seconds', () => {
+    expect(DATABASE_STANDING_TTL_MS).toBeLessThanOrEqual(5_000);
+  });
+
+  it('keeps tenants apart: suspending one database does not touch another', async () => {
+    const suspended = fakePool([{ suspended_at: new Date(), suspended_reason: 'admin' }]);
+    const live = fakePool([{ suspended_at: null, suspended_reason: null }]);
+
+    expect((await standingLoader.resolve(ctx(suspended.pool, 'db-a'))).suspended).toBe(true);
+    expect((await standingLoader.resolve(ctx(live.pool, 'db-b'))).suspended).toBe(false);
+  });
+});

--- a/packages/express-context/src/index.ts
+++ b/packages/express-context/src/index.ts
@@ -50,6 +50,7 @@ export type {
   ConstructiveAPIToken,
   ConstructiveContext,
   DatabaseSettings,
+  DatabaseStanding,
   EventsConfig,
   IdentityProviderConfig,
   IdentityProvidersModule,
@@ -152,6 +153,8 @@ export {
   createDefaultRegistry,
   createLoaderRegistry,
   createModuleLoader,
+  DATABASE_STANDING_SQL,
+  DATABASE_STANDING_TTL_MS,
   databaseSettingsLoader,
   eventsLoader,
   identityProvidersLoader,
@@ -162,6 +165,7 @@ export {
   requireDatabaseId,
   requireIdentityProvider,
   rlsLoader,
+  standingLoader,
   webauthnLoader,
 } from './loaders';
 

--- a/packages/express-context/src/loaders/index.ts
+++ b/packages/express-context/src/loaders/index.ts
@@ -10,6 +10,7 @@
  *   - corsOrigins     (routing-plane cors_settings)
  *   - databaseSettings(routing-plane database_settings)
  *   - requestProtection (routing-plane database_settings/api_settings bounds)
+ *   - standing        (metaschema_public.database suspended_at/suspended_reason, 5s TTL)
  *   - pubkeyChallengeSettings (routing-plane pubkey_settings)
  *   - webauthnSettings(routing-plane webauthn_settings)
  *   - authSettings    (metaschema_modules_public.sessions_module → tenant DB)
@@ -59,6 +60,7 @@ export { llmLoader } from './llm';
 export { pubkeyLoader } from './pubkey';
 export { requestProtectionLoader } from './request-protection';
 export { rlsLoader } from './rls';
+export { DATABASE_STANDING_SQL, DATABASE_STANDING_TTL_MS, standingLoader } from './standing';
 export { webauthnLoader } from './webauthn';
 
 /**
@@ -78,6 +80,7 @@ import { pubkeyLoader } from './pubkey';
 import { createLoaderRegistry } from './registry';
 import { requestProtectionLoader } from './request-protection';
 import { rlsLoader } from './rls';
+import { standingLoader } from './standing';
 import { webauthnLoader } from './webauthn';
 
 export function createDefaultRegistry() {
@@ -96,5 +99,6 @@ export function createDefaultRegistry() {
   registry.register(computeLoader);
   registry.register(eventsLoader);
   registry.register(requestProtectionLoader);
+  registry.register(standingLoader);
   return registry;
 }

--- a/packages/express-context/src/loaders/standing.ts
+++ b/packages/express-context/src/loaders/standing.ts
@@ -1,0 +1,58 @@
+/**
+ * Database Standing Loader
+ *
+ * Whether a database may be served right now. The state is the two
+ * system-controlled columns on `metaschema_public.database`
+ * (`suspended_at`, `suspended_reason`) that billing and platform admins write;
+ * every lane reads it through this loader so the policy behind "suspended" can
+ * change without touching a serving path.
+ *
+ * The TTL is deliberately short: it bounds how long an established client
+ * keeps being served after its database is suspended.
+ *
+ * A plane without `metaschema_public.database` resolves to `undefined` like any
+ * other absent module (the factory's undefined_table handling); any other read
+ * failure propagates so the caller fails closed. A database the plane does not
+ * know is *not* servable — a request pinned to it has nothing to run against.
+ */
+
+import type { DatabaseStanding } from '../types';
+import { createModuleLoader } from './create-loader';
+import type { LoaderContext, ModuleLoader } from './types';
+
+// ─── SQL ────────────────────────────────────────────────────────────────────
+
+export const DATABASE_STANDING_SQL = `
+  SELECT suspended_at, suspended_reason
+  FROM metaschema_public.database
+  WHERE id = $1
+`;
+
+export const DATABASE_STANDING_TTL_MS = 5_000;
+
+// ─── Row Types ──────────────────────────────────────────────────────────────
+
+interface DatabaseStandingRow {
+  suspended_at: Date | string | null;
+  suspended_reason: string | null;
+}
+
+// ─── Loader ─────────────────────────────────────────────────────────────────
+
+export const standingLoader: ModuleLoader<DatabaseStanding> = createModuleLoader<DatabaseStanding>({
+  name: 'standing',
+  ttlMs: DATABASE_STANDING_TTL_MS,
+  async resolve(ctx: LoaderContext) {
+    const { routingPool, databaseId } = ctx;
+    const { rows } = await routingPool.query<DatabaseStandingRow>(DATABASE_STANDING_SQL, [databaseId]);
+    const row = rows[0];
+    if (!row) return { exists: false, suspended: false, suspendedAt: null, reason: null };
+    const suspendedAt = row.suspended_at === null ? null : new Date(row.suspended_at);
+    return {
+      exists: true,
+      suspended: suspendedAt !== null,
+      suspendedAt,
+      reason: row.suspended_reason
+    };
+  }
+});

--- a/packages/express-context/src/types.ts
+++ b/packages/express-context/src/types.ts
@@ -243,6 +243,18 @@ export interface LlmConfig {
   ragContextLimit: number | null;
 }
 
+/**
+ * Whether a database may be served right now, as read from
+ * `metaschema_public.database`. A database the plane does not know is not
+ * servable either (`exists: false`).
+ */
+export interface DatabaseStanding {
+  exists: boolean;
+  suspended: boolean;
+  suspendedAt: Date | null;
+  reason: string | null;
+}
+
 // ─── Module Types Map ───────────────────────────────────────────────────────
 
 /**
@@ -269,6 +281,7 @@ export interface BuiltinModuleMap {
   compute: ComputeConfig;
   events: EventsConfig;
   requestProtection: RequestProtection;
+  standing: DatabaseStanding;
 }
 
 // ─── Constructive Context ───────────────────────────────────────────────────

--- a/pgpm.json
+++ b/pgpm.json
@@ -8,10 +8,10 @@
     "@constructive-db/routing": "8.2.0",
     "@constructive-db/routing-platform": "7.1.0",
     "@pgpm/database-jobs": "0.44.0",
-    "@pgpm/function-resolution": "0.44.0",
+    "@pgpm/function-resolution": "0.44.2",
     "@pgpm/jwt-claims": "0.44.0",
-    "@pgpm/metaschema-modules": "0.44.1",
-    "@pgpm/metaschema-schema": "0.44.0",
+    "@pgpm/metaschema-modules": "0.44.2",
+    "@pgpm/metaschema-schema": "0.44.2",
     "@pgpm/stamps": "0.44.0",
     "@pgpm/uuid": "0.44.0"
   }


### PR DESCRIPTION
## Summary

GraphQL is the one serving lane that does not use `@constructive-db/module-loader`, so it gets the same database-standing check through its own loader registry (`@constructive-io/express-context`). Companion to constructive-db#3701 (state) / #3705 (pg-wire enforcement) and the lane-consumers PR in constructive-db.

**Loader** — `packages/express-context/src/loaders/standing.ts`, registered as `standing` in `createDefaultRegistry()` and typed on `BuiltinModuleMap`:

```ts
SELECT suspended_at, suspended_reason FROM metaschema_public.database WHERE id = $1   -- routingPool, 5s TTL
→ DatabaseStanding { exists, suspended, suspendedAt, reason }
```
- no row → `exists: false` (a request pinned to an unknown database has nothing to run against)
- read failure → propagates (no fail-open fallback); a plane without the table resolves to `undefined` via the factory's existing 42P01 handling like any absent module.

**Middleware** — `graphql/server/src/middleware/standing.ts`, mounted in `server.ts` right after `createContextMiddleware` and before request-protection, so a suspended tenant spends nothing:

```ts
standing = await req.constructive?.useModule('standing')   // throws → next(e), never next()
if (standing && (!standing.exists || standing.suspended))
  respondWithGraphQLError(res, errors.ACCESS_SUSPENDED({ reason }), { status: 403 })
```
Uses the existing public `ACCESS_SUSPENDED` error (#1814); `reason` (`billing`/`admin`) travels in `extensions.context`.

Tests: loader (scoping, suspended/missing rows, propagation, cache+invalidate, tenant isolation) and middleware (pass/refuse/unknown/no-module/fail-closed).


Link to Devin session: https://app.devin.ai/sessions/86a73d903b3546c1afbf5361bfa384b6
Open in Devin Desktop: https://app.devin.ai/desktop/session/86a73d903b3546c1afbf5361bfa384b6?variant=devin
Requested by: @pyramation