### PR TITLE
fix(graphql-server): exempt schema introspection from the depth/cost gate

### DIFF
--- a/graphql/server/src/protection/__tests__/document-gate.test.ts
+++ b/graphql/server/src/protection/__tests__/document-gate.test.ts
@@ -181,6 +181,28 @@ describe('introspection', () => {
     expect(() => enforce('{ __schema { queryType { name } } }')).not.toThrow();
   });
 
+  it('does not charge the standard introspection document against the depth budget', () => {
+    const source = `
+      { __schema { types { fields { args { type { ...TypeRef } } } } } }
+      fragment TypeRef on __Type {
+        kind name
+        ofType { kind name ofType { kind name ofType { kind name ofType { kind name
+          ofType { kind name ofType { kind name ofType { kind name } } } } } } }
+      }
+    `;
+    expect(enforce(source, { maxQueryDepth: 3 })).toEqual({ depth: 1, cost: 0 });
+  });
+
+  it('still measures the rest of an operation that also introspects', () => {
+    expect(
+      codeOf(() =>
+        enforce('{ __schema { queryType { name } } user(id: "1") { manager { manager { name } } } }', {
+          maxQueryDepth: 3
+        })
+      )
+    ).toBe('QUERY_TOO_DEEP');
+  });
+
   it('never blocks __typename, which is not introspection of the schema', () => {
     expect(() =>
       enforce('{ user(id: "1") { __typename name } }', { enableIntrospection: false })

--- a/graphql/server/src/protection/document-gate.ts
+++ b/graphql/server/src/protection/document-gate.ts
@@ -16,6 +16,13 @@
  * The walk is manual rather than `visitWithTypeInfo` because fragment spreads
  * have to be followed (a document can hide its depth entirely inside
  * fragments) and the visitor does not follow them.
+ *
+ * Schema introspection (`__schema` / `__type`) is governed only by
+ * `enableIntrospection`. Its selections are not walked: the introspection types
+ * carry no connections, so there is nothing to cost, and the standard
+ * introspection document nests a fixed `ofType` chain deeper than a sensible
+ * tenant depth budget, so charging depth would make the budget decide whether
+ * clients can introspect at all — a decision the dedicated switch already owns.
  */
 
 import type { ConstructiveError } from '@constructive-io/errors';
@@ -119,6 +126,7 @@ function walkSelectionSet(
         if (!walk.protection.enableIntrospection) {
           reject(errors.INTROSPECTION_DISABLED());
         }
+        continue;
       }
 
       const field =


### PR DESCRIPTION
## Summary

Fixes constructive-hub `propagate-to-dashboard` (failing every run since Sep 1, e.g. https://github.com/constructive-io/constructive-hub/actions/runs/34269003613): `apps/admin` codegen dies with `Failed to fetch schema: The query is nested too deeply`.

Since #1753 the document gate charges introspection against the tenant's `max_query_depth`. The codegen's `SCHEMA_INTROSPECTION_QUERY` (and graphql-js's `getIntrospectionQuery`) nests `__schema → types → fields → args → type → ofType×7` = depth 13, over the default of 12 — so any protected endpoint refuses introspection.

Change in `walkSelectionSet`:

```diff
 if (name === '__schema' || name === '__type') {
   if (!protection.enableIntrospection) reject(INTROSPECTION_DISABLED);
+  continue;   // introspection selections are not walked for depth/cost
 }
```

Why this rather than raising the default: introspection already has its own switch (`enable_introspection`), its types carry no connections so cost is always 0, and its shape is fixed by the spec rather than by the client — the depth budget exists to bound data queries, and a tenant lowering it for their API should not silently lose introspection. Raising the default would only move the cliff.

Sibling fields in the same operation are still measured (test added).

Link to Devin session: https://app.devin.ai/sessions/1c0e1e05988944c2995bd82bb7e0c215
Open in Devin Desktop: https://app.devin.ai/desktop/session/1c0e1e05988944c2995bd82bb7e0c215?variant=devin
Requested by: @pyramation