### PR TITLE
fix(graphile-llm): bump graphile-search peer to ^2; document Node 22 floor

### DIFF
--- a/.agents/skills/constructive-monorepo-setup/SKILL.md
+++ b/.agents/skills/constructive-monorepo-setup/SKILL.md
@@ -4,7 +4,7 @@ Set up the Constructive monorepo for local development and testing.
 
 ## Prerequisites
 
-- Node.js 20+
+- Node.js 22+
 - pnpm 9+
 - Docker (for PostgreSQL)
 - pgpm CLI (`npm install -g pgpm`)

--- a/graphile/graphile-llm/package.json
+++ b/graphile/graphile-llm/package.json
@@ -40,7 +40,7 @@
     "graphile-build": "^5.1.1",
     "graphile-build-pg": "^5.1.3",
     "graphile-config": "^1.1.0",
-    "graphile-search": "^1.18.0",
+    "graphile-search": "^2.0.0",
     "graphile-utils": "^5.0.3",
     "graphql": "^16.9.0",
     "pg-sql2": "^5.0.1",


### PR DESCRIPTION
## Summary

Fixes the peer-dependency conflict a fresh `npm install pgpm@5.30.5` reports:

```
npm warn Conflicting peer dependency: postgraphile@5.0.3
npm warn   peer postgraphile@"5.0.3" from graphile-search@1.21.6
npm warn     peerOptional graphile-search@"^1.18.0" from graphile-llm@1.15.8
```

Root cause: `graphile-llm` still declared `peerDependencies["graphile-search"] = "^1.18.0"` while the workspace (and `graphile-settings`) ship `graphile-search@2.14.6`. npm satisfies the stale optional peer by hoisting the last 1.x (`1.21.6`, which pins *exact* peers `postgraphile@5.0.3`, `graphile-build@5.0.2`, …) next to the 2.14.6 the rest of the tree uses — an extraneous second copy with peers a minor behind. `graphile-llm` is already built and tested against the workspace 2.x via its `devDependencies`, so the pin was simply never bumped.

```diff
- "graphile-search": "^1.18.0",
+ "graphile-search": "^2.0.0",
```

Only stale internal peer in the repo (checked every `peerDependencies` entry naming a workspace package against that package's current version).

Also: `constructive-monorepo-setup` skill said "Node.js 20+"; the root `engines` and postgraphile/grafast/@dataplan/pg all declare `node >=22` (and grafast needs `Promise.withResolvers`), so the skill now says 22+. Companion doc fixes: constructive.io prerequisites page and constructive-platform README.


Link to Devin session: https://app.devin.ai/sessions/6d533da4fa5a48399ad2c7508dffa32b
Open in Devin Desktop: https://app.devin.ai/desktop/session/6d533da4fa5a48399ad2c7508dffa32b?variant=devin
Requested by: @pyramation