### PR TITLE
chore(fixtures): bump @constructive-db platform module pins to current publish

### DIFF
--- a/pgpm.json
+++ b/pgpm.json
@@ -3,10 +3,10 @@
     "testing/*"
   ],
   "dependencies": {
-    "@constructive-db/apps": "7.1.0",
-    "@constructive-db/catalog": "6.1.0",
-    "@constructive-db/routing": "8.2.0",
-    "@constructive-db/routing-platform": "7.1.0",
+    "@constructive-db/apps": "7.1.1",
+    "@constructive-db/catalog": "6.2.0",
+    "@constructive-db/routing": "8.3.0",
+    "@constructive-db/routing-platform": "7.1.1",
     "@pgpm/database-jobs": "0.44.0",
     "@pgpm/function-resolution": "0.44.2",
     "@pgpm/jwt-claims": "0.44.0",


### PR DESCRIPTION
## Summary
Bump the ephemeral-fixture pins in the root `pgpm.json` to the `@constructive-db/*` versions just published from constructive-platform#27, so `pnpm fixtures:install` / `seed.pgpm` deploy the current control-plane schema (catalog `functions.access_channels`/`anonymous_callable`, routing `apis.is_published`):

```
apps             7.1.0 -> 7.1.1
catalog          6.1.0 -> 6.2.0
routing          8.2.0 -> 8.3.0
routing-platform 7.1.0 -> 7.1.1
```

No code changes.

Link to Devin session: https://app.devin.ai/sessions/86a73d903b3546c1afbf5361bfa384b6
Open in Devin Desktop: https://app.devin.ai/desktop/session/86a73d903b3546c1afbf5361bfa384b6?variant=devin
Requested by: @pyramation