### PR TITLE
feat(errors): register SIGN_UP_REQUIRES_INVITE and INVITE_PHONE_NOT_FOUND

### DIFF
--- a/packages/errors/scripts/db-error-inventory.json
+++ b/packages/errors/scripts/db-error-inventory.json
@@ -2164,11 +2164,12 @@
     "n_generated": 6
   },
   "EMAIL_NOT_VERIFIED": {
-    "count": 12,
+    "count": 10,
     "dynamic": false,
     "sample": "EMAIL_NOT_VERIFIED",
     "n_source": 2,
-    "n_generated": 4
+    "n_generated": 4,
+    "class": "public"
   },
   "ENTITY_CLAIM_REQUIRED": {
     "count": 4,
@@ -3373,25 +3374,36 @@
     "n_generated": 6
   },
   "INVITE_EMAIL_NOT_FOUND": {
-    "count": 16,
+    "count": 14,
     "dynamic": false,
     "sample": "INVITE_EMAIL_NOT_FOUND",
     "n_source": 2,
-    "n_generated": 4
+    "n_generated": 4,
+    "class": "public"
   },
   "INVITE_LIMIT": {
-    "count": 12,
+    "count": 10,
     "dynamic": false,
     "sample": "INVITE_LIMIT",
     "n_source": 2,
-    "n_generated": 4
+    "n_generated": 4,
+    "class": "public"
   },
   "INVITE_NOT_FOUND": {
     "count": 12,
     "dynamic": false,
     "sample": "INVITE_NOT_FOUND",
-    "n_source": 2,
-    "n_generated": 4
+    "n_source": 3,
+    "n_generated": 4,
+    "class": "public"
+  },
+  "INVITE_PHONE_NOT_FOUND": {
+    "count": 6,
+    "dynamic": false,
+    "sample": "INVITE_PHONE_NOT_FOUND",
+    "n_source": 1,
+    "n_generated": 3,
+    "class": "public"
   },
   "INVOCATION_ANONYMOUS_NOT_AUTHORIZED": {
     "count": 2,
@@ -4097,11 +4109,11 @@
     "class": "internal"
   },
   "MODULE_ENTRY_MALFORMED": {
-    "count": 2,
+    "count": 4,
     "dynamic": false,
     "sample": "MODULE_ENTRY_MALFORMED",
     "n_source": 1,
-    "n_generated": 0,
+    "n_generated": 1,
     "class": "internal"
   },
   "MODULE_SECURITY_POLICY_ENTRY_MISSING_TYPE": {
@@ -4214,7 +4226,7 @@
     "class": "public"
   },
   "OBJECT_NOT_FOUND": {
-    "count": 26,
+    "count": 24,
     "dynamic": false,
     "sample": "OBJECT_NOT_FOUND",
     "n_source": 9,
@@ -5297,11 +5309,19 @@
     "class": "public"
   },
   "SIGN_UP_DISABLED": {
-    "count": 6,
+    "count": 8,
     "dynamic": false,
     "sample": "SIGN_UP_DISABLED",
     "n_source": 0,
-    "n_generated": 4,
+    "n_generated": 5,
+    "class": "public"
+  },
+  "SIGN_UP_REQUIRES_INVITE": {
+    "count": 13,
+    "dynamic": false,
+    "sample": "SIGN_UP_REQUIRES_INVITE",
+    "n_source": 1,
+    "n_generated": 6,
     "class": "public"
   },
   "SITE_INSTALLATION_MEMBER_NOT_SERVABLE": {

--- a/packages/errors/src/generated/registry.generated.ts
+++ b/packages/errors/src/generated/registry.generated.ts
@@ -2,7 +2,7 @@
 /**
  * GENERATED FILE — DO NOT EDIT BY HAND.
  *
- * Source of truth: the constructive-db error audit (784 distinct codes
+ * Source of truth: the constructive-db error audit (786 distinct codes
  * raised via EXCEPTION/THROW across deploy sources + generated output).
  * Regenerate with `python3 scripts/generate-registry.py` (see README.md).
  *
@@ -10,7 +10,7 @@
  * codes carry their raw message (with %-args rendered as {{argN}}). Curated
  * entries in `registry.ts` override anything here (typed context + refined copy).
  *
- * Counts: 784 total, 576 public, 208 internal.
+ * Counts: 786 total, 578 public, 208 internal.
  */
 import { defineError, type DefinedError } from '../define';
 import type { ErrorContext } from '../types';
@@ -455,6 +455,7 @@ export const generatedRegistry: Record<string, DefinedError<ErrorContext>> = {
   'INVITE_EMAIL_NOT_FOUND': defineError({ code: 'INVITE_EMAIL_NOT_FOUND', class: 'public', http: 404, message: 'Invite email not found.' }),
   'INVITE_LIMIT': defineError({ code: 'INVITE_LIMIT', class: 'public', http: 429, message: 'Invite limit.' }),
   'INVITE_NOT_FOUND': defineError({ code: 'INVITE_NOT_FOUND', class: 'public', http: 404, message: 'Invite not found.' }),
+  'INVITE_PHONE_NOT_FOUND': defineError({ code: 'INVITE_PHONE_NOT_FOUND', class: 'public', http: 404, message: 'Invite phone not found.' }),
   'INVOCATION_ANONYMOUS_NOT_AUTHORIZED': defineError({ code: 'INVOCATION_ANONYMOUS_NOT_AUTHORIZED', class: 'public', http: 400, message: 'Invocation anonymous not authorized.' }),
   'INVOCATION_ANONYMOUS_NOT_CALLABLE': defineError({ code: 'INVOCATION_ANONYMOUS_NOT_CALLABLE', class: 'public', http: 400, message: 'Invocation anonymous not callable.' }),
   'INVOCATION_ANONYMOUS_ROUTE_REQUIRED': defineError({ code: 'INVOCATION_ANONYMOUS_ROUTE_REQUIRED', class: 'public', http: 400, message: 'Invocation anonymous route required.' }),
@@ -698,6 +699,7 @@ export const generatedRegistry: Record<string, DefinedError<ErrorContext>> = {
   'SESSION_TTL_EXCEEDS_PARENT': defineError({ code: 'SESSION_TTL_EXCEEDS_PARENT', class: 'public', http: 400, message: 'Session ttl exceeds parent.' }),
   'SETTINGS_SURFACE_NOT_PROVISIONED': defineError({ code: 'SETTINGS_SURFACE_NOT_PROVISIONED', class: 'public', http: 400, message: 'Settings surface not provisioned.' }),
   'SIGN_UP_DISABLED': defineError({ code: 'SIGN_UP_DISABLED', class: 'public', http: 403, message: 'Sign up disabled.' }),
+  'SIGN_UP_REQUIRES_INVITE': defineError({ code: 'SIGN_UP_REQUIRES_INVITE', class: 'public', http: 403, message: 'Sign up requires invite.' }),
   'SITE_INSTALLATION_MEMBER_NOT_SERVABLE': defineError({ code: 'SITE_INSTALLATION_MEMBER_NOT_SERVABLE', class: 'internal', http: 500, message: 'Site installation member not servable.' }),
   'SITE_NOT_FOUND': defineError({ code: 'SITE_NOT_FOUND', class: 'public', http: 404, message: 'Site not found.' }),
   'SITE_NOT_PROVISIONED': defineError({ code: 'SITE_NOT_PROVISIONED', class: 'public', http: 400, message: 'Site not provisioned.' }),
@@ -1243,6 +1245,7 @@ export const GENERATED_CODE_META: Record<string, GeneratedCodeMeta> = {
   'INVITE_EMAIL_NOT_FOUND': { class: 'public', dynamic: false, generatedOnly: false },
   'INVITE_LIMIT': { class: 'public', dynamic: false, generatedOnly: false },
   'INVITE_NOT_FOUND': { class: 'public', dynamic: false, generatedOnly: false },
+  'INVITE_PHONE_NOT_FOUND': { class: 'public', dynamic: false, generatedOnly: false },
   'INVOCATION_ANONYMOUS_NOT_AUTHORIZED': { class: 'public', dynamic: false, generatedOnly: false },
   'INVOCATION_ANONYMOUS_NOT_CALLABLE': { class: 'public', dynamic: false, generatedOnly: false },
   'INVOCATION_ANONYMOUS_ROUTE_REQUIRED': { class: 'public', dynamic: false, generatedOnly: false },
@@ -1486,6 +1489,7 @@ export const GENERATED_CODE_META: Record<string, GeneratedCodeMeta> = {
   'SESSION_TTL_EXCEEDS_PARENT': { class: 'public', dynamic: false, generatedOnly: true },
   'SETTINGS_SURFACE_NOT_PROVISIONED': { class: 'public', dynamic: false, generatedOnly: false },
   'SIGN_UP_DISABLED': { class: 'public', dynamic: false, generatedOnly: true },
+  'SIGN_UP_REQUIRES_INVITE': { class: 'public', dynamic: false, generatedOnly: false },
   'SITE_INSTALLATION_MEMBER_NOT_SERVABLE': { class: 'internal', dynamic: false, generatedOnly: true },
   'SITE_NOT_FOUND': { class: 'public', dynamic: false, generatedOnly: false },
   'SITE_NOT_PROVISIONED': { class: 'public', dynamic: false, generatedOnly: false },
@@ -1599,4 +1603,4 @@ export const GENERATED_CODE_META: Record<string, GeneratedCodeMeta> = {
 };
 
 /** Total number of codes collected from constructive-db. */
-export const GENERATED_CODE_COUNT = 784;
+export const GENERATED_CODE_COUNT = 786;

--- a/packages/errors/src/registry.ts
+++ b/packages/errors/src/registry.ts
@@ -91,6 +91,12 @@ export const registry = {
     http: 403,
     message: 'Sign-up is currently disabled.'
   }),
+  SIGN_UP_REQUIRES_INVITE: defineError({
+    code: 'SIGN_UP_REQUIRES_INVITE',
+    class: 'public',
+    http: 403,
+    message: 'Sign-up is by invitation only. Please provide a valid invite code.'
+  }),
 
   // ===========================================================================
   // Auth / account (public) — migrated from the server graphile SAFE_ERROR_CODES
@@ -230,6 +236,13 @@ export const registry = {
     http: 404,
     message:
       'This email is not associated with the invitation. Please use the email address the invitation was sent to.'
+  }),
+  INVITE_PHONE_NOT_FOUND: defineError({
+    code: 'INVITE_PHONE_NOT_FOUND',
+    class: 'public',
+    http: 404,
+    message:
+      'This phone number is not associated with the invitation. Please use the phone number the invitation was sent to.'
   }),
 
   // ===========================================================================


### PR DESCRIPTION
## Summary

Registers the two public error codes introduced by invite-only sign-up in constructive-io/constructive-db#3730 so transports classify them as `public` (403/404) instead of failing safe to an unregistered `500`.

- `SIGN_UP_REQUIRES_INVITE` (403) — raised by every `sign_up*` function when `app_settings_auth.sign_up_requires_invite` is on and no `invite_token` was supplied.
- `INVITE_PHONE_NOT_FOUND` (404) — raised by `claim_app_invite` when a phone-addressed invite is claimed by a user who doesn't own that phone (mirror of `INVITE_EMAIL_NOT_FOUND`).

`scripts/db-error-inventory.json` and `src/generated/registry.generated.ts` were regenerated via `audit-db-errors.py` + `generate-registry.py` against that branch; curated copy for both codes was added to `registry.ts`.


Link to Devin session: https://app.devin.ai/sessions/b594a9d9c24e40ec9968fef407df5af3
Open in Devin Desktop: https://app.devin.ai/desktop/session/b594a9d9c24e40ec9968fef407df5af3?variant=devin
Requested by: @pyramation